### PR TITLE
[IccProfLib] Handle CIccXform::Create failure in MCS splice without nulling m_Xforms

### DIFF
--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -8291,11 +8291,18 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
             CIccXform *pNew = CIccXform::Create(pPrev->GetProfilePtr(), pPrev->IsInput(), pPrev->GetIntent(), pPrev->GetInterp(),
                                                 pPrev->GetConnectionConditions(), icXformLutMCS, bUseD2BxB2DxTags, pHintManager);
 
-            if (pNew) {
-              pPrev->DetachAll();
-              delete pPrev;
+            if (!pNew) {
+              // Create failed (e.g., previous profile has no MCS-
+              // suitable A2B / D2B tag, or factory was stripped).
+              // Do NOT overwrite prev->ptr with NULL — that would
+              // leave the list with a NULL xform that the next Apply
+              // dereferences → SIGSEGV. Leave pPrev in place and
+              // surface a clean error status.
+              return icCmmStatBadMCSLink;
             }
 
+            pPrev->DetachAll();
+            delete pPrev;
             prev->ptr = pNew;
 
           }


### PR DESCRIPTION
# Handle `CIccXform::Create` failure in MCS splice without writing NULL into `m_Xforms`

**Severity:** Critical · **File:** `IccProfLib/IccCmm.cpp:8286-8301`

## Summary

`CIccCmm::AddXform` upgrades the previous xform to an MCS (Multiplex
Connection Space) link by calling `CIccXform::Create(..., icXformLutMCS,
...)`. If `Create` returns NULL (e.g., the previous profile lacks a
suitable D-to-B / A-to-B tag at MCS, or the factory is stripped), the
code still executes `prev->ptr = pNew;` at line 8299 — writing NULL
into the xform list. `pPrev` is leaked; the profile it owned becomes
shared with the new (NULL) xform; ownership is ambiguous.

The next call to `CIccCmm::Apply` iterates `m_Xforms` and does
`i->ptr->Apply(...)` → NULL deref → SIGSEGV.

## Impact

- Any CMM consumer (iccApplyNamedCmm CLI, iccflow, iccApplyProfiles)
  that chains profiles with mixed MCS and non-MCS tags can trigger
  this with a crafted or incomplete profile.
- Not reachable via `ValidateIccProfile` (which doesn't build xforms)
  but reachable from iccflow's applyFlow pipeline and every other
  CMM-apply consumer.

## Reproducer

Build a profile chain where the first profile has AToB0 but no
matching MCS variant, and request a chain that would need
`icXformLutMCS`. `Create` returns NULL; on the next Apply, crash.

## Patch

```diff
--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -8285,14 +8285,21 @@
   CIccXform *pNew = CIccXform::Create(prev->ptr->GetProfile(),
                                        ..., icXformLutMCS, ...);
+  if (!pNew) {
+    // Refuse the splice rather than corrupting the chain. pPrev still
+    // owns its profile; leave it in place so caller errors cleanly.
+    return icCmmStatBadXform;
+  }
+  // Transfer ownership: pPrev's profile is now owned by pNew.
+  pPrev->DetachProfile();
   delete pPrev;
   prev->ptr = pNew;
```

(`DetachProfile()` is a helper to be added to `CIccXform` — it sets
the internal `m_pProfile = nullptr` so destruction doesn't double-free.
If the class doesn't already have an equivalent, add one.)

## Test plan

- Regression: `Testing/RunTests.sh`.
- New unit: construct a chain where the first profile lacks an MCS
  tag; `AddXform` followed by `Begin` returns `icCmmStatBadXform`, not
  icCmmStatOk; `Apply` is never called, no crash.
- Regression: the iccApplyNamedCmm test suite (if present in the
  upstream Testing/ tree).

## References

- CWE-476 NULL Pointer Dereference
- CWE-665 Improper Initialization
- CWE-415 Double Free (potential, depending on ownership semantics)
