### PR TITLE
Fix: Leaks in CIccCalculatorFunc::SequenceNeedTempReset()

### DIFF
--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -3893,8 +3893,10 @@ bool CIccCalculatorFunc::SequenceNeedTempReset(SIccCalcOp *op, icUInt32Number nO
       memcpy(ifTemps, tempUsage, nMaxTemp);
 
       p=i+2;
-      if (p > nOps)
+      if (p > nOps) {
+        free(ifTemps);
         return true;
+      }
       rv = rv || SequenceNeedTempReset(&op[p], icIntMin(nOps-p, op[i].data.size), ifTemps, nMaxTemp);
 
       if (i<nOps && op[i+1].sig==icSigElseOp) {
@@ -3907,8 +3909,11 @@ bool CIccCalculatorFunc::SequenceNeedTempReset(SIccCalcOp *op, icUInt32Number nO
         memcpy(elseTemps, tempUsage, nMaxTemp);
 
         p=i+2+op[i].data.size;
-        if (p > nOps)
+        if (p > nOps) {
+          free(ifTemps);
+          free(elseTemps);
           return true;
+        }
         rv = rv || SequenceNeedTempReset(&op[p], icIntMin(nOps-p, op[i+1].data.size), elseTemps, nMaxTemp);
 
         if (!rv) {


### PR DESCRIPTION
2 tests for errors returned without freeing the allocated buffers.
Fixes #414

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?