### PR TITLE
[IccLibXML] Move NULL check before fbuf[len]=0 write

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -1536,13 +1536,21 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string &parse
     size_t len = file->GetLength();
 
     if (!stricmp(icXmlAttrValue(pNode, "Format", "text"), "text")) {
+      // Cap `len` so the +1 below can't wrap on an oversized file.
+      static const size_t kMaxFbufLen = 256ULL * 1024 * 1024;  // 256 MB
+      if (len > kMaxFbufLen) {
+        parseStr += "File exceeds 256 MB limit\n";
+        delete file;
+        return false;
+      }
+
       char *fbuf = (char*)malloc(len+1);
-      fbuf[len]=0;
       if (!fbuf) {
         parseStr += "Memory error!\n";
         delete file;
         return false;
       }
+      fbuf[len]=0;
 
       if (file->Read8(fbuf, len)!=len) {
         parseStr += "Read error of (";


### PR DESCRIPTION
# Move NULL check before buffer write in `IccTagXml.cpp`

**Severity:** High · **File:** `IccXML/IccLibXML/IccTagXml.cpp:1539-1541`

## Summary

```cpp
char *fbuf = (char*)malloc(len + 1);
fbuf[len] = 0;              // write happens BEFORE the NULL check
if (!fbuf) { ... }
```

If `malloc` returns NULL, `fbuf[len] = 0` writes to the NULL pointer
offset by `len`. On Linux this is a SIGSEGV at an attacker-controlled
offset — predictable DoS. On bare-metal / embedded targets it can hit
mapped memory.

Additionally, if `len == SIZE_MAX` (or close), `malloc(len + 1)`
wraps to 0, `malloc(0)` returns a minimal non-NULL pointer, and
`fbuf[SIZE_MAX] = 0` is a wild write anyway.

## Patch

```diff
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -1536,9 +1536,14 @@
-  char *fbuf = (char*)malloc(len + 1);
-  fbuf[len] = 0;
-  if (!fbuf) { return false; }
+  // Cap `len` before the add so the +1 can't wrap. 256 MB is
+  // generous for any legitimate embedded XML payload.
+  static const size_t kMaxLen = 256ULL * 1024 * 1024;
+  if (len > kMaxLen) return false;
+
+  char *fbuf = (char*)malloc(len + 1);
+  if (!fbuf) return false;
+  fbuf[len] = 0;
```

Audit the file for the same pattern elsewhere:

```sh
git grep -n 'fbuf\[len\]\s*=\s*0' IccXML/
```

## Test plan

- Regression: `Testing/RunXmlTests.sh`.
- New unit: inject a `malloc` failure via an allocator-override hook
  at this site — `ParseXml` returns `false`, no SIGSEGV.

## References

- CWE-476 NULL Pointer Dereference
- CWE-190 Integer Overflow or Wraparound (the wrap case)
