### PR TITLE
Fix: Bisect f21a76b illuminant

### DIFF
--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -21,6 +21,7 @@ Test 18 (Regression Bisect).
 |--------|-------|-----|-------|
 | `.github/scripts/iccdev-mluc-setter-regression-tests.sh` | #928 | `multiLocalizedUnicodeType` setters included safety terminators in serialized `mluc` string lengths | Rebuilds `sRGB_D65_MAT.icc` and `NamedColor.icc` from XML and verifies canonical `desc`/`mluc` sizes |
 | `.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh` | #928 follow-up | `multiLocalizedUnicodeType` reader accepted malformed record lengths, string offsets, and UTF-16 surrogate data | Mutates `sRGB_D65_MAT.icc` in `/tmp` and verifies malformed `mluc` records are rejected without sanitizer findings |
+| `.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh` | #958 | Non-standard PCC viewing-condition illuminant XYZ with zero Y divided by zero or fell back to D50 | Compiles a small PCC helper and verifies zero-Y custom illuminants are rejected without sanitizer findings or D50 substitution |
 
 ## Adding a new PoC
 

--- a/.github/ci/regression/pcc-zero-illuminant.cpp
+++ b/.github/ci/regression/pcc-zero-illuminant.cpp
@@ -1,0 +1,78 @@
+#include "IccPcc.h"
+#include "IccProfile.h"
+#include "IccTagBasic.h"
+#include "IccUtil.h"
+
+#include <cmath>
+#include <cstring>
+
+static bool is_near(icFloatNumber a, icFloatNumber b)
+{
+  return std::fabs(a - b) < 0.00001f;
+}
+
+static bool is_zero_xyz(const icFloatNumber *xyz)
+{
+  return is_near(xyz[0], 0.0f) &&
+         is_near(xyz[1], 0.0f) &&
+         is_near(xyz[2], 0.0f);
+}
+
+static bool is_d50_xyz(const icFloatNumber *xyz)
+{
+  return is_near(xyz[0], icD50XYZ[0]) &&
+         is_near(xyz[1], icD50XYZ[1]) &&
+         is_near(xyz[2], icD50XYZ[2]);
+}
+
+int main()
+{
+  CIccProfile profile;
+  profile.InitHeader();
+  profile.m_Header.version = icVersionNumberV5;
+
+  icSpectralRange emptyRange;
+  std::memset(&emptyRange, 0, sizeof(emptyRange));
+
+  CIccTagSpectralViewingConditions *view = new CIccTagSpectralViewingConditions();
+  if (!view)
+    return 1;
+
+  if (!view->setIlluminant(icIlluminantCustom, emptyRange, nullptr)) {
+    delete view;
+    return 2;
+  }
+
+  if (!view->setObserver(icStdObsCustom, emptyRange, nullptr)) {
+    delete view;
+    return 3;
+  }
+
+  view->m_illuminantXYZ.X = 12.5f;
+  view->m_illuminantXYZ.Y = 0.0f;
+  view->m_illuminantXYZ.Z = 3.75f;
+
+  if (!profile.AttachTag(icSigSpectralViewingConditionsTag, view)) {
+    delete view;
+    return 4;
+  }
+
+  icFloatNumber xyz[3] = {-1.0f, -1.0f, -1.0f};
+  profile.getNormIlluminantXYZ(xyz);
+  if (!is_zero_xyz(xyz))
+    return 5;
+  if (is_d50_xyz(xyz))
+    return 6;
+
+  CIccCombinedConnectionConditions combined(&profile, &profile, true);
+  xyz[0] = xyz[1] = xyz[2] = -1.0f;
+  combined.getNormIlluminantXYZ(xyz);
+  if (!is_zero_xyz(xyz))
+    return 7;
+
+  icFloatNumber mediaXYZ[3] = {-1.0f, -1.0f, -1.0f};
+  if (combined.getMediaWhiteXYZ(mediaXYZ))
+    return 8;
+
+  return 0;
+}

