### PR TITLE
Fix: SAST Report of Memory error: Use of zero allocated at Tools/CmdLine/IccCommon/IccJsonUtil.cpp

### DIFF
--- a/Tools/CmdLine/IccCommon/IccJsonUtil.cpp
+++ b/Tools/CmdLine/IccCommon/IccJsonUtil.cpp
@@ -440,7 +440,7 @@ bool loadJsonFrom(json& j, const char* szFname)
     fseek(f, 0, SEEK_SET);
     char* buf = (char*)malloc(flen+1);
 
-    if (buf) {
+    if (buf && flen) {
       buf[flen] = 0;
       if (fread(buf, 1, flen, f) == flen) {
         try {


### PR DESCRIPTION
Add extra check that the file length is not zero, to avoid a static analysis warning.
Fixes #452

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?