### PR TITLE
[IccProfLib] Widen CIccTagArray::Read bounds math to 64-bit + cap count

### DIFF
--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1256,7 +1256,16 @@ bool CIccTagArray::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read32(&count))
     return false;
 
-  if (headerSize + count*sizeof(icPositionNumber) > size)
+  // 64-bit widened bounds check so attacker-controlled `count` can't
+  // wrap the multiplication on wasm32 (size_t == u32) and bypass the
+  // guard before `new icPositionNumber[count]` is attempted. Mirror
+  // the u64 pattern already in CIccTagStruct::Read above.
+  static const icUInt32Number kMaxArrayEntries = 0x100000;  // 2^20
+  if (count > kMaxArrayEntries)
+    return false;
+  icUInt64Number tableBytes =
+      static_cast<icUInt64Number>(count) * sizeof(icPositionNumber);
+  if (static_cast<icUInt64Number>(headerSize) + tableBytes > size)
     return false;
 
   if (count) {


### PR DESCRIPTION
# Widen `CIccTagArray::Read` bounds math to 64-bit

**Severity:** Medium · **File:** `IccProfLib/IccTagComposite.cpp:1259-1263`

## Summary

`CIccTagArray::Read` checks `headerSize + count * sizeof(icPositionNumber)
> size`. `count` is `icUInt32Number`, `sizeof(icPositionNumber) == 8`.
On 32-bit `size_t` (wasm32), `count * 8` wraps when `count >=
0x20000000`. An attacker sets `count = 0x20000001`; product wraps to 8;
check passes; `new icPositionNumber[count]` then either throws
`std::bad_array_new_length` (uncaught → crash) or — on older stdlib
versions — succeeds with attacker-friendly size.

The sibling parser `CIccTagStruct::Read` at line ~394 does this math
correctly with `(icUInt64Number)count*...*3`. Port the same pattern
here.

## Patch

```diff
--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1256,12 +1256,19 @@
-  if (headerSize + count*sizeof(icPositionNumber) > size)
+  // 64-bit widened bounds check so attacker-controlled `count` can't
+  // wrap the product on wasm32 and bypass the length guard.
+  icUInt64Number tableBytes =
+      static_cast<icUInt64Number>(count) * sizeof(icPositionNumber);
+  if (static_cast<icUInt64Number>(headerSize) + tableBytes > size)
     return false;
+
+  // Cap count defensively — no legitimate array tag has 2^20 entries.
+  static const icUInt32Number kMaxArrayEntries = 0x100000;
+  if (count > kMaxArrayEntries)
+    return false;
 
   if (count) {
     icPositionNumber *tagPos = new icPositionNumber[count];
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: array tag with `count = 0x20000001` — must return `false`
  on wasm32 build without attempting the `new []`.
- New unit: legitimately-sized array (count = 16) still parses.

## References

- CWE-190 Integer Overflow or Wraparound
- CWE-789 Memory Allocation with Excessive Size Value