--- a/.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh
+++ b/.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh
@@ -1,0 +1,162 @@
+#!/bin/bash
+###############################################################################
+# iccDEV PCC zero-illuminant regression tests
+###############################################################################
+#
+# Issue:
+#   https://github.com/InternationalColorConsortium/iccDEV/issues/958
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_BUILD_DIR   -- path to CMake build directory
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+BUILD_DIR="${ICCDEV_BUILD_DIR:-}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-pcc-zero-illuminant-regressions}"
+mkdir -p "$OUTDIR"
+
+if [ -z "$BUILD_DIR" ] && [ -d "$TOOLS_DIR" ]; then
+  BUILD_DIR="$(cd "$TOOLS_DIR/.." && pwd)"
+fi
+
+if [ -z "$BUILD_DIR" ] || [ ! -d "$BUILD_DIR/IccProfLib" ]; then
+  for candidate in "$REPO_ROOT/build" "$REPO_ROOT/Build" "$REPO_ROOT/build-sani"; do
+    if [ -d "$candidate/IccProfLib" ]; then
+      BUILD_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "${CXX:-}" ]; then
+  if command -v clang++-18 >/dev/null 2>&1; then
+    CXX=clang++-18
+  elif command -v clang++ >/dev/null 2>&1; then
+    CXX=clang++
+  else
+    CXX=c++
+  fi
+fi
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=1,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+fail_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [FAIL] $name -- $reason"
+  FAIL=$((FAIL + 1))
+}
+
+pass_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [PASS] $name -- $reason"
+  PASS=$((PASS + 1))
+}
+
+run_zero_illuminant_helper() {
+  local name="pcc-zero-illuminant"
+  local helper_cpp="$REPO_ROOT/.github/ci/regression/pcc-zero-illuminant.cpp"
+  local helper_bin="$OUTDIR/$name"
+  local compile_log="$OUTDIR/$name.compile.log"
+  local run_log="$OUTDIR/$name.run.log"
+  local lib_dir="$BUILD_DIR/IccProfLib"
+  local lib_arg=""
+  local san_flags=()
+  local run_ec=0
+
+  TOTAL=$((TOTAL + 1))
+
+  if [ -z "$BUILD_DIR" ] || [ ! -d "$lib_dir" ]; then
+    fail_case "$name" "missing build directory with IccProfLib"
+    return
+  fi
+
+  for lib_name in IccProfLib2d IccProfLib2; do
+    if [ -f "$lib_dir/lib${lib_name}.so" ]; then
+      lib_arg="-l${lib_name}"
+      break
+    fi
+  done
+
+  if [ -z "$lib_arg" ]; then
+    fail_case "$name" "missing shared IccProfLib library in $lib_dir"
+    return
+  fi
+
+  if [ ! -f "$helper_cpp" ]; then
+    fail_case "$name" "missing helper source $helper_cpp"
+    return
+  fi
+
+  if [ -f "$BUILD_DIR/CMakeCache.txt" ]; then
+    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      if "$CXX" --version 2>/dev/null | grep -qi clang; then
+        san_flags+=("-fsanitize=address,undefined,integer,float-divide-by-zero,float-cast-overflow")
+      else
+        san_flags+=("-fsanitize=address,undefined")
+      fi
+    else
+      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+        san_flags+=("-fsanitize=address")
+      fi
+      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+        san_flags+=("-fsanitize=undefined")
+      fi
+      if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
+         "$CXX" --version 2>/dev/null | grep -qi clang; then
+        san_flags+=("-fsanitize=integer")
+      fi
+    fi
+  fi
+
+  if ! "$CXX" -std=c++17 "${san_flags[@]}" \
+      -I"$REPO_ROOT/IccProfLib" \
+      -I"$BUILD_DIR/IccProfLib" \
+      "$helper_cpp" \
+      -L"$lib_dir" "$lib_arg" -Wl,-rpath,"$lib_dir" \
+      -o "$helper_bin" > "$compile_log" 2>&1; then
+    fail_case "$name" "failed to compile helper"
+    sed -n '1,80p' "$compile_log"
+    return
+  fi
+
+  LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}" "$helper_bin" > "$run_log" 2>&1 || run_ec=$?
+
+  if grep -q "ERROR: AddressSanitizer\\|runtime error:" "$run_log" 2>/dev/null; then
+    fail_case "$name" "sanitizer finding while checking zero-Y PCC illuminant"
+    sed -n '1,80p' "$run_log"
+    return
+  fi
+
+  if [ "$run_ec" -ne 0 ]; then
+    fail_case "$name" "helper exited $run_ec"
+    sed -n '1,80p' "$run_log"
+    return
+  fi
+
+  pass_case "$name" "zero-Y custom PCC illuminant is rejected without D50 fallback"
+}
+
+echo "=== PCC zero-illuminant regression ==="
+
+run_zero_illuminant_helper
+
+echo "PCC zero-illuminant regression: $PASS passed, $FAIL failed, $TOTAL total"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -1916,6 +1916,32 @@ jobs:
           passed=$((passed + r20_pass))
           failed=$((failed + r20_fail))
 
