### PR TITLE
[IccLibXML] Cap CIccMpeXmlCalculator::ParseXml recursion depth

### DIFF
--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -3205,11 +3205,29 @@ bool CIccMpeXmlCalculator::ParseChanMap(ChanVarMap& chanMap, const char *szNames
 
 bool CIccMpeXmlCalculator::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
+  // Guard against nested <CalculatorElement><SubElements>…</> recursion.
+  // Each level is one C++ stack frame; on Emscripten's ~1 MB stack a
+  // crafted XML with a few thousand nested CalculatorElements blows
+  // through it. 32 levels is generous for any legitimate iccMAX
+  // calculator.
+  static thread_local int s_xmlCalcDepth = 0;
+  static const int kMaxXmlCalcDepth = 32;
+
+  struct DepthGuard {
+    int *p;
+    DepthGuard(int *pp) : p(pp) { ++*p; }
+    ~DepthGuard() { --*p; }
+  } depthGuard(&s_xmlCalcDepth);
+  if (s_xmlCalcDepth > kMaxXmlCalcDepth) {
+    parseStr += "CalculatorElement nesting exceeds 32 levels\n";
+    return false;
+  }
+
   xmlNode *pChild;
 
   if (!pNode)
     return false;
-  
+
   SetSize(atoi(icXmlAttrValue(pNode, "InputChannels")),
           atoi(icXmlAttrValue(pNode, "OutputChannels")));
 


### PR DESCRIPTION
# Cap recursion and canonicalise import paths in `CIccMpeXmlCalculator`

**Severity:** Medium · **Files:** `IccXML/IccLibXML/IccMpeXml.cpp:2392-2449, 2587-2644, 3158-3181`

## Summary

Two recursion bugs in the XML Calculator parser:

1. **Unbounded sub-element recursion**: A `<CalculatorElement>` can
   contain a `<SubElements>` with nested `<CalculatorElement>`s, each
   of which calls `ParseXml` on itself with no depth cap. Same shape
   as PRs #04 (binary Calc), #14 (embedded profile), #26 (JSON Calc)
   but reached via XML.

2. **Weak import-cycle detection**: `ParseImport` uses `strstr
   (importPath, "*name*")` to de-dup. Trivially defeated:
   - Different directory prefixes but same basename match falsely
     (`a/foo.xml` == `b/foo.xml`).
   - Case differences on macOS/Windows bypass the match, so `foo.xml`
     vs. `Foo.xml` can recurse forever.

## Patch

```diff
--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ ...
+  static const int kMaxXmlCalcDepth = 32;
+
   bool CIccMpeXmlCalculator::ParseXml(xmlNode *pNode, ...)
+  {
+    return ParseXml(pNode, ..., /*nDepth=*/ 0);
+  }
+
+  bool CIccMpeXmlCalculator::ParseXml(xmlNode *pNode, ..., int nDepth)
   {
+    if (nDepth > kMaxXmlCalcDepth) return false;
     // ... existing body; recursive calls pass nDepth+1
   }
```

For imports, replace the substring-match with a canonicalised set:

```diff
-  if (strstr(importPath, name)) return false;  // weak cycle check
+  std::string canonical = canonicalise(name);  // lowercase, resolve ..
+  if (visitedImports.count(canonical)) return false;
+  visitedImports.insert(canonical);
```

Also bail at a modest import-count cap (e.g. 32) to prevent
N-to-N imports creating an exponential workload.

## Test plan

- Regression: `Testing/RunXmlTests.sh`.
- New unit: calculator XML with 1000 nested `<SubElements>` — parse
  returns `false`, no SIGSEGV.
- New unit: two files importing each other (`a.xml` → `Foo.xml`,
  `foo.xml` → `a.xml` on a case-insensitive filesystem) — terminates.

## References

- CWE-674 Uncontrolled Recursion
- CWE-834 Excessive Iteration
