### PR TITLE
[IccProfLib] Fix new[]/delete mismatch in CIccTagParametricCurve::SetFunctionType

### DIFF
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -981,7 +981,7 @@ bool CIccTagParametricCurve::SetFunctionType(icUInt16Number nFunctionType)
   }
 
   if (m_dParam)
-    delete m_dParam;
+    delete [] m_dParam;
   m_nNumParam = nNumParam;
   m_nFunctionType = nFunctionType;
 


### PR DESCRIPTION
# Fix `new[]` / `delete` mismatch in `CIccTagParametricCurve::SetFunctionType`

**Severity:** Medium · **File:** `IccProfLib/IccTagLut.cpp:983-991`

## Summary

`m_dParam` is allocated with `new icFloatNumber[m_nNumParam]` at line
989 but released with `delete m_dParam` at line 984 — missing the
array-delete syntax. Mismatch between array and non-array form is
undefined behaviour in C++. In practice this is latent on most
allocators for POD types, but trips AddressSanitizer and
UndefinedBehaviorSanitizer, and *can* crash on hardened libc++
configurations.

Reached any time a `CIccTagParametricCurve` is round-tripped through
`SetFunctionType` twice (e.g. re-import from XML).

## Root cause

```cpp
// IccTagLut.cpp:983-989
if (m_dParam)
  delete m_dParam;                              // ← should be delete[]
...
if (m_nNumParam)
  m_dParam = new icFloatNumber[m_nNumParam];    // ← new[]
```

## Patch

```diff
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -981,7 +981,7 @@
     default:
       nNumParam = 0;
   }
 
   if (m_dParam)
-    delete m_dParam;
+    delete [] m_dParam;
   m_nNumParam = nNumParam;
   m_nFunctionType = nFunctionType;
```

## Sweep

Similar `new[] / delete` mismatches likely exist elsewhere. Run:

```sh
git grep -nE 'delete[[:space:]]+m_' IccProfLib/ | grep -v 'delete[[:space:]]*\['
```

and audit each hit.

## Test plan

- Build with AddressSanitizer + UBSAN.
- Run `Testing/RunTests.sh` — no runtime diagnostics on ParametricCurve
  round-trips.
- New unit: instantiate `CIccTagParametricCurve`, call
  `SetFunctionType` twice — no UBSAN warning.

## References

- CWE-763 Release of Invalid Pointer or Reference
