### PR TITLE
Fix: SBO in CIccTagNum<(icTagTypeSignature)>::GetValues()

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -6074,17 +6074,20 @@ bool CIccTagNum<T, Tsig>::GetValues(icFloatNumber *DstVector, icUInt32Number nSt
 {
   if (nVectorSize+nStart >m_nSize)
     return false;
+    
+  if (nVectorSize > m_nSize)
+    return false;
 
   icUInt32Number i;
   
   switch (Tsig) {
     case icSigUInt8ArrayType:
-      for (i=0; i<m_nSize; i++) {
+      for (i=0; i<nVectorSize; i++) {
         DstVector[i] = icU8toF((icUInt8Number)(m_Num[i+nStart]));
       }
       break;
     case icSigUInt16ArrayType:
-      for (i=0; i<m_nSize; i++) {
+      for (i=0; i<nVectorSize; i++) {
         DstVector[i] = icU16toF((icUInt16Number)(m_Num[i+nStart]));
       }
       break;


### PR DESCRIPTION
And check that the output size is less than or equal to the input
Fixes #618

## Pull Request Checklist

- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?