### PR TITLE
Add: iccConnect Updates

### DIFF
--- a/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
+++ b/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
@@ -4,15 +4,14 @@
 ###############################################################################
 #
 # Verifies that iccApplyProfiles produces bit-identical TIFF output under
-# every -threads mode supported by CIccConnectCmm::EnableThreading():
-#   -threads -1   single-threaded (no CIccThreadedCmm wrapper, per-pixel apply)
-#   -threads  1   wrapper with one worker (row-batched apply, no concurrency)
+# every non-negative -threads mode supported by CIccConnectCmm::CreateStandard():
+#   -threads  1   single-threaded (no CIccThreadedCmm wrapper, per-pixel apply)
 #   -threads  0   wrapper with std::thread::hardware_concurrency() workers
 #   -threads  N   wrapper with N workers (default N=4 here)
 #
 # Catches partitioning regressions in CIccApplyThreadedCmm::Apply()'s strip
 # split / async-launch / last-strip-on-caller logic, and any future ownership
-# regression in CIccConnectCmm::EnableThreading().
+# regression in CIccConnectCmm threaded initialization.
 #
 # Input: a deterministic 512x512 sRGB TIFF generated on the fly so this test
 # does not depend on a checked-in image with a specific colour space. Python 3
@@ -164,7 +163,7 @@ run_threads() {
 }
 
 REF=""
-for entry in "-1:single" "1:t1" "0:auto" "4:t4"; do
+for entry in "1:t1" "0:auto" "4:t4"; do
   TOTAL=$((TOTAL + 1))
   nthreads="${entry%%:*}"
   label="${entry##*:}"

