### PR TITLE
Fix: Bisect: 1f0a9dd DevicePix & icFloatNumber

### DIFF
--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -24,6 +24,7 @@ Test 18 (Regression Bisect).
 | `.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh` | #958 | Non-standard PCC viewing-condition illuminant XYZ with zero Y divided by zero or fell back to D50 | Compiles a small PCC helper and verifies zero-Y custom illuminants are rejected without sanitizer findings or D50 substitution |
 | `.github/scripts/iccdev-calculator-regression-tests.sh` | `bisect-ce59fa8-calculator` | Calculator round/truncate/select casts and if/else offset arithmetic accepted malformed profile data without sanitizer-safe guards | Rebuilds `srgbCalcTest`, exercises calculator debug apply, and verifies malformed CalcTest operator fixtures reject without sanitizer findings |
 | `.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh` | #955 | `lut16Type` write path took `&curve[0]` for zero-entry curves, binding a reference through a null curve buffer | Compiles a small `CIccTagLut16` writer and verifies invalid table counts are rejected without sanitizer findings |
+| `.github/scripts/iccdev-namedcolor-apply-regression-tests.sh` | AFL apply namedColor2 | `CIccXformNamedColor::Apply` copied more than 16 device coordinates and accepted negative lookup results | Builds a small helper that verifies valid lookup, color-not-found, and too-many-device-coordinate paths without sanitizer findings |
 
 ## Adding a new PoC
 

