### PR TITLE
[IccProfLib] Cap recursion depth in CIccCalculatorFunc::ApplySequence

### DIFF
--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -3699,8 +3699,14 @@ bool CIccCalculatorFunc::InitSelectOp(SIccCalcOp *ops, icUInt32Number nOps)
 * 
 * Return: 
 ******************************************************************************/
-bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32Number nOps, SIccCalcOp *ops) const
+bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32Number nOps, SIccCalcOp *ops, int nDepth) const
 {
+  // Cap recursion depth. A crafted Calc tag with nested if/else/select
+  // opcodes can otherwise exhaust the C++ stack (~30K frames on wasm's
+  // 1 MB default stack). 64 levels is well beyond any legitimate profile.
+  static const int kMaxCalcRecursionDepth = 64;
+  if (nDepth > kMaxCalcRecursionDepth)
+    return false;
   SIccCalcOp *op;
   SIccOpState os;
 
@@ -3736,7 +3742,7 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
           if (os.idx+1 + dataSize >= nOps)
             return false;
 
-          if (!ApplySequence(pApply, dataSize, &ops[os.idx+1]))
+          if (!ApplySequence(pApply, dataSize, &ops[os.idx+1], nDepth + 1))
             return false;
         }
         else {
@@ -3748,7 +3754,7 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
           if (newOpIndex + nNewOps > nOps)  // now add and test the real limit
             return false;
 
-          if (!ApplySequence(pApply, nNewOps, &ops[os.idx+1 + op->data.size]))
+          if (!ApplySequence(pApply, nNewOps, &ops[os.idx+1 + op->data.size], nDepth + 1))
             return false;
         }
         os.idx += op->data.size + ops[os.idx].data.size;
@@ -3761,7 +3767,7 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
           if (os.idx+dataSize >= nOps)
             return false;
 
-          if (!ApplySequence(pApply, op->data.size, &ops[os.idx+1]))
+          if (!ApplySequence(pApply, op->data.size, &ops[os.idx+1], nDepth + 1))
             return false;
         }
         os.idx+= op->data.size;
@@ -3801,7 +3807,7 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
           if ((nDefOff + dataSize) >= nOps)
             return false;
           
-          if (!ApplySequence(pApply, dataSize, &ops[offset]))
+          if (!ApplySequence(pApply, dataSize, &ops[offset], nDepth + 1))
             break;
         }
       }
@@ -3821,7 +3827,7 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
         if (offset >= nOps)
           return false;
         
-        if (!ApplySequence(pApply, dataSize, &ops[offset]))
+        if (!ApplySequence(pApply, dataSize, &ops[offset], nDepth + 1))
           break;
       }
 

--- a/IccProfLib/IccMpeCalc.h
+++ b/IccProfLib/IccMpeCalc.h
@@ -412,7 +412,7 @@ protected:
   void InsertBlanks(std::string &sDescription, int nBlanks);
   void DescribeSequence(std::string &sDescription,
                         icUInt32Number nOps, SIccCalcOp *op, int nBlanks);
-  bool ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32Number nOps, SIccCalcOp *op) const;
+  bool ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32Number nOps, SIccCalcOp *op, int nDepth = 0) const;
 
   const char *ParseFuncDef(const char *szFuncDef, CIccCalcOpList &m_list, std::string &sReport);
 


### PR DESCRIPTION
# Add recursion-depth cap to `CIccCalculatorFunc::ApplySequence`

**Severity:** High · **File:** `IccProfLib/IccMpeCalc.cpp:3702-3824`

## Summary

`CIccCalculatorFunc::ApplySequence` recurses every time it encounters a
nested control-flow opcode (`icSigIfOp`, `icSigElseOp`, `icSigSelectOp`,
etc.). There is no depth counter and no stack-usage guard. A crafted
iccMAX profile with a deeply nested Calc tag blows the C++ call stack.

