### PR TITLE
Fix: NPD in CIccTagXmlUnknown::ParseXml() at IccXML/IccLibXML/IccTagXml.cpp:98:47

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -95,9 +95,11 @@ bool CIccTagXmlUnknown::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccTagXmlUnknown::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
 {
-  const char *tagType = icXmlAttrValue(pNode->parent, "type");
-  if (tagType) {
-    m_nType = (icTagTypeSignature)icGetSigVal(tagType);
+  if (pNode) {
+    const char *tagType = icXmlAttrValue(pNode->parent, "type");
+    if (tagType) {
+      m_nType = (icTagTypeSignature)icGetSigVal(tagType);
+    }
   }
 
   pNode = icXmlFindNode(pNode, "UnknownData");


### PR DESCRIPTION
But allow other parsing to continue.
Fixes #374

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?