### PR TITLE
Fix: UB runtime error: member call at IccProfLib/IccMpeBasic.cpp#L4051

### DIFF
--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -4632,7 +4632,7 @@ bool CIccMpeToneMap::Write(CIccIO* pIO)
   icPositionNumber lumPos;
   lumPos.offset = (icUInt32Number)(pIO->Tell()- nTagStartPos);
 
-  if (!m_pLumCurve->Write(pIO))
+  if (!m_pLumCurve || !m_pLumCurve->Write(pIO))
     return false;
 
   lumPos.size = (icUInt32Number)(pIO->Tell() - (lumPos.offset + nTagStartPos));
@@ -4642,7 +4642,7 @@ bool CIccMpeToneMap::Write(CIccIO* pIO)
 
   //write out first tone function
   funcPos[0].offset = (icUInt32Number)(pIO->Tell() - nTagStartPos);
-  if (!m_pToneFuncs[0]->Write(pIO)) {
+  if (!m_pToneFuncs[0] || !m_pToneFuncs[0]->Write(pIO)) {
     return false;
   }
   funcPos[0].size = (icUInt32Number)(pIO->Tell() - (funcPos[0].offset + nTagStartPos));
@@ -4658,7 +4658,7 @@ bool CIccMpeToneMap::Write(CIccIO* pIO)
     }
     else {
       funcPos[i].offset = (icUInt32Number)(pIO->Tell() - nTagStartPos);
-      if (!m_pToneFuncs[i]->Write(pIO)) {
+      if (!m_pToneFuncs[i] || !m_pToneFuncs[i]->Write(pIO)) {
         return false;
       }
       funcPos[i].size = (icUInt32Number)(pIO->Tell() - (funcPos[i].offset + nTagStartPos));

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -1819,6 +1819,7 @@ bool CIccMpeXmlToneMap::ParseXml(xmlNode* pNode, std::string& parseStr)
   }
   else {
     parseStr += "Missing Luminance Curve";
+    return false;
   }
 
   pSubNode = icXmlFindNode(pNode->children, "ToneMapFunctions");
@@ -1872,6 +1873,7 @@ bool CIccMpeXmlToneMap::ParseXml(xmlNode* pNode, std::string& parseStr)
     }
     if (nIndex < m_nOutputChannels) {
       parseStr += "Missing ToneMap Functions\n";
+      return false;
     }
   }
 


### PR DESCRIPTION
Fixes #394

Either fix alone solves the null dereference, but both make the code a lot safer.

## Pull Request Checklist

- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?