This is a *shape* bug, not a *size* bug — the file size needed to trigger
it is small. A Calc body of a few kilobytes can produce hundreds of
thousands of recursive frames. This is what slips past allocation caps.

## Impact

- Native: stack overflow → SIGSEGV / process crash. The exact depth
  depends on thread stack size (typically 8 MB on Linux, 1 MB on
  Windows).
- WASM (my apps): the Emscripten default stack is 1 MB (smaller in
  some configurations); I've seen abort within ~30 K frames. A
  drop-a-profile → kill-tab primitive that our input-size caps don't
  cover.
- Also reachable from CMM `Apply` paths, i.e. any code path that runs a
  profile chain containing a malicious Calc tag against real pixels.

## Reproducer

Minimal hand-crafted Calc body:

- Declare one calculator function.
- Its op sequence: nested `icSigIfOp { icSigIfOp { icSigIfOp { ... }}}`
  to depth N. Each `if` is ~12 bytes → a 1-MB Calc tag reaches N ≈ 80 K.
- Drop into `iccflow` as the source or destination profile; run Process.

## Root cause

The relevant recursion sites (paraphrased; see lines 3702-3824):

```cpp
icStatusCMM CIccCalculatorFunc::ApplySequence(...) {
  switch (op) {
    case icSigIfOp:
      stat = ApplySequence(..., thenBranch);  // no depth guard
      if (stat) return stat;
      if (elseBranch)
        stat = ApplySequence(..., elseBranch);
      break;
    case icSigSelectOp:
      for (case in cases)
        stat = ApplySequence(..., case);      // no depth guard
      break;
    ...
  }
}
```

## Patch

```diff
--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -X,Y +X,Y @@
+// Recursion-depth cap for nested Calc control flow. A crafted profile
+// with nested ifOp/selectOp bodies can otherwise exhaust the C++ stack
+// (~30 K frames on wasm, ~250 K on Linux). 64 levels is more than any
+// legitimate profile needs.
+static const int kMaxCalcRecursionDepth = 64;
+
 icStatusCMM CIccCalculatorFunc::ApplySequence(CIccApplyMpe *pApply,
                                               icFloatNumber *pDestPixel,
                                               icFloatNumber *pSrcPixel,
                                               SIccOpSeq &opseq)
+{
+  return ApplySequence(pApply, pDestPixel, pSrcPixel, opseq, 0);
+}
+
+icStatusCMM CIccCalculatorFunc::ApplySequence(CIccApplyMpe *pApply,
+                                              icFloatNumber *pDestPixel,
+                                              icFloatNumber *pSrcPixel,
+                                              SIccOpSeq &opseq,
+                                              int nDepth)
 {
+  if (nDepth > kMaxCalcRecursionDepth)
+    return icCmmStatInvalidProfile;
   // ... original body, but every recursive call site passes nDepth+1:
-  stat = ApplySequence(pApply, pDestPixel, pSrcPixel, thenBranch);
+  stat = ApplySequence(pApply, pDestPixel, pSrcPixel, thenBranch, nDepth + 1);
   ...
```

(The header `IccMpeCalc.h` needs the matching overload declaration.)

Alternative low-touch fix: convert the recursion to an explicit
`std::stack<SIccOpSeq*>` worklist. More invasive but eliminates the
depth question entirely. Recommended as a follow-up PR.

## Test plan

- Regression: `Testing/RunTests.sh` — including all Calc-related tests.
- New unit: build a profile with `nDepth = kMaxCalcRecursionDepth + 1`
  levels of nested ifOp; `Apply` returns a non-success status, no crash.
- New unit: a legitimately-nested profile with `nDepth = 10` must still
  evaluate correctly.
- Fuzz: feed random byte strings through `CIccTagMPE::Read` then
  `Apply` against a 3-channel pixel; no SIGSEGV on any input.

## References

- CWE-674 Uncontrolled Recursion
- CWE-400 Uncontrolled Resource Consumption
