### PR TITLE
Fix: Stack Overflow in CIccMpeXmlCalculator::Flatten() at IccXML/IccLibXML/IccMpeXml.cpp

### DIFF
--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2703,6 +2703,12 @@ bool CIccMpeXmlCalculator::Flatten(std::string &flatStr, std::string macroName, 
 
       MacroMap::iterator m = m_macroMap.find(name.c_str());
       if (m != m_macroMap.end()) {
+        if (name == macroName) {
+          // there is a self/circular reference in the macro, error out before we recurse infinitely
+          parseStr += "Self reference in macro '" + macroName + "'\n";
+          return false;
+        }
+
         icUInt16Number nLocalsSize = 0;
         TempDeclVarMap::iterator locals = m_macroLocalMap.find(macroName);
         if (locals != m_macroLocalMap.end()) {


### PR DESCRIPTION
Avoiding infinite recursion, at least for self references in a macro.
Fixes #384

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?