### PR TITLE
Visualize ql issues

### DIFF
--- a/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
@@ -148,13 +148,21 @@ void PDFWriter::CloseFile() {
 
   if (!m_filename.empty()) {
     if (PageCount() > 0) {
-        std::ofstream out(m_filename);
-        WriteHeader(out);
-        WriteObjects(out);
-        WriteXRefs(out);
-        WriteFooter(out);
-        out.close();
-        m_objects.clear();
+        try  {
+          std::ofstream out(m_filename);
+          WriteHeader(out);
+          WriteObjects(out);
+          WriteXRefs(out);
+          WriteFooter(out);
+          out.close();
+          m_objects.clear();
+        }
+        catch (const std::exception& e) {
+          fprintf(stderr, "PDF writing error in '%s': '%s'\n", m_filename.c_str(), e.what() );
+        }
+        catch (...) {
+          fprintf(stderr, "PDF writing error in '%s': unknown exception\n", m_filename.c_str());
+        }
     }
     m_filename.clear();
   }

--- a/Tools/CmdLine/IccProfileVisualize/MiniSVG.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniSVG.cpp
@@ -71,7 +71,8 @@
 
 /******************************************************************************/
 
-void SVGOut::OpenFile( const std::string &filename ) {
+void SVGOut::OpenFile( const std::string &filename )
+{
   if (!m_filename.empty()) {
     fprintf(stderr,"WARNING - SVG file already open!\n");
   }
@@ -85,25 +86,38 @@ void SVGOut::OpenFile( const std::string &filename ) {
 
 /******************************************************************************/
 
-void SVGOut::CloseFile() {
+void SVGOut::CloseFile()
+{
   if (m_pageInProgress) {
     m_buf << "</g>\n";
     m_pageInProgress = false;
   }
+  
   if (m_GroupLevel > 0)
     fprintf(stderr,"WARNING - SVG group levels not closed.\n");
   if (m_GroupLevel < 0)
     fprintf(stderr,"WARNING - Too many SVG group levels closed.\n");
+
   if (!m_filename.empty()) {
     if (m_pageCount > 0) {
+      try  {
         std::ofstream out(m_filename);
         WriteHeader(out);
         out << m_buf.str();
         WriteFooter(out);
         out.close();
-    }
+      }
+      catch (const std::exception& e) {
+        fprintf(stderr, "SVG writing error in '%s': '%s'\n", m_filename.c_str(), e.what() );
+      }
+      catch (...) {
+        fprintf(stderr, "SVG writing error in '%s': unknown exception\n", m_filename.c_str());
+      }
+    }   // if pages > 0
+    
     m_filename.clear();
-  }
+  } // if filename !empty
+
 }
 
 /******************************************************************************/

--- a/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
@@ -76,7 +76,7 @@
 /******************************************************************************/
 
 // NOTE - we don't have to worry about byte order, because the TIFF will always be written in host byte order
-// returns false if written correctly, true if the write failed
+// returns true if the write failed, otherwise false
 static
 bool putByte( uint8_t val, FILE *out )
 {

--- a/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
@@ -76,42 +76,49 @@
 /******************************************************************************/
 
 // NOTE - we don't have to worry about byte order, because the TIFF will always be written in host byte order
+// returns false if written correctly, true if the write failed
 static
-void putShort( uint16_t val, FILE *out )
+bool putByte( uint8_t val, FILE *out )
 {
-  fwrite( &val, 2, 1, out );
+  return fputc( val, out ) != val;
 }
 
 static
-void putShort( int16_t val, FILE *out )
+bool putShort( uint16_t val, FILE *out )
 {
-  fwrite( &val, 2, 1, out );
+  return fwrite( &val, 2, 1, out ) != 1;
 }
 
 static
-void putLong( uint32_t val, FILE *out )
+bool putShort( int16_t val, FILE *out )
 {
-  fwrite( &val, 4, 1, out );
+  return fwrite( &val, 2, 1, out ) != 1;
 }
 
 static
-void putLong( int32_t val, FILE *out )
+bool putLong( uint32_t val, FILE *out )
 {
-  fwrite( &val, 4, 1, out );
+  return fwrite( &val, 4, 1, out ) != 1;
+}
+
+static
+bool putLong( int32_t val, FILE *out )
+{
+  return fwrite( &val, 4, 1, out ) != 1;
 }
 
 #if 0
 // not supporting BIGTIFF yet, and don't need any other 8 byte quantities
 static
-void putLongLong( uint64_t val, FILE *out )
+bool putLongLong( uint64_t val, FILE *out )
 {
-  fwrite( &val, 8, 1, out );
+  return fwrite( &val, 8, 1, out ) != 1;
 }
 
 static
-void putLongLong( int64_t val, FILE *out )
+bool putLongLong( int64_t val, FILE *out )
 {
-  fwrite( &val, 8, 1, out );
+  return fwrite( &val, 8, 1, out ) != 1;
 }
 #endif
 
@@ -166,17 +173,24 @@ void shiftTIFFLAB( uint16_t *in, size_t count )
 
 /******************************************************************************/
 
+// returns true if write failed
 static
-void putIFDLong( uint16_t tag, uint16_t type, uint32_t count, uint32_t value, FILE *out )
+bool putIFDLong( uint16_t tag, uint16_t type, uint32_t count, uint32_t value, FILE *out )
 {
   uint16_t tagval = tag;
   uint16_t typeval = type;
   uint32_t countval = count;
 
-  fwrite( &tagval, 2, 1, out );
-  fwrite( &typeval, 2, 1, out );
-  fwrite( &countval, 4, 1, out );
-  fwrite( &value, 4, 1, out );
+  if (fwrite( &tagval, 2, 1, out ) != 1)
+    return true;
+  if (fwrite( &typeval, 2, 1, out ) != 1)
+    return true;
+  if (fwrite( &countval, 4, 1, out ) != 1)
+    return true;
+  if (fwrite( &value, 4, 1, out ) != 1)
+    return true;
+  
+  return false;
 }
 
 /******************************************************************************/
@@ -209,7 +223,7 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
         size_t width, size_t height, int channels, int depth )
 {
   FILE *outfile = NULL;
-  bool writeOk = true;
+  bool writeFailed = false;
 
   // see if we can create or update this filename
   outfile = icOpenWriteBinaryFile(name.c_str());
@@ -221,26 +235,34 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   // TIFF header, and byte order indicator
   // if constexpr (std::endian::native == std::endian::big) {  // only works in C++20 and up
   if (bigEndian) {
-    putc('M',outfile);
-    putc('M',outfile);
+    writeFailed |= putByte('M',outfile);
+    writeFailed |= putByte('M',outfile);
   } else {
-    putc('I',outfile);
-    putc('I',outfile);
+    writeFailed |= putByte('I',outfile);
+    writeFailed |= putByte('I',outfile);
   }
 
-  putShort( (int16_t)42, outfile );
-  putLong( (int32_t)8, outfile );  // offset to first IFD, from start of file
+  writeFailed |= putShort( (int16_t)42, outfile );
+  writeFailed |= putLong( (int32_t)8, outfile );  // offset to first IFD, from start of file
+
+  // check for early failure
+  if (writeFailed || ferror(outfile)) {
+    fprintf(stderr, "ERROR: I/O error writing TIFF header to %s\n", name.c_str() );
+    fclose(outfile);
+    return false;
+  }
 
   // IFD
   // number of entries
 // TODO: make a data structure to store IFD entries, sort, then write values and offsets
   uint16_t tagCount = 15;
-  putShort( tagCount, outfile );
+  writeFailed |= putShort( tagCount, outfile );
+  
 
   uint32_t width32 = uint32_t(width);
-  putIFDLong( TIFF_WIDTH, TIFF_LONG, 1, width32, outfile );
+  writeFailed |= putIFDLong( TIFF_WIDTH, TIFF_LONG, 1, width32, outfile );
   uint32_t height32 = uint32_t(height);
-  putIFDLong( TIFF_HEIGHT, TIFF_LONG, 1, height32, outfile );
+  writeFailed |= putIFDLong( TIFF_HEIGHT, TIFF_LONG, 1, height32, outfile );
 
   uint16_t bits = (uint16_t) depth;
 
@@ -254,13 +276,13 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
 
   // some readers break if the bitsPerSample is not a short value
   if (channels == 1)
-    putIFDLong( TIFF_BITSPERSAMPLE, TIFF_LONG, 1, bits, outfile );
+    writeFailed |= putIFDLong( TIFF_BITSPERSAMPLE, TIFF_LONG, 1, bits, outfile );
   else if (channels == 2)
-    putIFDLong( TIFF_BITSPERSAMPLE, TIFF_SHORT, (uint32_t)channels, ((uint32_t)bits << 16) | bits, outfile );
+    writeFailed |= putIFDLong( TIFF_BITSPERSAMPLE, TIFF_SHORT, (uint32_t)channels, ((uint32_t)bits << 16) | bits, outfile );
   else
-    putIFDLong( TIFF_BITSPERSAMPLE, TIFF_SHORT, (uint32_t)channels, bits_offset, outfile );
+    writeFailed |= putIFDLong( TIFF_BITSPERSAMPLE, TIFF_SHORT, (uint32_t)channels, bits_offset, outfile );
 
-  putIFDLong( TIFF_COMPRESSION, TIFF_LONG, 1, TIFF_COMPRESS_NONE, outfile );
+  writeFailed |= putIFDLong( TIFF_COMPRESSION, TIFF_LONG, 1, TIFF_COMPRESS_NONE, outfile );
 
   size_t nrowBytes = ( (size_t)channels * (size_t)width * (size_t)depth + 7) / 8;
   assert( nrowBytes > 0 );
@@ -279,69 +301,76 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   assert( (stripByteCount_offset + stripCountSize) <= UINT_MAX );
   uint32_t pixelData_offset = uint32_t ( stripByteCount_offset + stripCountSize );
 
-  putIFDLong( TIFF_INTERPRETATION, TIFF_LONG, 1, (uint32_t)color_model, outfile );
+  writeFailed |= putIFDLong( TIFF_INTERPRETATION, TIFF_LONG, 1, (uint32_t)color_model, outfile );
 
   // using an offset for offsets and bytecounts trips up tiffinfo
   if (stripCount > 1)
-    putIFDLong( TIFF_STRIPOFFSETS, TIFF_LONG, uint32_t(stripCount), stripOffset_offset, outfile );
+    writeFailed |= putIFDLong( TIFF_STRIPOFFSETS, TIFF_LONG, uint32_t(stripCount), stripOffset_offset, outfile );
   else
-    putIFDLong( TIFF_STRIPOFFSETS, TIFF_LONG, 1, pixelData_offset, outfile );
+    writeFailed |= putIFDLong( TIFF_STRIPOFFSETS, TIFF_LONG, 1, pixelData_offset, outfile );
 
-  putIFDLong( TIFF_SAMPLESPERPIXEL, TIFF_LONG, 1, (uint32_t)channels, outfile );
-  putIFDLong( TIFF_ROWSPERSTRIP, TIFF_LONG, 1, uint32_t(rowsPerStrip), outfile );
+  writeFailed |= putIFDLong( TIFF_SAMPLESPERPIXEL, TIFF_LONG, 1, (uint32_t)channels, outfile );
+  writeFailed |= putIFDLong( TIFF_ROWSPERSTRIP, TIFF_LONG, 1, uint32_t(rowsPerStrip), outfile );
 
   long byteCountOffset = ftell( outfile );
   if (stripCount > 1)
-    putIFDLong( TIFF_STRIPBYTECOUNTS, TIFF_LONG, uint32_t(stripCount), stripByteCount_offset, outfile );
+    writeFailed |= putIFDLong( TIFF_STRIPBYTECOUNTS, TIFF_LONG, uint32_t(stripCount), stripByteCount_offset, outfile );
   else
-    putIFDLong( TIFF_STRIPBYTECOUNTS, TIFF_LONG, 1, 0, outfile );
+    writeFailed |= putIFDLong( TIFF_STRIPBYTECOUNTS, TIFF_LONG, 1, 0, outfile );
 
   uint32_t resDenom32 = 1000;
   uint32_t resRatio32 = (uint32_t)(dpi * resDenom32);
-  putIFDLong( TIFF_XRESOLUTION, TIFF_RATIO, 1, xres_offset, outfile );
-  putIFDLong( TIFF_YRESOLUTION, TIFF_RATIO, 1, yres_offset, outfile );
-  putIFDLong( TIFF_PLANARCONFIG, TIFF_LONG, 1, 1, outfile );
-  putIFDLong( TIFF_RESOLUTIONUNIT, TIFF_LONG, 1, 2, outfile );  // inches
+  writeFailed |= putIFDLong( TIFF_XRESOLUTION, TIFF_RATIO, 1, xres_offset, outfile );
+  writeFailed |= putIFDLong( TIFF_YRESOLUTION, TIFF_RATIO, 1, yres_offset, outfile );
+  writeFailed |= putIFDLong( TIFF_PLANARCONFIG, TIFF_LONG, 1, 1, outfile );
+  writeFailed |= putIFDLong( TIFF_RESOLUTIONUNIT, TIFF_LONG, 1, 2, outfile );  // inches
 
-  putIFDLong( TIFF_PREDICTOR, TIFF_LONG, 1, 1, outfile );  // no predictor
+  writeFailed |= putIFDLong( TIFF_PREDICTOR, TIFF_LONG, 1, 1, outfile );  // no predictor
 
   if (bits == 32 || bits == 64)
-    putIFDLong( TIFF_SAMPLE_FORMAT, TIFF_LONG, 1, TIFF_SAMPLE_FLOAT, outfile );
+    writeFailed |= putIFDLong( TIFF_SAMPLE_FORMAT, TIFF_LONG, 1, TIFF_SAMPLE_FLOAT, outfile );
   else
-    putIFDLong( TIFF_SAMPLE_FORMAT, TIFF_LONG, 1, TIFF_SAMPLE_UINT, outfile );
+    writeFailed |= putIFDLong( TIFF_SAMPLE_FORMAT, TIFF_LONG, 1, TIFF_SAMPLE_UINT, outfile );
 
-  putLong( (uint32_t)0, outfile );  // offset to next IFD
+  writeFailed |= putLong( (uint32_t)0, outfile );  // offset to next IFD
 
   // align to 4 byte boundary
   for (uint32_t i = 0; i < align_bytes; ++i)
-    putc( 0, outfile );
+    writeFailed |= putByte( 0, outfile );
 
 // bits_offset:
   // bits per sample, because some readers break if it's just a byte instead of short
   for (int i = 0; i < channels; ++i)
-    putShort( bits, outfile );
+    writeFailed |= putShort( bits, outfile );
 
   // resolution ratios
 // xres_offset:
-  putLong( resRatio32, outfile );  // X dpi
-  putLong( resDenom32, outfile );  // denominator
+  writeFailed |= putLong( resRatio32, outfile );  // X dpi
+  writeFailed |= putLong( resDenom32, outfile );  // denominator
 
 // yres_offset:
-  putLong( resRatio32, outfile );  // Y dpi
-  putLong( resDenom32, outfile );  // denominator
+  writeFailed |= putLong( resRatio32, outfile );  // Y dpi
+  writeFailed |= putLong( resDenom32, outfile );  // denominator
 
 // stripOffset_offset
   // file with zeros, then backfill once we compress the strips
   for (size_t i = 0; i < stripCount; ++i)
-    putLong( 0, outfile );
+    writeFailed |= putLong( 0, outfile );
 
 // stripByteCount_offset
   // file with zeros, then backfill once we compress the strips
   for (size_t i = 0; i < stripCount; ++i)
-    putLong( 0, outfile );
+    writeFailed |= putLong( 0, outfile );
 
 // pixelData_offset:
   // Pixel Data
+  
+  // check again after writing the tag directory
+  if (writeFailed || ferror(outfile)) {
+    fprintf(stderr, "ERROR: I/O error writing TIFF directory to %s\n", name.c_str() );
+    fclose(outfile);
+    return false;
+  }
 
   std::vector<uint32_t> stripOffsetList( stripCount );
   std::vector<uint32_t> stripSizeList( stripCount );
@@ -365,21 +394,21 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
 
     long stripStart = ftell( outfile );
     if (stripStart < 0 || (unsigned long)stripStart > UINT32_MAX) {
-      fprintf(stderr, "WriteTIFF: strip offset exceeds 32-bit range\n");
+      fprintf(stderr, "ERROR: TIFF strip offset exceeds 32-bit range\n");
       fclose(outfile);
       return false;
     }
 
     size_t pixelBytes = (size_t)width * (size_t)channels * (size_t)(depth/8);
     if (fwrite( buffer + offset, pixelBytes, rowCount, outfile ) != rowCount) {
-      fprintf(stderr, "WriteTIFF: failed to write pixel data\n");
+      fprintf(stderr, "ERROR: TIFF failed to write pixel data\n");
       fclose(outfile);
       return false;
     }
 
     long stripEnd = ftell( outfile );
     if (stripEnd < 0 || (unsigned long)stripEnd > UINT32_MAX) {
-      fprintf(stderr, "WriteTIFF: strip end offset exceeds 32-bit range\n");
+      fprintf(stderr, "ERROR: TIFF strip end offset exceeds 32-bit range\n");
       fclose(outfile);
       return false;
     }
@@ -393,26 +422,26 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   if (stripCount == 1) {
     fseek(outfile, byteCountOffset, SEEK_SET);
     uint32_t compressed = stripSizeList[0];
-    putIFDLong( TIFF_STRIPBYTECOUNTS, TIFF_LONG, 1, compressed, outfile );
+    writeFailed |= putIFDLong( TIFF_STRIPBYTECOUNTS, TIFF_LONG, 1, compressed, outfile );
   } else {
     fseek(outfile, stripOffset_offset, SEEK_SET);
     for (size_t i = 0; i < stripCount; ++i)
-      putLong( stripOffsetList[i], outfile );
+      writeFailed |= putLong( stripOffsetList[i], outfile );
 
     fseek(outfile, stripByteCount_offset, SEEK_SET);
     for (size_t i = 0; i < stripCount; ++i)
-      putLong( stripSizeList[i], outfile );
+      writeFailed |= putLong( stripSizeList[i], outfile );
   }
 
-  if (!writeOk || ferror(outfile)) {
-    fprintf(stderr, "WriteTIFF: I/O error writing TIFF data\n");
+  if (writeFailed || ferror(outfile)) {
+    fprintf(stderr, "ERROR: I/O error writing TIFF data to %s\n", name.c_str() );
     fclose(outfile);
     return false;
   }
 
   // and close the file
   if (fclose(outfile) != 0) {
-    fprintf(stderr, "Warning: fclose failed for TIFF output\n");
+    fprintf(stderr, "WARNING: fclose failed for %s\n", name.c_str() );
   }
 
   return true;

--- a/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
@@ -420,15 +420,15 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
 
   // and update our strip offsets and sizes
   if (stripCount == 1) {
-    fseek(outfile, byteCountOffset, SEEK_SET);
+    writeFailed |= (fseek(outfile, byteCountOffset, SEEK_SET) != 0);
     uint32_t compressed = stripSizeList[0];
     writeFailed |= putIFDLong( TIFF_STRIPBYTECOUNTS, TIFF_LONG, 1, compressed, outfile );
   } else {
-    fseek(outfile, stripOffset_offset, SEEK_SET);
+    writeFailed |= (fseek(outfile, stripOffset_offset, SEEK_SET) != 0);
     for (size_t i = 0; i < stripCount; ++i)
       writeFailed |= putLong( stripOffsetList[i], outfile );
 
-    fseek(outfile, stripByteCount_offset, SEEK_SET);
+    writeFailed |= (fseek(outfile, stripByteCount_offset, SEEK_SET) != 0);
     for (size_t i = 0; i < stripCount; ++i)
       writeFailed |= putLong( stripSizeList[i], outfile );
   }

--- a/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
@@ -66,6 +66,11 @@
 #include <vector>
 #include <cmath>
 #include <memory>
+#if !defined(_WIN32)
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 #include "MiniTIFF.hpp"
 
 /******************************************************************************/
@@ -176,6 +181,29 @@ void putIFDLong( uint16_t tag, uint16_t type, uint32_t count, uint32_t value, FI
 
 /******************************************************************************/
 
+static
+FILE* icOpenWriteBinaryFile(const char* szFname)
+{
+  if (!szFname || !szFname[0])
+    return stdout;
+
+#if defined(_WIN32)
+  return fopen(szFname, "wb");
+#else
+  int fd = open(szFname, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+  if (fd < 0)
+    return nullptr;
+
+  FILE* f = fdopen(fd, "wb");
+  if (!f)
+    close(fd);
+
+  return f;
+#endif
+}
+
+/******************************************************************************/
+
 /// Write the image buffer to a TIFF (.tif) file
 bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *buffer,
         size_t width, size_t height, int channels, int depth )
@@ -184,7 +212,7 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   bool writeOk = true;
 
   // see if we can create or update this filename
-  outfile = fopen(name.c_str(),"wb");
+  outfile = icOpenWriteBinaryFile(name.c_str());
   if(outfile==NULL) {
     fprintf(stderr,"Could not create output file %s\n", name.c_str());
     return false;

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -386,12 +386,58 @@ void describe1DLUT( CIccTagCurve *curve, std::string &description )
 static
 void describe1DLUT( CIccTagParametricCurve *curve, std::string &description )
 {
+  std::string path("parametricCurve");
+  std::string report;
+  if (curve->Validate(path, report, NULL) > icValidateWarning) {
+    fprintf(stderr,"WARNING - curve failed validation: %s\n", report.c_str() );
+    description = "parametric";
+    return;
+  }
   curve->Describe( description, 100 );
 }
+
+/******************************************************************************/
 
 static
 void describe1DLUT( CIccTagSegmentedCurve *curve, std::string &description )
 {
+  std::string path("segmentedCurve");
+  std::string report;
+  if (curve->Validate(path, report, NULL) > icValidateWarning) {
+    fprintf(stderr,"WARNING - curve failed validation: %s\n", report.c_str() );
+    description = "segmented";
+    return;
+  }
+  curve->Describe( description, 100 );
+}
+
+/******************************************************************************/
+
+static
+void describe1DLUT( CIccCurve *curve, std::string &description )
+{
+  std::string path("unknownCurve");
+  std::string report;
+  if (curve->Validate(path, report, NULL) > icValidateWarning) {
+    fprintf(stderr,"WARNING - curve failed validation: %s\n", report.c_str() );
+    description = "unknown";
+    return;
+  }
+  curve->Describe( description, 100 );
+}
+
+/******************************************************************************/
+
+static
+void describe3DLUT( CIccMBB *curve, CIccProfile *pIcc, std::string &description )
+{
+  std::string path("MBBLut");
+  std::string report;
+  if (curve->Validate(path, report, pIcc ) > icValidateWarning) {
+    fprintf(stderr,"WARNING - table failed validation: %s\n", report.c_str() );
+    description = "MBBLut";
+    return;
+  }
   curve->Describe( description, 100 );
 }
 
@@ -466,7 +512,7 @@ void output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigD
       CIccCurve *uCurve = dynamic_cast<CIccCurve*> (tag);
       if (uCurve) {
         std::string description;
-        uCurve->Describe( description, 100 );
+        describe1DLUT( uCurve, description );
 #if USE_SVG
         graph1DLUTSVG( uCurve, sigDesc, description, svgfile, 1000 );
 #endif
@@ -564,7 +610,7 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     CIccMBB *lut = dynamic_cast<CIccMBB*> (tag);
     if (lut) {
       std::string description;
-      lut->Describe( description, 100 );
+      describe3DLUT( lut, pIcc, description );
 
       // output input and output curves
       CIccCurve **curveA = lut->GetCurvesA();

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1036,32 +1036,28 @@ int main(int argc, char* argv[])
 
 // if we need options in the future, then parse -* and add all unknowns to a list of filenames
 
-#if defined(_DEBUG) || defined(DEBUG)
-  int nValid = 0;
-#endif
-
   for (int k = 1; k < argc; ++k) {
-    CIccProfile *pIcc = OpenIccProfile( argv[k] );
-    if (!pIcc) {
-      printf("Unable to parse '%s' as ICC profile!\n", argv[k]);
-      continue;
-    }
-// DEBUGGING printf("Processing profile '%s'\n", argv[k]);
-    auto count = processLuts( pIcc, argv[k] );
-    if (!count) {
+    try {
+      CIccProfile *pIcc = OpenIccProfile( argv[k] );
+      if (!pIcc) {
+        printf("Unable to parse '%s' as ICC profile!\n", argv[k]);
+        continue;
+      }
+      // DEBUGGING printf("Processing profile '%s'\n", argv[k]);
+      auto count = processLuts( pIcc, argv[k] );
+      if (!count) {
         printf("Profile %s had no content for output\n", argv[k] );
+      }
+      delete pIcc;
     }
-#if defined(_DEBUG) || defined(DEBUG)
-    else {
-      nValid++;
+    catch (const std::exception& e) {
+      fprintf(stderr, "ERROR processing '%s': '%s'\n", argv[k], e.what() );
     }
-#endif
-    delete pIcc;
-  }
+    catch (...) {
+      fprintf(stderr, "ERROR processing '%s': unknown exception\n", argv[k] );
+    }
 
-#if defined(_DEBUG) || defined(DEBUG)
-  printf("EXIT %d\n", nValid);
-#endif
+  }
 
   return 0;
 }

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -599,9 +599,7 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
   icTagTypeSignature typeSig = tag->GetType();
   switch(typeSig) {
 
-// CIccTagLut8, CIccTagLut16, CIccTagLutAtoB, icSigLutBtoAType are subclases of CIccMBB
-// this might be usable for all types
-
+  // these are all subclases of CIccMBB, and can share most of the code
   case icSigLut8Type:   // CIccTagLut8
   case icSigLut16Type:  // CIccTagLut16
   case icSigLutAtoBType:  // CIccTagLutAtoB
@@ -796,17 +794,17 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     }
 
 #else
-      size_t n001 = tileWidth * tileHeight * outputChannels;
-      size_t n010 = tileWidth * outputChannels;
-      size_t n100 = outputChannels;
+      size_t n001 = (size_t)tileWidth * (size_t)tileHeight * (size_t)outputChannels;
+      size_t n010 = (size_t)tileWidth * (size_t)outputChannels;
+      size_t n100 = (size_t)outputChannels;
 
       if (inputChannels < 2)
         std::swap(n010,n100);
 
-      size_t outTileStepV = imageWidth * tileHeight * outputChannels;
-      size_t outTileStepH = tileWidth * outputChannels;
-      size_t outColStep = outputChannels;
-      size_t outRowStep = imageWidth * outputChannels;
+      size_t outTileStepV = (size_t)imageWidth * (size_t)tileHeight * (size_t)outputChannels;
+      size_t outTileStepH = (size_t)tileWidth * (size_t)outputChannels;
+      size_t outColStep = (size_t)outputChannels;
+      size_t outRowStep = (size_t)imageWidth * (size_t)outputChannels;
 
       for (int z = 0; z < tiles; ++z) {
         int z2 = z % tilesWide; // tile # horiz

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -566,6 +566,7 @@ int TIFFColorModelFromICCModel( icColorSpaceSignature colorSig )
 
     default:
       // and N-ink should be multichannel
+      // where white = no ink, black = full ink
       return TIFF_MODE_GRAY_WHITEZERO;
       break;
 
@@ -724,6 +725,7 @@ int output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       return outputCount;
     }
 
+    // validate is called back before the Describe call
     clut->Begin();  // initialize some grid information
 
     int gridPoints = clut->GridPoints(); // gridSize[0]

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -67,6 +67,7 @@
 #include <fstream>
 #include <cstring>
 #include <cmath>
+#include <limits>
 #include <string>
 #include <memory>
 #include <algorithm>
@@ -341,18 +342,20 @@ void graph1DLUTPDF( CIccCurve *curve, const std::string &name,
     steps = 2;
   float scale = (7.5f-0.5f)*inch2point;
   const point2D base( 0.5f*inch2point, 0.5f*inch2point );
-  commands << base << " m\n";
-  for (int i = 0; i <= steps; ++i ) {
-    float input = i / (float)steps;
-    float output = curve->Apply( input );
-    if (std::isnan(output)) output = 0.0f;
-    if (std::isinf(output)) output = 1.0f;
-    if (output > 1.0f) output = 1.0f;
-    if (output < 0.0f) output = 0.0f;
-    point2D currentPt( input*scale, output*scale );
-    commands << (base+currentPt) << " l\n";
+  if (steps > 0) {
+      commands << base << " m\n";
+      for (int i = 0; i <= steps; ++i ) {
+        float input = i / (float)steps;
+        float output = curve->Apply( input );
+        if (std::isnan(output)) output = 0.0f;
+        if (std::isinf(output)) output = 1.0f;
+        if (output > 1.0f) output = 1.0f;
+        if (output < 0.0f) output = 0.0f;
+        point2D currentPt( input*scale, output*scale );
+        commands << (base+currentPt) << " l\n";
+      }
+      commands << "S\n";
   }
-  commands << "S\n";
 
   // and finally create the graphics object and page
   PDFGraphic *graphics = new PDFGraphic( commands.str() );
@@ -583,6 +586,38 @@ std::string channelName(int index, bool isInputMatrix, icColorSpaceSignature inp
 
 /******************************************************************************/
 
+static
+uint8_t ClipU8( const icFloatNumber &input )
+{
+  if (std::isnan(input))
+    return 0;
+  if (std::isinf(input))
+    return 255;
+  if (input < 0)
+    return 0;
+  if (input > 255)
+    return 255;
+  return (uint8_t)input;
+}
+
+/******************************************************************************/
+
+static
+uint16_t ClipU16( const icFloatNumber &input )
+{
+  if (std::isnan(input))
+    return 0;
+  if (std::isinf(input))
+    return 65535;
+  if (input < 0)
+    return 0;
+  if (input > 65535)
+    return 65535;
+  return (uint16_t)input;
+}
+
+/******************************************************************************/
+
 // output graphic representation of nD LUTs
 static
 void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
@@ -729,7 +764,17 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       }
 
       // find tile arrangement closest to a square
-      int tilesWide = (int)std::sqrt(tiles);
+      if (tiles <= 0) {
+        fprintf(stderr,"WARNING - tile count overflow.\n");
+        tiles = 1;
+      }
+      
+      auto tempResult = std::sqrt(tiles);
+      if (tempResult > std::numeric_limits<int>::max()) {
+        fprintf(stderr,"ERROR - sqrt bad result!\n");
+        tempResult = tiles/2;
+      }
+      int tilesWide = (int)tempResult;
 
       // some odd counts need a tweak to align and look more sane
       if (inputChannels > 3 && (inputChannels & 1)) {
@@ -787,10 +832,10 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
             imageBuf32[outputIndex+c] = clutData[inputIndex+c];
         else if (bytes == 2)
           for (int c = 0; c < outputChannels; ++c)
-            imageBuf16[outputIndex+c] = clutData[inputIndex+c] * 65535.0;
+            imageBuf16[outputIndex+c] = ClipU16( clutData[inputIndex+c] * 65535.0f );
         else
           for (int c = 0; c < outputChannels; ++c)
-            imageBuf[outputIndex+c] = clutData[inputIndex+c] * 255.0;
+            imageBuf[outputIndex+c] = ClipU8( clutData[inputIndex+c] * 255.0f );
     }
 
 #else
@@ -818,10 +863,10 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
               imageBuf32[outputIndex+c] = clutData[inputIndex+c];
           else if (bytes == 2)
             for (int c = 0; c < outputChannels; ++c)
-              imageBuf16[outputIndex+c] = clutData[inputIndex+c] * 65535.0;
+              imageBuf16[outputIndex+c] = ClipU16( clutData[inputIndex+c] * 65535.0f );
           else
             for (int c = 0; c < outputChannels; ++c)
-              imageBuf[outputIndex+c] = clutData[inputIndex+c] * 255.0;
+              imageBuf[outputIndex+c] = ClipU8( clutData[inputIndex+c] * 255.0f );
         }
       }
 #endif

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -277,19 +277,19 @@ void graph1DLUTSVG( CIccCurve *curve, const std::string &name,
 
 std::vector<std::string> splitLines(const std::string& str)
 {
-    const char newline = '\n';
-    std::vector<std::string> lines;
-    size_t start = 0;
-    size_t end = str.find(newline);
-    while (end != std::string::npos) {
-        lines.push_back(str.substr(start, end - start));
-        start = end + 1;
-        end = str.find(newline, start);
-    }
-    auto temp = str.substr(start);
-    if (temp.size() > 0)
-        lines.push_back(temp);
-    return lines;
+  const char newline = '\n';
+  std::vector<std::string> lines;
+  size_t start = 0;
+  size_t end = str.find(newline);
+  while (end != std::string::npos) {
+    lines.push_back(str.substr(start, end - start));
+    start = end + 1;
+    end = str.find(newline, start);
+  }
+  auto temp = str.substr(start);
+  if (temp.size() > 0)
+    lines.push_back(temp);
+  return lines;
 }
 
 /******************************************************************************/
@@ -364,7 +364,6 @@ void graph1DLUTPDF( CIccCurve *curve, const std::string &name,
 
   pdffile.AddPage( content );
 }
-
 
 /******************************************************************************/
 
@@ -447,8 +446,9 @@ void describe3DLUT( CIccMBB *curve, CIccProfile *pIcc, std::string &description 
 /******************************************************************************/
 
 // output graphic representation of 1D LUTs
+// return 1 if output created, 0 if none
 static
-void output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDesc,
+int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDesc,
         PDFWriter &pdffile )
 {
   const size_t bufSize = 64;
@@ -456,7 +456,7 @@ void output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigD
 
   if (!tag) {
     fprintf(stderr, "ERROR - missing data for %s\n", sigDesc.c_str());
-    return;
+    return 0;
   }
 
   icTagTypeSignature typeSig = tag->GetType();
@@ -474,6 +474,7 @@ void output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigD
         graph1DLUTSVG( curve, sigDesc, description, svgfile, steps );
 #endif
         graph1DLUTPDF( curve, sigDesc, description, pdffile, steps );
+        return 1;
         }
       }
       break;
@@ -489,6 +490,7 @@ void output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigD
         graph1DLUTSVG( pCurve, sigDesc, description, svgfile, 1000 );
 #endif
         graph1DLUTPDF( pCurve, sigDesc, description, pdffile, 1000 );
+        return 1;
         }
       }
       break;
@@ -504,6 +506,7 @@ void output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigD
         graph1DLUTSVG( sCurve, sigDesc, description, svgfile, 1000 );
 #endif
         graph1DLUTPDF( sCurve, sigDesc, description, pdffile, 1000 );
+        return 1;
         }
       }
       break;
@@ -520,11 +523,14 @@ void output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigD
         graph1DLUTSVG( uCurve, sigDesc, description, svgfile, 1000 );
 #endif
         graph1DLUTPDF( uCurve, sigDesc, description, pdffile, 1000 );
+        return 1;
         }
       }
       break;
 
   }   // end switch by type
+  
+  return 0; // no output created
 
 }   // end output1DLUT()
 
@@ -619,16 +625,18 @@ uint16_t ClipU16( const icFloatNumber &input )
 /******************************************************************************/
 
 // output graphic representation of nD LUTs
+// return count of output objects created, 0 if none
 static
-void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
+int output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
         const std::string &basename, PDFWriter &pdffile )
 {
   const size_t bufSize = 128;
   char buf[bufSize];
+  int outputCount = 0;
 
   if (!tag) {
     fprintf(stderr, "Skipping %s: unable to load tag\n", sigDesc.c_str());
-    return;
+    return 0;
   }
 
   icTagTypeSignature typeSig = tag->GetType();
@@ -641,179 +649,183 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
   case icSigLutBtoAType:  // CIccTagLutBtoA
     {
     CIccMBB *lut = dynamic_cast<CIccMBB*> (tag);
-    if (lut) {
-      std::string description;
-      describe3DLUT( lut, pIcc, description );
+    if (!lut) {
+      fprintf(stderr, "Skipping %s: unable to convert LUT\n", sigDesc.c_str());
+      return outputCount;
+    }
+    
+    std::string description;
+    describe3DLUT( lut, pIcc, description );
 
-      // output input and output curves
-      CIccCurve **curveA = lut->GetCurvesA();
-      CIccCurve **curveB = lut->GetCurvesB();
-      CIccCurve **curveM = lut->GetCurvesM();
-      std::string curveDesc = sigDesc + ": ";
+    // output input and output curves
+    CIccCurve **curveA = lut->GetCurvesA();
+    CIccCurve **curveB = lut->GetCurvesB();
+    CIccCurve **curveM = lut->GetCurvesM();
+    std::string curveDesc = sigDesc + ": ";
 
-      int inputChannels = lut->InputChannels();
-      int outputChannels = lut->OutputChannels();
-      icColorSpaceSignature inputSpace = lut->GetCsInput();
-      icColorSpaceSignature outputSpace = lut->GetCsOutput();
-      bool isInputMatrix = lut->IsInputMatrix();
+    int inputChannels = lut->InputChannels();
+    int outputChannels = lut->OutputChannels();
+    icColorSpaceSignature inputSpace = lut->GetCsInput();
+    icColorSpaceSignature outputSpace = lut->GetCsOutput();
+    bool isInputMatrix = lut->IsInputMatrix();
 
-      if (inputChannels <= 0 || outputChannels <= 0) {
-        fprintf(stderr, "Skipping %s: invalid channel count\n", sigDesc.c_str());
-        return;
-      }
+    if (inputChannels <= 0 || outputChannels <= 0) {
+      fprintf(stderr, "Skipping %s: invalid channel count\n", sigDesc.c_str());
+      return outputCount;
+    }
 
-      if (curveA) {
-        int curveACount = isInputMatrix ? outputChannels : inputChannels;
-        for (int i = 0; i < curveACount; ++i) {
-          if (curveA[i]) {
+    if (curveA) {
+      int curveACount = isInputMatrix ? outputChannels : inputChannels;
+      for (int i = 0; i < curveACount; ++i) {
+        if (curveA[i]) {
           std::string channel = channelName( i, !isInputMatrix,
                     inputSpace, outputSpace, inputChannels, outputChannels );
           std::string channelDesc = curveDesc + "curveA[ " + channel + " ]";
-          output1DLUT( pIcc, curveA[i], channelDesc, pdffile );
-          }
+          outputCount += output1DLUT( pIcc, curveA[i], channelDesc, pdffile );
         }
       }
+    }
 
-      if (curveB) {
-        int curveBCount = isInputMatrix ? inputChannels : outputChannels;
-        for (int i = 0; i < curveBCount; ++i) {
-          if (curveB[i]) {
+    if (curveB) {
+      int curveBCount = isInputMatrix ? inputChannels : outputChannels;
+      for (int i = 0; i < curveBCount; ++i) {
+        if (curveB[i]) {
           std::string channel = channelName( i, isInputMatrix,
-                  inputSpace, outputSpace, inputChannels, outputChannels );
+                    inputSpace, outputSpace, inputChannels, outputChannels );
           std::string channelDesc = curveDesc + "curveB[ " + channel + " ]";
-          output1DLUT( pIcc, curveB[i], channelDesc, pdffile );
-          }
+          outputCount += output1DLUT( pIcc, curveB[i], channelDesc, pdffile );
         }
       }
+    }
 
-      if (curveM) {
-        int curveMCount = isInputMatrix ? inputChannels : outputChannels;
-        for (int i = 0; i < curveMCount; ++i) {
-          if (curveM[i]) {
+    if (curveM) {
+      int curveMCount = isInputMatrix ? inputChannels : outputChannels;
+      for (int i = 0; i < curveMCount; ++i) {
+        if (curveM[i]) {
           std::string channel = channelName( i, isInputMatrix,
                     inputSpace, outputSpace, inputChannels, outputChannels );
           std::string channelDesc = curveDesc + "curveM[ " + channel + " ]";
-          output1DLUT( pIcc, curveM[i], channelDesc, pdffile );
-          }
+          outputCount += output1DLUT( pIcc, curveM[i], channelDesc, pdffile );
         }
       }
+    }
 
 
     // write nD Data to TIFF
-      int bytes = lut->GetPrecision();    // currently only 1 or 2
-      CIccCLUT *clut = lut->GetCLUT();
-      if (!clut) {
-        // clut is optional in mAB and mBA tags - only report if it isn't one of those
-        if ( !(typeSig == icSigLutAtoBType || typeSig == icSigLutBtoAType) ) {
-            std::string typeDesc = icGetSigStr(buf, bufSize, typeSig);
-            fprintf(stderr,"ERROR - clut data could not be read for tag '%s' of type '%s' in file '%s'\n", sigDesc.c_str(), typeDesc.c_str(), basename.c_str() );
+    int bytes = lut->GetPrecision();    // currently only 1 or 2
+    CIccCLUT *clut = lut->GetCLUT();
+    if (!clut) {
+      // clut is optional in mAB and mBA tags - only report if it isn't one of those
+      if ( !(typeSig == icSigLutAtoBType || typeSig == icSigLutBtoAType) ) {
+        std::string typeDesc = icGetSigStr(buf, bufSize, typeSig);
+        fprintf(stderr,"ERROR - clut data could not be read for tag '%s' of type '%s' in file '%s'\n",
+                sigDesc.c_str(), typeDesc.c_str(), basename.c_str() );
+      }
+      return outputCount;
+    }
+
+    clut->Begin();  // initialize some grid information
+
+    int gridPoints = clut->GridPoints(); // gridSize[0]
+    int tiles = gridPoints;
+    if (gridPoints <= 0) {
+      fprintf(stderr, "Skipping %s: invalid CLUT grid\n", sigDesc.c_str());
+      return outputCount;
+    }
+    
+    int tileWidth = 1;
+    int tileHeight = 1;
+
+    if (inputChannels >= 2) {
+      tileWidth = clut->GridPoint(1);
+      if (tileWidth <= 0) {
+        fprintf(stderr, "Skipping %s: invalid CLUT width\n", sigDesc.c_str());
+        return outputCount;
+      }
+    }
+
+    if (inputChannels >= 3) {
+      tileHeight = clut->GridPoint(2);
+      if (tileHeight <= 0) {
+        fprintf(stderr, "Skipping %s: invalid CLUT height\n", sigDesc.c_str());
+        return outputCount;
+      }
+    }
+
+    if (inputChannels > 3) {
+      for (int i = 3; i < inputChannels; ++i) {
+        int extraGridPoints = clut->GridPoint(i);
+        if (extraGridPoints <= 0) {
+          fprintf(stderr, "Skipping %s: invalid CLUT tile count\n", sigDesc.c_str());
+          return outputCount;
         }
-        return;
+        tiles *= extraGridPoints;
       }
-
-      clut->Begin();  // initialize some grid information
-
-      int gridPoints = clut->GridPoints(); // gridSize[0]
-      int tiles = gridPoints;
-      if (gridPoints <= 0) {
-        fprintf(stderr, "Skipping %s: invalid CLUT grid\n", sigDesc.c_str());
-        return;
-      }
-
-      int tileWidth = 1;
-      int tileHeight = 1;
-
-      if (inputChannels >= 2) {
-        tileWidth = clut->GridPoint(1);
-        if (tileWidth <= 0) {
-          fprintf(stderr, "Skipping %s: invalid CLUT width\n", sigDesc.c_str());
-          return;
-        }
-      }
-
-      if (inputChannels >= 3) {
-        tileHeight = clut->GridPoint(2);
-        if (tileHeight <= 0) {
-          fprintf(stderr, "Skipping %s: invalid CLUT height\n", sigDesc.c_str());
-          return;
-        }
-      }
-
-      if (inputChannels > 3) {
-        for (int i = 3; i < inputChannels; ++i) {
-          int extraGridPoints = clut->GridPoint(i);
-          if (extraGridPoints <= 0) {
-            fprintf(stderr, "Skipping %s: invalid CLUT tile count\n", sigDesc.c_str());
-            return;
-          }
-          tiles *= extraGridPoints;
-        }
-      }
+    }
 
       // special case for single dimensional LUT
-      if (inputChannels == 1) {
-        tileWidth = tiles;
-        tiles = 1;
-        tileHeight = 1;
-      }
+    if (inputChannels == 1) {
+      tileWidth = tiles;
+      tiles = 1;
+      tileHeight = 1;
+    }
 
       // special case for 2 dimensional LUT
-      if (inputChannels == 2) {
-        tileHeight = tiles;
-        tiles = 1;
-      }
+    if (inputChannels == 2) {
+      tileHeight = tiles;
+      tiles = 1;
+    }
 
       // find tile arrangement closest to a square
-      if (tiles <= 0) {
-        fprintf(stderr,"WARNING - tile count overflow.\n");
-        tiles = 1;
-      }
+    if (tiles <= 0) {
+      fprintf(stderr,"WARNING - tile count overflow.\n");
+      tiles = 1;
+    }
       
-      auto tempResult = std::sqrt(tiles);
-      if (tempResult > std::numeric_limits<int>::max()) {
-        fprintf(stderr,"ERROR - sqrt bad result!\n");
-        tempResult = tiles/2;
+    auto tempResult = std::sqrt(tiles);
+    if (tempResult > std::numeric_limits<int>::max()) {
+      fprintf(stderr,"ERROR - sqrt bad result!\n");
+      tempResult = tiles/2;
+    }
+    int tilesWide = (int)tempResult;
+
+    // some odd counts need a tweak to align and look more sane
+    if (inputChannels > 3 && (inputChannels & 1)) {
+      auto oldValue = tilesWide;
+      // round down to a multiple of the grid size to better align rows
+      tilesWide -= (tilesWide % (gridPoints*tileWidth));
+      if (tilesWide == 0) {
+        // this does happen -- should I round up in some cases?
+        tilesWide = oldValue;
       }
-      int tilesWide = (int)tempResult;
+    }
 
-      // some odd counts need a tweak to align and look more sane
-      if (inputChannels > 3 && (inputChannels & 1)) {
-        auto oldValue = tilesWide;
-        // round down to a multiple of the grid size to better align rows
-        tilesWide -= (tilesWide % (gridPoints*tileWidth));
-        if (tilesWide == 0) {
-            // this does happen -- should I round up in some cases?
-            tilesWide = oldValue;
-        }
-      }
+    int tilesHigh = (tiles + (tilesWide-1)) / tilesWide;
 
-      int tilesHigh = (tiles + (tilesWide-1)) / tilesWide;
+    // multiply out by tile size
+    int imageWidth = tilesWide * tileWidth;
+    int imageHeight = tilesHigh * tileHeight;
+    if (imageWidth <= 0 || imageHeight <= 0 || bytes <= 0) {
+      fprintf(stderr, "Skipping %s: invalid image geometry\n", sigDesc.c_str());
+      return outputCount;
+    }
 
-      // multiply out by tile size
-      int imageWidth = tilesWide * tileWidth;
-      int imageHeight = tilesHigh * tileHeight;
-      if (imageWidth <= 0 || imageHeight <= 0 || bytes <= 0) {
-        fprintf(stderr, "Skipping %s: invalid image geometry\n", sigDesc.c_str());
-        return;
-      }
+    //size_t clutSize = (size_t)tiles * (size_t)tileWidth * (size_t)tileHeight * (size_t)outputChannels;
+    size_t bufferSize = (size_t)imageWidth * (size_t)imageHeight * (size_t)outputChannels * bytes;
+    // NOTE that bufferSize will usually be greater than clutSize
+    if (!bufferSize) {
+      fprintf(stderr, "Skipping %s: empty image buffer\n", sigDesc.c_str());
+      return outputCount;
+    }
 
-      //size_t clutSize = (size_t)tiles * (size_t)tileWidth * (size_t)tileHeight * (size_t)outputChannels;
-      size_t bufferSize = (size_t)imageWidth * (size_t)imageHeight * (size_t)outputChannels * bytes;
-      // NOTE that bufferSize will usually be greater than clutSize
-      if (!bufferSize) {
-        fprintf(stderr, "Skipping %s: empty image buffer\n", sigDesc.c_str());
-        return;
-      }
+    std::unique_ptr<uint8_t[]> imageBuffer( new uint8_t[ bufferSize ] );
+    uint8_t *imageBuf = imageBuffer.get();
+    uint16_t *imageBuf16 = (uint16_t *)imageBuf;
+    float *imageBuf32 = (float *)imageBuf;
+    memset( imageBuf, 0, bufferSize );
 
-      std::unique_ptr<uint8_t[]> imageBuffer( new uint8_t[ bufferSize ] );
-      uint8_t *imageBuf = imageBuffer.get();
-      uint16_t *imageBuf16 = (uint16_t *)imageBuf;
-      float *imageBuf32 = (float *)imageBuf;
-      memset( imageBuf, 0, bufferSize );
-
-      // copy data from CLUT to image buffer
-      icFloatNumber *clutData = clut->GetData(0);
-
+    // copy data from CLUT to image buffer
+    icFloatNumber *clutData = clut->GetData(0);
 
 
 #if 0
@@ -874,11 +886,11 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       std::string tiffPath2 = basename + "_" + sigDesc + ".tif";
       int tiffColor = TIFFColorModelFromICCModel( outputSpace );
       if (!WriteTIFF( tiffPath2.c_str(), 100, tiffColor, imageBuf,
-                imageWidth, imageHeight, outputChannels, 8*bytes )) {
+                        imageWidth, imageHeight, outputChannels, 8*bytes )) {
         fprintf(stderr, "Failed to write TIFF: %s\n", tiffPath2.c_str());
-        }
       }
     }
+    return ++outputCount;
     break;
 
   case icSigMultiProcessElementType:
@@ -890,7 +902,10 @@ void output3DLUT(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
          icGetSig(buf, bufSize, typeSig),
          sigDesc.c_str() );
     break;
+
   }   // end switch by type
+  
+  return 0; // no output was created
 
 }   // end output3DLUT()
 
@@ -954,8 +969,7 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
         {
         const char *sigDesc = icGetSigStr(buf1, bufSize, sig);
         CIccTag *pTag = pIcc->FindTag(tag); // load if needed
-        output1DLUT(pIcc, pTag, sigDesc, pdffile );
-        outputItems++;
+        outputItems += output1DLUT(pIcc, pTag, sigDesc, pdffile );
         }
         break;
 
@@ -975,8 +989,7 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
         {
         std::string sigDesc = icGetSigStr(buf1, bufSize, sig);
         CIccTag *pTag = pIcc->FindTag(tag); // load if needed
-        output3DLUT(pIcc, pTag, sigDesc, basename, pdffile );
-        outputItems++;
+        outputItems += output3DLUT(pIcc, pTag, sigDesc, basename, pdffile );
         }
         break;
 
@@ -1002,8 +1015,8 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
 static
 void printUsage(void)
 {
-  printf("Usage: iccProfileVisualize input_profile\n");
-  printf("  output will be TIFF and PDF files next to the input profile.\n");
+  printf("Usage: iccProfileVisualize input_profiles\n");
+  printf("  output will be TIFF and PDF files next to each input profile.\n");
   printf("iccProfileVisualize built with IccProfLib version " ICCPROFLIBVER "\n\n");
 }
 
@@ -1043,13 +1056,15 @@ int main(int argc, char* argv[])
         printf("Unable to parse '%s' as ICC profile!\n", argv[k]);
         continue;
       }
+      
       // DEBUGGING printf("Processing profile '%s'\n", argv[k]);
       auto count = processLuts( pIcc, argv[k] );
       if (!count) {
         printf("Profile %s had no content for output\n", argv[k] );
       }
+      
       delete pIcc;
-    }
+    }   // end try
     catch (const std::exception& e) {
       fprintf(stderr, "ERROR processing '%s': '%s'\n", argv[k], e.what() );
     }
@@ -1057,7 +1072,7 @@ int main(int argc, char* argv[])
       fprintf(stderr, "ERROR processing '%s': unknown exception\n", argv[k] );
     }
 
-  }
+  } // end for argc
 
   return 0;
 }


### PR DESCRIPTION
## PR Summary

Fixing #1010  CodeQL issues, adding additional safety to iccProfileVisualize

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
