### PR TITLE
Fix: Bisect 60bbb8c & 1f0a9dd

### DIFF
--- a/.github/scripts/iccdev-json-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-json-parser-regression-tests.sh
@@ -4,7 +4,8 @@
 ###############################################################################
 #
 # Exercises malformed ICC JSON and JSON config helpers that must fail cleanly
-# instead of being silently accepted or retaining stale state.
+# and sibling XML payloads that must fail cleanly instead of being silently
+# accepted or retaining stale state.
 #
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
@@ -23,6 +24,7 @@ mkdir -p "$OUTDIR"
 
 TOJSON="$TOOLS_DIR/IccToJson/iccToJson"
 FROMJSON="$TOOLS_DIR/IccFromJson/iccFromJson"
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
 BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd)"
 
 export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
@@ -106,8 +108,61 @@ run_reject_test() {
   PASS=$((PASS + 1))
 }
 
-if [ ! -x "$TOJSON" ] || [ ! -x "$FROMJSON" ]; then
-  echo "ERROR: IccToJson and IccFromJson are required"
+run_xml_reject_test() {
+  local name="$1"
+  local xml_file="$2"
+  local expected_text="$3"
+  local output_file="$OUTDIR/${name}.icc"
+  local logfile="$OUTDIR/${name}.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$output_file" "$logfile"
+
+  timeout 30 "$FROMXML" "$xml_file" "$output_file" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ "$exit_code" -eq 124 ]; then
+    echo "  [FAIL] $name -- timed out"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ "$exit_code" -ge 129 ] && [ "$exit_code" -le 192 ]; then
+    echo "  [FAIL] $name -- crashed with signal $((exit_code - 128))"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ "$exit_code" -eq 0 ]; then
+    echo "  [FAIL] $name -- malformed XML parsed successfully"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ -s "$output_file" ]; then
+    echo "  [FAIL] $name -- parser wrote output profile despite failure"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if ! grep -Fq "$expected_text" "$logfile" 2>/dev/null; then
+    echo "  [FAIL] $name -- expected diagnostic not found: $expected_text"
+    sed -n '1,5p' "$logfile"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  echo "  [PASS] $name (rejected, exit=$exit_code)"
+  PASS=$((PASS + 1))
+}
+
+if [ ! -x "$TOJSON" ] || [ ! -x "$FROMJSON" ] || [ ! -x "$FROMXML" ]; then
+  echo "ERROR: IccToJson, IccFromJson, and IccFromXml are required"
   exit 1
 fi
 
@@ -128,6 +183,26 @@ fi
 
 if [ -z "$PROFILE" ]; then
   echo "ERROR: No ICC profile found in $TESTING_DIR"
+  exit 1
+fi
+
+XML_PROFILE=""
+for candidate in \
+  "$TESTING_DIR/ICS/Spec400_10_700-D50_2deg-Part1.xml" \
+  "$TESTING_DIR/HDR/BT2100HlgFullScene.xml" \
+  "$TESTING_DIR/ICS/Rec2100HlgFull-Part2.xml"; do
+  if [ -f "$candidate" ]; then
+    XML_PROFILE="$candidate"
+    break
+  fi
+done
+
+if [ -z "$XML_PROFILE" ]; then
+  XML_PROFILE="$(find "$TESTING_DIR" -name '*.xml' -size +100c 2>/dev/null | sed -n '1p')"
+fi
+
+if [ -z "$XML_PROFILE" ]; then
+  echo "ERROR: No XML profile found in $TESTING_DIR"
   exit 1
 fi
 
@@ -178,6 +253,30 @@ write("inline-clut-truncated", {
     }]
 })
 
