### PR TITLE
[IccProfLib] Fix 6 infinite-loop sites in CIccTagDict Unicode getters

### DIFF
--- a/IccProfLib/IccTagDict.cpp
+++ b/IccProfLib/IccTagDict.cpp
@@ -1107,7 +1107,7 @@ CIccDictEntry* CIccTagDict::Get(const icUnicodeChar *szName) const
 {
   std::wstring sName;
   while(*szName)
-    sName += *szName;
+    sName += *szName++;
 
   return Get(sName);
 }
@@ -1182,7 +1182,7 @@ std::wstring CIccTagDict::GetValue(const icUnicodeChar *szName, bool *bIsSet) co
 {
   std::wstring sName;
   while(*szName)
-    sName += *szName;
+    sName += *szName++;
 
   return GetValue(sName, bIsSet);
 }
@@ -1247,7 +1247,7 @@ CIccTagMultiLocalizedUnicode* CIccTagDict::GetNameLocalized(const icUnicodeChar 
 {
   std::wstring sName;
   while(*szName)
-    sName += *szName;
+    sName += *szName++;
 
   return GetNameLocalized(sName);
 }
@@ -1314,7 +1314,7 @@ CIccTagMultiLocalizedUnicode* CIccTagDict::GetValueLocalized(const icUnicodeChar
 {
   std::wstring sName;
   while(*szName)
-    sName += *szName;
+    sName += *szName++;
 
   return GetValueLocalized(sName);
 }
@@ -1388,7 +1388,7 @@ bool CIccTagDict::Remove(const icUnicodeChar *szName)
 {
   std::wstring sName;
   while(*szName)
-    sName += *szName;
+    sName += *szName++;
 
   return Remove(sName);
 
@@ -1460,7 +1460,7 @@ bool CIccTagDict::Set(const icUnicodeChar *szName, const icUnicodeChar *szValue)
 {
   std::wstring sName;
   while(*szName)
-    sName += *szName;
+    sName += *szName++;
 
   std::wstring sValue;
 


### PR DESCRIPTION
# Fix missing `++` in `CIccTagDict` Unicode-key getters

**Severity:** Low · **File:** `IccProfLib/IccTagDict.cpp:1109-1110, 1184-1185, 1249-1250, 1316-1317, 1389-1391`

## Summary

Five `CIccTagDict` methods that accept `const icUnicodeChar *szName`
have an identical bug:

```cpp
while (*szName) sName += *szName;   // ← szName is never incremented
```

The pointer never advances, so the loop runs forever on any non-empty
input, appending `*szName` to `sName` each iteration until memory is
exhausted.

The fix is already present in the sibling `Set(const icUnicodeChar*)`
overload (line 1510/1544) — just never ported to the getters.

Not reachable from profile parsing — `CIccTagDict::Read` builds the
map via its own machinery. Reachable from any SDK client that calls
`Get`, `GetValue`, `GetNameLocalized`, `GetValueLocalized`, or
`Remove` with a `icUnicodeChar*` argument.

## Patch

```diff
--- a/IccProfLib/IccTagDict.cpp
+++ b/IccProfLib/IccTagDict.cpp
@@ -1108,7 +1108,7 @@
 {
   std::basic_string<icUnicodeChar> sName;
-  while(*szName) sName += *szName;
+  while(*szName) sName += *szName++;
```

Apply the same one-char fix at each of the five sites listed above.

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: call `CIccTagDict::Get(u"foo")` — returns in finite time,
  not an infinite loop.

## References

- CWE-835 Loop with Unreachable Exit Condition
- CWE-400 Uncontrolled Resource Consumption