--- a/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
+++ b/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+###############################################################################
+# iccDEV iccApplyProfiles threading equivalence regression tests
+###############################################################################
+#
+# Verifies that iccApplyProfiles produces bit-identical TIFF output under
+# every -threads mode supported by CIccConnectCmm::EnableThreading():
+#   -threads -1   single-threaded (no CIccThreadedCmm wrapper, per-pixel apply)
+#   -threads  1   wrapper with one worker (row-batched apply, no concurrency)
+#   -threads  0   wrapper with std::thread::hardware_concurrency() workers
+#   -threads  N   wrapper with N workers (default N=4 here)
+#
+# Catches partitioning regressions in CIccApplyThreadedCmm::Apply()'s strip
+# split / async-launch / last-strip-on-caller logic, and any future ownership
+# regression in CIccConnectCmm::EnableThreading().
+#
+# Input: a deterministic 512x512 sRGB TIFF generated on the fly so this test
+# does not depend on a checked-in image with a specific colour space. Python 3
+# with Pillow is required for synthesis; the test SKIPs cleanly if either is
+# unavailable.
+#
+# Environment variables (set by CI workflow):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/ (contains tool subdirs)
+#   ICCDEV_TESTING_DIR -- path to Testing/ (contains sRGB_v4_ICC_preference.icc)
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit code: 0 = all pass, 1 = test failure, 2 = ASAN/UBSAN finding
+###############################################################################
+
+set -uo pipefail
+
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:?Set ICCDEV_TOOLS_DIR to iccDEV Build/Tools path}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:?Set ICCDEV_TESTING_DIR to iccDEV Testing path}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-iccapplyprofiles-threading}"
+mkdir -p "$OUTDIR"
+
+APPLY_PROFILES="$TOOLS_DIR/IccApplyProfiles/iccApplyProfiles"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+SKIP=0
+ASAN_FINDINGS=0
+UBSAN_FINDINGS=0
+TOTAL=0
+
+echo "=== iccApplyProfiles -threads equivalence ==="
+
+if [ ! -x "$APPLY_PROFILES" ]; then
+  echo "  [SKIP] iccApplyProfiles not found at $APPLY_PROFILES"
+  exit 0
+fi
+
+SRGB_PROFILE=""
+for candidate in \
+  "$TESTING_DIR/sRGB_v4_ICC_preference.icc" \
+  "$TESTING_DIR/../Testing/sRGB_v4_ICC_preference.icc"; do
+  if [ -f "$candidate" ]; then
+    SRGB_PROFILE="$candidate"
+    break
+  fi
+done
+
+if [ -z "$SRGB_PROFILE" ]; then
+  echo "  [SKIP] sRGB_v4_ICC_preference.icc not found under $TESTING_DIR"
+  exit 0
+fi
+
+# Synthesize a deterministic 512x512 sRGB TIFF with the sRGB profile embedded.
+# 512x512 = 262144 pixels: comfortably larger than std::thread::hardware_concurrency()
+# so the threaded apply path actually engages every worker on typical hosts.
+SRC_TIFF="$OUTDIR/threading-equiv-src.tif"
+PY_LOG="$OUTDIR/threading-equiv-pyinput.log"
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  [SKIP] python3 not available -- cannot synthesize deterministic source TIFF"
+  exit 0
+fi
+
+python3 - "$SRC_TIFF" "$SRGB_PROFILE" >"$PY_LOG" 2>&1 <<'PY'
+import sys
+from PIL import Image
+
+out_path, icc_path = sys.argv[1], sys.argv[2]
+with open(icc_path, "rb") as f:
+    icc_bytes = f.read()
+
+w, h = 512, 512
+# Deterministic gradient: R = x, G = y, B = (x+y)/2 -- full 8-bit range, no compression.
+data = bytearray(w * h * 3)
+for y in range(h):
+    base = y * w * 3
+    for x in range(w):
+        i = base + x * 3
+        data[i]     = x & 0xFF
+        data[i + 1] = y & 0xFF
+        data[i + 2] = ((x + y) >> 1) & 0xFF
+
+img = Image.frombytes("RGB", (w, h), bytes(data))
+img.save(out_path, format="TIFF", compression="raw", icc_profile=icc_bytes)
+print(f"wrote {out_path} ({w}x{h})")
+PY
+PY_EC=$?
+if [ "$PY_EC" -ne 0 ] || [ ! -s "$SRC_TIFF" ]; then
+  echo "  [SKIP] Pillow/PIL unavailable or input generation failed -- see $PY_LOG"
+  sed -n '1,10p' "$PY_LOG"
+  exit 0
+fi
+
+# Build a -cfg JSON pointing at the synthetic input. The profile sequence uses
+# the embedded source profile (empty iccFile + iccFile entries) followed by an
+# explicit sRGB destination; this exercises CIccConnectCmm::CreateStandard's
+# embedded-profile branch alongside a normal AddXform call.
+CFG_JSON="$OUTDIR/threading-equiv.cfg.json"
+cat > "$CFG_JSON" <<EOF
+{
+  "imageFiles": {
+    "srcImageFile": "$SRC_TIFF",
+    "dstImageFile": "__DST__",
+    "dstEncoding": "16Bit",
+    "dstCompression": false,
+    "dstPlanar": false,
+    "dstEmbedIcc": false
+  },
+  "profileSequence": [
+    { "iccFile": "",              "intent": 1, "interpolation": "tetrahedral" },
+    { "iccFile": "$SRGB_PROFILE", "intent": 1, "interpolation": "tetrahedral" }
+  ]
+}
+EOF
+
+# run_threads N out_label -> writes $OUTDIR/threading-equiv-<label>.tif
+run_threads() {
+  local nthreads="$1"
+  local label="$2"
+  local cfg="$OUTDIR/threading-equiv-${label}.cfg.json"
+  local dst="$OUTDIR/threading-equiv-${label}.tif"
+  local log="$OUTDIR/threading-equiv-${label}.log"
+
+  sed "s|__DST__|$dst|" "$CFG_JSON" > "$cfg"
+
+  rm -f "$dst"
+  local ec=0
+  timeout 120 "$APPLY_PROFILES" -threads "$nthreads" -cfg "$cfg" > "$log" 2>&1 || ec=$?
+
+  if grep -q "ERROR: AddressSanitizer" "$log" 2>/dev/null; then
+    echo "  [ASAN] -threads $nthreads -- AddressSanitizer finding"
+    ASAN_FINDINGS=$((ASAN_FINDINGS + 1))
+    return 1
+  fi
+  if grep -q "runtime error:" "$log" 2>/dev/null; then
+    echo "  [UBSAN] -threads $nthreads -- undefined behavior"
+    UBSAN_FINDINGS=$((UBSAN_FINDINGS + 1))
+    return 1
+  fi
+  if [ "$ec" -ne 0 ] || [ ! -s "$dst" ]; then
+    echo "  [FAIL] -threads $nthreads exit=$ec (no output)"
+    sed -n '1,20p' "$log"
+    return 1
+  fi
+  echo "$dst"
+  return 0
+}
+
+REF=""
+for entry in "-1:single" "1:t1" "0:auto" "4:t4"; do
+  TOTAL=$((TOTAL + 1))
+  nthreads="${entry%%:*}"
+  label="${entry##*:}"
+
+  out="$(run_threads "$nthreads" "$label")" || { FAIL=$((FAIL + 1)); continue; }
+
+  if [ -z "$REF" ]; then
+    REF="$out"
+    echo "  [PASS] -threads $nthreads (reference output: $(basename "$REF"))"
+    PASS=$((PASS + 1))
+    continue
+  fi
+
+  if cmp -s "$REF" "$out"; then
+    echo "  [PASS] -threads $nthreads matches $(basename "$REF")"
+    PASS=$((PASS + 1))
+  else
+    echo "  [FAIL] -threads $nthreads diverges from $(basename "$REF")"
+    # Help diagnose: report first differing byte offset.
+    cmp "$REF" "$out" 2>&1 | head -1 || true
+    FAIL=$((FAIL + 1))
+  fi
+done
+
+echo "iccApplyProfiles threading equivalence: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total"
+
+if [ "$ASAN_FINDINGS" -ne 0 ] || [ "$UBSAN_FINDINGS" -ne 0 ]; then
+  exit 2
+fi
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/IccProfLib/IccCmmSearch.cpp
+++ b/IccProfLib/IccCmmSearch.cpp
@@ -228,6 +228,9 @@ CIccCmmSearch::~CIccCmmSearch()
   if (m_pDstProfile)
     delete m_pDstProfile;
 
