### PR TITLE
[IccProfLib] Guard CIccArrayNamedColor::Find* against div-by-zero + fix copy-paste

### DIFF
--- a/IccProfLib/IccArrayBasic.cpp
+++ b/IccProfLib/IccArrayBasic.cpp
@@ -330,6 +330,7 @@ CIccStructNamedColor* CIccArrayNamedColor::FindDeviceColor(const icFloatNumber *
       CIccTag *pTag = pNamedColor->GetElem(icSigNmclDeviceDataMbr);
       if (pTag && pTag->IsNumArrayType()) {
         CIccTagNumArray *v = (CIccTagNumArray*)pTag;
+        if (!m_nDeviceSamples) continue;
         icUInt32Number sampleCount = v->GetNumValues()/m_nDeviceSamples;
         if (sampleCount) {
           v->GetValues(temp, (sampleCount-1)*m_nDeviceSamples, m_nDeviceSamples);
@@ -370,6 +371,7 @@ CIccStructNamedColor* CIccArrayNamedColor::FindPcsColor(const icFloatNumber *pPC
       CIccTag *pTag = pNamedColor->GetElem(icSigNmclDeviceDataMbr);
       if (pTag && pTag->IsNumArrayType()) {
         CIccTagNumArray *v = (CIccTagNumArray*)pTag;
+        if (!m_nDeviceSamples) continue;
         icUInt32Number sampleCount = v->GetNumValues()/m_nDeviceSamples;
         if (sampleCount) {
           v->GetValues(pLab, (sampleCount-1)*m_nDeviceSamples, 3);
@@ -405,7 +407,8 @@ CIccStructNamedColor* CIccArrayNamedColor::FindSpectralColor(const icFloatNumber
       CIccTag *pTag = pNamedColor->GetElem(icSigNmclDeviceDataMbr);
       if (pTag && pTag->IsNumArrayType()) {
         CIccTagNumArray *v = (CIccTagNumArray*)pTag;
-        icUInt32Number sampleCount = v->GetNumValues()/m_nDeviceSamples;
+        if (!m_nSpectralSamples) continue;
+        icUInt32Number sampleCount = v->GetNumValues()/m_nSpectralSamples;
         if (sampleCount) {
           v->GetValues(temp, (sampleCount-1)*m_nSpectralSamples, m_nSpectralSamples);
 


### PR DESCRIPTION
# Guard `CIccArrayNamedColor::Find*` against division by zero + fix copy-paste bug

**Severity:** Medium · **File:** `IccProfLib/IccArrayBasic.cpp:333, 373, 408`

## Summary

Two bugs in three related functions.

**Div-by-zero**: Each of `FindDeviceColor`, `FindPcsColor`, and
`FindSpectralColor` divides by a sample count derived from
`icGetSpaceSamples()`. That function returns 0 for unknown colorspace
signatures. An attacker profile with `colorSpace = 'xxxx'` (unknown
sig) and a named-colour array reaches one of these divisions through
a CMM apply path, hitting SIGFPE.

Note: `Validate` has its own guard at lines 517/538, but the Find
paths don't — `Validate` isn't on the hot apply path.

**Copy-paste bug**: At line 408, `FindSpectralColor` divides by
`m_nDeviceSamples` when it should divide by `m_nSpectralSamples`.

## Patch

```diff
--- a/IccProfLib/IccArrayBasic.cpp
+++ b/IccProfLib/IccArrayBasic.cpp
@@ -330,6 +330,7 @@
 CIccArrayNamedColor::Find...(...) {
+  if (!m_nDeviceSamples) return NULL;
   icUInt32Number sampleCount = v->GetNumValues() / m_nDeviceSamples;
   // ...
 }
@@ -370,6 +371,7 @@
 CIccArrayNamedColor::FindPcsColor(...) {
+  if (!m_nPcsSamples) return NULL;
   icUInt32Number sampleCount = v->GetNumValues() / m_nPcsSamples;
 }
@@ -405,7 +407,8 @@
 CIccArrayNamedColor::FindSpectralColor(...) {
-  icUInt32Number sampleCount = v->GetNumValues() / m_nDeviceSamples;
+  if (!m_nSpectralSamples) return NULL;
+  icUInt32Number sampleCount = v->GetNumValues() / m_nSpectralSamples;
 }
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: profile with `colorSpace = 'xxxx'` + named-colour array +
  CMM apply path — returns NULL cleanly, no SIGFPE.
- Unit: verify `FindSpectralColor` returns spectrally-correct results
  after the divisor fix (may require updating the associated test
  reference data — the fix changes behaviour).

## References

- CWE-369 Divide By Zero
- CWE-682 Incorrect Calculation (copy-paste bug)