+write("mpe-matrix-huge-channels", {
+    "type": "multiProcessElementType",
+    "inputChannels": 1,
+    "outputChannels": 1,
+    "elements": [{
+        "type": "MatrixElement",
+        "inputChannels": 65535,
+        "outputChannels": 65535,
+        "matrix": []
+    }]
+})
+
+write("mpe-matrix-short-data", {
+    "type": "multiProcessElementType",
+    "inputChannels": 3,
+    "outputChannels": 3,
+    "elements": [{
+        "type": "MatrixElement",
+        "inputChannels": 3,
+        "outputChannels": 3,
+        "matrix": [1.0]
+    }]
+})
+
 write("spectral-white-short", {
     "type": "multiProcessElementType",
     "inputChannels": 1,
@@ -189,6 +288,20 @@ write("spectral-white-short", {
         "wavelengths": {"start": 400.0, "end": 420.0, "steps": 3},
         "whiteData": [1.0],
         "matrixData": [1.0, 1.0, 1.0]
+    }]
+})
+
+write("spectral-matrix-huge-channels", {
+    "type": "multiProcessElementType",
+    "inputChannels": 1,
+    "outputChannels": 1,
+    "elements": [{
+        "type": "EmissionMatrixElement",
+        "inputChannels": 65535,
+        "outputChannels": 65535,
+        "wavelengths": {"start": 400.0, "end": 420.0, "steps": 3},
+        "whiteData": [1.0, 1.0, 1.0],
+        "matrixData": []
     }]
 })
 
@@ -215,15 +328,39 @@ write("struct-bad-member", {
 })
 ' "$BASE_JSON" "$OUTDIR"
 
+XML_MATRIX_HUGE="$OUTDIR/xml-matrix-huge-channels.xml"
+python3 -c '
+import pathlib
+import re
+import sys
+
+src_path, dst_path = sys.argv[1:3]
+text = pathlib.Path(src_path).read_text(encoding="utf-8")
+pattern = re.compile(r"(<MatrixElement\b[^>]*\bInputChannels=\")[^\"]+(\"[^>]*\bOutputChannels=\")[^\"]+(\")")
+
+def replace(match):
+    return match.group(1) + "65535" + match.group(2) + "65535" + match.group(3)
+
+text, count = pattern.subn(replace, text, count=1)
+if count != 1:
+    raise SystemExit("No MatrixElement InputChannels/OutputChannels pair found")
+pathlib.Path(dst_path).write_text(text, encoding="utf-8")
+' "$XML_PROFILE" "$XML_MATRIX_HUGE"
+
 echo "Using base profile: $PROFILE"
+echo "Using XML profile:  $XML_PROFILE"
 echo "Tools dir: $TOOLS_DIR"
 echo ""
 
 run_reject_test "mpe-calculator-missing-main" "$OUTDIR/mpe-calculator-missing-main.json" "Missing mainFunction in CalculatorElement"
 run_reject_test "inline-clut-truncated" "$OUTDIR/inline-clut-truncated.json" "Inline CLUT data count does not match CLUT size"
+run_reject_test "mpe-matrix-huge-channels" "$OUTDIR/mpe-matrix-huge-channels.json" "Invalid inputChannels or outputChannels in MatrixElement"
+run_reject_test "mpe-matrix-short-data" "$OUTDIR/mpe-matrix-short-data.json" "matrix count does not match MatrixElement size"
 run_reject_test "spectral-white-short" "$OUTDIR/spectral-white-short.json" "whiteData count does not match spectral element size"
+run_reject_test "spectral-matrix-huge-channels" "$OUTDIR/spectral-matrix-huge-channels.json" "Invalid inputChannels or outputChannels in spectral matrix element"
 run_reject_test "spectral-offset-short" "$OUTDIR/spectral-offset-short.json" "offsetData count does not match spectral element size"
 run_reject_test "struct-bad-member" "$OUTDIR/struct-bad-member.json" "MemberTag 'badMember' missing 'type' field"
+run_xml_reject_test "xml-matrix-huge-channels" "$XML_MATRIX_HUGE" "Invalid InputChannels or OutputChannels In MatrixElement"
 
 HELPER_SRC="$OUTDIR/json-config-helper-test.cpp"
 HELPER_BIN="$OUTDIR/json-config-helper-test"
