### PR TITLE
[IccLibJSON] Cap CIccProfileJson::LoadJson input file size at 64 MB

### DIFF
--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -524,11 +524,25 @@ bool CIccProfileJson::ParseJson(const IccJson &root, std::string &parseStr)
 
 bool CIccProfileJson::LoadJson(const char *szFilename, std::string *parseStr)
 {
-  std::ifstream f(szFilename);
+  std::ifstream f(szFilename, std::ios::binary | std::ios::ate);
   if (!f.is_open()) {
     if (parseStr) *parseStr += std::string("Unable to open file: ") + szFilename + "\n";
     return false;
   }
+
+  // Cap raw JSON size. nlohmann's default nesting + size limits are
+  // effectively "everything fits in memory", which is a DoS primitive
+  // when the JSON comes from an untrusted source. 64 MB is generous
+  // for any legitimate ICC profile round-trip — real JSON dumps of
+  // even big iccMAX spectral profiles top out around 5 MB.
+  static const std::streamsize kMaxJsonFileBytes =
+      static_cast<std::streamsize>(64) * 1024 * 1024;
+  auto sz = f.tellg();
+  if (sz < 0 || sz > kMaxJsonFileBytes) {
+    if (parseStr) *parseStr += std::string("JSON file exceeds 64 MB limit\n");
+    return false;
+  }
+  f.seekg(0, std::ios::beg);
 
   IccJson root;
   try {


### PR DESCRIPTION
# Cap top-level JSON input size and parse nesting

**Severity:** Medium · **Files:** `json-wrapper.cpp` (consumer), `IccProfileJson.cpp:521`

## Summary

`IccJson::parse(json)` is called with no max-size limit and no
`reject_on_nesting_depth`. nlohmann's defaults have effectively no
cap. A 1 GB string of `[[[[[…]]]]` chews memory and stack inside
nlohmann before IccLibJSON ever sees it. JS callers can easily push
hundreds of MB via `TextEncoder`.

Consumer-side fix (icctools) is straightforward: we already cap ICC
profile bytes; do the same for JSON strings before calling into wasm.
Library-side fix is to wire up nlohmann's size guards in the
published `LoadJson` / `ParseJson` entry points.

## Consumer-side patch (icctools)

```diff
--- a/validator-wasm/xml-wrapper.cpp  (json sibling)
+++ b/validator-wasm/xml-wrapper.cpp
@@ ...
+  static const std::size_t kMaxJsonBytes = 32ULL * 1024 * 1024;  // 32 MB
+  if (json.size() > kMaxJsonBytes) {
+    throw std::runtime_error("JSON exceeds 32 MB limit");
+  }
+
   IccJson root;
   try {
     root = IccJson::parse(json);
   } catch (...) { /* ... */ }
```

## Library-side patch

```diff
--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -519,6 +519,15 @@
 bool CIccProfileJson::LoadJson(const char *szFilename, std::string *parseStr)
 {
+  // Cap the raw JSON blob to prevent a pathological 10-GB file from
+  // chewing memory inside nlohmann before we see any structure.
+  std::ifstream probe(szFilename, std::ios::binary | std::ios::ate);
+  if (probe.is_open()) {
+    auto sz = probe.tellg();
+    if (sz > 64LL * 1024 * 1024) {
+      if (parseStr) *parseStr += "JSON file exceeds 64 MB limit\n";
+      return false;
+    }
+  }
```

For `ParseJson`, use nlohmann's size-check SAX callback to cap nesting
at `kMaxJsonParseDepth` from PR #26.

## Test plan

- Regression: `Testing/RunJsonTests.sh`.
- New unit: 100 MB JSON file rejected quickly.
- New unit: JSON with 10 000 levels of `[[[...]]]` rejected before
  full parse.

## References

- CWE-400 Uncontrolled Resource Consumption
- CWE-789 Memory Allocation with Excessive Size Value
