### PR TITLE
Update version to 2.3.2.0

### DIFF
--- a/.github/instructions/build-system.instructions.md
+++ b/.github/instructions/build-system.instructions.md
@@ -8,7 +8,7 @@ applyTo: "Build/**"
 
 Primary build file: `Build/Cmake/CMakeLists.txt`
 
-- Project: RefIccMAX v2.3.1.8
+- Project: RefIccMAX v2.3.2.0
 - Minimum CMake: 3.21
 - C++ standard: C++17
 - Compiler floor: GCC 11+, Clang 10+, MSVC 19.30+

--- a/.github/workflows/ci-vcpkg-ports.yml
+++ b/.github/workflows/ci-vcpkg-ports.yml
@@ -1,6 +1,6 @@
 ###############################################################
 #
-# ci-vcpkg-ports.yml — Cross-platform vcpkg port overlay test
+# ci-vcpkg-ports.yml - Cross-platform vcpkg port overlay test
 #
 # Validates that the ports/iccdev overlay installs correctly
 # on Windows, Linux, and macOS via vcpkg.
@@ -33,7 +33,7 @@ concurrency:
 
 jobs:
   vcpkg-overlay-test:
-    name: "vcpkg overlay – ${{ matrix.os }}"
+    name: "vcpkg overlay - ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -44,14 +44,14 @@ jobs:
         os: [ windows-latest, ubuntu-24.04, macos-14 ]
 
     steps:
-      # ── Checkout (pinned SHA, no credentials) ──────────────
+      # Checkout (pinned SHA, no credentials)
       - name: Checkout repository
         uses: actions/checkout@c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5  # v5.0.0
         with:
           fetch-depth: 1
           persist-credentials: false
 
-      # ── Bootstrap vcpkg ────────────────────────────────────
+      # Bootstrap vcpkg
       - name: Bootstrap vcpkg (Unix)
         if: runner.os != 'Windows'
         shell: bash --noprofile --norc {0}
@@ -84,7 +84,7 @@ jobs:
           git -C "$env:RUNNER_TEMP\vcpkg" checkout 1940ee77e81573713c0d364c42f5990172198be1
           & "$env:RUNNER_TEMP\vcpkg\bootstrap-vcpkg.bat" -disableMetrics
           Add-Content -Path $env:GITHUB_ENV -Value "VCPKG_ROOT=$env:RUNNER_TEMP\vcpkg"
-      # ── Install port via overlay ───────────────────────────
+      # Install port via overlay
       - name: Install iccdev port (Unix)
         if: runner.os != 'Windows'
         shell: bash --noprofile --norc {0}
@@ -151,7 +151,7 @@ jobs:
             throw "vcpkg install failed with exit code $LASTEXITCODE"
           }
           Write-Host "::endgroup::"
-      # ── Verify installed artifacts ─────────────────────────
+      # Verify installed artifacts
       - name: Verify installed artifacts (Unix)
         if: runner.os != 'Windows'
         shell: bash --noprofile --norc {0}
@@ -184,53 +184,53 @@ jobs:
           # Check headers
           if [ -d "$PREFIX/include/RefIccMAX/IccProfLib2" ]; then
             hdr_count=$(find "$PREFIX/include/RefIccMAX/IccProfLib2" -name '*.h' | wc -l)
-            echo "✅ IccProfLib2 headers: $hdr_count files"
+            echo "[OK] IccProfLib2 headers: $hdr_count files"
           else
-            echo "❌ IccProfLib2 headers NOT found"
+            echo "[FAIL] IccProfLib2 headers NOT found"
             errors=$((errors + 1))
           fi
           # Check libraries
           for lib in libIccProfLib2 libIccXML2 libIccJSON2; do
             if ls "$PREFIX/lib/"${lib}* 1>/dev/null 2>&1; then
-              echo "✅ $lib found"
+              echo "[OK] $lib found"
             else
-              echo "❌ $lib NOT found"
+              echo "[FAIL] $lib NOT found"
               errors=$((errors + 1))
             fi
           done
           # Check cmake config
           if [ -f "$PREFIX/share/RefIccMAX/RefIccMAXConfig.cmake" ] || \
              [ -f "$PREFIX/share/reficcmax/RefIccMAXConfig.cmake" ]; then
-            echo "✅ CMake config found"
+            echo "[OK] CMake config found"
           else
-            echo "❌ CMake config NOT found"
+            echo "[FAIL] CMake config NOT found"
             errors=$((errors + 1))
           fi
           # Check tools
           for tool in iccDumpProfile iccRoundTrip iccFromXml iccToXml iccFromJson iccToJson; do
             if [ -x "$PREFIX/tools/iccdev/$tool" ]; then
