### PR TITLE
IccProfLib: enforce Read()-time bounds on profile-controlled count fields

### DIFF
--- a/IccProfLib/IccSparseMatrix.cpp
+++ b/IccProfLib/IccSparseMatrix.cpp
@@ -149,6 +149,21 @@ bool CIccSparseMatrix::Init(icUInt16Number nRows, icUInt16Number nCols, bool bSe
   if (!m_pMatrix)
     return false;
 
+  // Hard upper bound on profile-controlled dimensions to defend
+  // Union()/iteration loops against malformed sparse matrix data
+  // (CWE-400/CWE-834). Real ICC spectral matrices have ~36-95 rows
+  // (visible-spectrum sampling); 4096 is a generous ceiling.
+  const icUInt16Number kMaxSparseMatrixDim = 4096;
+  if (nRows > kMaxSparseMatrixDim || nCols > kMaxSparseMatrixDim) {
+    m_nRows = 0;
+    m_nCols = 0;
+    m_Data = NULL;
+    m_RowStart = NULL;
+    m_ColumnIndices = NULL;
+    m_nMaxEntries = 0;
+    return false;
+  }
+
   icUInt16Number *Dim = (icUInt16Number*)m_pMatrix;
 
   if (m_Data)

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -3158,6 +3158,15 @@ bool CIccTagNamedColor2::Read(icUInt32Number size, CIccIO *pIO)
   m_szPrefix[sizeof(m_szPrefix)-1] = 0;
   m_szSufix[sizeof(m_szSufix)-1] = 0;
 
+  // Hard upper bounds on profile-controlled counts to defend
+  // Describe()/Find()/Apply() loops against malformed tags
+  // (CWE-400/CWE-834). Real profiles have a few thousand named
+  // colors at most and well under 16 device channels.
+  const icUInt32Number kMaxNamedColorEntries = 65536;
+  const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+  if (nNum > kMaxNamedColorEntries || nCoords > kMaxNamedColorDeviceCoords)
+    return false;
+
   size -= nTagHdrSize;
 
   size_t nCount = size / (32+(3+(size_t)nCoords)*sizeof(icUInt16Number));
@@ -4793,6 +4802,12 @@ bool CIccTagSparseMatrixArray::Read(icUInt32Number size, CIccIO *pIO)
   
   // reject tags with invalid counts of items
   if (nNumMatrices < 1 || nChannels < 1)
+    return false;
+
+  // Hard upper bound on profile-controlled matrix count to defend
+  // Validate()/Apply() loops against malformed tags (CWE-400/CWE-834).
+  const icUInt32Number kMaxSparseMatrixArrayCount = 65536;
+  if (nNumMatrices > kMaxSparseMatrixArrayCount)
     return false;
 
   m_nMatrixType = (icSparseMatrixType)nMatrixType;


### PR DESCRIPTION
## Summary

Adds explicit upper bounds on profile-controlled count fields at four `Read()` / `Init()` entry points so downstream `Describe()`/`Find()`/`Validate()`/`Apply()`/`Union()` loops cannot run unbounded on malformed tag data.

Closes 4 open `iccdev/unbounded-profile-loop` CodeQL alerts:

| Field | Site | Cap | Alert |
|-------|------|-----|-------|
| `nNum` (→ `m_nSize`) | `CIccTagNamedColor2::Read` | 65 536 | #942 |
| `nCoords` (→ `m_nDeviceCoords`) | `CIccTagNamedColor2::Read` | 256 | #948 |
| `nNumMatrices` (→ `m_nSize`) | `CIccTagSparseMatrixArray::Read` | 65 536 | #932 |
| `nRows` / `nCols` (→ `m_nRows` / `m_nCols`) | `CIccSparseMatrix::Init` | 4 096 | #911 |

## Why these specific fields

These are the four open `unbounded-profile-loop` alerts whose count fields are **not** type-narrowed at the C++ level (NamedColor2 `m_nSize`/`m_nDeviceCoords` are `icUInt32Number`; SparseMatrixArray `m_nSize` is `icUInt32Number`; SparseMatrix `m_nRows` is u16 but iteration cost is significant) and **not** already capped at `Read()` (unlike `CIccMpeCalculator::Read` which already enforces `MAX_CALC_ELEMENTS = 65536` per #769).

The other 10 open `unbounded-profile-loop` alerts are either:
- `m_nInput` / `m_nOutput` declared as `icUInt8Number` (max 255) — type-bounded with cooperative `&& sink.ShouldContinue()` guards in MBB/CLUT,
- `m_nOutputChannels` declared as `icUInt16Number` (max 65 535) with one virtual call per iteration in ToneMap, or
- `m_nSubElem` already capped at `Read()` by `MAX_CALC_ELEMENTS = 65536`.

Those will be dismissed with a written rationale rather than guarded again at each use site (see follow-up issue on rule precision).

## Cap rationale

Caps are sized well above realistic profile content but tight enough to bound worst-case DoS:

- **NamedColor2 entries (65 536)** — Pantone-style libraries are typically 1 000–3 000 entries; X-Rite extended palettes ~10 000. 65 536 is generous.
- **NamedColor2 device coords (256)** — legacy nCLR profiles cap at 15; nChannel allows up to u16 max but device coords stored per named-color entry must fit in stride `(3 + nCoords) * 2` bytes per entry, and 256 channels is already well past any realistic colour transform.
- **SparseMatrixArray matrix count (65 536)** — same rationale as NamedColor2 entries.
- **SparseMatrix dimensions (4 096)** — matrices in ICC v5 carry spectral PCS transforms; visible-spectrum sampling at 1 nm steps is ~400 bands. 4 096 lets through any realistic spectral resolution.

## Test plan

- [x] `cmake --build build-baseline -j4` — clean rebuild on top of `upstream/master`.
- [x] `ctest --output-on-failure` — 17/17 pass.
- [x] Reads through `IccTagBasic.cpp:3128`, `IccTagBasic.cpp:4768`, and `IccSparseMatrix.cpp:147` to confirm the new checks sit ahead of the first profile-controlled allocation/loop.

## Out of scope

- The 7 `iccdev/describe-without-validate` alerts on `Tools/CmdLine/IccDescribeSinkTest/iccDescribeSinkTest.cpp` are addressed by #988 (path move outside `Tools/`).
- Rule-precision improvements to `unbounded-profile-loop.ql` are the subject of a separate proposal issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)