### PR TITLE
[IccLibJSON] Gate icCLUTFromJson file loader + cap read size

### DIFF
--- a/IccJSON/IccLibJSON/IccJsonConfig.h
+++ b/IccJSON/IccLibJSON/IccJsonConfig.h
@@ -74,4 +74,10 @@ typedef enum {
 #define icJsonFloatFmt  "%.12f"
 #define icJsonDoubleFmt "%.24lf"
 
+// Library-wide flag: permit `"imports": [{"file": "..."}]` and similar
+// file-loader paths in IccLibJSON. Off by default because the JSON is
+// usually attacker-controlled in library/service/WASM contexts. The
+// iccFromJson CLI tool flips this on after argument parsing.
+extern bool g_IccJsonAllowFileImports;
+
 #endif // _ICCJSONCONFIG_H

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1588,6 +1588,21 @@ bool CIccMpeJsonCalculator::ParseImport(const IccJson &j, std::string importPath
         parseStr += "Missing file in import entry\n";
         return false;
       }
+      // File-based imports are useful for the iccFromJson CLI but
+      // dangerous when IccLibJSON is embedded in a library/service/WASM
+      // context where the JSON input is attacker-controlled. Gate them
+      // behind an opt-in (see IccJsonConfig.h), and reject anything
+      // that looks like a path escape even when allowed.
+      if (!g_IccJsonAllowFileImports) {
+        parseStr += "File imports disabled; ignored '" + file + "'\n";
+        continue;
+      }
+      if (file.find('/')  != std::string::npos ||
+          file.find('\\') != std::string::npos ||
+          file.find("..") != std::string::npos) {
+        parseStr += "Unsafe import path '" + file + "'\n";
+        return false;
+      }
       std::string look = "*" + file + "*";
       if (strstr(importPath.c_str(), look.c_str()))
         continue;  // Already imported -- skip

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -1763,6 +1763,21 @@ CIccCLUT *icCLUTFromJson(const IccJson &j, int nIn, int nOut,
   // -----------------------------------------------------------------------
   if (jsonExistsField(j, "file") && j["file"].is_string()) {
     std::string filename = j["file"].get<std::string>();
+
+    // Same gate as CIccMpeJsonCalculator::ParseImport: file-based loads
+    // are opt-in. In library/service/WASM contexts, JSON input is
+    // attacker-controlled and arbitrary file paths must be refused.
+    if (!g_IccJsonAllowFileImports) {
+      parseStr += "File loaders disabled; ignored CLUT file '" + filename + "'\n";
+      delete pCLUT; return nullptr;
+    }
+    if (filename.find('/')  != std::string::npos ||
+        filename.find('\\') != std::string::npos ||
+        filename.find("..") != std::string::npos) {
+      parseStr += "Unsafe CLUT file path '" + filename + "'\n";
+      delete pCLUT; return nullptr;
+    }
+
     std::string format   = "text";
     std::string encoding;
     std::string endian   = "big";
@@ -1780,6 +1795,13 @@ CIccCLUT *icCLUTFromJson(const IccJson &j, int nIn, int nOut,
     if (!file) {
       parseStr += "Error! - File '" + filename + "' not found.\n";
       delete pCLUT; return nullptr;
+    }
+
+    // Size cap so a multi-GB file doesn't OOM the library.
+    static const size_t kMaxClutFileBytes = 64ULL * 1024 * 1024;
+    if (file->GetLength() > kMaxClutFileBytes) {
+      parseStr += "CLUT file '" + filename + "' exceeds 64 MB limit\n";
+      delete file; delete pCLUT; return nullptr;
     }
 
     bool ok = false;

--- a/IccJSON/IccLibJSON/IccUtilJson.cpp
+++ b/IccJSON/IccLibJSON/IccUtilJson.cpp
@@ -65,6 +65,11 @@
 #include <sstream>
 #include <iomanip>
 
+// Library-wide flag: off by default (library/service/WASM contexts).
+// The iccFromJson CLI tool sets this to true after argument parsing so
+// file-based `"imports"` and `"file"` directives work in that context.
+bool g_IccJsonAllowFileImports = false;
+
 // Safely narrow size_t to icUInt32Number; returns 0 on truncation
 static inline icUInt32Number icJsonSafeU32(size_t n)
 {


### PR DESCRIPTION
# Gate `icCLUTFromJson` file loader + cap read size

**Severity:** High · **File:** `IccJSON/IccLibJSON/IccTagJson.cpp:1764-1884`

## Summary

`icCLUTFromJson` accepts `"clut": {"file": "...", "format": "binary|text"}`
and opens the named path via `IccJsonOpenFileIO(filename, "rb")`. Same
class of bug as PR #24 — arbitrary path, no sandbox, attacker can
redirect to any readable file.

Additional failure mode specific to this site: for `"format":"text"`
the code does `malloc(num + 1)` where `num = file->GetLength()`. A
path pointing at a multi-GB file on native (or `/dev/zero` on Linux)
either kills the process on OOM or hangs it on the read loop. The
malloc return *is* checked, but the attacker chooses the file; on a
native CLI an instant OOM-kill is a trivial DoS.

## Impact

- Native: file-disclosure primitive + OOM DoS.
- WASM (icctools): bounded by MEMFS contents, but the OOM path still
  applies if a large file is ever mounted.

## Patch

```diff
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -1760,10 +1760,23 @@
 static bool icCLUTFromJson(CIccCLUT *pCLUT, const IccJson &jCLUT, ...)
 {
+  // External-file reads are opt-in; mirror the `imports` gate from
+  // CIccMpeJsonCalculator::ParseImport (PR #24).
+  if (jCLUT.contains("file") && !g_IccJsonAllowFileImports) {
+    return false;
+  }
+
   if (jCLUT.contains("file") && jCLUT["file"].is_string()) {
     std::string filename = jCLUT["file"].get<std::string>();
+    if (filename.find('/') != std::string::npos ||
+        filename.find('\\') != std::string::npos ||
+        filename.find("..") != std::string::npos) {
+      return false;
+    }
     auto file = IccJsonOpenFileIO(filename.c_str(), "rb");
     if (!file) return false;
 
+    static const icUInt64Number kMaxClutFileBytes = 64ULL * 1024 * 1024;  // 64 MB
+    if (file->GetLength() > kMaxClutFileBytes) return false;
+
     icUInt32Number num = file->GetLength();
     // ... existing branches using `num`
   }
```

## Test plan

- Regression: `Testing/RunJsonTests.sh` with the CLI flag set.
- New unit: library default + JSON with `"file":"/etc/passwd"` —
  rejected, no file opened.
- New unit: flag on + 100 MB file — rejected by size cap.

## References

- CWE-22 Path Traversal · CWE-789 Memory Allocation with Excessive Size
