### PR TITLE
[IccProfLib] Widen CIccTagDict::Read bounds math to 64-bit + cap count

### DIFF
--- a/IccProfLib/IccTagDict.cpp
+++ b/IccProfLib/IccTagDict.cpp
@@ -574,7 +574,18 @@ bool CIccTagDict::Read(icUInt32Number size, CIccIO *pIO)
   if (reclen!=16 && reclen!=24 && reclen!=32)
     return false;
 
-  if ((headerSize + (size_t)count*reclen) > (size_t)size)
+  // 64-bit widened bounds check. On wasm32 (size_t == u32) the product
+  // `count * reclen` can otherwise wrap, bypassing the guard and letting
+  // the subsequent calloc under-allocate while the Read loop writes
+  // `count` records into it.
+  icUInt64Number tableBytes =
+      static_cast<icUInt64Number>(count) * reclen;
+  if (static_cast<icUInt64Number>(headerSize) + tableBytes > size)
+    return false;
+
+  // Defensive upper cap: no legitimate dict tag has 2^20 entries.
+  static const icUInt32Number kMaxDictEntries = 0x100000;
+  if (count > kMaxDictEntries)
     return false;
 
   icDictRecordPos *pos = (icDictRecordPos*)calloc(count, sizeof(icDictRecordPos));


### PR DESCRIPTION
# Widen `CIccTagDict::Read` bounds math to 64-bit

**Severity:** High · **File:** `IccProfLib/IccTagDict.cpp:577-580`

## Summary

```cpp
if (headerSize + (size_t)count * reclen > (size_t)size)  // line 577
  return false;
...
m_Dict = (icDictRecordPos*)calloc(count, sizeof(icDictRecordPos));  // line 580
```

On wasm32, `size_t` is 32-bit. A crafted `count = 0x08000001` with
`reclen = 32` yields `count * reclen = 0x0000_0020` after truncation,
bypassing the bounds check. `calloc(count, 32)` in Emscripten's libc
also multiplies internally; the product wraps to 32 bytes, returning
a tiny allocation. The subsequent `for (i = 0; i < count; i++)` write
loop at lines 585-614 then writes past the 32-byte buffer.

Same shape as the Critical PR #13 (sparse-matrix array) — distinct
code site.

## Impact

- wasm32 (icctools today): direct heap-OOB write on crafted `dict`
  tag. Contained by the wasm sandbox but corrupts adjacent heap data
  for subsequent parse operations.
- 64-bit native: `calloc` is asked for ~4 GB, typically fails
  gracefully — still a 4 GB allocation attempt = DoS.

## Patch

```diff
--- a/IccProfLib/IccTagDict.cpp
+++ b/IccProfLib/IccTagDict.cpp
@@ -575,12 +575,19 @@
-  if (headerSize + (size_t)count * reclen > (size_t)size)
+  // 64-bit widened bounds check. On wasm32, size_t is 32-bit; this
+  // multiplication otherwise wraps and bypasses the guard.
+  icUInt64Number tableBytes =
+      static_cast<icUInt64Number>(count) * reclen;
+  if (static_cast<icUInt64Number>(headerSize) + tableBytes > size)
+    return false;
+
+  // Defensive upper cap — no legitimate dictionary tag has 2^20 entries.
+  static const icUInt32Number kMaxDictEntries = 0x100000;
+  if (count > kMaxDictEntries)
     return false;
 
-  m_Dict = (icDictRecordPos*)calloc(count, sizeof(icDictRecordPos));
+  // calloc already rejects oversize products on most libcs, but
+  // double-check for portability.
+  m_Dict = (icDictRecordPos*)calloc(count, sizeof(icDictRecordPos));
+  if (!m_Dict) return false;
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: dict tag with `count = 0x08000001` on wasm32 — must return
  `false`, no allocation.
- New unit: legitimate dict tag with 16 entries parses.

## References

- CWE-190 Integer Overflow or Wraparound
- CWE-787 Out-of-bounds Write
