### PR TITLE
[IccLibJSON] Cap embedded-profile JSON nesting depth

### DIFF
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -2821,8 +2821,31 @@ bool CIccTagJsonEmbeddedProfile::ToJson(IccJson &j)
   return pProfile->ToJson(j["IccProfile"]);
 }
 
+// Guard against attacker-crafted JSON that nests <IccProfile>-in-embedded-
+// tag arbitrarily deep. The recursion path goes
+//   CIccProfileJson::ParseJson -> tag loop -> CIccTagJsonEmbeddedProfile::
+//   ParseJson -> CIccProfileJson::ParseJson -> ...
+// One C++ stack frame per level; Emscripten's ~1 MB stack aborts around
+// 500-2000 levels.
+namespace {
+  static thread_local int s_jsonEmbeddedDepth = 0;
+  static const int kMaxJsonEmbeddedDepth = 8;
+
+  struct JsonEmbedDepthGuard {
+    JsonEmbedDepthGuard()  { ++s_jsonEmbeddedDepth; }
+    ~JsonEmbedDepthGuard() { --s_jsonEmbeddedDepth; }
+    bool TooDeep() const { return s_jsonEmbeddedDepth > kMaxJsonEmbeddedDepth; }
+  };
+}
+
 bool CIccTagJsonEmbeddedProfile::ParseJson(const IccJson &j, std::string &parseStr)
 {
+  JsonEmbedDepthGuard depthGuard;
+  if (depthGuard.TooDeep()) {
+    parseStr += "Embedded profile nesting exceeds 8 levels\n";
+    return false;
+  }
+
   if (!j.contains("IccProfile") || !j["IccProfile"].is_object()) {
     parseStr += "Cannot find IccProfile in embedded profile tag\n";
     return false;


### PR DESCRIPTION
# Cap recursion depth across IccLibJSON parsers

**Severity:** High · **Files:** `IccTagJson.cpp:2824` (embedded profile); `IccMpeJson.cpp:1716-1777` (calculator sub-elements); `IccMpeJson.cpp:415` (sampled calculator curve)

## Summary

Three recursion sites in the JSON parser have no depth cap:

1. `CIccTagJsonEmbeddedProfile::ParseJson` calls
   `CIccProfileJson::ParseJson`, which iterates tags, which can
   contain another embedded profile, etc. Same shape as PR #14 but
   reached via JSON.
2. `CIccMpeJsonCalculator::ParseImport` iterates sub-elements, each of
   which may be a `CalculatorElement` with its own `subElements`.
3. `SampledCalculatorCurve` → embedded `Calculator` → `subElements` →
   `SampledCalculatorCurve` → …

With Emscripten's ~1 MB stack, ~500-2000 nesting levels blow the stack.
A few-KB JSON is enough.

## Reproducer

```json
{"IccProfile":{"Tags":[{"AToB0Tag":{"data":{"type":"mpet",
  "subElements":[{"type":"CalculatorElement",
    "inputChannels":1,"outputChannels":1,"mainFunction":"if(...)",
    "subElements":[...  /* 2000 levels deep */ ...]}]}}}]}}
```

## Patch

Introduce a single depth counter threaded through all JSON parse
entry points. Reject above 32.

```diff
--- a/IccJSON/IccLibJSON/IccProfileJson.h
+++ b/IccJSON/IccLibJSON/IccProfileJson.h
@@ ...
+  static const int kMaxJsonParseDepth = 32;
+
   virtual bool ParseJson(const IccJson &j, std::string &parseStr);
+  virtual bool ParseJson(const IccJson &j, std::string &parseStr, int nDepth);
```

Thread `nDepth` through every `ParseTag` → sub-element parser →
nested `ParseJson` chain. Bail `if (nDepth > kMaxJsonParseDepth)`.
Mirror the approach proposed in PR #04 (Calc recursion) and #14
(embedded profiles).

## Test plan

- Regression: `Testing/RunJsonTests.sh`.
- New unit: JSON nested to depth 33 — returns `false`.
- New unit: JSON nested to depth 10 — parses correctly.
- Fuzz: random nesting generator, no SIGSEGV / abort on any input.

## References

- CWE-674 Uncontrolled Recursion
