### PR TITLE
Fix: Bisect 1f0a9dd icSameSpectralRange

### DIFF
--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -23,6 +23,7 @@ Test 18 (Regression Bisect).
 | `.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh` | #928 follow-up | `multiLocalizedUnicodeType` reader accepted malformed record lengths, string offsets, and UTF-16 surrogate data | Mutates `sRGB_D65_MAT.icc` in `/tmp` and verifies malformed `mluc` records are rejected without sanitizer findings |
 | `.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh` | #958 | Non-standard PCC viewing-condition illuminant XYZ with zero Y divided by zero or fell back to D50 | Compiles a small PCC helper and verifies zero-Y custom illuminants are rejected without sanitizer findings or D50 substitution |
 | `.github/scripts/iccdev-calculator-regression-tests.sh` | `bisect-ce59fa8-calculator` | Calculator round/truncate/select casts and if/else offset arithmetic accepted malformed profile data without sanitizer-safe guards | Rebuilds `srgbCalcTest`, exercises calculator debug apply, and verifies malformed CalcTest operator fixtures reject without sanitizer findings |
+| `.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh` | #955 | `lut16Type` write path took `&curve[0]` for zero-entry curves, binding a reference through a null curve buffer | Compiles a small `CIccTagLut16` writer and verifies zero-entry B/A curves serialize without sanitizer findings |
 
 ## Adding a new PoC
 

--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -23,7 +23,7 @@ Test 18 (Regression Bisect).
 | `.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh` | #928 follow-up | `multiLocalizedUnicodeType` reader accepted malformed record lengths, string offsets, and UTF-16 surrogate data | Mutates `sRGB_D65_MAT.icc` in `/tmp` and verifies malformed `mluc` records are rejected without sanitizer findings |
 | `.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh` | #958 | Non-standard PCC viewing-condition illuminant XYZ with zero Y divided by zero or fell back to D50 | Compiles a small PCC helper and verifies zero-Y custom illuminants are rejected without sanitizer findings or D50 substitution |
 | `.github/scripts/iccdev-calculator-regression-tests.sh` | `bisect-ce59fa8-calculator` | Calculator round/truncate/select casts and if/else offset arithmetic accepted malformed profile data without sanitizer-safe guards | Rebuilds `srgbCalcTest`, exercises calculator debug apply, and verifies malformed CalcTest operator fixtures reject without sanitizer findings |
-| `.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh` | #955 | `lut16Type` write path took `&curve[0]` for zero-entry curves, binding a reference through a null curve buffer | Compiles a small `CIccTagLut16` writer and verifies zero-entry B/A curves serialize without sanitizer findings |
+| `.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh` | #955 | `lut16Type` write path took `&curve[0]` for zero-entry curves, binding a reference through a null curve buffer | Compiles a small `CIccTagLut16` writer and verifies invalid table counts are rejected without sanitizer findings |
 
 ## Adding a new PoC
 

--- a/.github/ci/regression/lut16-zero-entry-curve-write.cpp
+++ b/.github/ci/regression/lut16-zero-entry-curve-write.cpp
@@ -1,0 +1,41 @@
+#include "IccIO.h"
+#include "IccTagLut.h"
+
+int main()
+{
+  CIccTagLut16 lut;
+  lut.Init(3, 3);
+  lut.SetColorSpaces(icSigRgbData, icSigXYZData);
+
+  LPIccCurve *bCurves = lut.NewCurvesB();
+  LPIccCurve *aCurves = lut.NewCurvesA();
+  if (!bCurves || !aCurves)
+    return 2;
+
+  for (int i = 0; i < 3; i++) {
+    CIccTagCurve *curve = new CIccTagCurve();
+    if (!curve || !curve->SetSize(0))
+      return 3;
+    bCurves[i] = curve;
+  }
+
+  for (int i = 0; i < 3; i++) {
+    CIccTagCurve *curve = new CIccTagCurve();
+    if (!curve || !curve->SetSize(0))
+      return 4;
+    aCurves[i] = curve;
+  }
+
+  icUInt8Number grid[16] = {2, 2, 2};
+  if (!lut.NewCLUT(grid, 2))
+    return 5;
+
+  CIccMemIO io;
+  if (!io.Alloc(4096, true))
+    return 6;
+
+  if (!lut.Write(&io))
+    return 7;
+
+  return io.Tell() > 0 ? 0 : 8;
+}

--- a/.github/ci/regression/lut16-zero-entry-curve-write.cpp
+++ b/.github/ci/regression/lut16-zero-entry-curve-write.cpp
@@ -1,41 +1,69 @@
 #include "IccIO.h"
 #include "IccTagLut.h"
 
