### PR TITLE
Fix: CIccProfileXml::LoadXml to return false instead of NULL

### DIFF
--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -877,7 +877,7 @@ bool CIccProfileXml::LoadXml(const char *szFilename, const char *szRelaxNGDir, s
   doc = xmlReadFile(szFilename, NULL, 0);
 
   if (doc == NULL) 
-    return NULL;
+    return false;
 
   if (szRelaxNGDir && szRelaxNGDir[0]) {
     xmlRelaxNGParserCtxt* rlxParser;


### PR DESCRIPTION
## Pull Request Checklist

- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?