### PR TITLE
[IccProfLib] Use 64-bit math in CIccCLUT::Init size accounting

### DIFF
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -1900,10 +1900,17 @@ bool CIccCLUT::Init(const icUInt8Number *pGridPoints, icUInt32Number nMaxSize, i
   }
   m_nNumPoints = (icUInt32Number)nNumPoints;
 
-  icUInt32Number nSize = NumPoints() * m_nOutput;
-
-  if (!nSize)
+  // Use 64-bit math to catch overflows even when no nMaxSize was
+  // supplied (the earlier nMaxSize guard is skipped when nMaxSize==0,
+  // e.g. callers that don't pre-cap; multiplication in u32 then wraps
+  // and allocates a tiny buffer while downstream code addresses the
+  // full grid).
+  icUInt64Number nSize64 =
+      static_cast<icUInt64Number>(NumPoints()) *
+      static_cast<icUInt64Number>(m_nOutput);
+  if (nSize64 == 0 || nSize64 > 0xFFFFFFFFu)
     return false;
+  icUInt32Number nSize = static_cast<icUInt32Number>(nSize64);
 
   m_pData = new icFloatNumber[nSize];
 


### PR DESCRIPTION
# Widen `CIccCLUT::Init` size accounting to 64-bit when `nMaxSize == 0`

**Severity:** High · **File:** `IccProfLib/IccTagLut.cpp:1903`

## Summary

```cpp
icUInt32Number nSize = NumPoints() * m_nOutput;  // both u32
```

Both operands are `u32`; multiplication is performed in `u32`. The
code *does* have a 64-bit guard at line 1898 that rejects oversized
products — but only when `nMaxSize > 0`. When callers pass
`nMaxSize == 0`, the 64-bit guard is skipped, `m_nNumPoints =
(icUInt32Number)nNumPoints` silently truncates, and then `nSize =
truncated * m_nOutput` wraps. `new icFloatNumber[nSize]` allocates a
tiny buffer while `ReadData`/`Interp` address the full (truncated)
grid via pointer arithmetic.

`ValidateIccProfile` in wasm always passes non-zero `nMaxSize` from
internal callers, so icctools/iccflow are not exposed today — but the
overload is in the public SDK and any external caller using default
arguments trips it.

## Patch

```diff
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -1900,7 +1900,12 @@
-  icUInt32Number nSize = NumPoints() * m_nOutput;
+  // Use 64-bit math to catch overflows even when no nMaxSize is
+  // supplied (nMaxSize == 0 skips the earlier guard).
+  icUInt64Number nSize64 = static_cast<icUInt64Number>(NumPoints()) *
+                           static_cast<icUInt64Number>(m_nOutput);
+  if (nSize64 > UINT32_MAX) return false;
+  icUInt32Number nSize = static_cast<icUInt32Number>(nSize64);
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: call `Init` overload with `nMaxSize = 0` and dimensions
  that overflow `u32` — must return `false`.
- New unit: normal CLUT parse through `ValidateIccProfile` still
  succeeds.

## References

- CWE-190 Integer Overflow or Wraparound