-int main()
+static bool set_lut_curves(CIccTagLut16 &lut, icUInt32Number nEntries)
 {
-  CIccTagLut16 lut;
-  lut.Init(3, 3);
-  lut.SetColorSpaces(icSigRgbData, icSigXYZData);
-
   LPIccCurve *bCurves = lut.NewCurvesB();
   LPIccCurve *aCurves = lut.NewCurvesA();
   if (!bCurves || !aCurves)
-    return 2;
+    return false;
 
   for (int i = 0; i < 3; i++) {
     CIccTagCurve *curve = new CIccTagCurve();
-    if (!curve || !curve->SetSize(0))
-      return 3;
+    if (!curve || !curve->SetSize(nEntries))
+      return false;
     bCurves[i] = curve;
   }
 
   for (int i = 0; i < 3; i++) {
     CIccTagCurve *curve = new CIccTagCurve();
-    if (!curve || !curve->SetSize(0))
-      return 4;
+    if (!curve || !curve->SetSize(nEntries))
+      return false;
     aCurves[i] = curve;
   }
 
+  return true;
+}
+
+static int run_lut16_write_case(icUInt32Number nEntries, bool bExpectedWrite)
+{
+  CIccTagLut16 lut;
+  lut.Init(3, 3);
+  lut.SetColorSpaces(icSigRgbData, icSigXYZData);
+
+  if (!set_lut_curves(lut, nEntries))
+    return 2;
+
   icUInt8Number grid[16] = {2, 2, 2};
   if (!lut.NewCLUT(grid, 2))
-    return 5;
+    return 3;
 
   CIccMemIO io;
-  if (!io.Alloc(4096, true))
-    return 6;
+  if (!io.Alloc(131072, true))
+    return 4;
 
-  if (!lut.Write(&io))
+  bool bWrote = lut.Write(&io);
+  if (bWrote != bExpectedWrite)
+    return bExpectedWrite ? 5 : 6;
+
+  if (bExpectedWrite && io.Tell() == 0)
     return 7;
 
-  return io.Tell() > 0 ? 0 : 8;
+  return 0;
+}
+
+int main()
+{
+  if (run_lut16_write_case(0, false))
+    return 10;
+  if (run_lut16_write_case(1, false))
+    return 11;
+  if (run_lut16_write_case(2, true))
+    return 12;
+  if (run_lut16_write_case(4096, true))
+    return 13;
+  if (run_lut16_write_case(4097, false))
+    return 14;
+
+  return 0;
 }

