### PR TITLE
[IccLibXML] Gate File=/Filename= attribute loaders behind opt-in flag

### DIFF
--- a/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
+++ b/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
@@ -9,6 +9,7 @@
 #include "IccUtil.h"
 #include "IccProfLibVer.h"
 #include "IccLibXMLVer.h"
+#include "IccXmlConfig.h"
 #include <cstring> /* C strings strcpy, memcpy ... */
 
 int main(int argc, char* argv[])
@@ -18,6 +19,12 @@ int main(int argc, char* argv[])
     printf("Usage: IccFromXml xml_file saved_profile_file {-noid -v{=[relax_ng_schema_file - optional]}}\n");
     return 0;
   }
+
+  // Profile XML on the CLI tool's filesystem is trusted by the invoking
+  // user (same trust boundary as the XML file itself), so opt in to
+  // <tag File="..."/> / <tag Filename="..."/> loaders. Library/WASM
+  // callers leave the flag at its default-off state.
+  IccXmlSetAllowFileIncludes(true);
 
   CIccTagCreator::PushFactory(new CIccTagXmlFactory());
   CIccMpeCreator::PushFactory(new CIccMpeXmlFactory());

--- a/IccXML/IccLibXML/IccIoXml.cpp
+++ b/IccXML/IccLibXML/IccIoXml.cpp
@@ -61,7 +61,9 @@ Copyright:  (c) see ICC Software License
  * 
  */
 
+#include <cstring>
 #include "IccIoXml.h"
+#include "IccXmlConfig.h"
 
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
@@ -109,6 +111,39 @@ CIccIO* IccOpenFileIO(const icChar *szFilename, const char *szAttr)
 void IccSetOpenFileIO(IIccOpenFileIO *pOpenIO)
 {
   g_pIccFileIO = pOpenIO;
+}
+
+// Library-wide flag. Default off; iccFromXml sets it on after argv parse.
+// Hidden file-scope global accessed via exported accessors (see
+// IccXmlConfig.h) so the DLL interface works on Windows MSVC where
+// WINDOWS_EXPORT_ALL_SYMBOLS does not export data symbols.
+static bool g_IccXmlAllowFileIncludes = false;
+
+void IccXmlSetAllowFileIncludes(bool allow) { g_IccXmlAllowFileIncludes = allow; }
+bool IccXmlGetAllowFileIncludes() { return g_IccXmlAllowFileIncludes; }
+
+CIccIO* IccXmlSafeOpenFileIO(const icChar *szFilename, const char *szAttr)
+{
+  if (!g_IccXmlAllowFileIncludes) return NULL;
+  if (!szFilename || !szFilename[0]) return NULL;
+
+  // Reject absolute paths: POSIX "/foo", Windows "\foo" or "C:\foo".
+  if (szFilename[0] == '/' || szFilename[0] == '\\') return NULL;
+  if (szFilename[1] == ':') return NULL;
+
+  // Reject any ".." path component (prevents traversal across a leading
+  // "../", a middle "/../", and a trailing "/.."; also the bare "..").
+  for (const char *p = szFilename; *p; ) {
+    if (p[0] == '.' && p[1] == '.' &&
+        (p[2] == '\0' || p[2] == '/' || p[2] == '\\')) {
+      if (p == szFilename) return NULL;
+      char prev = p[-1];
+      if (prev == '/' || prev == '\\') return NULL;
+    }
+    ++p;
+  }
+
+  return IccOpenFileIO(szFilename, szAttr);
 }
 
 //////////////////////////////////////////////////////////////////////

--- a/IccXML/IccLibXML/IccIoXml.cpp
+++ b/IccXML/IccLibXML/IccIoXml.cpp
@@ -61,7 +61,6 @@ Copyright:  (c) see ICC Software License
  * 
  */
 
-#include <cstring>
 #include "IccIoXml.h"
 #include "IccXmlConfig.h"
 
@@ -122,27 +121,33 @@ static bool g_IccXmlAllowFileIncludes = false;
 void IccXmlSetAllowFileIncludes(bool allow) { g_IccXmlAllowFileIncludes = allow; }
 bool IccXmlGetAllowFileIncludes() { return g_IccXmlAllowFileIncludes; }
 