-              echo "✅ Tool $tool found"
+              echo "[OK] Tool $tool found"
             else
-              echo "❌ Tool $tool NOT found"
+              echo "[FAIL] Tool $tool NOT found"
               errors=$((errors + 1))
             fi
           done
           # Summary
           {
-            echo "## vcpkg Port Verification — $(sanitize_line "$RUNNER_OS")"
+            echo "## vcpkg Port Verification - $(sanitize_line "$RUNNER_OS")"
             echo ""
             echo "| Check | Result |"
             echo "|-------|--------|"
-            echo "| Headers | $([ -d "$PREFIX/include/RefIccMAX/IccProfLib2" ] && echo '✅' || echo '❌') |"
-            echo "| Libraries | $(ls "$PREFIX/lib/"libIccProfLib2* >/dev/null 2>&1 && echo '✅' || echo '❌') |"
-            echo "| CMake config | $([ -f "$PREFIX/share/RefIccMAX/RefIccMAXConfig.cmake" ] || [ -f "$PREFIX/share/reficcmax/RefIccMAXConfig.cmake" ] && echo '✅' || echo '❌') |"
-            echo "| Tools | $([ -x "$PREFIX/tools/iccdev/iccDumpProfile" ] && echo '✅' || echo '❌') |"
+            echo "| Headers | $([ -d "$PREFIX/include/RefIccMAX/IccProfLib2" ] && echo '[OK]' || echo '[FAIL]') |"
+            echo "| Libraries | $(ls "$PREFIX/lib/"libIccProfLib2* >/dev/null 2>&1 && echo '[OK]' || echo '[FAIL]') |"
+            echo "| CMake config | $([ -f "$PREFIX/share/RefIccMAX/RefIccMAXConfig.cmake" ] || [ -f "$PREFIX/share/reficcmax/RefIccMAXConfig.cmake" ] && echo '[OK]' || echo '[FAIL]') |"
+            echo "| Tools | $([ -x "$PREFIX/tools/iccdev/iccDumpProfile" ] && echo '[OK]' || echo '[FAIL]') |"
           } >> "$GITHUB_STEP_SUMMARY"
           if [ "$errors" -gt 0 ]; then
             echo "::error::$errors verification checks failed"
             exit 1
           fi
-          echo "All verification checks passed ✅"
+          echo "All verification checks passed [OK]"
       - name: Verify installed artifacts (Windows)
         if: runner.os == 'Windows'
         shell: pwsh -NoProfile -NoLogo -NonInteractive -Command {0}
@@ -258,17 +258,17 @@ jobs:
           $hdrDir = "$prefix\include\RefIccMAX\IccProfLib2"
           if (Test-Path $hdrDir) {
             $count = (Get-ChildItem $hdrDir -Filter *.h).Count
-            Write-Host "✅ IccProfLib2 headers: $count files"
+            Write-Host "[OK] IccProfLib2 headers: $count files"
           } else {
-            Write-Host "❌ IccProfLib2 headers NOT found"
+            Write-Host "[FAIL] IccProfLib2 headers NOT found"
             $errors++
           }
           # Check libraries
           foreach ($lib in @('IccProfLib2-static.lib','IccXML2-static.lib','IccJSON2-static.lib')) {
             if (Test-Path "$prefix\lib\$lib") {
-              Write-Host "✅ $lib found"
+              Write-Host "[OK] $lib found"
             } else {
-              Write-Host "❌ $lib NOT found"
+              Write-Host "[FAIL] $lib NOT found"
               $errors++
             }
           }
@@ -276,39 +276,39 @@ jobs:
           $cmakeFound = (Test-Path "$prefix\share\RefIccMAX\RefIccMAXConfig.cmake") -or
                         (Test-Path "$prefix\share\reficcmax\RefIccMAXConfig.cmake")
           if ($cmakeFound) {
-            Write-Host "✅ CMake config found"
+            Write-Host "[OK] CMake config found"
           } else {
-            Write-Host "❌ CMake config NOT found"
+            Write-Host "[FAIL] CMake config NOT found"
             $errors++
           }
           # Check tools
           foreach ($tool in @('iccDumpProfile.exe','iccRoundTrip.exe','iccFromXml.exe','iccToXml.exe','iccFromJson.exe','iccToJson.exe')) {
             if (Test-Path "$prefix\tools\iccdev\$tool") {
-              Write-Host "✅ Tool $tool found"
+              Write-Host "[OK] Tool $tool found"
             } else {
-              Write-Host "❌ Tool $tool NOT found"
+              Write-Host "[FAIL] Tool $tool NOT found"
               $errors++
             }
           }
           # Summary
           $os = Sanitize-Line "Windows"
           @"
