### PR TITLE
[IccProfLib] Null-check calloc return in CIccTagSparseMatrixArray copy-ctor

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -4502,6 +4502,13 @@ CIccTagSparseMatrixArray::CIccTagSparseMatrixArray(const CIccTagSparseMatrixArra
   m_nMatrixType = ITSMA.m_nMatrixType;
 
   m_RawData = (icUInt8Number*)calloc(m_nSize, GetBytesPerMatrix());
+  if (!m_RawData) {
+    // calloc failed — leave the object in a safe, empty state rather
+    // than dereference NULL in the memcpy below.
+    m_nSize = 0;
+    m_bNonZeroPadding = false;
+    return;
+  }
   memcpy(m_RawData, ITSMA.m_RawData, (size_t)m_nSize*GetBytesPerMatrix());
 
   m_bNonZeroPadding = ITSMA.m_bNonZeroPadding;


### PR DESCRIPTION
# Check `calloc` return before `memcpy` in `CIccTagSparseMatrixArray` copy

**Severity:** Low · **File:** `IccProfLib/IccTagBasic.cpp:4504-4505`

## Summary

```cpp
m_RawData = (icUInt8Number*)calloc(m_nSize, GetBytesPerMatrix());
memcpy(m_RawData, ITSMA.m_RawData, (size_t)m_nSize*GetBytesPerMatrix());
```

If `calloc` fails (same large product as the primary Critical finding
#13; reachable when deep-copying a sparse-matrix tag from a large
profile under memory pressure), `m_RawData` is `NULL` and `memcpy`
dereferences it.

## Patch

```diff
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -4500,9 +4500,14 @@
-  m_RawData = (icUInt8Number*)calloc(m_nSize, GetBytesPerMatrix());
-  memcpy(m_RawData, ITSMA.m_RawData, (size_t)m_nSize*GetBytesPerMatrix());
+  m_RawData = (icUInt8Number*)calloc(m_nSize, GetBytesPerMatrix());
+  if (!m_RawData) {
+    m_nSize = 0;
+    return;  // (or `throw std::bad_alloc{}` if callers expect exceptions)
+  }
+  memcpy(m_RawData, ITSMA.m_RawData,
+         (size_t)m_nSize * GetBytesPerMatrix());
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: copy-construct a sparse-matrix tag under simulated
  allocation failure — no crash, resulting object has `m_nSize == 0`.

## References

- CWE-476 NULL Pointer Dereference
- CWE-252 Unchecked Return Value
