### PR TITLE
[IccLibJSON] Gate CIccMpeJsonCalculator::ParseImport file loads behind opt-in flag

### DIFF
--- a/IccJSON/IccLibJSON/IccJsonConfig.h
+++ b/IccJSON/IccLibJSON/IccJsonConfig.h
@@ -74,4 +74,10 @@ typedef enum {
 #define icJsonFloatFmt  "%.12f"
 #define icJsonDoubleFmt "%.24lf"
 
+// Library-wide flag: permit `"imports": [{"file": "..."}]` and similar
+// file-loader paths in IccLibJSON. Off by default because the JSON is
+// usually attacker-controlled in library/service/WASM contexts. The
+// iccFromJson CLI tool flips this on after argument parsing.
+extern bool g_IccJsonAllowFileImports;
+
 #endif // _ICCJSONCONFIG_H

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1588,6 +1588,21 @@ bool CIccMpeJsonCalculator::ParseImport(const IccJson &j, std::string importPath
         parseStr += "Missing file in import entry\n";
         return false;
       }
+      // File-based imports are useful for the iccFromJson CLI but
+      // dangerous when IccLibJSON is embedded in a library/service/WASM
+      // context where the JSON input is attacker-controlled. Gate them
+      // behind an opt-in (see IccJsonConfig.h), and reject anything
+      // that looks like a path escape even when allowed.
+      if (!g_IccJsonAllowFileImports) {
+        parseStr += "File imports disabled; ignored '" + file + "'\n";
+        continue;
+      }
+      if (file.find('/')  != std::string::npos ||
+          file.find('\\') != std::string::npos ||
+          file.find("..") != std::string::npos) {
+        parseStr += "Unsafe import path '" + file + "'\n";
+        return false;
+      }
       std::string look = "*" + file + "*";
       if (strstr(importPath.c_str(), look.c_str()))
         continue;  // Already imported -- skip

--- a/IccJSON/IccLibJSON/IccUtilJson.cpp
+++ b/IccJSON/IccLibJSON/IccUtilJson.cpp
@@ -65,6 +65,11 @@
 #include <sstream>
 #include <iomanip>
 
+// Library-wide flag: off by default (library/service/WASM contexts).
+// The iccFromJson CLI tool sets this to true after argument parsing so
+// file-based `"imports"` and `"file"` directives work in that context.
+bool g_IccJsonAllowFileImports = false;
+
 // Safely narrow size_t to icUInt32Number; returns 0 on truncation
 static inline icUInt32Number icJsonSafeU32(size_t n)
 {


### PR DESCRIPTION
# Gate `CIccMpeJsonCalculator::ParseImport` file loads behind an opt-in flag

**Severity:** High · **File:** `IccJSON/IccLibJSON/IccMpeJson.cpp:1579-1612`

## Summary

The calculator-element JSON supports an `"imports":[{"file":"..."}]`
array. `ParseImport` opens each path verbatim via
`std::ifstream ifs(file); ifs >> jImport;`. Absolute paths, `../`
traversal, and any path the process can read are accepted.

On native CLI tools (`iccFromJson`) this is a direct local file
disclosure for any target path the process can open. On WASM (icctools)
MEMFS is narrow so practical leakage is bounded, but:

- The implementation's recursion limiter is a substring match on
  `importPath` that's trivially defeated (`"file":"a"` then `"file":"./a"`).
- Nothing prevents probing for which paths exist (side-channel).
- Embedders that add more files to MEMFS (future features, plugins)
  expose more surface.

## Impact

- **Native (CLI)**: file read primitive. `iccFromJson` can be weaponised
  into a tiny file-exfiltration tool against anything readable by its
  uid.
- **WASM (icctools)**: bounded but present. Attacker can enumerate
  MEMFS.
- **Library users generally**: any consumer using IccLibJSON in a
  service context (ICC-profile validation endpoint) exposes local
  filesystem.

## Reproducer

```json
{"IccProfile":{"Tags":[{"AToB0Tag":{"data":{"type":"mpet",
  "subElements":[{"type":"CalculatorElement",
    "imports":[{"file":"/etc/passwd"}]}]}}}]}}
```

`ParseImport` opens `/etc/passwd`, parses it as JSON (fails — but the
open itself is the primitive; an attacker with a compliant JSON
symlink target gets the contents merged into the calculator import
set).

## Patch

```diff
--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1570,8 +1570,20 @@
 static bool ParseImport(const IccJson &jImport, ImportedElementMap &imports,
                         std::string &importPath, int &nDepth)
 {
-  std::string file;
-  if (jImport.contains("file") && jImport["file"].is_string()) {
+  // File-based imports are a command-line ergonomic, not something we
+  // accept from arbitrary attacker-supplied JSON. Require an opt-in
+  // flag set by the host; reject path-separators/traversal outright.
+  if (!g_IccJsonAllowFileImports) {
+    // Silently ignore — or return false, per caller preference
+    return true;
+  }
+  std::string file;
+  if (jImport.contains("file") && jImport["file"].is_string()) {
     file = jImport["file"].get<std::string>();
+    // Path sanitisation: reject anything that isn't a plain filename.
+    if (file.find('/')  != std::string::npos ||
+        file.find('\\') != std::string::npos ||
+        file.find("..") != std::string::npos ||
+        (file.size() > 1 && file[1] == ':'))
+      return false;
   }
```

Declare `g_IccJsonAllowFileImports` in `IccJsonConfig.h` defaulting
`false`; the CLI tool (`iccFromJson.cpp`) flips it to `true` after
argument parsing. Library embedders like icctools leave it `false`.

Additionally, replace the substring-match depth limiter with an
explicit counter and hard cap (8 levels, matching the recursion
depth for the same reasons as #04/#14):

```diff
-  if (importPath.find(file) != std::string::npos) return false;
-  importPath += file;
+  if (nDepth >= g_IccJsonMaxImportDepth) return false;
+  nDepth++;
```

## Test plan

- Regression: `Testing/RunJsonTests.sh` (CLI `iccFromJson` paths set
  the flag; library tests leave it off).
- New unit: library default + JSON with `"file":"/etc/passwd"` — must
  be silently dropped or return false; no file open attempted.
- New unit: CLI with the flag on + JSON with `"file":"../../../etc"` —
  must be rejected by path sanitisation.

## References

- CWE-22 Improper Limitation of a Pathname to a Restricted Directory
- CWE-73 External Control of File Name or Path
