### PR TITLE
[IccProfLib] Reorder null-check before pIO->Tell() in TextDescription::Read

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -2082,13 +2082,13 @@ CIccTagTextDescription::~CIccTagTextDescription()
  */
 bool CIccTagTextDescription::Read(icUInt32Number size, CIccIO *pIO)
 {
+  if (!pIO || size < 3 * sizeof(icUInt32Number))
+    return false;
+
   icTagTypeSignature sig;
 
   m_szText[0] = '\0';
   int64_t nEnd = pIO->Tell() + size;
-
-  if (size<3*sizeof(icUInt32Number) || !pIO)
-    return false;
 
   icUInt32Number nSize;
 


### PR DESCRIPTION
# Reorder null-check before use in `CIccTagTextDescription::Read`

**Severity:** Low · **File:** `IccProfLib/IccTagBasic.cpp:2088-2090`

## Summary

`CIccTagTextDescription::Read` uses `pIO->Tell()` at line 2088 before
the null-check at line 2090 returns on `pIO == nullptr`. Currently no
caller passes `nullptr` — all invocations go through `LoadTag` which
guards — but the pattern is brittle and ASAN/static analysers flag it.

## Impact

Latent. Becomes a crash only if a future refactor changes the caller
contract.

## Patch

```diff
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -2085,13 +2085,13 @@ bool CIccTagTextDescription::Read(icUInt32Number size, CIccIO *pIO)
-  icUInt32Number nEnd;
-
-  int64_t nEndPos = pIO->Tell() + size;
-
-  if (sizeof(icTagTypeSignature) +
-      sizeof(icUInt32Number) +
-      sizeof(icUInt32Number) > size ||
-      !pIO)
+  if (!pIO ||
+      sizeof(icTagTypeSignature) +
+      sizeof(icUInt32Number) +
+      sizeof(icUInt32Number) > size)
     return false;
+
+  icUInt32Number nEnd;
+  int64_t nEndPos = pIO->Tell() + size;
```

## Sweep

Audit all `CIccTag*::Read` overrides for the same shape:

```sh
git grep -nE 'pIO->(Tell|Read|Seek).*!pIO' IccProfLib/
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- Build with `-Wnonnull-compare`; no new warnings.

## References

- CWE-476 NULL Pointer Dereference (defensive reorder)
