### PR TITLE
codeql-queries: tighten unbounded-profile-loop.ql precision (closes #990)

### DIFF
--- a/.github/codeql-queries/unbounded-profile-loop.ql
+++ b/.github/codeql-queries/unbounded-profile-loop.ql
@@ -24,11 +24,24 @@ where
   fa.getTarget().getName().regexpMatch("(?i).*(count|num|size|length|steps|nInput|nOutput|m_n).*") and
   // The field is from a class/struct (not a local)
   exists(fa.getTarget().getDeclaringType()) and
-  // No bounds check before the loop (simple heuristic: no if/min in the 3 lines before)
+  // Exempt loops with a cooperative-cancellation guard in the condition
+  // (e.g., && sink.ShouldContinue()) — bounded by IDescribeSink contract.
+  not loop.getCondition().getAChild*().toString().matches("%ShouldContinue%") and
+  // Exempt loops driven by u8/u16-narrowed fields — already capped at
+  // 255/65535 by the field type itself.
+  not exists(IntegralType t |
+    t = fa.getTarget().getType() and
+    t.getSize() <= 2
+  ) and
+  // No bounds check anywhere earlier in the same function. Cross-function
+  // bounds (e.g., guards in Read() applying to fields used in Apply())
+  // require dataflow and are out of scope for this rule.
   not exists(IfStmt guard |
-    guard.getLocation().getStartLine() >= loop.getLocation().getStartLine() - 5 and
+    guard.getEnclosingFunction() = loop.getEnclosingFunction() and
     guard.getLocation().getStartLine() < loop.getLocation().getStartLine() and
-    guard.getCondition().getAChild*().toString().regexpMatch(".*(?i)(max|limit|bound|INT_MAX).*")
+    guard.getCondition().getAChild*().toString().regexpMatch(
+      "(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|MAX_CALC_ELEMENTS).*"
+    )
   ) and
   not exists(FunctionCall minCall |
     minCall.getTarget().getName().matches("%min%") and


### PR DESCRIPTION
## Summary

Per agreement on #990 ("100% Agreed, do PR"), three precision refinements to `.github/codeql-queries/unbounded-profile-loop.ql`. Net effect: ~10 false-positive auto-closures on the next CodeQL re-scan, no change to real coverage.

Closes #990.

## What changed in the rule

**1. Cooperative-cancellation guard.** Exempt loops whose condition contains `ShouldContinue()` — that's the `IDescribeSink` cancellation contract from PR #981. A budgeted sink halts the loop the moment the byte budget is exhausted.

```ql
not loop.getCondition().getAChild*().toString().matches("%ShouldContinue%")
```

**2. Field-type narrowing.** Exempt loops driven by `icUInt8Number` / `icUInt16Number` fields. The iteration count is type-bounded at 255 / 65 535, and per-iteration work at the alerted sites is trivial (one `snprintf` or one virtual call).

```ql
not exists(IntegralType t |
  t = fa.getTarget().getType() and
  t.getSize() <= 2
)
```

**3. Function-scoped bounds-check lookback.** Replace the 5-line proximity check with a same-function existential, and broaden the keyword set with cap idioms observed in this codebase (`icMaxEnum`, `4096`, `65535`, `MAX_CALC_ELEMENTS`).

```ql
not exists(IfStmt guard |
  guard.getEnclosingFunction() = loop.getEnclosingFunction() and
  guard.getLocation().getStartLine() < loop.getLocation().getStartLine() and
  guard.getCondition().getAChild*().toString().regexpMatch(
    "(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|MAX_CALC_ELEMENTS).*"
  )
)
```

## Expected delta

The 14 historical `unbounded-profile-loop` alerts I just triaged (now all dismissed):

| Refinement | Closes |
|---|---|
| #1 cooperative-cancellation | #1763, #1764, #1765, #1766, #1768 |
| #2 field-type narrowing | #1769, #978, #984, #863 (and the #1 set, redundantly) |
| #3 function-scoped lookback | #978, #984 (already covered by #2), #885 |
| **Auto-closed total** | 10 of 14 |

The remaining 4 alerts (#911, #932, #942, #948) were the ones whose loop counts are NOT type-narrowed (`icUInt32Number m_nSize` / `m_nDeviceCoords`) and whose Read-time bounds are in a *different* function from the loop. Those were addressed at parse time by PR #989. Cross-function bounds (true dataflow) remain out of scope for this rule — that's noted in the rule comment.

## Trade-offs

- **#1** is token-based (`%ShouldContinue%` substring) — a future loop could call `ShouldContinue()` on something unrelated to the bound. iccDEV's pattern is consistent today; this is no worse than the existing keyword regexes.
- **#2** trusts the field's declared type. If a future field is widened from u16 to u32 without changing its name, the rule will start firing — which is correct behaviour.
- **#3** widens the false-negative surface vs. the 5-line lookback: an unrelated `max`-mentioning guard 200 lines above won't actually constrain the field reaching the loop. Heuristic improvement; true dataflow would be more precise.

## Verification

No local CodeQL CLI verification — per the issue, relying on GitHub Actions' CodeQL re-scan on this branch (and the `main`-merge re-scan) for the alert delta. Will read the numbers off the PR's "Code scanning results" tab once the workflow finishes.

## Out of scope

- Other custom rules (`describe-without-validate.ql`'s 14-line literal-`Validate`-call lookback, etc.) — happy to file follow-up issues if useful.
- Cross-function (call-graph) bounds checking that would catch parse-time guards applying to use-site loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)