### PR TITLE
[IccProfLib] Guard icIsLegalUTF8Sequence against empty input

### DIFF
--- a/IccProfLib/IccConvertUTF.cpp
+++ b/IccProfLib/IccConvertUTF.cpp
@@ -480,6 +480,11 @@ static Boolean isLegalUTF8(const UTF8 *source, int length)
 */
 Boolean icIsLegalUTF8Sequence(const UTF8 *source, const UTF8 *sourceEnd)
 {
+  // Reject empty range before dereferencing *source. Otherwise this
+  // reads one byte past the end of the supplied buffer.
+  if (source >= sourceEnd)
+    return false;
+
   int length = trailingBytesForUTF8[*source]+1;
   if (source+length > sourceEnd) {
     return false;


### PR DESCRIPTION
# Guard empty input in `icIsLegalUTF8Sequence`

**Severity:** Low · **File:** `IccProfLib/IccConvertUTF.cpp:481-488`

## Summary

```cpp
Boolean icIsLegalUTF8Sequence(const UTF8 *source, const UTF8 *sourceEnd) {
  int length = trailingBytesForUTF8[*source] + 1;   // ← *source before bounds
  if (source + length > sourceEnd) return false;
  ...
}
```

Reading `*source` when `source == sourceEnd` is a 1-byte OOB read.
Not invoked from the validator today, but the function is library-
exported and documented, and the header encourages external use.

## Patch

```diff
--- a/IccProfLib/IccConvertUTF.cpp
+++ b/IccProfLib/IccConvertUTF.cpp
@@ -480,7 +480,10 @@
 Boolean icIsLegalUTF8Sequence(const UTF8 *source, const UTF8 *sourceEnd)
 {
-  int length = trailingBytesForUTF8[*source] + 1;
+  if (source >= sourceEnd)
+    return false;
+
+  int length = trailingBytesForUTF8[*source] + 1;
   if (source + length > sourceEnd)
     return false;
```

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: `icIsLegalUTF8Sequence(p, p)` returns `false` without
  reading `*p`.
- Build with ASAN — no heap-buffer-overflow on empty-range calls.

## References

- CWE-125 Out-of-bounds Read
- CWE-20 Improper Input Validation