+          # --- R21: Issue #958 PCC zero-Y illuminant validation ---
+          echo "--- R21: Issue #958 PCC zero-Y illuminant validation ---"
+          r21_pass=0 r21_fail=0
+          PCC_ILLUMINANT_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh"
+          if [ -f "$PCC_ILLUMINANT_SCRIPT" ]; then
+            chmod +x "$PCC_ILLUMINANT_SCRIPT"
+            r21_ec=0
+            ICCDEV_TOOLS_DIR="${WORKSPACE_DIR}/build/Tools" \
+              ICCDEV_TESTING_DIR="${WORKSPACE_DIR}/Testing" \
+              ICCDEV_TEST_OUTDIR="$OUTDIR/r21-pcc-zero-illuminant" \
+              "$PCC_ILLUMINANT_SCRIPT" > "$OUTDIR/r21-pcc-zero-illuminant.log" 2>&1 || r21_ec=$?
+            cat "$OUTDIR/r21-pcc-zero-illuminant.log"
+            if [ "$r21_ec" -eq 0 ]; then
+              echo "  [OK]    Issue #958 PCC zero-Y illuminants rejected cleanly"
+              r21_pass=$((r21_pass + 1))
+            else
+              echo "  [FAIL]  Issue #958 PCC zero-Y illuminant regression script exited $r21_ec"
+              r21_fail=$((r21_fail + 1))
+            fi
+          else
+            echo "  [SKIP]  PCC zero-Y illuminant regression script not found"
+          fi
+          echo "  Issue #958 PCC zero-Y illuminant validation: $r21_pass passed, $r21_fail failed"
+          passed=$((passed + r21_pass))
+          failed=$((failed + r21_fail))
+
           echo ""
           echo "Regression checks: $passed passed, $failed failed"
           if [ "$failed" -gt 0 ]; then exit 1; fi
@@ -2050,7 +2076,7 @@ jobs:
               ["15"]="iccApplySearch (CMM search optimization)"
               ["16"]="MCS regression (iccApplyProfiles TIFF pipeline)"
               ["17"]="iccV5DspObsToV4Dsp (v5 display to v4 conversion)"
-              ["18"]="Regression checks (bisect fixes: 599,736,744,751,752,763,769; stdobserver aliases; issue #928 mluc setter/read)"
+              ["18"]="Regression checks (bisect fixes: 599,736,744,751,752,763,769; stdobserver aliases; issue #928 mluc setter/read; issue #958 PCC illuminant)"
             )
 
             for phase in $(seq 1 18); do

--- a/.github/workflows/ci-tool-tests.yml
+++ b/.github/workflows/ci-tool-tests.yml
@@ -12,7 +12,8 @@
 #   3. JSON CLI exercise (125 tests) -- all CLI option combos
 #   4. Regression checks -- bisect fix PoCs, JSON parser/config failures,
 #      standard observer XML/JSON alias compatibility, issue #928 mluc setter
-#      canonical length checks, and mluc read/UTF-16 validation
+#      canonical length checks, mluc read/UTF-16 validation, and issue #958
+#      PCC zero-Y illuminant validation
 #
 # Hardening:
 #   - sanitize-sed.sh sourced in every step
