### PR TITLE
Fix: Bisect 3f23c2e pad

### DIFF
--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -522,8 +522,11 @@ int main(int argc, char* argv[])
         // Number of actual padding bytes between this tag and closest neighbour (or EOF)
         // Should be 0-3 if compliant. Negative number if tags overlap!
         // Guard against unsigned integer overflow in subtraction
-        if (i->TagInfo.offset + (icUInt64Number)i->TagInfo.size > (icUInt64Number)closest)
-            pad = -((int)((icUInt64Number)i->TagInfo.offset + i->TagInfo.size - closest));
+        icUInt64Number tagEnd = (icUInt64Number)i->TagInfo.offset + i->TagInfo.size;
+        if (tagEnd > (icUInt64Number)closest) {
+            icUInt64Number overlap = tagEnd - (icUInt64Number)closest;
+            pad = (overlap > (icUInt64Number)INT_MAX) ? INT_MIN : -(int)overlap;
+        }
         else
             pad = closest - i->TagInfo.offset - i->TagInfo.size;
 


### PR DESCRIPTION
## PR Summary

#949 

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
