### PR TITLE
[IccLibJSON] Cap countOfDeviceCoords in NamedColor2 parser

### DIFF
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -692,6 +692,11 @@ bool CIccTagJsonNamedColor2::ParseJson(const IccJson &j, std::string & /*parseSt
 {
   icUInt32Number nDevCoords = 0;
   jGetValue(j, "countOfDeviceCoords", nDevCoords);
+  // ICC spec caps device colorants at 15. Reject pathologically large
+  // counts before SetSize (which allocates nColors * (33 + nDevCoords*4)
+  // bytes — an unbounded multiplication otherwise).
+  if (nDevCoords > 15u)
+    return false;
   icUInt32Number nColors = (jsonExistsField(j, "colors") && j["colors"].is_array())
                            ? icJsonSafeU32(j["colors"].size()) : 0;
 


### PR DESCRIPTION
# Cap user-controlled allocation-driving count fields in JSON parsers

**Severity:** Medium · **Files:**
- `IccTagJson.cpp:691-723` (`CIccTagJsonNamedColor2::ParseJson`)
- `IccTagJson.cpp:2197-2250` (`CIccTagJsonDict::ParseJson`)
- `IccTagJson.cpp:2520-2598` (`CIccTagJsonArray::ParseJson`)
- `IccTagJson.cpp:2643-2722` (`CIccTagJsonGamutBoundaryDesc::ParseJson`)

## Summary

Several JSON tag parsers pass attacker-controlled count fields
directly into `SetSize` → `calloc` / `new[]`. The binary parsers
have per-tag caps (`MAX_UNICODE_SIZE` etc.) — the JSON mirrors don't.

Worst case: `CIccTagJsonNamedColor2::ParseJson` reads
`countOfDeviceCoords` as `u32` with no upper bound. `SetSize(nColors,
nDevCoords)` → `calloc(nColors, 32 + 1 + nDevCoords * 4)`. Large
`nDevCoords` (e.g. `2^30`) × any `nColors` overflows the calloc
multiplication on wasm32 to a small allocation; the loop
`for d in range(nDevCoords)` is clamped against the per-entry array
length, *not* against what was actually allocated — so a single entry
with 3 `"deviceCoords"` and a declared `countOfDeviceCoords` of 2^30
writes 3 device coords into an undersized buffer. (Still OOB in the
same direction; the oversized declared count wins on header math.)

Secondary: gamut `nPCSCh` is bounded (`<= 32767`) but the cross-
product `nPCSTotal = pcsArr.size() / nPCSCh` uses the attacker-
controlled array size; a 500 MB `PCSValues` array allocates a 2 GB
float buffer.

## Reproducer

```json
{"data":{"type":"ncl2 ","countOfDeviceCoords":1073741824,
  "colors":[{"name":"x","pcsCoords":[0,0,0],"deviceCoords":[0,0,0,0]}]}}
```

## Patch

```diff
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -691,6 +691,9 @@
+  // ICC spec caps device colorants at icMaxNumColorants (15).
+  if (nDevCoords > icMaxNumColorants) {
+    return false;
+  }
   if (!SetSize(nColors, nDevCoords)) return false;
```

Apply the same tag-allocation cap (library-wide
`g_IccMaxTagAlloc`, same as the pattern flagged for binary parsers
in the README systemic-patterns section) to Dict, Array, and
GamutBoundaryDesc parsers.

## Test plan

- Regression: `Testing/RunJsonTests.sh`.
- New unit: ncl2 tag with `countOfDeviceCoords = 0x40000000` rejected.
- New unit: legitimate tag with `countOfDeviceCoords = 4` succeeds.

## References

- CWE-789 Memory Allocation with Excessive Size Value
- CWE-190 Integer Overflow or Wraparound