--- a/.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh
+++ b/.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+###############################################################################
+# iccDEV lut16 zero-entry curve write regression tests
+###############################################################################
+#
+# Issue:
+#   https://github.com/InternationalColorConsortium/iccDEV/issues/955
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_BUILD_DIR   -- path to CMake build directory
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+BUILD_DIR="${ICCDEV_BUILD_DIR:-}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-lut16-zero-curve-regressions}"
+mkdir -p "$OUTDIR"
+
+if [ -z "$BUILD_DIR" ] && [ -d "$TOOLS_DIR" ]; then
+  BUILD_DIR="$(cd "$TOOLS_DIR/.." && pwd)"
+fi
+
+if [ -z "$BUILD_DIR" ] || [ ! -d "$BUILD_DIR/IccProfLib" ]; then
+  for candidate in "$REPO_ROOT/build" "$REPO_ROOT/Build" "$REPO_ROOT/build-sani"; do
+    if [ -d "$candidate/IccProfLib" ]; then
+      BUILD_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ -z "${CXX:-}" ]; then
+  if command -v clang++-18 >/dev/null 2>&1; then
+    CXX=clang++-18
+  elif command -v clang++ >/dev/null 2>&1; then
+    CXX=clang++
+  else
+    CXX=c++
+  fi
+fi
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=1,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+fail_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [FAIL] $name -- $reason"
+  FAIL=$((FAIL + 1))
+}
+
+pass_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [PASS] $name -- $reason"
+  PASS=$((PASS + 1))
+}
+
+run_zero_curve_write() {
+  local name="lut16-zero-entry-curve-write"
+  local helper_cpp="$REPO_ROOT/.github/ci/regression/lut16-zero-entry-curve-write.cpp"
+  local helper_bin="$OUTDIR/$name"
+  local compile_log="$OUTDIR/$name.compile.log"
+  local run_log="$OUTDIR/$name.run.log"
+  local lib_dir="$BUILD_DIR/IccProfLib"
+  local lib_arg=""
+  local san_flags=()
+  local run_ec=0
+
+  TOTAL=$((TOTAL + 1))
+
+  if [ -z "$BUILD_DIR" ] || [ ! -d "$lib_dir" ]; then
+    fail_case "$name" "missing build directory with IccProfLib"
+    return
+  fi
+
+  for lib_name in IccProfLib2d IccProfLib2; do
+    if [ -f "$lib_dir/lib${lib_name}.so" ]; then
+      lib_arg="-l${lib_name}"
+      break
+    fi
+  done
+
+  if [ -z "$lib_arg" ]; then
+    fail_case "$name" "missing shared IccProfLib library in $lib_dir"
+    return
+  fi
+
+  if [ ! -f "$helper_cpp" ]; then
+    fail_case "$name" "missing helper source $helper_cpp"
+    return
+  fi
+
+  if [ -f "$BUILD_DIR/CMakeCache.txt" ]; then
+    if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      san_flags+=("-fsanitize=address")
+    fi
+    if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      san_flags+=("-fsanitize=undefined")
+    fi
+    if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
+       "$CXX" --version 2>/dev/null | grep -qi clang; then
+      san_flags+=("-fsanitize=integer")
+    fi
+  fi
+
+  if ! "$CXX" -std=c++17 "${san_flags[@]}" \
+      -I"$REPO_ROOT/IccProfLib" \
+      -I"$BUILD_DIR/IccProfLib" \
+      "$helper_cpp" \
+      -L"$lib_dir" "$lib_arg" -Wl,-rpath,"$lib_dir" \
+      -o "$helper_bin" > "$compile_log" 2>&1; then
+    fail_case "$name" "failed to compile helper"
+    sed -n '1,80p' "$compile_log"
+    return
+  fi
+
+  LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}" "$helper_bin" > "$run_log" 2>&1 || run_ec=$?
+
+  if grep -q "ERROR: AddressSanitizer\\|runtime error:" "$run_log" 2>/dev/null; then
+    fail_case "$name" "sanitizer finding while writing zero-entry curves"
+    sed -n '1,80p' "$run_log"
+    return
+  fi
+
+  if [ "$run_ec" -ne 0 ]; then
+    fail_case "$name" "helper exited $run_ec"
+    sed -n '1,80p' "$run_log"
+    return
+  fi
+
+  pass_case "$name" "zero-entry lut16 curves write without sanitizer findings"
+}
+
+echo "=== lut16 zero-entry curve write regression ==="
+
+run_zero_curve_write
+
+echo "lut16 zero-entry curve write regression: $PASS passed, $FAIL failed, $TOTAL total"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh
+++ b/.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ###############################################################################
-# iccDEV lut16 zero-entry curve write regression tests
+# iccDEV lut16 invalid curve count regression tests
 ###############################################################################
 #
 # Issue:
@@ -101,15 +101,23 @@ run_zero_curve_write() {
   fi
 
   if [ -f "$BUILD_DIR/CMakeCache.txt" ]; then
-    if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
-      san_flags+=("-fsanitize=address")
-    fi
-    if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
-      san_flags+=("-fsanitize=undefined")
-    fi
-    if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
-       "$CXX" --version 2>/dev/null | grep -qi clang; then
-      san_flags+=("-fsanitize=integer")
+    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      if "$CXX" --version 2>/dev/null | grep -qi clang; then
+        san_flags+=("-fsanitize=address,undefined,integer,float-divide-by-zero,float-cast-overflow")
+      else
+        san_flags+=("-fsanitize=address,undefined")
+      fi
+    else
+      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+        san_flags+=("-fsanitize=address")
+      fi
+      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+        san_flags+=("-fsanitize=undefined")
+      fi
+      if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
+         "$CXX" --version 2>/dev/null | grep -qi clang; then
+        san_flags+=("-fsanitize=integer")
+      fi
     fi
   fi
 
@@ -127,7 +135,7 @@ run_zero_curve_write() {
   LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}" "$helper_bin" > "$run_log" 2>&1 || run_ec=$?
 
   if grep -q "ERROR: AddressSanitizer\\|runtime error:" "$run_log" 2>/dev/null; then
-    fail_case "$name" "sanitizer finding while writing zero-entry curves"
+    fail_case "$name" "sanitizer finding while checking invalid lut16 curve counts"
     sed -n '1,80p' "$run_log"
     return
   fi
@@ -138,14 +146,14 @@ run_zero_curve_write() {
     return
   fi
 
-  pass_case "$name" "zero-entry lut16 curves write without sanitizer findings"
+  pass_case "$name" "invalid lut16 curve counts rejected without sanitizer findings"
 }
 
-echo "=== lut16 zero-entry curve write regression ==="
+echo "=== lut16 invalid curve count regression ==="
 
 run_zero_curve_write
 
-echo "lut16 zero-entry curve write regression: $PASS passed, $FAIL failed, $TOTAL total"
+echo "lut16 invalid curve count regression: $PASS passed, $FAIL failed, $TOTAL total"
 
 if [ "$FAIL" -ne 0 ]; then
   exit 1

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -1968,6 +1968,32 @@ jobs:
           passed=$((passed + r22_pass))
           failed=$((failed + r22_fail))
 
+          # --- R23: Issue #955 lut16 zero-entry curve write validation ---
+          echo "--- R23: Issue #955 lut16 zero-entry curve write validation ---"
+          r23_pass=0 r23_fail=0
+          LUT16_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh"
+          if [ -f "$LUT16_SCRIPT" ]; then
+            chmod +x "$LUT16_SCRIPT"
+            r23_ec=0
+            ICCDEV_TOOLS_DIR="${WORKSPACE_DIR}/build/Tools" \
+              ICCDEV_BUILD_DIR="${WORKSPACE_DIR}/build" \
+              ICCDEV_TEST_OUTDIR="$OUTDIR/r23-lut16-zero-curve" \
+              "$LUT16_SCRIPT" > "$OUTDIR/r23-lut16-zero-curve.log" 2>&1 || r23_ec=$?
+            cat "$OUTDIR/r23-lut16-zero-curve.log"
+            if [ "$r23_ec" -eq 0 ]; then
+              echo "  [OK]    Issue #955 lut16 zero-entry curves write cleanly"
+              r23_pass=$((r23_pass + 1))
+            else
+              echo "  [FAIL]  Issue #955 lut16 zero-curve regression script exited $r23_ec"
+              r23_fail=$((r23_fail + 1))
+            fi
+          else
+            echo "  [SKIP]  lut16 zero-curve regression script not found"
+          fi
+          echo "  Issue #955 lut16 zero-entry curve write validation: $r23_pass passed, $r23_fail failed"
+          passed=$((passed + r23_pass))
+          failed=$((failed + r23_fail))
+
           echo ""
           echo "Regression checks: $passed passed, $failed failed"
           if [ "$failed" -gt 0 ]; then exit 1; fi
@@ -2102,7 +2128,7 @@ jobs:
               ["15"]="iccApplySearch (CMM search optimization)"
               ["16"]="MCS regression (iccApplyProfiles TIFF pipeline)"
               ["17"]="iccV5DspObsToV4Dsp (v5 display to v4 conversion)"
-              ["18"]="Regression checks (bisect fixes: 599,736,744,751,752,763,769; stdobserver aliases; issue #928 mluc setter/read; issue #958 PCC illuminant; calculator sanitizer)"
+              ["18"]="Regression checks (bisect fixes: 599,736,744,751,752,763,769; stdobserver aliases; issue #928 mluc setter/read; issue #958 PCC illuminant; issue #955 lut16 zero curves; calculator sanitizer)"
             )
 
             for phase in $(seq 1 18); do

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -1968,8 +1968,8 @@ jobs:
           passed=$((passed + r22_pass))
           failed=$((failed + r22_fail))
 
-          # --- R23: Issue #955 lut16 zero-entry curve write validation ---
-          echo "--- R23: Issue #955 lut16 zero-entry curve write validation ---"
+          # --- R23: Issue #955 lut16 invalid curve count validation ---
+          echo "--- R23: Issue #955 lut16 invalid curve count validation ---"
           r23_pass=0 r23_fail=0
           LUT16_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh"
           if [ -f "$LUT16_SCRIPT" ]; then
@@ -1981,7 +1981,7 @@ jobs:
               "$LUT16_SCRIPT" > "$OUTDIR/r23-lut16-zero-curve.log" 2>&1 || r23_ec=$?
             cat "$OUTDIR/r23-lut16-zero-curve.log"
             if [ "$r23_ec" -eq 0 ]; then
-              echo "  [OK]    Issue #955 lut16 zero-entry curves write cleanly"
+              echo "  [OK]    Issue #955 invalid lut16 curve counts rejected cleanly"
               r23_pass=$((r23_pass + 1))
             else
               echo "  [FAIL]  Issue #955 lut16 zero-curve regression script exited $r23_ec"
@@ -1990,7 +1990,7 @@ jobs:
           else
             echo "  [SKIP]  lut16 zero-curve regression script not found"
           fi
-          echo "  Issue #955 lut16 zero-entry curve write validation: $r23_pass passed, $r23_fail failed"
+          echo "  Issue #955 lut16 invalid curve count validation: $r23_pass passed, $r23_fail failed"
           passed=$((passed + r23_pass))
           failed=$((failed + r23_fail))
 
@@ -2152,7 +2152,7 @@ jobs:
               ["15"]="iccApplySearch (CMM search optimization)"
               ["16"]="MCS regression (iccApplyProfiles TIFF pipeline)"
               ["17"]="iccV5DspObsToV4Dsp (v5 display to v4 conversion)"
