### PR TITLE
[IccProfLib] Fix icConvertUTF16toUTF32 vector overload signature mismatch

### DIFF
--- a/IccProfLib/IccConvertUTF.cpp
+++ b/IccProfLib/IccConvertUTF.cpp
@@ -199,8 +199,14 @@ icUtfConversionResult icConvertUTF16toUTF32 (const UTF16** sourceStart, const UT
   return result;
 }
 
-icUtfConversionResult icConvertUTF16toUTF32 (const UTF16* source, const UTF16* sourceEnd, 
-                                             icUtf32Vector target, UTF32* /* targetEnd */, icUtfConversionFlags flags)
+// Take `target` by reference so caller sees the populated vector, and
+// drop the dead `UTF32* targetEnd` parameter. The header declares this
+// overload with a reference (see IccConvertUTF.h); the previous
+// by-value signature here never matched the header, so the header's
+// declaration went undefined and any caller silently got a local-only
+// populate + empty return — classic data-loss bug.
+icUtfConversionResult icConvertUTF16toUTF32 (const UTF16* source, const UTF16* sourceEnd,
+                                             icUtf32Vector &target, icUtfConversionFlags flags)
 {
   icUtfConversionResult result = conversionOK;
   target.clear();


### PR DESCRIPTION
# Pass `target` by reference in `icConvertUTF16toUTF32` vector overload

**Severity:** Low · **File:** `IccProfLib/IccConvertUTF.cpp:202-248`

## Summary

The vector-overload signature is:

```cpp
ConversionResult icConvertUTF16toUTF32(const UTF16 *source, const UTF16 *sourceEnd,
                                       icUtf32Vector target,           // ← by value
                                       ConversionFlags flags);
```

All subsequent `target.clear()` and `target.push_back(…)` calls operate
on a local copy. The caller's vector is never touched. Not a crash, but
a silent data-loss bug: callers expect the conversion to populate their
buffer.

## Patch

```diff
--- a/IccProfLib/IccConvertUTF.cpp
+++ b/IccProfLib/IccConvertUTF.cpp
@@ -200,7 +200,7 @@
 ConversionResult icConvertUTF16toUTF32(const UTF16 *source,
                                         const UTF16 *sourceEnd,
-                                        icUtf32Vector target,
+                                        icUtf32Vector &target,
                                         ConversionFlags flags)
```

Apply the same fix to the corresponding header declaration in
`IccConvertUTF.h`.

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: convert a known UTF-16 string, verify `target` contains the
  expected code points after return.

## References

- Silent data-loss, not CWE-categorised (pass-by-value when a reference
  was intended).
