### PR TITLE
Fix: sast reports in IccCmmConfig.cpp

### DIFF
--- a/Tools/CmdLine/IccCommon/IccCmmConfig.cpp
+++ b/Tools/CmdLine/IccCommon/IccCmmConfig.cpp
@@ -851,8 +851,7 @@ int CIccCfgPccWeight::fromArgs(const char** args, int nArg, bool /*bReset*/)
     m_pccPath = args[0];
     m_dWeight = (icFloatNumber)atof(args[1]);
 
-    args += 2;
-    nArg -= 2;
+//    args += 2;    // static analysis says value unread
     nUsed += 2;
   }
 
@@ -1101,7 +1100,7 @@ bool CIccCfgSearchApply::fromJsonInit(json j)
 
   m_bInitialized = true;
 
-  int intent;
+  int intent = icUnknownIntent; // just incase json parsing fails
   icGetJsonRenderingIntent(j["intent"], intent);
   m_intentInitial = (icRenderingIntent)intent;
 


### PR DESCRIPTION
fix unused value, leave comment for why it differs from similar functions. set default intent incase JSON parsing fails.
Fixes #262

## Pull Request Checklist

- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?