### PR TITLE
[IccLibXML] Add icXmlParseU16/U32 range-checking parsers + one usage site

### DIFF
--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -107,10 +107,21 @@ bool CIccMpeXmlUnknown::ToXml(std::string &xml, std::string blanks/* = ""*/)
 }
 
 
-bool CIccMpeXmlUnknown::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
+bool CIccMpeXmlUnknown::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
   SetType((icElemTypeSignature)icXmlStrToSig(icXmlAttrValue(pNode, "type")));
-  SetChannels(atoi(icXmlAttrValue(pNode, "InputChannels")), atoi(icXmlAttrValue(pNode, "OutputChannels")));
+
+  // Demonstration use of the range-checked parsers: InputChannels /
+  // OutputChannels are u16 in SetChannels. atoi + silent narrowing
+  // previously accepted "65537" as 1 or "-1" as 65535; icXmlParseU16
+  // refuses both.
+  icUInt16Number nIn = 0, nOut = 0;
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "InputChannels"),  nIn) ||
+      !icXmlParseU16(icXmlAttrValue(pNode, "OutputChannels"), nOut)) {
+    parseStr += "Invalid InputChannels or OutputChannels attribute on Unknown MPE element\n";
+    return false;
+  }
+  SetChannels(nIn, nOut);
 
   if (pNode->children && pNode->children->type == XML_TEXT_NODE && pNode->children->content) {
     icUInt32Number nSize = icXmlGetHexDataSize((const char *)pNode->children->content);

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -109,16 +109,19 @@ bool CIccMpeXmlUnknown::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlUnknown::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  SetType((icElemTypeSignature)icXmlStrToSig(icXmlAttrValue(pNode, "type")));
+  SetType((icElemTypeSignature)icXmlStrToSig(icXmlAttrValue(pNode, "Type")));
 
   // Demonstration use of the range-checked parsers: InputChannels /
   // OutputChannels are u16 in SetChannels. atoi + silent narrowing
   // previously accepted "65537" as 1 or "-1" as 65535; icXmlParseU16
   // refuses both.
   icUInt16Number nIn = 0, nOut = 0;
-  if (!icXmlParseU16(icXmlAttrValue(pNode, "InputChannels"),  nIn) ||
-      !icXmlParseU16(icXmlAttrValue(pNode, "OutputChannels"), nOut)) {
-    parseStr += "Invalid InputChannels or OutputChannels attribute on Unknown MPE element\n";
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "InputChannels"), nIn)) {
+    parseStr += "Invalid InputChannels attribute on Unknown MPE element\n";
+    return false;
+  }
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "OutputChannels"), nOut)) {
+    parseStr += "Invalid OutputChannels attribute on Unknown MPE element\n";
     return false;
   }
   SetChannels(nIn, nOut);

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -61,6 +61,8 @@
  * 
  */
 
+#include <cstdlib>  /* std::strtoul, std::strtoull */
+#include <cerrno>   /* errno, ERANGE */
 #include <time.h>
 #include "IccUtilXml.h"
 #include "IccConvertUTF.h"
@@ -1244,9 +1246,13 @@ const std::string icGetPadSpace(double value)
 bool icXmlParseU16(const char *s, icUInt16Number &out, icUInt16Number max_value)
 {
   if (!s || !*s) return false;
+  // strtoul accepts an optional leading sign; explicitly reject '-' so
+  // that "-0", "-1", etc. are refused rather than wrapping or returning 0.
+  if (*s == '-') return false;
   char *end = nullptr;
+  errno = 0;
   unsigned long v = std::strtoul(s, &end, 10);
-  if (*end != '\0' || v > max_value) return false;
+  if (*end != '\0' || errno == ERANGE || v > max_value) return false;
   out = static_cast<icUInt16Number>(v);
   return true;
 }
@@ -1254,9 +1260,12 @@ bool icXmlParseU16(const char *s, icUInt16Number &out, icUInt16Number max_value)
 bool icXmlParseU32(const char *s, icUInt32Number &out, icUInt32Number max_value)
 {
   if (!s || !*s) return false;
+  // Same sign guard as icXmlParseU16.
+  if (*s == '-') return false;
   char *end = nullptr;
+  errno = 0;
   unsigned long long v = std::strtoull(s, &end, 10);
-  if (*end != '\0' || v > max_value) return false;
+  if (*end != '\0' || errno == ERANGE || v > max_value) return false;
   out = static_cast<icUInt32Number>(v);
   return true;
 }

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -1238,3 +1238,25 @@ const std::string icGetPadSpace(double value)
 
    return space;
 }
+
+// See IccUtilXml.h for rationale — safe integer parsers to replace
+// `atoi(icXmlAttrValue(...))` patterns that silently narrow to u8/u16.
+bool icXmlParseU16(const char *s, icUInt16Number &out, icUInt16Number max_value)
+{
+  if (!s || !*s) return false;
+  char *end = nullptr;
+  unsigned long v = std::strtoul(s, &end, 10);
+  if (*end != '\0' || v > max_value) return false;
+  out = static_cast<icUInt16Number>(v);
+  return true;
+}
+
+bool icXmlParseU32(const char *s, icUInt32Number &out, icUInt32Number max_value)
+{
+  if (!s || !*s) return false;
+  char *end = nullptr;
+  unsigned long long v = std::strtoull(s, &end, 10);
+  if (*end != '\0' || v > max_value) return false;
+  out = static_cast<icUInt32Number>(v);
+  return true;
+}

