### PR TITLE
Fix: UB invalid enum at wxProfileDump/wxProfileDump.cpp

### DIFF
--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -941,10 +941,13 @@ typedef enum {
 } icColorSpaceSignature;
 
 
-typedef enum {
+typedef enum : icUInt32Number {
   icSigNoMCSData                 = 0x00000000,
   icSigMCSData                   = 0x6d630000,  /* "mc0000" */
-  /*Note: "nc0001" through "ncFFFF" are also valid signatures defined using macro icNColorSpaceSig()*/
+  /*Note: "mc0001" through "mcFFFF" are also valid signatures defined using macro icNColorSpaceSig()*/
+  icSigMCSDataEnd                = 0x6d63FFFF,   // provide clues to UBSan
+
+  icSigMCSMaxEnumData            = 0xFFFFFFFF,
 } icMaterialColorSignature;
 
 #define icGetColorSpaceType(sig) ((icColorSpaceSignature)(((icUInt32Number)sig)&0xffff0000))


### PR DESCRIPTION
About UBSan warnings by giving the type a size, and larger range.
Fixes #361

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?