### PR TITLE
[IccProfLib] Cap nCount and guard position arithmetic in ProfSeqDesc::Read

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -9699,6 +9699,14 @@ bool CIccTagProfileSeqDesc::Read(icUInt32Number size, CIccIO *pIO)
   size_t nPos;
   CIccProfileDescStruct ProfileDescStruct;
 
+  // Reject counts that can't possibly fit even a bare-minimum record
+  // per entry (20 bytes: mfg + model + attrs + tech). Without this,
+  // a crafted nCount of ~40,000 drives ~1M nested MLU allocations
+  // before per-iteration Read*() finally fails on EOF.
+  static const icUInt32Number kProfSeqDescMinBytesPerEntry = 20;
+  if (nCount > size / kProfSeqDescMinBytesPerEntry)
+    return false;
+
   for (i=0; i<nCount; i++) {
 
     if (!pIO->Read32(&ProfileDescStruct.m_deviceMfg) ||
@@ -9709,10 +9717,19 @@ bool CIccTagProfileSeqDesc::Read(icUInt32Number size, CIccIO *pIO)
 
     nPos = pIO->Tell();
 
+    // Guard against previous iteration having advanced the cursor past
+    // our tag window; otherwise (nEnd - nPos) wraps to near UINT32_MAX
+    // and is passed as `size` to the nested MLU Read — a second,
+    // independent overflow primitive.
+    if (nPos >= nEnd)
+      return false;
+
     if (!ProfileDescStruct.m_deviceMfgDesc.Read((icUInt32Number)(nEnd - nPos), pIO))
       return false;
-    
+
     nPos = pIO->Tell();
+    if (nPos >= nEnd)
+      return false;
     if (!ProfileDescStruct.m_deviceModelDesc.Read((icUInt32Number)(nEnd - nPos), pIO))
       return false;
 


### PR DESCRIPTION
# Cap `nCount` and tighten position-arithmetic in `CIccTagProfileSeqDesc::Read`

**Severity:** Medium · **File:** `IccProfLib/IccTagBasic.cpp:9670-9723`

## Summary

Two bugs in the ProfileSequenceDesc parser.

1. **Unbounded count**: `nCount` is read as `u32` at line 9687 and
   used directly as the outer loop bound at 9702 with no upper cap.
   For a 1 MB profile, `nCount ≈ 40 000` yields ~1 M
   `new CIccTagMultiLocalizedUnicode` allocations (each ~200 bytes);
   a few-MB profile exhausts RAM. The loop's only safety is that each
   iteration consumes enough bytes to eventually fail a `pIO->Read*`.

2. **Negative-size wrap**: At line 9710, `(icUInt32Number)(nEnd - nPos)`
   can underflow when a previous iteration's inner `Read` advanced the
   cursor past `nEnd`. The result wraps to near `UINT32_MAX` and is
   passed as `size` to the nested tag's `Read`, enabling oversized
   parses.

## Patch

```diff
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -9685,6 +9685,13 @@
   if (!pIO->Read32(&nCount))
     return false;
 
+  // Reject counts that couldn't possibly fit in the remaining tag
+  // body. Each sequence entry is at least 24 bytes (icProfileDesc
+  // fixed part) before any nested MLU/TextDesc bytes.
+  static const icUInt32Number kSeqDescFixedPartBytes = 24;
+  if (nCount > (size - (pIO->Tell() - tagStart)) / kSeqDescFixedPartBytes)
+    return false;
+
@@ -9708,6 +9715,9 @@
   for (i = 0; i < nCount; i++) {
+    if (nPos >= nEnd)
+      return false;  // ran past our allotted bytes
+
     icUInt32Number remaining = nEnd - nPos;
     // ... nested read with `remaining` instead of raw (nEnd - nPos)
   }
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: ProfileSeqDesc tag with `nCount = 40000` and only a few
  bytes of actual body — must reject without allocating.
- New unit: pathologically-sized nested MLU advances cursor past
  `nEnd` — outer loop terminates cleanly, no wraparound.

## References

- CWE-789 Memory Allocation with Excessive Size Value
- CWE-191 Integer Underflow (Wrap or Wraparound)
