### PR TITLE
Fix: Bisect 1f0a9dd & b1722f9 sparsematrix

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -5,7 +5,7 @@
 
     Version:    V1
 
-    Copyright:  © see ICC Software License
+    Copyright:  see ICC Software License
 */
 
 /*
@@ -1108,7 +1108,11 @@ bool CIccTagXmlSparseMatrixArray::ToXml(std::string &xml, std::string blanks/* =
   icUInt32Number bytesPerMatrix = GetBytesPerMatrix();
 
   for (i=0; i<(int)m_nSize; i++) {
-    mtx.Reset(m_RawData+i*bytesPerMatrix, bytesPerMatrix, icSparseMatrixFloatNum, true);
+    if (!mtx.Reset(m_RawData+i*bytesPerMatrix, bytesPerMatrix, icSparseMatrixFloatNum, true) ||
+        mtx.GetNumEntries() > mtx.GetMaxEntries() ||
+        !mtx.IsValid())
+      return false;
+
     snprintf(buf, bufSize, " <SparseMatrix rows=\"%d\" cols=\"%d\">\n", mtx.Rows(), mtx.Cols());
     xml += blanks + buf;
 


### PR DESCRIPTION
## PR Summary

#947 

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
