### PR TITLE
fix size mismatch compiler warnings

### DIFF
--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -736,7 +736,7 @@ bool CIccMpeJsonTintArray::ParseJson(const IccJson &j, std::string &parseStr)
       size_t fileLen = pIO->GetLength();
       char *buf = new(std::nothrow) char[fileLen + 1];
       if (!buf) { delete pIO; parseStr += "Out of memory\n"; delete pTag; return false; }
-      icUInt32Number nRead = pIO->Read8(buf, (icUInt32Number)fileLen);
+      size_t nRead = pIO->Read8(buf, (icUInt32Number)fileLen);
       buf[nRead] = '\0';
       delete pIO;
 

--- a/IccJSON/IccLibJSON/IccUtilJson.cpp
+++ b/IccJSON/IccLibJSON/IccUtilJson.cpp
@@ -94,10 +94,10 @@ static int hexVal(char c)
   return -1;
 }
 
-icUInt32Number icJsonGetHexData(void *pBuf, const char *szText, icUInt32Number nBufSize)
+size_t icJsonGetHexData(void *pBuf, const char *szText, size_t nBufSize)
 {
   unsigned char *pDest = (unsigned char*)pBuf;
-  icUInt32Number rv = 0;
+  size_t rv = 0;
   while (rv < nBufSize && *szText) {
     int c1 = hexVal(szText[0]);
     if (c1 >= 0 && szText[1]) {

--- a/IccJSON/IccLibJSON/IccUtilJson.h
+++ b/IccJSON/IccLibJSON/IccUtilJson.h
@@ -76,7 +76,7 @@ using IccJson = nlohmann::json;
 // ---------------------------------------------------------------------------
 // Hex data helpers (binary blobs stored as hex strings in JSON)
 // ---------------------------------------------------------------------------
-icUInt32Number icJsonGetHexData(void *pBuf, const char *szText, icUInt32Number nBufSize);
+size_t icJsonGetHexData(void *pBuf, const char *szText, size_t nBufSize);
 icUInt32Number icJsonGetHexDataSize(const char *szText);
 std::string    icJsonDumpHexData(const void *pBuf, size_t nBufSize);
 

--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -5643,7 +5643,7 @@ bool CIccMpeCLUT::Read(icUInt32Number size, CIccIO *pIO)
     return false;
   }
 
-  icUInt32Number nPoints = (icUInt32Number)m_nInputChannels * m_nOutputChannels;
+  size_t nPoints = (size_t)m_nInputChannels * m_nOutputChannels;
 
   if (m_nInputChannels > 16 || nPoints > dataSize || nPoints * sizeof (icFloat32Number) > dataSize)
     return false;
@@ -5664,7 +5664,6 @@ bool CIccMpeCLUT::Read(icUInt32Number size, CIccIO *pIO)
 
   nPoints = (size_t)m_pCLUT->NumPoints()*m_nOutputChannels;
 
-    // ERROR - comparison of values with different signs!
   if (pIO->ReadFloat32Float(pData,nPoints)!= nPoints)
     return false;
   

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -96,7 +96,7 @@ static icInt32Number icCalcSaturatingIntCast(double v)
   if (v <= (double)std::numeric_limits<icInt32Number>::lowest())
     return std::numeric_limits<icInt32Number>::lowest();
 
-  return std::lround(std::trunc(v));
+  return (icInt32Number) std::lround(std::trunc(v));
 }
 
 static icInt32Number icCalcSaturatingRound(icFloatNumber v)


### PR DESCRIPTION
Fixes #992

## PR Summary
Fixing size_t and uint32 mismatch compiler warnings.

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [X] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