-              ["18"]="Regression checks (bisect fixes: 599,736,744,751,752,763,769; stdobserver aliases; issue #928 mluc setter/read; issue #958 PCC illuminant; issue #955 lut16 zero curves; calculator sanitizer)"
+              ["18"]="Regression checks (bisect fixes: 599,736,744,751,752,763,769; stdobserver aliases; issue #928 mluc setter/read; issue #958 PCC illuminant; issue #955 lut16 invalid curve counts; calculator sanitizer)"
             )
 
             for phase in $(seq 1 18); do

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -2021,7 +2021,31 @@ jobs:
 
           OUTDIR="/tmp/iccdev-tool-output"
 
-          # Count ASAN and UBSAN across all logs
+          find_matching_logs() {
+            local root="$1"
+            local pattern="$2"
+            [ -d "$root" ] || return 0
+            while IFS= read -r -d '' logf; do
+              if grep -q -- "$pattern" "$logf" 2>/dev/null; then
+                printf '%s\n' "$logf"
+              fi
+            done < <(find "$root" -name '*.log' -type f -print0 2>/dev/null)
+          }
+
+          count_matching_logs() {
+            local root="$1"
+            local pattern="$2"
+            local matches
+            matches="$(find_matching_logs "$root" "$pattern")"
+            if [ -n "$matches" ]; then
+              grep -c . <<< "$matches" 2>/dev/null || echo 0
+            else
+              echo 0
+            fi
+          }
+
+          # Count ASAN and UBSAN across text logs only. Some tests write binary
+          # ICC artifacts under OUTDIR; recursive grep can misclassify them.
           ASAN_FILES=""
           UBSAN_FILES=""
           TOTAL_LOGS=0
@@ -2029,8 +2053,8 @@ jobs:
           TOTAL_FAIL=0
           TOTAL_READ_FAIL=0
           if [ -d "$OUTDIR" ]; then
