### PR TITLE
[IccLibXML] Fix missing +1 byte + NUL-terminate text buffer

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -439,7 +439,12 @@ bool CIccTagXmlTextDescription::ParseXml(xmlNode *pNode, std::string &parseStr)
     }
 
     size_t fileLength = file->GetLength();
-    char *buf = (char *)malloc(fileLength);
+    // +1 for the NUL terminator. icUtf8ToAnsi(buf) and CIccUTF16String(buf)
+    // both treat `buf` as a C-string and walk it with strlen-like logic;
+    // without the extra byte plus the explicit terminator below, those
+    // functions read past the allocation until they happen to find a
+    // zero byte in adjacent heap.
+    char *buf = (char *)malloc(fileLength + 1);
 
     if (!buf) {
       perror("Memory Error");
@@ -449,6 +454,7 @@ bool CIccTagXmlTextDescription::ParseXml(xmlNode *pNode, std::string &parseStr)
       delete file;
       return false;
     }
+    buf[fileLength] = '\0';
 
     if (file->ReadLine(buf, fileLength)!=fileLength) {
       parseStr += "Error while reading file '";


### PR DESCRIPTION
# Fix `malloc(fileLength)`-missing-`+1` buffer overreads in XML file readers

**Severity:** High · **Files:** `IccXML/IccLibXML/IccTagXml.cpp:240-266, 441-498`

## Summary

`CIccTagXmlTextDescription::ParseXml` and the helper
`icXmlParseTextString` allocate `malloc(fileLength + 1)` in one code
path but `malloc(fileLength)` without the `+1` in another (line
442). The buffer is then passed to:

- `icUtf8ToAnsi(buf)` — walks `buf` with `strlen` until NUL.
- `CIccUTF16String wstr(buf)` — walks `buf` reading until NUL.

Both walk off the end of the allocation into adjacent heap memory
until they happen to find a zero byte.

Additional bug at line 496: `memcpy(m_szScriptText, buf, 67)` copies
67 bytes unconditionally, regardless of `fileLength`. A 4-byte file
yields a 63-byte heap over-read. Also `m_nScriptSize = fileLength + 1`
silently truncates to u8 for files >254 bytes.

## Impact

- **Heap over-read**: attacker can cause the library to read up to
  `strlen(buf)` bytes past the allocation — potentially leaking heap
  contents into the parsed profile's description fields (and then
  into a round-tripped binary/XML).
- **ScriptText over-read**: 67-byte `memcpy` from an attacker-sized
  file leaks adjacent heap bytes into `m_szScriptText`.

Requires a crafted path in `<TextData File="...">` — combined with
PR #42's path-gating, reduces exposure significantly, but the data-
integrity bug in the regular `File="..."` code path remains.

## Patch

```diff
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -440,7 +440,7 @@
-  char *buf = (char*)malloc(fileLength);
+  char *buf = (char*)malloc(fileLength + 1);
   if (!buf) return false;
   file->Read8(buf, fileLength);
+  buf[fileLength] = '\0';
```

```diff
@@ -493,7 +494,9 @@
-  m_nScriptSize = fileLength + 1;
-  memcpy(m_szScriptText, buf, 67);
+  m_nScriptSize = (fileLength < 255) ? static_cast<icUInt8Number>(fileLength + 1) : 255;
+  size_t copyBytes = std::min<size_t>(fileLength, sizeof(m_szScriptText));
+  memcpy(m_szScriptText, buf, copyBytes);
+  // m_szScriptText is a fixed-size field; zero the tail.
+  if (copyBytes < sizeof(m_szScriptText))
+    memset(m_szScriptText + copyBytes, 0, sizeof(m_szScriptText) - copyBytes);
```

## Test plan

- Regression: `Testing/RunXmlTests.sh`.
- New unit (requires PR #42 in place with the flag on): TextDescription
  referencing a 4-byte file — parse succeeds, `m_szScriptText` is NUL-
  padded, no heap over-read under ASAN.
- New unit: TextDescription with a 500 MB file referenced — parse
  rejects or truncates cleanly.
- ASAN run of full XML test suite — no heap-buffer-overflow.

## References

- CWE-125 Out-of-bounds Read
- CWE-170 Improper Null Termination
