### PR TITLE
[IccLibJSON] Cap CIccTagJsonUnknown hex blob at 16 MB

### DIFF
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -127,9 +127,14 @@ bool CIccTagJsonUnknown::ToJson(IccJson &j)
 
 bool CIccTagJsonUnknown::ParseJson(const IccJson &j, std::string & /*parseStr*/)
 {
+  // Cap hex blob size so a multi-MB string doesn't allocate a 4-GB
+  // buffer. 16 MB is generous for any legitimate unknown-tag payload.
+  static const icUInt32Number kMaxUnknownTagBytes = 16u * 1024 * 1024;
+
   std::string hex;
   if (jGetString(j, "unknownData", hex)) {
     m_nSize = icJsonGetHexDataSize(hex.c_str());
+    if (m_nSize > kMaxUnknownTagBytes) return false;
     if (m_pData) { delete[] m_pData; m_pData = NULL; }
     if (m_nSize) {
       m_pData = new(std::nothrow) icUInt8Number[m_nSize];


### PR DESCRIPTION
# Cap hex-data blob size in `CIccTagJsonUnknown` and siblings

**Severity:** Medium · **Files:** `IccTagJson.cpp:128-141, 192-224, 1104-1116, 2739-2806`

## Summary

The hex-data readers in `CIccTagJsonUnknown::ParseJson`,
compressed-data tags, generic `TagData`, and the embedded
Normal/Height image tags allow arbitrary-size hex strings.
`icJsonGetHexDataSize` returns a `u32` derived from the string length
(clamped to 0 on overflow), and then `m_pData = new
icUInt8Number[m_nSize]` allocates up to 4 GB in one shot.

In the browser this reliably OOMs the WASM module before the allocation
succeeds. On native it's a DoS.

## Patch

```diff
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ ...
+  static const icUInt32Number kMaxHexBlobBytes = 16u * 1024 * 1024;  // 16 MB
+  if (m_nSize > kMaxHexBlobBytes) return false;
+
   m_pData = new icUInt8Number[m_nSize];
```

Apply to all four sites.

## Test plan

- Regression: `Testing/RunJsonTests.sh`.
- New unit: tag with 64 MB of hex data rejected.
- New unit: tag with 1 MB of hex data succeeds.

## References

- CWE-789 Memory Allocation with Excessive Size Value