@@ -366,7 +503,7 @@ fi
 rm -f "$HELPER_BIN"
 
 echo ""
-echo "JSON parser/config regression summary:"
+echo "JSON/XML parser/config regression summary:"
 echo "  Total:      $TOTAL"
 echo "  Passed:     $PASS"
 echo "  Failed:     $FAIL"

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -1812,8 +1812,8 @@ jobs:
           passed=$((passed + r16_pass))
           failed=$((failed + r16_fail))
 
-          # --- R17: ICC JSON parser/config rejects malformed and stale data ---
-          echo "--- R17: ICC JSON parser/config malformed-data rejection ---"
+          # --- R17: ICC JSON/XML parser/config rejects malformed and stale data ---
+          echo "--- R17: ICC JSON/XML parser/config malformed-data rejection ---"
           r17_pass=0 r17_fail=0
           PARSER_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-json-parser-regression-tests.sh"
           if [ -f "$PARSER_SCRIPT" ]; then
@@ -1825,8 +1825,8 @@ jobs:
               "$PARSER_SCRIPT" > "$OUTDIR/r17-json-parser.log" 2>&1 || r17_ec=$?
             cat "$OUTDIR/r17-json-parser.log"
             if [ "$r17_ec" -eq 0 ]; then
-              echo "  [OK]    ICC JSON parser/config rejected malformed and stale data"
-              r17_pass=$((r17_pass + 8))
+              echo "  [OK]    ICC JSON/XML parser/config rejected malformed and stale data"
+              r17_pass=$((r17_pass + 12))
             else
               echo "  [FAIL]  ICC JSON parser regression script exited $r17_ec"
               r17_fail=$((r17_fail + 1))
@@ -1834,7 +1834,7 @@ jobs:
           else
             echo "  [SKIP]  parser regression script not found"
           fi
-          echo "  JSON parser/config malformed-data rejection: $r17_pass passed, $r17_fail failed"
+          echo "  JSON/XML parser/config malformed-data rejection: $r17_pass passed, $r17_fail failed"
           passed=$((passed + r17_pass))
           failed=$((failed + r17_fail))
 

--- a/.github/workflows/ci-tool-tests.yml
+++ b/.github/workflows/ci-tool-tests.yml
@@ -10,7 +10,7 @@
 #   1. Coverage baseline (105 tests) -- all 14 CLI tools
 #   2. JSON -cfg tests (33 tests) -- config mode validation
 #   3. JSON CLI exercise (125 tests) -- all CLI option combos
-#   4. Regression checks -- bisect fix PoCs, JSON parser/config failures,
+#   4. Regression checks -- bisect fix PoCs, JSON/XML parser/config failures,
 #      standard observer XML/JSON alias compatibility, issue #928 mluc setter
 #      canonical length checks, and mluc read/UTF-16 validation
 #
@@ -47,6 +47,7 @@ on:
       - '.github/workflows/ci-tool-tests.yml'
       - '.github/scripts/iccdev-tool-coverage-baseline.sh'
       - '.github/scripts/iccdev-json-cfg-tests.sh'
+      - '.github/scripts/iccdev-json-parser-regression-tests.sh'
       - '.github/scripts/iccdev-stdobserver-regression-tests.sh'
       - '.github/scripts/iccdev-mluc-setter-regression-tests.sh'
       - '.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh'
@@ -948,8 +949,8 @@ jobs:
           passed=$((passed + r12_pass))
           failed=$((failed + r12_fail))
 
-          # --- R13: ICC JSON parser/config rejects malformed and stale data ---
-          echo "--- R13: ICC JSON parser/config malformed-data rejection ---"
+          # --- R13: ICC JSON/XML parser/config rejects malformed and stale data ---
+          echo "--- R13: ICC JSON/XML parser/config malformed-data rejection ---"
           r13_pass=0 r13_fail=0
           PARSER_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-json-parser-regression-tests.sh"
           if [ -f "$PARSER_SCRIPT" ]; then
