### PR TITLE
[IccProfLib] Check profile magic before reading full header

### DIFF
--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1210,6 +1210,22 @@ void CIccProfile::InitHeader()
  */
 bool CIccProfile::ReadBasic(CIccIO *pIO)
 {
+  // Defense-in-depth: peek the magic field before reading the full
+  // 128-byte header. Random / non-ICC files that happen to pass
+  // upstream heuristics are otherwise walked through every header
+  // field + profileID hash before being rejected.
+  {
+    icInt64Number startPos = pIO->Tell();
+    icUInt32Number magic = 0;
+    if (pIO->Seek(startPos + 36, icSeekSet) < 0 ||
+        !pIO->Read32(&magic) ||
+        magic != icMagicNumber) {
+      pIO->Seek(startPos, icSeekSet);
+      return false;
+    }
+    pIO->Seek(startPos, icSeekSet);
+  }
+
   //Read Header
   if (pIO->Seek(0, icSeekSet)<0 ||
       !pIO->Read32(&m_Header.size) ||


### PR DESCRIPTION
# Check profile magic early to short-circuit allocation on non-profiles

**Severity:** Low · **File:** `IccProfLib/IccProfile.cpp:1214-1253`

## Summary

`CIccProfile::ReadBasic` reads the entire 128-byte header and computes
the profile ID (via `CalcProfileID`) before comparing `m_Header.magic`
to `icMagicNumber` at line 1252. For any non-ICC file dropped into the
parser (browser mis-type, random binary, etc.), we've already hashed up
to 128 bytes.

Defense-in-depth: reject early on magic mismatch so pathological inputs
that pass other library heuristics can't drive MD5 hashing work.

## Impact

- CPU waste, not security-critical.
- Modest DoS amplification if many non-profiles are pushed through
  (nominal — MD5 of 128 bytes is trivial).
- Worth fixing purely because it makes the error path cleaner.

## Patch

```diff
--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1214,12 +1214,25 @@ bool CIccProfile::ReadBasic(CIccIO *pIO)
+  // Quick magic check before doing any expensive header work. Peek
+  // the magic at offset 36, reject if not 'acsp', then rewind.
+  const icUInt32Number kMagicOffset = 36;
+  icInt64Number startPos = pIO->Tell();
+  if (pIO->Seek(startPos + kMagicOffset, icSeekSet) < 0)
+    return false;
+  icUInt32Number magic = 0;
+  if (!pIO->Read32(&magic) || magic != icMagicNumber) {
+    pIO->Seek(startPos, icSeekSet);
+    return false;
+  }
+  pIO->Seek(startPos, icSeekSet);
+
   // ... existing full header read continues
```

Remove the later `if (m_Header.magic != icMagicNumber) return false;`
check since the early one covers it.

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: pass a 1 KB file of random bytes to `CIccProfile::Read` —
  must return `false` quickly without triggering `CalcProfileID`.

## References

- CWE-20 Improper Input Validation (defense-in-depth)
