### PR TITLE
Fix: SEGV in CIccMpeCurveSet::SetSize()

### DIFF
--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -3036,6 +3036,7 @@ CIccMpeCurveSet::CIccMpeCurveSet(const CIccMpeCurveSet &curveSet)
   else {
     m_nInputChannels = m_nOutputChannels = 0;
     m_curve = NULL;
+    m_position = NULL;
   }
 }
 
@@ -3080,6 +3081,7 @@ CIccMpeCurveSet &CIccMpeCurveSet::operator=(const CIccMpeCurveSet &curveSet)
   else {
     m_nInputChannels = m_nOutputChannels = 0;
     m_curve = NULL;
+    m_position = NULL;
   }
 
   return *this;
@@ -3123,9 +3125,11 @@ bool CIccMpeCurveSet::SetSize(int nNewSize)
       }
     }
     free(m_curve);
+    m_curve = NULL;
   }
   if (m_position) {
     free(m_position);
+    m_position = NULL;
   }
 
   if (nNewSize) {


### PR DESCRIPTION
All set pointers to NULL after freeing to avoid potential problems.
Fixes #550

## Pull Request Checklist

- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?