### PR TITLE
Modify: CWE-400 CalculatorOps

### DIFF
--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -22,6 +22,7 @@ Test 18 (Regression Bisect).
 | `.github/scripts/iccdev-mluc-setter-regression-tests.sh` | #928 | `multiLocalizedUnicodeType` setters included safety terminators in serialized `mluc` string lengths | Rebuilds `sRGB_D65_MAT.icc` and `NamedColor.icc` from XML and verifies canonical `desc`/`mluc` sizes |
 | `.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh` | #928 follow-up | `multiLocalizedUnicodeType` reader accepted malformed record lengths, string offsets, and UTF-16 surrogate data | Mutates `sRGB_D65_MAT.icc` in `/tmp` and verifies malformed `mluc` records are rejected without sanitizer findings |
 | `.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh` | #958 | Non-standard PCC viewing-condition illuminant XYZ with zero Y divided by zero or fell back to D50 | Compiles a small PCC helper and verifies zero-Y custom illuminants are rejected without sanitizer findings or D50 substitution |
+| `.github/scripts/iccdev-calculator-regression-tests.sh` | `bisect-ce59fa8-calculator` | Calculator round/truncate/select casts and if/else offset arithmetic accepted malformed profile data without sanitizer-safe guards | Rebuilds `srgbCalcTest`, exercises calculator debug apply, and verifies malformed CalcTest operator fixtures reject without sanitizer findings |
 
 ## Adding a new PoC
 