--- a/.github/ci/regression/namedcolor-apply-guard.cpp
+++ b/.github/ci/regression/namedcolor-apply-guard.cpp
@@ -1,0 +1,79 @@
+#include "IccCmm.h"
+#include "IccTagBasic.h"
+
+#include <cstdio>
+#include <cstring>
+
+static int expect_status(const char *name, icStatusCMM got, icStatusCMM want)
+{
+  if (got != want) {
+    std::printf("%s: got %d, expected %d\n", name, got, want);
+    return 1;
+  }
+  std::printf("%s: status %d\n", name, got);
+  return 0;
+}
+
+static void init_named_entry(CIccTagNamedColor2 &tag, const char *rootName)
+{
+  SIccNamedColorEntry *entry = tag.GetEntry(0);
+  std::snprintf(entry->rootName, sizeof(entry->rootName), "%s", rootName);
+
+  for (int i = 0; i < 3; ++i) {
+    entry->pcsCoords[i] = 0.0f;
+  }
+
+  for (icUInt32Number i = 0; i < tag.GetDeviceCoords(); ++i) {
+    entry->deviceCoords[i] = 0.05f * static_cast<icFloatNumber>(i + 1);
+  }
+}
+
+static icStatusCMM run_pixel_to_name(CIccTagNamedColor2 &tag,
+                                     icColorSpaceSignature deviceSpace,
+                                     icChar *name,
+                                     const icFloatNumber *src)
+{
+  CIccXformNamedColor xform(&tag, icSigLabData, deviceSpace);
+  icStatusCMM status = xform.SetSrcSpace(deviceSpace);
+  if (status != icCmmStatOk) {
+    return status;
+  }
+
+  status = xform.SetDestSpace(icSigNamedData);
+  if (status != icCmmStatOk) {
+    return status;
+  }
+
+  return xform.Apply(NULL, name, src);
+}
+
+int main()
+{
+  icFloatNumber src[17] = {};
+  icChar name[256] = {};
+  int failures = 0;
+
+  CIccTagNamedColor2 valid(1, 3);
+  init_named_entry(valid, "valid-device-color");
+  failures += expect_status("valid-device-color",
+                            run_pixel_to_name(valid, icSigRgbData, name, src),
+                            icCmmStatOk);
+  if (std::strcmp(name, "valid-device-color")) {
+    std::printf("valid-device-color: unexpected name '%s'\n", name);
+    failures++;
+  }
+
+  CIccTagNamedColor2 noDeviceCoords(1, 0);
+  init_named_entry(noDeviceCoords, "no-device-coordinates");
+  failures += expect_status("no-device-coordinates",
+                            run_pixel_to_name(noDeviceCoords, icSigRgbData, name, src),
+                            icCmmStatColorNotFound);
+
+  CIccTagNamedColor2 tooManyDeviceCoords(1, 17);
+  init_named_entry(tooManyDeviceCoords, "too-many-device-coordinates");
+  failures += expect_status("too-many-device-coordinates",
+                            run_pixel_to_name(tooManyDeviceCoords, icSigRgbData, name, src),
+                            icCmmStatTooManySamples);
+
+  return failures ? 1 : 0;
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,7 @@ Canonical regression scripts:
 - `.github/scripts/iccdev-stdobserver-regression-tests.sh`
 - `.github/scripts/iccdev-mluc-setter-regression-tests.sh`
 - `.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh`
+- `.github/scripts/iccdev-namedcolor-apply-regression-tests.sh`
 
 For regression workflow updates, use
 `.github/skills/regression-workflow-governance/SKILL.md` and

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -29,6 +29,7 @@ Script-based gates live in `.github/scripts/`, including:
 - `iccdev-stdobserver-regression-tests.sh`
 - `iccdev-mluc-setter-regression-tests.sh`
 - `iccdev-mluc-read-utf16-regression-tests.sh`
+- `iccdev-namedcolor-apply-regression-tests.sh`
 
 When adding a new regression input, add the matching script or workflow assertion
 in the same change.

--- a/.github/scripts/ci-safe-apt-update.sh
+++ b/.github/scripts/ci-safe-apt-update.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+###############################################################################
+# Disable nonessential third-party apt sources that can break GitHub-hosted
+# Ubuntu runners, then run apt-get update.
+###############################################################################
+
+set -euo pipefail
+
+disabled_dir="${RUNNER_TEMP:-/tmp}/iccdev-disabled-apt-sources"
+sudo mkdir -p "$disabled_dir"
+
+for source_file in /etc/apt/sources.list.d/*; do
+  [ -e "$source_file" ] || continue
+  if sudo grep -qs 'packages\.microsoft\.com' "$source_file"; then
+    safe_name="$(basename "$source_file")"
+    echo "[INFO] Disabling apt source with packages.microsoft.com: $safe_name"
+    sudo mv "$source_file" "$disabled_dir/$safe_name.disabled"
+  fi
+done
+
+sudo apt-get update -qq

--- a/.github/scripts/iccdev-namedcolor-apply-regression-tests.sh
+++ b/.github/scripts/iccdev-namedcolor-apply-regression-tests.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+###############################################################################
+# iccDEV namedColor2 pixel-to-name apply regression tests
+###############################################################################
+#
+# Exercises CIccXformNamedColor::Apply() for malformed namedColor2 device data
+# that previously reached sanitizer findings through iccApplyNamedCmm.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-namedcolor-apply-regressions}"
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd)"
+mkdir -p "$OUTDIR"
+
+HELPER_SRC="$REPO_ROOT/.github/ci/regression/namedcolor-apply-guard.cpp"
+HELPER_BIN="$OUTDIR/namedcolor-apply-guard"
+HELPER_LOG="$OUTDIR/namedcolor-apply-guard.log"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=1,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+TOTAL=1
+
+find_library_file() {
+  local dir="$1"
+  local base="$2"
+
+  find "$dir" -maxdepth 1 \( \
+      -name "lib${base}*.so" -o \
+      -name "lib${base}*.dylib" -o \
+      -name "lib${base}*.a" \
+    \) -print 2>/dev/null | sort | head -n 1
+}
+
+echo "=== namedColor2 apply regression ==="
+
+if [ ! -f "$HELPER_SRC" ]; then
+  echo "  [FAIL] missing helper source: $HELPER_SRC"
+  exit 1
+fi
+
+if [ -z "$BUILD_ROOT" ] || [ ! -d "$BUILD_ROOT/IccProfLib" ]; then
+  echo "  [FAIL] unable to locate build root from ICCDEV_TOOLS_DIR=$TOOLS_DIR"
+  exit 1
+fi
+
+if [ -n "${CXX:-}" ]; then
+  HELPER_CXX="$CXX"
+elif command -v clang++-18 >/dev/null 2>&1; then
+  HELPER_CXX="clang++-18"
+elif command -v clang++ >/dev/null 2>&1; then
+  HELPER_CXX="clang++"
+else
+  HELPER_CXX="c++"
+fi
+
+PROFLIB="$(find_library_file "$BUILD_ROOT/IccProfLib" "IccProfLib2" || true)"
+if [ -z "$PROFLIB" ]; then
+  echo "  [FAIL] missing linkable IccProfLib library under $BUILD_ROOT/IccProfLib"
+  exit 1
+fi
+
+SAN_FLAGS="-fsanitize=address,undefined"
+if "$HELPER_CXX" --version 2>/dev/null | grep -qi clang; then
+  SAN_FLAGS="-fsanitize=address,undefined,integer -fno-sanitize-recover=undefined -fno-sanitize-recover=integer"
+fi
+
+compile_ec=0
+# shellcheck disable=SC2086
+"$HELPER_CXX" -std=c++17 $SAN_FLAGS \
+  -I"$BUILD_ROOT/IccProfLib" \
+  -I"$REPO_ROOT/IccProfLib" \
+  -I"$REPO_ROOT" \
+  "$HELPER_SRC" \
+  -Wl,-rpath,"$BUILD_ROOT/IccProfLib" \
+  "$PROFLIB" \
+  -o "$HELPER_BIN" > "$HELPER_LOG" 2>&1 || compile_ec=$?
+
+if [ "$compile_ec" -ne 0 ]; then
+  echo "  [FAIL] helper build failed"
+  sed -n '1,30p' "$HELPER_LOG"
+  FAIL=$((FAIL + 1))
+elif "$HELPER_BIN" >> "$HELPER_LOG" 2>&1; then
+  if grep -q "ERROR: AddressSanitizer\\|runtime error:" "$HELPER_LOG" 2>/dev/null; then
+    echo "  [FAIL] helper produced sanitizer findings"
+    sed -n '1,60p' "$HELPER_LOG"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  [PASS] namedColor2 pixel-to-name guard"
+    PASS=$((PASS + 1))
+  fi
+else
+  echo "  [FAIL] helper runtime failed"
+  sed -n '1,60p' "$HELPER_LOG"
+  FAIL=$((FAIL + 1))
+fi
+
+rm -f "$HELPER_BIN"
+
+echo "namedColor2 apply regression: $PASS passed, $FAIL failed, $TOTAL total"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/.github/workflows/ci-comprehensive-build-test.yml
+++ b/.github/workflows/ci-comprehensive-build-test.yml
@@ -156,7 +156,7 @@ jobs:
           git config --add safe.directory "$PWD"
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
-          sudo apt-get update -qq
+          bash .github/scripts/ci-safe-apt-update.sh
           sudo apt-get install -y \
             build-essential cmake gcc g++ clang ccache \
             libpng-dev libxml2-dev libtiff-dev \
@@ -395,7 +395,7 @@ jobs:
           git config --add safe.directory "$PWD"
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
-          sudo apt-get update -qq
+          bash .github/scripts/ci-safe-apt-update.sh
           sudo apt-get install -y \
             build-essential cmake clang llvm \
             libpng-dev libxml2-dev libtiff-dev nlohmann-json3-dev
@@ -595,7 +595,7 @@ jobs:
           git config --add safe.directory "$PWD"
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
-          sudo apt-get update -qq
+          bash .github/scripts/ci-safe-apt-update.sh
           sudo apt-get install -y \
             build-essential cmake clang \
             libpng-dev libxml2-dev libtiff-dev nlohmann-json3-dev
@@ -868,7 +868,7 @@ jobs:
           git config --add safe.directory "$PWD"
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
-          sudo apt-get update -qq
+          bash .github/scripts/ci-safe-apt-update.sh
           sudo apt-get install -y build-essential cmake libpng-dev libxml2-dev libtiff-dev nlohmann-json3-dev
 
       - name: Disable wxWidgets (headless CI)
@@ -959,7 +959,7 @@ jobs:
           git config --add safe.directory "$PWD"
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
-          sudo apt-get update -qq
+          bash .github/scripts/ci-safe-apt-update.sh
           sudo apt-get install -y build-essential cmake libpng-dev libxml2-dev libtiff-dev nlohmann-json3-dev
 
       - name: Disable wxWidgets (headless CI)
@@ -1066,7 +1066,7 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
-          sudo apt-get update -qq
+          bash .github/scripts/ci-safe-apt-update.sh
           sudo apt-get install -y build-essential cmake libpng-dev libxml2-dev libtiff-dev nlohmann-json3-dev
 
       # ── macOS dependencies ──

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -64,7 +64,7 @@ jobs:
           set -euo pipefail
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
-          sudo apt-get update -qq
+          bash .github/scripts/ci-safe-apt-update.sh
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake \
             clang-18 clang++-18 llvm-18 \
@@ -1993,6 +1993,32 @@ jobs:
           echo "  Issue #955 lut16 invalid curve count validation: $r23_pass passed, $r23_fail failed"
           passed=$((passed + r23_pass))
           failed=$((failed + r23_fail))
+
+          # --- R24: namedColor2 pixel-to-name apply validation ---
+          echo "--- R24: namedColor2 pixel-to-name apply validation ---"
+          r24_pass=0 r24_fail=0
+          NAMEDCOLOR_APPLY_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-namedcolor-apply-regression-tests.sh"
+          if [ -f "$NAMEDCOLOR_APPLY_SCRIPT" ]; then
+            chmod +x "$NAMEDCOLOR_APPLY_SCRIPT"
+            r24_ec=0
+            ICCDEV_TOOLS_DIR="${WORKSPACE_DIR}/build/Tools" \
+              ICCDEV_TESTING_DIR="${WORKSPACE_DIR}/Testing" \
+              ICCDEV_TEST_OUTDIR="$OUTDIR/r24-namedcolor-apply" \
+              "$NAMEDCOLOR_APPLY_SCRIPT" > "$OUTDIR/r24-namedcolor-apply.log" 2>&1 || r24_ec=$?
+            cat "$OUTDIR/r24-namedcolor-apply.log"
+            if [ "$r24_ec" -eq 0 ]; then
+              echo "  [OK]    namedColor2 pixel-to-name apply rejects malformed device data"
+              r24_pass=$((r24_pass + 1))
+            else
+              echo "  [FAIL]  namedColor2 apply regression script exited $r24_ec"
+              r24_fail=$((r24_fail + 1))
+            fi
+          else
+            echo "  [SKIP]  namedColor2 apply regression script not found"
+          fi
+          echo "  namedColor2 pixel-to-name apply validation: $r24_pass passed, $r24_fail failed"
+          passed=$((passed + r24_pass))
+          failed=$((failed + r24_fail))
 
           echo ""
           echo "Regression checks: $passed passed, $failed failed"

--- a/.github/workflows/ci-tool-tests.yml
+++ b/.github/workflows/ci-tool-tests.yml
@@ -14,7 +14,8 @@
 #      standard observer XML/JSON alias compatibility, issue #928 mluc setter
 #      canonical length checks, mluc read/UTF-16 validation, and issue #958
 #      PCC zero-Y illuminant validation, calculator sanitizer regressions,
-#      and lut16 invalid curve count validation
+#      lut16 invalid curve count validation, and namedColor2 pixel-to-name
+#      apply guards
 #
 # Hardening:
 #   - sanitize-sed.sh sourced in every step
@@ -36,6 +37,7 @@
 #   .github/scripts/iccdev-calculator-regression-tests.sh
 #   .github/scripts/iccdev-lut16-zero-curve-regression-tests.sh
 #   .github/ci/regression/lut16-zero-entry-curve-write.cpp
+#   .github/scripts/iccdev-namedcolor-apply-regression-tests.sh
 #
 ###############################################################
 
@@ -61,9 +63,12 @@ on:
       - '.github/ci/regression/pcc-zero-illuminant.cpp'
       - '.github/scripts/iccdev-calculator-regression-tests.sh'
       - '.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh'
+      - '.github/scripts/iccdev-namedcolor-apply-regression-tests.sh'
+      - '.github/scripts/ci-safe-apt-update.sh'
       - '.github/scripts/json-cli-exercise.sh'
       - '.github/ci/regression/lut16-zero-entry-curve-write.cpp'
       - '.github/ci/test-data/**'
+      - '.github/ci/regression/**'
       - 'IccProfLib/**'
       - 'IccXML/**'
       - 'IccJSON/**'
@@ -143,7 +148,7 @@ jobs:
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
 
-          sudo apt-get update -qq
+          bash .github/scripts/ci-safe-apt-update.sh
           sudo apt-get install -y --no-install-recommends \
             build-essential cmake clang-18 clang++-18 \
             libxml2-dev libtiff-dev libpng-dev libjpeg-dev \
@@ -1141,6 +1146,32 @@ jobs:
           echo "  Issue #955 lut16 invalid curve count validation: $r19_pass passed, $r19_fail failed"
           passed=$((passed + r19_pass))
           failed=$((failed + r19_fail))
+
+          # --- R20: namedColor2 pixel-to-name apply validation ---
+          echo "--- R20: namedColor2 pixel-to-name apply validation ---"
+          r20_pass=0 r20_fail=0
+          NAMEDCOLOR_APPLY_SCRIPT="${WORKSPACE_DIR}/.github/scripts/iccdev-namedcolor-apply-regression-tests.sh"
+          if [ -f "$NAMEDCOLOR_APPLY_SCRIPT" ]; then
+            chmod +x "$NAMEDCOLOR_APPLY_SCRIPT"
+            r20_ec=0
+            ICCDEV_TOOLS_DIR="${WORKSPACE_DIR}/build/Tools" \
+              ICCDEV_TESTING_DIR="${WORKSPACE_DIR}/Testing" \
+              ICCDEV_TEST_OUTDIR="$OUTDIR/r20-namedcolor-apply" \
+              "$NAMEDCOLOR_APPLY_SCRIPT" > "$OUTDIR/r20-namedcolor-apply.log" 2>&1 || r20_ec=$?
+            cat "$OUTDIR/r20-namedcolor-apply.log"
+            if [ "$r20_ec" -eq 0 ]; then
+              echo "  [OK]    namedColor2 pixel-to-name apply rejects malformed device data"
+              r20_pass=$((r20_pass + 1))
+            else
+              echo "  [FAIL]  namedColor2 apply regression script exited $r20_ec"
+              r20_fail=$((r20_fail + 1))
+            fi
+          else
+            echo "  [SKIP]  namedColor2 apply regression script not found"
+          fi
+          echo "  namedColor2 pixel-to-name apply validation: $r20_pass passed, $r20_fail failed"
+          passed=$((passed + r20_pass))
+          failed=$((failed + r20_fail))
 
           echo ""
           echo "Regression checks: $passed passed, $failed failed"

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -6900,7 +6900,8 @@ icStatusCMM CIccXformNamedColor::Apply(CIccApplyXform* pApply, icChar *DstColorN
 
     icFloatNumber DevicePix[16], PCSPix[3];
     std::string NamedColor;
-    icUInt32Number i, j;
+    icUInt32Number i;
+    icInt32Number j;
 
     if (IsSrcPCS()) {
       if (m_bSrcPcsConversion)
@@ -6910,14 +6911,20 @@ icStatusCMM CIccXformNamedColor::Apply(CIccApplyXform* pApply, icChar *DstColorN
         PCSPix[i] = SrcPixel[i];
 
       j = pTag->FindCachedPCSColor(PCSPix);
-      pTag->GetColorName(NamedColor, j);
+      if (j<0 || !pTag->GetColorName(NamedColor, j))
+        return icCmmStatColorNotFound;
     }
     else {
-      for(i=0; i<m_pTag->GetDeviceCoords(); i++)
+      const icUInt32Number nDeviceCoords = pTag->GetDeviceCoords();
+      if (nDeviceCoords > 16)
+        return icCmmStatTooManySamples;
+
+      for(i=0; i<nDeviceCoords; i++)
         DevicePix[i] = SrcPixel[i];
 
       j = pTag->FindDeviceColor(DevicePix);
-      pTag->GetColorName(NamedColor, j);
+      if (j<0 || !pTag->GetColorName(NamedColor, j))
+        return icCmmStatColorNotFound;
     }
 
     snprintf(DstColorName, 256, "%s", NamedColor.c_str());
@@ -9932,7 +9939,10 @@ icStatusCMM CIccApplyNamedColorCmm::Apply(icFloatNumber *DstPixel, const icFloat
           break;
 
         case icApplyPixel2Named:
-          pXform->Apply(pApply, NamedColor, pSrc);
+          rv = pXform->Apply(pApply, NamedColor, pSrc);
+          if (rv) {
+            return rv;
+          }
 #ifdef DEBUG_CMM_APPLY
           printf("Xfm%d: \"%s\"\n", nCount++, NamedColor);
 #endif
@@ -10088,7 +10098,10 @@ icStatusCMM CIccApplyNamedColorCmm::Apply(icFloatNumber *DstPixel, const icFloat
             break;
 
           case icApplyPixel2Named:
-            pXform->Apply(pApply, NamedColor, pSrc);
+            rv = pXform->Apply(pApply, NamedColor, pSrc);
+            if (rv) {
+              return rv;
+            }
             break;
 
           case icApplyNamed2Pixel:
@@ -10213,7 +10226,10 @@ icStatusCMM CIccApplyNamedColorCmm::Apply(icChar* DstColorName, const icFloatNum
           break;
 
         case icApplyPixel2Named:
-          pXform->Apply(pApply, NamedColor, pSrc);
+          rv = pXform->Apply(pApply, NamedColor, pSrc);
+          if (rv) {
+            return rv;
+          }
           break;
 
         case icApplyNamed2Pixel:
@@ -10249,7 +10265,10 @@ icStatusCMM CIccApplyNamedColorCmm::Apply(icChar* DstColorName, const icFloatNum
       switch(pXform->GetInterface()) {
 
       case icApplyPixel2Named:
-        pXform->Apply(pApply, DstColorName, pSrc);
+        rv = pXform->Apply(pApply, DstColorName, pSrc);
+        if (rv) {
+          return rv;
+        }
         break;
 
       case icApplyPixel2Pixel:
@@ -10274,7 +10293,10 @@ icStatusCMM CIccApplyNamedColorCmm::Apply(icChar* DstColorName, const icFloatNum
     }
 
     pXform = (CIccXformNamedColor*)pApplyXform;
-    pXform->Apply(pApply, DstColorName, pSrc);
+    rv = pXform->Apply(pApply, DstColorName, pSrc);
+    if (rv) {
+      return rv;
+    }
   }
 
   return icCmmStatOk;
@@ -10475,7 +10497,10 @@ icStatusCMM CIccApplyNamedColorCmm::Apply(icChar *DstColorName, const icChar *Sr
 
 
         case icApplyPixel2Named:
-          pXform->Apply(pApply, NamedColor, pSrc);
+          rv = pXform->Apply(pApply, NamedColor, pSrc);
+          if (rv) {
+            return rv;
+          }
           break;
 
         case icApplyNamed2Pixel:
@@ -10504,7 +10529,10 @@ icStatusCMM CIccApplyNamedColorCmm::Apply(icChar *DstColorName, const icChar *Sr
       pXform = (CIccXformNamedColor*)pApplyXform;
       switch(pXform->GetInterface()) {
       case icApplyPixel2Named:
-        pXform->Apply(pApply, DstColorName, pSrc);
+        rv = pXform->Apply(pApply, DstColorName, pSrc);
+        if (rv) {
+          return rv;
+        }
         break;
 
       case icApplyPixel2Pixel:


### PR DESCRIPTION
## PR Summary

#961 #963

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant profile tests (`Testing/CreateAllProfiles.*` and `Testing/RunTests.*`)
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## CI Mods
-  `.github/scripts/iccdev-namedcolor-apply-regression-tests.sh` | #963 #961 AFL apply namedColor2 | `CIccXformNamedColor::Apply` copied more than 16 device coordinates and accepted negative lookup results | Builds a small helper that verifies valid lookup, color-not-found, and too-many-device-coordinate paths without sanitizer finding