### PR TITLE
[IccLibXML] Fix operator-precedence bug in ZipUtf8Text / ZipXml size calc

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -309,8 +309,8 @@ bool CIccTagXmlZipUtf8Text::ParseXml(xmlNode *pNode, std::string &parseStr)
     if (pNode->type==XML_ELEMENT_NODE) {
       if (!icXmlStrCmp(pNode->name, "HexCompressedData") && pNode->children && pNode->children->content) {
         CIccUInt8Array buf;
-        if (!buf.SetSize(icXmlGetHexDataSize((const icChar*)pNode->children->content) ||
-            icXmlGetHexData(buf.GetBuf(), (const icChar*)pNode->children->content, buf.GetSize())!=buf.GetSize()))
+        if (!buf.SetSize(icXmlGetHexDataSize((const icChar*)pNode->children->content)) ||
+            icXmlGetHexData(buf.GetBuf(), (const icChar*)pNode->children->content, buf.GetSize())!=buf.GetSize())
           return false;
   
         AllocBuffer(buf.GetSize());
@@ -336,8 +336,8 @@ bool CIccTagXmlZipXml::ParseXml(xmlNode *pNode, std::string &parseStr)
     if (pNode->type==XML_ELEMENT_NODE) {
       if (!icXmlStrCmp(pNode->name, "HexCompressedData") && pNode->children && pNode->children->content) {
         CIccUInt8Array buf;
-        if (!buf.SetSize(icXmlGetHexDataSize((const icChar*)pNode->children->content) ||
-          icXmlGetHexData(buf.GetBuf(), (const icChar*)pNode->children->content, buf.GetSize())!=buf.GetSize()))
+        if (!buf.SetSize(icXmlGetHexDataSize((const icChar*)pNode->children->content)) ||
+          icXmlGetHexData(buf.GetBuf(), (const icChar*)pNode->children->content, buf.GetSize())!=buf.GetSize())
           return false;
 
         AllocBuffer(buf.GetSize());


### PR DESCRIPTION
# Fix operator-precedence bug in `ZipUtf8Text`/`ZipXml` size calculation

**Severity:** Medium · **File:** `IccXML/IccLibXML/IccTagXml.cpp:312-313, 339-340`

## Summary

```cpp
if (!buf.SetSize(icXmlGetHexDataSize(...) ||
    icXmlGetHexData(buf.GetBuf(), ..., buf.GetSize()) != buf.GetSize()))
  return false;
```

The `||` binds *inside* `SetSize(...)`. `SetSize` receives a boolean
(cast to 1), allocating a 1-byte buffer. The hex-data-decode then
copies at most 1 byte into it, and the `memcpy(m_pZipBuf, buf.GetBuf(),
m_nBufSize)` afterwards also copies 1 byte.

The net result is that every compressed-text tag silently fails to
parse correctly — round-trips through the XML path drop compressed
content. Not a memory-corruption bug (sizes match, just wrong), but
a clear data-integrity failure produced by broken parenthesisation.

## Patch

```diff
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -310,9 +310,9 @@
-  if (!buf.SetSize(icXmlGetHexDataSize(...) ||
-      icXmlGetHexData(buf.GetBuf(), ..., buf.GetSize()) != buf.GetSize()))
+  if (!buf.SetSize(icXmlGetHexDataSize(...)) ||
+      icXmlGetHexData(buf.GetBuf(), ..., buf.GetSize()) != buf.GetSize())
     return false;
```

Same treatment at line 339-340 for the matching path.

## Test plan

- Regression: `Testing/RunXmlTests.sh` — compressed-text round-trip
  tests should start passing if they weren't already (may indicate
  the current suite doesn't exercise this path).
- New unit: parse XML with a `<CompressedData>` tag of non-trivial
  size; verify `m_pZipBuf` contains the full decompressed content,
  not just 1 byte.

## References

- Not a security CWE; correctness/data-integrity bug from precedence.
