### PR TITLE
Fix: UB runtime error: null pointer passed as argument at IccProfLib/IccTagBasic.cpp

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -4501,7 +4501,7 @@ CIccTagSparseMatrixArray &CIccTagSparseMatrixArray::operator=(const CIccTagSpars
 
   if (m_RawData)
     free(m_RawData);
-  m_RawData = (icUInt8Number*)calloc(m_nSize, m_nChannelsPerMatrix);
+  m_RawData = (icUInt8Number*)calloc(m_nSize, GetBytesPerMatrix());
   memcpy(m_RawData, ITSMA.m_RawData, m_nSize*GetBytesPerMatrix());
 
   m_bNonZeroPadding = ITSMA.m_bNonZeroPadding;
@@ -4564,6 +4564,10 @@ bool CIccTagSparseMatrixArray::Read(icUInt32Number size, CIccIO *pIO)
       !pIO->Read16(&nChannels) ||
       !pIO->Read16(&nMatrixType) ||
       !pIO->Read32(&nNumMatrices))
+    return false;
+  
+  // reject tags with invalid counts of items
+  if (nNumMatrices < 1 || nChannels < 1)
     return false;
 
   m_nMatrixType = (icSparseMatrixType)nMatrixType;


### PR DESCRIPTION
Don't allow zero size, or zero channels.
Fix copy operator to match the rest of the code, and allocate the correct amount of data.
Fixes #367

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?