### PR TITLE
Fix: Bisect 1f0a9dd & b1722f9 sparsematrix

### DIFF
--- a/IccProfLib/IccMpeSpectral.cpp
+++ b/IccProfLib/IccMpeSpectral.cpp
@@ -5,7 +5,7 @@
 
     Version:    V1
 
-    Copyright:  � see ICC Software License
+    Copyright:  see ICC Software License
 */
 
 /*
@@ -339,8 +339,10 @@ void CIccMpeSpectralMatrix::Describe(std::string &sDescription, int /* nVerbosen
   sDescription += "\n";
 
   if (data) {
+    icUInt16Number nVectors = numVectors();
+
     sDescription += "CHANNEL_DATA\n";
-    for (j=0; j<m_nOutputChannels; j++) {
+    for (j=0; j<(int)nVectors; j++) {
       for (i=0; i<(int)m_Range.steps; i++) {
         if (i)
           sDescription += " ";
@@ -348,7 +350,7 @@ void CIccMpeSpectralMatrix::Describe(std::string &sDescription, int /* nVerbosen
         sDescription += buf;
       }
       sDescription += "\n";
-      data += m_nInputChannels;
+      data += m_Range.steps;
     }
   }
 


### PR DESCRIPTION
## PR Summary

#947 

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
