### PR TITLE
[IccProfLib] Fix uninit/stale read in CIccSparseMatrix::IsValid empty-row case

### DIFF
--- a/IccProfLib/IccSparseMatrix.cpp
+++ b/IccProfLib/IccSparseMatrix.cpp
@@ -492,6 +492,13 @@ bool CIccSparseMatrix::IsValid()
     if (m_RowStart[r]>m_RowStart[r+1])
       return false;
 
+    // Empty-row case: skip both the inner loop AND the post-loop
+    // column-range check. Otherwise `i` is either uninitialised on
+    // the first outer iteration (r=0) or stale from the previous
+    // iteration, and `m_ColumnIndices[i]` reads from a garbage offset.
+    if (m_RowStart[r+1] == m_RowStart[r])
+      continue;
+
     for (i=m_RowStart[r]; i<(int)m_RowStart[r+1]-1; i++) {
       if (m_ColumnIndices[i]>=m_ColumnIndices[i+1] || m_ColumnIndices[i]>m_nCols)
         return false;


### PR DESCRIPTION
# Fix uninitialised-read + OOB in `CIccSparseMatrix::IsValid`

**Severity:** Medium · **File:** `IccProfLib/IccSparseMatrix.cpp:489-499`

## Summary

```cpp
int r, i;
for (r = 0; r < m_nRows; r++) {
  ...
  for (i = m_RowStart[r]; i < m_RowStart[r+1] - 1; i++) { ... }
  if (m_ColumnIndices[i] > m_nCols)  return false;
}
```

If `m_RowStart[0+1] - 1 <= m_RowStart[0]` — a legitimately empty first
row — the inner loop doesn't execute, and `i` is still uninitialised
when used in the post-loop check. `m_ColumnIndices[i]` is then a read
from a garbage offset.

A crafted sparse-matrix tag with row 0 empty reliably triggers this.
Consequence is either a crash (OOB read past the column-indices buffer)
or an undefined-behavior-flagged info leak through the comparison
result.

## Patch

```diff
--- a/IccProfLib/IccSparseMatrix.cpp
+++ b/IccProfLib/IccSparseMatrix.cpp
@@ -485,14 +485,19 @@
   int r, i;
   for (r = 0; r < m_nRows; r++) {
     if (m_RowStart[r+1] < m_RowStart[r])
       return false;
 
-    for (i = m_RowStart[r]; i < m_RowStart[r+1]-1; i++) {
+    // If the row is empty we have nothing to check — skip both the
+    // inner loop *and* the post-loop column-range check, which would
+    // otherwise read from uninitialised `i`.
+    if (m_RowStart[r+1] == m_RowStart[r])
+      continue;
+
+    for (i = m_RowStart[r]; i < m_RowStart[r+1] - 1; i++) {
       if (m_ColumnIndices[i] >= m_ColumnIndices[i+1])
         return false;
     }
     if (m_ColumnIndices[i] > m_nCols)
       return false;
   }
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: sparse matrix where `m_RowStart[1] == m_RowStart[0] == 0` —
  `IsValid` must return `true`, no UBSAN-flagged uninitialised read.
- Build with `-fsanitize=undefined,address`.

## References

- CWE-908 Use of Uninitialized Resource
- CWE-125 Out-of-bounds Read