--- a/.github/scripts/iccdev-calculator-regression-tests.sh
+++ b/.github/scripts/iccdev-calculator-regression-tests.sh
@@ -1,0 +1,231 @@
+#!/bin/bash
+###############################################################################
+# iccDEV calculator sanitizer regression tests
+###############################################################################
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-calculator-regressions}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+DUMP="$TOOLS_DIR/IccDumpProfile/iccDumpProfile"
+APPLYNCM="$TOOLS_DIR/IccApplyNamedCmm/iccApplyNamedCmm"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+fail_case() {
+  local name="$1"
+  local detail="$2"
+
+  echo "  [FAIL] $name -- $detail"
+  FAIL=$((FAIL + 1))
+}
+
+pass_case() {
+  local name="$1"
+
+  echo "  [PASS] $name"
+  PASS=$((PASS + 1))
+}
+
+check_log() {
+  local name="$1"
+  local logfile="$2"
+
+  if grep -q "ERROR: AddressSanitizer" "$logfile" 2>/dev/null; then
+    fail_case "$name" "AddressSanitizer finding"
+    return 1
+  fi
+
+  if grep -q "runtime error:" "$logfile" 2>/dev/null; then
+    if grep "runtime error:" "$logfile" | grep -v "/IccProfLib/IccMD5.cpp:" >/dev/null 2>&1; then
+      fail_case "$name" "undefined behavior"
+      return 1
+    fi
+    echo "  [WARN] $name -- ignored known MD5 unsigned-shift instrumentation noise"
+  fi
+
+  return 0
+}
+
+require_tool() {
+  local tool="$1"
+  local label="$2"
+
+  if [ ! -x "$tool" ]; then
+    fail_case "$label" "missing executable: $tool"
+    return 1
+  fi
+
+  return 0
+}
+
+run_valid_calc_apply() {
+  local name="valid-srgb-calculator-apply"
+  local calc_dir="$TESTING_DIR/Calc"
+  local source_xml="$calc_dir/srgbCalcTest.xml"
+  local source_txt="$calc_dir/srgbCalcTest.txt"
+  local target_icc="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+  local built_icc="$OUTDIR/srgbCalcTest.icc"
+  local fromxml_log="$OUTDIR/${name}-fromxml.log"
+  local apply_log="$OUTDIR/${name}-apply.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$built_icc" "$fromxml_log" "$apply_log"
+
+  if [ ! -f "$source_xml" ] || [ ! -f "$source_txt" ] || [ ! -f "$target_icc" ]; then
+    fail_case "$name" "missing srgbCalcTest input fixture"
+    return
+  fi
+
+  (cd "$calc_dir" && timeout 30 "$FROMXML" "srgbCalcTest.xml" "$built_icc" > "$fromxml_log" 2>&1) || exit_code=$?
+  if ! check_log "$name/fromxml" "$fromxml_log"; then
+    return
+  fi
+  if [ "$exit_code" -ne 0 ] || [ ! -s "$built_icc" ]; then
+    fail_case "$name" "iccFromXml failed with exit=$exit_code"
+    sed -n '1,20p' "$fromxml_log"
+    return
+  fi
+
+  exit_code=0
+  timeout 30 "$APPLYNCM" "$source_txt" 2 0 "$built_icc" 3 "$target_icc" 3 > "$apply_log" 2>&1 || exit_code=$?
+  if ! check_log "$name/apply" "$apply_log"; then
+    return
+  fi
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "iccApplyNamedCmm failed with exit=$exit_code"
+    sed -n '1,20p' "$apply_log"
+    return
+  fi
+
+  pass_case "$name"
+}
+
+run_debug_calc_apply() {
+  local name="debug-calculator-operator-exercise"
+  local calc_dir="$TESTING_DIR/CalcTest"
+  local source_xml="$calc_dir/calcExercizeOps.xml"
+  local source_txt="$calc_dir/rgbExercise8bit.txt"
+  local built_icc="$OUTDIR/calcExercizeOps.icc"
+  local fromxml_log="$OUTDIR/${name}-fromxml.log"
+  local apply_log="$OUTDIR/${name}-apply.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$built_icc" "$fromxml_log" "$apply_log"
+
+  if [ ! -f "$source_xml" ] || [ ! -f "$source_txt" ]; then
+    fail_case "$name" "missing CalcTest operator fixture"
+    return
+  fi
+
+  (cd "$calc_dir" && timeout 30 "$FROMXML" "calcExercizeOps.xml" "$built_icc" > "$fromxml_log" 2>&1) || exit_code=$?
+  if ! check_log "$name/fromxml" "$fromxml_log"; then
+    return
+  fi
+  if [ "$exit_code" -ne 0 ] || [ ! -s "$built_icc" ]; then
+    fail_case "$name" "iccFromXml failed with exit=$exit_code"
+    sed -n '1,20p' "$fromxml_log"
+    return
+  fi
+
+  exit_code=0
+  timeout 30 "$APPLYNCM" -debugcalc "$source_txt" 0 1 "$built_icc" 1 > "$apply_log" 2>&1 || exit_code=$?
+  if ! check_log "$name/apply" "$apply_log"; then
+    return
+  fi
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "iccApplyNamedCmm -debugcalc failed with exit=$exit_code"
+    sed -n '1,30p' "$apply_log"
+    return
+  fi
+
+  pass_case "$name"
+}
+
+run_reject_profile() {
+  local fixture="$1"
+  local name="reject-${fixture%.icc}"
+  local profile="$TESTING_DIR/CalcTest/$fixture"
+  local log="$OUTDIR/${name}.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$log"
+
+  if [ ! -f "$profile" ]; then
+    fail_case "$name" "missing fixture: $profile"
+    return
+  fi
+
+  timeout 30 "$DUMP" -v "$profile" > "$log" 2>&1 || exit_code=$?
+  if ! check_log "$name" "$log"; then
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "malformed calculator profile was accepted"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "iccDumpProfile timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 129 ] && [ "$exit_code" -le 192 ]; then
+    fail_case "$name" "iccDumpProfile crashed with signal $((exit_code - 128))"
+    return
+  fi
+
+  pass_case "$name"
+}
+
+require_tool "$FROMXML" "iccFromXml" || true
+require_tool "$DUMP" "iccDumpProfile" || true
+require_tool "$APPLYNCM" "iccApplyNamedCmm" || true
+
+if [ "$FAIL" -eq 0 ]; then
+  run_valid_calc_apply
+  run_debug_calc_apply
+  run_reject_profile "calcUnderStack_rond.icc"
+  run_reject_profile "calcUnderStack_trnc.icc"
+  run_reject_profile "calcUnderStack_mod.icc"
+  run_reject_profile "calcUnderStack_sel.icc"
+  run_reject_profile "calcUnderStack_if.icc"
+  run_reject_profile "calcOverMem_tget.icc"
+  run_reject_profile "calcOverMem_tput.icc"
+  run_reject_profile "calcOverMem_tsav.icc"
+fi
+
+echo "Calculator regression tests: $PASS passed, $FAIL failed, $TOTAL total"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh
+++ b/.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh
@@ -68,7 +68,7 @@ pass_case() {
 run_zero_illuminant_helper() {
   local name="pcc-zero-illuminant"
   local helper_cpp="$REPO_ROOT/.github/ci/regression/pcc-zero-illuminant.cpp"
-  local helper_bin="$OUTDIR/$name"
+  local helper_bin="${TMPDIR:-/tmp}/iccdev-${name}-helper-$$"
   local compile_log="$OUTDIR/$name.compile.log"
   local run_log="$OUTDIR/$name.run.log"
   local lib_dir="$BUILD_DIR/IccProfLib"
@@ -129,6 +129,7 @@ run_zero_illuminant_helper() {
       -o "$helper_bin" > "$compile_log" 2>&1; then
     fail_case "$name" "failed to compile helper"
     sed -n '1,80p' "$compile_log"
+    rm -f "$helper_bin"
     return
   fi
 
@@ -137,15 +138,18 @@ run_zero_illuminant_helper() {
   if grep -q "ERROR: AddressSanitizer\\|runtime error:" "$run_log" 2>/dev/null; then
     fail_case "$name" "sanitizer finding while checking zero-Y PCC illuminant"
     sed -n '1,80p' "$run_log"
+    rm -f "$helper_bin"
     return
   fi
 
   if [ "$run_ec" -ne 0 ]; then
     fail_case "$name" "helper exited $run_ec"
     sed -n '1,80p' "$run_log"
+    rm -f "$helper_bin"
     return
   fi
 
+  rm -f "$helper_bin"
   pass_case "$name" "zero-Y custom PCC illuminant is rejected without D50 fallback"
 }
 

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -2003,8 +2003,8 @@ jobs:
           TOTAL_FAIL=0
           TOTAL_READ_FAIL=0
           if [ -d "$OUTDIR" ]; then
-            ASAN_FILES=$({ grep -rl "ERROR: AddressSanitizer" "$OUTDIR"/ 2>/dev/null || true; })
-            UBSAN_FILES=$({ grep -rl "runtime error:" "$OUTDIR"/ 2>/dev/null || true; })
+            ASAN_FILES=$({ grep -Irl "ERROR: AddressSanitizer" "$OUTDIR"/ 2>/dev/null || true; })
+            UBSAN_FILES=$({ grep -Irl "runtime error:" "$OUTDIR"/ 2>/dev/null || true; })
             TOTAL_LOGS=$(find "$OUTDIR" -name '*.log' -type f 2>/dev/null | wc -l)
             # Count pass/fail across per-profile logs (exit code in log content)
             for logf in "$OUTDIR"/*/*.log; do
@@ -2111,11 +2111,11 @@ jobs:
               pdir="$OUTDIR/$dir"
               if [ ! -d "$pdir" ]; then
                 echo "| $phase | $name | SKIP |"
-              elif grep -rq "ERROR: AddressSanitizer" "$pdir"/ 2>/dev/null; then
-                pa=$(grep -rl "ERROR: AddressSanitizer" "$pdir"/ 2>/dev/null | wc -l)
+              elif grep -Irq "ERROR: AddressSanitizer" "$pdir"/ 2>/dev/null; then
+                pa=$(grep -Irl "ERROR: AddressSanitizer" "$pdir"/ 2>/dev/null | wc -l)
                 echo "| $phase | $name | ASAN ($pa files) |"
-              elif grep -rq "runtime error:" "$pdir"/ 2>/dev/null; then
-                pu=$(grep -rl "runtime error:" "$pdir"/ 2>/dev/null | wc -l)
+              elif grep -Irq "runtime error:" "$pdir"/ 2>/dev/null; then
+                pu=$(grep -Irl "runtime error:" "$pdir"/ 2>/dev/null | wc -l)
                 echo "| $phase | $name | UBSAN ($pu files) |"
               elif [ -f "$pdir/.phase-fail" ]; then
                 reason="$(sanitize_line "$(sed -n '1p' "$pdir/.phase-fail")")"

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -1942,6 +1942,32 @@ jobs:
           passed=$((passed + r21_pass))
           failed=$((failed + r21_fail))
 
+          # --- R22: Calculator cast/offset sanitizer regression ---
+          echo "--- R22: Calculator cast/offset sanitizer regression ---"
+          r22_pass=0 r22_fail=0
+          CALC_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-calculator-regression-tests.sh"
+          if [ -f "$CALC_SCRIPT" ]; then
+            chmod +x "$CALC_SCRIPT"
+            r22_ec=0
+            ICCDEV_TOOLS_DIR="${WORKSPACE_DIR}/build/Tools" \
+              ICCDEV_TESTING_DIR="${WORKSPACE_DIR}/Testing" \
+              ICCDEV_TEST_OUTDIR="$OUTDIR/r22-calculator" \
+              "$CALC_SCRIPT" > "$OUTDIR/r22-calculator.log" 2>&1 || r22_ec=$?
+            cat "$OUTDIR/r22-calculator.log"
+            if [ "$r22_ec" -eq 0 ]; then
+              echo "  [OK]    Calculator operator and malformed-profile regressions pass"
+              r22_pass=$((r22_pass + 10))
+            else
+              echo "  [FAIL]  Calculator regression script exited $r22_ec"
+              r22_fail=$((r22_fail + 1))
+            fi
+          else
+            echo "  [SKIP]  calculator regression script not found"
+          fi
+          echo "  Calculator cast/offset sanitizer regression: $r22_pass passed, $r22_fail failed"
+          passed=$((passed + r22_pass))
+          failed=$((failed + r22_fail))
+
           echo ""
           echo "Regression checks: $passed passed, $failed failed"
           if [ "$failed" -gt 0 ]; then exit 1; fi
@@ -2076,7 +2102,7 @@ jobs:
               ["15"]="iccApplySearch (CMM search optimization)"
               ["16"]="MCS regression (iccApplyProfiles TIFF pipeline)"
               ["17"]="iccV5DspObsToV4Dsp (v5 display to v4 conversion)"
-              ["18"]="Regression checks (bisect fixes: 599,736,744,751,752,763,769; stdobserver aliases; issue #928 mluc setter/read; issue #958 PCC illuminant)"
+              ["18"]="Regression checks (bisect fixes: 599,736,744,751,752,763,769; stdobserver aliases; issue #928 mluc setter/read; issue #958 PCC illuminant; calculator sanitizer)"
             )
 
             for phase in $(seq 1 18); do

--- a/.github/workflows/ci-tool-tests.yml
+++ b/.github/workflows/ci-tool-tests.yml
@@ -13,7 +13,7 @@
 #   4. Regression checks -- bisect fix PoCs, JSON/XML parser/config failures,
 #      standard observer XML/JSON alias compatibility, issue #928 mluc setter
 #      canonical length checks, mluc read/UTF-16 validation, and issue #958
-#      PCC zero-Y illuminant validation
+#      PCC zero-Y illuminant validation, and calculator sanitizer regressions
 #
 # Hardening:
 #   - sanitize-sed.sh sourced in every step
@@ -32,6 +32,7 @@
 #   .github/scripts/iccdev-mluc-setter-regression-tests.sh
 #   .github/scripts/iccdev-mluc-read-utf16-regression-tests.sh
 #   .github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh
+#   .github/scripts/iccdev-calculator-regression-tests.sh
 #
 ###############################################################
 
@@ -55,6 +56,7 @@ on:
       - '.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh'
       - '.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh'
       - '.github/ci/regression/pcc-zero-illuminant.cpp'
+      - '.github/scripts/iccdev-calculator-regression-tests.sh'
       - '.github/scripts/json-cli-exercise.sh'
       - '.github/ci/test-data/**'
       - 'IccProfLib/**'
@@ -1082,6 +1084,32 @@ jobs:
           echo "  Issue #958 PCC zero-Y illuminant validation: $r17_pass passed, $r17_fail failed"
           passed=$((passed + r17_pass))
           failed=$((failed + r17_fail))
+
+          # --- R18: Calculator cast/offset sanitizer regression ---
+          echo "--- R18: Calculator cast/offset sanitizer regression ---"
+          r18_pass=0 r18_fail=0
+          CALC_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-calculator-regression-tests.sh"
+          if [ -f "$CALC_SCRIPT" ]; then
+            chmod +x "$CALC_SCRIPT"
+            r18_ec=0
+            ICCDEV_TOOLS_DIR="${WORKSPACE_DIR}/build/Tools" \
+              ICCDEV_TESTING_DIR="${WORKSPACE_DIR}/Testing" \
+              ICCDEV_TEST_OUTDIR="$OUTDIR/r18-calculator" \
+              "$CALC_SCRIPT" > "$OUTDIR/r18-calculator.log" 2>&1 || r18_ec=$?
+            cat "$OUTDIR/r18-calculator.log"
+            if [ "$r18_ec" -eq 0 ]; then
+              echo "  [OK]    Calculator operator and malformed-profile regressions pass"
+              r18_pass=$((r18_pass + 10))
+            else
+              echo "  [FAIL]  Calculator regression script exited $r18_ec"
+              r18_fail=$((r18_fail + 1))
+            fi
+          else
+            echo "  [SKIP]  calculator regression script not found"
+          fi
+          echo "  Calculator cast/offset sanitizer regression: $r18_pass passed, $r18_fail failed"
+          passed=$((passed + r18_pass))
+          failed=$((failed + r18_fail))
 
           echo ""
           echo "Regression checks: $passed passed, $failed failed"

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -93,6 +93,39 @@ static bool icJsonValidMatrixChannels(int nIn, int nOut)
          nOut <= kIccJsonMaxMatrixChannels;
 }
 
+static bool icJsonGetFloatNumber(const IccJson &jv, icFloatNumber &v)
+{
+  if (jv.is_number()) {
+    v = (icFloatNumber)jv.get<double>();
+    return true;
+  }
+  return false;
+}
+
+static bool icJsonGetBoolValue(const IccJson &jv, bool &v)
+{
+  if (jv.is_boolean()) {
+    v = jv.get<bool>();
+    return true;
+  }
+  return false;
+}
+
+static bool icJsonGetRequiredFloat(const IccJson &j, const char *field,
+                                   icFloatNumber &v, std::string &parseStr,
+                                   const char *context)
+{
+  if (!j.contains(field)) {
+    parseStr += std::string("Missing ") + field + " in " + context + "\n";
+    return false;
+  }
+  if (!icJsonGetFloatNumber(j[field], v)) {
+    parseStr += std::string("Invalid ") + field + " in " + context + "\n";
+    return false;
+  }
+  return true;
+}
+
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
 #endif
@@ -187,7 +220,8 @@ public:
     if (m_nReserved2)
       j["reserved2"]  = (int)m_nReserved2;
     IccJson params = IccJson::array();
-    for (int i = 0; i < m_nParameters; i++)
+    const int nParameters = (int)m_nParameters;
+    for (int i = 0; i < nParameters; i++)
       params.push_back((double)m_params[i]);
     j["parameters"] = params;
     return true;
@@ -216,8 +250,12 @@ public:
       for (int i = 0; i < nParams; i++) m_params[i] = 0.0f;
       if (jsonExistsField(j, "parameters") && j["parameters"].is_array()) {
         int cnt = std::min(nParams, (int)j["parameters"].size());
-        for (int i = 0; i < cnt; i++)
-          m_params[i] = (icFloatNumber)j["parameters"][i].get<double>();
+        for (int i = 0; i < cnt; i++) {
+          if (!icJsonGetFloatNumber(j["parameters"][i], m_params[i])) {
+            parseStr += "parameters contains non-numeric value in FormulaSegment\n";
+            return false;
+          }
+        }
       }
     }
     return true;
@@ -236,7 +274,8 @@ public:
   bool ToJson(IccJson &j) const {
     j["type"] = "SampledSegment";
     IccJson samples = IccJson::array();
-    for (icUInt32Number i = 0; i < m_nCount; i++)
+    const icUInt32Number nCount = m_nCount;
+    for (icUInt32Number i = 0; i < nCount; i++)
       samples.push_back((double)m_pSamples[i]);
     j["samples"] = samples;
     return true;
@@ -250,8 +289,12 @@ public:
     const IccJson &arr = j["samples"];
     if (!SetSize(icJsonSafeU32(arr.size())))
       return false;
-    for (icUInt32Number i = 0; i < icJsonSafeU32(arr.size()); i++)
-      m_pSamples[i] = (icFloatNumber)arr[i].get<double>();
+    for (icUInt32Number i = 0; i < icJsonSafeU32(arr.size()); i++) {
+      if (!icJsonGetFloatNumber(arr[i], m_pSamples[i])) {
+        parseStr += "samples contains non-numeric value in SampledSegment\n";
+        return false;
+      }
+    }
     return true;
   }
 };
@@ -341,15 +384,24 @@ public:
     if (m_nReserved)
       j["reserved"] = (int)m_nReserved;
     IccJson samples = IccJson::array();
-    for (icUInt32Number i = 0; i < m_nCount; i++)
+    const icUInt32Number nCount = m_nCount;
+    for (icUInt32Number i = 0; i < nCount; i++)
       samples.push_back((double)m_pSamples[i]);
     j["samples"] = samples;
     return true;
   }
 
   bool ParseJson(const IccJson &j, std::string &parseStr) {
-    icFloatNumber first = j.contains("firstEntry") ? (icFloatNumber)j["firstEntry"].get<double>() : 0.0f;
-    icFloatNumber last  = j.contains("lastEntry")  ? (icFloatNumber)j["lastEntry"].get<double>()  : 1.0f;
+    icFloatNumber first = 0.0f;
+    icFloatNumber last = 1.0f;
+    if (j.contains("firstEntry") && !icJsonGetFloatNumber(j["firstEntry"], first)) {
+      parseStr += "firstEntry must be numeric in SingleSampledCurve\n";
+      return false;
+    }
+    if (j.contains("lastEntry") && !icJsonGetFloatNumber(j["lastEntry"], last)) {
+      parseStr += "lastEntry must be numeric in SingleSampledCurve\n";
+      return false;
+    }
     SetRange(first, last);
 
     int storageType   = (int)icValueTypeFloat32;
@@ -369,8 +421,12 @@ public:
     const IccJson &arr = j["samples"];
     if (!SetSize(icJsonSafeU32(arr.size())))
       return false;
-    for (icUInt32Number i = 0; i < icJsonSafeU32(arr.size()); i++)
-      m_pSamples[i] = (icFloatNumber)arr[i].get<double>();
+    for (icUInt32Number i = 0; i < icJsonSafeU32(arr.size()); i++) {
+      if (!icJsonGetFloatNumber(arr[i], m_pSamples[i])) {
+        parseStr += "samples contains non-numeric value in SingleSampledCurve\n";
+        return false;
+      }
+    }
     return true;
   }
 };
@@ -409,8 +465,16 @@ public:
   }
 
   bool ParseJson(const IccJson &j, std::string &parseStr) {
-    icFloatNumber first = j.contains("firstEntry") ? (icFloatNumber)j["firstEntry"].get<double>() : 0.0f;
-    icFloatNumber last  = j.contains("lastEntry")  ? (icFloatNumber)j["lastEntry"].get<double>()  : 1.0f;
+    icFloatNumber first = 0.0f;
+    icFloatNumber last = 1.0f;
+    if (j.contains("firstEntry") && !icJsonGetFloatNumber(j["firstEntry"], first)) {
+      parseStr += "firstEntry must be numeric in SampledCalculatorCurve\n";
+      return false;
+    }
+    if (j.contains("lastEntry") && !icJsonGetFloatNumber(j["lastEntry"], last)) {
+      parseStr += "lastEntry must be numeric in SampledCalculatorCurve\n";
+      return false;
+    }
     SetRange(first, last);
 
     int extensionType = 0, desiredSize = 256, reserved2 = 0;
@@ -726,7 +790,8 @@ bool CIccJsonToneMapFunc::ToJson(IccJson &j)
   if (m_nReserved2)
     j["reserved2"] = (int)m_nReserved2;
   IccJson params = IccJson::array();
-  for (icUInt8Number i = 0; i < m_nParameters; i++)
+  const int nParameters = (int)m_nParameters;
+  for (int i = 0; i < nParameters; i++)
     params.push_back((double)m_params[i]);
   j["parameters"] = params;
   return true;
@@ -750,12 +815,17 @@ bool CIccJsonToneMapFunc::ParseJson(const IccJson &j, std::string &parseStr)
   if (m_params) { free(m_params); m_params = nullptr; }
   m_params = (icFloatNumber*)malloc(m_nParameters * sizeof(icFloatNumber));
   if (!m_params) return false;
-  for (int i = 0; i < m_nParameters; i++) m_params[i] = 0.0f;
+  const int nParameters = (int)m_nParameters;
+  for (int i = 0; i < nParameters; i++) m_params[i] = 0.0f;
 
   if (j.contains("parameters") && j["parameters"].is_array()) {
-    int cnt = std::min((int)m_nParameters, (int)j["parameters"].size());
-    for (int i = 0; i < cnt; i++)
-      m_params[i] = (icFloatNumber)j["parameters"][i].get<double>();
+    int cnt = std::min(nParameters, (int)j["parameters"].size());
+    for (int i = 0; i < cnt; i++) {
+      if (!icJsonGetFloatNumber(j["parameters"][i], m_params[i])) {
+        parseStr += "parameters contains non-numeric value in ToneMapFunction\n";
+        return false;
+      }
+    }
   }
   return true;
 }
@@ -779,7 +849,8 @@ bool CIccMpeJsonToneMap::ToJson(IccJson &j)
 
   // Tone map functions (with duplicate detection)
   IccJson funcs = IccJson::array();
-  for (int i = 0; i < (int)m_nOutputChannels; i++) {
+  const int nOutputChannels = (int)m_nOutputChannels;
+  for (int i = 0; i < nOutputChannels; i++) {
     int dupIdx = -1;
     for (int k = 0; k < i; k++) {
       if (m_pToneFuncs[i] == m_pToneFuncs[k]) { dupIdx = k; break; }
@@ -882,7 +953,6 @@ bool CIccMpeJsonMatrix::ToJson(IccJson &j)
   if (m_pMatrix) {
     IccJson matrix = IccJson::array();
     icUInt64Number nEntries64 = (icUInt64Number)m_nInputChannels * m_nOutputChannels;
-    if (nEntries64 > 0xFFFFFFFFUL) return false;
     icUInt32Number nEntries = (icUInt32Number)nEntries64;
     for (icUInt32Number i = 0; i < nEntries; i++)
       matrix.push_back((double)m_pMatrix[i]);
@@ -891,7 +961,8 @@ bool CIccMpeJsonMatrix::ToJson(IccJson &j)
   // Preserve serialized matrix constants even when they are all zero.
   if (m_pConstants) {
     IccJson constants = IccJson::array();
-    for (icUInt16Number i = 0; i < m_nOutputChannels; i++)
+    const icUInt16Number nOutputChannels = m_nOutputChannels;
+    for (icUInt16Number i = 0; i < nOutputChannels; i++)
       constants.push_back((double)m_pConstants[i]);
     j["constants"] = constants;
   }
@@ -953,8 +1024,9 @@ bool CIccMpeJsonMatrix::ParseJson(const IccJson &j, std::string &parseStr)
       m_pMatrix[i] = (icFloatNumber)mat[i].get<double>();
     }
 
-    bool bInvert = j.contains("invertMatrix") && j["invertMatrix"].is_boolean()
-                   ? j["invertMatrix"].get<bool>() : false;
+    bool bInvert = false;
+    if (j.contains("invertMatrix"))
+      icJsonGetBoolValue(j["invertMatrix"], bInvert);
     if (bInvert) {
       if (nIn != nOut) {
         parseStr += "Inversion of matrix requires square matrix\n";
@@ -1148,40 +1220,34 @@ static bool icCAMParamsFromJson(const IccJson &j, std::string &parseStr, CIccCam
     return false;
   }
   icFloatNumber xyz[3];
-  xyz[0] = (icFloatNumber)jCAM["whitePoint"][0].get<double>();
-  xyz[1] = (icFloatNumber)jCAM["whitePoint"][1].get<double>();
-  xyz[2] = (icFloatNumber)jCAM["whitePoint"][2].get<double>();
+  if (!icJsonGetFloatNumber(jCAM["whitePoint"][0], xyz[0]) ||
+      !icJsonGetFloatNumber(jCAM["whitePoint"][1], xyz[1]) ||
+      !icJsonGetFloatNumber(jCAM["whitePoint"][2], xyz[2])) {
+    parseStr += "whitePoint contains non-numeric value in colorAppearanceParams\n";
+    return false;
+  }
   pCAM->SetParameter_WhitePoint(xyz);
 
-  if (!jCAM.contains("luminance")) {
-    parseStr += "Missing luminance in colorAppearanceParams\n";
+  icFloatNumber param = 0.0f;
+  if (!icJsonGetRequiredFloat(jCAM, "luminance", param, parseStr, "colorAppearanceParams"))
     return false;
-  }
-  pCAM->SetParameter_La((icFloatNumber)jCAM["luminance"].get<double>());
+  pCAM->SetParameter_La(param);
 
-  if (!jCAM.contains("backgroundLuminance")) {
-    parseStr += "Missing backgroundLuminance in colorAppearanceParams\n";
+  if (!icJsonGetRequiredFloat(jCAM, "backgroundLuminance", param, parseStr, "colorAppearanceParams"))
     return false;
-  }
-  pCAM->SetParameter_Yb((icFloatNumber)jCAM["backgroundLuminance"].get<double>());
+  pCAM->SetParameter_Yb(param);
 
-  if (!jCAM.contains("impactSurround")) {
-    parseStr += "Missing impactSurround in colorAppearanceParams\n";
+  if (!icJsonGetRequiredFloat(jCAM, "impactSurround", param, parseStr, "colorAppearanceParams"))
     return false;
-  }
-  pCAM->SetParameter_C((icFloatNumber)jCAM["impactSurround"].get<double>());
+  pCAM->SetParameter_C(param);
 
-  if (!jCAM.contains("chromaticInductionFactor")) {
-    parseStr += "Missing chromaticInductionFactor in colorAppearanceParams\n";
+  if (!icJsonGetRequiredFloat(jCAM, "chromaticInductionFactor", param, parseStr, "colorAppearanceParams"))
     return false;
-  }
-  pCAM->SetParameter_Nc((icFloatNumber)jCAM["chromaticInductionFactor"].get<double>());
+  pCAM->SetParameter_Nc(param);
 
-  if (!jCAM.contains("adaptationFactor")) {
-    parseStr += "Missing adaptationFactor in colorAppearanceParams\n";
+  if (!icJsonGetRequiredFloat(jCAM, "adaptationFactor", param, parseStr, "colorAppearanceParams"))
     return false;
-  }
-  pCAM->SetParameter_F((icFloatNumber)jCAM["adaptationFactor"].get<double>());
+  pCAM->SetParameter_F(param);
 
   return true;
 }
@@ -2019,7 +2085,7 @@ static bool icSpectralRangeFromJson(const IccJson &j, icSpectralRange &range, st
   jGetValue(jw, "start", dStart);
   jGetValue(jw, "end",   dEnd);
   jGetValue(jw, "steps", nSteps);
-  if (nSteps <= 0 || nSteps > kIccJsonMaxSpectralSteps) {
+  if (dStart >= dEnd || nSteps < 2 || nSteps > kIccJsonMaxSpectralSteps) {
     parseStr += "Invalid spectral range (steps out of range)\n";
     return false;
   }
@@ -2056,11 +2122,10 @@ static bool icFloatArrayFromJson(const IccJson &j, const char *field,
     return false;
   }
   for (int i = 0; i < n; i++) {
-    if (!arr[i].is_number()) {
+    if (!icJsonGetFloatNumber(arr[i], buf[i])) {
       parseStr += std::string(field) + " contains non-numeric value in spectral element\n";
       return false;
     }
-    buf[i] = (icFloatNumber)arr[i].get<double>();
   }
   return true;
 }
@@ -2104,6 +2169,7 @@ static bool icSpectralMatrixFromJson(const IccJson &j, CIccMpeSpectralMatrix *pM
   if (!icSpectralRangeFromJson(j, range, parseStr))
     return false;
 
+  const int nSteps = (int)range.steps;
   icUInt64Number nMatrixValues64 = (icUInt64Number)nVectors * range.steps;
   if (nMatrixValues64 > 0x7fffffffUL) {
     parseStr += "spectral matrix element size is too large\n";
@@ -2116,17 +2182,17 @@ static bool icSpectralMatrixFromJson(const IccJson &j, CIccMpeSpectralMatrix *pM
     return false;
   }
 
-  if (!icFloatArrayFromJson(j, "whiteData", pMtx->GetWhite(), range.steps, parseStr))
+  if (!icFloatArrayFromJson(j, "whiteData", pMtx->GetWhite(), nSteps, parseStr))
     return false;
   if (!icFloatArrayFromJson(j, "matrixData", pMtx->GetMatrix(), nMatrixValues, parseStr))
     return false;
   // offsetData optional -- zero-fill if absent
   if (j.contains("offsetData")) {
-    if (!icFloatArrayFromJson(j, "offsetData", pMtx->GetOffset(), range.steps, parseStr, false))
+    if (!icFloatArrayFromJson(j, "offsetData", pMtx->GetOffset(), nSteps, parseStr, false))
       return false;
   }
   else {
-    memset(pMtx->GetOffset(), 0, range.steps * sizeof(icFloatNumber));
+    memset(pMtx->GetOffset(), 0, nSteps * sizeof(icFloatNumber));
   }
   return true;
 }
@@ -2139,8 +2205,13 @@ bool CIccMpeJsonEmissionMatrix::ToJson(IccJson &j)
 bool CIccMpeJsonEmissionMatrix::ParseJson(const IccJson &j, std::string &parseStr)
 {
   // For EmissionMatrix numVectors() == m_nInputChannels; parse nIn first then pass it
-  int nIn = 0;
+  int nIn = 0, nOut = 0;
   jGetValue(j, "inputChannels", nIn);
+  jGetValue(j, "outputChannels", nOut);
+  if (nIn < 1 || nOut != 3) {
+    parseStr += "Invalid inputChannels or outputChannels in EmissionMatrixElement\n";
+    return false;
+  }
   return icSpectralMatrixFromJson(j, this, nIn, parseStr);
 }
 
@@ -2152,8 +2223,13 @@ bool CIccMpeJsonInvEmissionMatrix::ToJson(IccJson &j)
 bool CIccMpeJsonInvEmissionMatrix::ParseJson(const IccJson &j, std::string &parseStr)
 {
   // For InvEmissionMatrix numVectors() == m_nOutputChannels; parse nOut first then pass it
-  int nOut = 0;
+  int nIn = 0, nOut = 0;
+  jGetValue(j, "inputChannels", nIn);
   jGetValue(j, "outputChannels", nOut);
+  if (nIn != 3 || nOut != 3) {
+    parseStr += "Invalid inputChannels or outputChannels in InvEmissionMatrixElement\n";
+    return false;
+  }
   return icSpectralMatrixFromJson(j, this, nOut, parseStr);
 }
 

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -699,7 +699,7 @@ bool CIccTagJsonNamedColor2::ParseJson(const IccJson &j, std::string & /*parseSt
   jGetValue(j, "countOfDeviceCoords", nDevCoords);
   // ICC spec caps device colorants at 15. Reject pathologically large
   // counts before SetSize (which allocates nColors * (33 + nDevCoords*4)
-  // bytes — an unbounded multiplication otherwise).
+  // bytes - an unbounded multiplication otherwise).
   if (nDevCoords > 15u)
     return false;
   icUInt32Number nColors = (jsonExistsField(j, "colors") && j["colors"].is_array())
@@ -744,7 +744,8 @@ bool CIccTagJsonNamedColor2::ParseJson(const IccJson &j, std::string & /*parseSt
 bool CIccTagJsonColorantOrder::ToJson(IccJson &j)
 {
   IccJson arr = IccJson::array();
-  for (icUInt32Number i = 0; i < m_nCount; i++)
+  const icUInt32Number nCount = m_nCount;
+  for (icUInt32Number i = 0; i < nCount; i++)
     arr.push_back((int)m_pData[i]);
   j["colorantOrder"] = arr;
   return true;
@@ -769,7 +770,8 @@ bool CIccTagJsonColorantTable::ToJson(IccJson &j)
 {
   j["pcsEncoding"] = "Lab";
   IccJson arr = IccJson::array();
-  for (icUInt32Number i = 0; i < m_nCount; i++) {
+  const icUInt32Number nCount = m_nCount;
+  for (icUInt32Number i = 0; i < nCount; i++) {
     icFloatNumber pcs[3];
     pcs[0] = icU16toF(m_pData[i].data[0]);
     pcs[1] = icU16toF(m_pData[i].data[1]);

--- a/IccJSON/IccLibJSON/IccUtilJson.cpp
+++ b/IccJSON/IccLibJSON/IccUtilJson.cpp
@@ -71,9 +71,14 @@
 bool g_IccJsonAllowFileImports = false;
 
 // Safely narrow size_t to icUInt32Number; returns 0 on truncation
-static inline icUInt32Number icJsonSafeU32(size_t n)
+static inline icUInt32Number icJsonSafeU32(size_t n, bool *overflow = nullptr)
 {
-  return (n > (size_t)UINT32_MAX) ? 0 : (icUInt32Number)n;
+  if (n > (size_t)UINT32_MAX) {
+    if (overflow) *overflow = true;
+    return 0;
+  }
+  if (overflow) *overflow = false;
+  return (icUInt32Number)n;
 }
 
 // ---------------------------------------------------------------------------
@@ -465,10 +470,15 @@ bool CIccJsonArrayType<T, Tsig>::ParseArray(T *buf, icUInt32Number nBufSize,
                                              const IccJson &j)
 {
   if (!j.is_array()) return false;
-  icUInt32Number n = icJsonSafeU32(j.size());
+  bool overflow = false;
+  icUInt32Number n = icJsonSafeU32(j.size(), &overflow);
+  if (overflow) return false;
   if (n > nBufSize) n = nBufSize;
-  for (icUInt32Number i = 0; i < n; i++)
+  for (icUInt32Number i = 0; i < n; i++) {
+    if (!j[i].is_number())
+      return false;
     buf[i] = j[i].get<T>();
+  }
   return true;
 }
 
@@ -476,11 +486,15 @@ template <class T, icTagTypeSignature Tsig>
 bool CIccJsonArrayType<T, Tsig>::ParseArray(const IccJson &j)
 {
   if (!j.is_array()) return false;
-  icUInt32Number n = icJsonSafeU32(j.size());
-  if (!n && j.size()) return false;
+  bool overflow = false;
+  icUInt32Number n = icJsonSafeU32(j.size(), &overflow);
+  if (overflow) return false;
   if (!SetSize(n)) return false;
-  for (icUInt32Number i = 0; i < n; i++)
+  for (icUInt32Number i = 0; i < n; i++) {
+    if (!j[i].is_number())
+      return false;
     m_pBuf[i] = j[i].get<T>();
+  }
   return true;
 }
 

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -85,6 +85,41 @@
 
 //#define ICC_VERBOSE_CALC_APPLY 1
 
+static icInt32Number icCalcSaturatingIntCast(double v)
+{
+  if (std::isnan(v))
+    return 0;
+
+  if (v >= (double)std::numeric_limits<icInt32Number>::max())
+    return std::numeric_limits<icInt32Number>::max();
+
+  if (v <= (double)std::numeric_limits<icInt32Number>::lowest())
+    return std::numeric_limits<icInt32Number>::lowest();
+
+  return std::lround(std::trunc(v));
+}
+
+static icInt32Number icCalcSaturatingRound(icFloatNumber v)
+{
+  if (std::isnan(v))
+    return 0;
+
+  if (std::isinf(v))
+    return (v < 0.0f) ? std::numeric_limits<icInt32Number>::lowest() : std::numeric_limits<icInt32Number>::max();
+
+  double rounded = (v >= 0.0f) ? (double)v + 0.5 : (double)v - 0.5;
+  return icCalcSaturatingIntCast(rounded);
+}
+
+static bool icCalcAddUInt32(icUInt32Number a, icUInt32Number b, icUInt32Number &sum)
+{
+  if (a > std::numeric_limits<icUInt32Number>::max() - b)
+    return false;
+
+  sum = a + b;
+  return true;
+}
+
 
 class CIccConsoleDebugger : public IIccCalcDebugger
 {
@@ -953,7 +988,7 @@ public:
         || std::isnan(tempN) || std::isinf(tempN) || fabs(tempN) < epsilon)
         s[j] = 0.0;
       else
-        s[j] = temp - (icFloatNumber)((int)(temp / tempN))*tempN;
+        s[j] = (icFloatNumber)fmod(temp, tempN);
     }
     OsShrinkArgs(n);
     return true;
@@ -1222,7 +1257,7 @@ public:
             s[j] = (icFloatNumber)std::numeric_limits<int>::lowest();
       }
       else
-        s[j] = (icFloatNumber)((int)temp);
+        s[j] = (icFloatNumber)icCalcSaturatingIntCast(temp);
     }
     return true;
   }
@@ -1278,10 +1313,7 @@ public:
         temp = 0.0;
       else if (std::isinf(temp))
         temp = 10000.0;          // value chosen arbitrarily to not overflow int
-      if (temp < 0.0)
-        s[j] = icFloatNumber((int)(temp-0.5));
-      else
-        s[j] = icFloatNumber((int)(temp+0.5));
+      s[j] = (icFloatNumber)icCalcSaturatingRound(temp);
     }
     return true;
   }
@@ -3739,7 +3771,10 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
           icUInt32Number dataSize = op->data.size;
           if (dataSize >= nOps)       // check first in case of overflow
             return false;
-          if (os.idx+1 + dataSize >= nOps)
+          icUInt32Number ifEnd = 0;
+          if (!icCalcAddUInt32(os.idx, 1, ifEnd) ||
+              !icCalcAddUInt32(ifEnd, dataSize, ifEnd) ||
+              ifEnd >= nOps)
             return false;
 
           if (!ApplySequence(pApply, dataSize, &ops[os.idx+1], nDepth + 1))
@@ -3748,49 +3783,54 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
         else {
           icUInt32Number nNewOps = ops[os.idx].data.size;
           icUInt32Number dataSize = op->data.size;
-          icUInt32Number newOpIndex = os.idx+1 + dataSize;
+          icUInt32Number newOpIndex = 0;
+          if (!icCalcAddUInt32(os.idx, 1, newOpIndex) ||
+              !icCalcAddUInt32(newOpIndex, dataSize, newOpIndex))
+            return false;
           if (nNewOps > nOps || dataSize > nOps || newOpIndex > nOps)   // check first in case of overflow
             return false;
-          if (newOpIndex + nNewOps > nOps)  // now add and test the real limit
+          if (nNewOps > nOps - newOpIndex)  // now add and test the real limit
             return false;
 
-          if (!ApplySequence(pApply, nNewOps, &ops[os.idx+1 + op->data.size], nDepth + 1))
+          if (!ApplySequence(pApply, nNewOps, &ops[newOpIndex], nDepth + 1))
             return false;
         }
-        os.idx += op->data.size + ops[os.idx].data.size;
+        icUInt32Number advance = 0;
+        if (!icCalcAddUInt32(op->data.size, ops[os.idx].data.size, advance) ||
+            !icCalcAddUInt32(os.idx, advance, os.idx))
+          return false;
       }
       else {
         if (a1>=0.5) {
           icUInt32Number dataSize = op->data.size;
           if (dataSize >= nOps)       // check first in case of overflow
             return false;
-          if (os.idx+dataSize >= nOps)
+          icUInt32Number ifEnd = 0;
+          if (!icCalcAddUInt32(os.idx, dataSize, ifEnd) ||
+              ifEnd >= nOps)
             return false;
 
           if (!ApplySequence(pApply, op->data.size, &ops[os.idx+1], nDepth + 1))
             return false;
         }
-        os.idx+= op->data.size;
+        if (!icCalcAddUInt32(os.idx, op->data.size, os.idx))
+          return false;
       }
     }
     else if (op->sig==icSigSelectOp) {
       icFloatNumber a1;
       OsPopArg(a1);
-      if (std::isnan(a1))
-        a1 = 0.0;
-        
-      icInt32Number nSel;
-      if (std::isinf(a1)) {
-        nSel = (a1 < 0.0) ? std::numeric_limits<icInt32Number>::lowest() : std::numeric_limits<icInt32Number>::max();
-      }
-      else
-        nSel = (a1 >= 0.0) ? (icInt32Number)(a1+0.5f) : (icInt32Number)(a1-0.5f);
+      icInt32Number nSel = icCalcSaturatingRound(a1);
 
       if (!op->extra) {
         return false;
       }
       
-      icUInt32Number nDefOff = (icUInt32Number)(os.idx+1 + op->extra);
+      size_t defOffset = (size_t)os.idx + 1 + op->extra;
+      if (defOffset > std::numeric_limits<icUInt32Number>::max())
+        return false;
+
+      icUInt32Number nDefOff = (icUInt32Number)defOffset;
       if (nDefOff >= nOps)
         return false;
 
@@ -3812,7 +3852,11 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
         }
       }
       else {
-        icUInt32Number nOff = os.idx+1 + nSel;
+        size_t caseOffset = (size_t)os.idx + 1 + (icUInt32Number)nSel;
+        if (caseOffset > std::numeric_limits<icUInt32Number>::max())
+          return false;
+
+        icUInt32Number nOff = (icUInt32Number)caseOffset;
 
         if (nOff >= nOps) 
           return false;
@@ -3835,21 +3879,27 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
         icUInt32Number dataSize = ops[nDefOff].data.size;
         if (dataSize >= nOps)       // check first in case of overflow
           return false;
-        if (os.idx+1 + ops[nDefOff].extra + dataSize > nOps)
+        size_t nextIndex = (size_t)os.idx + ops[nDefOff].extra + dataSize;
+        if (nextIndex > nOps || nextIndex > std::numeric_limits<icUInt32Number>::max() ||
+            nextIndex + 1 > nOps)
           return false;
 
-        os.idx = (icUInt32Number)(os.idx + ops[nDefOff].extra + dataSize);
+        os.idx = (icUInt32Number)nextIndex;
       }
       else if (op->extra) {
-        unsigned long nOff = os.idx + op->extra;
+        size_t nOff = (size_t)os.idx + op->extra;
+        if (nOff >= nOps)
+          return false;
 
         icUInt32Number dataSize = ops[nOff].data.size;
         if (dataSize >= nOps)       // check first in case of overflow
           return false;
-        if (os.idx+1 + ops[nOff].extra + dataSize > nOps)
+        size_t nextIndex = (size_t)os.idx + ops[nOff].extra + dataSize;
+        if (nextIndex > nOps || nextIndex > std::numeric_limits<icUInt32Number>::max() ||
+            nextIndex + 1 > nOps)
           return false;
 
-        os.idx = (icUInt32Number)(os.idx + ops[nOff].extra + dataSize);
+        os.idx = (icUInt32Number)nextIndex;
       }
       else 
         return false;
@@ -4050,7 +4100,10 @@ bool CIccCalculatorFunc::SequenceNeedTempReset(SIccCalcOp *op, icUInt32Number nO
 
       memcpy(ifTemps, tempUsage, nMaxTemp);
 
-      p=i+2;
+      if (!icCalcAddUInt32(i, 2, p)) {
+        free(ifTemps);
+        return true;
+      }
       if (p > nOps) {
         free(ifTemps);
         return true;
@@ -4066,7 +4119,12 @@ bool CIccCalculatorFunc::SequenceNeedTempReset(SIccCalcOp *op, icUInt32Number nO
 
         memcpy(elseTemps, tempUsage, nMaxTemp);
 
-        p=i+2+op[i].data.size;
+        if (!icCalcAddUInt32(i, 2, p) ||
+            !icCalcAddUInt32(p, op[i].data.size, p)) {
+          free(ifTemps);
+          free(elseTemps);
+          return true;
+        }
         if (p > nOps) {
           free(ifTemps);
           free(elseTemps);
@@ -4082,10 +4140,23 @@ bool CIccCalculatorFunc::SequenceNeedTempReset(SIccCalcOp *op, icUInt32Number nO
 
         free(elseTemps);
 
-        i += 1 + op[i].data.size + op[i+1].data.size;
+        icUInt32Number nextI = 0;
+        icUInt32Number advance = 0;
+        if (!icCalcAddUInt32(1, op[i].data.size, advance) ||
+            !icCalcAddUInt32(advance, op[i+1].data.size, advance) ||
+            !icCalcAddUInt32(i, advance, nextI)) {
+          free(ifTemps);
+          return true;
+        }
+        i = nextI;
       }
       else {
-        i += op[i].data.size;
+        icUInt32Number nextI = 0;
+        if (!icCalcAddUInt32(i, op[i].data.size, nextI)) {
+          free(ifTemps);
+          return true;
+        }
+        i = nextI;
       }
 
       free(ifTemps);
@@ -4154,7 +4225,8 @@ int CIccCalculatorFunc::CheckUnderflowOverflow(SIccCalcOp *op, icUInt32Number nO
     if (op[i].sig == icSigIfOp) {
       icUInt32Number incI = 0;
       if (i+1<nOps && op[i+1].sig==icSigElseOp) {
-        p = i+2; 
+        if (!icCalcAddUInt32(i, 2, p))
+          return -1;
         if (p > nOps)
           return -1;
         nIfArgs = CheckUnderflowOverflow(&op[p], icIntMin(nOps-p, op[i].data.size), nArgs, bCheckUnderflow, sReport);
@@ -4163,20 +4235,25 @@ int CIccCalculatorFunc::CheckUnderflowOverflow(SIccCalcOp *op, icUInt32Number nO
         incI = op[i].data.size;
         if (incI > nOps)
           return -1;
-        p = i+2+incI;
+        if (!icCalcAddUInt32(i, 2, p) ||
+            !icCalcAddUInt32(p, incI, p))
+          return -1;
         if (p > nOps)
           return -1;
         nElseArgs = CheckUnderflowOverflow(&op[p], icIntMin(nOps-p, op[i+1].data.size), nArgs, bCheckUnderflow, sReport);
         if (nElseArgs<0)
           return -1;
-        incI += op[i+1].data.size;
+        if (!icCalcAddUInt32(incI, op[i+1].data.size, incI))
+          return -1;
 
         nArgs = bCheckUnderflow ? icIntMin(nIfArgs, nElseArgs) : icIntMax(nIfArgs, nElseArgs) ;
         i++;
-        i+=incI;
+        if (!icCalcAddUInt32(i, incI, i))
+          return -1;
       }
       else {
-        p = i+1; 
+        if (!icCalcAddUInt32(i, 1, p))
+          return -1;
         if (p > nOps)
           return -1;
         nIfArgs = CheckUnderflowOverflow(&op[p], icIntMin(nOps-p, op[i].data.size), nArgs, bCheckUnderflow, sReport);
@@ -4184,7 +4261,8 @@ int CIccCalculatorFunc::CheckUnderflowOverflow(SIccCalcOp *op, icUInt32Number nO
           return -1;
         nArgs = bCheckUnderflow ? icIntMin(nArgs, nIfArgs) : icIntMax(nArgs, nIfArgs);
 
-        i+= op[i].data.size;
+        if (!icCalcAddUInt32(i, op[i].data.size, i))
+          return -1;
       }
     }
     else if (op[i].sig == icSigSelectOp) {
@@ -4206,7 +4284,10 @@ int CIccCalculatorFunc::CheckUnderflowOverflow(SIccCalcOp *op, icUInt32Number nO
       if (!n)
         return -1;
 
-      icUInt32Number pos = i+1 + n;
+      icUInt32Number pos = 0;
+      if (!icCalcAddUInt32(i, 1, pos) ||
+          !icCalcAddUInt32(pos, n, pos))
+        return -1;
       for (p=0; p<n; p++) {
         SIccCalcOp *sop = &op[i+1+p];
         icUInt32Number len = sop->data.size;
@@ -4224,7 +4305,8 @@ int CIccCalculatorFunc::CheckUnderflowOverflow(SIccCalcOp *op, icUInt32Number nO
         else
           nSelArgs = bCheckUnderflow ? icIntMin(nSelArgs, nCaseArgs) : icIntMax(nSelArgs, nCaseArgs);
 
-        pos += sop->data.size;
+        if (!icCalcAddUInt32(pos, sop->data.size, pos))
+          return -1;
       }
       nArgs = nSelArgs;
 
@@ -5305,6 +5387,3 @@ bool CIccApplyMpeCalculator::GetEnvVar(icSigCmmEnvVar sigEnv, icFloatNumber &val
   }
   return m_pCmmEnvVarLookup->GetEnvVar(sigEnv, val);
 }
-
-
-

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -767,7 +767,7 @@ bool CIccTagParametricCurve::Read(icUInt32Number size, CIccIO *pIO)
   if (!m_nNumParam) {
     // Unknown nFunctionType path. Previously this fell back to
     // `(icUInt16Number)((size - nHdrSize) / 4)` which silently
-    // truncates large-size tags to a small number of parameters —
+    // truncates large-size tags to a small number of parameters -
     // a parse-desync primitive. Use u32 math and refuse pathological
     // derived counts instead.
     icUInt32Number derived =
@@ -780,10 +780,11 @@ bool CIccTagParametricCurve::Read(icUInt32Number size, CIccIO *pIO)
 
   if (m_nNumParam) {
     int i;
-    if (nHdrSize + m_nNumParam*sizeof(icS15Fixed16Number) > size)
+    const icUInt16Number nNumParam = m_nNumParam;
+    if (nHdrSize + nNumParam*sizeof(icS15Fixed16Number) > size)
       return false;
 
-    for (i=0; i<m_nNumParam; i++) {
+    for (i=0; i<nNumParam; i++) {
       icS15Fixed16Number num;
       if (!pIO->Read32(&num, 1))
         return false;
@@ -826,7 +827,8 @@ bool CIccTagParametricCurve::Write(CIccIO *pIO)
 
   if (m_nNumParam) {
     int i;
-    for (i=0; i<m_nNumParam; i++) {
+    const icUInt16Number nNumParam = m_nNumParam;
+    for (i=0; i<nNumParam; i++) {
       icS15Fixed16Number num = icDtoF(m_dParam[i]);
       if (!pIO->Write32(&num, 1))
         return false;
@@ -914,7 +916,8 @@ default:
   snprintf(buf, bufSize, "Unknown Function with %d parameters:\n", m_nNumParam);
   sDescription += buf;
 
-  for (i=0; i<m_nNumParam; i++) {
+  const icUInt16Number nNumParam = m_nNumParam;
+  for (i=0; i<nNumParam; i++) {
     snprintf(buf, bufSize, "Param[%d] = %.4lf\n", i, m_dParam[i]);
     sDescription += buf;
   }
@@ -3286,7 +3289,8 @@ icValidateStatus CIccCLUT::Validate(std::string sigPath, std::string &sReport, c
   if (sig==icSigLutAtoBType || sig==icSigLutBtoAType) {
     const size_t tempSize = 256;
     char temp[tempSize];
-    for (int i=0; i<m_nInput; i++) {
+    const int nInput = (int)m_nInput;
+    for (int i=0; i<nInput; i++) {
       if (m_GridPoints[i]<2) {
         sReport += icMsgValidateCriticalError;
         sReport += sSigPathName;
@@ -4161,7 +4165,7 @@ bool CIccTagLutAtoB::Read(icUInt32Number size, CIccIO *pIO)
   if (Offset[1]) {
     icS15Fixed16Number tmp;
 
-    // 64-bit widened bounds check — the prior u32 addition wrapped
+    // 64-bit widened bounds check - the prior u32 addition wrapped
     // when Offset[1] was close to 2^32.
     if (static_cast<icUInt64Number>(Offset[1]) +
         12u * sizeof(icS15Fixed16Number) > size)

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -68,6 +68,7 @@
 #include "IccXmlConfig.h"
 #include "IccCAM.h"
 
+#include <algorithm>
 #include <new>     /* std::nothrow */
 #include <cstring> /* C strings strcpy, memcpy ... */
 
@@ -85,6 +86,12 @@ namespace iccDEV {
 // Match the defensive cap used by CIccMpeMatrix::Read before narrowing
 // user-controlled matrix-family XML channel counts.
 static const icUInt16Number kIccXmlMaxMatrixChannels = 255;
+static const int kIccXmlMaxSpectralSteps = 65535;
+
+static int icXmlBoundedSpectralSteps(const icSpectralRange &range)
+{
+  return std::min<int>((int)range.steps, kIccXmlMaxSpectralSteps);
+}
 
 static bool icXmlParseMatrixChannels(xmlNode *pNode, icUInt16Number &nInputChannels,
                                      icUInt16Number &nOutputChannels,
@@ -109,7 +116,7 @@ static bool icXmlParseSpectralRange(xmlNode *pNode, icSpectralRange &range,
   icFloatNumber dEnd = (icFloatNumber)atof(icXmlAttrValue(pNode, "end"));
   icUInt16Number nSteps = 0;
 
-  if (!icXmlParseU16(icXmlAttrValue(pNode, "steps"), nSteps) || !nSteps) {
+  if (dStart >= dEnd || !icXmlParseU16(icXmlAttrValue(pNode, "steps"), nSteps) || nSteps < 2) {
     parseStr += "Invalid Spectral Range\n";
     return false;
   }
@@ -1453,6 +1460,7 @@ bool CIccMpeXmlEmissionMatrix::ToXml(std::string &xml, std::string blanks/* = ""
 {
   const size_t bufSize = 128;
   char buf[bufSize];
+  const int nSteps = icXmlBoundedSpectralSteps(m_Range);
   snprintf(buf, bufSize, "<EmissionMatrixElement InputChannels=\"%d\" OutputChannels=\"%d\"", NumInputChannels(), NumOutputChannels());
   xml += blanks + buf;
 
@@ -1462,7 +1470,7 @@ bool CIccMpeXmlEmissionMatrix::ToXml(std::string &xml, std::string blanks/* = ""
   }
   xml += ">\n";
 
-  snprintf(buf, bufSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_Range.start), icF16toF(m_Range.end), m_Range.steps);
+  snprintf(buf, bufSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_Range.start), icF16toF(m_Range.end), nSteps);
   xml += blanks + buf;
 
   int i, j, n;
@@ -1471,7 +1479,7 @@ bool CIccMpeXmlEmissionMatrix::ToXml(std::string &xml, std::string blanks/* = ""
     xml += blanks + "  <WhiteData>\n";
 
     xml += blanks + "   ";
-    for (i=0; i<(int)m_Range.steps; i++) {
+    for (i=0; i<nSteps; i++) {
       snprintf(buf, bufSize, " " icXmlFloatFmt, m_pWhite[i]);
       xml += buf;
     }
@@ -1485,7 +1493,7 @@ bool CIccMpeXmlEmissionMatrix::ToXml(std::string &xml, std::string blanks/* = ""
 
     for (n=0, j=0; j<numVectors(); j++) {
       xml += blanks + "   ";
-      for (i=0; i<(int)m_Range.steps; i++, n++) {
+      for (i=0; i<nSteps; i++, n++) {
         snprintf(buf, bufSize, " " icXmlFloatFmt, m_pMatrix[n]);
         xml += buf;
       }
@@ -1498,7 +1506,7 @@ bool CIccMpeXmlEmissionMatrix::ToXml(std::string &xml, std::string blanks/* = ""
     xml += blanks + "  <OffsetData>\n";
 
     xml += blanks + "   ";
-    for (i=0; i<(int)m_Range.steps; i++) {
+    for (i=0; i<nSteps; i++) {
       snprintf(buf, bufSize, " " icXmlFloatFmt, m_pOffset[i]);
       xml += buf;
     }
@@ -1519,6 +1527,10 @@ bool CIccMpeXmlEmissionMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
   icUInt16Number nOutputChannels = 0;
   if (!icXmlParseMatrixChannels(pNode, nInputChannels, nOutputChannels,
                                 "EmissionMatrixElement", parseStr)) {
+    return false;
+  }
+  if (nOutputChannels != 3) {
+    parseStr += "Invalid OutputChannels In EmissionMatrixElement\n";
     return false;
   }
 
@@ -1571,6 +1583,7 @@ bool CIccMpeXmlInvEmissionMatrix::ToXml(std::string &xml, std::string blanks/* =
 {
   const size_t bufSize = 128;
   char buf[bufSize];
+  const int nSteps = icXmlBoundedSpectralSteps(m_Range);
   snprintf(buf, bufSize, "<InvEmissionMatrixElement InputChannels=\"%d\" OutputChannels=\"%d\"", NumInputChannels(), NumOutputChannels());
   xml += blanks + buf;
 
@@ -1580,7 +1593,7 @@ bool CIccMpeXmlInvEmissionMatrix::ToXml(std::string &xml, std::string blanks/* =
   }
   xml += ">\n";
 
-  snprintf(buf, bufSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_Range.start), icF16toF(m_Range.end), m_Range.steps);
+  snprintf(buf, bufSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_Range.start), icF16toF(m_Range.end), nSteps);
   xml += blanks + buf;
 
   int i, j, n;
@@ -1589,7 +1602,7 @@ bool CIccMpeXmlInvEmissionMatrix::ToXml(std::string &xml, std::string blanks/* =
     xml += blanks + "  <WhiteData>\n";
 
     xml += blanks + "   ";
-    for (i=0; i<(int)m_Range.steps; i++) {
+    for (i=0; i<nSteps; i++) {
       snprintf(buf, bufSize, " " icXmlFloatFmt, m_pWhite[i]);
       xml += buf;
     }
@@ -1603,7 +1616,7 @@ bool CIccMpeXmlInvEmissionMatrix::ToXml(std::string &xml, std::string blanks/* =
 
     for (n=0, j=0; j<numVectors(); j++) {
       xml += blanks + "   ";
-      for (i=0; i<(int)m_Range.steps; i++, n++) {
+      for (i=0; i<nSteps; i++, n++) {
         snprintf(buf, bufSize, " " icXmlFloatFmt, m_pMatrix[n]);
         xml += buf;
       }
@@ -1616,7 +1629,7 @@ bool CIccMpeXmlInvEmissionMatrix::ToXml(std::string &xml, std::string blanks/* =
     xml += blanks + "  <OffsetData>\n";
 
     xml += blanks + "   ";
-    for (i=0; i<(int)m_Range.steps; i++) {
+    for (i=0; i<nSteps; i++) {
       snprintf(buf, bufSize, " " icXmlFloatFmt, m_pOffset[i]);
       xml += buf;
     }
@@ -1637,6 +1650,10 @@ bool CIccMpeXmlInvEmissionMatrix::ParseXml(xmlNode *pNode, std::string &parseStr
   icUInt16Number nOutputChannels = 0;
   if (!icXmlParseMatrixChannels(pNode, nInputChannels, nOutputChannels,
                                 "InvEmissionMatrixElement", parseStr)) {
+    return false;
+  }
+  if (nInputChannels != 3 || nOutputChannels != 3) {
+    parseStr += "Invalid InputChannels or OutputChannels In InvEmissionMatrixElement\n";
     return false;
   }
 
@@ -2539,7 +2556,7 @@ bool CIccMpeXmlCalculator::ParseImport(xmlNode *pNode, std::string importPath, s
 
             /* Parse the file and get the DOM. See IccProfileXml.cpp for
              * the rationale for dropping XML_PARSE_HUGE and adding
-             * XML_PARSE_NOENT — matches the main LoadXml entry point.
+             * XML_PARSE_NOENT - matches the main LoadXml entry point.
              */
             doc = xmlReadFile(file.c_str(), NULL, XML_PARSE_NONET | XML_PARSE_NOENT);
 
@@ -3290,7 +3307,7 @@ bool CIccMpeXmlCalculator::ParseChanMap(ChanVarMap& chanMap, const char *szNames
 
 bool CIccMpeXmlCalculator::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  // Guard against nested <CalculatorElement><SubElements>…</> recursion.
+  // Guard against nested <CalculatorElement><SubElements>...</> recursion.
   // Each level is one C++ stack frame; on Emscripten's ~1 MB stack a
   // crafted XML with a few thousand nested CalculatorElements blows
   // through it. 32 levels is generous for any legitimate iccMAX


### PR DESCRIPTION
## PR Summary

#662 

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## CI Mods
- .github/scripts/iccdev-calculator-regression-tests.sh | #662 `bisect-ce59fa8-calculator` | Calculator round/truncate/select casts and if/else offset arithmetic accepted malformed profile data without sanitizer-safe guards | Rebuilds `srgbCalcTest`, exercises calculator debug apply, and verifies malformed CalcTest operator fixtures reject without sanitizer findings