-CIccIO* IccXmlSafeOpenFileIO(const icChar *szFilename, const char *szAttr)
+bool IccXmlIsPathSafe(const icChar *szFilename)
 {
-  if (!g_IccXmlAllowFileIncludes) return NULL;
-  if (!szFilename || !szFilename[0]) return NULL;
+  if (!szFilename || !szFilename[0]) return false;
 
   // Reject absolute paths: POSIX "/foo", Windows "\foo" or "C:\foo".
-  if (szFilename[0] == '/' || szFilename[0] == '\\') return NULL;
-  if (szFilename[1] == ':') return NULL;
+  if (szFilename[0] == '/' || szFilename[0] == '\\') return false;
+  if (szFilename[1] == ':') return false;
 
   // Reject any ".." path component (prevents traversal across a leading
   // "../", a middle "/../", and a trailing "/.."; also the bare "..").
   for (const char *p = szFilename; *p; ) {
     if (p[0] == '.' && p[1] == '.' &&
         (p[2] == '\0' || p[2] == '/' || p[2] == '\\')) {
-      if (p == szFilename) return NULL;
+      if (p == szFilename) return false;
       char prev = p[-1];
-      if (prev == '/' || prev == '\\') return NULL;
+      if (prev == '/' || prev == '\\') return false;
     }
     ++p;
   }
 
+  return true;
+}
+
+CIccIO* IccXmlSafeOpenFileIO(const icChar *szFilename, const char *szAttr)
+{
+  if (!g_IccXmlAllowFileIncludes) return NULL;
+  if (!IccXmlIsPathSafe(szFilename)) return NULL;
   return IccOpenFileIO(szFilename, szAttr);
 }
 

--- a/IccXML/IccLibXML/IccIoXml.h
+++ b/IccXML/IccLibXML/IccIoXml.h
@@ -108,10 +108,12 @@ public:
 ICCPROFLIB_API void IccSetOpenFileIO(IIccOpenFileIO *pOpenIO);
 ICCPROFLIB_API CIccIO* IccOpenFileIO(const icChar *szFilename, const char *szAttr);
 
-// Safe wrapper: gated on g_IccXmlAllowFileIncludes (default false) and
-// refuses attacker-ish paths containing '/', '\', or '..'. All
-// ParseXml callers that open a user-supplied filename should use this
-// instead of IccOpenFileIO directly.
+// Safe wrapper: gated on IccXmlGetAllowFileIncludes() (default false).
+// Rejects absolute paths (leading '/' or '\'), Windows drive-prefixed
+// paths (second char ':'), and paths with '..' traversal components.
+// All ParseXml callers that open a user-supplied filename should use
+// this instead of IccOpenFileIO directly.
+ICCPROFLIB_API bool    IccXmlIsPathSafe(const icChar *szFilename);
 ICCPROFLIB_API CIccIO* IccXmlSafeOpenFileIO(const icChar *szFilename, const char *szAttr);
 
 #ifdef USEICCDEVNAMESPACE

--- a/IccXML/IccLibXML/IccIoXml.h
+++ b/IccXML/IccLibXML/IccIoXml.h
@@ -108,6 +108,12 @@ public:
 ICCPROFLIB_API void IccSetOpenFileIO(IIccOpenFileIO *pOpenIO);
 ICCPROFLIB_API CIccIO* IccOpenFileIO(const icChar *szFilename, const char *szAttr);
 
