### PR TITLE
Fix: heap-buffer-overflow in CIccCLUT::Init() at IccProfLib/IccTagLut.cpp

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -3383,6 +3383,11 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
     CIccUInt8Array points;
 
     if (points.ParseArray(grid->children)) {
+      if (points.GetSize() < nInput) {
+        parseStr += "Error! - The number of GridPoints and InputChannels do not match.\n";
+        delete pCLUT;
+        return NULL;
+      }
       if (!pCLUT->Init(points.GetBuf())) {
         parseStr += "Error in setting the size of GridPoints. Check values of GridPoints, InputChannel, or OutputChannels.\n";
         delete pCLUT;


### PR DESCRIPTION
Add a check that the size of gridpoints array read in match up (equal or greater) to the expected number of inputs. Return an error string when they do not match.
Fixes #466

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?