### PR TITLE
[IccLibJSON] NUL-terminate m_szPrefix/m_szSufix after strncpy

### DIFF
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -699,10 +699,14 @@ bool CIccTagJsonNamedColor2::ParseJson(const IccJson &j, std::string & /*parseSt
 
   jGetValue(j, "vendorFlag", m_nVendorFlags);
   std::string prefix, suffix;
-  if (jGetString(j, "colorantPrefix", prefix))
+  if (jGetString(j, "colorantPrefix", prefix)) {
     strncpy(m_szPrefix, prefix.c_str(), sizeof(m_szPrefix)-1);
-  if (jGetString(j, "colorantSuffix", suffix))
+    m_szPrefix[sizeof(m_szPrefix)-1] = '\0';  // strncpy doesn't guarantee NUL
+  }
+  if (jGetString(j, "colorantSuffix", suffix)) {
     strncpy(m_szSufix,  suffix.c_str(), sizeof(m_szSufix)-1);
+    m_szSufix[sizeof(m_szSufix)-1]  = '\0';
+  }
 
   if (jsonExistsField(j, "colors") && j["colors"].is_array()) {
     const IccJson &colors = j["colors"];


### PR DESCRIPTION
# Null-terminate `m_szPrefix`/`m_szSuffix` after `strncpy` in NamedColor2 JSON parser

**Severity:** Medium · **File:** `IccJSON/IccLibJSON/IccTagJson.cpp:703, 705, 713`

## Summary

`CIccTagJsonNamedColor2::ParseJson` copies the attacker-supplied
`colorantPrefix` / `colorantSuffix` strings via:

```cpp
strncpy(m_szPrefix, prefix.c_str(), sizeof(m_szPrefix) - 1);
```

`strncpy` does **not** guarantee NUL termination when the source is
at least `n` bytes long. If `prefix` is 32+ bytes, `m_szPrefix`'s
final byte is whatever was previously there (typically uninitialised
heap). Subsequent `strlen` / `strcpy` on `m_szPrefix` (at
`IccTagBasic.cpp:2867` and elsewhere) walks past the buffer into
adjacent memory.

ICC spec caps these fields at 32 bytes; a JSON-crafted 64-byte
`colorantPrefix` defeats that cap.

## Patch

```diff
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -700,9 +700,14 @@
-    strncpy(m_szPrefix, prefix.c_str(), sizeof(m_szPrefix)-1);
+    strncpy(m_szPrefix, prefix.c_str(), sizeof(m_szPrefix) - 1);
+    m_szPrefix[sizeof(m_szPrefix) - 1] = '\0';
@@ -703,5 +708,6 @@
-    strncpy(m_szSuffix, suffix.c_str(), sizeof(m_szSuffix)-1);
+    strncpy(m_szSuffix, suffix.c_str(), sizeof(m_szSuffix) - 1);
+    m_szSuffix[sizeof(m_szSuffix) - 1] = '\0';
```

## Test plan

- Regression: `Testing/RunJsonTests.sh`.
- New unit: ncl2 tag with 64-char `colorantPrefix` — after parse,
  `m_szPrefix` is properly NUL-terminated at byte 31.
- Build with ASAN — no heap-buffer-overflow reports on subsequent
  `strlen`/`strcpy` of `m_szPrefix`.

## References

- CWE-170 Improper Null Termination
- CWE-126 Buffer Over-read