+  if (m_pDstInitProfile)
+    delete m_pDstInitProfile;
+
   for (auto pPcc : m_pcc) {
     delete pPcc;
   }

--- a/docs/documentation-maintenance.md
+++ b/docs/documentation-maintenance.md
@@ -14,6 +14,9 @@ point to deeper references.
 | CLI tools and shared option tables | `docs/tools-cli-reference.md` |
 | JSON workflow | `docs/iccjson.md` |
 | JSON tag examples | `docs/iccjson-tag-types.md` |
+| IccConnect library and `CIccConnectCmm` factory | `docs/icc-connect.md` |
+| IccConnect JSON config schema | `docs/icc-connect-config.schema.json` |
+| Threaded CMM apply (`CIccThreadedCmm`) | `docs/icc-cmm-threading.md` |
 | Bisect workflow | `docs/bisect.md` |
 | Pre-PR security cycle | `docs/pre-pr-security-cycle.md` and `.github/skills/pre-pr-security-cycle/SKILL.md` |
 | Regression workflow updates | `docs/regression-workflow-governance.md` |

--- a/docs/icc-cmm-threading.md
+++ b/docs/icc-cmm-threading.md
@@ -1,0 +1,150 @@
+# CIccThreadedCmm — Parallel CMM Apply
+
+`CIccThreadedCmm` is a decorator over an existing `CIccCmm` that runs
+multi-pixel `Apply()` calls in parallel by splitting the pixel buffer into
+contiguous strips and processing each strip on its own worker. It lives in
+[IccProfLib/IccCmmThread.h](../IccProfLib/IccCmmThread.h) and is part of
+`IccProfLib2`.
+
+It is a drop-in wrapper: callers keep the `CIccCmm*` API; the threading is
+internal.
+
+## When to Use
+
+- Bulk pixel processing where a single `Apply(dst, src, nPixels)` call covers
+  many independent pixels (TIFF rows, full images, batched CGATS data, etc.).
+- The wrapped CMM has already been fully configured (`AddXform` + `Begin()`).
+- Single-pixel `Apply()` does not benefit; it is forwarded to one worker.
+
+Threading is unhelpful (and skipped automatically) when `nPixels` is smaller
+than the requested thread count.
+
+## Construction Model
+
+`CIccThreadedCmm` cannot be built incrementally. It wraps a CMM that is
+already valid:
+
+```cpp
+CIccCmm *cmm = new CIccCmm(srcSpace, dstSpace, bInputProfile);
+cmm->AddXform(...);
+cmm->AddXform(...);
+if (cmm->Begin() != icCmmStatOk) { delete cmm; /* handle error */ }
+
+// nThreads = 0 -> std::thread::hardware_concurrency()
+CIccThreadedCmm *tcmm = CIccThreadedCmm::Attach(cmm, /*nThreads=*/0,
+                                                /*bDeleteCmm=*/true);
+if (!tcmm) { /* cmm has already been deleted on failure */ }
+
+tcmm->Apply(dst, src, nPixels);
+
+delete tcmm;   // deletes the wrapped cmm when bDeleteCmm=true
+```
+
+`Attach()` parameters:
+
+| Parameter | Meaning |
+|-----------|---------|
+| `pCmm` | A `Begin()`-ed `CIccCmm`. `Valid()` must return true. |
+| `nThreads` | `0` selects `std::thread::hardware_concurrency()`; clamped to `>= 1`. |
+| `bDeleteCmm` | Take ownership of `pCmm`. Also deletes `pCmm` if `Attach` fails. |
+
+`AddXform()` is disabled on the wrapper — every overload returns
+`icCmmStatBad`. Build the transform chain on the wrapped CMM before calling
+`Attach()`.
+
+## Apply Semantics
+
+`CIccApplyThreadedCmm::Apply(dst, src, nPixels)` does the following:
+
+1. Caps the active worker count at `min(nPixels, nThreads)`.
+2. Splits the buffer into `nActive` contiguous strips, with the first
+   `nPixels % nActive` strips receiving one extra pixel.
+3. Launches `nActive - 1` strips via `std::async(std::launch::async)`; runs
+   the final strip on the calling thread to overlap with the launches.
+4. Collects results and returns the first non-OK status, if any.
+
+`Apply(dst, src)` (single pixel) is forwarded to worker `[0]` without any
+thread launches.
+
+## Concurrency Rules
+
+- **Per-apply-object**: a single `CIccApplyThreadedCmm` instance must not be
+  used from more than one thread at a time. Internally each strip uses its
+  own private `CIccApplyCmm`, but the apply object itself is not reentrant.
+- **Across apply objects**: to apply from several threads simultaneously,
+  call `tcmm->GetNewApplyCmm(status)` once per caller. Each returned object
+  owns its own pool of worker apply objects.
+- **No shared mutable xform state**: every worker allocates its own
+  `CIccApplyCmm` from the wrapped CMM, so transforms that maintain
+  per-apply scratch state (e.g. calculator stacks) stay isolated.
+
+## Buffer Requirements
+
+- `dst` must hold `nPixels * GetDestSamples()` floats.
+- `src` must hold `nPixels * GetSourceSamples()` floats.
+- Strip partitioning is contiguous, so callers do not need to align on any
+  boundary; `dst` and `src` must not alias the same memory region.
+
+## CLI Example: `iccApplyProfiles -threads`
+
+[`iccApplyProfiles`](../Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp)
+exposes the wrapper through a `-threads` flag. Internally it builds the
+CMM with [`CIccConnectCmm::CreateStandard`](icc-connect.md) and then calls
+`pConnect->EnableThreading(nThreads)` — this is the canonical example of
+the connect-side threading pattern, including the row-batched float
+buffer that feeds `Apply(dst, src, nPixels)`.
+
+```text
+iccApplyProfiles -threads N -cfg config.json
+```
+
+| Value | Behaviour |
+|-------|-----------|
+| omitted | Defaults to `nThreads = 0` (hardware concurrency). |
+| `-threads 0` | Use `std::thread::hardware_concurrency()`. |
+| `-threads 1` | Threaded code path with a single worker (row-batched apply, no concurrency). |
+| `-threads N` (N > 1) | Use exactly `N` workers. |
+| `-threads -1` | Disable threading; per-pixel apply on the unwrapped CMM. |
+
+The flag is parsed before `-cfg`, so it must come first.
+
+## Failure Modes
+
+`Attach()` returns `NULL` and (when `bDeleteCmm=true`) deletes the wrapped
+CMM if any of these are true:
+
+- `pCmm` is null or `pCmm->Valid()` is false (typically `Begin()` was not
+  called or failed).
+- Worker allocation fails for the default apply object.
+
+Strip workers preserve the first non-OK status across the parallel apply.
+Subsequent strips still run; partial output in `dst` for failing strips is
+undefined.
+
+## Use From IccConnect
+
+When a CMM has been built through [`CIccConnectCmm`](icc-connect.md),
+call `EnableThreading(nThreads)` instead of attaching directly. The
+connect object keeps single ownership and rewraps `m_pCmm` for you, so
+there is no ownership coordination between two wrappers:
+
+```cpp
+CIccConnectCmm *conn = CIccConnectCmm::CreateStandard(cfg.m_profiles);
+if (!conn) { /* error */ }
+if (!conn->EnableThreading(0)) { delete conn; /* error */ }
+conn->GetCmm()->Apply(dst, src, nPixels);
+delete conn;   // tears down the threaded wrapper and the underlying CMM
+```
+
+`conn->IsThreaded()` reports whether the wrapper has been installed.
+After threading is on, the type-specific accessors `GetNamedCmm()` and
+`GetSearchCmm()` return null — striped apply only fits the standard
+pixel-pipeline use case.
+
+## See Also
+
+- [IccConnect library](icc-connect.md) — factory that constructs a
+  `Begin()`-ed CMM from JSON config, with `EnableThreading()` for
+  in-place parallel apply.
+- [CLI tool reference](tools-cli-reference.md) — shared option tables for
+  the `iccApply*` tools.

