### PR TITLE
[IccLibXML] Cover third new[] site + size cap + NUL-terminate file buffers

### DIFF
--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -319,7 +319,20 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         delete file;
         return false;
       }
-      char *buf = new char[num];
+      // 256 MB ceiling so `num+1` can't wrap size_t and the
+      // downstream ParseTextArrayNum doesn't chew gigabytes.
+      static const size_t kMaxTextFileBytes = 256ULL * 1024 * 1024;
+      if (num > kMaxTextFileBytes) {
+        parseStr += "'";
+        parseStr += filename;
+        parseStr += "' exceeds 256 MB limit.\n";
+        delete file;
+        return false;
+      }
+      // +1 and explicit NUL: ParseTextArrayNum eventually calls
+      // ParseText which scans until '\0'. Without a terminator
+      // it reads past the allocation into adjacent heap.
+      char *buf = new(std::nothrow) char[num + 1];
 
       if (!buf) {          
         perror("Memory Error");
@@ -339,6 +352,7 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         delete file;             
         return false;
       }   
+      buf[num] = '\0';  // NUL-terminate for ParseText downstream
 
       CIccFloatArray data;
 
@@ -745,7 +759,20 @@ bool CIccSingleSampledCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         delete file;
         return false;
       }
-      char *buf = new char[num];
+      // 256 MB ceiling so `num+1` can't wrap size_t and the
+      // downstream ParseTextArrayNum doesn't chew gigabytes.
+      static const size_t kMaxTextFileBytes = 256ULL * 1024 * 1024;
+      if (num > kMaxTextFileBytes) {
+        parseStr += "'";
+        parseStr += filename;
+        parseStr += "' exceeds 256 MB limit.\n";
+        delete file;
+        return false;
+      }
+      // +1 and explicit NUL: ParseTextArrayNum eventually calls
+      // ParseText which scans until '\0'. Without a terminator
+      // it reads past the allocation into adjacent heap.
+      char *buf = new(std::nothrow) char[num + 1];
 
       if (!buf) {
         perror("Memory Error");
@@ -765,6 +792,7 @@ bool CIccSingleSampledCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         delete file;
         return false;
       }
+      buf[num] = '\0';  // NUL-terminate for ParseText downstream
 
       // lut8type
       if (m_storageType == icValueTypeUInt8) {

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -67,6 +67,7 @@
 #include "IccIoXml.h"
 #include "IccCAM.h"
 
+#include <new>     /* std::nothrow */
 #include <cstring> /* C strings strcpy, memcpy ... */
 
 #ifdef WIN32
@@ -319,10 +320,9 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         delete file;
         return false;
       }
