### PR TITLE
[IccProfLib] Guard CIccSparseMatrix ctor / Reset against short buffers

### DIFF
--- a/IccProfLib/IccSparseMatrix.cpp
+++ b/IccProfLib/IccSparseMatrix.cpp
@@ -9,7 +9,10 @@ CIccSparseMatrix::CIccSparseMatrix(void *pMatrix, size_t nSize, icSparseMatrixTy
   m_nType = nType;
   m_Data = NULL;
 
-  if (bInitFromData) {
+  // bInitFromData dereferences the first 4 bytes of pMatrix. Callers
+  // inside IccProfLib guarantee at least 4 bytes, but this ctor is
+  // public API — external callers might pass a short buffer.
+  if (bInitFromData && pMatrix && nSize >= 2*sizeof(icUInt16Number)) {
     icUInt16Number nRows = *((icUInt16Number*)pMatrix);
     icUInt16Number nCols = *((icUInt16Number*)(m_pMatrix+sizeof(icUInt16Number)));
     Init(nRows, nCols);
@@ -123,7 +126,8 @@ bool CIccSparseMatrix::Reset(void *pMatrix, size_t nSize, icSparseMatrixType nTy
   m_nType = nType;
   m_Data = NULL;
 
-  if (bInitFromData) {
+  // Same guard as the ctor: don't dereference short buffers.
+  if (bInitFromData && pMatrix && nSize >= 2*sizeof(icUInt16Number)) {
     icUInt16Number nRows = *((icUInt16Number*)pMatrix);
     icUInt16Number nCols = *((icUInt16Number*)(m_pMatrix+sizeof(icUInt16Number)));
     return Init(nRows, nCols);


### PR DESCRIPTION
# Guard `CIccSparseMatrix` constructor / `Reset` against short buffers

**Severity:** Medium · **Files:** `IccProfLib/IccSparseMatrix.cpp:13-15, 126-128`

## Summary

`CIccSparseMatrix::CIccSparseMatrix(icUInt8Number *pMatrix, …)` and
`::Reset(…)` dereference the first four bytes unconditionally:

```cpp
icUInt16Number nRows = *((icUInt16Number*)pMatrix);
icUInt16Number nCols = *((icUInt16Number*)(m_pMatrix+sizeof(icUInt16Number)));
```

No check that `nSize >= 4`. Current internal callers in
`IccTagBasic.cpp:4658` guarantee this, but the constructor is public
API: any library client calling it with a short buffer reads OOB.

Defense-in-depth; low reachability today, but cheap to fix.

## Patch

```diff
--- a/IccProfLib/IccSparseMatrix.cpp
+++ b/IccProfLib/IccSparseMatrix.cpp
@@ -10,8 +10,14 @@
-CIccSparseMatrix::CIccSparseMatrix(icUInt8Number *pMatrix, icUInt32Number nSize, bool bInitFromData)
+CIccSparseMatrix::CIccSparseMatrix(icUInt8Number *pMatrix, icUInt32Number nSize, bool bInitFromData)
 {
   m_pMatrix = pMatrix;
   m_nSize = nSize;
+
+  if (!pMatrix || nSize < 2 * sizeof(icUInt16Number)) {
+    m_nRows = m_nCols = 0;
+    m_RowStart = nullptr;
+    m_ColumnIndices = nullptr;
+    return;
+  }
 
   icUInt16Number nRows = *((icUInt16Number*)pMatrix);
   icUInt16Number nCols = *((icUInt16Number*)(m_pMatrix+sizeof(icUInt16Number)));
```

Apply the same guard in `Reset` at line 126.

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: `CIccSparseMatrix(nullptr, 0, true)` — no crash.
- New unit: `CIccSparseMatrix(buf, 2, true)` with a 2-byte buffer — no
  OOB read (verify with ASAN).

## References

- CWE-125 Out-of-bounds Read
- CWE-20 Improper Input Validation
