### PR TITLE
[IccProfLib] Use size_t (not int) for CIccMpeMatrix byte-count arithmetic

### DIFF
--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -4931,7 +4931,7 @@ CIccMpeMatrix::CIccMpeMatrix(const CIccMpeMatrix &matrix)
 
   m_size = matrix.m_size;
   if(matrix.m_pMatrix) {
-    int num = m_size * sizeof(icFloatNumber);
+    size_t num = static_cast<size_t>(m_size) * sizeof(icFloatNumber);
     m_pMatrix = (icFloatNumber*)malloc(num);
     memcpy(m_pMatrix, matrix.m_pMatrix, num);
   }
@@ -4975,7 +4975,7 @@ CIccMpeMatrix &CIccMpeMatrix::operator=(const CIccMpeMatrix &matrix)
 
   m_size = matrix.m_size;
   if (matrix.m_pMatrix) {
-    int num = m_size * sizeof(icFloatNumber);
+    size_t num = static_cast<size_t>(m_size) * sizeof(icFloatNumber);
     m_pMatrix = (icFloatNumber*)malloc(num);
     memcpy(m_pMatrix, matrix.m_pMatrix, num);
   }


### PR DESCRIPTION
# Use `size_t` for matrix-copy byte count in `CIccMpeMatrix`

**Severity:** Medium · **File:** `IccProfLib/IccMpeBasic.cpp:4934, 4943, 4978, 4989`

## Summary

The `CIccMpeMatrix` copy constructor and `operator=` compute their byte
count as `int num = m_size * sizeof(icFloatNumber)`. `int` is 32-bit
signed. If finding #5's bounds check is bypassed (or if an already-
deserialised matrix is subsequently copied), `m_size * 4` can go
negative, then the cast to `size_t` for `malloc` becomes `SIZE_MAX -
small`, producing an enormous allocation or memcpy.

The bug is dormant today only because `CIccMpeMatrix::Read` refuses
oversized matrices (once finding #5 is fixed). Independent hardening.

## Root cause

```cpp
// IccMpeBasic.cpp:4934
int num = m_size * sizeof(icFloatNumber);
```

Signed-int multiplication of an attacker-reachable `m_size`.

## Patch

```diff
--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -4931,7 +4931,7 @@
 {
   if (mpe.m_pMatrix) {
-    int num = m_size * sizeof(icFloatNumber);
+    size_t num = static_cast<size_t>(m_size) * sizeof(icFloatNumber);
     m_pMatrix = (icFloatNumber*)malloc(num);
     if (m_pMatrix)
       memcpy(m_pMatrix, mpe.m_pMatrix, num);
```

(Apply to all four sites: 4934, 4943, 4978, 4989.)

## Test plan

- Build with UBSAN (`-fsanitize=signed-integer-overflow`). The existing
  testsuite exercising Matrix MPE elements must pass without UBSAN
  diagnostics.

## References

- CWE-190 Integer Overflow or Wraparound
- CWE-195 Signed to Unsigned Conversion Error
