### PR TITLE
[IccLibXML] Harden filename[0] accesses with explicit null check

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -227,7 +227,7 @@ static bool icXmlParseTextString(xmlNode *pNode, std::string &parseStr, std::str
         const icChar *filename = icXmlAttrValue(pNode, "File");
 
         // file exists
-        if (filename[0]) {        
+        if (filename && filename[0]) {        
           CIccIO *file = IccOpenFileIO(filename, "rb");        
           if (!file){          
             parseStr += "Error! - File '";
@@ -427,7 +427,7 @@ bool CIccTagXmlTextDescription::ParseXml(xmlNode *pNode, std::string &parseStr)
   const icChar *filename = icXmlAttrValue(pNode, "File");
 
   // file exists
-  if (filename[0]) {
+  if (filename && filename[0]) {
     CIccIO *file = IccOpenFileIO(filename, "rb");
 
     if (!file){
@@ -1523,7 +1523,7 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string &parse
 
   A a;
 
-  if (filename[0]) {
+  if (filename && filename[0]) {
     CIccIO *file = IccOpenFileIO(filename, "rb");
     if (!file){
       parseStr += "Error! - File '";
@@ -2659,7 +2659,7 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
     const char *filename = icXmlAttrValue(pCurveNode, "File");
 
     // file exists
-    if (filename[0]) {
+    if (filename && filename[0]) {
       CIccIO *file = IccOpenFileIO(filename, "rb");
       if (!file){
         parseStr += "Error! - File '";
@@ -3513,7 +3513,7 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
       filename = icXmlAttrValue(table, "File");
     }
 
-    if (filename[0]) {
+    if (filename && filename[0]) {
       CIccIO *file = IccOpenFileIO(filename, "rb");
 
       if (!file) {
@@ -5300,7 +5300,7 @@ bool CIccTagXmlEmbeddedHeightImage::ParseXml(xmlNode *pNode, std::string &parseS
     }
 
     // file exists
-    if (filename[0]) {
+    if (filename && filename[0]) {
       CIccIO *file = IccOpenFileIO(filename, "rb");
       if (!file) {
         parseStr += "Error! - File '";
@@ -5401,7 +5401,7 @@ bool CIccTagXmlEmbeddedNormalImage::ParseXml(xmlNode *pNode, std::string &parseS
     }
 
     // file exists
-    if (filename[0]) {
+    if (filename && filename[0]) {
       CIccIO *file = IccOpenFileIO(filename, "rb");
       if (!file) {
         parseStr += "Error! - File '";


### PR DESCRIPTION
# Consistent NULL + empty-string handling for `<Image>` file attributes

**Severity:** Low · **Files:** `IccXML/IccLibXML/IccTagXml.cpp:5239, 5334`

## Summary

```cpp
const char *filename = icXmlAttrValue(pImageNode, "File");
if (!filename || !filename[0]) {
  filename = icXmlAttrValue(pImageNode, "Filename");
}
if (filename[0]) { ... }        // ← no NULL check
```

Today `icXmlAttrValue` returns `""` (empty string) when the attribute
is absent — so `filename[0]` is `'\0'` and the fall-through is safe.
But the earlier `!filename` check *expects* NULL as a possible return
value; the two halves disagree on the attribute-absent convention.

If a future refactor makes `icXmlAttrValue` actually return NULL on
absence (consistent with its naming), `filename[0]` will deref NULL.

Latent bug — cheap to make consistent now.

## Patch

```diff
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -5233,7 +5233,7 @@
-  if (filename[0]) {
+  if (filename && filename[0]) {
     // ... use filename ...
   }
```

Same change at line 5334. Also sweep the file for the pattern:

```sh
git grep -nE 'filename\[0\]' IccXML/IccLibXML/
```

## Test plan

- Regression: `Testing/RunXmlTests.sh`.
- Compile-time: add `-Wnonnull-compare` and fix any hits.

## References

- CWE-476 NULL Pointer Dereference (latent)