-          ## vcpkg Port Verification — $os
+          ## vcpkg Port Verification - $os
           | Check | Result |
           |-------|--------|
-          | Headers | $(if (Test-Path $hdrDir) {'✅'} else {'❌'}) |
-          | Libraries | $(if (Test-Path "$prefix\lib\IccProfLib2-static.lib") {'✅'} else {'❌'}) |
-          | CMake config | $(if ($cmakeFound) {'✅'} else {'❌'}) |
-          | Tools | $(if (Test-Path "$prefix\tools\iccdev\iccDumpProfile.exe") {'✅'} else {'❌'}) |
+          | Headers | $(if (Test-Path $hdrDir) {'[OK]'} else {'[FAIL]'}) |
+          | Libraries | $(if (Test-Path "$prefix\lib\IccProfLib2-static.lib") {'[OK]'} else {'[FAIL]'}) |
+          | CMake config | $(if ($cmakeFound) {'[OK]'} else {'[FAIL]'}) |
+          | Tools | $(if (Test-Path "$prefix\tools\iccdev\iccDumpProfile.exe") {'[OK]'} else {'[FAIL]'}) |
           "@ >> $env:GITHUB_STEP_SUMMARY
           if ($errors -gt 0) {
             Write-Error "$errors verification checks failed"
             exit 1
           }
-          Write-Host "All verification checks passed ✅"
-  # ── Manifest mode test (VS-bundled vcpkg) ───────────────
+          Write-Host "All verification checks passed [OK]"
+  # Manifest mode test (VS-bundled vcpkg)
   vcpkg-manifest-test:
-    name: "vcpkg manifest – windows-latest"
+    name: "vcpkg manifest - windows-latest"
     runs-on: windows-latest
     permissions:
       contents: read
@@ -353,7 +353,7 @@ jobs:
             "builtin-baseline": "$baseline",
             "dependencies": [ "iccdev" ],
             "overrides": [
-              { "name": "iccdev", "version": "2.3.1.8", "port-version": 1 }
+              { "name": "iccdev", "version": "2.3.2.0" }
             ]
           }
           "@ | Set-Content "$testDir\vcpkg.json" -Encoding UTF8
@@ -440,17 +440,17 @@ jobs:
           if ($LASTEXITCODE -ne 0) { throw "Test executable failed" }
           if ($output -notmatch "IccProfLib") { throw "Missing IccProfLib version output" }
           if ($output -notmatch "OK") { throw "Missing OK output" }
-          Write-Host "✅ Manifest mode test passed"
+          Write-Host "[OK] Manifest mode test passed"
           # Load sanitizer for summary output
           if (Test-Path ".github/scripts/sanitize.ps1") {
             . .github/scripts/sanitize.ps1
           }
           # Summary
           @"
-          ## vcpkg Manifest Mode — Windows
+          ## vcpkg Manifest Mode - Windows
           | Check | Result |
           |-------|--------|
-          | CMake configure | ✅ |
-          | Build | ✅ |
-          | Run | ✅ |
+          | CMake configure | [OK] |
+          | Build | [OK] |
+          | Run | [OK] |
           "@ >> $env:GITHUB_STEP_SUMMARY

--- a/Build/Cmake/CMakeLists.txt
+++ b/Build/Cmake/CMakeLists.txt
@@ -127,11 +127,11 @@ project(RefIccMAX LANGUAGES C CXX)
 set(PROJECT_UP_NAME "REFICCMAX")
 set(PROJECT_DOWN_NAME "reficcmax")
 
-# Version components (4-part version: 2.3.1.8)
+# Version components (4-part version: 2.3.2.0)
 set(${PROJECT_UP_NAME}_MAJOR_VERSION 2)
 set(${PROJECT_UP_NAME}_MINOR_VERSION 3)
