### PR TITLE
IccProfLib: thread CLUT scratch buffers + per-tag Validate in describe-sink test

### DIFF
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -78,6 +78,7 @@
 #include <cmath>
 #include <cstring>
 #include <cstdlib>
+#include <vector>
 #include "IccTag.h"
 #include "IccUtil.h"
 #include "IccProfile.h"
@@ -1730,8 +1731,6 @@ CIccCLUT::CIccCLUT(icUInt8Number nInputChannels, icUInt16Number nOutputChannels,
   m_nPrecision = nPrecision;
   m_pData = NULL;
   m_nOffset = NULL;
-  m_pOutText = NULL;
-  m_pVal = NULL;
   m_nNumPoints = 0;
   m_nNodes = 0;
   m_csInput = icSigUnknownData;
@@ -2073,22 +2072,26 @@ bool CIccCLUT::Write(CIccIO *pIO)
  *  sDescription = string to concatenate data dump to,
  *  nIndex = the channel number,
  *  nPos = the current position in the CLUT
- *  bufSize = the size of the buffer m_pOutText, for error checking
+ *  bufSize = the size of the row-format scratch buffer, for error checking
  *
  *****************************************************************************
  */
 void CIccCLUT::Iterate(std::string &sDescription, icUInt8Number nIndex, icUInt32Number nPos, size_t bufSize, bool bUseLegacy )
 {
-  // Delegate to the sink-based recursion via a string sink. The legacy
-  // protected entry point is preserved so any external callers that
-  // override or invoke it directly keep working byte-for-byte.
+  // Delegate to the sink-based recursion via a string sink. Allocates the
+  // scratch buffers locally — keeps the legacy protected entry point
+  // self-contained so any external callers keep working byte-for-byte.
+  std::vector<icChar> outBuf(bufSize ? bufSize : 1);
+  icChar valBuf[40];
   StringDescribeSink sink(sDescription);
-  Iterate(sink, nIndex, nPos, bufSize, bUseLegacy, /*cellsRemaining=*/NULL);
+  Iterate(sink, nIndex, nPos, bufSize, bUseLegacy, /*cellsRemaining=*/NULL,
+          outBuf.data(), valBuf, sizeof(valBuf));
 }
 
 void CIccCLUT::Iterate(IDescribeSink &sink, icUInt8Number nIndex, icUInt32Number nPos,
                        size_t bufSize, bool bUseLegacy,
-                       std::size_t *cellsRemaining)
+                       std::size_t *cellsRemaining,
+                       icChar *pOutText, icChar *pVal, std::size_t valSize)
 {
   // CWE-674: ICC spec caps LUT input channels at 16 (icMaxChannels).
   // Bound recursion depth defensively even though m_nInput is icUInt8Number.
@@ -2103,7 +2106,8 @@ void CIccCLUT::Iterate(IDescribeSink &sink, icUInt8Number nIndex, icUInt32Number
     int i;
     for (i=0; i<m_GridPoints[nIndex]; i++) {
       m_GridAdr[nIndex] = i;
-      Iterate(sink, nIndex+1, nPos, bufSize, bUseLegacy, cellsRemaining);
+      Iterate(sink, nIndex+1, nPos, bufSize, bUseLegacy, cellsRemaining,
+              pOutText, pVal, valSize);
       if (cellsRemaining && *cellsRemaining == 0)
         return;
       if (!sink.ShouldContinue())
@@ -2112,19 +2116,18 @@ void CIccCLUT::Iterate(IDescribeSink &sink, icUInt8Number nIndex, icUInt32Number
     }
   }
   else {
-    icChar *ptr = m_pOutText;
+    icChar *ptr = pOutText;
     icChar *ptrEnd = ptr + bufSize;
     icFloatNumber *pData = &m_pData[nPos];
     int i;
 
     for (i=0; i<m_nInput; i++) {
-// TODO - hard coding size temporarily, really should be passed in
-      icColorValue(m_pVal, 40, (icFloatNumber)m_GridAdr[i] / (m_GridPoints[i]-1) , m_csInput, i, bUseLegacy);
+      icColorValue(pVal, valSize, (icFloatNumber)m_GridAdr[i] / (m_GridPoints[i]-1), m_csInput, i, bUseLegacy);
 
 // TODO - this buffer handling is sloppy, but should be ok for now
 // really needs to be refactored, needs some sort of error return if buffer overflows
 // right now it will terminate the output when the buffer overflows
-      ptr += snprintf(ptr, size_t(ptrEnd-ptr), " %s", m_pVal);
+      ptr += snprintf(ptr, size_t(ptrEnd-ptr), " %s", pVal);
       if (ptr >= ptrEnd)
             return;
     }
@@ -2132,15 +2135,14 @@ void CIccCLUT::Iterate(IDescribeSink &sink, icUInt8Number nIndex, icUInt32Number
     ptr += 2;
 
     for (i=0; i<m_nOutput; i++) {
-// TODO - hard coding size temporarily, really should be passed in
-      icColorValue(m_pVal, 40, pData[i], m_csOutput, i, bUseLegacy);
+      icColorValue(pVal, valSize, pData[i], m_csOutput, i, bUseLegacy);
 
-      ptr += snprintf(ptr, size_t(ptrEnd-ptr), " %s", m_pVal);
+      ptr += snprintf(ptr, size_t(ptrEnd-ptr), " %s", pVal);
       if (ptr >= ptrEnd)
             return;
     }
     strcpy(ptr, "\n");
-    sink.Write((const char*)m_pOutText, strlen(m_pOutText));
+    sink.Write((const char*)pOutText, strlen(pOutText));
 
     if (cellsRemaining && *cellsRemaining > 0)
       --(*cellsRemaining);
@@ -2300,13 +2302,11 @@ void CIccCLUT::DumpLut(IDescribeSink &sink, const icChar *szName,
   if (!sink.ShouldContinue())
     return;
 
-  // Initialize iteration member variables. Same instance-level scratch
-  // pointers as the legacy path — preserves the existing thread-safety
-  // contract (Describe is per-instance non-reentrant).
+  // Cache the colour-space signatures so Iterate can format channel labels.
+  // Scratch buffers are threaded through Iterate as parameters, which keeps
+  // the stack arrays' lifetimes confined to this function frame.
   m_csInput = csInput;
   m_csOutput = csOutput;
-  m_pOutText = szOutText;
-  m_pVal = szColor;
   memset(m_GridAdr, 0, 16);
 
   // Apply opts.max_clut_cells_per_tag as a budget on emitted cells.
@@ -2314,7 +2314,8 @@ void CIccCLUT::DumpLut(IDescribeSink &sink, const icChar *szName,
   std::size_t *budgetPtr = budget ? &budget : NULL;
   std::size_t budgetStart = budget;
 
-  Iterate(sink, 0, 0, outSize, bUseLegacy, budgetPtr);
+  Iterate(sink, 0, 0, outSize, bUseLegacy, budgetPtr,
+          szOutText, szColor, nameSize);
 
   // If we ran out of budget mid-dump, mark the truncation explicitly.
   if (budgetPtr && budget == 0 && sink.ShouldContinue()) {
@@ -2322,10 +2323,6 @@ void CIccCLUT::DumpLut(IDescribeSink &sink, const icChar *szName,
                  "[clut cells truncated after %zu]\n", budgetStart);
     if (n > 0) sink.Write(szOutText, (std::size_t)n);
   }
-
-  // Reset member pointers to avoid dangling references to stack arrays
-  m_pOutText = NULL;
-  m_pVal = NULL;
 }
 
 

--- a/IccProfLib/IccTagLut.h
+++ b/IccProfLib/IccTagLut.h
@@ -383,9 +383,13 @@ public:
 protected:
   void Iterate(std::string &sDescription, icUInt8Number nIndex, icUInt32Number nPos, size_t bufSize, bool bUseLegacy=false );
   // Sink-based iteration. `cellsRemaining`==NULL means unbounded.
+  // `pOutText` is a row-format scratch buffer of size `bufSize`; `pVal` is a
+  // per-channel-value scratch buffer of size `valSize`. Caller owns both —
+  // they replace the older instance-level scratch members.
   void Iterate(IDescribeSink &sink, icUInt8Number nIndex, icUInt32Number nPos,
                size_t bufSize, bool bUseLegacy,
-               std::size_t *cellsRemaining);
+               std::size_t *cellsRemaining,
+               icChar *pOutText, icChar *pVal, std::size_t valSize);
   void SubIterate(IIccCLUTExec* pExec, icUInt8Number nIndex, icUInt32Number nPos);
 
   icCLUTCLIPFUNC m_UnitClipFunc;
@@ -405,7 +409,6 @@ protected:
   //Iteration temporary variables
   icUInt8Number m_GridAdr[16];
   icFloatNumber m_fGridAdr[16];
-  icChar *m_pOutText, *m_pVal;
   icColorSpaceSignature m_csInput, m_csOutput;
 
   //Tetrahedral interpolation variables

--- a/Tools/CmdLine/IccDescribeSinkTest/iccDescribeSinkTest.cpp
+++ b/Tools/CmdLine/IccDescribeSinkTest/iccDescribeSinkTest.cpp
@@ -35,6 +35,7 @@
 #include "IccProfile.h"
 #include "IccTagBasic.h"
 #include "IccTagLut.h"
+#include "IccUtil.h"
 
 #include <cstdarg>
 #include <cstdio>
@@ -108,6 +109,17 @@ CIccTag *firstLutTag(CIccProfile *pProfile, icSignature *sigOut)
   return NULL;
 }
 
+// Per-tag Validate() — defensive against malformed tag data slipping past
+// whole-profile ValidateIccProfile(). Returns true if the tag is safe to
+// describe; false if Describe() should be skipped.
+bool validateTag(CIccTag *pTag, CIccProfile *pProfile, icSignature sig)
+{
+  std::string sigPath = "tag:" + icGetSigPath(sig);
+  std::string vReport;
+  icValidateStatus vStatus = pTag->Validate(sigPath, vReport, pProfile);
+  return vStatus < icValidateCriticalError;
+}
+
 } // namespace
 
 int main(int argc, char *argv[])
@@ -133,6 +145,11 @@ int main(int argc, char *argv[])
     char sigStr[5];
     tagSigToStr((icSignature)it->TagInfo.sig, sigStr);
 
+    if (!validateTag(pTag, pProfile, (icSignature)it->TagInfo.sig)) {
+      std::printf("[SKIP] tag '%s' failed per-tag Validate; skipping Describe\n", sigStr);
+      continue;
+    }
+
     std::string legacy;
     pTag->Describe(legacy, 100);
 
@@ -152,6 +169,10 @@ int main(int argc, char *argv[])
   // ── Tests 2 & 3: only meaningful on a CLUT-bearing tag ──────────────────
   icSignature lutSig = 0;
   CIccTag *pLutTag = firstLutTag(pProfile, &lutSig);
+  if (pLutTag && !validateTag(pLutTag, pProfile, lutSig)) {
+    std::printf("[SKIP] LUT tag failed per-tag Validate; Tests 2, 3, 5 skipped\n");
+    pLutTag = NULL;
+  }
   if (pLutTag) {
     char lutStr[5];
     tagSigToStr(lutSig, lutStr);
@@ -217,6 +238,9 @@ int main(int argc, char *argv[])
   for (auto it = pProfile->m_Tags.begin(); it != pProfile->m_Tags.end(); ++it) {
     CIccTag *pTag = pProfile->FindTag(it->TagInfo.sig);
     if (!pTag) continue;
+
+    if (!validateTag(pTag, pProfile, (icSignature)it->TagInfo.sig))
+      continue;
 
     std::string legacy;
     pTag->Describe(legacy, 100);


### PR DESCRIPTION
Follow-up to #981. Closes 9 CodeQL alerts introduced by that PR by addressing two underlying design points instead of dismissing the alerts.

## Changes

### 1. `CIccCLUT::Iterate` — pass scratch buffers as parameters

Removes the stack-address-escape pattern at `IccTagLut.cpp:2308-2309`:

```cpp
// Before
m_pOutText = szOutText;     // ← stack array assigned to instance member
m_pVal     = szColor;
memset(m_GridAdr, 0, 16);
Iterate(sink, 0, 0, outSize, bUseLegacy, budgetPtr);
// ... eventually:
m_pOutText = NULL;
m_pVal     = NULL;
```

`Iterate` now takes `pOutText` / `pVal` / `valSize` as explicit parameters; the recursive calls thread them through. The `m_pOutText` and `m_pVal` instance members are removed entirely (no external readers — verified via grep across IccProfLib + IccXML + IccJSON + Tools).

The legacy `CIccCLUT::Iterate(std::string&, ...)` protected entry point is preserved with its old signature; it allocates its own scratch buffers (`std::vector<icChar>` for the variable-size row buffer, `icChar[40]` for the per-value buffer) and forwards to the sink form.

### 2. Per-tag `pTag->Validate(...)` before each `Describe()` in the smoke test

`Tools/CmdLine/IccDescribeSinkTest/iccDescribeSinkTest.cpp` calls `ValidateIccProfile(argv[1], ...)` once at startup, but the custom CodeQL rule `iccdev/describe-without-validate` flags `pTag->Describe()` calls that don't have a *per-tag* validate immediately preceding. The rule's underlying point is real: `Describe()` is not contractually safe on tags that fail their own `Validate()` even when `ValidateIccProfile()` of the whole file passes.

This PR adds a `validateTag()` helper invoking `pTag->Validate(sigPath, vReport, pProfile)` before each Describe call, skipping the tag (with a logged note) if validation reports `icValidateCriticalError` or above. No test currently fails because `Testing/sRGB_v4_ICC_preference.icc` is known-good, but the test now correctly tolerates an adversarial-but-loadable profile passed via `argv[1]`.

## CodeQL alerts addressed

| # | Rule | File:line |
|---|---|---|
| 1760 | `cpp/stack-address-escape` | IccTagLut.cpp:2308 |
| 1761 | `cpp/stack-address-escape` | IccTagLut.cpp:2309 |
| 1770 | `iccdev/describe-without-validate` | iccDescribeSinkTest.cpp:137 |
| 1771 | `iccdev/describe-without-validate` | iccDescribeSinkTest.cpp:141 |
| 1772 | `iccdev/describe-without-validate` | iccDescribeSinkTest.cpp:166 |
| 1773 | `iccdev/describe-without-validate` | iccDescribeSinkTest.cpp:185 |
| 1774 | `iccdev/describe-without-validate` | iccDescribeSinkTest.cpp:222 |
| 1775 | `iccdev/describe-without-validate` | iccDescribeSinkTest.cpp:231 |
| 1776 | `iccdev/describe-without-validate` | iccDescribeSinkTest.cpp:264 |

## Backwards compatibility

- `CIccCLUT::DumpLut(IDescribeSink&, ...)` — public signature unchanged.
- `CIccCLUT::DumpLut(std::string&, ..., int)` — public signature unchanged.
- `CIccCLUT::Iterate(std::string&, ..., bool)` — protected signature unchanged.
- `CIccCLUT::Iterate(IDescribeSink&, ...)` — protected; signature gains three parameters (`pOutText`, `pVal`, `valSize`). Verified no callers outside `IccTagLut.cpp` itself across IccProfLib / IccXML / IccJSON / Tools.
- `m_pOutText` / `m_pVal` removal — both private members, no external readers.

Verified byte-for-byte equivalence on:
- `Testing/sRGB_v4_ICC_preference.icc` — 10,084-line dump (matrix-curves path)
- `Testing/hybrid/ICC/CMYK_Hybrid_Profile.icc` — CLUT-bearing (full Iterate path exercised)

Both produce **identical SHA256** before and after the change when invoked via the unchanged `iccDumpProfile 100 <profile> ALL` path.

## Test coverage

All 17 existing CTests pass. The `iccdev.describe-sink-api` smoke test also runs cleanly on an additional CMYK CLUT profile (`Testing/hybrid/ICC/CMYK_Hybrid_Profile.icc`):

```
[OK] byte-equivalence: every tag matches at verbosity 100
[OK] max_clut_cells_per_tag bounds CLUT cell output on 'A2B0'
[OK] emit_clut_cells=false suppresses CLUT cells on 'A2B0'
[OK] max_total_bytes truncates default fallback on 'desc'
[OK] ShouldContinue() cancellation honoured (BudgetedSink wrote 64/64 bytes before stopping)
```

## Out of scope

The 7 `iccdev/unbounded-profile-loop` alerts on PR #981's code (#1763–#1769) share a root cause with several pre-existing legacy alerts on the same rule. A focused fix at `CIccMBB::Read()` (capping `m_nInput`/`m_nOutput` at `icMaxEnumChannels`) closes them all at once; tracked in #983.

The `cpp/path-injection` alert (#1762) on the test's `argv[1]` → `ValidateIccProfile` is a structural pattern of every iccDEV CLI tool; addressing it meaningfully requires path canonicalisation in `CIccFileIO::Open`, tracked in #984. The alert itself has been dismissed as `won't fix` with a pointer to #984.

Refs: #976, #981, #983, #984
