### PR TITLE
Fix: HBO in CTiffImg::WriteLine()

### DIFF
--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -204,6 +204,9 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
 
   m_nCurLine = 0;
   m_nCurStrip = 0;
+  
+  // we should always calculate this
+  m_nBytesPerSample = m_nBitsPerSample / 8;
 
   if (bSep && m_nSamples>1) {
     m_nStripSamples = m_nSamples;
@@ -211,7 +214,6 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
       Close();
       return false;
     }
-    m_nBytesPerSample = m_nBitsPerSample / 8;
 
     m_nStripSize = (unsigned int)TIFFStripSize(m_hTif);
     m_nBytesPerStripLine = m_nWidth * m_nBytesPerSample;
@@ -408,7 +410,7 @@ bool CTiffImg::WriteLine(unsigned char *pBuf)
         src += m_nStripSize;
       }
     }
-    else if (TIFFWriteEncodedStrip(m_hTif, m_nCurStrip, pBuf, m_nBytesPerLine) < 0)
+    else if (TIFFWriteEncodedStrip(m_hTif, m_nCurStrip, pBuf, m_nWidth*m_nBytesPerSample) < 0)
       return false;
 
     m_nCurStrip++;

--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -205,7 +205,8 @@ int main(int argc, char* argv[]) {
   
   // use unique_ptr to automatically free the buffers
   std::unique_ptr<icUInt8Number> inbufffer( new icUInt8Number[ bytePerLine*nSamples ] );
-  std::unique_ptr<icUInt8Number> outbuffer( new icUInt8Number[ f->GetWidth() * bytesPerSample * nSamples ] );
+  size_t outSize = f->GetWidth() * bytesPerSample * nSamples;
+  std::unique_ptr<icUInt8Number> outbuffer( new icUInt8Number[ outSize ] );
   icUInt8Number *inbuf = inbufffer.get();
   icUInt8Number *outbuf = outbuffer.get();
 


### PR DESCRIPTION
And always calculate bytesPerSample
And make the output buffer calc easier to debug
Fixes #672

## Pull Request Checklist

- [x] Have you followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/InternationalColorConsortium/iccDEV/pulls) for the same change?
- [x] Have you built your Pull Request locally with the [Build Instructions](https://github.com/InternationalColorConsortium/iccDEV/blob/master/docs/build.md)?
- [x] Have you added or updated relevant tests?
- [x] Have you added or updated relevant docs?