@@ -30,6 +31,7 @@
 #   .github/scripts/iccdev-stdobserver-regression-tests.sh
 #   .github/scripts/iccdev-mluc-setter-regression-tests.sh
 #   .github/scripts/iccdev-mluc-read-utf16-regression-tests.sh
+#   .github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh
 #
 ###############################################################
 
@@ -50,6 +52,8 @@ on:
       - '.github/scripts/iccdev-stdobserver-regression-tests.sh'
       - '.github/scripts/iccdev-mluc-setter-regression-tests.sh'
       - '.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh'
+      - '.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh'
+      - '.github/ci/regression/pcc-zero-illuminant.cpp'
       - '.github/scripts/json-cli-exercise.sh'
       - '.github/ci/test-data/**'
       - 'IccProfLib/**'
@@ -1051,6 +1055,32 @@ jobs:
           echo "  Issue #928 follow-up mluc read/UTF-16 validation: $r16_pass passed, $r16_fail failed"
           passed=$((passed + r16_pass))
           failed=$((failed + r16_fail))
+
+          # --- R17: Issue #958 PCC zero-Y illuminant validation ---
+          echo "--- R17: Issue #958 PCC zero-Y illuminant validation ---"
+          r17_pass=0 r17_fail=0
+          PCC_ILLUMINANT_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh"
+          if [ -f "$PCC_ILLUMINANT_SCRIPT" ]; then
+            chmod +x "$PCC_ILLUMINANT_SCRIPT"
+            r17_ec=0
+            ICCDEV_TOOLS_DIR="${WORKSPACE_DIR}/build/Tools" \
+              ICCDEV_TESTING_DIR="${WORKSPACE_DIR}/Testing" \
+              ICCDEV_TEST_OUTDIR="$OUTDIR/r17-pcc-zero-illuminant" \
+              "$PCC_ILLUMINANT_SCRIPT" > "$OUTDIR/r17-pcc-zero-illuminant.log" 2>&1 || r17_ec=$?
+            cat "$OUTDIR/r17-pcc-zero-illuminant.log"
+            if [ "$r17_ec" -eq 0 ]; then
+              echo "  [OK]    Issue #958 PCC zero-Y illuminants rejected cleanly"
+              r17_pass=$((r17_pass + 1))
+            else
+              echo "  [FAIL]  Issue #958 PCC zero-Y illuminant regression script exited $r17_ec"
+              r17_fail=$((r17_fail + 1))
+            fi
+          else
+            echo "  [SKIP]  PCC zero-Y illuminant regression script not found"
+          fi
+          echo "  Issue #958 PCC zero-Y illuminant validation: $r17_pass passed, $r17_fail failed"
+          passed=$((passed + r17_pass))
+          failed=$((failed + r17_fail))
 
           echo ""
           echo "Regression checks: $passed passed, $failed failed"

--- a/IccProfLib/IccPcc.cpp
+++ b/IccProfLib/IccPcc.cpp
@@ -76,6 +76,17 @@
 #include "IccTag.h"
 #include "IccCmm.h"
 
