### PR TITLE
Fix: UB in CIccOpDefEnvVar::Exec()

### DIFF
--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -632,10 +632,13 @@ typedef enum {
 /************************************************************************
  * CMM environment variable signatures
  ************************************************************************/
-typedef enum {
+typedef enum : uint32_t {
   //Floating point constant operation
   icSigTrueVar                       = 0x74727565,  /* 'true' */
   icSigNotDefVar                     = 0x6e646566,  /* 'ndef' */
+  
+/* Convenience Enum Definitions - Not defined in ICC specification */
+  icMaxCmmEnvVar                     = 0xFFFFFFFF,
 }icSigCmmEnvVar;
 
 


### PR DESCRIPTION
so UB doesn't happen when we read bad values
Fixes #670

## Pull Request Checklist

- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?