### PR TITLE
[IccProfLib] Widen MLU Read bounds checks to 64-bit, cap nNumRec

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -7615,8 +7615,18 @@ bool CIccTagMultiLocalizedUnicode::Read(icUInt32Number size, CIccIO *pIO)
   CIccLocalizedUnicode Unicode;
   icUInt32Number nLastPos = 0;
 
+  // Hard-cap nNumRec so we neither loop forever nor overflow the bounds
+  // arithmetic below. 65536 localized records is already well beyond any
+  // plausible legitimate profile.
+  if (nNumRec > 65536u)
+    return false;
+
   for (i=0; i<nNumRec; i++) {
-    if (4*sizeof(icUInt32Number) + (i+1)*12 > size)
+    // 64-bit widened bounds check: 4*4 header + (i+1)*12 records.
+    icUInt64Number headerAndRecords =
+        static_cast<icUInt64Number>(4u * sizeof(icUInt32Number)) +
+        (static_cast<icUInt64Number>(i) + 1u) * 12u;
+    if (headerAndRecords > size)
       return false;
 
     pIO->Seek(nTagPos+4*sizeof(icUInt32Number) + i*12, icSeekSet);
@@ -7627,7 +7637,9 @@ bool CIccTagMultiLocalizedUnicode::Read(icUInt32Number size, CIccIO *pIO)
         !pIO->Read32(&nOffset))
       return false;
     
-    if (nOffset+nLength > size)
+    // 64-bit widened bounds check for the per-record string blob.
+    if (static_cast<icUInt64Number>(nOffset) +
+        static_cast<icUInt64Number>(nLength) > size)
       return false;
 
     //Find out position of the end of last named record


### PR DESCRIPTION
# Fix u32 wraparound in `CIccTagMultiLocalizedUnicode::Read` bounds check

**Severity:** High · **File:** `IccProfLib/IccTagBasic.cpp:7618-7631`

## Summary

`CIccTagMultiLocalizedUnicode::Read` performs two bounds checks that use
32-bit addition without widening:

```cpp
if (4*sizeof(icUInt32Number) + (i+1)*12 > size)    // line 7619 — wraps for large nNumRec
  return false;
...
if (nOffset+nLength > size)                         // line 7630 — wraps for large offsets
  return false;
```

Both checks can be bypassed by attacker-controlled values because the
sum wraps around `UINT32_MAX` before the comparison. This is the
reachability path for the Critical finding #2 (OOB write in
`CIccLocalizedUnicode::SetSize`).

Additionally, `nNumRec` is used as the loop bound with no upper cap, so
even if the per-iteration bounds check worked correctly, a profile with
`nNumRec = 0xFFFFFFFF` drives an unbounded `push_back` loop.

## Impact

- Direct: bypass of the Unicode-record bounds check, letting malformed
  `nOffset`/`nLength` pairs reach `SetSize` and `Seek` calls with
  attacker-controlled semantics.
- Indirect (via #2): OOB heap write.
- DoS: 2^32-iteration loop on a pathological `nNumRec`.

## Reproducer

See finding #2 for the full chain. For the isolated bypass of the
`nOffset+nLength > size` check alone:

- `size` (tag length) = 1 KB.
- `nOffset = 0x80000000`, `nLength = 0x80000000`.
- `nOffset + nLength` wraps to `0`, comparison `0 > 1024` is false, check passes.
- `pIO->Seek(nTagPos + 0x80000000, icSeekSet)` follows — for
  `CIccMemIO` this clamps silently, causing a parse desync.

## Patch

```diff
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -7614,12 +7614,25 @@
   icUInt32Number i; 
   CIccLocalizedUnicode Unicode;
   icUInt32Number nLastPos = 0;
 
+  // Hard-cap nNumRec so we neither loop forever nor overflow the
+  // bounds arithmetic below. 65536 localised records is already well
+  // beyond any plausible legitimate profile.
+  if (nNumRec > 65536u) {
+    return false;
+  }
+
   for (i=0; i<nNumRec; i++) {
-    if (4*sizeof(icUInt32Number) + (i+1)*12 > size)
+    // 64-bit widened bounds check — 4*4 header + (i+1)*12 records.
+    icUInt64Number headerAndRecords =
+        static_cast<icUInt64Number>(4u * sizeof(icUInt32Number)) +
+        (static_cast<icUInt64Number>(i) + 1u) * 12u;
+    if (headerAndRecords > size)
       return false;
 
     pIO->Seek(nTagPos+4*sizeof(icUInt32Number) + i*12, icSeekSet);
 
     if (!pIO->Read16(&nLanguageCode) ||
         !pIO->Read16(&nRegionCode) ||
         !pIO->Read32(&nLength) ||
         !pIO->Read32(&nOffset))
       return false;
     
-    if (nOffset+nLength > size)
+    // 64-bit widened bounds check for the per-record string blob.
+    if (static_cast<icUInt64Number>(nOffset) +
+        static_cast<icUInt64Number>(nLength) > size)
       return false;
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: `mluc` tag with `nNumRec = 0xFFFFFFFF` must return `false`
  in O(1) time (no loop iterations).
- New unit: `mluc` record with `nOffset = 0x80000000, nLength = 0x80000000`
  must return `false`.
- Fuzz harness as in finding #2.

## References

- CWE-190 Integer Overflow or Wraparound
- CWE-130 Improper Handling of Length Parameter Inconsistency
