### PR TITLE
Fix: HBO in CIccMpeToneMap::Read()

### DIFF
--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -4553,7 +4553,7 @@ bool CIccMpeToneMap::Read(icUInt32Number size, CIccIO* pIO)
   }
 
   for (int i = 1; i < m_nOutputChannels; i++) {
-    for (j = 0; j < i; i++) {
+    for (j = 0; j < i; j++) {
       if (funcPos[j].offset == funcPos[i].offset)
         break;
     }


### PR DESCRIPTION
Also probably the smallest fix I've ever made: 1 byte, difference of 1 bit.
Fixes #366

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?