### PR TITLE
Fix: Bisect ce59fa8 namedcolor

### DIFF
--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1681,6 +1681,9 @@ IIccStruct *icGetTagStructHandler(CIccTag *pTag)
 
 IIccStruct *icGetTagStructHandlerOfType(CIccTag* pTag, icStructSignature sig)
 {
+  if (!pTag)
+    return NULL;
+
   if (pTag->GetTagStructType()==sig)
     return icGetTagStructHandler(pTag);
 
@@ -1701,9 +1704,11 @@ IIccArray *icGetTagArrayHandler(CIccTag *pTag)
 
 IIccArray *icGetTagArrayHandlerOfType(CIccTag* pTag, icArraySignature sig)
 {
+  if (!pTag)
+    return NULL;
+
   if (pTag->GetTagArrayType()==sig)
     return icGetTagArrayHandler(pTag);
 
   return NULL;
 }
-

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -89,7 +89,7 @@
 
 #if defined(_WIN32) || defined(WIN32)
 #include <crtdbg.h>
-#elif __GLIBC__
+#elif defined(__GLIBC__)
 #include <mcheck.h>
 #endif
 
@@ -296,7 +296,7 @@ int main(int argc, char* argv[])
   tmp = tmp | _CRTDBG_LEAK_CHECK_DF | _CRTDBG_ALLOC_MEM_DF; // | _CRTDBG_CHECK_ALWAYS_DF;
   _CrtSetDbgFlag(tmp);
   //_CrtSetBreakAlloc(1163);
-#elif __GLIBC__
+#elif defined(__GLIBC__)
   mcheck(NULL);
 #endif // WIN32
 #endif // MEMORY_LEAK_CHECK && _DEBUG


### PR DESCRIPTION
## PR Summary

#952 

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
