### PR TITLE
[IccProfLib] Guard CIccEmbedIO::Read8 against size_t underflow

### DIFF
--- a/IccProfLib/IccIO.cpp
+++ b/IccProfLib/IccIO.cpp
@@ -610,8 +610,15 @@ size_t CIccEmbedIO::Read8(void *pBuf, size_t nNum)
 
   if (m_nSize > 0) {
     size_t nPos = m_pIO->Tell();
+    // If the underlying IO's cursor is below our window start (possible
+    // when another CIccEmbedIO sharing the backing IO has seeked
+    // backwards), don't underflow nOffset — just refuse the read.
+    if (nPos < m_nStartPos)
+      return 0;
     size_t nOffset = nPos - m_nStartPos;
 
+    if (nOffset > m_nSize)
+      return 0;
     if (nOffset + nNum > m_nSize)
       nNum = m_nSize - nOffset;
   }


### PR DESCRIPTION
# Harden `CIccEmbedIO::Read8` against `size_t` underflow on misaligned start

**Severity:** Medium · **File:** `IccProfLib/IccIO.cpp:611-617, 677`

## Summary

`CIccEmbedIO::Read8` computes the available window as
`nOffset = nPos - m_nStartPos`, both `size_t`. When the inner IO is at
a position less than `m_nStartPos` (possible when a second `CIccEmbedIO`
shares the backing IO and leaves the cursor before this one's start),
the subtraction underflows to a huge value. The subsequent
`nOffset + nNum > m_nSize` check wraps again, and the inner `Read8` is
invoked with the caller's full `nNum` — a read past the logical embed
window.

`CIccEmbedIO::Seek` at line 677 clamps `*>=*m_nStartPos*` but only on
`icSeekSet`; `icSeekCur` deltas pass through to the inner IO without
re-anchoring.

## Impact

- Read-past-end of the logical embed window. Inside a profile tag that
  uses `CIccEmbedIO` to isolate sub-profile bytes (e.g.
  `IccTagEmbedIcc.cpp`), this leaks bytes from the outer profile into
  the inner parser's view.
- Low-severity on its own (no write, no crash), but contributes to
  parser desync across nested profile boundaries.

## Root cause

```cpp
// IccIO.cpp:611-617
size_t nPos = (size_t)m_pIO->Tell();
size_t nOffset = nPos - m_nStartPos;            // ← underflow if nPos < m_nStartPos
if (nOffset + nNum > m_nSize)                   // ← then wrap here too
  nNum = m_nSize - nOffset;
return m_pIO->Read8(pBuf, nNum);
```

## Patch

```diff
--- a/IccProfLib/IccIO.cpp
+++ b/IccProfLib/IccIO.cpp
@@ -609,12 +609,17 @@
 size_t CIccEmbedIO::Read8(void *pBuf, size_t nNum)
 {
   if (!m_pIO)
     return 0;
 
   size_t nPos = (size_t)m_pIO->Tell();
-  size_t nOffset = nPos - m_nStartPos;
-  if (nOffset + nNum > m_nSize)
+  if (nPos < m_nStartPos) {
+    // Inner cursor moved behind our window (another embed IO shares
+    // the backing stream). Refuse rather than underflow the offset.
+    return 0;
+  }
+  size_t nOffset = nPos - m_nStartPos;
+  if (nOffset > m_nSize || nOffset + nNum > m_nSize)
     nNum = m_nSize - nOffset;
   return m_pIO->Read8(pBuf, nNum);
 }
```

Same underflow guard should be added to `Read16`, `Read32`, and any
other `CIccEmbedIO` method that computes an offset against
`m_nStartPos`.

## Test plan

- Regression: `Testing/RunTests.sh` — all profiles with embedded
  sub-profiles (embedIcc tag tests) must load unchanged.
- New unit: build a backing `CIccMemIO`, create two `CIccEmbedIO` views
  at different start offsets, seek one backwards past the other's
  `m_nStartPos`, call `Read8` on the other — must return 0.

## References

- CWE-191 Integer Underflow (Wrap or Wraparound)
- CWE-125 Out-of-bounds Read
