### PR TITLE
[IccLibJSON] Wrap ParseJson body in try/catch so nlohmann throws can't terminate()

### DIFF
--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -485,41 +485,57 @@ bool CIccProfileJson::ParseTag(const std::string &key, const IccJson &tagValue,
 
 bool CIccProfileJson::ParseJson(const IccJson &root, std::string &parseStr)
 {
-  // The root may be the IccProfile object directly or wrapped in {"IccProfile": ...}
-  const IccJson *pProfile = &root;
-  IccJson unwrapped;
-  if (root.contains("IccProfile")) {
-    unwrapped  = root["IccProfile"];
-    pProfile   = &unwrapped;
-  }
-
-  if (!pProfile->contains("Header") || !pProfile->contains("Tags")) {
-    parseStr += "Missing Header or Tags in JSON profile\n";
-    return false;
-  }
-
-  if (!ParseBasic((*pProfile)["Header"], parseStr))
-    return false;
-
-  const IccJson &tags = (*pProfile)["Tags"];
-  if (!tags.is_array()) {
-    parseStr += "Tags must be a JSON array\n";
-    return false;
-  }
-
-  std::map<std::string, icTagSignature> keyToSig;
-  for (const auto &entry : tags) {
-    if (!entry.is_object() || entry.size() != 1) {
-      parseStr += "Warning: tag entry must be a single-member object, skipping\n";
-      continue;
+  // Wrap the whole parse body in a try/catch so nlohmann's
+  // type_error / out_of_range exceptions (thrown from the many raw
+  // .get<T>() / operator[] sites in IccTagJson / IccMpeJson) can't
+  // propagate out to std::terminate. LoadJson() has its own wrap,
+  // but other callers (wasm wrappers, custom embedders) calling
+  // ParseJson() directly would otherwise abort the host.
+  try {
+    // The root may be the IccProfile object directly or wrapped in {"IccProfile": ...}
+    const IccJson *pProfile = &root;
+    IccJson unwrapped;
+    if (root.contains("IccProfile")) {
+      unwrapped  = root["IccProfile"];
+      pProfile   = &unwrapped;
     }
-    auto it = entry.begin();
-    const std::string &key   = it.key();
-    const IccJson     &value = it.value();
-    if (!ParseTag(key, value, keyToSig, parseStr))
+
+    if (!pProfile->contains("Header") || !pProfile->contains("Tags")) {
+      parseStr += "Missing Header or Tags in JSON profile\n";
       return false;
+    }
+
+    if (!ParseBasic((*pProfile)["Header"], parseStr))
+      return false;
+
+    const IccJson &tags = (*pProfile)["Tags"];
+    if (!tags.is_array()) {
+      parseStr += "Tags must be a JSON array\n";
+      return false;
+    }
+
+    std::map<std::string, icTagSignature> keyToSig;
+    for (const auto &entry : tags) {
+      if (!entry.is_object() || entry.size() != 1) {
+        parseStr += "Warning: tag entry must be a single-member object, skipping\n";
+        continue;
+      }
+      auto it = entry.begin();
+      const std::string &key   = it.key();
+      const IccJson     &value = it.value();
+      if (!ParseTag(key, value, keyToSig, parseStr))
+        return false;
+    }
+    return true;
   }
-  return true;
+  catch (const nlohmann::json::exception &e) {
+    parseStr += std::string("JSON type/range error during parse: ") + e.what() + "\n";
+    return false;
+  }
+  catch (const std::exception &e) {
+    parseStr += std::string("Unexpected error during JSON parse: ") + e.what() + "\n";
+    return false;
+  }
 }
 
 bool CIccProfileJson::LoadJson(const char *szFilename, std::string *parseStr)


### PR DESCRIPTION
# Catch nlohmann type/range exceptions in `CIccProfileJson::ParseJson`

**Severity:** Critical · **Files:** throughout `IccJSON/IccLibJSON/` — `IccProfileJson.cpp`, `IccTagJson.cpp`, `IccMpeJson.cpp`

## Summary

Dozens of call sites in IccLibJSON reach into parsed JSON via raw
`j[...].get<T>()`, `j[i].get<double>()`, or `j["key"].get<std::string>()`
without first verifying the JSON value's actual type. `nlohmann::
ordered_json` throws `type_error` on type mismatch and `out_of_range`
on short arrays. Neither `CIccProfileJson::ParseJson` nor the tag /
MPE `ParseJson` paths wrap these in `try`/`catch`.

Consequence: a single malformed JSON input — e.g. a number where a
string is expected, or vice-versa — raises an uncaught C++ exception.
On WASM this calls `std::terminate` → `abort()` → the module instance
is permanently dead. The icctools UI spinner hangs; the user has to
hard-reload the tab. A native CLI tool crashes.

## Impact

- **Directly reachable from icctools today.** Our
  `validator-wasm/xml-wrapper.cpp` (which also handles JSON→ICC via a
  sibling module) calls `profile.ParseJson(root, reason)` without
  wrapping it. One malformed JSON kills the module instance; every
  subsequent drop stays broken until reload.
- On native IccFromJson CLI, a single malformed input kills the
  process. Limited blast radius but noisy in automated pipelines.

## Affected call sites (not exhaustive)

- `IccProfileJson.cpp:393, 398, 436, 461` — header field reads.
- `IccTagJson.cpp:608, 647, 716-719, 857-858, 883-884, 917-918, 957,
  994, 1033, 1393-1395, 1505-1509, 1677, 1736, 1742, 1765, 1895, 2362,
  2394, 2419, 2565, 2590, 2656, 2675, 2679, 2697, 2716-2718`.
- `IccMpeJson.cpp:208, 242, 339-340, 361, 400-401, 903, 922,
  1095-1097, 2085, 2116`.
- Every `arr[i].get<double>()` inside array-of-numbers parsing loops.

## Reproducer

```json
{"IccProfile":{"Header":{},"Tags":[
  {"AToB0Tag":{"data":{"type":"mAB ",
      "inputChannels":"x","outputChannels":3}}}
]}}
```

`icCLUTFromJson` / `icMBBFromJson` / `CIccTagJsonStruct::ParseTag`
reach a raw `j["inputChannels"].get<int>()` on a string-typed value,
nlohmann throws `type_error::302`, the exception propagates through
`ParseJson` and into the host's `std::terminate`.

## Patch

Two complementary fixes:

**A. Wrap the top-level `ParseJson` in the library:**

```diff
--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -482,6 +482,14 @@
 bool CIccProfileJson::ParseJson(const IccJson &j, std::string &parseStr)
 {
+  try {
+    return ParseJsonInner(j, parseStr);
+  } catch (const nlohmann::json::exception &e) {
+    parseStr += std::string("JSON type/range error during parse: ") + e.what() + "\n";
+    return false;
+  } catch (const std::exception &e) {
+    parseStr += std::string("Unexpected error during parse: ") + e.what() + "\n";
+    return false;
+  }
+}
+
+bool CIccProfileJson::ParseJsonInner(const IccJson &j, std::string &parseStr)
+{
   // ... existing body here
 }
```

(`ParseJsonInner` is the existing body renamed; forward-declare in
`IccProfileJson.h`.)

**B. Prefer type-safe helpers for new code.** The `icJsonSafeU32` /
`icJsonSafeU16` helpers already exist — extend with `icJsonGetInt`,
`icJsonGetDouble`, `icJsonGetString` wrappers that check
`j.is_number()` / `j.is_string()` before calling `.get<T>()` and fall
back to a default. Sweep existing call sites incrementally.

## Immediate client-side mitigation (iccDEV-independent)

Consumers of IccLibJSON can protect themselves today by wrapping
`profile.ParseJson(root, reason)` in `try/catch` at the call site.
In our own icctools wrapper:

```diff
--- a/validator-wasm/xml-wrapper.cpp  (or the json sibling)
+++ b/validator-wasm/xml-wrapper.cpp
@@ ...
-  CIccProfileJson profile;
-  std::string reason;
-  if (!profile.ParseJson(root, reason)) {
+  CIccProfileJson profile;
+  std::string reason;
+  bool parsed;
+  try {
+    parsed = profile.ParseJson(root, reason);
+  } catch (const nlohmann::json::exception &e) {
+    throw std::runtime_error(std::string("JSON parse error: ") + e.what());
+  } catch (const std::exception &e) {
+    throw std::runtime_error(std::string("Parse error: ") + e.what());
+  }
+  if (!parsed) {
     // existing error path
```

This is a one-commit icctools change that fully protects our WASM
module from being killed by malformed input, even before iccDEV ships
its fix.

## Test plan

- Regression: `Testing/RunJsonTests.sh`.
- New unit: pass the reproducer JSON above to `CIccProfileJson::
  ParseJson` — must return `false`, not terminate.
- Fuzz: corrupt-field JSON fuzzer (swap types, truncate arrays,
  missing keys) — no uncaught exceptions on any input.

## References

- CWE-248 Uncaught Exception
- CWE-730 OWASP Top Ten 2021 Category A04 — Insecure Design (missing
  input validation)

## Related

- Finding #32 (`dictLocalizedFromJson` `.get<std::string>()` on non-
  strings) is a specific representative instance of this pattern.
