### PR TITLE
[IccLibJSON] Check sscanf return in header-flags / device-attr parsers

### DIFF
--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -103,8 +103,7 @@ static icUInt32Number icJsonParseHeaderFlags(const IccJson &j)
   jGetString(j, "VendorFlags", vendor);
   if (!vendor.empty()) {
     unsigned v = 0;
-    sscanf(vendor.c_str(), "%x", &v);
-    flags |= v;
+    if (sscanf(vendor.c_str(), "%x", &v) == 1) flags |= v;
   }
   return flags;
 }

--- a/IccJSON/IccLibJSON/IccUtilJson.cpp
+++ b/IccJSON/IccLibJSON/IccUtilJson.cpp
@@ -231,7 +231,7 @@ icUInt64Number icJsonParseDeviceAttr(const IccJson &j)
   s.clear(); jGetString(j, "VendorSpecific", s);
   if (!s.empty()) {
     unsigned long long vendor = 0;
-    sscanf(s.c_str(), "%llx", &vendor);
+    if (sscanf(s.c_str(), "%llx", &vendor) != 1) vendor = 0;
     attr |= (icUInt64Number)vendor;
   }
   return attr;


### PR DESCRIPTION
# Check `sscanf` return value in JSON header / device-attr parsers

**Severity:** Low · **Files:** `IccProfileJson.cpp:102-108`; `IccUtilJson.cpp:231-236`

## Summary

Both `icJsonParseHeaderFlags` and `icJsonParseDeviceAttr` call
`sscanf(s.c_str(), "%llx", &vendor);` without checking the return
value. If the input is not hex-parseable, `vendor` retains whatever
stack junk was there at entry — undefined behaviour, and historically
a source of information-leak primitives when compilers elect to keep
attacker-influenced earlier stack values live.

Low severity because the downstream uses of `vendor` are themselves
attacker-controlled (it goes straight back into the parsed profile).
But cheap to fix.

## Patch

```diff
--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -100,8 +100,10 @@
-  icUInt64Number vendor;
-  sscanf(s.c_str(), "%llx", &vendor);
+  icUInt64Number vendor = 0;
+  if (sscanf(s.c_str(), "%llx", &vendor) != 1) {
+    vendor = 0;  // or return false to reject
+  }
```

Same fix at `IccUtilJson.cpp:231-236`.

## Test plan

- Regression: `Testing/RunJsonTests.sh`.
- New unit: JSON with `"flags":"not-hex"` — vendor is 0, not garbage;
  no UBSAN warning.

## References

- CWE-252 Unchecked Return Value
- CWE-457 Use of Uninitialized Variable
