### PR TITLE
[IccProfLib] Fix CIccSparseMatrix::Copy memcpy size (u16 not u32)

### DIFF
--- a/IccProfLib/IccSparseMatrix.cpp
+++ b/IccProfLib/IccSparseMatrix.cpp
@@ -228,7 +228,10 @@ bool CIccSparseMatrix::Copy(const CIccSparseMatrix &mtx)
   if (!Init(mtx.m_nRows, mtx.m_nCols))
     return false;
 
-  memcpy(m_RowStart, mtx.m_RowStart, (m_nRows+1)*sizeof(icUInt32Number));
+  // m_RowStart is a u16* pointing at (m_nRows+1) u16 slots; copying with
+  // sizeof(icUInt32Number) stomps 2× the allocated region (into the
+  // adjacent m_ColumnIndices tail).
+  memcpy(m_RowStart, mtx.m_RowStart, (m_nRows+1)*sizeof(icUInt16Number));
   icUInt32Number nEntries = m_RowStart[m_nRows];
   icUInt32Number i;
 


### PR DESCRIPTION
# Fix sparse-matrix `m_RowStart` memcpy overrun

**Severity:** Medium · **File:** `IccProfLib/IccSparseMatrix.cpp:230`

## Summary

`CIccSparseMatrix::Copy` copies `m_RowStart` with the wrong element
size:

```cpp
memcpy(m_RowStart, mtx.m_RowStart, (m_nRows+1)*sizeof(icUInt32Number));
```

`m_RowStart` is a `u16 *` — it points at a `(nRows+1)`-slot *u16* array
packed into `m_pMatrix`. Using `sizeof(icUInt32Number)` (4 bytes)
copies twice as much as the slot holds, stomping the adjacent
`m_ColumnIndices` tail.

Observable when a sparse-matrix tag is copy-constructed or assigned —
`CIccTagSparseMatrixArray` does this on profile cloning paths.

## Patch

```diff
--- a/IccProfLib/IccSparseMatrix.cpp
+++ b/IccProfLib/IccSparseMatrix.cpp
@@ -228,7 +228,7 @@
   // m_RowStart is a u16* pointing at (m_nRows+1) u16 slots.
-  memcpy(m_RowStart, mtx.m_RowStart, (m_nRows+1)*sizeof(icUInt32Number));
+  memcpy(m_RowStart, mtx.m_RowStart, (m_nRows+1)*sizeof(icUInt16Number));
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: construct a `CIccSparseMatrix` with known row-start and
  column-indices, copy-construct it, verify both tails byte-for-byte.
- Build with ASAN — no heap-buffer-overflow reports.

## References

- CWE-787 Out-of-bounds Write
- CWE-131 Incorrect Calculation of Buffer Size
