### PR TITLE
[IccLibXML] Drop XML_PARSE_HUGE, refuse entity substitution

### DIFF
--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2461,8 +2461,11 @@ bool CIccMpeXmlCalculator::ParseImport(xmlNode *pNode, std::string importPath, s
               continue;
             }
 
-            /*parse the file and get the DOM */
-            doc = xmlReadFile(file.c_str(), NULL, XML_PARSE_HUGE | XML_PARSE_NONET);
+            /* Parse the file and get the DOM. See IccProfileXml.cpp for
+             * the rationale for dropping XML_PARSE_HUGE and adding
+             * XML_PARSE_NOENT — matches the main LoadXml entry point.
+             */
+            doc = xmlReadFile(file.c_str(), NULL, XML_PARSE_NONET | XML_PARSE_NOENT);
 
             if (doc == NULL) {
               parseStr += "Unable to import '";

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -874,8 +874,16 @@ bool CIccProfileXml::LoadXml(const char *szFilename, const char *szRelaxNGDir, s
   xmlDoc *doc = NULL;
   xmlNode *root_element = NULL;
 
-  /*parse the file and get the DOM */
-  doc = xmlReadFile(szFilename, NULL, XML_PARSE_HUGE | XML_PARSE_NONET);
+  /* Parse the file and get the DOM.
+   *
+   * Drop XML_PARSE_HUGE: it disables libxml2's depth cap, name-length
+   * cap, text-length cap, and the billion-laughs entity-expansion guard
+   * — all of which protect against crafted inputs. Keep XML_PARSE_NONET
+   * (no network) and add XML_PARSE_NOENT (refuse entity substitution)
+   * and XML_PARSE_DTDLOAD=false (don't pull in external DTDs). ICC
+   * profiles never use DTD entities legitimately.
+   */
+  doc = xmlReadFile(szFilename, NULL, XML_PARSE_NONET | XML_PARSE_NOENT);
 
   if (doc == NULL) 
     return false;


### PR DESCRIPTION
# Remove `XML_PARSE_HUGE` and add `xmlCtxtSetMaxAmplification`

**Severity:** High · **Files:** `IccXML/IccLibXML/IccProfileXml.cpp:878`; `IccXML/IccLibXML/IccMpeXml.cpp:2417`

## Summary

Both `xmlReadFile` call sites pass `XML_PARSE_HUGE | XML_PARSE_NONET`.
`XML_PARSE_HUGE` explicitly disables:

- max element-depth check
- max name length
- max text length
- **the entity-expansion-limit billion-laughs guard**

A tiny crafted XML with nested general entities produces gigabytes of
expansion before parsing completes — classic billion-laughs DoS.

Neither site passes `XML_PARSE_NOENT` to disable entity substitution
outright, nor blocks DTD loading. External DTDs can be fetched over
the network if network calls are enabled (they're blocked here via
`XML_PARSE_NONET`, but the library shouldn't be one misconfiguration
away from that surface).

For icctools specifically, the vendored libxml2 v2.12.6 supports
`xmlCtxtSetMaxAmplification` (2.9.11+) which is a finer-grained
replacement.

## Reproducer

```xml
<?xml version="1.0"?>
<!DOCTYPE IccProfile [
  <!ENTITY lol "lol">
  <!ENTITY lol2 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
  <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
  ...
]>
<IccProfile>
  <ProfileDescription>&lol9;</ProfileDescription>
</IccProfile>
```

10 nesting levels → billion characters of expansion.

## Patch

```diff
--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -876,8 +876,18 @@
-  xmlDocPtr doc = xmlReadFile(szFilename, NULL,
-                              XML_PARSE_HUGE | XML_PARSE_NONET);
+  xmlParserCtxtPtr ctxt = xmlNewParserCtxt();
+  if (!ctxt) return false;
+
+  // Bound entity-expansion amplification (DoS guard). Default is 5 ×
+  // since libxml2 2.9.11; tighten to a stricter factor for ICC XML
+  // which never legitimately uses entities.
+  xmlCtxtSetMaxAmplification(ctxt, 5);
+
+  xmlDocPtr doc = xmlCtxtReadFile(
+      ctxt, szFilename, NULL,
+      XML_PARSE_NONET | XML_PARSE_NOENT | XML_PARSE_DTDLOAD | XML_PARSE_NOXINCNODE);
+  xmlFreeParserCtxt(ctxt);
```

Same treatment at `IccMpeXml.cpp:2417`. Drop `XML_PARSE_HUGE` at
both sites.

For builds against libxml2 < 2.9.11, add a compile-time fallback
that keeps the default limits (which is still much safer than
`XML_PARSE_HUGE`).

## Test plan

- Regression: `Testing/RunXmlTests.sh`.
- New unit: billion-laughs XML file — `LoadXml` returns `false` (or
  produces a bounded-size tree); no multi-minute hang.
- New unit: XML with a 10-level element depth — parses cleanly.

## Consumer-side note

icctools' wasm wrapper (`xml-wrapper.cpp`) calls `LoadXml(srcPath, "", ...)`.
It already passes an empty RelaxNG path to skip schema validation.
Once this patch lands, no action is needed on our side — the parser
safety limits kick in automatically.

## References

- CWE-776 Improper Restriction of Recursive Entity References ("XEE")
- CWE-400 Uncontrolled Resource Consumption