-            ASAN_FILES=$({ grep -Irl "ERROR: AddressSanitizer" "$OUTDIR"/ 2>/dev/null || true; })
-            UBSAN_FILES=$({ grep -Irl "runtime error:" "$OUTDIR"/ 2>/dev/null || true; })
+            ASAN_FILES="$(find_matching_logs "$OUTDIR" "ERROR: AddressSanitizer")"
+            UBSAN_FILES="$(find_matching_logs "$OUTDIR" "runtime error:")"
             TOTAL_LOGS=$(find "$OUTDIR" -name '*.log' -type f 2>/dev/null | wc -l)
             # Count pass/fail across per-profile logs (exit code in log content)
             for logf in "$OUTDIR"/*/*.log; do
@@ -2137,11 +2161,11 @@ jobs:
               pdir="$OUTDIR/$dir"
               if [ ! -d "$pdir" ]; then
                 echo "| $phase | $name | SKIP |"
-              elif grep -Irq "ERROR: AddressSanitizer" "$pdir"/ 2>/dev/null; then
-                pa=$(grep -Irl "ERROR: AddressSanitizer" "$pdir"/ 2>/dev/null | wc -l)
+              elif [ "$(count_matching_logs "$pdir" "ERROR: AddressSanitizer")" -gt 0 ]; then
+                pa="$(count_matching_logs "$pdir" "ERROR: AddressSanitizer")"
                 echo "| $phase | $name | ASAN ($pa files) |"
-              elif grep -Irq "runtime error:" "$pdir"/ 2>/dev/null; then
-                pu=$(grep -Irl "runtime error:" "$pdir"/ 2>/dev/null | wc -l)
+              elif [ "$(count_matching_logs "$pdir" "runtime error:")" -gt 0 ]; then
+                pu="$(count_matching_logs "$pdir" "runtime error:")"
                 echo "| $phase | $name | UBSAN ($pu files) |"
               elif [ -f "$pdir/.phase-fail" ]; then
                 reason="$(sanitize_line "$(sed -n '1p' "$pdir/.phase-fail")")"
@@ -2169,11 +2193,11 @@ jobs:
                 {
                   echo "**${safe_fname}** (ASAN)"
                   echo '```'
-                  grep "ERROR: AddressSanitizer" "$logf" | sed -n '1,1p' | while IFS= read -r line; do
+                  { grep "ERROR: AddressSanitizer" "$logf" 2>/dev/null || true; } | sed -n '1,1p' | while IFS= read -r line; do
                     sanitize_line "$line"
                     echo ""
                   done
-                  grep -E '^\s+#[0-3]' "$logf" | sed -n '1,4p' | while IFS= read -r line; do
+                  { grep -E '^\s+#[0-3]' "$logf" 2>/dev/null || true; } | sed -n '1,4p' | while IFS= read -r line; do
                     sanitize_line "$line"
                     echo ""
                   done
@@ -2189,7 +2213,7 @@ jobs:
               echo '```' >> "$GITHUB_STEP_SUMMARY"
               echo "$UBSAN_FILES" | while IFS= read -r logf; do
                 [ -f "$logf" ] || continue
-                grep "runtime error:" "$logf" 2>/dev/null
+                grep "runtime error:" "$logf" 2>/dev/null || true
               done | sort -u | sed -n '1,20p' | while IFS= read -r line; do
                 sanitize_line "$line"
                 echo ""

--- a/.github/workflows/ci-tool-tests.yml
+++ b/.github/workflows/ci-tool-tests.yml
@@ -14,7 +14,7 @@
 #      standard observer XML/JSON alias compatibility, issue #928 mluc setter
 #      canonical length checks, mluc read/UTF-16 validation, and issue #958
 #      PCC zero-Y illuminant validation, calculator sanitizer regressions,
-#      and lut16 zero-entry curve write validation
+#      and lut16 invalid curve count validation
 #
 # Hardening:
 #   - sanitize-sed.sh sourced in every step
@@ -1116,8 +1116,8 @@ jobs:
           passed=$((passed + r18_pass))
           failed=$((failed + r18_fail))
 
-          # --- R19: Issue #955 lut16 zero-entry curve write validation ---
-          echo "--- R19: Issue #955 lut16 zero-entry curve write validation ---"
+          # --- R19: Issue #955 lut16 invalid curve count validation ---
+          echo "--- R19: Issue #955 lut16 invalid curve count validation ---"
           r19_pass=0 r19_fail=0
           LUT16_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh"
           if [ -f "$LUT16_SCRIPT" ]; then
@@ -1129,7 +1129,7 @@ jobs:
               "$LUT16_SCRIPT" > "$OUTDIR/r19-lut16-zero-curve.log" 2>&1 || r19_ec=$?
             cat "$OUTDIR/r19-lut16-zero-curve.log"
             if [ "$r19_ec" -eq 0 ]; then
-              echo "  [OK]    Issue #955 lut16 zero-entry curves write cleanly"
+              echo "  [OK]    Issue #955 invalid lut16 curve counts rejected cleanly"
               r19_pass=$((r19_pass + 1))
             else
               echo "  [FAIL]  Issue #955 lut16 zero-curve regression script exited $r19_ec"
@@ -1138,7 +1138,7 @@ jobs:
           else
             echo "  [SKIP]  lut16 zero-curve regression script not found"
           fi
-          echo "  Issue #955 lut16 zero-entry curve write validation: $r19_pass passed, $r19_fail failed"
+          echo "  Issue #955 lut16 invalid curve count validation: $r19_pass passed, $r19_fail failed"
           passed=$((passed + r19_pass))
           failed=$((failed + r19_fail))
 

--- a/.github/workflows/ci-tool-tests.yml
+++ b/.github/workflows/ci-tool-tests.yml
@@ -13,7 +13,8 @@
 #   4. Regression checks -- bisect fix PoCs, JSON/XML parser/config failures,
 #      standard observer XML/JSON alias compatibility, issue #928 mluc setter
 #      canonical length checks, mluc read/UTF-16 validation, and issue #958
-#      PCC zero-Y illuminant validation, and calculator sanitizer regressions
+#      PCC zero-Y illuminant validation, calculator sanitizer regressions,
+#      and lut16 zero-entry curve write validation
 #
 # Hardening:
 #   - sanitize-sed.sh sourced in every step
@@ -33,6 +34,8 @@
 #   .github/scripts/iccdev-mluc-read-utf16-regression-tests.sh
 #   .github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh
 #   .github/scripts/iccdev-calculator-regression-tests.sh
+#   .github/scripts/iccdev-lut16-zero-curve-regression-tests.sh
+#   .github/ci/regression/lut16-zero-entry-curve-write.cpp
 #
 ###############################################################
 
@@ -57,7 +60,9 @@ on:
       - '.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh'
       - '.github/ci/regression/pcc-zero-illuminant.cpp'
       - '.github/scripts/iccdev-calculator-regression-tests.sh'
+      - '.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh'
       - '.github/scripts/json-cli-exercise.sh'
+      - '.github/ci/regression/lut16-zero-entry-curve-write.cpp'
       - '.github/ci/test-data/**'
       - 'IccProfLib/**'
       - 'IccXML/**'
@@ -1110,6 +1115,32 @@ jobs:
           echo "  Calculator cast/offset sanitizer regression: $r18_pass passed, $r18_fail failed"
           passed=$((passed + r18_pass))
           failed=$((failed + r18_fail))
+
+          # --- R19: Issue #955 lut16 zero-entry curve write validation ---
+          echo "--- R19: Issue #955 lut16 zero-entry curve write validation ---"
+          r19_pass=0 r19_fail=0
+          LUT16_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh"
+          if [ -f "$LUT16_SCRIPT" ]; then
+            chmod +x "$LUT16_SCRIPT"
+            r19_ec=0
+            ICCDEV_TOOLS_DIR="${WORKSPACE_DIR}/build/Tools" \
+              ICCDEV_BUILD_DIR="${WORKSPACE_DIR}/build" \
+              ICCDEV_TEST_OUTDIR="$OUTDIR/r19-lut16-zero-curve" \
+              "$LUT16_SCRIPT" > "$OUTDIR/r19-lut16-zero-curve.log" 2>&1 || r19_ec=$?
+            cat "$OUTDIR/r19-lut16-zero-curve.log"
+            if [ "$r19_ec" -eq 0 ]; then
+              echo "  [OK]    Issue #955 lut16 zero-entry curves write cleanly"
+              r19_pass=$((r19_pass + 1))
+            else
+              echo "  [FAIL]  Issue #955 lut16 zero-curve regression script exited $r19_ec"
+              r19_fail=$((r19_fail + 1))
+            fi
+          else
+            echo "  [SKIP]  lut16 zero-curve regression script not found"
+          fi
+          echo "  Issue #955 lut16 zero-entry curve write validation: $r19_pass passed, $r19_fail failed"
+          passed=$((passed + r19_pass))
+          failed=$((failed + r19_fail))
 
           echo ""
           echo "Regression checks: $passed passed, $failed failed"

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -5351,6 +5351,7 @@ bool CIccTagLut16::Write(CIccIO *pIO)
   icUInt8Number i, nGrid;
   icS15Fixed16Number XYZMatrix[9];
   icUInt16Number nInputEntries, nOutputEntries;
+  icUInt32Number nInputCurveEntries, nOutputCurveEntries;
   LPIccCurve *pCurves;
   CIccTagCurve *pCurve;
 
@@ -5374,10 +5375,22 @@ bool CIccTagLut16::Write(CIccIO *pIO)
   if (!pCurves || !m_CurvesA || !m_CLUT)
     return false;
 
+  if (m_nInput < 1 || m_nOutput < 1 || m_nInput > 15 || m_nOutput > 15)
+    return false;
+
+  if (!pCurves[0] || pCurves[0]->GetType()!=icSigCurveType ||
+      !m_CurvesA[0] || m_CurvesA[0]->GetType()!=icSigCurveType)
+    return false;
+
   nGrid = m_CLUT->GridPoints();
 
-  nInputEntries = (icUInt16Number)(((CIccTagCurve*)pCurves[0])->GetSize());
-  nOutputEntries = (icUInt16Number)(((CIccTagCurve*)m_CurvesA[0])->GetSize());
+  nInputCurveEntries = ((CIccTagCurve*)pCurves[0])->GetSize();
+  nOutputCurveEntries = ((CIccTagCurve*)m_CurvesA[0])->GetSize();
+  if (nInputCurveEntries > 0xffff || nOutputCurveEntries > 0xffff)
+    return false;
+
+  nInputEntries = (icUInt16Number)nInputCurveEntries;
+  nOutputEntries = (icUInt16Number)nOutputCurveEntries;
 
   if (!pIO->Write32(&sig) ||
       !pIO->Write32(&m_nReserved) ||
@@ -5391,20 +5404,23 @@ bool CIccTagLut16::Write(CIccIO *pIO)
     return false;
 
   //B Curves
-  for (i=0; i<m_nInput; i++) {
-    if (pCurves[i]->GetType()!=icSigCurveType)
-      return false;
+  for (i=0; i<15; i++) {
+    if (i>=m_nInput)
+      break;
 
     pCurve = (CIccTagCurve*)pCurves[i];
-    if (!pCurve)
+    if (!pCurve || pCurve->GetType()!=icSigCurveType)
       return false;
     
     // validate that the sizes match between all curves
     if (pCurve->GetSize() != nInputEntries)
         return false;
 
-    if (pIO->WriteUInt16Float(&(*pCurve)[0], nInputEntries) != nInputEntries)
-      return false;
+    if (nInputEntries) {
+      icFloatNumber *pCurveData = pCurve->GetData(0);
+      if (!pCurveData || pIO->WriteUInt16Float(pCurveData, nInputEntries) != nInputEntries)
+        return false;
+    }
   }
 
   //CLUT
@@ -5414,18 +5430,23 @@ bool CIccTagLut16::Write(CIccIO *pIO)
   //A Curves
   pCurves = m_CurvesA;
 
-  for (i=0; i<m_nOutput; i++) {
-    if (pCurves[i]->GetType()!=icSigCurveType)
-      return false;
+  for (i=0; i<15; i++) {
+    if (i>=m_nOutput)
+      break;
 
     pCurve = (CIccTagCurve*)pCurves[i];
-    
+    if (!pCurve || pCurve->GetType()!=icSigCurveType)
+      return false;
+
     // validate that the sizes match between all curves
     if (pCurve->GetSize() != nOutputEntries)
         return false;
 
-    if (pIO->WriteUInt16Float(&(*pCurve)[0], nOutputEntries) != nOutputEntries)
-      return false;
+    if (nOutputEntries) {
+      icFloatNumber *pCurveData = pCurve->GetData(0);
+      if (!pCurveData || pIO->WriteUInt16Float(pCurveData, nOutputEntries) != nOutputEntries)
+        return false;
+    }
   }
   return true;
 }

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -5231,6 +5231,10 @@ bool CIccTagLut16::Read(icUInt32Number size, CIccIO *pIO)
   if (m_nInput > 15 || m_nOutput > 15)
     return false;
 
+  if (nInputEntries < 2 || nInputEntries > 4096 ||
+      nOutputEntries < 2 || nOutputEntries > 4096)
+    return false;
+
   //B Curves
   pCurves = NewCurvesB();
 
@@ -5386,7 +5390,8 @@ bool CIccTagLut16::Write(CIccIO *pIO)
 
   nInputCurveEntries = ((CIccTagCurve*)pCurves[0])->GetSize();
   nOutputCurveEntries = ((CIccTagCurve*)m_CurvesA[0])->GetSize();
-  if (nInputCurveEntries > 0xffff || nOutputCurveEntries > 0xffff)
+  if (nInputCurveEntries < 2 || nInputCurveEntries > 4096 ||
+      nOutputCurveEntries < 2 || nOutputCurveEntries > 4096)
     return false;
 
   nInputEntries = (icUInt16Number)nInputCurveEntries;
@@ -5507,10 +5512,11 @@ icValidateStatus CIccTagLut16::Validate(std::string sigPath, std::string &sRepor
             rv = icMaxStatus(rv, m_CurvesB[i]->Validate(sigPath+icGetSigPath(GetType()), sReport, pProfile));
             if (m_CurvesB[i]->GetType()==icSigCurveType) {
               CIccTagCurve *pTagCurve = (CIccTagCurve*)m_CurvesB[i];
-              if (pTagCurve->GetSize()==1) {
+              icUInt32Number nCurveEntries = pTagCurve->GetSize();
+              if (nCurveEntries < 2 || nCurveEntries > 4096) {
                 sReport += icMsgValidateCriticalError;
                 sReport += sSigPathName;
-                sReport += " - lut16Tags do not support single entry gamma curves.\n";
+                sReport += " - lut16Type input tables require 2 to 4096 entries.\n";
                 rv = icMaxStatus(rv, icValidateCriticalError);
               }
             }
@@ -5548,10 +5554,11 @@ icValidateStatus CIccTagLut16::Validate(std::string sigPath, std::string &sRepor
             rv = icMaxStatus(rv, m_CurvesA[i]->Validate(sigPath+icGetSigPath(GetType()), sReport, pProfile));
             if (m_CurvesA[i]->GetType()==icSigCurveType) {
               CIccTagCurve *pTagCurve = (CIccTagCurve*)m_CurvesA[i];
-              if (pTagCurve->GetSize()==1) {
+              icUInt32Number nCurveEntries = pTagCurve->GetSize();
+              if (nCurveEntries < 2 || nCurveEntries > 4096) {
                 sReport += icMsgValidateCriticalError;
                 sReport += sSigPathName;
-                sReport += " - lut16Tags do not support single entry gamma curves.\n";
+                sReport += " - lut16Type output tables require 2 to 4096 entries.\n";
                 rv = icMaxStatus(rv, icValidateCriticalError);
               }
             }

--- a/IccProfLib/IccTagLut.h
+++ b/IccProfLib/IccTagLut.h
@@ -140,7 +140,7 @@ public:
   virtual bool Write(CIccIO *pIO);
 
   icFloatNumber &operator[](icUInt32Number index) {return m_Curve[index];}
-  icFloatNumber *GetData(icUInt32Number index) {return &m_Curve[index];}
+  icFloatNumber *GetData(icUInt32Number index) {return m_Curve ? &m_Curve[index] : NULL;}
   icUInt32Number GetSize() const { return m_nSize; }
   bool SetSize(icUInt32Number nSize, icTagCurveSizeInit nSizeOpt=icInitZero);
   bool SetGamma(icFloatNumber gamma);


### PR DESCRIPTION
## PR Summary

#955 

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## CI Mods
-  `.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh` | #955 | `lut16Type` write path took `&curve[0]` for zero-entry curves, binding a reference through a null curve buffer | Compiles a small `CIccTagLut16` writer and verifies invalid table counts are rejected without sanitizer findings |