### PR TITLE
[IccLibJSON] Type-check before .get<std::string>() in dictLocalizedFromJson

### DIFF
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -2140,9 +2140,14 @@ static CIccTagMultiLocalizedUnicode *dictLocalizedFromJson(const IccJson &arr)
   CIccTagMultiLocalizedUnicode *pTag = new(std::nothrow) CIccTagMultiLocalizedUnicode();
   if (!pTag) return nullptr;
   for (const auto &loc : arr) {
-    std::string lang    = loc.contains("language") ? loc["language"].get<std::string>() : "  ";
-    std::string country = loc.contains("country")  ? loc["country"].get<std::string>()  : "  ";
-    std::string text    = loc.contains("text")     ? loc["text"].get<std::string>()     : "";
+    // Defensive type-check before .get<std::string>(): nlohmann throws
+    // type_error on mismatch, and this function is reachable from
+    // ParseJson which is not currently wrapped in try/catch. Falling
+    // back to the "  " / "" defaults keeps parsing alive rather than
+    // aborting the whole profile on a malformed localized entry.
+    std::string lang    = (loc.contains("language") && loc["language"].is_string()) ? loc["language"].get<std::string>() : "  ";
+    std::string country = (loc.contains("country")  && loc["country"].is_string())  ? loc["country"].get<std::string>()  : "  ";
+    std::string text    = (loc.contains("text")     && loc["text"].is_string())     ? loc["text"].get<std::string>()     : "";
     while (lang.size()    < 2) lang    += ' ';
     while (country.size() < 2) country += ' ';
     icLanguageCode langCode    = (icLanguageCode)((lang[0]    << 8) | lang[1]);


### PR DESCRIPTION
# Type-check before `.get<std::string>()` in `dictLocalizedFromJson`

**Severity:** Low · **File:** `IccJSON/IccLibJSON/IccTagJson.cpp:2143-2145`

## Summary

```cpp
std::string language = loc.contains("language")
    ? loc["language"].get<std::string>()
    : "  ";
```

If `"language"` is present but typed as number / bool / array /
object, `nlohmann::json::type_error` is thrown. This is a
representative instance of PR #23 — fixed wholesale by wrapping
`CIccProfileJson::ParseJson` in `try/catch`. Fixing locally is also
cheap and makes the call site self-defensive.

## Patch

```diff
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -2141,6 +2141,8 @@
-  std::string language = loc.contains("language") ? loc["language"].get<std::string>() : "  ";
+  std::string language = "  ";
+  if (loc.contains("language") && loc["language"].is_string()) {
+    language = loc["language"].get<std::string>();
+  }
```

Same treatment for `region` / `content` a few lines down.

## Test plan

- Regression: `Testing/RunJsonTests.sh`.
- New unit: JSON with `"language": 42` — parses successfully, language
  field defaults to `"  "`.

## References

- CWE-248 Uncaught Exception (specific site; see #23 for systemic fix)