-      // 256 MB ceiling so `num+1` can't wrap size_t and the
-      // downstream ParseTextArrayNum doesn't chew gigabytes.
-      static const size_t kMaxTextFileBytes = 256ULL * 1024 * 1024;
-      if (num > kMaxTextFileBytes) {
+      // Shared ceiling: prevents num+1 from wrapping size_t and caps
+      // downstream ParseTextArrayNum memory use. See IccUtilXml.h.
+      if (num > icXmlMaxTextFileBytes) {
         parseStr += "'";
         parseStr += filename;
         parseStr += "' exceeds 256 MB limit.\n";
@@ -334,24 +334,26 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
       // it reads past the allocation into adjacent heap.
       char *buf = new(std::nothrow) char[num + 1];
 
-      if (!buf) {          
-        perror("Memory Error");
-        parseStr += "'";
+      if (!buf) {
+        parseStr += "Out of memory allocating ";
+        parseStr += std::to_string(num + 1);
+        parseStr += " bytes for text buffer from '";
         parseStr += filename;
-        parseStr += "' may not be a valid text file.\n";
+        parseStr += "'.\n";
         delete file;
         return false;
       }
 
-      if (file->Read8(buf, num) !=num) {
-        perror("Read-File Error");
-        parseStr += "'";
+      if (file->Read8(buf, num) != num) {
+        parseStr += "Read error: could not read ";
+        parseStr += std::to_string(num);
+        parseStr += " bytes from '";
         parseStr += filename;
-        parseStr += "' may not be a valid text file.\n";
+        parseStr += "'.\n";
         delete[] buf;
-        delete file;             
+        delete file;
         return false;
-      }   
+      }
       buf[num] = '\0';  // NUL-terminate for ParseText downstream
 
       CIccFloatArray data;
@@ -759,10 +761,9 @@ bool CIccSingleSampledCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
         delete file;
         return false;
       }
-      // 256 MB ceiling so `num+1` can't wrap size_t and the
-      // downstream ParseTextArrayNum doesn't chew gigabytes.
-      static const size_t kMaxTextFileBytes = 256ULL * 1024 * 1024;
-      if (num > kMaxTextFileBytes) {
+      // Shared ceiling: prevents num+1 from wrapping size_t and caps
+      // downstream ParseTextArrayNum memory use. See IccUtilXml.h.
+      if (num > icXmlMaxTextFileBytes) {
         parseStr += "'";
         parseStr += filename;
         parseStr += "' exceeds 256 MB limit.\n";
@@ -775,19 +776,21 @@ bool CIccSingleSampledCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
       char *buf = new(std::nothrow) char[num + 1];
 
       if (!buf) {
-        perror("Memory Error");
-        parseStr += "'";
+        parseStr += "Out of memory allocating ";
+        parseStr += std::to_string(num + 1);
+        parseStr += " bytes for text buffer from '";
         parseStr += filename;
-        parseStr += "' may not be a valid text file.\n";
+        parseStr += "'.\n";
         delete file;
         return false;
       }
 
       if (file->Read8(buf, num) != num) {
-        perror("Read-File Error");
-        parseStr += "'";
+        parseStr += "Read error: could not read ";
+        parseStr += std::to_string(num);
+        parseStr += " bytes from '";
         parseStr += filename;
-        parseStr += "' may not be a valid text file.\n";
+        parseStr += "'.\n";
         delete [] buf;
         delete file;
         return false;

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -71,6 +71,7 @@
 #include "IccStructFactory.h"
 #include "IccArrayFactory.h"
 #include "IccConvertUTF.h"
+#include <new>     /* std::nothrow */
 #include <cstring> /* C strings strcpy, memcpy ... */
 #include <set>
 #include <map>
@@ -2678,10 +2679,9 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
           delete file;
           return false;
         }
-        // 256 MB ceiling so `num+1` can't wrap size_t and the
-        // downstream ParseTextArrayNum doesn't chew gigabytes.
-        static const size_t kMaxTextFileBytes = 256ULL * 1024 * 1024;
-        if (num > kMaxTextFileBytes) {
+        // Shared ceiling: prevents num+1 from wrapping size_t and caps
+        // downstream ParseTextArrayNum memory use. See IccUtilXml.h.
+        if (num > icXmlMaxTextFileBytes) {
           parseStr += "'";
           parseStr += filename;
           parseStr += "' exceeds 256 MB limit.\n";
@@ -2692,25 +2692,26 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
         // !buf check below actually fires on OOM.
         char *buf = new(std::nothrow) char[num + 1];
 
-        if (!buf) {          
-          perror("Memory Error");
-          parseStr += "'";
+        if (!buf) {
+          parseStr += "Out of memory allocating ";
+          parseStr += std::to_string(num + 1);
+          parseStr += " bytes for text buffer from '";
           parseStr += filename;
-          parseStr += "' may not be a valid text file.\n";
-          delete [] buf;
+          parseStr += "'.\n";
           delete file;
           return false;
         }
 
-        if (file->Read8(buf, num) !=num) {
-          perror("Read-File Error");
-          parseStr += "'";
+        if (file->Read8(buf, num) != num) {
+          parseStr += "Read error: could not read ";
+          parseStr += std::to_string(num);
+          parseStr += " bytes from '";
           parseStr += filename;
-          parseStr += "' may not be a valid text file.\n";
+          parseStr += "'.\n";
           delete [] buf;
-          delete file;             
+          delete file;
           return false;
-        }         
+        }
         buf[num] = '\0';  // NUL-terminate for ParseText downstream
 
         // lut8type

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -2678,7 +2678,19 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
           delete file;
           return false;
         }
-        char *buf = (char *) new char[num];
+        // 256 MB ceiling so `num+1` can't wrap size_t and the
+        // downstream ParseTextArrayNum doesn't chew gigabytes.
+        static const size_t kMaxTextFileBytes = 256ULL * 1024 * 1024;
+        if (num > kMaxTextFileBytes) {
+          parseStr += "'";
+          parseStr += filename;
+          parseStr += "' exceeds 256 MB limit.\n";
+          delete file;
+          return false;
+        }
+        // +1 and explicit NUL; use nothrow so the immediate
+        // !buf check below actually fires on OOM.
+        char *buf = new(std::nothrow) char[num + 1];
 
         if (!buf) {          
           perror("Memory Error");
@@ -2699,6 +2711,7 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
           delete file;             
           return false;
         }         
+        buf[num] = '\0';  // NUL-terminate for ParseText downstream
 
         // lut8type
         if (nType == icConvert8Bit) {

--- a/IccXML/IccLibXML/IccUtilXml.h
+++ b/IccXML/IccLibXML/IccUtilXml.h
@@ -94,6 +94,11 @@ size_t icXmlDumpHexData(std::string &xml, std::string blanks, void *pBuf, size_t
 
 bool icXmlValidateFileCount(size_t value, icUInt32Number &count, std::string &parseStr, const char *filename);
 
+// Maximum byte count for text file buffers: caps num+1 from wrapping size_t
+// and prevents downstream ParseTextArrayNum from consuming gigabytes.
+// Used at every new(std::nothrow) char[num+1] text-buffer site.
+static const size_t icXmlMaxTextFileBytes = 256ULL * 1024 * 1024;
+
 #define icXmlStrCmp(x, y) strcmp((const char *)(x), (const char*)(y))
 
 xmlAttr *icXmlFindAttr(xmlNode *pNode, const char *szAttrName);


### PR DESCRIPTION
# Fix \`new char[num]\` dead NULL-checks: add \`#include <new>\`, nothrow, size cap, NUL-terminate

**Severity:** Low · **Files:** \`IccXML/IccLibXML/IccTagXml.cpp\`, \`IccXML/IccLibXML/IccMpeXml.cpp\`

## Summary

Three sites used \`new char[num]\` with a dead \`if (!buf)\` NULL-check. Default \`operator new[]\`
throws \`std::bad_alloc\` on failure — the check never fires. Additionally, the allocated buffers
were not NUL-terminated before being passed to \`ParseTextArrayNum\`, which delegates to \`ParseText\`
and scans until \`'\0'\`; without a terminator this reads past the allocation into adjacent heap.

## Patch

- Replace \`new char[num]\` with \`new(std::nothrow) char[num + 1]\` so the existing NULL-check
  becomes reachable on genuine OOM.
- Add explicit \`buf[num] = '\0'\` immediately after the successful read.
- Add \`#include <new>\` to both translation units so \`std::nothrow\` is declared portably.
- Introduce \`icXmlMaxTextFileBytes\` (256 MB) as a shared constant in \`IccUtilXml.h\`; removes
  three identical \`function-local static\` copies.
- Replace \`perror("Memory Error")\` in OOM paths with a clear \`parseStr\` message that includes
  the requested byte count. \`new(std::nothrow)\` never sets \`errno\`, so \`perror\` previously
  printed "Success" or unrelated libc messages.
- Use \`icXmlValidateFileCount()\` at all file-size-to-count conversion sites for consistent
  bounds checking.

## Test plan

- Regression: \`Testing/RunTests.sh\`.
- Static analyser (clang-tidy \`bugprone-dead-code\` / \`modernize-avoid-c-arrays\`) — expect the
  "dead NULL check" warning to go away.

## References

- CWE-1117 Callable with Insufficient Behavioural Summary (dead code)
- CWE-404 Improper Resource Shutdown or Release (leak on later throw)