### PR TITLE
Fix: UB runtime error: member access .. null pointer at IccXML/IccLibXML/IccProfileXml.cpp

### DIFF
--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -342,7 +342,10 @@ static unsigned char parseVersion(const char *szVer)
 bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
 {  	  
   std::string temp;
-  memset(&m_Header, 0, sizeof(m_Header));  
+  memset(&m_Header, 0, sizeof(m_Header));
+  
+  if (!pNode)
+    return false;
 
   for (pNode=pNode->children; pNode; pNode=pNode->next) {
 	  if (pNode->type==XML_ELEMENT_NODE) {
@@ -437,15 +440,16 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
 		}		
 		else if (!icXmlStrCmp(pNode->name, "ProfileFlags")) {
 			m_Header.flags = 0;			
-			xmlAttr *attr = icXmlFindAttr(pNode, "EmbeddedInFile");
+      
+      xmlAttr *attr = icXmlFindAttr(pNode, "EmbeddedInFile");
       if (attr && !strcmp(icXmlAttrValue(attr), "true")) {
-				m_Header.flags |= icEmbeddedProfileTrue; 
-			}
+		m_Header.flags |= icEmbeddedProfileTrue;
+      }
 
-			attr = icXmlFindAttr(pNode, "UseWithEmbeddedDataOnly");
+        attr = icXmlFindAttr(pNode, "UseWithEmbeddedDataOnly");
       if (attr && !strcmp(icXmlAttrValue(attr), "true")) {
-					m_Header.flags |= icUseWithEmbeddedDataOnly;
-			}
+        m_Header.flags |= icUseWithEmbeddedDataOnly;
+      }
 
       attr = icXmlFindAttr(pNode, "ExtendedRangePCS");
       if (attr && !strcmp(icXmlAttrValue(attr), "true")) {
@@ -474,15 +478,18 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
 			m_Header.attributes = icGetDeviceAttrValue(pNode);
 		}
 		else if (!icXmlStrCmp(pNode->name, "RenderingIntent")) {
-			if (!strcmp((const char*)pNode->children->content, "Perceptual"))
-				m_Header.renderingIntent = icPerceptual;
-			else if (!strcmp((const char*)pNode->children->content, "Relative Colorimetric") || !strcmp((const char*)pNode->children->content, "Relative"))
-				m_Header.renderingIntent = icRelativeColorimetric;
-			else if (!strcmp((const char*)pNode->children->content, "Saturation"))
-				m_Header.renderingIntent = icSaturation;
-			else if (!strcmp((const char*)pNode->children->content, "Absolute Colorimetric") || !strcmp((const char*)pNode->children->content, "Absolute"))
-				m_Header.renderingIntent = icAbsoluteColorimetric;
-
+          if (!pNode->children) {
+            parseStr += "Cannot parse RenderingIntent, no value specified\n";
+            continue;
+          }
+          if (!strcmp((const char*)pNode->children->content, "Perceptual"))
+            m_Header.renderingIntent = icPerceptual;
+          else if (!strcmp((const char*)pNode->children->content, "Relative Colorimetric") || !strcmp((const char*)pNode->children->content, "Relative"))
+            m_Header.renderingIntent = icRelativeColorimetric;
+          else if (!strcmp((const char*)pNode->children->content, "Saturation"))
+            m_Header.renderingIntent = icSaturation;
+          else if (!strcmp((const char*)pNode->children->content, "Absolute Colorimetric") || !strcmp((const char*)pNode->children->content, "Absolute"))
+            m_Header.renderingIntent = icAbsoluteColorimetric;
 		}
 		else if (!icXmlStrCmp(pNode->name, "PCSIlluminant")) { 
 			xmlNode *xyzNode = icXmlFindNode(pNode->children, "XYZNumber");


### PR DESCRIPTION
Fix RenderingIntent parsing with NULL check, error message, and continue.
Add safety to main routine, check pNode is not NULL before dereferencing.
And fix some tab/space formatting along the way.
Fixes #372

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?