+// Safe wrapper: gated on g_IccXmlAllowFileIncludes (default false) and
+// refuses attacker-ish paths containing '/', '\', or '..'. All
+// ParseXml callers that open a user-supplied filename should use this
+// instead of IccOpenFileIO directly.
+ICCPROFLIB_API CIccIO* IccXmlSafeOpenFileIO(const icChar *szFilename, const char *szAttr);
+
 #ifdef USEICCDEVNAMESPACE
 } //namespace iccDEV
 #endif

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -301,7 +301,7 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   // file exists
   if (filename[0]) {
-    CIccIO *file = IccOpenFileIO(filename, "rb");
+    CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");
     if (!file){
       parseStr += "Error! - File '";
       parseStr += filename;
@@ -727,7 +727,7 @@ bool CIccSingleSampledCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   // file exists
   if (filename[0]) {
-    CIccIO *file = IccOpenFileIO(filename, "rb");
+    CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");
     if (!file) {
       parseStr += "Error! - File '";
       parseStr += filename;

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -65,6 +65,7 @@
 #include "IccMpeXml.h"
 #include "IccUtilXml.h"
 #include "IccIoXml.h"
+#include "IccXmlConfig.h"
 #include "IccCAM.h"
 
 #include <cstring> /* C strings strcpy, memcpy ... */
@@ -2451,6 +2452,17 @@ bool CIccMpeXmlCalculator::ParseImport(xmlNode *pNode, std::string importPath, s
             std::string file = icXmlAttrValue(attr);
             xmlDoc *doc = NULL;
             xmlNode *root_element = NULL;
+
+            // Gate behind the same allow-file-includes flag and path
+            // sanitizer used by IccXmlSafeOpenFileIO so that
+            // <Import Filename="..."> cannot be used as a file-read
+            // primitive when the library is in its default-off state.
+            if (!IccXmlGetAllowFileIncludes() || !IccXmlIsPathSafe(file.c_str())) {
+              parseStr += "File includes disabled or path rejected for import '";
+              parseStr += file;
+              parseStr += "' (file includes may be disabled or path rejected as unsafe)\n";
+              return false;
+            }
 
             std::string look = "*";
             look += file;

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -228,11 +228,11 @@ static bool icXmlParseTextString(xmlNode *pNode, std::string &parseStr, std::str
 
         // file exists
         if (filename && filename[0]) {        
-          CIccIO *file = IccOpenFileIO(filename, "rb");        
+          CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");        
           if (!file){          
             parseStr += "Error! - File '";
             parseStr += filename;
-            parseStr +="' not found.\n";
+            parseStr += "' could not be opened (file includes may be disabled or path rejected as unsafe).\n";
             delete file;
             return false;
           }
@@ -433,12 +433,12 @@ bool CIccTagXmlTextDescription::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   // file exists
   if (filename && filename[0]) {
-    CIccIO *file = IccOpenFileIO(filename, "rb");
+    CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");
 
     if (!file){
       parseStr += "Error! - File '";
       parseStr += filename;
-      parseStr +="' not found.\n";
+      parseStr += "' could not be opened (file includes may be disabled or path rejected as unsafe).\n";
       delete file;
       return false;
     }
@@ -1546,11 +1546,11 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string &parse
   A a;
 
   if (filename && filename[0]) {
-    CIccIO *file = IccOpenFileIO(filename, "rb");
+    CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");
     if (!file){
       parseStr += "Error! - File '";
       parseStr += filename;
-      parseStr +="' not found.\n";
+      parseStr += "' could not be opened (file includes may be disabled or path rejected as unsafe).\n";
       delete file;
       return false;
     }
@@ -2687,11 +2687,11 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
 
     // file exists
     if (filename && filename[0]) {
-      CIccIO *file = IccOpenFileIO(filename, "rb");
+      CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");
       if (!file){
         parseStr += "Error! - File '";
         parseStr += filename;
-        parseStr +="' not found.\n";
+        parseStr += "' could not be opened (file includes may be disabled or path rejected as unsafe).\n";
         delete file;
         return false;
       }
@@ -3541,13 +3541,13 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
     }
 
     if (filename && filename[0]) {
-      CIccIO *file = IccOpenFileIO(filename, "rb");
+      CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");
 
       if (!file) {
         // added error message
         parseStr += "Error! - File '";
         parseStr += filename;
-        parseStr +="' not found.\n";
+        parseStr += "' could not be opened (file includes may be disabled or path rejected as unsafe).\n";
         delete pCLUT;
         return NULL;
       }
@@ -5328,11 +5328,11 @@ bool CIccTagXmlEmbeddedHeightImage::ParseXml(xmlNode *pNode, std::string &parseS
 
     // file exists
     if (filename && filename[0]) {
-      CIccIO *file = IccOpenFileIO(filename, "rb");
+      CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");
       if (!file) {
         parseStr += "Error! - File '";
         parseStr += filename;
-        parseStr += "' not found.\n";
+        parseStr += "' could not be opened (file includes may be disabled or path rejected as unsafe).\n";
         delete file;
         return false;
       }
@@ -5429,11 +5429,11 @@ bool CIccTagXmlEmbeddedNormalImage::ParseXml(xmlNode *pNode, std::string &parseS
 
     // file exists
     if (filename && filename[0]) {
-      CIccIO *file = IccOpenFileIO(filename, "rb");
+      CIccIO *file = IccXmlSafeOpenFileIO(filename, "rb");
       if (!file) {
         parseStr += "Error! - File '";
         parseStr += filename;
-        parseStr += "' not found.\n";
+        parseStr += "' could not be opened (file includes may be disabled or path rejected as unsafe).\n";
         delete file;
         return false;
       }

--- a/IccXML/IccLibXML/IccXmlConfig.h
+++ b/IccXML/IccLibXML/IccXmlConfig.h
@@ -79,7 +79,15 @@ typedef enum {
 // CLI tool flips this on after argument parsing. Exposed as accessor
 // functions (not a bare extern bool) so the DLL interface works on
 // Windows MSVC where WINDOWS_EXPORT_ALL_SYMBOLS does not export data.
+#ifdef USEICCDEVNAMESPACE
+namespace iccDEV {
+#endif
+
 ICCPROFLIB_API void IccXmlSetAllowFileIncludes(bool allow);
 ICCPROFLIB_API bool IccXmlGetAllowFileIncludes();
+
+#ifdef USEICCDEVNAMESPACE
+} // namespace iccDEV
+#endif
 
 #endif

--- a/IccXML/IccLibXML/IccXmlConfig.h
+++ b/IccXML/IccLibXML/IccXmlConfig.h
@@ -60,6 +60,8 @@
 #ifndef _ICCXMLCONFIG_H
 #define _ICCXMLCONFIG_H
 
+#include "IccProfLibConf.h"
+
 typedef enum {
   icConvert8Bit=0,
   icConvert16Bit,
@@ -70,5 +72,14 @@ typedef enum {
 #define icXmlHalfFmt "%.8f"
 #define icXmlFloatFmt "%.12f"
 #define icXmlDoubleFmt "%.24lf"
+
+// Library-wide opt-in for <tag File="..."/> / <tag Filename="..."/>
+// loaders in IccLibXML. Off by default because the XML is usually
+// attacker-controlled in library/service/WASM contexts. The iccFromXml
+// CLI tool flips this on after argument parsing. Exposed as accessor
+// functions (not a bare extern bool) so the DLL interface works on
+// Windows MSVC where WINDOWS_EXPORT_ALL_SYMBOLS does not export data.
+ICCPROFLIB_API void IccXmlSetAllowFileIncludes(bool allow);
+ICCPROFLIB_API bool IccXmlGetAllowFileIncludes();
 
 #endif


### PR DESCRIPTION
# Gate \`File=\`/\`Filename=\` attribute readers behind opt-in flag, sanitise paths

**Severity:** High · **Files:** 11+ \`ParseXml\` methods in \`IccTagXml.cpp\` and \`IccMpeXml.cpp\`

## Summary

At least 11 distinct \`ParseXml\` methods read \`icXmlAttrValue(node,
\"File\")\` / \`\"Filename\"\` and pass the value verbatim to
\`IccOpenFileIO(filename, \"rb\")\` or \`xmlReadFile()\`. No path
constraints, no sandboxing, no allow-listing, no \`..\` rejection.

Affected sites:

- \`IccTagXml.cpp:231, 427, 1519, 1527, 2643, 2647, 3476, 3482, 5233, 5240, 5328, 5335\`
- \`IccMpeXml.cpp:300, 304, 702, 706, 2402, 2417\`

Under \`CalculatorElement\`, \`<Import Filename=\"...\">\` similarly opens
attacker-controlled paths via \`xmlReadFile()\` — also gated by this PR.

Same class of bug as JSON #24 / #25 but reached via XML, and with
more call sites (11+ vs. 2).

## Impact

- **Native CLI (iccToXml/iccFromXml)**: arbitrary local file read. An
  attacker who controls the XML input can slurp any readable file
  into the resulting profile.
- **WASM (icctools)**: bounded by MEMFS contents; still a probe
  surface (attackers can enumerate what's mounted).
- **Server/service embedders**: direct file-disclosure vector.

## Reproducer

\`\`\`xml
<TextDescription>
  <TextData File="/etc/passwd"/>
</TextDescription>
\`\`\`

## Patch

Introduce \`IccXmlSetAllowFileIncludes(bool)\` / \`IccXmlGetAllowFileIncludes()\`
accessor functions (exported via \`IccXmlConfig.h\`, defined in \`IccIoXml.cpp\`).
Declarations are wrapped in the matching \`USEICCDEVNAMESPACE\` guard to avoid
ODR/link mismatches when the iccDEV namespace is enabled.

Default \`false\` in library, set \`true\` in \`iccFromXml\` CLI. At every
affected \`IccOpenFileIO\` site, replace with \`IccXmlSafeOpenFileIO\` which:
1. Returns \`NULL\` if the flag is off.
2. Delegates to \`IccXmlIsPathSafe()\` (also exported) which rejects
   absolute paths (leading \`/\` or \`\\`), Windows drive-prefixed paths
   (second char \`:\`), and paths with \`...\` traversal components.

\`CIccMpeXmlCalculator::ParseImport\` is gated with the same
\`IccXmlGetAllowFileIncludes() + IccXmlIsPathSafe()\` checks before its
\`xmlReadFile()\` call.

## Test plan

- Regression: \`Testing/RunTests.sh\` (CLI paths flip the flag on).
- New unit: library default + XML with \`<TextData File="/etc/passwd"/>\`
  — parse returns \`false\`, no file open.
- New unit: CLI with flag on + path containing \`...\` — rejected by
  sanitiser.

## References

- CWE-22 Improper Limitation of a Pathname to a Restricted Directory
- CWE-73 External Control of File Name or Path