### PR TITLE
Fix: heap-buffer-overflow in SIccCalcOp::Describe() at IccProfLib/IccMpeCalc.cpp:1816

### DIFF
--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -2995,8 +2995,8 @@ void CIccCalculatorFunc::DescribeSequence(std::string &sDescription,
 
       if  ((i+1)<nOps && op[1].sig == icSigElseOp) {
         SIccCalcOp *elseop = &op[1];
-        // TODO - nOps-i probably should be nOps-i-2 as in CIccCalculatorFunc::CheckUnderflowOverflow
-        icUInt32Number nSubOps = (icUInt32Number)icIntMin(nOps-i, ifop->data.size);
+        icUInt32Number remaining = nOps - i - 2;
+        icUInt32Number nSubOps = (icUInt32Number)icIntMin(remaining, ifop->data.size);
         op++;
         i++;
         funcDesc += "\n";
@@ -3008,8 +3008,8 @@ void CIccCalculatorFunc::DescribeSequence(std::string &sDescription,
         funcDesc += "else\n";
         //pos = 0;  // value overwritten below
         
-        // TODO - nOps-i probably should be nOps-i-2 as in CIccCalculatorFunc::CheckUnderflowOverflow
-        nSubOps = (icUInt32Number)icIntMin(nOps-i, elseop->data.size);
+        remaining = nOps - i - 1;
+        nSubOps = (icUInt32Number)icIntMin(remaining, elseop->data.size);
         DescribeSequence(funcDesc, nSubOps, &op[1], nBlanks+2);
         op += nSubOps;
         i += nSubOps;


### PR DESCRIPTION
Fixes #475

## Pull Request Checklist
- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?