--- a/IccXML/IccLibXML/IccUtilXml.h
+++ b/IccXML/IccLibXML/IccUtilXml.h
@@ -157,11 +157,15 @@ const std::string icGetDeviceAttrName(icUInt64Number devAttr);
 const std::string icGetHeaderFlagsName(icUInt32Number flags, bool bUsesMCS=false);
 const std::string icGetPadSpace(double value);
 
-// Safe integer parsers for XML attribute values. Unlike atoi these
-// return false (and leave `out` unchanged) on non-numeric input,
-// negative values, or values exceeding `max_value`. Intended as a
-// drop-in replacement at ParseXml sites that previously used atoi
-// followed by a silent narrowing cast.
+// Safe unsigned-integer parsers for XML attribute values.
+// Return false (leaving `out` unchanged) when:
+//   - the string is NULL or empty,
+//   - it has a leading '-' (explicitly rejected; strtoul would wrap),
+//   - it contains non-digit characters or trailing whitespace,
+//   - the value exceeds max_value, or
+//   - strtoul/strtoull sets errno == ERANGE.
+// These are stricter than atoi: they do not silently narrow, do not
+// accept trailing garbage, and do not wrap negative inputs.
 //
 //   icUInt16Number nRows = 0;
 //   if (!icXmlParseU16(icXmlAttrValue(node, "Rows"), nRows))

--- a/IccXML/IccLibXML/IccUtilXml.h
+++ b/IccXML/IccLibXML/IccUtilXml.h
@@ -157,7 +157,20 @@ const std::string icGetDeviceAttrName(icUInt64Number devAttr);
 const std::string icGetHeaderFlagsName(icUInt32Number flags, bool bUsesMCS=false);
 const std::string icGetPadSpace(double value);
 
-
+// Safe integer parsers for XML attribute values. Unlike atoi these
+// return false (and leave `out` unchanged) on non-numeric input,
+// negative values, or values exceeding `max_value`. Intended as a
+// drop-in replacement at ParseXml sites that previously used atoi
+// followed by a silent narrowing cast.
+//
+//   icUInt16Number nRows = 0;
+//   if (!icXmlParseU16(icXmlAttrValue(node, "Rows"), nRows))
+//     return false;
+//
+bool icXmlParseU16(const char *s, icUInt16Number &out,
+                   icUInt16Number max_value = 0xFFFFu);
+bool icXmlParseU32(const char *s, icUInt32Number &out,
+                   icUInt32Number max_value = 0xFFFFFFFFu);
 
 
 #endif //_ICCUTILXML_H


### PR DESCRIPTION
# Replace \`atoi\` with range-checking integer parsers in XML attribute readers

**Severity:** Low · **Files:** \`IccXML/IccLibXML/IccUtilXml.cpp\`, \`IccXML/IccLibXML/IccUtilXml.h\`, \`IccXML/IccLibXML/IccMpeXml.cpp\`

## Summary

\`atoi(icXmlAttrValue(...))\` returns \`int\` and is silently cast to \`icUInt16Number\`/\`icUInt32Number\`.
An input like \`"65538"\` becomes \`2\`; \`"-1"\` becomes \`65535\`. Most callers validate downstream
but the pattern makes defensive review hard and is a latent source of future bugs.

## Patch

Introduce \`icXmlParseU16\` / \`icXmlParseU32\` in \`IccUtilXml.cpp\`. These are **stricter than atoi**:
- Reject NULL/empty strings
- Explicitly reject a leading \`'-'\` (strtoul accepts optional sign; \`"-0"\` would otherwise pass)
- Reject trailing non-digit characters
- Set \`errno = 0\` before conversion; reject if \`errno == ERANGE\`
- Reject values exceeding \`max_value\`

\`#include <cstdlib>\` and \`<cerrno>\` added so \`std::strtoul\`/\`strtoull\`/\`errno\`/\`ERANGE\`
are declared portably.

Usage site in \`CIccMpeXmlUnknown::ParseXml\`:
- \`"type"\` attribute corrected to \`"Type"\` to match \`ToXml\` output (\`icXmlFindAttr\` is case-sensitive — roundtrip was silently broken)
- \`InputChannels\` / \`OutputChannels\` error messages split into separate checks for diagnosability

## Test plan

- Regression: \`Testing/RunTests.sh\`.
- New unit: XML with \`InputChannels="65536"\` (overflows u16) — parse rejects instead of silently wrapping to 0.
- New unit: XML with \`InputChannels="-1"\` — parse rejects instead of wrapping to 65535.

## References

- CWE-681 Incorrect Conversion between Numeric Types
- CWE-190 Integer Overflow or Wraparound (downstream risk)