### PR TITLE
Refactor IO code to fix signed/unsigned comparisons

### DIFF
--- a/IccProfLib/IccIO.cpp
+++ b/IccProfLib/IccIO.cpp
@@ -90,9 +90,9 @@ namespace iccDEV {
 //////////////////////////////////////////////////////////////////////
 
 
-icInt32Number CIccIO::ReadLine(void *pBuf8, icInt32Number nNum/*=256*/)
+size_t CIccIO::ReadLine(void *pBuf8, size_t nNum/*=256*/)
 {
-  icInt32Number n=0;
+  size_t n=0;
   icInt8Number c, *ptr=(icInt8Number*)pBuf8;
 
   while(n<nNum) {
@@ -111,7 +111,7 @@ icInt32Number CIccIO::ReadLine(void *pBuf8, icInt32Number nNum/*=256*/)
   return n;
 }
 
-icInt32Number CIccIO::Read16(void *pBuf16, icInt32Number nNum)
+size_t CIccIO::Read16(void *pBuf16, size_t nNum)
 {
   nNum = Read8(pBuf16, nNum<<1)>>1;
   icSwab16Array(pBuf16, nNum);
@@ -119,14 +119,14 @@ icInt32Number CIccIO::Read16(void *pBuf16, icInt32Number nNum)
   return nNum;
 }
 
-icInt32Number CIccIO::Write16(void *pBuf16, icInt32Number nNum)
+size_t CIccIO::Write16(void *pBuf16, size_t nNum)
 {
 #ifndef ICC_BYTE_ORDER_LITTLE_ENDIAN
   return Write8(pBuf16, nNum<<1)>>1;
 #else
   icUInt16Number *ptr = (icUInt16Number*)pBuf16;
   icUInt16Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     tmp = *ptr;
@@ -140,7 +140,7 @@ icInt32Number CIccIO::Write16(void *pBuf16, icInt32Number nNum)
 #endif
 }
 
-icInt32Number CIccIO::Read32(void *pBuf32, icInt32Number nNum)
+size_t CIccIO::Read32(void *pBuf32, size_t nNum)
 {
   nNum = Read8(pBuf32, nNum<<2)>>2;
   icSwab32Array(pBuf32, nNum);
@@ -149,14 +149,14 @@ icInt32Number CIccIO::Read32(void *pBuf32, icInt32Number nNum)
 }
 
 
-icInt32Number CIccIO::Write32(void *pBuf32, icInt32Number nNum)
+size_t CIccIO::Write32(void *pBuf32, size_t nNum)
 {
 #ifndef ICC_BYTE_ORDER_LITTLE_ENDIAN
   return Write8(pBuf32, nNum<<2)>>2;
 #else
   icUInt32Number *ptr = (icUInt32Number*)pBuf32;
   icUInt32Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     tmp = *ptr;
@@ -170,7 +170,7 @@ icInt32Number CIccIO::Write32(void *pBuf32, icInt32Number nNum)
 #endif
 }
 
-icInt32Number CIccIO::Read64(void *pBuf64, icInt32Number nNum)
+size_t CIccIO::Read64(void *pBuf64, size_t nNum)
 {
   nNum = Read8(pBuf64, nNum<<3)>>3;
   icSwab64Array(pBuf64, nNum);
@@ -179,14 +179,14 @@ icInt32Number CIccIO::Read64(void *pBuf64, icInt32Number nNum)
 }
 
 
-icInt32Number CIccIO::Write64(void *pBuf64, icInt32Number nNum)
+size_t CIccIO::Write64(void *pBuf64, size_t nNum)
 {
 #ifndef ICC_BYTE_ORDER_LITTLE_ENDIAN
   return Write8(pBuf64, nNum<<3)>>3;
 #else
   icUInt64Number *ptr = (icUInt64Number*)pBuf64;
   icUInt64Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     tmp = *ptr;
@@ -200,11 +200,11 @@ icInt32Number CIccIO::Write64(void *pBuf64, icInt32Number nNum)
 #endif
 }
 
-icInt32Number CIccIO::ReadUInt8Float(void *pBufFloat, icInt32Number nNum)
+size_t CIccIO::ReadUInt8Float(void *pBufFloat, size_t nNum)
 {
   icFloatNumber *ptr = (icFloatNumber*)pBufFloat;
   icUInt8Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     if (Read8(&tmp, 1)!=1)
@@ -216,11 +216,11 @@ icInt32Number CIccIO::ReadUInt8Float(void *pBufFloat, icInt32Number nNum)
   return i;
 }
 
-icInt32Number CIccIO::WriteUInt8Float(void *pBufFloat, icInt32Number nNum)
+size_t CIccIO::WriteUInt8Float(void *pBufFloat, size_t nNum)
 {
   icFloatNumber *ptr = (icFloatNumber*)pBufFloat;
   icUInt8Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     tmp = (icUInt8Number)(__max(0.0, __min(1.0, *ptr)) * 255.0 + 0.5);
@@ -233,11 +233,11 @@ icInt32Number CIccIO::WriteUInt8Float(void *pBufFloat, icInt32Number nNum)
   return i;
 }
 
-icInt32Number CIccIO::ReadUInt16Float(void *pBufFloat, icInt32Number nNum)
+size_t CIccIO::ReadUInt16Float(void *pBufFloat, size_t nNum)
 {
   icFloatNumber *ptr = (icFloatNumber*)pBufFloat;
   icUInt16Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     if (Read16(&tmp, 1)!=1)
@@ -249,11 +249,11 @@ icInt32Number CIccIO::ReadUInt16Float(void *pBufFloat, icInt32Number nNum)
   return i;
 }
 
-icInt32Number CIccIO::WriteUInt16Float(void *pBufFloat, icInt32Number nNum)
+size_t CIccIO::WriteUInt16Float(void *pBufFloat, size_t nNum)
 {
   icFloatNumber *ptr = (icFloatNumber*)pBufFloat;
   icUInt16Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     tmp = (icUInt16Number)(__max(0.0, __min(1.0, *ptr)) * 65535.0 + 0.5);
@@ -266,11 +266,11 @@ icInt32Number CIccIO::WriteUInt16Float(void *pBufFloat, icInt32Number nNum)
   return i;
 }
 
-icInt32Number CIccIO::ReadFloat16Float(void *pBufFloat, icInt32Number nNum)
+size_t CIccIO::ReadFloat16Float(void *pBufFloat, size_t nNum)
 {
   icFloatNumber *ptr = (icFloatNumber*)pBufFloat;
   icFloat16Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     if (Read16(&tmp, 1)!=1)
@@ -282,11 +282,11 @@ icInt32Number CIccIO::ReadFloat16Float(void *pBufFloat, icInt32Number nNum)
   return i;
 }
 
-icInt32Number CIccIO::WriteFloat16Float(void *pBufFloat, icInt32Number nNum)
+size_t CIccIO::WriteFloat16Float(void *pBufFloat, size_t nNum)
 {
   icFloatNumber *ptr = (icFloatNumber*)pBufFloat;
   icUInt16Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     tmp = icFtoF16(*ptr);
@@ -299,14 +299,14 @@ icInt32Number CIccIO::WriteFloat16Float(void *pBufFloat, icInt32Number nNum)
   return i;
 }
 
-icInt32Number CIccIO::ReadFloat32Float(void *pBufFloat, icInt32Number nNum)
+size_t CIccIO::ReadFloat32Float(void *pBufFloat, size_t nNum)
 {
   if (sizeof(icFloat32Number)==sizeof(icFloatNumber))
     return Read32(pBufFloat, nNum);
 
   icFloatNumber *ptr = (icFloatNumber*)pBufFloat;
   icFloat32Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     if (Read32(&tmp, 1)!=1)
@@ -318,14 +318,14 @@ icInt32Number CIccIO::ReadFloat32Float(void *pBufFloat, icInt32Number nNum)
   return i;
 }
 
-icInt32Number CIccIO::WriteFloat32Float(void *pBufFloat, icInt32Number nNum)
+size_t CIccIO::WriteFloat32Float(void *pBufFloat, size_t nNum)
 {
   if (sizeof(icFloat32Number)==sizeof(icFloatNumber))
     return Write32(pBufFloat, nNum);
 
   icFloatNumber *ptr = (icFloatNumber*)pBufFloat;
   icFloat32Number tmp;
-  icInt32Number i;
+  size_t i;
 
   for (i=0; i<nNum; i++) {
     tmp = (icFloat32Number)*ptr;
@@ -340,7 +340,7 @@ icInt32Number CIccIO::WriteFloat32Float(void *pBufFloat, icInt32Number nNum)
 
 bool CIccIO::Align32()
 {
-  int mod = GetLength() % 4;
+  size_t mod = GetLength() % 4;
   if (mod != 0) {
     icUInt8Number buf[4]={0,0,0,0};
     if (Seek(0, icSeekEnd)<0)
@@ -354,11 +354,11 @@ bool CIccIO::Align32()
 
 }
 
-bool CIccIO::Sync32(icUInt32Number nOffset)
+bool CIccIO::Sync32(size_t nOffset)
 {
   nOffset &= 0x3;
 
-  icUInt32Number nPos = ((Tell() - nOffset + 3)>>2)<<2;
+  size_t nPos = ((Tell() - nOffset + 3)>>2)<<2;
   if (Seek(nPos + nOffset, icSeekSet)<0)
     return false;
   return true;
@@ -449,53 +449,53 @@ void CIccFileIO::Close()
 }
 
 
-icInt32Number CIccFileIO::Read8(void *pBuf, icInt32Number nNum)
+size_t CIccFileIO::Read8(void *pBuf, size_t nNum)
 {
   if (!m_fFile)
     return 0;
 
-  return (icInt32Number)fread(pBuf, 1, nNum, m_fFile);
+  return fread(pBuf, 1, nNum, m_fFile);
 }
 
 
-icInt32Number CIccFileIO::Write8(void *pBuf, icInt32Number nNum)
+size_t CIccFileIO::Write8(void *pBuf, size_t nNum)
 {
   if (!m_fFile)
     return 0;
 
-  return (icInt32Number)fwrite(pBuf, 1, nNum, m_fFile);
+  return fwrite(pBuf, 1, nNum, m_fFile);
 }
 
 
-icInt32Number CIccFileIO::GetLength()
+size_t CIccFileIO::GetLength()
 {
   if (!m_fFile)
     return 0;
 
   fflush(m_fFile);
-  icInt32Number current = (icInt32Number)ftell(m_fFile), end;
+  size_t current = ftell(m_fFile);
   fseek (m_fFile, 0, SEEK_END);
-  end = (icInt32Number)ftell(m_fFile);
+  size_t end = ftell(m_fFile);
   fseek (m_fFile, current, SEEK_SET);
   return end;
 }
 
 
-icInt32Number CIccFileIO::Seek(icInt32Number nOffset, icSeekVal pos)
+size_t CIccFileIO::Seek(size_t nOffset, icSeekVal pos)
 {
   if (!m_fFile)
     return -1;
 
-  return !fseek(m_fFile, nOffset, pos) ? (icInt32Number)ftell(m_fFile) : -1;
+  return !fseek(m_fFile, nOffset, pos) ? ftell(m_fFile) : -1;
 }
 
 
-icInt32Number CIccFileIO::Tell()
+size_t CIccFileIO::Tell()
 {
   if (!m_fFile)
     return -1;
 
-  return (icInt32Number)ftell(m_fFile);
+  return ftell(m_fFile);
 }
 
 
@@ -516,7 +516,7 @@ CIccEmbedIO::~CIccEmbedIO()
   Close();
 }
 
-bool CIccEmbedIO::Attach(CIccIO *pIO, icInt32Number nSize/* =0 */, bool bOwnIO/* =false */)
+bool CIccEmbedIO::Attach(CIccIO *pIO, size_t nSize/* =0 */, bool bOwnIO/* =false */)
 {
   if (!pIO)
     return false;
@@ -544,16 +544,16 @@ void CIccEmbedIO::Close()
 }
 
 
-icInt32Number CIccEmbedIO::Read8(void *pBuf, icInt32Number nNum)
+size_t CIccEmbedIO::Read8(void *pBuf, size_t nNum)
 {
   if (!m_pIO)
     return 0;
 
   if (m_nSize > 0) {
-    icUInt32Number nPos = m_pIO->Tell();
-    icUInt32Number nOffset = nPos - m_nStartPos;
+    size_t nPos = m_pIO->Tell();
+    size_t nOffset = nPos - m_nStartPos;
 
-    if (nOffset + nNum > (icUInt64Number)m_nSize)
+    if (nOffset + nNum > m_nSize)
       nNum = m_nSize - nOffset;
   }
 
@@ -561,7 +561,7 @@ icInt32Number CIccEmbedIO::Read8(void *pBuf, icInt32Number nNum)
 }
 
 
-icInt32Number CIccEmbedIO::Write8(void *pBuf, icInt32Number nNum)
+size_t CIccEmbedIO::Write8(void *pBuf, size_t nNum)
 {
   if (!m_pIO)
     return 0;
@@ -570,7 +570,7 @@ icInt32Number CIccEmbedIO::Write8(void *pBuf, icInt32Number nNum)
 }
 
 
-icInt32Number CIccEmbedIO::GetLength()
+size_t CIccEmbedIO::GetLength()
 {
   if (!m_pIO)
     return 0;
@@ -582,9 +582,9 @@ icInt32Number CIccEmbedIO::GetLength()
 }
 
 
-icInt32Number CIccEmbedIO::Seek(icInt32Number nOffset, icSeekVal pos)
+size_t CIccEmbedIO::Seek(size_t nOffset, icSeekVal pos)
 {
-  icInt32Number nPos;
+  size_t nPos;
   if (!m_pIO)
     return -1;
 
@@ -628,14 +628,14 @@ icInt32Number CIccEmbedIO::Seek(icInt32Number nOffset, icSeekVal pos)
 }
 
 
-icInt32Number CIccEmbedIO::Tell()
+size_t CIccEmbedIO::Tell()
 {
   if (!m_pIO)
     return -1;
 
-  icUInt32Number nPos = m_pIO->Tell();
+  size_t nPos = m_pIO->Tell();
 
-  if ((icInt32Number)nPos >= m_nStartPos)
+  if (nPos >= m_nStartPos)
     return nPos - m_nStartPos;
 
   return nPos;
@@ -662,7 +662,7 @@ CIccMemIO::~CIccMemIO()
 }
 
 
-bool CIccMemIO::Alloc(icUInt32Number nSize, bool bWrite)
+bool CIccMemIO::Alloc(size_t nSize, bool bWrite)
 {
   if (m_pData)
     Close();
@@ -683,7 +683,7 @@ bool CIccMemIO::Alloc(icUInt32Number nSize, bool bWrite)
 }
 
 
-bool CIccMemIO::Attach(icUInt8Number *pData, icUInt32Number nSize, bool bWrite)
+bool CIccMemIO::Attach(icUInt8Number *pData, size_t nSize, bool bWrite)
 {
   if (!pData)
     return false;
@@ -719,12 +719,12 @@ void CIccMemIO::Close()
 }
 
 
-icInt32Number CIccMemIO::Read8(void *pBuf, icInt32Number nNum)
+size_t CIccMemIO::Read8(void *pBuf, size_t nNum)
 {
   if (!m_pData)
     return 0;
   if (nNum > 0) {
-      nNum = __min((icInt32Number) (m_nSize - m_nPos), nNum);
+      nNum = __min((m_nSize - m_nPos), nNum);
       memcpy(pBuf, m_pData + m_nPos, nNum);
       m_nPos += nNum;
   }
@@ -732,12 +732,12 @@ icInt32Number CIccMemIO::Read8(void *pBuf, icInt32Number nNum)
 }
 
 
-icInt32Number CIccMemIO::Write8(void *pBuf, icInt32Number nNum)
+size_t CIccMemIO::Write8(void *pBuf, size_t nNum)
 {
   if (!m_pData)
     return 0;
 
-  nNum = __min((icInt32Number)(m_nAvail-m_nPos), nNum);
+  nNum = __min((m_nAvail-m_nPos), nNum);
 
   memcpy(m_pData + m_nPos, pBuf, nNum);
 
@@ -749,7 +749,7 @@ icInt32Number CIccMemIO::Write8(void *pBuf, icInt32Number nNum)
 }
 
 
-icInt32Number CIccMemIO::GetLength()
+size_t CIccMemIO::GetLength()
 {
   if (!m_pData)
     return 0;
@@ -758,21 +758,21 @@ icInt32Number CIccMemIO::GetLength()
 }
 
 
-icInt32Number CIccMemIO::Seek(icInt32Number nOffset, icSeekVal pos)
+size_t CIccMemIO::Seek(size_t nOffset, icSeekVal pos)
 {
   if (!m_pData)
     return -1;
 
-  icInt32Number nPos;
+  size_t nPos;
   switch(pos) {
   case icSeekSet:
     nPos = nOffset;
     break;
   case icSeekCur:
-    nPos = (icInt32Number)m_nPos + nOffset;
+    nPos = m_nPos + nOffset;
     break;
   case icSeekEnd:
-    nPos = (icInt32Number)m_nSize + nOffset;
+    nPos = m_nSize + nOffset;
     break;
   default:
     nPos = 0;
@@ -797,12 +797,12 @@ icInt32Number CIccMemIO::Seek(icInt32Number nOffset, icSeekVal pos)
 }
 
 
-icInt32Number CIccMemIO::Tell()
+size_t CIccMemIO::Tell()
 {
   if (!m_pData)
     return -1;
 
-  return (icInt32Number)m_nPos;
+  return m_nPos;
 }
 
 ///////////////////////////////
@@ -835,10 +835,10 @@ void CIccNullIO::Close()
 }
 
 
-icInt32Number CIccNullIO::Read8(void *pBuf, icInt32Number nNum)
+size_t CIccNullIO::Read8(void *pBuf, size_t nNum)
 {
-  icInt32Number nLeft = m_nSize - m_nPos;
-  icInt32Number nRead = (nNum <= (icInt32Number)nLeft) ? nNum : nLeft;
+  size_t nLeft = m_nSize - m_nPos;
+  size_t nRead = (nNum <= nLeft) ? nNum : nLeft;
 
   memset(pBuf, 0, nRead);
   m_nPos += nRead;
@@ -847,7 +847,7 @@ icInt32Number CIccNullIO::Read8(void *pBuf, icInt32Number nNum)
 }
 
 
-icInt32Number CIccNullIO::Write8(void * /* pBuf */, icInt32Number nNum)
+size_t CIccNullIO::Write8(void * /* pBuf */, size_t nNum)
 {
   m_nPos += nNum;
   if (m_nPos > m_nSize)
@@ -857,24 +857,24 @@ icInt32Number CIccNullIO::Write8(void * /* pBuf */, icInt32Number nNum)
 }
 
 
-icInt32Number CIccNullIO::GetLength()
+size_t CIccNullIO::GetLength()
 {
   return m_nSize;
 }
 
 
-icInt32Number CIccNullIO::Seek(icInt32Number nOffset, icSeekVal pos)
+size_t CIccNullIO::Seek(size_t nOffset, icSeekVal pos)
 {
-  icInt32Number nPos;
+  size_t nPos;
   switch(pos) {
   case icSeekSet:
     nPos = nOffset;
     break;
   case icSeekCur:
-    nPos = (icInt32Number)m_nPos + nOffset;
+    nPos = m_nPos + nOffset;
     break;
   case icSeekEnd:
-    nPos = (icInt32Number)m_nSize + nOffset;
+    nPos = m_nSize + nOffset;
     break;
   default:
     nPos = 0;
@@ -884,7 +884,7 @@ icInt32Number CIccNullIO::Seek(icInt32Number nOffset, icSeekVal pos)
   if (nPos < 0)
     return -1;
 
-  m_nPos = (icUInt32Number)nPos;
+  m_nPos = nPos;
 
   if (m_nPos>m_nSize)
     m_nSize = m_nPos;
@@ -893,9 +893,9 @@ icInt32Number CIccNullIO::Seek(icInt32Number nOffset, icSeekVal pos)
 }
 
 
-icInt32Number CIccNullIO::Tell()
+size_t CIccNullIO::Tell()
 {
-  return (icInt32Number)m_nPos;
+  return m_nPos;
 }
 
 

--- a/IccProfLib/IccIO.h
+++ b/IccProfLib/IccIO.h
@@ -97,43 +97,43 @@ public:
 
   virtual void Close() {}
 
-// unused param is needed to define default value for overrides, changing would require a lot of additional changes
-  virtual icInt32Number Read8(void * /*pBuf8*/, icInt32Number nNum=1) { (void)nNum; return 0; }
-  virtual icInt32Number Write8(void * /*pBuf8*/, icInt32Number nNum=1) { (void)nNum; return 0; }
+// the unused param is needed to define default value for overrides, changing would require a lot of additional changes
+  virtual size_t Read8(void * /*pBuf8*/, size_t nNum=1) { (void)nNum; return 0; }
+  virtual size_t Write8(void * /*pBuf8*/, size_t nNum=1) { (void)nNum; return 0; }
 
-  icInt32Number ReadLine(void *pBuf8, icInt32Number nNum=256);
+  size_t ReadLine(void *pBuf8, size_t nNum=256);
 
-  icInt32Number Read16(void *pBuf16, icInt32Number nNum=1);
-  icInt32Number Write16(void *pBuf16, icInt32Number nNum=1);
+  size_t Read16(void *pBuf16, size_t nNum=1);
+  size_t Write16(void *pBuf16, size_t nNum=1);
 
-  icInt32Number Read32(void *pBuf32, icInt32Number nNum=1);
-  icInt32Number Write32(void *pBuf32, icInt32Number nNum=1);
+  size_t Read32(void *pBuf32, size_t nNum=1);
+  size_t Write32(void *pBuf32, size_t nNum=1);
 
-  icInt32Number Read64(void *pBuf64, icInt32Number nNum=1);
-  icInt32Number Write64(void *pBuf64, icInt32Number nNum=1);
+  size_t Read64(void *pBuf64, size_t nNum=1);
+  size_t Write64(void *pBuf64, size_t nNum=1);
 
-  icInt32Number ReadUInt8Float(void *pBufFloat, icInt32Number nNum=1);
-  icInt32Number WriteUInt8Float(void *pBuf16, icInt32Number nNum=1);
+  size_t ReadUInt8Float(void *pBufFloat, size_t nNum=1);
+  size_t WriteUInt8Float(void *pBuf16, size_t nNum=1);
 
-  icInt32Number ReadUInt16Float(void *pBufFloat, icInt32Number nNum=1);
-  icInt32Number WriteUInt16Float(void *pBuf16, icInt32Number nNum=1);
+  size_t ReadUInt16Float(void *pBufFloat, size_t nNum=1);
+  size_t WriteUInt16Float(void *pBuf16, size_t nNum=1);
 
-  icInt32Number ReadFloat16Float(void *pBufFloat, icInt32Number nNum=1);
-  icInt32Number WriteFloat16Float(void *pBuf16, icInt32Number nNum=1);
+  size_t ReadFloat16Float(void *pBufFloat, size_t nNum=1);
+  size_t WriteFloat16Float(void *pBuf16, size_t nNum=1);
 
-  icInt32Number ReadFloat32Float(void *pBufFloat, icInt32Number nNum=1);
-  icInt32Number WriteFloat32Float(void *pBufFloat, icInt32Number nNum=1);
+  size_t ReadFloat32Float(void *pBufFloat, size_t nNum=1);
+  size_t WriteFloat32Float(void *pBufFloat, size_t nNum=1);
 
-  virtual icInt32Number GetLength() {return 0;}
+  virtual size_t GetLength() {return 0;}
 
-  virtual icInt32Number Seek(icInt32Number /*nOffset*/, icSeekVal /*pos*/) {return -1;}
-  virtual icInt32Number Tell() {return 0;}
+  virtual size_t Seek(size_t /*nOffset*/, icSeekVal /*pos*/) {return -1;}
+  virtual size_t Tell() {return 0;}
 
   ///Write operation to make sure that filelength is evenly divisible by 4
   bool Align32(); 
 
   ///Operation to make sure read position is evenly divisible by 4
-  bool Sync32(icUInt32Number nOffset=0); 
+  bool Sync32(size_t nOffset=0); 
 };
 
 /**
@@ -159,13 +159,13 @@ public:
 
   virtual void Close();
 
-  virtual icInt32Number Read8(void *pBuf, icInt32Number nNum=1);
-  virtual icInt32Number Write8(void *pBuf, icInt32Number nNum=1);
+  virtual size_t Read8(void *pBuf, size_t nNum=1);
+  virtual size_t Write8(void *pBuf, size_t nNum=1);
 
-  virtual icInt32Number GetLength();
+  virtual size_t GetLength();
 
-  virtual icInt32Number Seek(icInt32Number nOffset, icSeekVal pos);
-  virtual icInt32Number Tell();
+  virtual size_t Seek(size_t nOffset, icSeekVal pos);
+  virtual size_t Tell();
 
 protected:
   FILE *m_fFile;
@@ -184,21 +184,21 @@ public:
   CIccEmbedIO();
   virtual ~CIccEmbedIO();
 
-  bool Attach(CIccIO *pIO, icInt32Number nSize=0, bool bOwnIO=false);
+  bool Attach(CIccIO *pIO, size_t nSize=0, bool bOwnIO=false);
   virtual void Close();
 
-  virtual icInt32Number Read8(void *pBuf, icInt32Number nNum = 1);
-  virtual icInt32Number Write8(void *pBuf, icInt32Number nNum = 1);
+  virtual size_t Read8(void *pBuf, size_t nNum = 1);
+  virtual size_t Write8(void *pBuf, size_t nNum = 1);
 
-  virtual icInt32Number GetLength();
+  virtual size_t GetLength();
 
-  virtual icInt32Number Seek(icInt32Number nOffset, icSeekVal pos);
-  virtual icInt32Number Tell();
+  virtual size_t Seek(size_t nOffset, icSeekVal pos);
+  virtual size_t Tell();
 
 protected:
  CIccIO *m_pIO;
- icInt32Number m_nStartPos;
- icInt32Number m_nSize;
+ size_t m_nStartPos;
+ size_t m_nSize;
  bool m_bOwnIO;
 };
 
@@ -216,26 +216,26 @@ public:
   CIccMemIO();
   virtual ~CIccMemIO();
 
-  bool Alloc(icUInt32Number nSize, bool bWrite = false);
+  bool Alloc(size_t nSize, bool bWrite = false);
 
-  bool Attach(icUInt8Number *pData, icUInt32Number nSize, bool bWrite=false);
+  bool Attach(icUInt8Number *pData, size_t nSize, bool bWrite=false);
   virtual void Close();
 
-  virtual icInt32Number Read8(void *pBuf, icInt32Number nNum=1);
-  virtual icInt32Number Write8(void *pBuf, icInt32Number nNum=1);
+  virtual size_t Read8(void *pBuf, size_t nNum=1);
+  virtual size_t Write8(void *pBuf, size_t nNum=1);
 
-  virtual icInt32Number GetLength();
+  virtual size_t GetLength();
 
-  virtual icInt32Number Seek(icInt32Number nOffset, icSeekVal pos);
-  virtual icInt32Number Tell();
+  virtual size_t Seek(size_t nOffset, icSeekVal pos);
+  virtual size_t Tell();
 
   icUInt8Number *GetData() { return m_pData; }
 
 protected:
   icUInt8Number *m_pData;
-  icUInt32Number m_nSize;
-  icUInt32Number m_nAvail;
-  icUInt32Number m_nPos;
+  size_t m_nSize;
+  size_t m_nAvail;
+  size_t m_nPos;
 
   bool m_bFreeData;
 };
@@ -258,17 +258,17 @@ public:
   virtual void Close();
 
 
-  virtual icInt32Number Read8(void *pBuf, icInt32Number nNum=1);   //Read zero's into buf
-  virtual icInt32Number Write8(void *pBuf, icInt32Number nNum=1);
+  virtual size_t Read8(void *pBuf, size_t nNum=1);   //Read zero's into buf
+  virtual size_t Write8(void *pBuf, size_t nNum=1);
 
-  virtual icInt32Number GetLength();
+  virtual size_t GetLength();
 
-  virtual icInt32Number Seek(icInt32Number nOffset, icSeekVal pos);
-  virtual icInt32Number Tell();
+  virtual size_t Seek(size_t nOffset, icSeekVal pos);
+  virtual size_t Tell();
 
 protected:
-  icUInt32Number m_nSize;
-  icUInt32Number m_nPos;
+  size_t m_nSize;
+  size_t m_nPos;
 };
 
 

--- a/IccProfLib/IccMpeACS.cpp
+++ b/IccProfLib/IccMpeACS.cpp
@@ -187,13 +187,13 @@ bool CIccMpeAcs::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read32(&m_signature))
     return false;
 
-  icUInt32Number dataSize = size - headerSize;
+  size_t dataSize = size - headerSize;
 
   if (!AllocData(dataSize))
     return false;
 
   if (dataSize) {
-    if (pIO->Read8(m_pData, dataSize)!=(icInt32Number)dataSize)
+    if (pIO->Read8(m_pData, dataSize)!=dataSize)
       return false;
   }
 
@@ -235,7 +235,7 @@ bool CIccMpeAcs::Write(CIccIO *pIO)
   if (m_pData && m_nDataSize) {
     // ERROR - sign and unsigned comparison, this should be fixed at a higher level
     // cast type to get it compiling for now
-    if (pIO->Write8(m_pData, m_nDataSize) != (icInt32Number)m_nDataSize)
+    if (pIO->Write8(m_pData, m_nDataSize) != m_nDataSize)
       return false;
   }
 
@@ -302,7 +302,7 @@ icValidateStatus CIccMpeAcs::Validate(std::string sigPath, std::string &sReport,
 * 
 * Return: 
 ******************************************************************************/
-bool CIccMpeAcs::AllocData(icUInt32Number size)
+bool CIccMpeAcs::AllocData(size_t size)
 {
   if (m_pData)
     free(m_pData);

--- a/IccProfLib/IccMpeACS.h
+++ b/IccProfLib/IccMpeACS.h
@@ -100,9 +100,9 @@ public:
 
   virtual bool IsAcs() { return true; }
 
-  bool AllocData(icUInt32Number size);
+  bool AllocData(size_t size);
   icUInt8Number* GetData() { return m_pData; }
-  icUInt32Number GetDataSize() { return m_nDataSize; }
+  size_t GetDataSize() { return m_nDataSize; }
 
   virtual icAcsSignature GetAcsSig() { return m_signature; }
 
@@ -110,7 +110,7 @@ protected:
   CIccMpeAcs();
   icAcsSignature m_signature;
 
-  icUInt32Number m_nDataSize;
+  size_t m_nDataSize;
   icUInt8Number *m_pData;
 };
 

--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -363,11 +363,11 @@ void CIccFormulaCurveSegment::SetFunction(icUInt16Number functionType, icUInt8Nu
  * 
  * Return: 
  ******************************************************************************/
-bool CIccFormulaCurveSegment::Read(icUInt32Number size, CIccIO *pIO)
+bool CIccFormulaCurveSegment::Read(size_t size, CIccIO *pIO)
 {
   icCurveSegSignature sig;
 
-  icUInt32Number headerSize = sizeof(icTagTypeSignature) + 
+  size_t headerSize = sizeof(icTagTypeSignature) + 
     sizeof(icUInt32Number) + 
     sizeof(icUInt16Number) + 
     sizeof(icUInt16Number);
@@ -1067,11 +1067,11 @@ void CIccSampledCurveSegment::Describe(std::string &sDescription, int /* nVerbos
  * 
  * Return: 
  ******************************************************************************/
-bool CIccSampledCurveSegment::Read(icUInt32Number size, CIccIO *pIO)
+bool CIccSampledCurveSegment::Read(size_t size, CIccIO *pIO)
 {
   icCurveSegSignature sig;
 
-  icUInt32Number headerSize = sizeof(icTagTypeSignature) + 
+  size_t headerSize = sizeof(icTagTypeSignature) + 
     sizeof(icUInt32Number) + 
     sizeof(icUInt32Number);
 
@@ -1101,7 +1101,7 @@ bool CIccSampledCurveSegment::Read(icUInt32Number size, CIccIO *pIO)
     return false;
 
   if (m_nCount) {
-    if (pIO->ReadFloat32Float(m_pSamples+1, m_nCount-1)!=(icInt32Number)(m_nCount-1))
+    if (pIO->ReadFloat32Float(m_pSamples+1, m_nCount-1) != (m_nCount-1))
       return false;
   }
 
@@ -1134,7 +1134,7 @@ bool CIccSampledCurveSegment::Write(CIccIO *pIO)
   if (!pIO->Write32(&m_nReserved))
     return false;
 
-  icUInt32Number nCount;
+  size_t nCount;
 
   if (m_nCount)
     nCount = m_nCount -1;
@@ -1146,7 +1146,7 @@ bool CIccSampledCurveSegment::Write(CIccIO *pIO)
 
   //First point in samples is ONLY for interpolation (not saved)
   if (nCount) {
-    if (pIO->WriteFloat32Float(m_pSamples+1, nCount)!=(icInt32Number)nCount)
+    if (pIO->WriteFloat32Float(m_pSamples+1, nCount)!= nCount)
       return false;
   }
 
@@ -1596,7 +1596,7 @@ void CIccSingleSampledCurve::Describe(std::string &sDescription, int /* nVerbose
 ******************************************************************************/
 bool CIccSingleSampledCurve::Read(icUInt32Number size, CIccIO *pIO)
 {
-  icCurveSegSignature sig;
+  icCurveElemSignature sig;
 
   icUInt32Number headerSize = sizeof(icTagTypeSignature) + 
     sizeof(icUInt32Number) + 
@@ -1613,7 +1613,6 @@ bool CIccSingleSampledCurve::Read(icUInt32Number size, CIccIO *pIO)
     return false;
   }
 
-  // ERROR - comparison of different enum types!
   if (!pIO->Read32(&sig) || sig!=GetType())
     return false;
 
@@ -1647,28 +1646,28 @@ bool CIccSingleSampledCurve::Read(icUInt32Number size, CIccIO *pIO)
         if (m_nCount * sizeof(icUInt8Number) > size - headerSize)
           return false;
 
-        if (pIO->ReadUInt8Float(m_pSamples, m_nCount)!=(icInt32Number)(m_nCount))
+        if (pIO->ReadUInt8Float(m_pSamples, m_nCount)!= m_nCount)
           return false;
         break;
       case icValueTypeUInt16:
         if (m_nCount * 2 > size - headerSize)
           return false;
 
-        if (pIO->ReadUInt16Float(m_pSamples, m_nCount)!=(icInt32Number)(m_nCount))
+        if (pIO->ReadUInt16Float(m_pSamples, m_nCount)!= m_nCount)
           return false;
         break;
       case icValueTypeFloat16:
         if (m_nCount * 2 > size - headerSize)
           return false;
 
-        if (pIO->ReadFloat16Float(m_pSamples, m_nCount)!=(icInt32Number)(m_nCount))
+        if (pIO->ReadFloat16Float(m_pSamples, m_nCount)!= m_nCount)
           return false;
         break;
       case icValueTypeFloat32:
         if (m_nCount * sizeof(icFloat32Number) > size - headerSize)
           return false;
 
-        if (pIO->ReadFloat32Float(m_pSamples, m_nCount)!=(icInt32Number)(m_nCount))
+        if (pIO->ReadFloat32Float(m_pSamples, m_nCount)!= m_nCount)
           return false;
         break;
       default:
@@ -1721,19 +1720,19 @@ bool CIccSingleSampledCurve::Write(CIccIO *pIO)
 
     switch(m_storageType) {
       case icValueTypeUInt8:
-        if (pIO->WriteUInt8Float(m_pSamples, m_nCount)!=(icInt32Number)(m_nCount))
+        if (pIO->WriteUInt8Float(m_pSamples, m_nCount)!= m_nCount)
           return false;
         break;
       case icValueTypeUInt16:
-        if (pIO->WriteUInt16Float(m_pSamples, m_nCount)!=(icInt32Number)(m_nCount))
+        if (pIO->WriteUInt16Float(m_pSamples, m_nCount)!= m_nCount)
           return false;
         break;
       case icValueTypeFloat16:
-        if (pIO->WriteFloat16Float(m_pSamples, m_nCount)!=(icInt32Number)(m_nCount))
+        if (pIO->WriteFloat16Float(m_pSamples, m_nCount)!= m_nCount)
           return false;
         break;
       case icValueTypeFloat32:
-        if (pIO->WriteFloat32Float(m_pSamples, m_nCount)!=(icInt32Number)(m_nCount))
+        if (pIO->WriteFloat32Float(m_pSamples, m_nCount)!= m_nCount)
           return false;
         break;
       default:
@@ -2237,7 +2236,7 @@ void CIccSampledCalculatorCurve::Describe(std::string &sDescription, int nVerbos
 ******************************************************************************/
 bool CIccSampledCalculatorCurve::Read(icUInt32Number size, CIccIO *pIO)
 {
-  icCurveSegSignature sig;
+  icCurveElemSignature sig;
 
   icUInt32Number headerSize = sizeof(icTagTypeSignature) +
     sizeof(icUInt32Number) +
@@ -2254,7 +2253,6 @@ bool CIccSampledCalculatorCurve::Read(icUInt32Number size, CIccIO *pIO)
     return false;
   }
 
-  // ERROR - comparison of different enum types!
   if (!pIO->Read32(&sig) || sig != GetType())
     return false;
 
@@ -2639,9 +2637,9 @@ bool CIccSegmentedCurve::Read(icUInt32Number size, CIccIO *pIO)
 {
   icCurveElemSignature sig;
 
-  icUInt32Number startPos = pIO->Tell();
+  size_t startPos = pIO->Tell();
   
-  icUInt32Number headerSize = sizeof(icCurveElemSignature) + 
+  size_t headerSize = sizeof(icCurveElemSignature) + 
     sizeof(icUInt32Number) + 
     sizeof(icUInt16Number) + 
     sizeof(icUInt16Number);
@@ -2672,7 +2670,7 @@ bool CIccSegmentedCurve::Read(icUInt32Number size, CIccIO *pIO)
 
   Reset();
 
-  icUInt32Number pos = pIO->Tell();
+  size_t pos = pIO->Tell();
   icCurveSegSignature segSig;
   CIccCurveSegment *pSeg;
 
@@ -2716,7 +2714,7 @@ bool CIccSegmentedCurve::Read(icUInt32Number size, CIccIO *pIO)
         free(breakpoints);
         return false;
       }
-      if (pIO->Seek(pos, icSeekSet)!=(icInt32Number)pos)
+      if (pIO->Seek(pos, icSeekSet) != pos)
         return false;;
 
       if (!i)
@@ -3228,9 +3226,9 @@ bool CIccMpeCurveSet::Read(icUInt32Number size, CIccIO *pIO)
 {
   icElemTypeSignature sig;
 
-  icUInt32Number startPos = pIO->Tell();
+  size_t startPos = pIO->Tell();
   
-  icUInt32Number headerSize = sizeof(icTagTypeSignature) + 
+  size_t headerSize = sizeof(icTagTypeSignature) + 
     sizeof(icUInt32Number) + 
     sizeof(icUInt16Number) + 
     sizeof(icUInt16Number);
@@ -3284,13 +3282,13 @@ bool CIccMpeCurveSet::Read(icUInt32Number size, CIccIO *pIO)
     icCurveElemSignature curveSig;
     for (i=0; i<m_nInputChannels; i++) {
       if (!map[m_position[i].offset]) {
-        icUInt32Number pos;
+        size_t pos;
         if (!m_position[i].offset || !m_position[i].size) {
           return false;
         }
 
         pos = startPos + m_position[i].offset;
-        if (pIO->Seek(pos, icSeekSet)!=(icInt32Number)pos) {
+        if (pIO->Seek(pos, icSeekSet) != pos) {
           return false;
         }
         
@@ -3303,7 +3301,7 @@ bool CIccMpeCurveSet::Read(icUInt32Number size, CIccIO *pIO)
           return false;
         }
 
-        if (pIO->Seek(pos, icSeekSet)!=(icInt32Number)pos) {
+        if (pIO->Seek(pos, icSeekSet) != pos) {
           return false;
         }
       
@@ -3339,7 +3337,7 @@ bool CIccMpeCurveSet::Write(CIccIO *pIO)
   if (!pIO)
     return false;
 
-  icUInt32Number elemStart = pIO->Tell();
+  size_t elemStart = pIO->Tell();
 
   if (!pIO->Write32(&sig))
     return false;
@@ -3356,11 +3354,11 @@ bool CIccMpeCurveSet::Write(CIccIO *pIO)
   if (m_curve && m_nInputChannels) {
     int i;
     icCurvePtrMap map;
-    icUInt32Number start, end;
+    size_t start, end;
     icUInt32Number zeros[2] = { 0, 0};
     icPositionNumber position;
 
-    icUInt32Number startTable = pIO->Tell();
+    size_t startTable = pIO->Tell();
 
     //First write empty position table
     for (i=0; i<m_nInputChannels; i++) {
@@ -3376,8 +3374,8 @@ bool CIccMpeCurveSet::Write(CIccIO *pIO)
           m_curve[i]->Write(pIO);
           end = pIO->Tell();
           pIO->Align32();
-          position.offset = start - elemStart;
-          position.size = end - start;
+          position.offset = (icUInt32Number)(start - elemStart);
+          position.size = (icUInt32Number)(end - start);
           map[m_curve[i]] = position;
         }
         m_position[i] = map[m_curve[i]];
@@ -3691,7 +3689,7 @@ bool CIccMpeTintArray::Read(icUInt32Number size, CIccIO *pIO)
   m_nInputChannels = nInputChannels;
   m_nOutputChannels = nOutputChannels;
 
-  icUInt32Number arrayPos = pIO->Tell();
+  size_t arrayPos = pIO->Tell();
 
   icTagTypeSignature tagType;
   if (!pIO->Read32(&tagType))
@@ -3982,9 +3980,9 @@ void CIccToneMapFunc::Describe(std::string& sDescription, int /* nVerboseness */
 
 bool CIccToneMapFunc::Read(icUInt32Number size, CIccIO* pIO)
 {
-  icCurveSegSignature sig;
+  icToneFunctionSignature sig;
 
-  icUInt32Number headerSize = sizeof(icTagTypeSignature) +
+  size_t headerSize = sizeof(icTagTypeSignature) +
     sizeof(icUInt32Number) +
     sizeof(icUInt16Number) +
     sizeof(icUInt16Number);
@@ -3999,7 +3997,6 @@ bool CIccToneMapFunc::Read(icUInt32Number size, CIccIO* pIO)
   if (!pIO->Read32(&sig))
     return false;
 
-  // ERROR - comparison of different enum types!
   if (sig != icSigToneMapFunction)
     return false;
 
@@ -4424,9 +4421,9 @@ bool CIccMpeToneMap::Read(icUInt32Number size, CIccIO* pIO)
 
   icElemTypeSignature sig;
 
-  icUInt32Number startPos = pIO->Tell();
+  size_t startPos = pIO->Tell();
 
-  icUInt32Number headerSize = sizeof(icElemTypeSignature) +
+  size_t headerSize = sizeof(icElemTypeSignature) +
     sizeof(icUInt32Number) +
     sizeof(icUInt16Number) +
     sizeof(icUInt16Number) +
@@ -4465,7 +4462,7 @@ bool CIccMpeToneMap::Read(icUInt32Number size, CIccIO* pIO)
       !pIO->Read32(&lumPos.size))
     return false;
 
-  icUInt32Number curPos = pIO->Tell();
+  size_t curPos = pIO->Tell();
 
   //We need signature of curve type to construct and read it
   icCurveElemSignature curveSig;
@@ -4586,7 +4583,7 @@ bool CIccMpeToneMap::Write(CIccIO* pIO)
   if (!pIO)
     return false;
 
-  icUInt32Number nTagStartPos = pIO->Tell();
+  size_t nTagStartPos = pIO->Tell();
 
   if (!pIO->Write32(&sig))
     return false;
@@ -4600,7 +4597,7 @@ bool CIccMpeToneMap::Write(CIccIO* pIO)
   if (!pIO->Write16(&m_nOutputChannels))
     return false;
 
-  icUInt32Number lumOffset = pIO->Tell();
+  size_t lumOffset = pIO->Tell();
 
   //Reserve position entry for Luminance Curve
   icUInt32Number zero = 0;
@@ -4617,12 +4614,12 @@ bool CIccMpeToneMap::Write(CIccIO* pIO)
 
   //write out luminance curve
   icPositionNumber lumPos;
-  lumPos.offset = pIO->Tell()- nTagStartPos;
+  lumPos.offset = (icUInt32Number)(pIO->Tell()- nTagStartPos);
 
   if (!m_pLumCurve->Write(pIO))
     return false;
 
-  lumPos.size = pIO->Tell() - (lumPos.offset + nTagStartPos);
+  lumPos.size = (icUInt32Number)(pIO->Tell() - (lumPos.offset + nTagStartPos));
 
   //Keep track of tone function positions
   icPositionNumber* funcPos = new icPositionNumber[m_nOutputChannels];
@@ -4631,12 +4628,12 @@ bool CIccMpeToneMap::Write(CIccIO* pIO)
 
   //write out first tone function
   int j;
-  funcPos[0].offset = pIO->Tell() - nTagStartPos;
+  funcPos[0].offset = (icUInt32Number)(pIO->Tell() - nTagStartPos);
   if (!m_pToneFuncs[0]->Write(pIO)) {
     delete[] funcPos;
     return false;
   }
-  funcPos[0].size = pIO->Tell() - (funcPos[0].offset + nTagStartPos);
+  funcPos[0].size = (icUInt32Number)(pIO->Tell() - (funcPos[0].offset + nTagStartPos));
 
   //write out additional non-copied tone functions
   for (int i = 1; i < m_nOutputChannels; i++) {
@@ -4647,18 +4644,18 @@ bool CIccMpeToneMap::Write(CIccIO* pIO)
       funcPos[i] = funcPos[j];
     }
     else {
-      funcPos[i].offset = pIO->Tell() - nTagStartPos;
+      funcPos[i].offset = (icUInt32Number)(pIO->Tell() - nTagStartPos);
       if (!m_pToneFuncs[i]->Write(pIO)) {
         delete[] funcPos;
         return false;
       }
-      funcPos[i].size = pIO->Tell() - (funcPos[i].offset + nTagStartPos);
+      funcPos[i].size = (icUInt32Number)(pIO->Tell() - (funcPos[i].offset + nTagStartPos));
     }
   }
 
   //Everything but positions is written so make sure we end on 32 bit boundary
   pIO->Align32();
-  icUInt32Number endOffset = pIO->Tell();
+  size_t endOffset = pIO->Tell();
 
   //write out luminance curve position
   pIO->Seek(lumOffset, icSeekSet);
@@ -5086,7 +5083,7 @@ bool CIccMpeMatrix::Read(icUInt32Number size, CIccIO *pIO)
       return false;
 
     //Read Matrix data
-    if (pIO->ReadFloat32Float(m_pMatrix, m_size) != (icInt32Number)m_size)
+    if (pIO->ReadFloat32Float(m_pMatrix, m_size) != m_size)
       return false;
   }
   else if (dataSize < (icUInt32Number)nInputChannels * nOutputChannels *sizeof(icFloatNumber) &&
@@ -5118,7 +5115,7 @@ bool CIccMpeMatrix::Read(icUInt32Number size, CIccIO *pIO)
       return false;
 
     //Read Matrix data
-    if (pIO->ReadFloat32Float(m_pMatrix, m_size)!=(icInt32Number)m_size)
+    if (pIO->ReadFloat32Float(m_pMatrix, m_size)!= m_size)
       return false;
 
     //Read Constant data
@@ -5159,7 +5156,7 @@ bool CIccMpeMatrix::Write(CIccIO *pIO)
     return false;
 
   if (m_pMatrix) {
-    if (pIO->WriteFloat32Float(m_pMatrix, m_size)!=(icInt32Number)m_size)
+    if (pIO->WriteFloat32Float(m_pMatrix, m_size)!= m_size)
       return false;
   }
 
@@ -5612,7 +5609,7 @@ bool CIccMpeCLUT::Write(CIccIO *pIO)
       return false;
 
     icFloatNumber *pData = m_pCLUT->GetData(0);
-    icInt32Number nPoints = m_pCLUT->NumPoints()*m_nOutputChannels;
+    size_t nPoints = m_pCLUT->NumPoints()*m_nOutputChannels;
 
     if (pIO->WriteFloat32Float(pData, nPoints) != nPoints) 
       return false;
@@ -6065,7 +6062,7 @@ bool CIccMpeExtCLUT::Write(CIccIO *pIO)
       return false;
 
     icFloatNumber *pData = m_pCLUT->GetData(0);
-    icInt32Number nPoints = m_pCLUT->NumPoints()*m_nOutputChannels;
+    size_t nPoints = m_pCLUT->NumPoints()*m_nOutputChannels;
 
     switch(m_storageType) {
     case icValueTypeUInt8:
@@ -6142,7 +6139,7 @@ CIccMpeCAM::~CIccMpeCAM()
 
 bool CIccMpeCAM::Read(icUInt32Number size, CIccIO *pIO)
 {
-  icTagTypeSignature sig;
+  icElemTypeSignature sig;
 
   icUInt32Number headerSize = sizeof(icTagTypeSignature) + 
     sizeof(icUInt32Number) + 
@@ -6159,7 +6156,6 @@ bool CIccMpeCAM::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read32(&sig))
     return false;
 
-    // ERROR - comparing different enum types!
   if (sig!=GetType())
     return false;
 

--- a/IccProfLib/IccMpeBasic.h
+++ b/IccProfLib/IccMpeBasic.h
@@ -100,7 +100,7 @@ public:
 
   virtual void Describe(std::string &sDescription, int nVerboseness)=0;
 
-  virtual bool Read(icUInt32Number size, CIccIO *pIO)=0;
+  virtual bool Read(size_t size, CIccIO *pIO)=0;
   virtual bool Write(CIccIO *pIO)=0;
 
   virtual bool Begin(CIccCurveSegment *pPrevSeg) = 0;
@@ -141,7 +141,7 @@ public:
 
   void SetFunction(icUInt16Number functionType, icUInt8Number num_parameters, icFloatNumber *parameters);
 
-  virtual bool Read(icUInt32Number size, CIccIO *pIO);
+  virtual bool Read(size_t size, CIccIO *pIO);
   virtual bool Write(CIccIO *pIO);
 
   virtual bool Begin(CIccCurveSegment *pPrevSeg);
@@ -183,7 +183,7 @@ public:
 
   virtual void Describe(std::string &sDescription, int nVerboseness);
 
-  virtual bool Read(icUInt32Number size, CIccIO *pIO);
+  virtual bool Read(size_t size, CIccIO *pIO);
   virtual bool Write(CIccIO *pIO);
 
   virtual bool Begin(CIccCurveSegment *pPrevSeg);

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -4483,9 +4483,9 @@ bool CIccMpeCalculator::Read(icUInt32Number size, CIccIO *pIO)
 {
   icElemTypeSignature sig;
 
-  icUInt32Number startPos = pIO->Tell();
+  size_t startPos = pIO->Tell();
   
-  icUInt32Number headerSize = sizeof(icTagTypeSignature) + 
+  size_t headerSize = sizeof(icTagTypeSignature) + 
     sizeof(icUInt32Number) + 
     sizeof(icUInt16Number) + 
     sizeof(icUInt16Number) +
@@ -4610,7 +4610,7 @@ bool CIccMpeCalculator::Write(CIccIO *pIO)
   if (!pIO)
     return false;
 
-  icUInt32Number elemStart = pIO->Tell();
+  size_t elemStart = pIO->Tell();
 
   if (!pIO->Write32(&sig))
     return false;
@@ -4633,21 +4633,21 @@ bool CIccMpeCalculator::Write(CIccIO *pIO)
   if (!posvals) {
     return false;
   }
-  icUInt32Number nPositionStart = pIO->Tell();
+  size_t nPositionStart = pIO->Tell();
 
-  icUInt32Number n, np = nPos * (sizeof(icPositionNumber)/sizeof(icUInt32Number));
+  size_t n, np = nPos * (sizeof(icPositionNumber)/sizeof(icUInt32Number));
   if (pIO->Write32(posvals, np)!=np) {
     free(posvals);
     return false;
   }
 
   if (m_calcFunc) {
-    posvals[0].offset = pIO->Tell()-elemStart;
+    posvals[0].offset = (icUInt32Number)(pIO->Tell() - elemStart);
     if (!m_calcFunc->Write(pIO)) {
       free(posvals);
       return false;
     }
-    posvals[0].size = pIO->Tell()-elemStart - posvals[nPos-1].offset;
+    posvals[0].size = (icUInt32Number)(pIO->Tell() - elemStart - posvals[nPos-1].offset );
     pIO->Align32();
   }
 
@@ -4656,18 +4656,18 @@ bool CIccMpeCalculator::Write(CIccIO *pIO)
   if (m_nSubElem) {
     for(n=0; n<m_nSubElem; n++) {
       if (m_SubElem[n]) {
-        pos->offset = pIO->Tell()-elemStart;
+        pos->offset = (icUInt32Number)( pIO->Tell()-elemStart );
         if (!m_SubElem[n]->Write(pIO)) {
           free(posvals);
           return false;
         }
-        pos->size = pIO->Tell()-elemStart - pos->offset;
+        pos->size = (icUInt32Number)(pIO->Tell()-elemStart - pos->offset);
         pIO->Align32();
       }
       pos++;
     }
   }
-  icUInt32Number endPos = pIO->Tell();
+  size_t endPos = pIO->Tell();
 
   pIO->Seek(nPositionStart, icSeekSet);
 

--- a/IccProfLib/IccMpeSpectral.cpp
+++ b/IccProfLib/IccMpeSpectral.cpp
@@ -428,7 +428,7 @@ bool CIccMpeSpectralMatrix::Read(icUInt32Number size, CIccIO *pIO)
     return false;
 
   //Read Matrix data
-  if (pIO->ReadFloat32Float(m_pMatrix, m_size)!=(icInt32Number)m_size)
+  if (pIO->ReadFloat32Float(m_pMatrix, m_size)!= m_size)
     return false;
 
   if (size>=headerSize + 2*(int)range.steps*sizeof(icFloatNumber) + m_size * sizeof(icFloatNumber)) {
@@ -492,7 +492,7 @@ bool CIccMpeSpectralMatrix::Write(CIccIO *pIO)
   }
 
   if (m_pMatrix) {
-    if (pIO->WriteFloat32Float(m_pMatrix, m_size)!=(icInt32Number)m_size)
+    if (pIO->WriteFloat32Float(m_pMatrix, m_size)!= m_size)
       return false;
   }
 
@@ -1060,7 +1060,7 @@ bool CIccMpeSpectralCLUT::Read(icUInt32Number size, CIccIO *pIO)
   if (!pData)
     return false;
 
-  icInt32Number nPoints = m_pCLUT->NumPoints()*(int)m_Range.steps;
+  size_t nPoints = m_pCLUT->NumPoints()*(int)m_Range.steps;
 
   switch(m_nStorageType) {
     case icValueTypeUInt8:
@@ -1178,7 +1178,7 @@ bool CIccMpeSpectralCLUT::Write(CIccIO *pIO)
       return false;
 
     icFloatNumber *pData = m_pCLUT->GetData(0);
-    icInt32Number nPoints = m_pCLUT->NumPoints()*(int)m_Range.steps;
+    size_t nPoints = m_pCLUT->NumPoints()*(int)m_Range.steps;
 
     switch(m_nStorageType) {
     case icValueTypeUInt8:

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -285,7 +285,7 @@ bool CIccTagUnknown::Read(icUInt32Number size, CIccIO *pIO)
 
     m_pData = new icUInt8Number[m_nSize];
 
-    if (pIO->Read8(m_pData, m_nSize) != (icInt32Number)m_nSize) {
+    if (pIO->Read8(m_pData, m_nSize) != m_nSize) {
       return false;
     }
   } else {
@@ -318,7 +318,7 @@ bool CIccTagUnknown::Write(CIccIO *pIO)
    return false;
 
   if (m_nSize && m_pData) {
-   if (pIO->Write8(m_pData, m_nSize) != (icInt32Number)m_nSize)
+   if (pIO->Write8(m_pData, m_nSize) != m_nSize)
      return false;
   }
 
@@ -452,12 +452,12 @@ bool CIccTagText::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read32(&m_nReserved))
     return false;
 
-  icUInt32Number nSize = size - sizeof(icTagTypeSignature) - sizeof(icUInt32Number);
+  size_t nSize = size - sizeof(icTagTypeSignature) - sizeof(icUInt32Number);
 
-  icChar *pBuf = GetBuffer(nSize);
+  icChar *pBuf = GetBuffer((icUInt32Number)nSize);
 
   if (nSize) {
-    if (pIO->Read8(pBuf, nSize) != (icInt32Number)nSize) {
+    if (pIO->Read8(pBuf, nSize) != nSize) {
       return false;
     }
   }
@@ -496,9 +496,9 @@ bool CIccTagText::Write(CIccIO *pIO)
   if (!m_szText)
     return false;
 
-  icUInt32Number nSize = (icUInt32Number)strlen(m_szText)+1;
+  size_t nSize = strlen(m_szText)+1;
 
-  if (pIO->Write8(m_szText, nSize) != (icInt32Number)nSize)
+  if (pIO->Write8(m_szText, nSize) != nSize)
     return false;
 
   return true;
@@ -800,12 +800,12 @@ bool CIccTagUtf8Text::Read(icUInt32Number size, CIccIO *pIO)
   if (size < sizeof(icTagTypeSignature) + sizeof(icUInt32Number))
     return false;
 
-  icUInt32Number nSize = size - sizeof(icTagTypeSignature) - sizeof(icUInt32Number);
+  size_t nSize = size - sizeof(icTagTypeSignature) - sizeof(icUInt32Number);
 
-  icUChar *pBuf = GetBuffer(nSize);
+  icUChar *pBuf = GetBuffer((icUInt32Number)nSize);
 
   if (nSize) {
-    if (pIO->Read8(pBuf, nSize) != (icInt32Number)nSize) {
+    if (pIO->Read8(pBuf, nSize) != nSize) {
       return false;
     }
   }
@@ -844,9 +844,9 @@ bool CIccTagUtf8Text::Write(CIccIO *pIO)
   if (!m_szText)
     return false;
 
-  icUInt32Number nSize = (icUInt32Number)strlen((icChar*)m_szText)+1;
+  size_t nSize = strlen((icChar*)m_szText)+1;
 
-  if (pIO->Write8(m_szText, nSize) != (icInt32Number)nSize)
+  if (pIO->Write8(m_szText, nSize) != nSize)
     return false;
 
   return true;
@@ -1154,7 +1154,7 @@ bool CIccTagZipUtf8Text::Read(icUInt32Number size, CIccIO *pIO)
   icUChar *pBuf = AllocBuffer(nSize);
 
   if (m_nBufSize && pBuf) {
-    if (pIO->Read8(pBuf, m_nBufSize) != (icInt32Number)m_nBufSize) {
+    if (pIO->Read8(pBuf, m_nBufSize) != m_nBufSize) {
       return false;
     }
   }
@@ -1189,7 +1189,7 @@ bool CIccTagZipUtf8Text::Write(CIccIO *pIO)
     return false;
 
   if (m_pZipBuf) {
-    if (pIO->Write8(m_pZipBuf, m_nBufSize) != (icInt32Number)m_nBufSize)
+    if (pIO->Write8(m_pZipBuf, m_nBufSize) != m_nBufSize)
       return false;
   }
   return true;
@@ -1623,12 +1623,12 @@ bool CIccTagUtf16Text::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read32(&m_nReserved))
     return false;
 
-  icUInt32Number nSize = (size - sizeof(icTagTypeSignature) - sizeof(icUInt32Number))/sizeof(icUChar16);
+  size_t nSize = (size - sizeof(icTagTypeSignature) - sizeof(icUInt32Number))/sizeof(icUChar16);
 
-  icUChar16 *pBuf = GetBuffer(nSize);
+  icUChar16 *pBuf = GetBuffer((icUInt32Number)nSize);
 
   if (nSize) {
-    if (pIO->Read16(pBuf, nSize) != (icInt32Number)nSize) {
+    if (pIO->Read16(pBuf, nSize) != nSize) {
       return false;
     }
   }
@@ -1667,10 +1667,10 @@ bool CIccTagUtf16Text::Write(CIccIO *pIO)
   if (!m_szText)
     return false;
 
-  icUInt32Number nSize = GetLength();
+  size_t nSize = GetLength();
 
   if (nSize) {
-    if (pIO->Write16(m_szText, nSize) != (icInt32Number)nSize)
+    if (pIO->Write16(m_szText, nSize) != nSize)
       return false;
   }
 
@@ -2062,10 +2062,9 @@ CIccTagTextDescription::~CIccTagTextDescription()
 bool CIccTagTextDescription::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
-  icUInt32Number nEnd;
 
   m_szText[0] = '\0';
-  nEnd = pIO->Tell() + size;
+  size_t nEnd = pIO->Tell() + size;
 
   if (size<3*sizeof(icUInt32Number) || !pIO)
     return false;
@@ -2083,7 +2082,7 @@ bool CIccTagTextDescription::Read(icUInt32Number size, CIccIO *pIO)
   icChar *pBuf = GetBuffer(nSize);
 
   if (nSize) {
-    if (pIO->Read8(pBuf, nSize) != (icInt32Number)nSize) {
+    if (pIO->Read8(pBuf, nSize) != nSize) {
       return false;
     }
   }
@@ -2106,7 +2105,7 @@ bool CIccTagTextDescription::Read(icUInt32Number size, CIccIO *pIO)
   icUInt16Number *pBuf16 = GetUnicodeBuffer(nSize);
 
   if (nSize) {
-    if (pIO->Read16(pBuf16, nSize) != (icInt32Number)nSize) {
+    if (pIO->Read16(pBuf16, nSize) != nSize) {
       return false;
     }
   }
@@ -2115,18 +2114,18 @@ bool CIccTagTextDescription::Read(icUInt32Number size, CIccIO *pIO)
 
   ReleaseUnicode();
 
-  if (pIO->Tell()+3 > (icInt32Number)nEnd)
+  if (pIO->Tell()+3 > nEnd)
     return false;
 
   if (!pIO->Read16(&m_nScriptCode) ||
       !pIO->Read8(&m_nScriptSize))
      return false;
   
-  if (pIO->Tell() + m_nScriptSize> (icInt32Number)nEnd ||
+  if (pIO->Tell() + m_nScriptSize> nEnd ||
       m_nScriptSize > sizeof(m_szScriptText))
     return false;
 
-  int nScriptLen = pIO->Read8(m_szScriptText, 67);
+  size_t nScriptLen = pIO->Read8(m_szScriptText, 67);
 
   if (!nScriptLen)
     return false;
@@ -2166,7 +2165,7 @@ bool CIccTagTextDescription::Write(CIccIO *pIO)
     return false;
 
   if (m_nASCIISize) {
-    if (pIO->Write8(m_szText, m_nASCIISize) != (icInt32Number)m_nASCIISize)
+    if (pIO->Write8(m_szText, m_nASCIISize) != m_nASCIISize)
       return false;
   }
 
@@ -2175,7 +2174,7 @@ bool CIccTagTextDescription::Write(CIccIO *pIO)
 
   if (m_nUnicodeSize > 1) {
     if (!pIO->Write32(&m_nUnicodeSize) ||
-        pIO->Write16(m_uzUnicodeText, m_nUnicodeSize) != (icInt32Number)m_nUnicodeSize)
+        pIO->Write16(m_uzUnicodeText, m_nUnicodeSize) != m_nUnicodeSize)
       return false;
   }
   else {
@@ -2944,7 +2943,7 @@ bool CIccTagNamedColor2::Read(icUInt32Number size, CIccIO *pIO)
         pIO->ReadUInt16Float(&pNamedColor->pcsCoords, 3)!=3)
       return false;
     if (nCoords) {
-      if (pIO->ReadUInt16Float(&pNamedColor->deviceCoords, nCoords)!=(icInt32Number)nCoords)
+      if (pIO->ReadUInt16Float(&pNamedColor->deviceCoords, nCoords)!= nCoords)
         return false;
     }
     pNamedColor = (SIccNamedColorEntry*)((icChar*)pNamedColor + m_nColorEntrySize);
@@ -3003,7 +3002,7 @@ bool CIccTagNamedColor2::Write(CIccIO *pIO)
         pIO->WriteUInt16Float(&pNamedColor->pcsCoords, 3)!=3)
       return false;
     if (m_nDeviceCoords) {
-      if (pIO->WriteUInt16Float(&pNamedColor->deviceCoords, m_nDeviceCoords) != (icInt32Number)m_nDeviceCoords)
+      if (pIO->WriteUInt16Float(&pNamedColor->deviceCoords, m_nDeviceCoords) != m_nDeviceCoords)
         return false;
     }
     pNamedColor = (SIccNamedColorEntry*)((icChar*)pNamedColor + m_nColorEntrySize);
@@ -3624,7 +3623,7 @@ bool CIccTagXYZ::Read(icUInt32Number size, CIccIO *pIO)
   if (!SetSize(nNum))
     return false;
 
-  if (pIO->Read32(m_XYZ, nNum32) != (icInt32Number)nNum32 )
+  if (pIO->Read32(m_XYZ, nNum32) != nNum32 )
     return false;
 
   return true;
@@ -3660,7 +3659,7 @@ bool CIccTagXYZ::Write(CIccIO *pIO)
   icUInt32Number nNum32 = m_nSize * sizeof(icXYZNumber)/sizeof(icUInt32Number);
 
   if (
-    pIO->Write32(m_XYZ, nNum32) != (icInt32Number)nNum32)
+    pIO->Write32(m_XYZ, nNum32) != nNum32)
     return false;
 
   return true;
@@ -3899,7 +3898,7 @@ bool CIccTagChromaticity::Read(icUInt32Number size, CIccIO *pIO)
   if (!SetSize((icUInt16Number)nNum))
     return false;
 
-  if (pIO->Read32(&m_xy[0], nNum32) != (icInt32Number)nNum32 )
+  if (pIO->Read32(&m_xy[0], nNum32) != nNum32 )
     return false;
 
   return true;
@@ -3940,7 +3939,7 @@ bool CIccTagChromaticity::Write(CIccIO *pIO)
 
   icUInt32Number nNum32 = m_nChannels*sizeof(icChromaticityNumber)/sizeof(icU16Fixed16Number);
 
-  if (pIO->Write32(&m_xy[0], nNum32) != (icInt32Number)nNum32)
+  if (pIO->Write32(&m_xy[0], nNum32) != nNum32)
     return false;
 
   return true;
@@ -5283,7 +5282,7 @@ bool CIccTagFixedNum<T, Tsig>::Read(icUInt32Number size, CIccIO *pIO)
   if (!SetSize(nSize))
     return false;
 
-  if (pIO->Read32(m_Num, nSize) != (icInt32Number)nSize )
+  if (pIO->Read32(m_Num, nSize) != nSize )
     return false;
 
   return true;
@@ -5317,7 +5316,7 @@ bool CIccTagFixedNum<T, Tsig>::Write(CIccIO *pIO)
   if (!pIO->Write32(&m_nReserved))
     return false;
 
-  if (pIO->Write32(m_Num, m_nSize) != (icInt32Number)m_nSize)
+  if (pIO->Write32(m_Num, m_nSize) != m_nSize)
     return false;
  
   return true;
@@ -5748,19 +5747,19 @@ bool CIccTagNum<T, Tsig>::Read(icUInt32Number size, CIccIO *pIO)
     return false;
 
   if (sizeof(T)==sizeof(icUInt8Number)) {
-    if (pIO->Read8(m_Num, nSize) != (icInt32Number)nSize )
+    if (pIO->Read8(m_Num, nSize) != nSize )
       return false;
   }
   else if (sizeof(T)==sizeof(icUInt16Number)) {
-    if (pIO->Read16(m_Num, nSize) != (icInt32Number)nSize )
+    if (pIO->Read16(m_Num, nSize) != nSize )
       return false;
   }
   else if (sizeof(T)==sizeof(icUInt32Number)) {
-    if (pIO->Read32(m_Num, nSize) != (icInt32Number)nSize )
+    if (pIO->Read32(m_Num, nSize) != nSize )
       return false;
   }
   else if (sizeof(T)==sizeof(icUInt64Number)) {
-    if (pIO->Read64(m_Num, nSize) != (icInt32Number)nSize )
+    if (pIO->Read64(m_Num, nSize) != nSize )
       return false;
   }
   else
@@ -5798,19 +5797,19 @@ bool CIccTagNum<T, Tsig>::Write(CIccIO *pIO)
     return false;
 
   if (sizeof(T)==sizeof(icUInt8Number)) {
-    if (pIO->Write8(m_Num, m_nSize) != (icInt32Number)m_nSize)
+    if (pIO->Write8(m_Num, m_nSize) != m_nSize)
       return false;
   }
   else if (sizeof(T)==sizeof(icUInt16Number)) {
-    if (pIO->Write16(m_Num, m_nSize) != (icInt32Number)m_nSize)
+    if (pIO->Write16(m_Num, m_nSize) != m_nSize)
       return false;
   }
   else if (sizeof(T)==sizeof(icUInt32Number)) {
-    if (pIO->Write32(m_Num, m_nSize) != (icInt32Number)m_nSize)
+    if (pIO->Write32(m_Num, m_nSize) != m_nSize)
       return false;
   }
   else if (sizeof(T)==sizeof(icUInt64Number)) {
-    if (pIO->Write64(m_Num, m_nSize) != (icInt32Number)m_nSize)
+    if (pIO->Write64(m_Num, m_nSize) != m_nSize)
       return false;
   }
   else
@@ -6363,7 +6362,7 @@ bool CIccTagFloatNum<T, Tsig>::Read(icUInt32Number size, CIccIO *pIO)
     if (!SetSize(nSize))
       return false;
 
-    if (pIO->ReadFloat16Float(&m_Num[0], nSize) != (icInt32Number)nSize)
+    if (pIO->ReadFloat16Float(&m_Num[0], nSize) != nSize)
       return false;
   }
   else if (Tsig==icSigFloat32ArrayType) {
@@ -6372,7 +6371,7 @@ bool CIccTagFloatNum<T, Tsig>::Read(icUInt32Number size, CIccIO *pIO)
     if (!SetSize(nSize))
       return false;
 
-    if (pIO->Read32(m_Num, nSize) != (icInt32Number)nSize )
+    if (pIO->Read32(m_Num, nSize) != nSize )
       return false;
   }
   else if (Tsig==icSigFloat64ArrayType) {
@@ -6381,7 +6380,7 @@ bool CIccTagFloatNum<T, Tsig>::Read(icUInt32Number size, CIccIO *pIO)
     if (!SetSize(nSize))
       return false;
 
-    if (pIO->Read64(m_Num, nSize) != (icInt32Number)nSize )
+    if (pIO->Read64(m_Num, nSize) != nSize )
       return false;
   }
   else
@@ -6419,15 +6418,15 @@ bool CIccTagFloatNum<T, Tsig>::Write(CIccIO *pIO)
     return false;
 
   if (Tsig==icSigFloat16ArrayType) {
-    if (pIO->WriteFloat16Float(m_Num, m_nSize) != (icInt32Number)m_nSize)
+    if (pIO->WriteFloat16Float(m_Num, m_nSize) != m_nSize)
       return false;
   }
   else if (Tsig == icSigFloat32ArrayType) {
-    if (pIO->Write32(m_Num, m_nSize) != (icInt32Number)m_nSize)
+    if (pIO->Write32(m_Num, m_nSize) != m_nSize)
       return false;
   }
   else if (Tsig == icSigFloat64ArrayType) {
-    if (pIO->Write64(m_Num, m_nSize) != (icInt32Number)m_nSize)
+    if (pIO->Write64(m_Num, m_nSize) != m_nSize)
       return false;
   }
   else
@@ -6825,7 +6824,7 @@ bool CIccTagMeasurement::Read(icUInt32Number size, CIccIO *pIO)
 
   icUInt32Number nSize=sizeof(m_Data)/sizeof(icUInt32Number);
 
-  if (pIO->Read32(&m_Data,nSize) != (icInt32Number)nSize)
+  if (pIO->Read32(&m_Data,nSize) != nSize)
     return false;
 
   return true;
@@ -6860,7 +6859,7 @@ bool CIccTagMeasurement::Write(CIccIO *pIO)
 
   icUInt32Number nSize=sizeof(m_Data)/sizeof(icUInt32Number);
 
-  if (pIO->Write32(&m_Data,nSize) != (icInt32Number)nSize)
+  if (pIO->Write32(&m_Data,nSize) != nSize)
     return false;
 
   return true;
@@ -7492,7 +7491,7 @@ bool CIccTagMultiLocalizedUnicode::Read(icUInt32Number size, CIccIO *pIO)
     return false;
   }
 
-  icUInt32Number nTagPos = pIO->Tell();
+  size_t nTagPos = pIO->Tell();
   
   if (!pIO->Read32(&sig) ||
       !pIO->Read32(&m_nReserved) ||
@@ -7538,7 +7537,7 @@ bool CIccTagMultiLocalizedUnicode::Read(icUInt32Number size, CIccIO *pIO)
 
     pIO->Seek(nTagPos+nOffset, icSeekSet);
 
-    if (pIO->Read16(Unicode.GetBuf(), nNumChar) != (icInt32Number)nNumChar)
+    if (pIO->Read16(Unicode.GetBuf(), nNumChar) != nNumChar)
       return false;
 
     m_Strings->push_back(Unicode);
@@ -7601,7 +7600,7 @@ bool CIccTagMultiLocalizedUnicode::Write(CIccIO *pIO)
     nLength = i->GetLength();
 
     if (nLength) {
-      if (pIO->Write16(i->GetBuf(), nLength) != (icInt32Number)nLength)
+      if (pIO->Write16(i->GetBuf(), nLength) != nLength)
         return false;
     }
   }
@@ -7943,7 +7942,7 @@ bool CIccTagData::Read(icUInt32Number size, CIccIO *pIO)
   if (!SetSize(nNum))
     return false;
 
-  if (pIO->Read8(m_pData, nNum) != (icInt32Number)nNum)
+  if (pIO->Read8(m_pData, nNum) != nNum)
     return false;
 
   if (IsTypeCompressed()) {
@@ -7985,14 +7984,15 @@ bool CIccTagData::Write(CIccIO *pIO)
 
   if (IsTypeCompressed()) {
     icUInt32Number *pData = NULL;
-    icInt32Number nSize = 0;
-    //Compress data here
+    size_t nSize = 0;
 
-    if (pIO->Write8(pData, nSize) != (icInt32Number)nSize)
+// TODO, UNFINISHED - Compress data here
+
+    if (pIO->Write8(pData, nSize) != nSize)
       return false;
   }
   else {
-    if (pIO->Write8(m_pData, m_nSize) != (icInt32Number)m_nSize)
+    if (pIO->Write8(m_pData, m_nSize) != m_nSize)
       return false;
   }
 
@@ -8243,12 +8243,12 @@ bool CIccTagDateTime::Read(icUInt32Number size, CIccIO *pIO)
     return false;
 
 
-  icUInt32Number nsize = (size-2*sizeof(icUInt32Number))/sizeof(icUInt16Number);
+  size_t nsize = (size-2*sizeof(icUInt32Number))/sizeof(icUInt16Number);
 
   if (nsize > sizeof(m_DateTime) / sizeof(icUInt16Number))
     return false;
 
-  if (pIO->Read16(&m_DateTime,nsize) != (icInt32Number)nsize)
+  if (pIO->Read16(&m_DateTime,nsize) != nsize)
     return false;
 
   return true;
@@ -8468,7 +8468,7 @@ bool CIccTagColorantOrder::Read(icUInt32Number size, CIccIO *pIO)
   if (!SetSize((icUInt16Number)nCount))
     return false;
 
-  if (pIO->Read8(&m_pData[0], m_nCount) != (icInt32Number)m_nCount)
+  if (pIO->Read8(&m_pData[0], m_nCount) != m_nCount)
     return false;
 
   return true;
@@ -8505,7 +8505,7 @@ bool CIccTagColorantOrder::Write(CIccIO *pIO)
   if (!pIO->Write32(&m_nCount))
     return false;
 
-  if (pIO->Write8(&m_pData[0], m_nCount) != (icInt32Number)m_nCount)
+  if (pIO->Write8(&m_pData[0], m_nCount) != m_nCount)
     return false;
   
   return true;
@@ -8751,8 +8751,8 @@ bool CIccTagColorantTable::Read(icUInt32Number size, CIccIO *pIO)
     return false;
 
   icUInt32Number nNum = (size - 3*sizeof(icUInt32Number))/sizeof(icColorantTableEntry);
-  icUInt32Number nNum8 = sizeof(m_pData->name);
-  icUInt32Number nNum16 = sizeof(m_pData->data)/sizeof(icUInt16Number);
+  size_t nNum8 = sizeof(m_pData->name);
+  size_t nNum16 = sizeof(m_pData->data)/sizeof(icUInt16Number);
 
   if (nNum < nCount || nCount > 0xffff)
     return false;
@@ -8761,10 +8761,10 @@ bool CIccTagColorantTable::Read(icUInt32Number size, CIccIO *pIO)
     return false;
 
   for (icUInt32Number i=0; i<nCount; i++) {
-    if (pIO->Read8(&m_pData[i].name[0], nNum8) != (icInt32Number)nNum8)
+    if (pIO->Read8(&m_pData[i].name[0], nNum8) != nNum8)
       return false;
 
-    if (pIO->Read16(&m_pData[i].data[0], nNum16) != (icInt32Number)nNum16)
+    if (pIO->Read16(&m_pData[i].data[0], nNum16) != nNum16)
       return false;
   }
 
@@ -8801,14 +8801,14 @@ bool CIccTagColorantTable::Write(CIccIO *pIO)
   if (!pIO->Write32(&m_nCount))
     return false;
 
-  icUInt32Number nNum8 = sizeof(m_pData->name);
-  icUInt32Number nNum16 = sizeof(m_pData->data)/sizeof(icUInt16Number);
+  size_t nNum8 = sizeof(m_pData->name);
+  size_t nNum16 = sizeof(m_pData->data)/sizeof(icUInt16Number);
 
   for (icUInt32Number i=0; i<m_nCount; i++) {
-    if (pIO->Write8(&m_pData[i].name[0],nNum8) != (icInt32Number)nNum8)
+    if (pIO->Write8(&m_pData[i].name[0],nNum8) != nNum8)
       return false;
 
-    if (pIO->Write16(&m_pData[i].data[0],nNum16) != (icInt32Number)nNum16)
+    if (pIO->Write16(&m_pData[i].data[0],nNum16) != nNum16)
       return false;
   }
 
@@ -9361,10 +9361,9 @@ void CIccProfileDescText::Describe(std::string &sDescription, int nVerboseness)
 bool CIccProfileDescText::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
-  icUInt32Number nPos;
 
   //Check for description tag type signature
-  nPos = pIO->Tell();
+  size_t nPos = pIO->Tell();
 
   if ((nPos&0x03) != 0)
     m_bNeedsPading = true;
@@ -9574,9 +9573,9 @@ CIccTagProfileSeqDesc::~CIccTagProfileSeqDesc()
 bool CIccTagProfileSeqDesc::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
-  icUInt32Number nCount, nEnd;
+  icUInt32Number nCount;
 
-  nEnd = pIO->Tell() + size;
+  size_t nEnd = pIO->Tell() + size;
 
   if (sizeof(icTagTypeSignature) + 
       sizeof(icUInt32Number)*2 > size)
@@ -9599,7 +9598,8 @@ bool CIccTagProfileSeqDesc::Read(icUInt32Number size, CIccIO *pIO)
     sizeof(CIccProfileDescStruct) > size)
     return false;
 
-  icUInt32Number i, nPos; 
+  icUInt32Number i;
+  size_t nPos;
   CIccProfileDescStruct ProfileDescStruct;
 
   for (i=0; i<nCount; i++) {
@@ -9612,11 +9612,11 @@ bool CIccTagProfileSeqDesc::Read(icUInt32Number size, CIccIO *pIO)
 
     nPos = pIO->Tell();
 
-    if (!ProfileDescStruct.m_deviceMfgDesc.Read(nEnd - nPos, pIO))
+    if (!ProfileDescStruct.m_deviceMfgDesc.Read((icUInt32Number)(nEnd - nPos), pIO))
       return false;
     
     nPos = pIO->Tell();
-    if (!ProfileDescStruct.m_deviceModelDesc.Read(nEnd - nPos, pIO))
+    if (!ProfileDescStruct.m_deviceModelDesc.Read((icUInt32Number)(nEnd - nPos), pIO))
       return false;
 
     m_Descriptions->push_back(ProfileDescStruct);
@@ -9962,7 +9962,7 @@ bool CIccResponseCurveStruct::Read(icUInt32Number size, CIccIO *pIO)
   }
 
   icUInt32Number nNum32 = m_nChannels*sizeof(icXYZNumber)/sizeof(icS15Fixed16Number);
-  if (pIO->Read32(&m_maxColorantXYZ[0], nNum32) != (icInt32Number)nNum32) {
+  if (pIO->Read32(&m_maxColorantXYZ[0], nNum32) != nNum32) {
     delete[] nMeasurements;
     return false;
   }
@@ -10028,7 +10028,7 @@ bool CIccResponseCurveStruct::Write(CIccIO *pIO)
     delete [] nMeasurements;
 
     icUInt32Number nNum32 = m_nChannels*sizeof(icXYZNumber)/sizeof(icS15Fixed16Number);
-    if (pIO->Write32(&m_maxColorantXYZ[0], nNum32) != (icInt32Number)nNum32)
+    if (pIO->Write32(&m_maxColorantXYZ[0], nNum32) != nNum32)
       return false;
   }
   else
@@ -10251,7 +10251,7 @@ bool CIccTagResponseCurveSet16::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
 
-  icUInt32Number startPos = pIO->Tell();
+  size_t startPos = pIO->Tell();
 
   unsigned long headerSize = sizeof(icTagTypeSignature) +
                              sizeof(icUInt32Number) +
@@ -10330,7 +10330,7 @@ bool CIccTagResponseCurveSet16::Write(CIccIO *pIO)
     return false;
   }
 
-  icUInt32Number startPos = pIO->GetLength();
+  size_t startPos = pIO->GetLength();
 
   if (!pIO->Write32(&sig) ||
       !pIO->Write32(&m_nReserved))
@@ -10341,7 +10341,7 @@ bool CIccTagResponseCurveSet16::Write(CIccIO *pIO)
       !pIO->Write16(&nCountMeasmntTypes))
     return false;
 
-  icUInt32Number offsetPos = pIO->GetLength();
+  size_t offsetPos = pIO->GetLength();
   icUInt32Number* nOffset = new icUInt32Number[nCountMeasmntTypes];
 
 
@@ -10355,12 +10355,12 @@ bool CIccTagResponseCurveSet16::Write(CIccIO *pIO)
   CIccResponseCurveSet::iterator i;
 
   for (i=m_ResponseCurves->begin(), j=0; i!=m_ResponseCurves->end(); i++, j++) {
-    nOffset[j] = pIO->GetLength() - startPos;
+    nOffset[j] = (icUInt32Number)(pIO->GetLength() - startPos);
     if (!i->Write(pIO))
       return false;
   }
 
-  icUInt32Number curPOs = pIO->GetLength();
+  size_t curPOs = pIO->GetLength();
 
   pIO->Seek(offsetPos,icSeekSet);
 
@@ -11870,7 +11870,7 @@ bool CIccTagEmbeddedHeightImage::Read(icUInt32Number size, CIccIO *pIO)
   if (!SetSize(nNum))
     return false;
 
-  if (pIO->Read8(m_pData, nNum) != (icInt32Number)nNum)
+  if (pIO->Read8(m_pData, nNum) != nNum)
     return false;
 
   return true;
@@ -11915,7 +11915,7 @@ bool CIccTagEmbeddedHeightImage::Write(CIccIO *pIO)
   if (!pIO->WriteFloat32Float(&m_fMetersMaxPixelValue))
     return false;
 
-  if (pIO->Write8(m_pData, m_nSize) != (icInt32Number)m_nSize)
+  if (pIO->Write8(m_pData, m_nSize) != m_nSize)
     return false;
 
   return true;
@@ -12179,7 +12179,7 @@ bool CIccTagEmbeddedNormalImage::Read(icUInt32Number size, CIccIO *pIO)
   if (!SetSize(nNum))
     return false;
 
-  if (pIO->Read8(m_pData, nNum) != (icInt32Number)nNum)
+  if (pIO->Read8(m_pData, nNum) != nNum)
     return false;
 
   return true;
@@ -12218,7 +12218,7 @@ bool CIccTagEmbeddedNormalImage::Write(CIccIO *pIO)
   if (!pIO->Write32(&m_nEncodingFormat))
     return false;
 
-  if (pIO->Write8(m_pData, m_nSize) != (icInt32Number)m_nSize)
+  if (pIO->Write8(m_pData, m_nSize) != m_nSize)
     return false;
 
   return true;

--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -364,7 +364,7 @@ bool CIccTagStruct::Read(icUInt32Number size, CIccIO *pIO)
 
   Cleanup();
 
-  m_tagStart = pIO->Tell();
+  m_tagStart = (icUInt32Number) pIO->Tell();
 
   if (!pIO->Read32(&sig))
     return false;
@@ -430,7 +430,7 @@ bool CIccTagStruct::Write(CIccIO *pIO)
   if (!pIO)
     return false;
 
-  m_tagStart = pIO->Tell();
+  m_tagStart = (icUInt32Number) pIO->Tell();
 
   if (!pIO->Write32(&sig))
     return false;
@@ -451,7 +451,7 @@ bool CIccTagStruct::Write(CIccIO *pIO)
 
   pIO->Write32(&count);
 
-  icUInt32Number dirpos = pIO->Tell();
+  size_t dirpos = pIO->Tell();
 
   //Write Unintialized TagDir
   for (i=m_ElemEntries->begin(); i!= m_ElemEntries->end(); i++) {
@@ -474,9 +474,9 @@ bool CIccTagStruct::Write(CIccIO *pIO)
       }
 
       if (i==j) {
-        i->TagInfo.offset = pIO->GetLength();
+        i->TagInfo.offset = (icUInt32Number) pIO->GetLength();
         i->pTag->Write(pIO);
-        i->TagInfo.size = pIO->GetLength() - i->TagInfo.offset;
+        i->TagInfo.size = (icUInt32Number)( pIO->GetLength() - i->TagInfo.offset);
         i->TagInfo.offset -= m_tagStart;
 
         pIO->Align32();
@@ -487,7 +487,7 @@ bool CIccTagStruct::Write(CIccIO *pIO)
       }
     }
   }
-  icUInt32Number epos = pIO->Tell();
+  size_t epos = pIO->Tell();
 
   pIO->Seek(dirpos, icSeekSet);
 
@@ -1231,7 +1231,7 @@ bool CIccTagArray::Read(icUInt32Number size, CIccIO *pIO)
 
   Cleanup();
 
-  icUInt32Number nTagStart = pIO->Tell();
+  size_t nTagStart = pIO->Tell();
 
   if (!pIO->Read32(&sig))
     return false;
@@ -1334,7 +1334,7 @@ bool CIccTagArray::Write(CIccIO *pIO)
   if (!pIO)
     return false;
 
-  icUInt32Number nTagStart = pIO->Tell();
+  size_t nTagStart = pIO->Tell();
 
   if (!pIO->Write32(&sig))
     return false;
@@ -1351,7 +1351,7 @@ bool CIccTagArray::Write(CIccIO *pIO)
   if (m_nSize) {
     icUInt32Number i, j;
 
-    icUInt32Number pos = pIO->Tell();
+    size_t pos = pIO->Tell();
 
     //Write Unintialized TagPosition block
     icUInt32Number zero = 0;
@@ -1376,12 +1376,12 @@ bool CIccTagArray::Write(CIccIO *pIO)
           tagPos[i].size = tagPos[j].offset;
         }
         else {
-          tagPos[i].offset = pIO->Tell() - nTagStart;
+          tagPos[i].offset = (icUInt32Number)(pIO->Tell() - nTagStart);
           if (!m_TagVals[i].ptr->Write(pIO)) {
             delete [] tagPos;
             return false;
           }
-          tagPos[i].size =  pIO->Tell() - nTagStart - tagPos[i].offset;
+          tagPos[i].size = (icUInt32Number)( pIO->Tell() - nTagStart - tagPos[i].offset );
           pIO->Align32();
         }
       }
@@ -1390,7 +1390,7 @@ bool CIccTagArray::Write(CIccIO *pIO)
         tagPos[i].size = 0;
       }
     }
-    icUInt32Number endPos = pIO->Tell();
+    size_t endPos = pIO->Tell();
 
     //Update TagPosition block
     pIO->Seek(pos, icSeekSet);

--- a/IccProfLib/IccTagDict.cpp
+++ b/IccProfLib/IccTagDict.cpp
@@ -512,7 +512,7 @@ bool CIccTagDict::Read(icUInt32Number size, CIccIO *pIO)
 
   Cleanup();
 
-  m_tagStart = pIO->Tell();
+  m_tagStart = (icUInt32Number) pIO->Tell();
 
   if (!pIO->Read32(&sig))
     return false;
@@ -614,7 +614,7 @@ bool CIccTagDict::Read(icUInt32Number size, CIccIO *pIO)
         }
 
         num = pos[i].posName.size / sizeof(icUnicodeChar);
-        if (pIO->Read16(buf, num)!=(icInt32Number)num) {
+        if (pIO->Read16(buf, num)!= num) {
           free(pos);
           free(buf);
           delete ptr.ptr;
@@ -659,7 +659,7 @@ bool CIccTagDict::Read(icUInt32Number size, CIccIO *pIO)
         }
 
         num = pos[i].posValue.size / sizeof(icUnicodeChar);
-        if (pIO->Read16(buf, num)!=(icInt32Number)num) {
+        if (pIO->Read16(buf, num)!=num) {
           free(pos);
           free(buf);
           delete ptr.ptr;
@@ -798,7 +798,7 @@ bool CIccTagDict::Write(CIccIO *pIO)
   if (!pIO)
     return false;
 
-  m_tagStart = pIO->Tell();
+  m_tagStart = (icUInt32Number) pIO->Tell();
 
   if (!pIO->Write32(&sig))
     return false;
@@ -826,7 +826,8 @@ bool CIccTagDict::Write(CIccIO *pIO)
   if (!pos)
     return false;
 
-  icUInt32Number n, dirpos = pIO->Tell();
+  icUInt32Number n;
+  size_t dirpos = pIO->Tell();
 
   //Write Unintialized Dict rec offset array
   for (i=m_Dict->begin(); i!= m_Dict->end(); i++) {
@@ -840,42 +841,42 @@ bool CIccTagDict::Write(CIccIO *pIO)
   //Write Dict records
   for (n=0, i=m_Dict->begin(); i!= m_Dict->end(); i++) {
     if (i->ptr) {
-      pos[n].posName.offset = pIO->Tell()-m_tagStart;
+      pos[n].posName.offset = (icUInt32Number)( pIO->Tell()-m_tagStart );
 
       for(chrptr = i->ptr->GetName().begin(); chrptr!=i->ptr->GetName().end(); chrptr++) {
         c=(icUnicodeChar)*chrptr;
         pIO->Write16(&c, 1);
       }
-      pos[n].posName.size = pIO->Tell()-m_tagStart - pos[n].posName.offset;
+      pos[n].posName.size = (icUInt32Number)(pIO->Tell()-m_tagStart - pos[n].posName.offset);
       pIO->Align32();
 
       if (i->ptr->IsValueSet()) {
-        pos[n].posValue.offset = pIO->Tell()-m_tagStart;
+        pos[n].posValue.offset = (icUInt32Number)(pIO->Tell()-m_tagStart);
         for(chrptr = i->ptr->ValueBegin(); chrptr!=i->ptr->ValueEnd(); chrptr++) {
           c=(icUnicodeChar)*chrptr;
           pIO->Write16(&c, 1);
         }
-        pos[n].posValue.size = pIO->Tell()-m_tagStart - pos[n].posValue.offset;
+        pos[n].posValue.size = (icUInt32Number)(pIO->Tell()-m_tagStart - pos[n].posValue.offset);
         pIO->Align32();
       }
 
       if (recSize>16 && i->ptr->GetNameLocalized()) {
-        pos[n].posNameLocalized.offset = pIO->Tell()-m_tagStart;
+        pos[n].posNameLocalized.offset = (icUInt32Number)(pIO->Tell()-m_tagStart);
         i->ptr->GetNameLocalized()->Write(pIO);
-        pos[n].posNameLocalized.size = pIO->Tell()-m_tagStart - pos[n].posNameLocalized.offset;
+        pos[n].posNameLocalized.size = (icUInt32Number)(pIO->Tell()-m_tagStart - pos[n].posNameLocalized.offset);
         pIO->Align32();
       }
 
       if (recSize>24 && i->ptr->GetValueLocalized()) {
-        pos[n].posValueLocalized.offset = pIO->Tell()-m_tagStart;
+        pos[n].posValueLocalized.offset = (icUInt32Number)(pIO->Tell()-m_tagStart);
         i->ptr->GetValueLocalized()->Write(pIO);
-        pos[n].posValueLocalized.size = pIO->Tell()-m_tagStart - pos[n].posValueLocalized.offset;
+        pos[n].posValueLocalized.size = (icUInt32Number)(pIO->Tell()-m_tagStart - pos[n].posValueLocalized.offset);
         pIO->Align32();
       }
       n++;
     }
   }
-  icUInt32Number endpos = pIO->Tell();
+  size_t endpos = pIO->Tell();
 
   pIO->Seek(dirpos, icSeekSet);
 

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -258,7 +258,7 @@ bool CIccTagCurve::Read(icUInt32Number size, CIccIO *pIO)
     return false;
 
   if (m_nSize) {
-    if (pIO->ReadUInt16Float(m_Curve, m_nSize)!=(icInt32Number)m_nSize)
+    if (pIO->ReadUInt16Float(m_Curve, m_nSize)!= m_nSize)
       return false;
   }
 
@@ -296,7 +296,7 @@ bool CIccTagCurve::Write(CIccIO *pIO)
     return false;
 
   if (m_nSize)
-    if (pIO->WriteUInt16Float(m_Curve, m_nSize)!=(icInt32Number)m_nSize)
+    if (pIO->WriteUInt16Float(m_Curve, m_nSize)!= m_nSize)
       return false;
 
   pIO->Align32();
@@ -1911,11 +1911,11 @@ bool CIccCLUT::ReadData(icUInt32Number size, CIccIO *pIO, icUInt8Number nPrecisi
     return false;
 
   if (nPrecision==1) {
-    if (pIO->ReadUInt8Float(m_pData, nNum)!=(icInt32Number)nNum)
+    if (pIO->ReadUInt8Float(m_pData, nNum)!= nNum)
       return false;
   }
   else if (nPrecision==2) {
-    if (pIO->ReadUInt16Float(m_pData, nNum)!=(icInt32Number)nNum)
+    if (pIO->ReadUInt16Float(m_pData, nNum)!= nNum)
       return false;
   }
   else
@@ -1945,11 +1945,11 @@ bool CIccCLUT::WriteData(CIccIO *pIO, icUInt8Number nPrecision)
   icUInt32Number nNum=NumPoints() * m_nOutput;
 
   if (nPrecision==1) {
-    if (pIO->WriteUInt8Float(m_pData, nNum)!=(icInt32Number)nNum)
+    if (pIO->WriteUInt8Float(m_pData, nNum)!= nNum)
       return false;
   }
   else if (nPrecision==2) {
-    if (pIO->WriteUInt16Float(m_pData, nNum)!=(icInt32Number)nNum)
+    if (pIO->WriteUInt16Float(m_pData, nNum)!= nNum)
       return false;
   }
   else
@@ -3930,15 +3930,16 @@ CIccTagLutAtoB::~CIccTagLutAtoB()
 bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
-  icUInt32Number Offset[5], nStart, nEnd, nPos;
+  icUInt32Number Offset[5];
   icUInt8Number nCurves, i;
+  size_t nPos;
 
   if (size<8*sizeof(icUInt32Number) || !pIO) {
     return false;
   }
 
-  nStart = pIO->Tell();
-  nEnd = nStart + size;
+  size_t nStart = pIO->Tell();
+  size_t nEnd = nStart + size;
 
   if (!pIO->Read32(&sig) ||
       !pIO->Read32(&m_nReserved) ||
@@ -3974,7 +3975,7 @@ bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
 
       pCurves[i] = (CIccCurve*)CIccTag::Create(sig);
 
-      if (!pCurves[i]->Read(nEnd - pIO->Tell(), pIO))
+      if (!pCurves[i]->Read( (icUInt32Number)(nEnd - pIO->Tell()), pIO))
         return false;
 
       if (!pIO->Sync32(Offset[0]))
@@ -4025,7 +4026,7 @@ bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
 
       pCurves[i] = (CIccCurve*)CIccTag::Create(sig);
 
-      if (!pCurves[i]->Read(nEnd - pIO->Tell(), pIO))
+      if (!pCurves[i]->Read( (icUInt32Number)(nEnd - pIO->Tell()), pIO))
         return false;
 
       if (!pIO->Sync32(Offset[2]))
@@ -4040,7 +4041,7 @@ bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
 
     m_CLUT = new CIccCLUT(m_nInput, m_nOutput);
 
-    if (!m_CLUT->Read(nEnd - pIO->Tell(), pIO))
+    if (!m_CLUT->Read( (icUInt32Number)(nEnd - pIO->Tell()), pIO))
       return false;
   }
 
@@ -4067,7 +4068,7 @@ bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
 
       pCurves[i] = (CIccCurve*)CIccTag::Create(sig);
 
-      if (!pCurves[i]->Read(nEnd - pIO->Tell(), pIO))
+      if (!pCurves[i]->Read( (icUInt32Number)(nEnd - pIO->Tell()), pIO))
         return false;
 
       if (!pIO->Sync32(Offset[4]))
@@ -4095,10 +4096,10 @@ bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
 bool CIccTagLutAtoB::Write(CIccIO *pIO)
 {
   icTagTypeSignature sig = GetType();
-  icUInt32Number Offset[5], nStart, nEnd, nOffsetPos;
+  icUInt32Number Offset[5];
   icUInt8Number nCurves, i;
 
-  nStart = pIO->Tell();
+  size_t nStart = pIO->Tell();
   memset(&Offset[0], 0, sizeof(Offset));
   
   if (!pIO->Write32(&sig) ||
@@ -4108,13 +4109,13 @@ bool CIccTagLutAtoB::Write(CIccIO *pIO)
       !pIO->Write16(&m_nReservedWord))
     return false;
 
-  nOffsetPos = pIO->Tell();
+  size_t nOffsetPos = pIO->Tell();
   if (pIO->Write32(Offset, 5)!=5)
     return false;
 
   //B Curves
   if (m_CurvesB) {
-    Offset[0] = pIO->Tell() - nStart;
+    Offset[0] = (icUInt32Number)(pIO->Tell() - nStart);
     nCurves = IsInputB() ? m_nInput : m_nOutput;
 
     for (i=0; i<nCurves; i++) {
@@ -4133,7 +4134,7 @@ bool CIccTagLutAtoB::Write(CIccIO *pIO)
   if (m_Matrix) {
     icS15Fixed16Number tmp;
 
-    Offset[1] = pIO->Tell() - nStart;
+    Offset[1] = (icUInt32Number)(pIO->Tell() - nStart);
 
     for (i=0; i<12; i++) {
       tmp = icDtoF(m_Matrix->m_e[i]);
@@ -4145,7 +4146,7 @@ bool CIccTagLutAtoB::Write(CIccIO *pIO)
 
   //M Curves
   if (m_CurvesM) {
-    Offset[2] = pIO->Tell() - nStart;
+    Offset[2] = (icUInt32Number)(pIO->Tell() - nStart);
     nCurves = IsInputMatrix() ? m_nInput : m_nOutput;
 
     for (i=0; i<nCurves; i++) {
@@ -4162,7 +4163,7 @@ bool CIccTagLutAtoB::Write(CIccIO *pIO)
 
   //CLUT
   if (m_CLUT) {
-    Offset[3] = pIO->Tell() - nStart;
+    Offset[3] = (icUInt32Number)(pIO->Tell() - nStart);
 
     if (!m_CLUT->Write(pIO))
       return false;
@@ -4173,7 +4174,7 @@ bool CIccTagLutAtoB::Write(CIccIO *pIO)
 
   //A Curves
   if (m_CurvesA) {
-    Offset[4] = pIO->Tell() - nStart;
+    Offset[4] = (icUInt32Number)(pIO->Tell() - nStart);
     nCurves = !IsInputB() ? m_nInput : m_nOutput;
 
     for (i=0; i<nCurves; i++) {
@@ -4188,7 +4189,7 @@ bool CIccTagLutAtoB::Write(CIccIO *pIO)
     }
   }
 
-  nEnd = pIO->Tell();
+  size_t nEnd = pIO->Tell();
 
   if (!pIO->Seek(nOffsetPos, icSeekSet))
     return false;
@@ -4550,7 +4551,6 @@ CIccTagLut8::~CIccTagLut8()
 bool CIccTagLut8::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
-  icUInt32Number nStart, nEnd;
   icUInt8Number i, nGrid;
   LPIccCurve *pCurves;
   CIccTagCurve *pCurve;
@@ -4559,8 +4559,8 @@ bool CIccTagLut8::Read(icUInt32Number size, CIccIO *pIO)
     return false;
   }
 
-  nStart = pIO->Tell();
-  nEnd = nStart + size;
+  size_t nStart = pIO->Tell();
+  size_t nEnd = nStart + size;
  
   if (!pIO->Read32(&sig) ||
       !pIO->Read32(&m_nReserved) ||
@@ -4595,10 +4595,10 @@ bool CIccTagLut8::Read(icUInt32Number size, CIccIO *pIO)
   if (m_CLUT == NULL)
     return false;
 
-  if (!m_CLUT->Init(nGrid, nEnd - pIO->Tell(), 1))
+  if (!m_CLUT->Init(nGrid, (icUInt32Number)(nEnd - pIO->Tell()), 1))
     return false;
 
-  if (!m_CLUT->ReadData(nEnd - pIO->Tell(), pIO, 1))
+  if (!m_CLUT->ReadData( (icUInt32Number)(nEnd - pIO->Tell()), pIO, 1))
     return false;
 
   //A Curves
@@ -4997,7 +4997,6 @@ CIccTagLut16::~CIccTagLut16()
 bool CIccTagLut16::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
-  icUInt32Number nStart, nEnd;
   icUInt8Number i, nGrid;
   icUInt16Number nInputEntries, nOutputEntries;
   LPIccCurve *pCurves;
@@ -5007,8 +5006,8 @@ bool CIccTagLut16::Read(icUInt32Number size, CIccIO *pIO)
     return false;
   }
 
-  nStart = pIO->Tell();
-  nEnd = nStart + size;
+  size_t nStart = pIO->Tell();
+  size_t nEnd = nStart + size;
  
   if (!pIO->Read32(&sig) ||
       !pIO->Read32(&m_nReserved) ||
@@ -5044,10 +5043,10 @@ bool CIccTagLut16::Read(icUInt32Number size, CIccIO *pIO)
   //CLUT
   m_CLUT = new CIccCLUT(m_nInput, m_nOutput);
 
-  if (!m_CLUT->Init(nGrid, nEnd - pIO->Tell(), 2))
+  if (!m_CLUT->Init(nGrid, (icUInt32Number)(nEnd - pIO->Tell()), 2))
     return false;
 
-  if (!m_CLUT->ReadData(nEnd - pIO->Tell(), pIO, 2))
+  if (!m_CLUT->ReadData( (icUInt32Number)(nEnd - pIO->Tell()), pIO, 2))
     return false;
 
   //A Curves

--- a/IccProfLib/IccTagMPE.cpp
+++ b/IccProfLib/IccTagMPE.cpp
@@ -371,7 +371,7 @@ bool CIccMpeUnknown::Read(icUInt32Number nSize, CIccIO *pIO)
     if (!SetDataSize(nDataSize, false))
       return false;
 
-    if (pIO->Read8(m_pData, nDataSize)!=(icInt32Number)nDataSize)
+    if (pIO->Read8(m_pData, nDataSize)!= nDataSize)
       return false;
   }
 
@@ -408,7 +408,7 @@ bool CIccMpeUnknown::Write(CIccIO *pIO)
     return false;
 
   if (m_nSize) {
-    if (pIO->Write8(m_pData, m_nSize)!=(icInt32Number)m_nSize)
+    if (pIO->Write8(m_pData, m_nSize)!= m_nSize)
       return false;
   }
 
@@ -987,7 +987,7 @@ bool CIccTagMultiProcessElement::Read(icUInt32Number size, CIccIO *pIO)
 
   Clean();
 
-  icUInt32Number tagStart = pIO->Tell();
+  size_t tagStart = pIO->Tell();
 
   if (!pIO->Read32(&sig))
     return false;
@@ -1039,9 +1039,9 @@ bool CIccTagMultiProcessElement::Read(icUInt32Number size, CIccIO *pIO)
     //Use hash to cache offset duplication
     CIccMultiProcessElement *element = loadedElements[m_position[i].offset];
     if (!element) {
-      icUInt32Number pos = tagStart + m_position[i].offset;
+      size_t pos = tagStart + m_position[i].offset;
 
-      if (pIO->Seek(pos, icSeekSet)!=(icInt32Number)pos) {
+      if (pIO->Seek(pos, icSeekSet)!= pos) {
         return false;
       }
 
@@ -1049,7 +1049,7 @@ bool CIccTagMultiProcessElement::Read(icUInt32Number size, CIccIO *pIO)
         return false;
       }
       
-      if (pIO->Seek(pos, icSeekSet)!=(icInt32Number)pos) {
+      if (pIO->Seek(pos, icSeekSet)!= pos) {
         return false;
       }
 
@@ -1090,7 +1090,7 @@ bool CIccTagMultiProcessElement::Write(CIccIO *pIO)
   if (!pIO)
     return false;
 
-  icUInt32Number tagStart = pIO->Tell();
+  size_t tagStart = pIO->Tell();
 
   if (!pIO->Write32(&sig))
     return false;
@@ -1115,7 +1115,7 @@ bool CIccTagMultiProcessElement::Write(CIccIO *pIO)
     return false;
 
   if (m_nProcElements) {
-    icUInt32Number offsetPos = pIO->Tell();
+    size_t offsetPos = pIO->Tell();
 
     if (m_position) {
       free(m_position);
@@ -1135,31 +1135,30 @@ bool CIccTagMultiProcessElement::Write(CIccIO *pIO)
 
     CIccLutPtrMap map;
     CIccMultiProcessElementList::iterator i;
-    icUInt32Number start, end;
     icPositionNumber position;
 
     //Write out each process element
     for (j=0, i=m_list->begin(); i!=m_list->end(); i++, j++) {
       if (map.find(i->ptr)==map.end()) {
-        start = pIO->Tell();
+        size_t start = pIO->Tell();
 
         if (!i->ptr->Write(pIO))
           return false;
 
-        end = pIO->Tell();
+        size_t end = pIO->Tell();
 
         if (!pIO->Align32())
           return false;
 
-        position.offset = start - tagStart;
-        position.size = end - start;
+        position.offset = (icUInt32Number)(start - tagStart);
+        position.size = (icUInt32Number)(end - start);
 
         map[i->ptr] = position;
       }
       m_position[j] = map[i->ptr];
     }
 
-    icUInt32Number endPos = pIO->Tell();
+    size_t endPos = pIO->Tell();
 
     if (pIO->Seek(offsetPos, icSeekSet)<0)
       return false;

--- a/IccProfLib/IccTagProfSeqId.cpp
+++ b/IccProfLib/IccTagProfSeqId.cpp
@@ -476,7 +476,7 @@ bool CIccTagProfileSequenceId::Read(icUInt32Number size, CIccIO *pIO)
   m_list->clear();
 
   icUInt32Number sig;
-  icUInt32Number tagStart = pIO->Tell();
+  size_t tagStart = pIO->Tell();
 
   if (!pIO->Read32(&sig))
     return false;
@@ -548,7 +548,7 @@ bool CIccTagProfileSequenceId::Write(CIccIO *pIO)
   if (!pIO)
     return false;
 
-  icUInt32Number tagStart = pIO->Tell();
+  size_t tagStart = pIO->Tell();
 
   if (!pIO->Write32(&sig))
     return false;
@@ -564,7 +564,7 @@ bool CIccTagProfileSequenceId::Write(CIccIO *pIO)
   if (!pos)
     return false;
 
-  icUInt32Number dirpos = pIO->Tell();
+  size_t dirpos = pIO->Tell();
 
   //Write Unintialized TagDir
   for (i=0; i<count; i++) {
@@ -578,16 +578,16 @@ bool CIccTagProfileSequenceId::Write(CIccIO *pIO)
 
   //Write Tags
   for (i=0, j=m_list->begin(); j!= m_list->end(); i++, j++) {
-    pos[i].offset = pIO->Tell();
+    pos[i].offset = (icUInt32Number)pIO->Tell();
 
     j->Write(pIO);
-    pos[i].size = pIO->Tell() - pos[i].offset;
+    pos[i].size = (icUInt32Number)(pIO->Tell() - pos[i].offset);
     pos[i].offset -= tagStart;
 
     pIO->Align32();
   }
 
-  icUInt32Number endpos = pIO->Tell();
+  size_t endpos = pIO->Tell();
 
   pIO->Seek(dirpos, icSeekSet);
 

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -161,14 +161,15 @@ bool icIsNear(icFloatNumber v1, icFloatNumber v2, icFloatNumber nearRange /* = 1
 *  true pos is valid
 ******************************************************************************
 */
-bool icValidTagPos(const icPositionNumber& pos, icUInt32Number nTagHeaderSize, icUInt32Number nTagSize, bool bAllowEmpty)
+bool icValidTagPos(const icPositionNumber& pos, size_t nTagHeaderSize, size_t nTagSize, bool bAllowEmpty)
 {
   if ((bAllowEmpty && !pos.size) || !pos.offset)
     return true;
 
   if (pos.offset < nTagHeaderSize)
     return false;
-  if ((icUInt64Number)pos.offset + pos.size > (icUInt64Number)nTagSize)
+  
+  if ( ((size_t)pos.offset + pos.size) > nTagSize)
     return false;
 
   if (!pos.size && !bAllowEmpty)
@@ -948,7 +949,8 @@ void icXyzToPcs(icFloatNumber *XYZ)
 
 #define DUMPBYTESPERLINE 16
 
-void icMemDump(std::string &sDump, void *pBuf, icUInt32Number nNum)
+// This assumes that nNum is only 8 hex digits, 4 bytes, 32 bit value
+void icMemDump(std::string &sDump, void *pBuf, size_t nNum)
 {
   icUInt8Number *pData = (icUInt8Number *)pBuf;
   const size_t bufSize = 80;
@@ -956,13 +958,13 @@ void icMemDump(std::string &sDump, void *pBuf, icUInt32Number nNum)
   icChar buf[bufSize] = {0};
   icChar num[numSize] = {0};
 
-  icInt32Number i, j;
+  icInt32Number j;
   icUInt8Number c;
 
-  icInt32Number lines = (nNum + DUMPBYTESPERLINE - 1)/DUMPBYTESPERLINE;
+  size_t lines = (nNum + DUMPBYTESPERLINE - 1)/DUMPBYTESPERLINE;
   sDump.reserve(sDump.size() + lines*79);
 
-  for (i=0; i<(icInt32Number)nNum; i++, pData++) {
+  for (size_t i=0; i<nNum; i++, pData++) {
     j=i%DUMPBYTESPERLINE;
     if (!j) {
       if (i) {
@@ -972,7 +974,7 @@ void icMemDump(std::string &sDump, void *pBuf, icUInt32Number nNum)
       buf[76] = ' ';
       buf[77] = '\n';
       buf[78] = '\0';
-      snprintf(num, numSize, "%08X:", i);
+      snprintf(num, numSize, "%08lX:", i);
       strncpy(buf, num, 9);
     }
 

--- a/IccProfLib/IccUtil.h
+++ b/IccProfLib/IccUtil.h
@@ -158,7 +158,7 @@ ICCPROFLIB_API icFloatNumber icDeltaE(const icFloatNumber *Lab1, const icFloatNu
 
 ICCPROFLIB_API icFloatNumber icRmsDif(const icFloatNumber *v1, const icFloatNumber *v2, icUInt32Number nSample);
 
-ICCPROFLIB_API bool icValidTagPos(const icPositionNumber& pos, icUInt32Number nTagHeaderSize, icUInt32Number nTagSize, bool bAllowEmpty=false);
+ICCPROFLIB_API bool icValidTagPos(const icPositionNumber& pos, size_t nTagHeaderSize, size_t nTagSize, bool bAllowEmpty=false);
 ICCPROFLIB_API bool icValidOverlap(const icPositionNumber& pos1, const icPositionNumber& pos2, bool bAllowSame=true);
 
 /**Floating point encoding of Lab in PCS is in range 0.0 to 1.0 */
@@ -173,7 +173,7 @@ ICCPROFLIB_API void icXyzFromPcs(icFloatNumber *XYZ);
 ICCPROFLIB_API void icXyzToPcs(icFloatNumber *XYZ);
 
 
-ICCPROFLIB_API void icMemDump(std::string &sDump, void *pBuf, icUInt32Number nNum);
+ICCPROFLIB_API void icMemDump(std::string &sDump, void *pBuf, size_t nNum);
 ICCPROFLIB_API void icMatrixDump(std::string &sDump, icS15Fixed16Number *pMatrix);
 ICCPROFLIB_API const icChar* icGetSig(icChar *pBuf, size_t bufSize, icUInt32Number sig, bool bGetHexVal=true);
 ICCPROFLIB_API const icChar* icGet16bitSig(icChar* pBuf, size_t bufSize, icUInt16Number sig, bool bGetHexVal=true);
@@ -211,7 +211,7 @@ inline void icSwab16Ptr(void *pVoid)
   tmp = ptr[0]; ptr[0] = ptr[1]; ptr[1] = tmp;
 }
 
-inline void icSwab16Array(void *pVoid, int num)
+inline void icSwab16Array(void *pVoid, size_t num)
 {
   icUInt8Number *ptr = (icUInt8Number*)pVoid;
   icUInt8Number tmp;
@@ -232,7 +232,7 @@ inline void icSwab32Ptr(void *pVoid)
   tmp = ptr[1]; ptr[1] = ptr[2]; ptr[2] = tmp;
 }
 
-inline void icSwab32Array(void *pVoid, int num)
+inline void icSwab32Array(void *pVoid, size_t num)
 {
   icUInt8Number *ptr = (icUInt8Number*)pVoid;
   icUInt8Number tmp;
@@ -257,7 +257,7 @@ inline void icSwab64Ptr(void *pVoid)
   tmp = ptr[3]; ptr[3] = ptr[4]; ptr[4] = tmp;
 }
 
-inline void icSwab64Array(void *pVoid, int num)
+inline void icSwab64Array(void *pVoid, size_t num)
 {
   icUInt8Number *ptr = (icUInt8Number*)pVoid;
   icUInt8Number tmp;

--- a/IccXML/CmdLine/IccToXml/IccToXml.cpp
+++ b/IccXML/CmdLine/IccToXml/IccToXml.cpp
@@ -45,7 +45,7 @@ int main(int argc, char* argv[])
     return -1;
   }
 
-  if (dstIO.Write8((char*)xml.c_str(), (icInt32Number)xml.size())==(icInt32Number)xml.size()) {
+  if (dstIO.Write8((char*)xml.c_str(), xml.size())== xml.size()) {
     printf("XML successfully created\n");
   }
   else {

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -305,7 +305,7 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
 
     // format is text
     if (!strcmp(format, "text")) {
-      icUInt32Number num = file->GetLength();
+      size_t num = file->GetLength();
       char *buf = new char[num];
 
       if (!buf) {          
@@ -370,10 +370,10 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
       }
 
       if (storageType == icValueTypeUInt8){
-        icUInt32Number num = file->GetLength();
+        size_t num = file->GetLength();
         icUInt8Number value;
 
-        SetSize(num);
+        SetSize((icUInt32Number)num);
         icFloatNumber *dst =  m_pSamples;
         icUInt32Number i;
         for (i=0; i<num; i++) {
@@ -391,11 +391,11 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         return true;
       }        
       else if (storageType == icValueTypeUInt16){
-        icUInt32Number num = file->GetLength() / sizeof(icUInt16Number);
+        size_t num = file->GetLength() / sizeof(icUInt16Number);
         icUInt16Number value;
         icUInt8Number *m_ptr = (icUInt8Number*)&value;
 
-        SetSize(num);
+        SetSize((icUInt32Number)num);
         icFloatNumber *dst = m_pSamples;
         icUInt32Number i;
         for (i=0; i<num; i++) {
@@ -422,11 +422,11 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         return true;
       }
       else if (storageType == icValueTypeFloat16){
-        icUInt32Number num = file->GetLength() / sizeof(icFloat16Number);
+        size_t num = file->GetLength() / sizeof(icFloat16Number);
         icFloat16Number value;
         icUInt8Number *m_ptr = (icUInt8Number*)&value;
 
-        SetSize(num);
+        SetSize((icUInt32Number)num);
         icFloatNumber *dst = m_pSamples;
         icUInt32Number i;
         for (i=0; i<num; i++) {
@@ -453,11 +453,11 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         return true;
       }
       else if (storageType == icValueTypeFloat32) {
-        icUInt32Number num = file->GetLength()/sizeof(icFloat32Number);
+        size_t num = file->GetLength()/sizeof(icFloat32Number);
         icFloat32Number value;
         icUInt8Number *m_ptr = (icUInt8Number*)&value;
 
-        SetSize(num);
+        SetSize((icUInt32Number)num);
         icFloatNumber *dst = m_pSamples;
 
         icUInt32Number i;
@@ -687,7 +687,7 @@ bool CIccSinglSampledeCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
 
     // format is text
     if (!strcmp(format, "text")) {
-      icUInt32Number num = file->GetLength();
+      size_t num = file->GetLength();
       char *buf = new char[num];
 
       if (!buf) {
@@ -823,10 +823,10 @@ bool CIccSinglSampledeCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
       bool little_endian = !strcmp(order, "little");
 
       if (m_storageType == icValueTypeUInt8) {
-        icUInt32Number num = file->GetLength();
+        size_t num = file->GetLength();
         icUInt8Number value;
 
-        SetSize(num);
+        SetSize((icUInt32Number)num);
         icFloatNumber *dst = m_pSamples;
         icUInt32Number i;
         for (i = 0; i < num; i++) {
@@ -844,11 +844,11 @@ bool CIccSinglSampledeCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         return true;
       }
       else if (m_storageType == icValueTypeUInt16) {
-        icUInt32Number num = file->GetLength() / sizeof(icUInt16Number);
+        size_t num = file->GetLength() / sizeof(icUInt16Number);
         icUInt16Number value;
         icUInt8Number *m_ptr = (icUInt8Number*)&value;
 
-        SetSize(num);
+        SetSize((icUInt32Number)num);
         icFloatNumber *dst = m_pSamples;
         icUInt32Number i;
         for (i = 0; i < num; i++) {
@@ -875,11 +875,11 @@ bool CIccSinglSampledeCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         return true;
         }
       else if (m_storageType == icValueTypeFloat16) {
-        icUInt32Number num = file->GetLength() / sizeof(icFloat16Number);
+        size_t num = file->GetLength() / sizeof(icFloat16Number);
         icFloat16Number value;
         icUInt8Number *m_ptr = (icUInt8Number*)&value;
 
-        SetSize(num);
+        SetSize((icUInt32Number)num);
         icFloatNumber *dst = m_pSamples;
         icUInt32Number i;
         for (i = 0; i < num; i++) {
@@ -906,11 +906,11 @@ bool CIccSinglSampledeCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         return true;
         }
       else if (m_storageType == icValueTypeFloat32) {
-        icUInt32Number num = file->GetLength() / sizeof(icFloat32Number);
+        size_t num = file->GetLength() / sizeof(icFloat32Number);
         icFloat32Number value;
         icUInt8Number *m_ptr = (icUInt8Number*)&value;
 
-        SetSize(num);
+        SetSize((icUInt32Number)num);
         icFloatNumber *dst = m_pSamples;
 
         icUInt32Number i;

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -206,7 +206,7 @@ static std::string icXmlParseTextString(xmlNode *pNode, std::string &parseStr, b
             return str;
           }
 
-          icUInt32Number fileLength = file->GetLength();  
+          size_t fileLength = file->GetLength();
           char *ansiStr = (char *)malloc(fileLength+1);
 
           if (!ansiStr) {
@@ -403,7 +403,7 @@ bool CIccTagXmlTextDescription::ParseXml(xmlNode *pNode, std::string &parseStr)
       return false;
     }
 
-    icUInt32Number fileLength = file->GetLength();  
+    size_t fileLength = file->GetLength();
     char *buf = (char *)malloc(fileLength);
 
     if (!buf) {
@@ -1492,7 +1492,7 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string &parse
       return false;
     }
 
-    icUInt32Number len = file->GetLength();
+    size_t len = file->GetLength();
 
     if (!stricmp(icXmlAttrValue(pNode, "Format", "text"), "text")) {
       char *fbuf = (char*)malloc(len+1);
@@ -1533,7 +1533,7 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string &parse
       return true;
     }
     else if (Tsig==icSigFloat16ArrayType && sizeof(T)==sizeof(icFloat32Number)) {
-      icUInt32Number n = len/sizeof(icFloat32Number);
+      icUInt32Number n = (icUInt32Number)(len/sizeof(icFloat32Number));
       this->SetSize(n);
       if (file->ReadFloat16Float(&this->m_Num[0], n)!=n) {
         delete file;
@@ -1543,7 +1543,7 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string &parse
       return true;
     }
     else if (Tsig==icSigFloat32ArrayType && sizeof(T)==sizeof(icFloat32Number)) {
-      icUInt32Number n = len/sizeof(icFloat32Number);
+      icUInt32Number n =  (icUInt32Number)(len/sizeof(icFloat32Number));
       this->SetSize(n);
       if (file->ReadFloat32Float(&this->m_Num[0], n)!=n) {
         delete file;
@@ -1553,7 +1553,7 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string &parse
       return true;
     }
     else if (Tsig==icSigFloat64ArrayType && sizeof(T)==sizeof(icFloat64Number)) {
-      icUInt32Number n = len/sizeof(icFloat64Number);
+      icUInt32Number n =  (icUInt32Number)(len/sizeof(icFloat64Number));
       this->SetSize(n);
       if (file->Read64(&this->m_Num[0], n)!=n) {
         delete file;
@@ -2610,7 +2610,7 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
 
       // format is text
       if (!strcmp(format, "text")) {
-        icUInt32Number num = file->GetLength();
+        size_t num = file->GetLength();
         char *buf = (char *) new char[num];
 
         if (!buf) {          
@@ -2747,10 +2747,10 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
         bool little_endian = !strcmp(order, "little");    
 
         if (nType == icConvert8Bit){
-          icUInt32Number num = file->GetLength();
+          size_t num = file->GetLength();
           icUInt8Number value;
 
-          SetSize(num);
+          SetSize( (icUInt32Number)num);
           icFloatNumber *dst =  GetData(0);
           icUInt32Number i;
           for (i=0; i<num; i++) {
@@ -2768,13 +2768,13 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
           return true;
         }        
         else if (nType == icConvert16Bit || nType == icConvertVariable){
-          icUInt32Number num = file->GetLength() / sizeof(icUInt16Number);
+          size_t num = file->GetLength() / sizeof(icUInt16Number);
           icUInt16Number value;
           icUInt8Number *ptr = (icUInt8Number*)&value;
 
-          SetSize(num);
+          SetSize((icUInt32Number)num);
           icFloatNumber *dst = GetData(0);
-          icUInt32Number i;
+          size_t i;
           for (i=0; i<num; i++) {
             if (!file->Read16(&value)) {  //this assumes data is big endian
               perror("Read-File Error");
@@ -2799,14 +2799,14 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
           return true;
         }
         else if (nType == icConvertFloat) {
-          icUInt32Number num = file->GetLength()/sizeof(icFloat32Number);
+          size_t num = file->GetLength()/sizeof(icFloat32Number);
           icFloat32Number value;
           icUInt8Number *ptr = (icUInt8Number*)&value;
 
-          SetSize(num);
+          SetSize((icUInt32Number)num);
           icFloatNumber *dst = GetData(0);
 
-          icUInt32Number i;
+          size_t i;
           for (i=0; i<num; i++) {
             if (!file->ReadFloat32Float(&value)) { //assumes data is big endian
               perror("Read-File Error");
@@ -3438,7 +3438,7 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
       const char *format = icXmlAttrValue(table, "Format");
 
       if (!strcmp(format, "text")) {
-        icUInt32Number num = file->GetLength();
+        size_t num = file->GetLength();
         char *buf = (char *)malloc(num);
 
         if (!buf) {  
@@ -3608,8 +3608,8 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
         }
 
         if (nType == icConvert8Bit){
-          icUInt32Number num = file->GetLength();
-          icUInt8Number value;      
+          size_t num = file->GetLength();
+          icUInt8Number value;
           // if number of entries in file is not equal to size of CLUT table, flag as error
           if (num!=pCLUT->NumPoints()*pCLUT->GetOutputChannels()) {
             parseStr += "Error! - Number of entries in file '";
@@ -3637,7 +3637,7 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
           }
         }
         else if (nType == icConvert16Bit){
-          icUInt32Number num = file->GetLength() / sizeof(icUInt16Number);
+          size_t num = file->GetLength() / sizeof(icUInt16Number);
           icUInt16Number value;
           icUInt8Number *ptr = (icUInt8Number*)&value;
 
@@ -3677,7 +3677,7 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
           }
         }
         else if (nType == icConvertFloat){
-          icUInt32Number num = file->GetLength()/sizeof(icFloat32Number);
+          size_t num = file->GetLength()/sizeof(icFloat32Number);
           icFloat32Number value;
           icUInt8Number *ptr = (icUInt8Number*)&value;
 
@@ -5161,9 +5161,9 @@ bool CIccTagXmlEmbeddedHeightImage::ParseXml(xmlNode *pNode, std::string &parseS
         return false;
       }
 
-      icUInt32Number num = file->GetLength();
+      size_t num = file->GetLength();
 
-      SetSize(num);
+      SetSize((icUInt32Number)num);
       icUInt8Number *dst = GetData(0);
       if (file->Read8(dst, num)!=num) {
         perror("Read-File Error");
@@ -5256,9 +5256,9 @@ bool CIccTagXmlEmbeddedNormalImage::ParseXml(xmlNode *pNode, std::string &parseS
         return false;
       }
 
-      icUInt32Number num = file->GetLength();
+      size_t num = file->GetLength();
 
-      SetSize(num);
+      SetSize((icUInt32Number)num);
       icUInt8Number *dst = GetData(0);
       if (file->Read8(dst, num) != num) {
         perror("Read-File Error");

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -648,12 +648,12 @@ icUInt32Number icXmlGetHexDataSize(const char *szText)
   return rv;
 }
 
-icUInt32Number icXmlDumpHexData(std::string &xml, std::string blanks, void *pBuf, icUInt32Number nBufSize)
+size_t icXmlDumpHexData(std::string &xml, std::string blanks, void *pBuf, size_t nBufSize)
 {
   icUInt8Number *m_ptr = (icUInt8Number *)pBuf;
   const size_t bufSize = 15;
   char buf[bufSize];
-  icUInt32Number i;
+  size_t i;
 
   for (i=0; i<nBufSize; i++, m_ptr++) {
     if (!(i%32)) {
@@ -808,7 +808,7 @@ bool CIccXmlArrayType<T, Tsig>::ParseTextArray(xmlNode *pNode)
 }
 
 template <class T, icTagTypeSignature Tsig>
-bool CIccXmlArrayType<T, Tsig>::ParseTextArrayNum(const char *szText, icUInt32Number num, std::string &parseStr)
+bool CIccXmlArrayType<T, Tsig>::ParseTextArrayNum(const char *szText, size_t num, std::string &parseStr)
 {
   icUInt32Number n = ParseTextCountNum(szText, num, parseStr);
   if (n) {	  
@@ -924,7 +924,7 @@ static inline bool icIsNumChar(char c)
 // function used when checking contents of a file
 // count the number of entries.
 template <class T, icTagTypeSignature Tsig>
-icUInt32Number CIccXmlArrayType<T, Tsig>::ParseTextCountNum(const char *szText, icUInt32Number num, std::string &parseStr)
+icUInt32Number CIccXmlArrayType<T, Tsig>::ParseTextCountNum(const char *szText, size_t num, std::string &parseStr)
 {
   icUInt32Number n = 0;
   bool bInNum = false;

--- a/IccXML/IccLibXML/IccUtilXml.h
+++ b/IccXML/IccLibXML/IccUtilXml.h
@@ -125,7 +125,7 @@ icUInt32Number icXmlGetHexData(void *pBuf, const char *szText, icUInt32Number nB
 
 icUInt32Number icXmlGetHexDataSize(const char *szText);
 
-icUInt32Number icXmlDumpHexData(std::string &xml, std::string blanks, void *pBuf, icUInt32Number nBufSize);
+size_t icXmlDumpHexData(std::string &xml, std::string blanks, void *pBuf, size_t nBufSize);
 
 #define icXmlStrCmp(x, y) strcmp((const char *)(x), (const char*)(y))
 
@@ -149,12 +149,12 @@ public:
 
   static icUInt32Number ParseTextCount(const char *szText);
   static icUInt32Number ParseText(T *buf, icUInt32Number nBufSize, const char *szText);
-  static icUInt32Number ParseTextCountNum(const char *szText, icUInt32Number num, std::string &parseStr);
+  static icUInt32Number ParseTextCountNum(const char *szText, size_t num, std::string &parseStr);
 
   bool ParseArray(xmlNode *pNode);
   bool ParseTextArray(const char *szText);
   bool ParseTextArray(xmlNode *pNode);
-  bool ParseTextArrayNum(const char *szText, icUInt32Number num, std::string &parseStr);
+  bool ParseTextArrayNum(const char *szText, size_t num, std::string &parseStr);
 
   bool SetSize(icUInt32Number nSize);
 

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -438,7 +438,7 @@ int main(int argc, const char** argv)
 
   //Embed the last profile into output image as needed
   if (bEmbed && last_path) {
-    icInt32Number length = 0;
+    size_t length = 0;
     icUInt8Number *pDestProfile = NULL;
 
     CIccFileIO io;
@@ -447,7 +447,7 @@ int main(int argc, const char** argv)
       pDestProfile = (icUInt8Number *)malloc(length);
       if (pDestProfile) {
         io.Read8(pDestProfile, length);
-        DstImg.SetIccProfile(pDestProfile, length);
+        DstImg.SetIccProfile(pDestProfile, ( unsigned int) length);
         free(pDestProfile);
       }
       io.Close();


### PR DESCRIPTION
Fixes #190
Most of the changes are to IO code that used a mix of signed and unsigned values, frequently truncating 64 bit values.
Some changes are to loop variables and a few function calls that used fileIO results with mixed sign/unsigned values.
The fileIO code could use more cleanup, eventually, but this fixes all the sign mismatch warnings.
