### PR TITLE
[IccProfLib] Validate LutAtoB Offset[] fields individually in 64-bit

### DIFF
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -4092,6 +4092,17 @@ bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
   if (m_nInput > 15 || m_nOutput > 15)
     return false;
 
+  // Every Offset[] field is attacker-controlled. Validate each in u64
+  // against `size` before the corresponding pIO->Seek(nStart + Offset[i])
+  // to prevent u32 wraparound (e.g. Offset[1] = 0xFFFFFFC0 + 48 == 0x10
+  // would previously pass the 32-bit check). Also ensure Offset[i] alone
+  // doesn't overflow when added to nStart; CIccMemIO's Seek clamps
+  // silently, producing a parser-confusion primitive when bypassed.
+  for (int oi = 0; oi < 5; ++oi) {
+    if (Offset[oi] && static_cast<icUInt64Number>(Offset[oi]) > size)
+      return false;
+  }
+
   //B Curves
   if (Offset[0]) {
     nCurves = IsInputB() ? m_nInput : m_nOutput;
@@ -4129,7 +4140,10 @@ bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
   if (Offset[1]) {
     icS15Fixed16Number tmp;
 
-    if (Offset[1] + 12*sizeof(icS15Fixed16Number) >size)
+    // 64-bit widened bounds check — the prior u32 addition wrapped
+    // when Offset[1] was close to 2^32.
+    if (static_cast<icUInt64Number>(Offset[1]) +
+        12u * sizeof(icS15Fixed16Number) > size)
       return false;
 
     m_Matrix = new CIccMatrix();


### PR DESCRIPTION
# Validate LutAtoBType offsets individually in 64-bit before Seek

**Severity:** High · **File:** `IccProfLib/IccTagLut.cpp:4096-4132`

## Summary

`CIccTagLutAtoBType::Read` checks one combined bound for Offset[1]:

```cpp
if (Offset[1] + 12*sizeof(icS15Fixed16Number) > size)    // line ~4124
```

This addition is in 32-bit arithmetic. `Offset[1] = 0xFFFFFFC0` wraps to
`0x10`, passes the check, then `pIO->Seek(nStart + Offset[1], ...)`
lands at a nonsense absolute position. `CIccMemIO::Seek` masks the
offset against `m_nSize` and returns quietly, so subsequent `Read*`
calls read whichever bytes happen to be at the clamped position — a
*parser-confusion* primitive where attacker-controlled bytes get
interpreted as curve/CLUT/matrix subtables.

Additionally the sibling offsets (`Offset[0]`, `Offset[2]`, `Offset[3]`,
`Offset[4]`) have **no** bounds check before their respective Seek
calls.

## Impact

- Silent misparse: subsequent tags get attacker-chosen content without
  an error signal.
- Combined with finding #1 or #5 this becomes a path to oversized
  allocations in the B/M/A-curve subtables.
- Not directly memory-unsafe on its own, but a reliable primitive for
  making well-intentioned downstream code parse attacker content.

## Reproducer

`mAB ` (`lutAtoBType`) tag with:
- `Offset[1] = 0xFFFFFFC0`, declares 12 curves worth of data.
- All other offsets pointing to legitimate-looking tables.
- After the Read returns true, the loaded object contains attacker-
  chosen curve data taken from wherever `(nStart + 0xFFFFFFC0) &
  m_nSize` landed.

## Root cause

32-bit arithmetic in bounds checks plus missing per-offset checks.

## Patch

```diff
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -4090,8 +4090,24 @@
+  // Helper: every Offset[] is attacker-controlled. Validate in u64.
+  auto offsetOk = [size](icUInt32Number off, icUInt64Number need) -> bool {
+    if (off == 0) return true;     // 0 = "not present" per spec
+    return static_cast<icUInt64Number>(off) + need <= size;
+  };
+
+  // Per-offset bounds (header sizes for each of the 5 subtables).
+  if (!offsetOk(Offset[0], /* B curves */ kMinBCurveBytes))  return false;
+  if (!offsetOk(Offset[1], 12u * sizeof(icS15Fixed16Number))) return false;
+  if (!offsetOk(Offset[2], /* M curves */ kMinMCurveBytes))  return false;
+  if (!offsetOk(Offset[3], /* CLUT hdr */ 20u))              return false;
+  if (!offsetOk(Offset[4], /* A curves */ kMinACurveBytes))  return false;
+
-  if (Offset[1] + 12*sizeof(icS15Fixed16Number) > size)
-    return false;
```

(Define `kMinBCurveBytes`, `kMinMCurveBytes`, `kMinACurveBytes` as the
minimum sizes for each subtable per ICC.1 §10.12.)

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: `Offset[1] = 0xFFFFFFC0` must cause `Read` to return `false`.
- New unit: each of `Offset[0..4] = 0xFFFFFFFF` must cause `Read` to
  return `false`.
- New unit: `Offset[i] = 0` (not-present case) must still succeed when
  the corresponding table is legitimately absent.

## References

- CWE-190 Integer Overflow or Wraparound
- CWE-823 Use of Out-of-range Pointer Offset
