### PR TITLE
[IccProfLib] Null-check CIccTag::Create return in Lut8/Lut16 curve setup

### DIFF
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -4739,6 +4739,7 @@ bool CIccTagLut8::Read(icUInt32Number size, CIccIO *pIO)
       return false;
 
     pCurves[i] = pCurve = (CIccTagCurve*)CIccTag::Create(icSigCurveType);
+    if (!pCurve) return false;
 
     if (!pCurve->SetSize(256))
       return false;
@@ -4772,6 +4773,7 @@ bool CIccTagLut8::Read(icUInt32Number size, CIccIO *pIO)
       return false;
 
     pCurves[i] = pCurve = (CIccTagCurve*)CIccTag::Create(icSigCurveType);
+    if (!pCurve) return false;
 
     if (!pCurve->SetSize(256))
       return false;
@@ -4808,6 +4810,7 @@ void CIccTagLut8::SetColorSpaces(icColorSpaceSignature csInput, icColorSpaceSign
       CIccTagCurve *pCurve;
       for (i=0; i<m_nInput; i++) {
         pCurves[i] = pCurve = (CIccTagCurve*)CIccTag::Create(icSigCurveType);
+        if (!pCurve) return;
         pCurve->SetSize(0);
       }
 
@@ -5197,6 +5200,7 @@ bool CIccTagLut16::Read(icUInt32Number size, CIccIO *pIO)
       return false;
 
     pCurves[i] = pCurve = (CIccTagCurve*)CIccTag::Create(icSigCurveType);
+    if (!pCurve) return false;
 
     if (!pCurve->SetSize(nInputEntries))
       return false;
@@ -5226,6 +5230,7 @@ bool CIccTagLut16::Read(icUInt32Number size, CIccIO *pIO)
       return false;
 
     pCurves[i] = pCurve = (CIccTagCurve*)CIccTag::Create(icSigCurveType);
+    if (!pCurve) return false;
 
     if (!pCurve->SetSize(nOutputEntries))
       return false;
@@ -5262,6 +5267,7 @@ void CIccTagLut16::SetColorSpaces(icColorSpaceSignature csInput, icColorSpaceSig
       CIccTagCurve *pCurve;
       for (i=0; i<m_nInput; i++) {
         pCurves[i] = pCurve = (CIccTagCurve*)CIccTag::Create(icSigCurveType);
+        if (!pCurve) return;
         pCurve->SetSize(0);
       }
 


### PR DESCRIPTION
# Null-check `CIccTag::Create` return in Lut8/Lut16/LutAtoB readers

**Severity:** High · **File:** `IccProfLib/IccTagLut.cpp:4741-4747, 5199-5205, 5228-5234` (and LutAtoB sites at 4116/4120, 4169/4173, 4215/4219)

## Summary

Lut8, Lut16, and LutAtoB `Read` methods allocate curve objects via
`CIccTag::Create(icSigCurveType)` and immediately call `SetSize(...)`
on the returned pointer without checking for NULL. `Create` can return
NULL if:

- The curve factory was de-registered (stripped build / custom embedder).
- `new (std::nothrow)` was used inside the factory and returned NULL.
- Allocation failed under memory pressure.

Each case produces an immediate NULL deref on the next line.

## Impact

- Robustness issue. Less likely than #13 or #23 to be exploited for
  memory corruption, but any library consumer that configures a
  stripped factory set triggers this immediately on first LUT parse.
- SDK-surface bug — reachable by calling `CIccTagCreator::PushFactory`
  with a limited factory subset before loading profiles.

## Patch

```diff
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -4740,9 +4740,11 @@
   for (i = 0; i < m_nInput; i++) {
     pCurves[i] = pCurve = (CIccTagCurve*)CIccTag::Create(icSigCurveType);
+    if (!pCurve) return false;
     if (!pCurve->SetSize(nCurveSize))
       return false;
     // ... read curve data ...
   }
```

Apply the same NULL-guard at:
- `IccTagLut.cpp:5199-5205` (Lut16 input curves)
- `IccTagLut.cpp:5228-5234` (Lut16 output curves)
- `IccTagLut.cpp:4116, 4120, 4169, 4173, 4215, 4219` (LutAtoB subtables)

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: de-register the curve factory, attempt to load a profile
  containing a LUT tag — `Read` returns `false` cleanly, no SIGSEGV.

## References

- CWE-476 NULL Pointer Dereference
- CWE-252 Unchecked Return Value
