### PR TITLE
[IccProfLib] Widen CIccMpeMatrix::Read size arithmetic to 64-bit

### DIFF
--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -5143,8 +5143,25 @@ bool CIccMpeMatrix::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read16(&nOutputChannels))
     return false;
 
-  if (dataSize >= (icUInt32Number)nInputChannels * nOutputChannels * sizeof(icFloatNumber) &&
-      dataSize < ((icUInt32Number)nInputChannels+1) * nOutputChannels * sizeof(icFloatNumber)) {
+  // Widen bounds arithmetic to u64. A crafted tag with nInputChannels
+  // and/or nOutputChannels near 2^16 can otherwise wrap these u32
+  // products below, bypassing the size checks and letting SetSize
+  // attempt an 17 GB allocation. Also reject pathological channel
+  // counts early: iccMAX does not mandate a tight per-element cap,
+  // but 255 is already far beyond any legitimate profile.
+  static const icUInt16Number kMaxMatrixChannels = 255;
+  if (nInputChannels > kMaxMatrixChannels ||
+      nOutputChannels > kMaxMatrixChannels)
+    return false;
+
+  icUInt64Number matrixBytes =
+      static_cast<icUInt64Number>(nInputChannels) *
+      static_cast<icUInt64Number>(nOutputChannels) *
+      sizeof(icFloatNumber);
+  icUInt64Number constBytes =
+      static_cast<icUInt64Number>(nOutputChannels) * sizeof(icFloatNumber);
+
+  if (dataSize >= matrixBytes && dataSize < matrixBytes + constBytes) {
     //Matrix with no constants
     if (!SetSize(nInputChannels, nOutputChannels, false))
       return false;
@@ -5156,8 +5173,7 @@ bool CIccMpeMatrix::Read(icUInt32Number size, CIccIO *pIO)
     if (pIO->ReadFloat32Float(m_pMatrix, m_size) != m_size)
       return false;
   }
-  else if (dataSize < (icUInt32Number)nInputChannels * nOutputChannels *sizeof(icFloatNumber) &&
-           dataSize >= (icUInt32Number)nOutputChannels * sizeof(icFloatNumber)) {
+  else if (dataSize < matrixBytes && dataSize >= constBytes) {
     //Constants with no matrix
     if (!SetSize(0, nOutputChannels))
       return false;
@@ -5169,9 +5185,8 @@ bool CIccMpeMatrix::Read(icUInt32Number size, CIccIO *pIO)
       return false;
   }
   else {
-    if ((icUInt32Number)nInputChannels*nOutputChannels > dataSize ||
-        ((icUInt32Number)nInputChannels*nOutputChannels + nOutputChannels) > dataSize ||
-        ((icUInt32Number)nInputChannels*nOutputChannels + nOutputChannels) * sizeof(icFloat32Number) > dataSize)
+    if (matrixBytes > dataSize ||
+        matrixBytes + constBytes > dataSize)
       return false;
 
     //Matrix with constants


### PR DESCRIPTION
# Fix u32 overflow in `CIccMpeMatrix::Read` channel-count multiplication

**Severity:** High · **File:** `IccProfLib/IccMpeBasic.cpp:5146-5174`

## Summary

`CIccMpeMatrix::Read` validates the incoming tag body with a chain of
bounds checks that multiply `nInputChannels * nOutputChannels *
sizeof(icFloatNumber)` in 32-bit arithmetic. Both channel counts are
`icUInt16Number` with attacker-controlled values (no upper cap enforced
here — `IccTagLut.cpp:4092` does cap at 15 but MPE elements don't).

At `nInputChannels = nOutputChannels = 65535`:

- `(u32)65535 * 65535 = 0xFFFE0001` (fits in u32, just)
- `× sizeof(icFloatNumber) = 4` → `0x3FFF80004` → **wraps to `0x3FF80004`**.

The comparison `dataSize >= wrapped_value` then succeeds for small
`dataSize`, after which `SetSize(65535, 65535)` attempts to allocate
`m_size = 65535 * 65535 * 4 = ~17 GB` via `new icFloatNumber[m_size]`.

## Impact

- Native: `std::bad_alloc` on modest-memory systems, but sufficient swap
  can make this a read-past-end + corruption primitive.
- WASM: module abort at `MAXIMUM_MEMORY` limit (tab crash).

## Reproducer

iccMAX MPE element tag:

- `sig = icSigMatrixElemType`
- `nInputChannels = 0xFFFF`, `nOutputChannels = 0xFFFF`
- Any `dataSize` ≥ `0x3FF80004` (≈ 1 GB) satisfies the wrapped check.
  In practice an embedded `mpet` wrapper of just the declared header
  bytes is enough — the subsequent `ReadFloat32Float(m_pMatrix, m_size)`
  call can read short without tripping earlier code.

## Root cause

```cpp
// IccMpeBasic.cpp:5146-5147
if (dataSize >= (icUInt32Number)nInputChannels * nOutputChannels * sizeof(icFloatNumber) &&
    dataSize < ((icUInt32Number)nInputChannels+1) * nOutputChannels * sizeof(icFloatNumber)) {
```

The casts to `icUInt32Number` keep the arithmetic 32-bit. Similar
pattern repeats at lines 5159, 5172-5174, 5184.

## Patch

```diff
--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -5140,18 +5140,34 @@
   if (!pIO->Read16(&nInputChannels))
     return false;
 
   if (!pIO->Read16(&nOutputChannels))
     return false;
 
-  if (dataSize >= (icUInt32Number)nInputChannels * nOutputChannels * sizeof(icFloatNumber) &&
-      dataSize < ((icUInt32Number)nInputChannels+1) * nOutputChannels * sizeof(icFloatNumber)) {
+  // Reject pathological channel counts early — iccMAX does not mandate
+  // a tight upper bound per element, but 255 is the largest value any
+  // other module treats as legitimate, and even that's well beyond
+  // anything real-world.
+  static const icUInt16Number kMaxMatrixChannels = 255;
+  if (nInputChannels > kMaxMatrixChannels ||
+      nOutputChannels > kMaxMatrixChannels)
+    return false;
+
+  // Widen bounds arithmetic to u64. The product of two u16 channel
+  // counts × sizeof(icFloatNumber) can otherwise wrap u32 when either
+  // count is large.
+  icUInt64Number matrixBytes =
+      static_cast<icUInt64Number>(nInputChannels) *
+      static_cast<icUInt64Number>(nOutputChannels) *
+      sizeof(icFloatNumber);
+  icUInt64Number matrixPlusConstBytes = matrixBytes +
+      static_cast<icUInt64Number>(nOutputChannels) * sizeof(icFloatNumber);
+
+  if (dataSize >= matrixBytes && dataSize < matrixPlusConstBytes) {
     //Matrix with no constants
     if (!SetSize(nInputChannels, nOutputChannels, false))
       return false;
 
     if (!m_pMatrix)
       return false;
 
     //Read Matrix data
     if (pIO->ReadFloat32Float(m_pMatrix, m_size) != m_size)
       return false;
   }
-  else if (dataSize < (icUInt32Number)nInputChannels * nOutputChannels *sizeof(icFloatNumber) &&
-           dataSize >= (icUInt32Number)nOutputChannels * sizeof(icFloatNumber)) {
+  else if (dataSize < matrixBytes &&
+           dataSize >= static_cast<icUInt64Number>(nOutputChannels) * sizeof(icFloatNumber)) {
     //Constants with no matrix
     if (!SetSize(0, nOutputChannels))
       return false;
 
     m_nInputChannels = nInputChannels;
 
     //Read Constant data
     if (pIO->ReadFloat32Float(m_pConstants, m_nOutputChannels)!=m_nOutputChannels)
       return false;
   }
   else {
-    if ((icUInt32Number)nInputChannels*nOutputChannels > dataSize ||
-        ((icUInt32Number)nInputChannels*nOutputChannels + nOutputChannels) > dataSize ||
-        ((icUInt32Number)nInputChannels*nOutputChannels + nOutputChannels) * sizeof(icFloat32Number) > dataSize)
+    if (matrixBytes / sizeof(icFloatNumber) > dataSize ||
+        matrixPlusConstBytes / sizeof(icFloatNumber) > dataSize ||
+        matrixPlusConstBytes > dataSize)
       return false;
```

(Same u64-widening treatment applies further down in the file where the
matrix-with-constants branch continues.)

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: MPE matrix element with `nInputChannels = nOutputChannels =
  0xFFFF` must return `false` from `Read` without allocating.
- New unit: legitimately-sized matrix (e.g. 4×3) still parses.

## References

- CWE-190 Integer Overflow or Wraparound
- CWE-789 Memory Allocation with Excessive Size Value