--- a/docs/icc-connect.md
+++ b/docs/icc-connect.md
@@ -1,0 +1,170 @@
+# IccConnect Library
+
+`IccConnect` (target `IccConnect2`, static variant `IccConnect2-static`) is a
+small library that builds fully initialized `CIccCmm` transform objects from
+JSON-driven configuration. It exists so command-line tools and embedders
+share one path for profile loading, hint setup, Profile Connection Conditions
+(PCC) lifetime, and `Begin()`. Sources live in
+[IccConnect/IccLibConnect](../IccConnect/IccLibConnect).
+
+The library is intentionally narrow:
+
+| Header | Purpose |
+|--------|---------|
+| [IccCmmConfig.h](../IccConnect/IccLibConnect/IccCmmConfig.h) | C++ config objects (`CIccCfgProfile`, `CIccCfgProfileSequence`, `CIccCfgSearchApply`, …) and JSON / argv loaders. |
+| [IccJsonUtil.h](../IccConnect/IccLibConnect/IccJsonUtil.h) | nlohmann/json helpers shared by the config objects. |
+| [IccConnect.h](../IccConnect/IccLibConnect/IccConnect.h) | `CIccConnectCmm` factory that turns a config into a `Begin()`-ed CMM. |
+
+The JSON shape consumed by `IccCmmConfig` is described by
+[icc-connect-config.schema.json](icc-connect-config.schema.json).
+
+## Build and Linkage
+
+`IccConnect2` is built from [Build/Cmake/IccConnect/CMakeLists.txt](../Build/Cmake/IccConnect/CMakeLists.txt)
+and is enabled by the same `ENABLE_SHARED_LIBS` / `ENABLE_STATIC_LIBS`
+options used by `IccProfLib`. It depends on:
+
+- `IccProfLib2` (or `IccProfLib2-static`)
+- `nlohmann_json::nlohmann_json`
+
+Public headers are installed under
+`<install-prefix>/include/<target-folder>/IccConnect2/` when
+`ENABLE_INSTALL_RIM` is on. The version header
+`IccLibConnectVer.h` is generated at configure time.
+
+## `CIccConnectCmm` Factory
+
+`CIccConnectCmm` owns one wrapped `CIccCmm*` and exposes typed accessors for
+the underlying CMM. There is no public constructor; instances come from
+factory methods that load profiles, register hints, attach PCCs, and call
+`Begin()` for you.
+
+### Factory methods
+
+| Factory | Input | Use case |
+|---------|-------|----------|
+| `CreateStandard(profiles, embeddedData=null, embeddedLen=0)` | `CIccCfgProfileSequence` | Standard pixel-pipeline CMM; if `embeddedData` is supplied and the first profile config has an empty `iccFile`, that buffer is loaded as the first xform (e.g. for ICC profiles embedded in TIFF/JPEG). |
+| `CreateNamed(profiles, srcSpace=icSigUnknownData, bInputProfile=true)` | `CIccCfgProfileSequence` | Named-color CMM (`CIccNamedColorCmm`) for named-color workflows. |
+| `CreateSearch(searchApply)` | `CIccCfgSearchApply` | Spectral inverse-search CMM (`CIccCmmSearch`) with weighted PCC attach and optional destination init profile. |
+| `Attach(pCmm)` | Any `CIccCmm*` | Wraps an externally constructed CMM; the wrapper takes ownership. |
+
+All factories return `nullptr` on any failure (profile load, hint allocation,
+PCC load, `AddXform`, `Begin`). Loaded PCC profiles are released before
+return whether the call succeeds or fails. Embedded raw profile bytes
+passed to `CreateStandard` are not retained by the library.
+
+### Typed accessors
+
+```cpp
+CIccCmm*           GetCmm()       const;   // wrapped CMM (never null after success)
+CIccNamedColorCmm* GetNamedCmm()  const;   // non-null only for CreateNamed
+CIccCmmSearch*     GetSearchCmm() const;   // non-null only for CreateSearch
+icColorSpaceSignature GetSourceSpace() const;
+icColorSpaceSignature GetDestSpace()   const;
+```
+
+`~CIccConnectCmm()` deletes the wrapped CMM, so callers own exactly one
+object and free with `delete`.
+
+### Optional Parallel Apply
+
+After a successful factory call, threading can be enabled in place:
+
+```cpp
+bool EnableThreading(int nThreads = 0);   // 0 -> hardware_concurrency
+bool IsThreaded() const;
+```
+
+`EnableThreading` wraps the underlying CMM with `CIccThreadedCmm` (see
+[threading guide](icc-cmm-threading.md)) so subsequent multi-pixel
+`Apply()` calls run in parallel. The wrapper assumes ownership of the
+underlying CMM, so the single-owner contract of `CIccConnectCmm` is
+preserved — callers still free with one `delete`.
+
+Behaviour:
+
+| Condition | Result |
+|-----------|--------|
+| `m_pCmm` is null | Returns `false`. |
+| Already threaded | Returns `true`, no rewrap. |
+| Attach fails | Underlying CMM is destroyed by `CIccThreadedCmm::Attach`, `m_pCmm` becomes null, returns `false`. The connect object should be deleted. |
+| Success | `GetCmm()` returns the threaded wrapper; `IsThreaded()` returns `true`. |
+
+After threading is enabled, `GetNamedCmm()` and `GetSearchCmm()` return
+`nullptr` because the type-specific CMM is hidden behind the wrapper.
+Striped threading is most useful for `CreateStandard` pixel pipelines; if
+you need the named-color or search APIs, call them through the typed
+accessor before enabling threading, or skip `EnableThreading` for those
+factories.
+
+For a worked example, see
+[`Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp`](../Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp),
+which builds the CMM with `CreateStandard`, snapshots the underlying
+`CIccCmm*` for metadata queries the wrapper does not forward (e.g.
+`GetLastParentSpace`), calls `EnableThreading(nThreads)`, then drives
+row-batched `Apply(dst, src, nPixels)` calls. The `-threads` CLI flag
+maps straight through to that single argument.
+
+## Per-profile Hints Applied
+
+`AddXformFromConfig` translates each `CIccCfgProfile` entry to an `AddXform`
+call. The following hints are registered automatically when the config
+requests them:
+
+| Config flag | Hint installed |
+|-------------|----------------|
+| `useBPC` | `CIccApplyBPCHint` |
+| `adjustPcsLuminance` | `CIccLuminanceMatchingHint` |
+| `iccEnvVars` (non-empty) | `CIccCmmEnvVarHint` |
+| `pccEnvVars` (non-empty) | `CIccCmmPccEnvVarHint` |
+
+`pccFile` is opened once per profile entry, passed through as the PCC for
+that xform, and deleted after `Begin()` returns.
+
+## JSON Configuration
+
+The library does not parse a top-level "connect document"; callers populate
+a config object (typically `CIccCfgApply`, `CIccCfgImageApply`, or
+`CIccCfgSearchApply`) from JSON or argv, then hand its profile sequence to
+the appropriate factory. See:
+
+- [icc-connect-config.schema.json](icc-connect-config.schema.json) — full
+  schema for the config objects in `IccCmmConfig.h`.
+- [Tools/CmdLine/IccApplyNamedCmm](../Tools/CmdLine/IccApplyNamedCmm) and
+  the other `iccApply*` tools — concrete usage of `-cfg config.json` plus
+  argv-based fallback.
+
+## Typical Pipeline
+
+```cpp
+#include "IccConnect.h"
+
+CIccCfgApply cfg;
+if (!cfg.fromJson(jsonText)) { /* parse error */ }
+
+CIccConnectCmm *conn = CIccConnectCmm::CreateStandard(cfg.m_profiles);
+if (!conn) { /* failed to build CMM */ }
+
+// Optional: enable parallel apply.  Ownership stays with conn; the
+// connect object's destructor frees the threaded wrapper, which in turn
+// frees the underlying CMM.
+if (!conn->EnableThreading(/*nThreads=*/0)) {
+  delete conn;
+  /* threading failed; connect is already empty */
+}
+
+conn->GetCmm()->Apply(dst, src, nPixels);
+delete conn;
+```
+
+See [CIccThreadedCmm](icc-cmm-threading.md) for the parallel-apply
+decorator and the ownership pattern used by `iccApplyProfiles`.
+
+## See Also
+
+- [icc-connect-config.schema.json](icc-connect-config.schema.json) — JSON
+  Schema for IccConnect configuration objects.
+- [CIccThreadedCmm](icc-cmm-threading.md) — parallel apply over a
+  `Begin()`-ed CMM.
+- [CLI tool reference](tools-cli-reference.md) — `iccApply*` tools that use
+  this library.

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ working with ICC.1 and ICC.2/iccMAX color profiles.
 - [CLI tool reference](tools-cli-reference.md): command-line tool summary and shared options
 - [IccJSON guide](iccjson.md): JSON conversion workflow
 - [ICC JSON tag reference](iccjson-tag-types.md): detailed JSON tag examples