-set(${PROJECT_UP_NAME}_MICRO_VERSION 1)
-set(${PROJECT_UP_NAME}_PATCH_VERSION 8)
+set(${PROJECT_UP_NAME}_MICRO_VERSION 2)
+set(${PROJECT_UP_NAME}_PATCH_VERSION 0)
 
 # Composite versions
 set(${PROJECT_UP_NAME}_VERSION

--- a/Build/Cmake/vcpkg.json
+++ b/Build/Cmake/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "iccdev",
-  "version": "2.3.1.4",
+  "version": "2.3.2.0",
   "description": "Developer tools for ICC color profiles",
   "builtin-baseline": "1940ee77e81573713c0d364c42f5990172198be1",
   "dependencies": [

--- a/Doxyfile.full
+++ b/Doxyfile.full
@@ -6,7 +6,7 @@
 # and client-side search.
 
 PROJECT_NAME           = "iccDEV"
-PROJECT_NUMBER         = "2.3.1"
+PROJECT_NUMBER         = "2.3.2.0"
 PROJECT_BRIEF          = "ICC Color Profile Library - ProfLib, XML, JSON, and CLI Tools"
 OUTPUT_DIRECTORY       = docs/generated-full
 INPUT                  = IccProfLib \

--- a/IccProfLib/IccProfLibVer.h
+++ b/IccProfLib/IccProfLibVer.h
@@ -1,3 +1,3 @@
 #ifndef ICCPROFLIBVER
-#define ICCPROFLIBVER "2.3.1.8"
+#define ICCPROFLIBVER "2.3.2.0"
 #endif

--- a/Tools/Winnt/IccIisIsapi/iis-isapi.openapi.yaml
+++ b/Tools/Winnt/IccIisIsapi/iis-isapi.openapi.yaml
@@ -45,8 +45,8 @@ paths:
                 summary:
                   summary: Default summary
                   value: |
-                    IccProfLib version: 2.3.1.7+0cbfc46
-                    IccLibXML version: 2.3.1.7+0cbfc46
+                    IccProfLib version: 2.3.2.0+<sha>
+                    IccLibXML version: 2.3.2.0+<sha>
                     Profile spec ver: 4.00
                     XML payload bytes: 786
                     Hello from iccDEV IIS ISAPI!

--- a/examples/hello-iccdev/README.md
+++ b/examples/hello-iccdev/README.md
@@ -63,8 +63,8 @@ cmake --build unix
 ### Output
 
 ```
-IccProfLib version: 2.3.1.8+<sha>
-IccLibXML  version: 2.3.1.8+<sha>
+IccProfLib version: 2.3.2.0+<sha>
+IccLibXML  version: 2.3.2.0+<sha>
 Profile spec ver:  4.00
 
 XML round-trip OK (786 bytes)

--- a/examples/hello-iccdev/vcpkg.json
+++ b/examples/hello-iccdev/vcpkg.json
@@ -13,8 +13,7 @@
   "overrides": [
     {
       "name": "iccdev",
-      "version": "2.3.1.8",
-      "port-version": 1
+      "version": "2.3.2.0"
     }
   ]
 }

--- a/ports/iccdev/portfile.cmake
+++ b/ports/iccdev/portfile.cmake
@@ -42,8 +42,8 @@ else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO InternationalColorConsortium/iccDEV
-        REF 612dfb99355f88cd96b594d2d245b516b190347a
-        SHA512 14160c3b962a771527355506e9453aee3d436de5f824bda7c6a97a5cdb856f94c73065d532f7057be66ca952271e88b2d2ef805978e28bffd186bdb450e2bdcb
+        REF f6bf936c176f9645e0a271cb1f18291f9935655c
+        SHA512 0cbe2586b4dd6fb32158c2664c1f4a660afe9877f5ec2c3543e5875cdc66268a3ce5f0ac98cd22800f4a4726dae9f61f2d1c976199c7ec1aa05750040e901368
         HEAD_REF master
     )
 endif()

--- a/ports/iccdev/vcpkg.json
+++ b/ports/iccdev/vcpkg.json
@@ -1,7 +1,6 @@
 {
   "name": "iccdev",
-  "version": "2.3.1.8",
-  "port-version": 1,
+  "version": "2.3.2.0",
   "description": "ICC color profile libraries and tools (RefIccMAX / iccDEV)",
   "homepage": "https://github.com/InternationalColorConsortium/iccDEV",
   "license": "BSD-3-Clause",

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,6 @@
 {
   "name": "iccdev",
-  "version": "2.3.1.7",
+  "version": "2.3.2.0",
   "description": "Developer tools for ICC color profiles",
   "builtin-baseline": "1940ee77e81573713c0d364c42f5990172198be1",
   "dependencies": [


### PR DESCRIPTION
## PR Summary

#1007 

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Post Merge
- Maintainer should then manually run ci-latest-release & ci-docker via UI UX following the Merge or run:
  - gh workflow run ci-latest-release
  - gh workflow run ci-docker
- Create [v2.3.2.0 Release](https://github.com/InternationalColorConsortium/iccDEV/releases/new) or Assign @xsscx
