### PR TITLE
[IccProfLib] Reject pathological derived param count on unknown ParametricCurve

### DIFF
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -765,7 +765,16 @@ bool CIccTagParametricCurve::Read(icUInt32Number size, CIccIO *pIO)
   SetFunctionType(nFunctionType);
 
   if (!m_nNumParam) {
-    m_nNumParam = (icUInt16Number)((size-nHdrSize) / sizeof(icS15Fixed16Number));
+    // Unknown nFunctionType path. Previously this fell back to
+    // `(icUInt16Number)((size - nHdrSize) / 4)` which silently
+    // truncates large-size tags to a small number of parameters —
+    // a parse-desync primitive. Use u32 math and refuse pathological
+    // derived counts instead.
+    icUInt32Number derived =
+        static_cast<icUInt32Number>((size - nHdrSize) / sizeof(icS15Fixed16Number));
+    if (derived > 2048u)   // spec caps known types at 7; 2048 is a sane outer bound
+      return false;
+    m_nNumParam = static_cast<icUInt16Number>(derived);
     m_dParam = new icFloatNumber[m_nNumParam];
   }
 


### PR DESCRIPTION
# Reject unknown ParametricCurve function types instead of u16-truncating

**Severity:** Medium · **File:** `IccProfLib/IccTagLut.cpp:767-770`

## Summary

When `CIccTagParametricCurve::Read` encounters an unknown `nFunctionType`,
`SetFunctionType` sets `m_nNumParam = 0`. The caller then falls back to
computing parameter count as:

```cpp
m_nNumParam = (icUInt16Number)((size - nHdrSize) / sizeof(icS15Fixed16Number));
```

The cast to `u16` silently truncates. A tag with `size = 0x40100`
yields `0x1003F`, truncated to `0x003F`. Subsequent reads then consume
only 63 words from a tag that advertises 65599 words — a parse desync
primitive.

Not memory-unsafe on its own (alloc and read use the same truncated
value), but creates predictable state divergence between parser and
producer that's useful for chained exploits.

## Root cause

```cpp
// IccTagLut.cpp:767-770
else {
  m_nNumParam = (icUInt16Number)((size - nHdrSize) /
                                  sizeof(icS15Fixed16Number));
}
```

## Patch

Two options, pick one:

**Option A — reject unknown function types (strict):**

```diff
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -760,12 +760,10 @@
   // attempt lookup of the function type
   if (SetFunctionType(nFunctionType)) {
     // known function type — m_nNumParam was populated
   }
   else {
-    m_nNumParam = (icUInt16Number)((size - nHdrSize) /
-                                    sizeof(icS15Fixed16Number));
+    // Unknown function type — bail rather than guess.
+    return false;
   }
```

**Option B — widen and validate (lenient):**

```diff
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -760,7 +760,12 @@
   else {
-    m_nNumParam = (icUInt16Number)((size - nHdrSize) /
-                                    sizeof(icS15Fixed16Number));
+    icUInt32Number derived =
+        (size - nHdrSize) / sizeof(icS15Fixed16Number);
+    // Cap at 2048 — the ICC spec defines at most 7 parameters for any
+    // standard function type; unknown types at more than a small bound
+    // are almost certainly crafted.
+    if (derived > 2048u) return false;
+    m_nNumParam = derived;
   }
```

Option A is preferred if breaking on private/future function types is
acceptable. Option B is backward-compatible.

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: ParametricCurve with `nFunctionType = 0x9999` (unknown) and
  `size = 0x40100` — must return `false` (Option A) or succeed with
  sensible `m_nNumParam` (Option B).

## References

- CWE-681 Incorrect Conversion between Numeric Types
- CWE-130 Improper Handling of Length Parameter Inconsistency