+- [IccConnect library](icc-connect.md): JSON-driven CMM construction via `CIccConnectCmm`
+- [CIccThreadedCmm](icc-cmm-threading.md): parallel CMM apply decorator
 - [Bisecting regressions](bisect.md): focused debug workflow
 - [Linear stack workflow](linear-stack-workflow.md): rebase feature branches and stack commits without merge commits
 - [Pre-PR security cycle](pre-pr-security-cycle.md): maintainer loop for build/test, SAST, CodeQL, dynamic checks, and fixes
@@ -23,9 +25,10 @@ working with ICC.1 and ICC.2/iccMAX color profiles.
 
 | Library | Purpose |
 |---------|---------|
-| `IccProfLib` | Reference C++ library for reading, writing, applying, and validating ICC profiles. |
+| `IccProfLib` | Reference C++ library for reading, writing, applying, and validating ICC profiles. Includes `CIccThreadedCmm` for parallel apply (see [threading guide](icc-cmm-threading.md)). |
 | `IccLibXML` | XML serialization layer for profiles and profile objects. |
 | `IccLibJSON` | JSON serialization layer for profile inspection, editing, and round-tripping. |
+| `IccConnect` | Factory library that builds a fully initialized CMM from JSON-driven configuration (see [IccConnect guide](icc-connect.md)). |
 
 ## Tools
 


### PR DESCRIPTION
## PR Summary

This is the culmination of adding performance improvements CIccCmmThread with SIMD processing of CLUTs, creation of CIccConnect and refactoring of utiltiies to use CIccConnect which provides a centralized interface for intitializing a CMM using json files to configure and load profiles to apply.  Various bug fixes to the CIccCmmSearch are also included.

## Checklist

- [X] Built locally with the documented build flow in `docs/build.md`
- [X] Ran relevant CTest/profile tests from `docs/ctest.md`
- [X] Added or updated regression coverage for behavior changes
- [X] Checked sanitizer coverage for memory-safety or parser changes
- [X] Updated documentation for user-visible behavior changes
- [X] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [X] New source files include the ICC copyright and BSD 3-Clause license header
- [X] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
