### PR TITLE
[IccProfLib] Fix off-by-one and NULL deref in CIccTagArray::GetIndex

### DIFF
--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1564,7 +1564,13 @@ void CIccTagArray::Cleanup()
 */
 CIccTag* CIccTagArray::GetIndex(icUInt32Number nIndex) const
 {
-  if (nIndex>m_nSize)
+  // Two bugs: `>` should be `>=` (reads one past array), and m_TagVals
+  // can be NULL when SetSize(0) was never called (Read guards SetSize
+  // behind `if (count)` at ~line 1262; zero-length array leaves the
+  // pointer at its default NULL). CIccArrayNamedColor::Begin /
+  // FindColor call GetIndex(0) unconditionally, so this is reachable
+  // from CMM apply time.
+  if (!m_TagVals || nIndex>=m_nSize)
     return NULL;
 
   return m_TagVals[nIndex].ptr;


### PR DESCRIPTION
# Fix off-by-one and NULL deref in `CIccTagArray::GetIndex`

**Severity:** High · **File:** `IccProfLib/IccTagComposite.cpp:1565-1571`

## Summary

`CIccTagArray::GetIndex(icUInt32Number nIndex)` contains two bugs:

1. **Off-by-one**: `if (nIndex > m_nSize) return NULL;` should be `>=`.
   When `nIndex == m_nSize`, `m_TagVals[m_nSize]` reads one past the
   array.
2. **NULL deref**: If `SetSize(0)` was never called (the Read path
   guards `SetSize` behind `if (count)` at line ~1262), `m_TagVals`
   stays NULL (default-constructed at line ~1017). Callers such as
   `CIccArrayNamedColor::Begin` and `::FindColor` at
   `IccArrayBasic.cpp:289` call `m_pTag->GetIndex(0)` unconditionally —
   dereferencing NULL.

Reachable from CMM `Apply` paths on any profile containing a
zero-length named-colour array (valid per the spec).

## Impact

- Bug #1: OOB read of one `CIccTagPtr` (pointer-sized) past `m_TagVals`.
  Typically garbage, but predictable in the attacker's favour.
- Bug #2: NULL deref → crash at profile apply time. Reachable by
  dropping a profile with a zero-length `ncl2` array into any CMM
  consumer.

## Root cause

```cpp
// IccTagComposite.cpp:1565-1571
CIccTag* CIccTagArray::GetIndex(icUInt32Number nIndex) const
{
  if (nIndex > m_nSize)                    // ← should be >=
    return NULL;
  return m_TagVals[nIndex].ptr;            // ← also: m_TagVals may be NULL if m_nSize == 0
}
```

## Patch

```diff
--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1565,7 +1565,7 @@
 CIccTag* CIccTagArray::GetIndex(icUInt32Number nIndex) const
 {
-  if (nIndex > m_nSize)
+  if (!m_TagVals || nIndex >= m_nSize)
     return NULL;
   return m_TagVals[nIndex].ptr;
 }
```

Additionally, audit all `m_TagVals` accesses in `IccTagComposite.cpp`
(there are several similarly-shaped member functions on `CIccTagArray`
and `CIccTagStruct`) for the same pattern.

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: `CIccTagArray` with `m_nSize == 0`, call `GetIndex(0)` —
  must return `NULL`, no crash.
- New unit: `CIccTagArray` with 5 entries, call `GetIndex(5)` — must
  return `NULL`.
- New unit: profile containing a zero-length named-colour array driven
  through `CIccCmm::Apply` — must apply without crashing.

## References

- CWE-193 Off-by-one Error
- CWE-476 NULL Pointer Dereference
- CWE-125 Out-of-bounds Read
