### PR TITLE
Fix: invalid BCD version #979

### DIFF
--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -26,6 +26,7 @@ Test 18 (Regression Bisect).
 | `.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh` | #955 | `lut16Type` write path took `&curve[0]` for zero-entry curves, binding a reference through a null curve buffer | Compiles a small `CIccTagLut16` writer and verifies invalid table counts are rejected without sanitizer findings |
 | `.github/scripts/iccdev-namedcolor-apply-regression-tests.sh` | AFL apply namedColor2 | `CIccXformNamedColor::Apply` copied more than 16 device coordinates and accepted negative lookup results | Builds a small helper that verifies valid lookup, color-not-found, and too-many-device-coordinate paths without sanitizer findings |
 | `.github/scripts/iccdev-v5-namedcmm-regression-tests.sh` | v5 NamedCMM bring-up | v5 non-spectral DToB/BRDFDToB and matrix/TRC fallback paths were skipped by CMM selection | Recreates compact v5 profiles in the configured test output directory and verifies `iccApplyNamedCmm` plus `iccRoundTrip` complete without sanitizer findings |
+| `.github/scripts/iccdev-version-bcd-regression-tests.sh` | `bisect-version-bcd-report` | ICC header version bytes with non-BCD nibbles were decoded as decimal-looking versions such as 141.91 | Mutates a known-good ICC profile version to `0xDB91BA7B` and verifies explicit invalid BCD diagnostics plus valid-version compatibility |
 
 ## Adding a new PoC
 

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -37,7 +37,7 @@ ctest --test-dir out/vs2022-x64 -C Release --output-on-failure --no-tests=error
 cmake --build out/vs2022-x64 --config Release --target check
 ```
 
-Linux currently registers 14 CTest suites. Windows currently registers 2 CTest
+Linux currently registers 15 CTest suites. Windows currently registers 2 CTest
 suites through `Build/Cmake/Testing/RunWindowsBatchTest.cmake`. The Windows
 wrapper runs the batch scripts from a disposable copy of `Testing/` under the
 build tree and must not dirty the source `Testing/` directory.
@@ -62,6 +62,7 @@ Script-based gates live in `.github/scripts/`, including:
 - `iccdev-mluc-setter-regression-tests.sh`
 - `iccdev-mluc-read-utf16-regression-tests.sh`
 - `iccdev-namedcolor-apply-regression-tests.sh`
+- `iccdev-version-bcd-regression-tests.sh`
 
 When adding a new regression input, add the matching script or workflow assertion
 in the same change.

--- a/.github/scripts/iccdev-version-bcd-regression-tests.sh
+++ b/.github/scripts/iccdev-version-bcd-regression-tests.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+###############################################################################
+# iccDEV invalid BCD profile version regression tests
+###############################################################################
+#
+# Exercises ICC header version bytes with non-BCD nibbles. Malformed BCD values
+# must be reported as invalid instead of being decoded as decimal-looking ICC
+# versions such as 141.91.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-version-bcd-regressions}"
+mkdir -p "$OUTDIR"
+
+DUMP="$TOOLS_DIR/IccDumpProfile/iccDumpProfile"
+PROFILE="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+MUTATED="$OUTDIR/invalid-bcd-version.icc"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+ASAN_FINDINGS=0
+UBSAN_FINDINGS=0
+TOTAL=0
+
+check_sanitizers() {
+  local name="$1"
+  local logfile="$2"
+
+  if grep -q "ERROR: AddressSanitizer" "$logfile" 2>/dev/null; then
+    echo "  [ASAN] $name -- AddressSanitizer finding"
+    ASAN_FINDINGS=$((ASAN_FINDINGS + 1))
+    return 1
+  fi
+
+  if grep -q "runtime error:" "$logfile" 2>/dev/null; then
+    echo "  [UBSAN] $name -- undefined behavior"
+    UBSAN_FINDINGS=$((UBSAN_FINDINGS + 1))
+    return 1
+  fi
+
+  return 0
+}
+
+fail_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [FAIL] $name -- $reason"
+  FAIL=$((FAIL + 1))
+}
+
+pass_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [PASS] $name -- $reason"
+  PASS=$((PASS + 1))
+}
+
+require_text() {
+  local name="$1"
+  local logfile="$2"
+  local expected="$3"
+
+  if ! grep -Fq "$expected" "$logfile" 2>/dev/null; then
+    fail_case "$name" "missing expected text: $expected"
+    sed -n '1,40p' "$logfile"
+    return 1
+  fi
+
+  return 0
+}
+
+run_invalid_bcd_dump() {
+  local name="invalid-bcd-version-dump"
+  local logfile="$OUTDIR/$name.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$MUTATED" "$logfile"
+
+  if [ ! -x "$DUMP" ]; then
+    fail_case "$name" "missing executable $DUMP"
+    return
+  fi
+
+  if [ ! -f "$PROFILE" ]; then
+    fail_case "$name" "missing profile $PROFILE"
+    return
+  fi
+
+  if ! python3 -c 'import sys; src, dst = sys.argv[1:3]; data = bytearray(open(src, "rb").read()); assert len(data) >= 128; data[8:12] = bytes.fromhex("DB91BA7B"); data[120:124] = b"test"; open(dst, "wb").write(data)' "$PROFILE" "$MUTATED"; then
+    fail_case "$name" "failed to create mutated profile"
+    return
+  fi
+
+  timeout 30 "$DUMP" -v "$MUTATED" ALL > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+
+  if [ "$exit_code" -ge 129 ] && [ "$exit_code" -le 192 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    return
+  fi
+
+  require_text "$name" "$logfile" "Version:            Invalid BCD version 0xDB91BA7B" || return
+  require_text "$name" "$logfile" "SubClass Version:   Invalid BCD subclass version 0xBA7B" || return
+  require_text "$name" "$logfile" "Profile violates ICC specification for version Invalid BCD version 0xDB91BA7B" || return
+  require_text "$name" "$logfile" "Warning! - Version number 0xDB91BA7B contains non-BCD digit(s)." || return
+
+  if grep -Fq "Version:            141.91" "$logfile" 2>/dev/null; then
+    fail_case "$name" "invalid BCD value was decoded as 141.91"
+    return
+  fi
+
+  pass_case "$name" "invalid BCD version rejected with explicit diagnostics"
+}
+
+run_valid_bcd_smoke() {
+  local name="valid-bcd-version-smoke"
+  local logfile="$OUTDIR/$name.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile"
+
+  if [ ! -x "$DUMP" ]; then
+    fail_case "$name" "missing executable $DUMP"
+    return
+  fi
+
+  if [ ! -f "$PROFILE" ]; then
+    fail_case "$name" "missing profile $PROFILE"
+    return
+  fi
+
+  timeout 30 "$DUMP" -v "$PROFILE" ALL > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "valid profile exited $exit_code"
+    sed -n '1,40p' "$logfile"
+    return
+  fi
+
+  require_text "$name" "$logfile" "Version:            4.20" || return
+  require_text "$name" "$logfile" "Profile is valid for version 4.20" || return
+
+  if grep -Fq "Invalid BCD" "$logfile" 2>/dev/null; then
+    fail_case "$name" "valid BCD profile reported invalid BCD text"
+    return
+  fi
+
+  pass_case "$name" "valid BCD version formatting preserved"
+}
+
+echo "=== invalid BCD profile version regression ==="
+
+run_invalid_bcd_dump
+run_valid_bcd_smoke
+
+echo "invalid BCD profile version regression: $PASS passed, $FAIL failed, $TOTAL total"
+echo "sanitizer findings: ASAN=$ASAN_FINDINGS UBSAN=$UBSAN_FINDINGS"
+
+if [ "$FAIL" -ne 0 ] || [ "$ASAN_FINDINGS" -ne 0 ] || [ "$UBSAN_FINDINGS" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/.github/skills/maintainer-ci-ctest/SKILL.md
+++ b/.github/skills/maintainer-ci-ctest/SKILL.md
@@ -44,7 +44,7 @@ when practical.
 
 - `check` must exist on every platform.
 - `check` and workflow CTest execution must use `--no-tests=error`.
-- Linux suite count assertions currently expect `Total Tests: 14`.
+- Linux suite count assertions currently expect `Total Tests: 15`.
 - Windows currently registers 2 CTest suites and validates 129 profile parses.
 - JSON round-trip profile generation validates 129 profile parses.
 - WASM parity currently expects 207 generated ICC profiles.

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -128,8 +128,8 @@ jobs:
 
           CTEST_LIST="${BUILD_DIR}/ctest-list.txt"
           ctest --test-dir "${BUILD_DIR}" -N --no-tests=error | tee "${CTEST_LIST}"
-          if ! grep -q "^Total Tests: 15$" "${CTEST_LIST}"; then
-            echo "::error title=CTest Discovery::Expected Total Tests: 15"
+          if ! grep -q "^Total Tests: 16$" "${CTEST_LIST}"; then
+            echo "::error title=CTest Discovery::Expected Total Tests: 16"
             cat "${CTEST_LIST}"
             exit 1
           fi

--- a/.github/workflows/ci-pr-unix.yml
+++ b/.github/workflows/ci-pr-unix.yml
@@ -244,17 +244,22 @@ jobs:
         shell: bash --noprofile --norc {0}
         env:
           BASH_ENV: /dev/null
+          MATRIX_BUILD_TYPE: ${{ matrix.build_type }}
         run: |
           set -euo pipefail
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
           BITCODE_FOUND=0
-          for lib in Build/IccProfLib/libIccProfLib2-static.a \
-                     Build/IccXML/libIccXML2-static.a \
-                     Build/IccJSON/libIccJSON2-static.a; do
+          STATIC_POSTFIX=""
+          if [ "$MATRIX_BUILD_TYPE" = "Debug" ]; then
+            STATIC_POSTFIX="d"
+          fi
+          for lib in Build/IccProfLib/libIccProfLib2-static${STATIC_POSTFIX}.a \
+                     Build/IccXML/libIccXML2-static${STATIC_POSTFIX}.a \
+                     Build/IccJSON/libIccJSON2-static${STATIC_POSTFIX}.a; do
             if [ ! -f "$lib" ]; then
-              echo "[SKIP] $lib not found"
-              continue
+              echo "::error title=Missing Static Library::$lib not found"
+              exit 1
             fi
             TMP_DIR="$(mktemp -d)"
             (cd "$TMP_DIR" && ar x "$GITHUB_WORKSPACE/$lib")

--- a/.github/workflows/ci-tool-tests.yml
+++ b/.github/workflows/ci-tool-tests.yml
@@ -32,6 +32,7 @@ on:
       - '.github/scripts/iccdev-calculator-regression-tests.sh'
       - '.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh'
       - '.github/scripts/iccdev-namedcolor-apply-regression-tests.sh'
+      - '.github/scripts/iccdev-version-bcd-regression-tests.sh'
       - '.github/scripts/json-cli-exercise.sh'
       - '.github/ci/test-data/**'
       - '.github/ci/regression/**'
@@ -156,8 +157,8 @@ jobs:
 
           CTEST_LIST="${BUILD_DIR}/ctest-list.txt"
           ctest --test-dir "${BUILD_DIR}" -N --no-tests=error | tee "${CTEST_LIST}"
-          if ! grep -q "^Total Tests: 15$" "${CTEST_LIST}"; then
-            echo "::error title=CTest Discovery::Expected Total Tests: 15"
+          if ! grep -q "^Total Tests: 16$" "${CTEST_LIST}"; then
+            echo "::error title=CTest Discovery::Expected Total Tests: 16"
             cat "${CTEST_LIST}"
             exit 1
           fi

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -360,3 +360,14 @@ iccdev_add_script_test(
 set_tests_properties(iccdev.v5-namedcmm-regressions PROPERTIES
   FIXTURES_REQUIRED iccdev_profiles
 )
+
+iccdev_add_script_test(
+  iccdev.version-bcd-regressions
+  300
+  "iccdev;version;bcd;regression;asan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-version-bcd-regression-tests.sh"
+)
+set_tests_properties(iccdev.version-bcd-regressions PROPERTIES
+  FIXTURES_REQUIRED iccdev_profiles
+)

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1792,6 +1792,18 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
     }
 
     icUInt8Number  bcdpair = (icUInt8Number)(m_Header.version >> 24);
+    bool bInvalidVersionBcd =
+        ((bcdpair >> 4) > 9) || ((bcdpair & 0x0F) > 9) ||
+        ((((m_Header.version & 0x00FF0000) >> 20) & 0x0F) > 9) ||
+        ((((m_Header.version & 0x00FF0000) >> 16) & 0x0F) > 9);
+
+    if (bInvalidVersionBcd) {
+        sReport += icMsgValidateWarning;
+        snprintf(buf, bufSize, "Version number 0x%08X contains non-BCD digit(s).\n", m_Header.version);
+        sReport += buf;
+        rv = icMaxStatus(rv, icValidateWarning);
+    }
+
     // Report on unusual version (stored as BCD)
     if (bcdpair<0x05 && (m_Header.version & 0x0000FFFF)) {
         sReport += icMsgValidateWarning;

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -1498,8 +1498,19 @@ const icChar *CIccInfo::GetUnknownName(icUInt32Number val)
   return m_szStr;
 }
 
+static bool icIsValidBcdByte(icUInt32Number val)
+{
+  return ((val >> 4) & 0xf) <= 9 && (val & 0xf) <= 9;
+}
+
 const icChar *CIccInfo::GetVersionName(icUInt32Number val)
 {
+  if (!icIsValidBcdByte((val >> 24) & 0xff) ||
+      !icIsValidBcdByte((val >> 16) & 0xff)) {
+    snprintf(m_szStr, m_bufSize, "Invalid BCD version 0x%08X", val);
+    return m_szStr;
+  }
+
   icFloatNumber ver = (icFloatNumber)(((val>>28)&0xf)*10.0 + ((val>>24)&0xf) +
                                       ((val>>20)&0xf)/10.0 + ((val>>16)&0xf)/100.0);
 
@@ -1510,6 +1521,12 @@ const icChar *CIccInfo::GetVersionName(icUInt32Number val)
 
 const icChar *CIccInfo::GetSubClassVersionName(icUInt32Number val)
 {
+  if (!icIsValidBcdByte((val >> 8) & 0xff) ||
+      !icIsValidBcdByte(val & 0xff)) {
+    snprintf(m_szStr, m_bufSize, "Invalid BCD subclass version 0x%04X", val & 0xffff);
+    return m_szStr;
+  }
+
   icFloatNumber ver = (icFloatNumber)(((val >> 12) & 0xf)*10.0 + ((val >> 8) & 0xf) +
     ((val >> 4) & 0xf) / 10.0 + (val & 0xf) / 100.0);
 

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -2867,8 +2867,21 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
             return false;
           }
 
-          SetSize(num);
+          if (!SetSize(num)) {
+            parseStr += "Out of memory allocating curve data from '";
+            parseStr += filename;
+            parseStr += "'.\n";
+            delete file;
+            return false;
+          }
           icFloatNumber *dst =  GetData(0);
+          if (num && !dst) {
+            parseStr += "Curve data allocation failed for '";
+            parseStr += filename;
+            parseStr += "'.\n";
+            delete file;
+            return false;
+          }
           icUInt32Number i;
           for (i=0; i<num; i++) {
             if (!file->Read8(&value)) { 
@@ -2894,8 +2907,21 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
             return false;
           }
 
-          SetSize(num);
+          if (!SetSize(num)) {
+            parseStr += "Out of memory allocating curve data from '";
+            parseStr += filename;
+            parseStr += "'.\n";
+            delete file;
+            return false;
+          }
           icFloatNumber *dst = GetData(0);
+          if (num && !dst) {
+            parseStr += "Curve data allocation failed for '";
+            parseStr += filename;
+            parseStr += "'.\n";
+            delete file;
+            return false;
+          }
           icUInt32Number i;
           for (i=0; i<num; i++) {
             if (!file->Read16(&value)) {  //this assumes data is big endian
@@ -2930,8 +2956,21 @@ bool CIccTagXmlCurve::ParseXml(xmlNode *pNode, icConvertType nType, std::string 
             return false;
           }
 
-          SetSize(num);
+          if (!SetSize(num)) {
+            parseStr += "Out of memory allocating curve data from '";
+            parseStr += filename;
+            parseStr += "'.\n";
+            delete file;
+            return false;
+          }
           icFloatNumber *dst = GetData(0);
+          if (num && !dst) {
+            parseStr += "Curve data allocation failed for '";
+            parseStr += filename;
+            parseStr += "'.\n";
+            delete file;
+            return false;
+          }
 
           icUInt32Number i;
           for (i=0; i<num; i++) {

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -47,7 +47,7 @@ cannot pass as a green no-op.
 
 ## Registered Suites
 
-Linux currently registers 15 tests:
+Linux currently registers 16 tests:
 
 | Test | Source |
 |------|--------|
@@ -66,6 +66,7 @@ Linux currently registers 15 tests:
 | `iccdev.lut16-zero-curve-regressions` | `.github/scripts/iccdev-lut16-zero-curve-regression-tests.sh` |
 | `iccdev.namedcolor-apply-regressions` | `.github/scripts/iccdev-namedcolor-apply-regression-tests.sh` |
 | `iccdev.v5-namedcmm-regressions` | `.github/scripts/iccdev-v5-namedcmm-regression-tests.sh` |
+| `iccdev.version-bcd-regressions` | `.github/scripts/iccdev-version-bcd-regression-tests.sh` |
 
 `iccdev.legacy-run-tests` requires `iccToJson` and `iccFromJson` under CTest.
 The JSON round-trip uses a temporary directory for generated `.json` and


### PR DESCRIPTION
## PR Summary

Fix: invalid BCD version #979

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] Did change maintainer-owned workflow
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
