### PR TITLE
[IccProfLib] Widen CIccTagSparseMatrixArray::Reset allocation to 64-bit + guard caller

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -4609,9 +4609,11 @@ bool CIccTagSparseMatrixArray::Read(icUInt32Number size, CIccIO *pIO)
   // Sparse matrices store only non-zero entries, so file data is much smaller than the buffer.
   // Per-read bounds checks in the loop below validate actual file data consumption.
 
-  // this sets the sizes, and allocates a huge chunk of memory for matrix storage in m_RawData
-  Reset(nNumMatrices, nChannels);
-  
+  // this sets the sizes, and allocates a huge chunk of memory for matrix storage in m_RawData.
+  // Reset now refuses oversized allocations + returns false on OOM, so propagate the failure.
+  if (!Reset(nNumMatrices, nChannels))
+    return false;
+
   icUInt8Number *matrix_end = m_RawData + (size_t)m_nSize * nBytesPerMatrix;  // overflow detection
 
   if (m_nSize) {
@@ -5095,18 +5097,59 @@ bool CIccTagSparseMatrixArray::Reset(icUInt32Number nNumMatrices, icUInt16Number
   if (nNumMatrices==m_nSize && nChannelsPerMatrix==m_nChannelsPerMatrix)
     return true;
 
-  m_nSize = nNumMatrices;
-  m_nChannelsPerMatrix = nChannelsPerMatrix;
+  // Do the allocation math in explicit 64-bit. On 32-bit targets
+  // (wasm32 in particular, where size_t is u32) the product
+  // nNumMatrices * GetBytesPerMatrix() can wrap silently — returning
+  // a tiny allocation while leaving m_nSize huge, and the Read loop
+  // then writes records past the buffer end. Also cap the total at a
+  // library-wide 64 MB ceiling so a legitimately-sized tag can't
+  // coerce gigabytes of RAM.
+  const icUInt64Number perMatrix64 =
+      static_cast<icUInt64Number>(nChannelsPerMatrix) * sizeof(icFloatNumber);
+  const icUInt64Number total64 =
+      static_cast<icUInt64Number>(nNumMatrices) * perMatrix64;
 
-  size_t nSize = (size_t)m_nSize * GetBytesPerMatrix();
-  
-  m_RawData = (icUInt8Number *)icRealloc(m_RawData, nSize);
-
-  if (!m_RawData) {
-    m_nSize = 0;
+  static const icUInt64Number kMaxSparseMatrixArrayBytes =
+      64ULL * 1024 * 1024;
+  if (total64 > kMaxSparseMatrixArrayBytes ||
+      total64 > static_cast<icUInt64Number>(SIZE_MAX)) {
+    // Leave m_nSize untouched on failure so the object stays valid.
     return false;
   }
 
+  size_t nSize = static_cast<size_t>(total64);
+
+  // icRealloc (see IccUtil.cpp) diverges from std::realloc in two
+  // important ways:
+  //   1. icRealloc(ptr, 0) frees ptr and returns NULL (std::realloc's
+  //      behaviour here is implementation-defined).
+  //   2. On allocation failure (nptr == NULL && ptr != NULL) it frees
+  //      the old ptr — so the caller must NOT keep using m_RawData
+  //      after the call, regardless of the return value.
+  //
+  // Therefore we always write the result back to m_RawData and keep
+  // the object coherent (m_nSize / m_nChannelsPerMatrix match
+  // whatever m_RawData now is).
+  m_RawData = (icUInt8Number *)icRealloc(m_RawData, nSize);
+
+  if (nSize == 0) {
+    // Caller explicitly asked to clear. icRealloc returned NULL after
+    // freeing the old buffer — success, empty object.
+    m_nSize = 0;
+    m_nChannelsPerMatrix = 0;
+    return true;
+  }
+
+  if (!m_RawData) {
+    // Allocation failure. icRealloc already freed the old buffer.
+    // Keep the object in a safe empty state.
+    m_nSize = 0;
+    m_nChannelsPerMatrix = 0;
+    return false;
+  }
+
+  m_nSize = nNumMatrices;
+  m_nChannelsPerMatrix = nChannelsPerMatrix;
   memset(m_RawData, 0, nSize);
   return true;
 }


### PR DESCRIPTION
# Widen sparse-matrix allocation math to 64-bit to prevent heap OOB write

**Severity:** Critical · **Files:** `IccProfLib/IccTagBasic.cpp:4613, 5093-5112`

## Summary

`CIccTagSparseMatrixArray::Reset(nNumMatrices, nChannelsPerMatrix)` computes
`size_t nSize = (size_t)m_nSize * GetBytesPerMatrix()`. On 32-bit targets
(Emscripten/WASM32 is wasm32, `size_t = uint32_t`) this product wraps for
large attacker-controlled counts. A crafted tag with
`nNumMatrices = 0x40000001`, `nChannels = 8` (per-matrix = 32) produces
`0x40000001 * 32 = 0x0000000000000020` after truncation — a 32-byte
allocation.

Reset then sets `m_nSize = 0x40000001` unconditionally *before* checking
the allocation result. `Read` does not check `Reset`'s return value and
iterates `for (i = 0; i < m_nSize; i++)` writing to
`m_RawData + i * nBytesPerMatrix`. For `i = 1`, `pMatrix = m_RawData +
32 = end-of-buffer`, and `pIO->Read16(pMatrix, 2)` writes 4 bytes of
attacker-controlled data directly into adjacent heap.

The `matrix_end` overflow-detection check at line 4650 also uses
wrapped 32-bit arithmetic and only fires *after* the first OOB write.

## Impact

- Native on any 32-bit or 64-bit platform with a craftable wrap (see
  below). Classic exploit primitive: attacker-controlled bytes at
  attacker-predictable offset past a heap allocation.
- **WASM (my apps): directly exploitable on every build today.**
  Emscripten is wasm32. iccflow, icctools, icceval all expose this path
  via user-dropped profiles. Only mitigation right now is that WASM
  sandboxing contains the memory corruption inside the module — the
  host process is safe, but module state (including subsequent parsed
  tag data) is attacker-controlled.

On 64-bit builds the size_t multiplication wraps only at much larger
counts (`m_nSize * GetBytesPerMatrix() > 2^64`), which is practically
unreachable — so this bug is primarily a 32-bit issue.

## Reproducer

Sparse-matrix array tag (`CIccTagSparseMatrixArray`):

- `nNumMatrices = 0x40000001`
- `nChannelsPerMatrix = 8` (implies `GetBytesPerMatrix()` = 32)
- Matrix body bytes following the header, enough to cover at least the
  first two iterations of the read loop (~~70 bytes).

Drop into any of my three apps (or any consumer of `ValidateIccProfile`
that loads sparse-matrix arrays). On wasm32, Reset allocates 32 bytes,
`m_nSize` is 0x40000001, the second loop iteration writes past the
buffer.

## Root cause

```cpp
// IccTagBasic.cpp:5098-5103
m_nSize = nNumMatrices;
m_nChannelsPerMatrix = nChannelsPerMatrix;

size_t nSize = (size_t)m_nSize * GetBytesPerMatrix();  // 32-bit wrap on wasm32
m_RawData = (icUInt8Number *)icRealloc(m_RawData, nSize);

if (!m_RawData) {
  m_nSize = 0;           // ← set AFTER the alloc; on success-with-wrap m_nSize remains huge
  return false;
}
```

```cpp
// IccTagBasic.cpp:4613-4615  (caller)
Reset(nNumMatrices, nChannels);                        // ← return value ignored
icUInt8Number *matrix_end = m_RawData + (size_t)m_nSize * nBytesPerMatrix;  // ← wraps too
```

## Patch

```diff
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -5093,18 +5093,30 @@
 bool CIccTagSparseMatrixArray::Reset(icUInt32Number nNumMatrices, icUInt16Number nChannelsPerMatrix)
 {
   if (nNumMatrices==m_nSize && nChannelsPerMatrix==m_nChannelsPerMatrix)
     return true;
 
-  m_nSize = nNumMatrices;
-  m_nChannelsPerMatrix = nChannelsPerMatrix;
-
-  size_t nSize = (size_t)m_nSize * GetBytesPerMatrix();
-  
-  m_RawData = (icUInt8Number *)icRealloc(m_RawData, nSize);
-
-  if (!m_RawData) {
-    m_nSize = 0;
-    return false;
-  }
-
-  memset(m_RawData, 0, nSize);
+  // Do the allocation math in explicit 64-bit to avoid size_t wraparound
+  // on 32-bit targets (wasm32). A crafted tag can otherwise coax the
+  // product below into a tiny value, producing an oversized m_nSize over
+  // a tiny m_RawData buffer -> OOB write in Read().
+  const icUInt64Number perMatrix64 =
+      static_cast<icUInt64Number>(nChannelsPerMatrix) * sizeof(icFloatNumber);
+  const icUInt64Number total64 =
+      static_cast<icUInt64Number>(nNumMatrices) * perMatrix64;
+
+  // Refuse anything that doesn't fit in a native size_t or exceeds a
+  // sane library-wide cap (64 MB for a single sparse-matrix array tag).
+  static const icUInt64Number kMaxSparseMatrixArrayBytes = 64ULL * 1024 * 1024;
+  if (total64 > kMaxSparseMatrixArrayBytes || total64 > SIZE_MAX) {
+    return false;  // leave m_nSize untouched
+  }
+
+  size_t nSize = static_cast<size_t>(total64);
+  icUInt8Number *pNew = (icUInt8Number *)icRealloc(m_RawData, nSize);
+  if (!pNew) {
+    // Leave m_nSize untouched on failure — the old buffer is still valid.
+    return false;
+  }
+  m_RawData = pNew;
+  m_nSize = nNumMatrices;
+  m_nChannelsPerMatrix = nChannelsPerMatrix;
+  memset(m_RawData, 0, nSize);
   return true;
 }
```

And guard the caller:

```diff
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -4611,7 +4611,8 @@
   // this sets the sizes, and allocates a huge chunk of memory for matrix storage in m_RawData
-  Reset(nNumMatrices, nChannels);
+  if (!Reset(nNumMatrices, nChannels))
+    return false;
```

## Test plan

- Regression: `Testing/RunTests.sh` — sparse-matrix tests must still pass.
- New unit: `Reset(0x40000001, 8)` on a wasm32 build — must return
  `false`, `m_nSize` must be unchanged from its previous value.
- New unit: legitimate `Reset(1024, 4)` succeeds.
- Fuzz: feed random bytes through `CIccTagSparseMatrixArray::Read` —
  ASAN-clean on every input.

## References

- CWE-190 Integer Overflow or Wraparound
- CWE-787 Out-of-bounds Write
- CWE-252 Unchecked Return Value