@@ -961,8 +962,8 @@ jobs:
               "$PARSER_SCRIPT" > "$OUTDIR/r13-json-parser.log" 2>&1 || r13_ec=$?
             cat "$OUTDIR/r13-json-parser.log"
             if [ "$r13_ec" -eq 0 ]; then
-              echo "  [OK]    ICC JSON parser/config rejected malformed and stale data"
-              r13_pass=$((r13_pass + 8))
+              echo "  [OK]    ICC JSON/XML parser/config rejected malformed and stale data"
+              r13_pass=$((r13_pass + 12))
             else
               echo "  [FAIL]  ICC JSON parser regression script exited $r13_ec"
               r13_fail=$((r13_fail + 1))
@@ -970,7 +971,7 @@ jobs:
           else
             echo "  [SKIP]  parser regression script not found"
           fi
-          echo "  JSON parser/config malformed-data rejection: $r13_pass passed, $r13_fail failed"
+          echo "  JSON/XML parser/config malformed-data rejection: $r13_pass passed, $r13_fail failed"
           passed=$((passed + r13_pass))
           failed=$((failed + r13_fail))
 

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -81,6 +81,18 @@ static inline icUInt32Number icJsonSafeU32(size_t n, bool *overflow = nullptr)
   return (icUInt32Number)n;
 }
 
+// Match the defensive cap used by CIccMpeMatrix::Read for user-controlled
+// matrix-family payloads before narrowing channel counts.
+static const int kIccJsonMaxMatrixChannels = 255;
+static const int kIccJsonMaxSpectralSteps = 65535;
+
+static bool icJsonValidMatrixChannels(int nIn, int nOut)
+{
+  return nIn > 0 && nOut > 0 &&
+         nIn <= kIccJsonMaxMatrixChannels &&
+         nOut <= kIccJsonMaxMatrixChannels;
+}
+
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
 #endif
@@ -891,20 +903,55 @@ bool CIccMpeJsonMatrix::ParseJson(const IccJson &j, std::string &parseStr)
   int nInInt = 0, nOutInt = 0;
   jGetValue(j, "inputChannels",  nInInt);
   jGetValue(j, "outputChannels", nOutInt);
+
+  if (!icJsonValidMatrixChannels(nInInt, nOutInt)) {
+    parseStr += "Invalid inputChannels or outputChannels in MatrixElement\n";
+    return false;
+  }
+
   icUInt16Number nIn  = (icUInt16Number)nInInt;
   icUInt16Number nOut = (icUInt16Number)nOutInt;
+  icUInt64Number nEntries64 = (icUInt64Number)nIn * nOut;
+  if (nEntries64 > 0xFFFFFFFFUL) {
+    parseStr += "MatrixElement size is too large\n";
+    return false;
+  }
+  icUInt32Number nEntries = (icUInt32Number)nEntries64;
+
+  if (j.contains("matrix") && !j["matrix"].is_array()) {
+    parseStr += "matrix must be an array in MatrixElement\n";
+    return false;
+  }
+  if (j.contains("constants") && !j["constants"].is_array()) {
+    parseStr += "constants must be an array in MatrixElement\n";
+    return false;
+  }
 
   bool bHasMatrix = j.contains("matrix") && j["matrix"].is_array();
   bool bHasConstants = j.contains("constants") && j["constants"].is_array();