+static bool icCanMapSpectralRange(const icSpectralRange &srcRange, const icSpectralRange &dstRange)
+{
+  if (icSameSpectralRange(srcRange, dstRange))
+    return true;
+
+  return srcRange.steps > 1 &&
+         dstRange.steps > 1 &&
+         icNotZero(icF16toF(srcRange.end) - icF16toF(srcRange.start)) &&
+         icNotZero(icF16toF(dstRange.end) - icF16toF(dstRange.start));
+}
+
 bool IIccProfileConnectionConditions::isEquivalentPcc(IIccProfileConnectionConditions &IPCC)
 {
   icIlluminant illum = getPccIlluminant();
@@ -171,6 +182,12 @@ icFloatNumber IIccProfileConnectionConditions::getObserverIlluminantScaleFactor(
   icSpectralRange obsRange;
   const icFloatNumber *obs = pView->getObserver(obsRange);
 
+  if (!illum || !obs || !illumRange.steps || !obsRange.steps)
+    return 1.0;
+
+  if (!icCanMapSpectralRange(obsRange, illumRange))
+    return 1.0;
+
   int i, n = illumRange.steps;
   CIccMatrixMath *mapRange=CIccMatrixMath::rangeMap(obsRange, illumRange);
   icFloatNumber rv=0;
@@ -203,6 +220,12 @@ icFloatNumber IIccProfileConnectionConditions::getObserverWhiteScaleFactor(const
 
   icSpectralRange obsRange;
   const icFloatNumber *obs = pView->getObserver(obsRange);
+
+  if (!pWhite || !obs || !whiteRange.steps || !obsRange.steps)
+    return 1.0;
+
+  if (!icCanMapSpectralRange(obsRange, whiteRange))
+    return 1.0;
 
   int i, n = whiteRange.steps;
   CIccMatrixMath *mapRange=CIccMatrixMath::rangeMap(obsRange, whiteRange);
@@ -245,6 +268,10 @@ icFloatNumber *IIccProfileConnectionConditions::getEmissiveObserver(const icSpec
   if (!observer || observerRange.steps == 0)
     return NULL;
 
+  if (!range.steps || !icCanMapSpectralRange(observerRange, range))
+    return NULL;
+
+  bool allocObs = !obs;
   if (!obs)
     obs = (icFloatNumber*)malloc(size*sizeof(icFloatNumber));
 
@@ -273,6 +300,12 @@ icFloatNumber *IIccProfileConnectionConditions::getEmissiveObserver(const icSpec
       k += fptr[i]*pWhite[i];
     }
 
+    if (!icNotZero(k)) {
+      if (allocObs)
+        free(obs);
+      return NULL;
+    }
+
     //Scale observer so application of observer against white results in 1.0.
     for (i=0; i<size; i++) {
       obs[i] = obs[i] / k;
@@ -296,6 +329,9 @@ CIccMatrixMath *IIccProfileConnectionConditions::getReflectanceObserver(const ic
   icSpectralRange illumRange;
   const icFloatNumber *illum = pView->getIlluminant(illumRange);
 
+  if (!illum || !rangeRef.steps || !illumRange.steps || !icCanMapSpectralRange(rangeRef, illumRange))
+    return NULL;
+
   pMtx = CIccMatrixMath::rangeMap(rangeRef, illumRange);
   if (pMtx)
     pAdjust = pMtx;
@@ -308,8 +344,17 @@ CIccMatrixMath *IIccProfileConnectionConditions::getReflectanceObserver(const ic
   }
   pAdjust = pMtx;
 
+  if (!pAdjust)
+    return NULL;
+
   pAdjust->VectorScale(illum);
-  pAdjust->Scale(1.0f / pAdjust->RowSum(1));
+  icFloatNumber rowSum = pAdjust->RowSum(1);
+  if (!icNotZero(rowSum)) {
+    delete pAdjust;
+    return NULL;
+  }
+
+  pAdjust->Scale(1.0f / rowSum);
 
   return pAdjust;
 }
@@ -330,9 +375,14 @@ CIccCombinedConnectionConditions::CIccCombinedConnectionConditions(CIccProfile *
           m_pPCC = pAppliedPCC;
           m_pViewingConditions = NULL;
 
-          m_illuminantXYZ[0] = pView->m_illuminantXYZ.X / pView->m_illuminantXYZ.Y;
-          m_illuminantXYZ[1] = pView->m_illuminantXYZ.Y / pView->m_illuminantXYZ.Y;
-          m_illuminantXYZ[2] = pView->m_illuminantXYZ.Z / pView->m_illuminantXYZ.Y;
+          if (icNotZero(pView->m_illuminantXYZ.Y)) {
+            m_illuminantXYZ[0] = pView->m_illuminantXYZ.X / pView->m_illuminantXYZ.Y;
+            m_illuminantXYZ[1] = 1.0f;
+            m_illuminantXYZ[2] = pView->m_illuminantXYZ.Z / pView->m_illuminantXYZ.Y;
+          }
+          else {
+            memcpy(m_illuminantXYZ, icD50XYZ, 3 * sizeof(icFloatNumber));
+          }
           m_illuminantXYZLum[0] = pView->m_illuminantXYZ.X;
           m_illuminantXYZLum[1] = pView->m_illuminantXYZ.Y;
           m_illuminantXYZLum[2] = pView->m_illuminantXYZ.Z;

--- a/IccProfLib/IccPcc.cpp
+++ b/IccProfLib/IccPcc.cpp
@@ -375,18 +375,21 @@ CIccCombinedConnectionConditions::CIccCombinedConnectionConditions(CIccProfile *
           m_pPCC = pAppliedPCC;
           m_pViewingConditions = NULL;
 
-          if (icNotZero(pView->m_illuminantXYZ.Y)) {
+          bool bValidIlluminantXYZ = icNotZero(pView->m_illuminantXYZ.Y);
+          if (bValidIlluminantXYZ) {
             m_illuminantXYZ[0] = pView->m_illuminantXYZ.X / pView->m_illuminantXYZ.Y;
             m_illuminantXYZ[1] = 1.0f;
             m_illuminantXYZ[2] = pView->m_illuminantXYZ.Z / pView->m_illuminantXYZ.Y;
           }
           else {
-            memcpy(m_illuminantXYZ, icD50XYZ, 3 * sizeof(icFloatNumber));
+            memset(m_illuminantXYZ, 0, 3 * sizeof(icFloatNumber));
           }
           m_illuminantXYZLum[0] = pView->m_illuminantXYZ.X;
           m_illuminantXYZLum[1] = pView->m_illuminantXYZ.Y;
           m_illuminantXYZLum[2] = pView->m_illuminantXYZ.Z;
           m_bValidMediaXYZ = pProfile->calcMediaWhiteXYZ(m_mediaXYZ, pAppliedPCC);
+          if (!bValidIlluminantXYZ)
+            m_bValidMediaXYZ = false;
       }
       else {
           m_pPCC = pAppliedPCC;

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -3189,7 +3189,9 @@ void CIccProfile::getNormIlluminantXYZ(icFloatNumber *pXYZ)
         pXYZ[2] = pCond->m_illuminantXYZ.Z / illumY;
       }
       else {
-        memcpy(pXYZ, icD50XYZ, 3 * sizeof(icFloatNumber));
+        pXYZ[0] = 0.0f;
+        pXYZ[1] = 0.0f;
+        pXYZ[2] = 0.0f;
       }
     }
   }

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -5,7 +5,7 @@
 
     Version:    V1
 
-    Copyright:  � see ICC Software License
+    Copyright:  see ICC Software License
 */
 
 /*
@@ -3182,9 +3182,15 @@ void CIccProfile::getNormIlluminantXYZ(icFloatNumber *pXYZ)
       memcpy(pXYZ, icD50XYZ, 3 * sizeof(icFloatNumber));
     }
     else {
-      pXYZ[0] = pCond->m_illuminantXYZ.X / pCond->m_illuminantXYZ.Y;
-      pXYZ[1] = 1.0f;
-      pXYZ[2] = pCond->m_illuminantXYZ.Z / pCond->m_illuminantXYZ.Y;
+      icFloatNumber illumY = pCond->m_illuminantXYZ.Y;
+      if (icNotZero(illumY)) {
+        pXYZ[0] = pCond->m_illuminantXYZ.X / illumY;
+        pXYZ[1] = 1.0f;
+        pXYZ[2] = pCond->m_illuminantXYZ.Z / illumY;
+      }
+      else {
+        memcpy(pXYZ, icD50XYZ, 3 * sizeof(icFloatNumber));
+      }
     }
   }
 }


### PR DESCRIPTION
## PR Summary

#957 

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## CI Mods
-  .github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh | #958 | Non-standard PCC viewing-condition illuminant XYZ with zero Y divided by zero or fell back to D50 | Compiles a small PCC helper and verifies zero-Y custom illuminants are rejected without sanitizer findings or D50 substitution
