### PR TITLE
[IccProfLib] Bound tag-directory count against file size

### DIFF
--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1260,6 +1260,22 @@ bool CIccProfile::ReadBasic(CIccIO *pIO)
   if (!pIO->Read32(&count))
     return false;
 
+  // Bound `count` against the IO's actual length. Without this check a
+  // crafted count field can drive m_Tags into unbounded growth on a
+  // short profile body (OOM on native, wasm abort in browser builds).
+  //
+  // We intentionally don't cross-check against m_Header.size: that
+  // field is attacker-controlled (read from the file a few lines back)
+  // and, for legitimate round-trip flows that InitHeader() + Write()
+  // to a memory IO, it stays 0 until Write patches it up.
+  // pIO->GetLength() is the ground truth.
+  icUInt64Number minProfileBytes =
+      132u + static_cast<icUInt64Number>(count) * 12u;
+  icUInt64Number ioBytes = static_cast<icUInt64Number>(pIO->GetLength());
+  if (minProfileBytes > ioBytes) {
+    return false;
+  }
+
   //Read TagDir
   for (i=0; i<count; i++) {
     if (!pIO->Read32(&TagEntry.TagInfo.sig) ||


### PR DESCRIPTION
# Bound tag-directory count against file size before `vector::push_back` loop

**Severity:** High · **File:** `IccProfLib/IccProfile.cpp:1255-1274`

## Summary

`CIccProfile::ReadBasic` reads `count` (tag-table entry count) from the
profile and then loops `count` times, growing `m_Tags` with each
iteration. `count` is never checked against the remaining file size, so
an attacker who provides matching junk bytes can force the library to
grow the tag vector to billions of entries — typically OOM.

This is particularly easy in a TIFF-embedded profile (`iccflow` input
path), where the outer container can be megabytes of data even though
the declared ICC profile size is small. The `Read32` loop keeps
succeeding as long as the IO can return 12 more bytes per iteration.

## Impact

- Native: heap exhaustion / `std::bad_alloc` / process kill by OOM killer.
- WASM (all three of my apps): tab crashes once the module hits
  `MAXIMUM_MEMORY`. For iccflow/icctools/icceval users this is a
  drop-a-file → dead-tab primitive.

## Reproducer

Profile header with:
- `magic = acsp`, all other fields valid.
- `count = 0x10000000` immediately after header.
- Tag table body: repeat pattern `00 00 00 01 00 00 00 80 00 00 00 10`
  (valid-looking 12-byte entries) for as long as the containing file
  permits — can be as little as 12 bytes if the IO supports seeking past
  EOF silently (CIccMemIO reads zeros past end).

At ~12 bytes × `0x10000000` entries, the `m_Tags` vector tries to grow to
~3 GB.

## Root cause

```cpp
// IccProfile.cpp:1260-1271
if (!pIO->Read32(&count))
  return false;

for (i=0; i<count; i++) {
  if (!pIO->Read32(&TagEntry.TagInfo.sig) ||
      !pIO->Read32(&TagEntry.TagInfo.offset) ||
      !pIO->Read32(&TagEntry.TagInfo.size)) {
    return false;
  }
  m_Tags.push_back(TagEntry);
}
```

The spec says a profile's tag count × 12 + 132 (header + count field) must
fit within `m_Header.size`. We're not enforcing that.

## Patch

```diff
--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1255,12 +1255,28 @@ bool CIccProfile::ReadBasic(CIccIO *pIO)
   icUInt32Number count, i;
   IccTagEntry TagEntry = {};
 
   TagEntry.pTag = NULL;
 
   if (!pIO->Read32(&count))
     return false;
 
+  // Validate tag-directory size against both the declared profile size
+  // and the IO's actual length. 128 header + 4 count + count*12 table.
+  // Without this check a crafted `count` field can drive m_Tags into
+  // unbounded growth (attacker DoS).
+  icUInt64Number tagTableBytes =
+      static_cast<icUInt64Number>(count) * 12u;
+  icUInt64Number minProfileBytes = 132u + tagTableBytes;
+  icUInt64Number ioBytes = static_cast<icUInt64Number>(pIO->GetLength());
+  if (minProfileBytes > m_Header.size ||
+      minProfileBytes > ioBytes) {
+    return false;
+  }
+
+  // Reserve the exact amount so a later push_back cannot overallocate.
+  m_Tags.reserve(count);
+
   //Read TagDir
   for (i=0; i<count; i++) {
     if (!pIO->Read32(&TagEntry.TagInfo.sig) ||
         !pIO->Read32(&TagEntry.TagInfo.offset) ||
         !pIO->Read32(&TagEntry.TagInfo.size)) {
       return false;
     }
     m_Tags.push_back(TagEntry);
   }
```

## Test plan

- Regression: `Testing/RunTests.sh` — all profiles load.
- New unit: craft an in-memory profile with `count = 0x10000000` and
  verify `CIccProfile::Read` returns `false` without allocating
  `m_Tags` beyond the reserve.
- New unit: `count = (m_Header.size - 132) / 12` — the boundary case —
  must succeed.

## References

- CWE-789 Memory Allocation with Excessive Size Value
