### PR TITLE
Update CMakeLists.txt iccApplyProfiles Add JSON

### DIFF
--- a/Build/Cmake/Tools/IccApplyProfiles/CMakeLists.txt
+++ b/Build/Cmake/Tools/IccApplyProfiles/CMakeLists.txt
@@ -3,9 +3,9 @@
 # Copyright (©) 2024 The International Color Consortium. All rights reserved.
 #
 #
-# Last Updated: 09-APRIL-2025 1300 EDT  by David Hoyt
+# Last Updated: 28-JULY-2025 0100Z  by David Hoyt
 #
-# Changes:      Added TIFF Dependency
+# Changes:      Added JSON Dependency
 #               Adjusted Cross Platform Build Args
 #
 #
@@ -18,7 +18,10 @@ IF(NOT TARGET iccApplyProfiles)
   # Define the source path relative to this file
   SET(SRC_PATH ../../../..)
   SET(SOURCES ${SRC_PATH}/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
-              ${SRC_PATH}/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp )
+              ${SRC_PATH}/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+              ${SRC_PATH}/Tools/CmdLine/IccCommon/IccJsonUtil.cpp
+              ${SRC_PATH}/Tools/CmdLine/IccCommon/IccCmmConfig.cpp
+              )
   SET(TARGET_NAME iccApplyProfiles)
 
   # Define the executable target


### PR DESCRIPTION
# PR151 Repro

- Added JSON Dependency
  - Found during https://github.com/InternationalColorConsortium/DemoIccMAX/issues/150

1. Unix

```
export CXX=clang++
cd /tmp
git clone https://github.com/InternationalColorConsortium/DemoIccMAX.git
cd DemoIccMAX
git fetch origin pull/151/head:pr-151
git checkout pr-151
cd Build
sudo apt-get install -y libwxgtk3.2-dev libwxgtk-media3.2-dev libwxgtk-webview3.2-dev wx-common wx3.2-headers libtiff6 curl git make cmake clang clang-tools libxml2 libxml2-dev nlohmann-json3-dev build-essential
cmake -DCMAKE_INSTALL_PREFIX=$HOME/.local -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS="-g -fsanitize=address,undefined -fno-omit-frame-pointer -Wall" -Wno-dev Cmake/
make clean
make -j$(nproc)
cd ../Testing/
/bin/sh -c "$(curl -fsSL https://raw.githubusercontent.com/InternationalColorConsortium/DemoIccMAX/refs/heads/master/contrib/UnitTest/CreateAllProfiles.sh)" 
```

2. Windows

```
git clone https://github.com/InternationalColorConsortium/DemoIccMAX.git
cd DemoIccMAX
git fetch origin pull/151/head:pr-151
git checkout pr-151
cmake --preset vs2022-x64 -B . -S Build/Cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_CXX_FLAGS_DEBUG="/Zi /Od /fsanitize=address /Oy- /MDd" -DCMAKE_C_FLAGS_DEBUG="/Zi /Od /fsanitize=address /Oy- /MDd" -DCMAKE_TOOLCHAIN_FILE="C:/Program Files/Microsoft Visual Studio/2022/Enterprise/VC/vcpkg/scripts/buildsystems/vcpkg.cmake"
cmake --build . -- /m /maxcpucount
```