+
+  if (bHasMatrix && j["matrix"].size() != nEntries64) {
+    parseStr += "matrix count does not match MatrixElement size\n";
+    return false;
+  }
+  if (bHasConstants && j["constants"].size() != nOut) {
+    parseStr += "constants count does not match MatrixElement outputChannels\n";
+    return false;
+  }
+
   // Matrix elements require constants in serialized ICC data. For older JSON
   // that omitted all-zero constants, allocate them and leave them zero-filled.
   if (!SetSize(nIn, nOut, bHasMatrix || bHasConstants)) return false;
 
   if (bHasMatrix) {
     const IccJson &mat = j["matrix"];
-    icUInt32Number nEntries = nIn * nOut;
-    for (icUInt32Number i = 0; i < nEntries && i < icJsonSafeU32(mat.size()); i++)
+    for (icUInt32Number i = 0; i < nEntries; i++) {
+      if (!mat[i].is_number()) {
+        parseStr += "matrix contains non-numeric value in MatrixElement\n";
+        return false;
+      }
       m_pMatrix[i] = (icFloatNumber)mat[i].get<double>();
+    }
 
     bool bInvert = j.contains("invertMatrix") && j["invertMatrix"].is_boolean()
                    ? j["invertMatrix"].get<bool>() : false;
@@ -922,8 +969,13 @@ bool CIccMpeJsonMatrix::ParseJson(const IccJson &j, std::string &parseStr)
   }
   if (bHasConstants) {
     const IccJson &con = j["constants"];
-    for (icUInt16Number i = 0; i < nOut && i < con.size(); i++)
+    for (icUInt16Number i = 0; i < nOut; i++) {
+      if (!con[i].is_number()) {
+        parseStr += "constants contains non-numeric value in MatrixElement\n";
+        return false;
+      }
       m_pConstants[i] = (icFloatNumber)con[i].get<double>();
+    }
   }
   return true;
 }
