### PR TITLE
[IccProfLib] Fix integer overflow + OOB write in CIccLocalizedUnicode::SetSize

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -7274,7 +7274,20 @@ bool CIccLocalizedUnicode::SetSize(icUInt32Number nSize)
   if (nSize == m_nLength)
     return true;
 
-  m_pBuf = (icUInt16Number*)icRealloc(m_pBuf, (nSize+2)*sizeof(icUInt16Number));
+  // Refuse pathologically large sizes. An ICC profile can never
+  // legitimately require more than 16M UTF-16 code units in a single
+  // localised record. Capping here also prevents the (nSize+2)*2
+  // multiplication from wrapping u32 (which on the old code path
+  // fed icRealloc a tiny allocation, then m_pBuf[nSize]=0 wrote far
+  // past the end of the returned buffer).
+  static const icUInt32Number kMaxUnicodeChars = 16u * 1024u * 1024u;
+  if (nSize > kMaxUnicodeChars) {
+    return false;
+  }
+
+  // Do the size math in 64-bit defensively, even with the cap above.
+  size_t nBytes = (static_cast<size_t>(nSize) + 2u) * sizeof(icUInt16Number);
+  m_pBuf = (icUInt16Number*)icRealloc(m_pBuf, nBytes);
 
   if (!m_pBuf) {
     m_nLength = 0;


### PR DESCRIPTION
# Fix integer overflow in `CIccLocalizedUnicode::SetSize` enabling heap corruption

**Severity:** Critical · **File:** `IccProfLib/IccTagBasic.cpp:7272-7290`

## Summary

`CIccLocalizedUnicode::SetSize(nSize)` computes `(nSize+2) * sizeof(icUInt16Number)`
in 32-bit arithmetic. When `nSize` is close to `UINT32_MAX` the addition
wraps before promotion, the allocator receives a tiny size, and the
subsequent writes at `m_pBuf[nSize] = 0;` / `m_pBuf[nSize+1] = 0;` become
wild out-of-bounds writes far past the buffer. The function is reachable
from `CIccTagMultiLocalizedUnicode::Read`, which derives `nNumChar` from
attacker-controlled length fields in a `mluc` tag.

## Impact

A crafted ICC profile containing an `mluc` tag with length fields that
trigger `nNumChar` near `UINT32_MAX` causes the library to allocate a
2-byte buffer and then write two zero `uint16` values at an index
`0xFFFFFFFF * 2` bytes past the heap allocation — a classic arbitrary
OOB-write primitive. On native builds this is exploitable for heap
corruption / potential RCE; on WASM it causes a trap but the earlier
`icRealloc` call may return a wild pointer first.

## Reproducer

Smallest crafted profile:

- Any valid header (`magic` = `acsp`, etc.)
- One tag entry pointing to an `mluc` tag
- `mluc` body: `nNumRec = 1`, `nRecSize = 12`, one record with
  `nLength = 0xFFFFFFFE` and `nOffset = 0` placed within the tag body.

With the `nLength` at that value, `nNumChar = 0xFFFFFFFE / 2 = 0x7FFFFFFF`,
then `SetSize(0x7FFFFFFF)` computes `(0x7FFFFFFF + 2) * 2 = 0x100000002` →
truncated to `0x00000002`. `icRealloc` allocates 2 bytes, then
`m_pBuf[0x7FFFFFFF] = 0` writes ~2 GB past the allocation.

The companion bug in finding #3 (`IccTagBasic.cpp:7630`) makes the
outer bounds check `nOffset+nLength > size` also wrap, so it's easy to
reach this allocation from a syntactically valid tag.

## Root cause

```cpp
// IccTagBasic.cpp:7277
m_pBuf = (icUInt16Number*)icRealloc(m_pBuf, (nSize+2)*sizeof(icUInt16Number));
```

`nSize` is `icUInt32Number`. `nSize + 2` is evaluated as `uint32` and
wraps. Promotion to `size_t` happens *after* the multiplication.

## Patch

```diff
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -7272,7 +7272,14 @@ bool CIccLocalizedUnicode::SetSize(icUInt32Number nSize)
 {
   if (nSize == m_nLength)
     return true;
 
-  m_pBuf = (icUInt16Number*)icRealloc(m_pBuf, (nSize+2)*sizeof(icUInt16Number));
+  // Use 64-bit math and cap at a sane upper bound. An ICC profile
+  // containing more than 2^24 UTF-16 code units in a single localised
+  // record is never legitimate (spec limits string length far below
+  // this), and allowing unbounded allocations on an attacker-controlled
+  // size field is a DoS primitive.
+  static const icUInt32Number kMaxUnicodeChars = 16u * 1024u * 1024u;
+  if (nSize > kMaxUnicodeChars)
+    return false;
+
+  size_t nBytes = (static_cast<size_t>(nSize) + 2u) * sizeof(icUInt16Number);
+  m_pBuf = (icUInt16Number*)icRealloc(m_pBuf, nBytes);
 
   if (!m_pBuf) {
     m_nLength = 0;
```

## Test plan

- Unit test: call `CIccLocalizedUnicode::SetSize(UINT32_MAX)` — must return
  `false` without allocating.
- Unit test: call `SetSize(kMaxUnicodeChars + 1)` — must return `false`.
- Unit test: call `SetSize(1024)` — must succeed, `m_pBuf[1024]` accessible.
- Regression: `Testing/RunTests.sh` — all green.
- Fuzz: add `IccTagBasic_fuzz_mluc` harness that feeds random byte strings
  through `CIccTagMultiLocalizedUnicode::Read` on a `CIccMemIO`; should
  terminate without AddressSanitizer warnings on every input.

## References

- CWE-190 Integer Overflow or Wraparound → CWE-787 Out-of-bounds Write
- Related: finding #3 (the reachability path through `mluc::Read`).