@@ -1966,8 +2018,8 @@ static bool icSpectralRangeFromJson(const IccJson &j, icSpectralRange &range, st
   jGetValue(jw, "start", dStart);
   jGetValue(jw, "end",   dEnd);
   jGetValue(jw, "steps", nSteps);
-  if (!nSteps) {
-    parseStr += "Invalid spectral range (steps==0)\n";
+  if (nSteps <= 0 || nSteps > kIccJsonMaxSpectralSteps) {
+    parseStr += "Invalid spectral range (steps out of range)\n";
     return false;
   }
   range.start = icFtoF16((icFloat32Number)dStart);
@@ -1998,7 +2050,7 @@ static bool icFloatArrayFromJson(const IccJson &j, const char *field,
     return false;
   }
   const IccJson &arr = j[field];
-  if ((int)arr.size() != n) {
+  if (n < 0 || arr.size() != (size_t)n) {
     parseStr += std::string(field) + " count does not match spectral element size\n";
     return false;
   }
@@ -2038,14 +2090,25 @@ static bool icSpectralMatrixFromJson(const IccJson &j, CIccMpeSpectralMatrix *pM
   int nIn = 0, nOut = 0;
   jGetValue(j, "inputChannels",  nIn);
   jGetValue(j, "outputChannels", nOut);
-  if (!nIn || !nOut) {
+  if (!icJsonValidMatrixChannels(nIn, nOut)) {
     parseStr += "Invalid inputChannels or outputChannels in spectral matrix element\n";
+    return false;
+  }
+  if (nVectors <= 0 || nVectors > kIccJsonMaxMatrixChannels) {
+    parseStr += "Invalid vector count in spectral matrix element\n";
     return false;
   }
 
   icSpectralRange range{};
   if (!icSpectralRangeFromJson(j, range, parseStr))
     return false;
+
+  icUInt64Number nMatrixValues64 = (icUInt64Number)nVectors * range.steps;
+  if (nMatrixValues64 > 0x7fffffffUL) {
+    parseStr += "spectral matrix element size is too large\n";
+    return false;
+  }
+  int nMatrixValues = (int)nMatrixValues64;
 
   if (!pMtx->SetSize((icUInt16Number)nIn, (icUInt16Number)nOut, range)) {
     parseStr += "Unable to SetSize in spectral matrix element\n";
@@ -2054,7 +2117,7 @@ static bool icSpectralMatrixFromJson(const IccJson &j, CIccMpeSpectralMatrix *pM
 
   if (!icFloatArrayFromJson(j, "whiteData", pMtx->GetWhite(), range.steps, parseStr))
     return false;
-  if (!icFloatArrayFromJson(j, "matrixData", pMtx->GetMatrix(), nVectors * range.steps, parseStr))
+  if (!icFloatArrayFromJson(j, "matrixData", pMtx->GetMatrix(), nMatrixValues, parseStr))
     return false;
   // offsetData optional -- zero-fill if absent
   if (j.contains("offsetData")) {

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -82,6 +82,44 @@
 namespace iccDEV {
 #endif
 
+// Match the defensive cap used by CIccMpeMatrix::Read before narrowing
+// user-controlled matrix-family XML channel counts.
+static const icUInt16Number kIccXmlMaxMatrixChannels = 255;
+
+static bool icXmlParseMatrixChannels(xmlNode *pNode, icUInt16Number &nInputChannels,
+                                     icUInt16Number &nOutputChannels,
+                                     const char *elementName, std::string &parseStr)
+{
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "InputChannels"), nInputChannels,
+                     kIccXmlMaxMatrixChannels) ||
+      !icXmlParseU16(icXmlAttrValue(pNode, "OutputChannels"), nOutputChannels,
+                     kIccXmlMaxMatrixChannels) ||
+      !nInputChannels || !nOutputChannels) {
+    parseStr += std::string("Invalid InputChannels or OutputChannels In ") + elementName + "\n";
+    return false;
+  }
+
+  return true;
+}
+
+static bool icXmlParseSpectralRange(xmlNode *pNode, icSpectralRange &range,
+                                    std::string &parseStr)
+{
+  icFloatNumber dStart = (icFloatNumber)atof(icXmlAttrValue(pNode, "start"));
+  icFloatNumber dEnd = (icFloatNumber)atof(icXmlAttrValue(pNode, "end"));
+  icUInt16Number nSteps = 0;
+
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "steps"), nSteps) || !nSteps) {
+    parseStr += "Invalid Spectral Range\n";
+    return false;
+  }
+
+  range.start = icFtoF16(dStart);
+  range.end = icFtoF16(dEnd);
+  range.steps = nSteps;
+  return true;
+}
+
 bool CIccMpeXmlUnknown::ToXml(std::string &xml, std::string blanks/* = ""*/)
 {
   //icUInt8Number *m_ptr = m_pData;
@@ -1368,10 +1406,10 @@ bool CIccMpeXmlMatrix::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  icUInt16Number nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  icUInt16Number nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-  if (!nInputChannels || !nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In MatrixElement\n";
+  icUInt16Number nInputChannels = 0;
+  icUInt16Number nOutputChannels = 0;
+  if (!icXmlParseMatrixChannels(pNode, nInputChannels, nOutputChannels,
+                                "MatrixElement", parseStr)) {
     return false;
   }
 
@@ -1381,7 +1419,8 @@ bool CIccMpeXmlMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
   if (pData) {
     SetSize(nInputChannels, nOutputChannels);
 
-    if (!CIccFloatArray::ParseArray(m_pMatrix, m_nInputChannels*m_nOutputChannels, pData->children))
+    icUInt32Number nMatrixEntries = (icUInt32Number)nInputChannels * nOutputChannels;
+    if (!CIccFloatArray::ParseArray(m_pMatrix, nMatrixEntries, pData->children))
       return false;
 
     const char *invert = icXmlAttrValue(pData, "InvertMatrix", "false");
@@ -1476,11 +1515,10 @@ bool CIccMpeXmlEmissionMatrix::ToXml(std::string &xml, std::string blanks/* = ""
 
 bool CIccMpeXmlEmissionMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  icUInt16Number nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  icUInt16Number nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-
-  if (!nInputChannels || !nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In MatrixElement\n";
+  icUInt16Number nInputChannels = 0;
+  icUInt16Number nOutputChannels = 0;
+  if (!icXmlParseMatrixChannels(pNode, nInputChannels, nOutputChannels,
+                                "EmissionMatrixElement", parseStr)) {
     return false;
   }
 
@@ -1488,17 +1526,8 @@ bool CIccMpeXmlEmissionMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   pData = icXmlFindNode(pNode->children, "Wavelengths");
   if (pData) {
-    icFloatNumber dStart = (icFloatNumber)atof(icXmlAttrValue(pData, "start"));
-    icFloatNumber dEnd = (icFloatNumber)atof(icXmlAttrValue(pData, "end"));
-    icUInt16Number nSteps = atoi(icXmlAttrValue(pData, "steps"));
-
-    if (!nSteps) {
-      parseStr += "Invalid Spectral Range\n";
+    if (!icXmlParseSpectralRange(pData, m_Range, parseStr))
       return false;
-    }
-    m_Range.start = icFtoF16(dStart);
-    m_Range.end = icFtoF16(dEnd);
-    m_Range.steps = nSteps;
   }
 
   SetSize(nInputChannels, nOutputChannels, m_Range);
@@ -1604,11 +1633,10 @@ bool CIccMpeXmlInvEmissionMatrix::ToXml(std::string &xml, std::string blanks/* =
 
 bool CIccMpeXmlInvEmissionMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  icUInt16Number nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  icUInt16Number nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-
-  if (!nInputChannels || !nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In MatrixElement\n";
+  icUInt16Number nInputChannels = 0;
+  icUInt16Number nOutputChannels = 0;
+  if (!icXmlParseMatrixChannels(pNode, nInputChannels, nOutputChannels,
+                                "InvEmissionMatrixElement", parseStr)) {
     return false;
   }
 
@@ -1616,17 +1644,8 @@ bool CIccMpeXmlInvEmissionMatrix::ParseXml(xmlNode *pNode, std::string &parseStr
 
   pData = icXmlFindNode(pNode->children, "Wavelengths");
   if (pData) {
-    icFloatNumber dStart = (icFloatNumber)atof(icXmlAttrValue(pData, "start"));
-    icFloatNumber dEnd = (icFloatNumber)atof(icXmlAttrValue(pData, "end"));
-    icUInt16Number nSteps = atoi(icXmlAttrValue(pData, "steps"));
-
-    if (!nSteps) {
-      parseStr += "Invalid Spectral Range\n";
+    if (!icXmlParseSpectralRange(pData, m_Range, parseStr))
       return false;
-    }
-    m_Range.start = icFtoF16(dStart);
-    m_Range.end = icFtoF16(dEnd);
-    m_Range.steps = nSteps;
   }
 
   SetSize(nInputChannels, nOutputChannels, m_Range);


### PR DESCRIPTION
## PR Summary

#942 #946 

This PR addresses a `sio` in Json & Xml

### Impact

Before this patch, malformed `MatrixElement` / spectral matrix inputs could be accepted or partially interpreted when channel counts or array sizes were inconsistent with the declared element shape. That creates risk for incorrect profile construction, allocation pressure, integer narrowing, or downstream parser instability.

This is defensive hardening for a legacy parser surface. It is not intended to change valid ICC/iccMAX profile behavior.

### Fix Summary

- Adds explicit JSON matrix channel validation before narrowing channel counts.
- Requires `matrix`, `constants`, `whiteData`, `matrixData`, and `offsetData` counts to match declared dimensions.
- Rejects non-numeric matrix and constants values instead of partially consuming arrays.
- Caps JSON/XML matrix-family channel counts consistently with the defensive matrix reader behavior.
- Adds XML helper parsing for matrix channel attributes and spectral ranges.
- Extends parser regression coverage from JSON-only to JSON/XML malformed-input rejection.

### Regression Coverage

The regression script now checks malformed JSON and sibling XML payloads, including:

- huge matrix channel counts
- truncated matrix data
- oversized spectral matrix dimensions
- malformed XML matrix channel declarations
- clean rejection without sanitizer findings
- no output profile written after rejected input

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
