### PR TITLE
Fix applying hybrid spectral profile and refactor err mgs in IccConnect

### DIFF
--- a/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
+++ b/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
@@ -67,7 +67,9 @@ if [ -z "$SRGB_PROFILE" ]; then
   exit 0
 fi
 
-# Synthesize a deterministic 512x512 sRGB TIFF with the sRGB profile embedded.
+# Synthesize a deterministic 512x512 RGB TIFF.  No embedded profile -- the
+# profile chain below uses explicit iccFile paths so the test stays focused on
+# threading equivalence rather than embedded-profile handling.
 # 512x512 = 262144 pixels: comfortably larger than std::thread::hardware_concurrency()
 # so the threaded apply path actually engages every worker on typical hosts.
 SRC_TIFF="$OUTDIR/threading-equiv-src.tif"
@@ -77,13 +79,11 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 0
 fi
 
-python3 - "$SRC_TIFF" "$SRGB_PROFILE" >"$PY_LOG" 2>&1 <<'PY'
+python3 - "$SRC_TIFF" >"$PY_LOG" 2>&1 <<'PY'
 import sys
 from PIL import Image
 
-out_path, icc_path = sys.argv[1], sys.argv[2]
-with open(icc_path, "rb") as f:
-    icc_bytes = f.read()
+out_path = sys.argv[1]
 
 w, h = 512, 512
 # Deterministic gradient: R = x, G = y, B = (x+y)/2 -- full 8-bit range, no compression.
@@ -97,7 +97,7 @@ for y in range(h):
         data[i + 2] = ((x + y) >> 1) & 0xFF
 
 img = Image.frombytes("RGB", (w, h), bytes(data))
-img.save(out_path, format="TIFF", compression="raw", icc_profile=icc_bytes)
+img.save(out_path, format="TIFF", compression="raw")
 print(f"wrote {out_path} ({w}x{h})")
 PY
 PY_EC=$?
@@ -107,10 +107,11 @@ if [ "$PY_EC" -ne 0 ] || [ ! -s "$SRC_TIFF" ]; then
   exit 0
 fi
 
-# Build a -cfg JSON pointing at the synthetic input. The profile sequence uses
-# the embedded source profile (empty iccFile + iccFile entries) followed by an
-# explicit sRGB destination; this exercises CIccConnectCmm::CreateStandard's
-# embedded-profile branch alongside a normal AddXform call.
+# Build a -cfg JSON pointing at the synthetic input. The profile sequence is
+# sRGB->PCS->sRGB (the same explicit profile twice): a deterministic two-stage
+# chain that exercises CIccConnectCmm::CreateStandard with a normal AddXform
+# call per stage. Embedded-profile handling is intentionally NOT exercised
+# here; this test targets threading equivalence only.
 CFG_JSON="$OUTDIR/threading-equiv.cfg.json"
 cat > "$CFG_JSON" <<EOF
 {
@@ -123,7 +124,7 @@ cat > "$CFG_JSON" <<EOF
     "dstEmbedIcc": false
   },
   "profileSequence": [
-    { "iccFile": "",              "intent": 1, "interpolation": "tetrahedral" },
+    { "iccFile": "$SRGB_PROFILE", "intent": 1, "interpolation": "tetrahedral" },
     { "iccFile": "$SRGB_PROFILE", "intent": 1, "interpolation": "tetrahedral" }
   ]
 }

--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -749,6 +749,7 @@ bool CIccCfgProfile::fromJson(json j, bool bReset)
   jsonToValue(j["useBPC"], m_useBPC);
   jsonToValue(j["useHToS"], m_useHToS);
   jsonToValue(j["useV5SubProfile"], m_useV5SubProfile);
+  jsonToValue(j["useD2BxB2Dx"], m_useD2BxB2Dx);
 
   if (jsonToValue(j["interpolation"], str)) {
     int i;
@@ -800,12 +801,14 @@ void CIccCfgProfile::toJson(json& j) const
     j["useHToS"] = m_useHToS;
   if (m_useV5SubProfile)
     j["useV5SubProfile"] = m_useV5SubProfile;
+  if (m_useD2BxB2Dx)
+    j["useD2BxB2Dx"] = m_useD2BxB2Dx;
   int i;
   for (i = 0; icInterpNames[i]; i++)
     if (icInterpValues[i] == m_interpolation)
       break;
   if (icInterpNames[i] && icInterpValues[i] == icInterpLinear)
-    j["interpolation"] = icInterpNames[i];  
+    j["interpolation"] = icInterpNames[i];
 }
 
 CIccCfgProfileSequence::CIccCfgProfileSequence()

--- a/IccConnect/IccLibConnect/IccConnect.cpp
+++ b/IccConnect/IccLibConnect/IccConnect.cpp
@@ -71,6 +71,7 @@
 #include "IccEnvVar.h"
 #include <memory>
 #include <new>
+#include <sstream>
 
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
@@ -154,45 +155,56 @@ static CIccConnectCmm* AttachStandardCmm(std::unique_ptr<CIccCmm>& pCmm,
 
 icStatusCMM CIccConnectCmm::AddXformFromConfig(CIccCmm* pCmm,
                                                 CIccCfgProfile* pCfg,
-                                                IccProfilePtrList& pccList)
+                                                IccProfilePtrList& pccList,
+                                                std::string& sErrorMsg)
 {
   CIccProfile* pPcc = nullptr;
   CIccCreateXformHintManager Hint;
 
   if (pCfg->m_useBPC) {
     icStatusCMM stat = AddHintNoThrow(Hint, new (std::nothrow) CIccApplyBPCHint());
-    if (stat != icCmmStatOk)
+    if (stat != icCmmStatOk) {
+      sErrorMsg = "failed to attach BPC hint for '" + pCfg->m_iccFile + "'";
       return stat;
+    }
   }
 
   if (pCfg->m_adjustPcsLuminance) {
     icStatusCMM stat = AddHintNoThrow(Hint, new (std::nothrow) CIccLuminanceMatchingHint());
-    if (stat != icCmmStatOk)
+    if (stat != icCmmStatOk) {
+      sErrorMsg = "failed to attach PCS-luminance hint for '" + pCfg->m_iccFile + "'";
       return stat;
+    }
   }
 
   if (!pCfg->m_pccFile.empty()) {
     // Caller-selected config paths intentionally name ICC/PCC profile files.
     // codeql[cpp/path-injection]
     pPcc = OpenIccProfile(pCfg->m_pccFile.c_str());
-    if (!pPcc)
+    if (!pPcc) {
+      sErrorMsg = "unable to open PCC profile '" + pCfg->m_pccFile + "'";
       return icCmmStatBad;
+    }
     pccList.push_back(pPcc);
   }
 
   if (!pCfg->m_iccEnvVars.empty()) {
     icStatusCMM stat = AddHintNoThrow(Hint, new (std::nothrow) CIccCmmEnvVarHint(pCfg->m_iccEnvVars));
-    if (stat != icCmmStatOk)
+    if (stat != icCmmStatOk) {
+      sErrorMsg = "failed to attach ICC env-var hint for '" + pCfg->m_iccFile + "'";
       return stat;
+    }
   }
 
   if (!pCfg->m_pccEnvVars.empty()) {
     icStatusCMM stat = AddHintNoThrow(Hint, new (std::nothrow) CIccCmmPccEnvVarHint(pCfg->m_pccEnvVars));
-    if (stat != icCmmStatOk)
+    if (stat != icCmmStatOk) {
+      sErrorMsg = "failed to attach PCC env-var hint for '" + pCfg->m_iccFile + "'";
       return stat;
+    }
   }
 
-  return pCmm->AddXform(
+  icStatusCMM stat = pCmm->AddXform(
     pCfg->m_iccFile.c_str(),
     pCfg->m_intent < 0 ? icUnknownIntent : (icRenderingIntent)pCfg->m_intent,
     pCfg->m_interpolation,
@@ -202,31 +214,58 @@ icStatusCMM CIccConnectCmm::AddXformFromConfig(CIccCmm* pCmm,
     &Hint,
     pCfg->m_useV5SubProfile
   );
+  if (stat == icCmmStatCantOpenProfile) {
+    sErrorMsg = "unable to open ICC profile '" + pCfg->m_iccFile + "'";
+  }
+  else if (stat != icCmmStatOk) {
+    std::ostringstream oss;
+    oss << "AddXform failed for '" << pCfg->m_iccFile << "' (status " << (int)stat << ")";
+    sErrorMsg = oss.str();
+  }
+  return stat;
 }
 
 CIccConnectCmm* CIccConnectCmm::CreateNamed(const CIccCfgProfileSequence& profiles,
                                               icColorSpaceSignature srcSpace,
-                                              bool bInputProfile)
+                                              bool bInputProfile,
+                                              std::string* pErrorMsg)
 {
+  std::string localErr;
+  std::string& sErrorMsg = pErrorMsg ? *pErrorMsg : localErr;
+
   IccProfilePtrList pccList;
   auto pCmm = std::unique_ptr<CIccNamedColorCmm>(
     new (std::nothrow) CIccNamedColorCmm(srcSpace, icSigUnknownData, bInputProfile));
-  if (!pCmm)
+  if (!pCmm) {
+    sErrorMsg = "failed to allocate named-color CMM";
     return nullptr;
+  }
 
+  size_t stageIdx = 0;
   for (const auto& profPtr : profiles.m_profiles) {
     CIccCfgProfile* pCfg = profPtr.get();
-    if (!pCfg)
+    if (!pCfg) {
+      ++stageIdx;
       continue;
+    }
 
-    icStatusCMM stat = AddXformFromConfig(pCmm.get(), pCfg, pccList);
+    std::string sStageErr;
+    icStatusCMM stat = AddXformFromConfig(pCmm.get(), pCfg, pccList, sStageErr);
     if (stat != icCmmStatOk) {
+      std::ostringstream oss;
+      oss << "stage " << stageIdx << ": " << sStageErr;
+      sErrorMsg = oss.str();
       ReleasePccList(pccList);
       return nullptr;
     }
+    ++stageIdx;
   }
 
-  if (pCmm->Begin() != icCmmStatOk) {
+  icStatusCMM beginStat = pCmm->Begin();
+  if (beginStat != icCmmStatOk) {
+    std::ostringstream oss;
+    oss << "Begin() failed (status " << (int)beginStat << "); profile chain is incompatible";
+    sErrorMsg = oss.str();
     ReleasePccList(pccList);
     return nullptr;
   }
@@ -238,23 +277,34 @@ CIccConnectCmm* CIccConnectCmm::CreateNamed(const CIccCfgProfileSequence& profil
 CIccConnectCmm* CIccConnectCmm::CreateStandard(const CIccCfgProfileSequence& profiles,
                                                  const unsigned char* pEmbeddedData,
                                                  unsigned int nEmbeddedLen,
-                                                 int nThreads)
+                                                 int nThreads,
+                                                 std::string* pErrorMsg)
 {
+  std::string localErr;
+  std::string& sErrorMsg = pErrorMsg ? *pErrorMsg : localErr;
+
   IccProfilePtrList pccList;
   auto pCmm = std::unique_ptr<CIccCmm>(
     new (std::nothrow) CIccCmm(icSigUnknownData, icSigUnknownData, true));
-  if (!pCmm)
+  if (!pCmm) {
+    sErrorMsg = "failed to allocate CMM";
     return nullptr;
+  }
 
   bool bFirst = true;
+  size_t stageIdx = 0;
   for (const auto& profPtr : profiles.m_profiles) {
     CIccCfgProfile* pCfg = profPtr.get();
     if (!pCfg) {
+      std::ostringstream oss;
+      oss << "stage " << stageIdx << ": null profile config entry";
+      sErrorMsg = oss.str();
       ReleasePccList(pccList);
       return nullptr;
     }
 
     icStatusCMM stat;
+    std::string sStageErr;
 
     if (bFirst && pCfg->m_iccFile.empty() && pEmbeddedData && nEmbeddedLen) {
       CIccProfile* pPcc = nullptr;
@@ -262,26 +312,42 @@ CIccConnectCmm* CIccConnectCmm::CreateStandard(const CIccCfgProfileSequence& pro
 
       if (pCfg->m_useBPC) {
         stat = AddHintNoThrow(Hint, new (std::nothrow) CIccApplyBPCHint());
-        if (stat != icCmmStatOk) { ReleasePccList(pccList); return nullptr; }
+        if (stat != icCmmStatOk) {
+          sStageErr = "failed to attach BPC hint for embedded source profile";
+          goto stage_failed;
+        }
       }
       if (pCfg->m_adjustPcsLuminance) {
         stat = AddHintNoThrow(Hint, new (std::nothrow) CIccLuminanceMatchingHint());
-        if (stat != icCmmStatOk) { ReleasePccList(pccList); return nullptr; }
+        if (stat != icCmmStatOk) {
+          sStageErr = "failed to attach PCS-luminance hint for embedded source profile";
+          goto stage_failed;
+        }
       }
       if (!pCfg->m_pccFile.empty()) {
         // Caller-selected config paths intentionally name ICC/PCC profile files.
         // codeql[cpp/path-injection]
         pPcc = OpenIccProfile(pCfg->m_pccFile.c_str());
-        if (!pPcc) { ReleasePccList(pccList); return nullptr; }
+        if (!pPcc) {
+          sStageErr = "unable to open PCC profile '" + pCfg->m_pccFile + "' for embedded source profile";
+          stat = icCmmStatBad;
+          goto stage_failed;
+        }
         pccList.push_back(pPcc);
       }
       if (!pCfg->m_iccEnvVars.empty()) {
         stat = AddHintNoThrow(Hint, new (std::nothrow) CIccCmmEnvVarHint(pCfg->m_iccEnvVars));
-        if (stat != icCmmStatOk) { ReleasePccList(pccList); return nullptr; }
+        if (stat != icCmmStatOk) {
+          sStageErr = "failed to attach ICC env-var hint for embedded source profile";
+          goto stage_failed;
+        }
       }
       if (!pCfg->m_pccEnvVars.empty()) {
         stat = AddHintNoThrow(Hint, new (std::nothrow) CIccCmmPccEnvVarHint(pCfg->m_pccEnvVars));
-        if (stat != icCmmStatOk) { ReleasePccList(pccList); return nullptr; }
+        if (stat != icCmmStatOk) {
+          sStageErr = "failed to attach PCC env-var hint for embedded source profile";
+          goto stage_failed;
+        }
       }
 
       stat = pCmm->AddXform(
@@ -295,19 +361,36 @@ CIccConnectCmm* CIccConnectCmm::CreateStandard(const CIccCfgProfileSequence& pro
         &Hint,
         pCfg->m_useV5SubProfile
       );
+      if (stat != icCmmStatOk) {
+        std::ostringstream oss;
+        oss << "AddXform failed for embedded source profile (status " << (int)stat << ")";
+        sStageErr = oss.str();
+      }
     }
     else {
-      stat = AddXformFromConfig(pCmm.get(), pCfg, pccList);
+      stat = AddXformFromConfig(pCmm.get(), pCfg, pccList, sStageErr);
     }
 
+  stage_failed:
     if (stat != icCmmStatOk) {
+      std::ostringstream oss;
+      oss << "stage " << stageIdx << ": " << sStageErr;
+      sErrorMsg = oss.str();
       ReleasePccList(pccList);
       return nullptr;
     }
     bFirst = false;
+    ++stageIdx;
   }
 
-  if (pCmm->Begin() != icCmmStatOk) {
+  icStatusCMM beginStat = pCmm->Begin();
+  if (beginStat != icCmmStatOk) {
+    std::ostringstream oss;
+    oss << "Begin() failed (status " << (int)beginStat
+        << "); profile chain is incompatible (srcSpace=0x"
+        << std::hex << (unsigned)pCmm->GetSourceSpace()
+        << " dstSpace=0x" << (unsigned)pCmm->GetDestSpace() << ")";
+    sErrorMsg = oss.str();
     ReleasePccList(pccList);
     return nullptr;
   }
@@ -316,41 +399,62 @@ CIccConnectCmm* CIccConnectCmm::CreateStandard(const CIccCfgProfileSequence& pro
   return AttachStandardCmm(pCmm, nThreads);
 }
 
-CIccConnectCmm* CIccConnectCmm::CreateSearch(const CIccCfgSearchApply& searchApply)
+CIccConnectCmm* CIccConnectCmm::CreateSearch(const CIccCfgSearchApply& searchApply,
+                                              std::string* pErrorMsg)
 {
+  std::string localErr;
+  std::string& sErrorMsg = pErrorMsg ? *pErrorMsg : localErr;
+
   IccProfilePtrList pccList;
   auto pCmm = std::unique_ptr<CIccCmmSearch>(new (std::nothrow) CIccCmmSearch());
-  if (!pCmm)
+  if (!pCmm) {
+    sErrorMsg = "failed to allocate search CMM";
     return nullptr;
+  }
 
   // Add forward profile chain.  Explicitly scope to CIccCmm::AddXform to bypass
   // CIccCmmSearch's override which is reserved for the reverse/destination profile.
+  size_t stageIdx = 0;
   for (const auto& profPtr : searchApply.m_profiles) {
     CIccCfgProfile* pCfg = profPtr.get();
-    if (!pCfg)
+    if (!pCfg) {
+      ++stageIdx;
       continue;
+    }
 
     CIccProfile* pPcc = nullptr;
     CIccCreateXformHintManager Hint;
+    icStatusCMM stat = icCmmStatOk;
+    std::string sStageErr;
 
     if (!pCfg->m_pccFile.empty()) {
       // Caller-selected config paths intentionally name ICC/PCC profile files.
       // codeql[cpp/path-injection]
       pPcc = OpenIccProfile(pCfg->m_pccFile.c_str());
-      if (!pPcc) { ReleasePccList(pccList); return nullptr; }
+      if (!pPcc) {
+        sStageErr = "unable to open PCC profile '" + pCfg->m_pccFile + "'";
+        stat = icCmmStatBad;
+        goto search_stage_failed;
+      }
       pccList.push_back(pPcc);
     }
 
     if (!pCfg->m_iccEnvVars.empty()) {
-      icStatusCMM stat = AddHintNoThrow(Hint, new (std::nothrow) CIccCmmEnvVarHint(pCfg->m_iccEnvVars));
-      if (stat != icCmmStatOk) { ReleasePccList(pccList); return nullptr; }
+      stat = AddHintNoThrow(Hint, new (std::nothrow) CIccCmmEnvVarHint(pCfg->m_iccEnvVars));
+      if (stat != icCmmStatOk) {
+        sStageErr = "failed to attach ICC env-var hint for '" + pCfg->m_iccFile + "'";
+        goto search_stage_failed;
+      }
     }
     if (!pCfg->m_pccEnvVars.empty()) {
-      icStatusCMM stat = AddHintNoThrow(Hint, new (std::nothrow) CIccCmmPccEnvVarHint(pCfg->m_pccEnvVars));
-      if (stat != icCmmStatOk) { ReleasePccList(pccList); return nullptr; }
+      stat = AddHintNoThrow(Hint, new (std::nothrow) CIccCmmPccEnvVarHint(pCfg->m_pccEnvVars));
+      if (stat != icCmmStatOk) {
+        sStageErr = "failed to attach PCC env-var hint for '" + pCfg->m_iccFile + "'";
+        goto search_stage_failed;
+      }
     }
 
-    icStatusCMM stat = pCmm->CIccCmm::AddXform(
+    stat = pCmm->CIccCmm::AddXform(
       pCfg->m_iccFile.c_str(),
       pCfg->m_intent < 0 ? icUnknownIntent : (icRenderingIntent)pCfg->m_intent,
       pCfg->m_interpolation,
@@ -360,31 +464,58 @@ CIccConnectCmm* CIccConnectCmm::CreateSearch(const CIccCfgSearchApply& searchApp
       &Hint,
       pCfg->m_useV5SubProfile
     );
+    if (stat == icCmmStatCantOpenProfile) {
+      sStageErr = "unable to open ICC profile '" + pCfg->m_iccFile + "'";
+    }
+    else if (stat != icCmmStatOk) {
+      std::ostringstream oss;
+      oss << "AddXform failed for '" << pCfg->m_iccFile << "' (status " << (int)stat << ")";
+      sStageErr = oss.str();
+    }
+
+  search_stage_failed:
     if (stat != icCmmStatOk) {
+      std::ostringstream oss;
+      oss << "stage " << stageIdx << ": " << sStageErr;
+      sErrorMsg = oss.str();
       ReleasePccList(pccList);
       return nullptr;
     }
+    ++stageIdx;
   }
 
   // Attach weighted PCC profiles for spectral search computation.
+  size_t pccIdx = 0;
   for (const auto& pccPtr : searchApply.m_pccWeights) {
     CIccCfgPccWeight* pPccWeight = pccPtr.get();
-    if (!pPccWeight)
+    if (!pPccWeight) {
+      ++pccIdx;
       continue;
+    }
 
     // Caller-selected config paths intentionally name ICC/PCC profile files.
     // codeql[cpp/path-injection]
     CIccProfile* pPcc = OpenIccProfile(pPccWeight->m_pccPath.c_str());
     if (!pPcc || !pPcc->ReadPccTags()) {
+      std::ostringstream oss;
+      oss << "weighted PCC " << pccIdx << ": unable to open or read PCC tags from '"
+          << pPccWeight->m_pccPath << "'";
+      sErrorMsg = oss.str();
+      delete pPcc;
       ReleasePccList(pccList);
       return nullptr;
     }
     pPcc->Detach();
 
     if (pCmm->AttachPCC(pPcc, pPccWeight->m_dWeight) != icCmmStatOk) {
+      std::ostringstream oss;
+      oss << "weighted PCC " << pccIdx << ": AttachPCC failed for '"
+          << pPccWeight->m_pccPath << "'";
+      sErrorMsg = oss.str();
       ReleasePccList(pccList);
       return nullptr;
     }
+    ++pccIdx;
   }
 
   // Set the destination initial profile for the reverse search.
@@ -396,6 +527,7 @@ CIccConnectCmm* CIccConnectCmm::CreateSearch(const CIccCfgSearchApply& searchApp
                                             searchApply.m_useV5SubProfileInitial);
     CIccProfile* pPcc = nullptr;
     if (!pProfile) {
+      sErrorMsg = "initial-destination: unable to open ICC profile '" + pLastCfg->m_iccFile + "'";
       ReleasePccList(pccList);
       return nullptr;
     }
@@ -405,6 +537,7 @@ CIccConnectCmm* CIccConnectCmm::CreateSearch(const CIccCfgSearchApply& searchApp
       // codeql[cpp/path-injection]
       pPcc = OpenIccProfile(pLastCfg->m_pccFile.c_str());
       if (!pPcc) {
+        sErrorMsg = "initial-destination: unable to open PCC profile '" + pLastCfg->m_pccFile + "'";
         delete pProfile;
         ReleasePccList(pccList);
         return nullptr;
@@ -422,7 +555,12 @@ CIccConnectCmm* CIccConnectCmm::CreateSearch(const CIccCfgSearchApply& searchApp
     );
   }
 
-  if (pCmm->Begin() != icCmmStatOk) {
+  icStatusCMM beginStat = pCmm->Begin();
+  if (beginStat != icCmmStatOk) {
+    std::ostringstream oss;
+    oss << "Begin() failed (status " << (int)beginStat
+        << "); search-profile chain is incompatible";
+    sErrorMsg = oss.str();
     ReleasePccList(pccList);
     return nullptr;
   }

--- a/IccConnect/IccLibConnect/IccConnect.h
+++ b/IccConnect/IccLibConnect/IccConnect.h
@@ -72,6 +72,7 @@
 #include "IccCmm.h"
 #include "IccCmmSearch.h"
 #include <list>
+#include <string>
 
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
@@ -94,20 +95,30 @@ public:
   // Creates a named-color CMM from a profile sequence configuration.
   // srcSpace: hint for source color space (icSigUnknownData = auto-detect)
   // bInputProfile: true if the transform starts from a device (input) profile
+  // pErrorMsg (optional): on failure, populated with a human-readable
+  //   description of the first failure encountered (e.g. which profile path
+  //   could not be opened). Callers are responsible for emitting it.
   static CIccConnectCmm* CreateNamed(const CIccCfgProfileSequence& profiles,
                                       icColorSpaceSignature srcSpace = icSigUnknownData,
-                                      bool bInputProfile = true);
+                                      bool bInputProfile = true,
+                                      std::string* pErrorMsg = nullptr);
 
   // Creates a standard CMM from a profile sequence configuration.
   // pEmbeddedData/nEmbeddedLen: when provided and the first profile config has
   // an empty m_iccFile, these embedded ICC profile bytes are used for the first xform.
+  // pErrorMsg (optional): on failure, populated with a human-readable
+  //   description of the first failure encountered.  Callers print it.
   static CIccConnectCmm* CreateStandard(const CIccCfgProfileSequence& profiles,
                                           const unsigned char* pEmbeddedData = nullptr,
                                           unsigned int nEmbeddedLen = 0,
-                                          int nThreads = 1);
+                                          int nThreads = 1,
+                                          std::string* pErrorMsg = nullptr);
 
   // Creates a spectral search CMM from a search apply configuration.
-  static CIccConnectCmm* CreateSearch(const CIccCfgSearchApply& searchApply);
+  // pErrorMsg (optional): on failure, populated with a human-readable
+  //   description of the first failure encountered.  Callers print it.
+  static CIccConnectCmm* CreateSearch(const CIccCfgSearchApply& searchApply,
+                                       std::string* pErrorMsg = nullptr);
 
   // Wraps an already-initialized CMM (takes ownership).
   static CIccConnectCmm* Attach(CIccCmm* pCmm);
@@ -126,10 +137,13 @@ protected:
 
   // Prepares hints and PCC from a profile config entry and calls
   // pCmm->AddXform() via the file path.  pccList holds the PCC profile
-  // pointers until after Begin() is called.
+  // pointers until after Begin() is called.  On failure, sErrorMsg is
+  // populated with a description of the first failed step (file path,
+  // hint allocation, etc.); the caller decides whether to log it.
   static icStatusCMM AddXformFromConfig(CIccCmm* pCmm,
                                          CIccCfgProfile* pCfg,
-                                         IccProfilePtrList& pccList);
+                                         IccProfilePtrList& pccList,
+                                         std::string& sErrorMsg);
 
   static void ReleasePccList(IccProfilePtrList& pccList);
 

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -559,7 +559,11 @@ CIccXform *CIccXform::Create(CIccProfile *pProfile,
     case icXformLutColor:
       if (bInput) {
         CIccTag *pTag = NULL;
-        if (bUseD2BTags) {
+        // Spectral-only profiles have no AToBx tag to fall back to; their MPE pipeline
+        // lives in DToBx tags regardless of how the caller set bUseD2BTags. Opening
+        // that path here lets icXformLutColor + a spectral source profile resolve
+        // without the caller having to set useD2BxB2Dx explicitly.
+        if (bUseD2BTags || pProfile->m_Header.spectralPCS) {
           if (nLutType != icXformLutColorimetric &&
               (pProfile->m_Header.spectralPCS || pProfile->m_Header.version >= icVersionNumberV5)) {
             pTag = pProfile->FindTag(icSigDToB0Tag + nTagIntent);
@@ -692,8 +696,10 @@ CIccXform *CIccXform::Create(CIccProfile *pProfile,
         if (nLutType == icXformLutColorimetric && pProfile->m_Header.version >= icVersionNumberV5) {
           bUseD2BTags = false;
         }
-        
-        if (bUseD2BTags) {
+
+        // Spectral-only destination profiles only carry BToDx tags; let icXformLutColor
+        // resolve them without requiring the caller to set useD2BxB2Dx.
+        if (bUseD2BTags || (nLutType != icXformLutColorimetric && pProfile->m_Header.spectralPCS)) {
           pTag = pProfile->FindTag(icSigBToD0Tag + nTagIntent);
 
           //Additional precedence not prescribed by the v4 ICC Specification
@@ -8276,7 +8282,13 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
         nSrcSpace = pProfile->m_Header.colorSpace;
         nParentSpace = pProfile->GetParentColorSpace();
 
-        if (nLutType == icXformLutSpectral || (bUseD2BxB2DxTags && pProfile->m_Header.spectralPCS && nLutType != icXformLutColorimetric))
+        // Use spectralPCS as the destination when nLutType explicitly asks for
+        // it, when the caller opted in via bUseD2BxB2DxTags, or when the
+        // profile is spectral-only (no colorimetric pcs) so spectralPCS is the
+        // only valid destination - matches the DToBx fallback in CIccXform::Create.
+        if (nLutType == icXformLutSpectral ||
+            (pProfile->m_Header.spectralPCS && nLutType != icXformLutColorimetric &&
+             (bUseD2BxB2DxTags || !pProfile->m_Header.pcs)))
           nDstSpace = (icColorSpaceSignature)pProfile->m_Header.spectralPCS;
         else
           nDstSpace = pProfile->m_Header.pcs;
@@ -8290,7 +8302,11 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
           nIntent = icPerceptual; // Note: icPerceptualIntent = 0
         }
 
-        if (nLutType == icXformLutSpectral || (bUseD2BxB2DxTags && pProfile->m_Header.spectralPCS && nLutType != icXformLutColorimetric))
+        // Symmetric to the bInput branch above: spectral-only destination profiles
+        // accept their spectralPCS as the source space even without bUseD2BxB2DxTags.
+        if (nLutType == icXformLutSpectral ||
+            (pProfile->m_Header.spectralPCS && nLutType != icXformLutColorimetric &&
+             (bUseD2BxB2DxTags || !pProfile->m_Header.pcs)))
           nSrcSpace = (icColorSpaceSignature)pProfile->m_Header.spectralPCS;
         else
           nSrcSpace = pProfile->m_Header.pcs;

--- a/Testing/hybrid/CMYK_Hybrid_Profile.xml
+++ b/Testing/hybrid/CMYK_Hybrid_Profile.xml
@@ -27015,7 +27015,7 @@
         <ProfileID>1</ProfileID>
         <SpectralPCS>rs0024</SpectralPCS>
         <SpectralRange>
-         <Wavelengths start="380.00000000" end="720.00000000" steps="36"/>
+         <Wavelengths start="380.00000000" end="730.00000000" steps="36"/>
         </SpectralRange>
       </Header>
       <Tags>

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -388,11 +388,15 @@ int main(int argc, const char* argv[])
     }
   }
 
+  std::string sConnectError;
   std::unique_ptr<CIccConnectCmm> pConnect(
-    CIccConnectCmm::CreateNamed(cfgProfiles, SrcspaceSig, bInputProfile));
+    CIccConnectCmm::CreateNamed(cfgProfiles, SrcspaceSig, bInputProfile, &sConnectError));
 
   if (!pConnect) {
-    printf("Error - Unable to begin profile application - Possibly invalid or incompatible profiles\n");
+    if (!sConnectError.empty())
+      printf("Error - %s\n", sConnectError.c_str());
+    else
+      printf("Error - Unable to begin profile application - Possibly invalid or incompatible profiles\n");
     return -1;
   }
 

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -411,11 +411,16 @@ int main(int argc, const char** argv)
     nEmbeddedLen = nSrcProfileLen;
   }
 
+  std::string sConnectError;
   std::unique_ptr<CIccConnectCmm> pConnect(
-    CIccConnectCmm::CreateStandard(cfgProfiles, pEmbedded, nEmbeddedLen, cfgConnect.m_nThreads));
+    CIccConnectCmm::CreateStandard(cfgProfiles, pEmbedded, nEmbeddedLen,
+                                   cfgConnect.m_nThreads, &sConnectError));
 
   if (!pConnect) {
-    printf("Error - Unable to begin profile application - Possibly invalid or incompatible profiles\n");
+    if (!sConnectError.empty())
+      printf("Error - %s\n", sConnectError.c_str());
+    else
+      printf("Error - Unable to begin profile application - Possibly invalid or incompatible profiles\n");
     return -1;
   }
 

--- a/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
+++ b/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
@@ -379,10 +379,14 @@ int main(int argc, const char* argv[])
   //Setup source encoding
   srcEncoding = cfgData.m_encoding;
 
-  std::unique_ptr<CIccConnectCmm> pConnect(CIccConnectCmm::CreateSearch(cfgSearchApply));
+  std::string sConnectError;
+  std::unique_ptr<CIccConnectCmm> pConnect(
+    CIccConnectCmm::CreateSearch(cfgSearchApply, &sConnectError));
 
   if (!pConnect) {
-    printf("Error - Unable to begin profile application - Possibly invalid or incompatible profiles\n");
+    if (!sConnectError.empty())
+      printf("Error - %s\n", sConnectError.c_str());
+    printf("Unable to begin profile application - Possibly invalid or incompatible profiles\n");
     return -1;
   }
 

--- a/docs/icc-cmm-threading.md
+++ b/docs/icc-cmm-threading.md
@@ -88,11 +88,10 @@ thread launches.
 ## CLI Example: `iccApplyProfiles -threads`
 
 [`iccApplyProfiles`](../Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp)
-exposes the wrapper through a `-threads` flag. Internally it builds the
-CMM with [`CIccConnectCmm::CreateStandard`](icc-connect.md) and then calls
-`pConnect->EnableThreading(nThreads)` — this is the canonical example of
-the connect-side threading pattern, including the row-batched float
-buffer that feeds `Apply(dst, src, nPixels)`.
+exposes the wrapper through a `-threads` flag. The value is forwarded
+into [`CIccConnectCmm::CreateStandard`](icc-connect.md)'s `nThreads`
+parameter; the connect factory installs the `CIccThreadedCmm` wrapper
+when `nThreads != 1` and returns the underlying CMM otherwise.
 
 ```text
 iccApplyProfiles -threads N -cfg config.json
@@ -100,11 +99,10 @@ iccApplyProfiles -threads N -cfg config.json
 
 | Value | Behaviour |
 |-------|-----------|
-| omitted | Defaults to `nThreads = 0` (hardware concurrency). |
+| omitted | Defaults to `nThreads = 1` (no wrapper; underlying CMM is used directly). |
 | `-threads 0` | Use `std::thread::hardware_concurrency()`. |
-| `-threads 1` | Threaded code path with a single worker (row-batched apply, no concurrency). |
+| `-threads 1` | No threaded wrapper. |
 | `-threads N` (N > 1) | Use exactly `N` workers. |
-| `-threads -1` | Disable threading; per-pixel apply on the unwrapped CMM. |
 
 The flag is parsed before `-cfg`, so it must come first.
 
@@ -123,28 +121,37 @@ undefined.
 
 ## Use From IccConnect
 
-When a CMM has been built through [`CIccConnectCmm`](icc-connect.md),
-call `EnableThreading(nThreads)` instead of attaching directly. The
-connect object keeps single ownership and rewraps `m_pCmm` for you, so
-there is no ownership coordination between two wrappers:
+When a CMM is built through [`CIccConnectCmm`](icc-connect.md), pass
+`nThreads` into `CreateStandard` directly — the factory installs the
+wrapper internally and `CIccConnectCmm` keeps single ownership of the
+whole stack:
 
 ```cpp
-CIccConnectCmm *conn = CIccConnectCmm::CreateStandard(cfg.m_profiles);
-if (!conn) { /* error */ }
-if (!conn->EnableThreading(0)) { delete conn; /* error */ }
-conn->GetCmm()->Apply(dst, src, nPixels);
-delete conn;   // tears down the threaded wrapper and the underlying CMM
+std::string sError;
+CIccConnectCmm *conn = CIccConnectCmm::CreateStandard(
+    cfg.m_profiles,
+    /*pEmbeddedData=*/nullptr, /*nEmbeddedLen=*/0,
+    /*nThreads=*/0,                  // 0 = hardware_concurrency, 1 = no wrapper
+    &sError);
+if (!conn) {
+  fprintf(stderr, "%s\n", sError.c_str());
+  return -1;
+}
+
+conn->GetCmm()->Apply(dst, src, nPixels);   // threaded when nThreads != 1
+delete conn;                                 // tears down wrapper + underlying CMM
 ```
 
-`conn->IsThreaded()` reports whether the wrapper has been installed.
-After threading is on, the type-specific accessors `GetNamedCmm()` and
-`GetSearchCmm()` return null — striped apply only fits the standard
-pixel-pipeline use case.
+`conn->IsThreaded()` reports whether the wrapper was installed;
+`conn->GetThreadedCmm()` returns the wrapper directly when needed. The
+type-specific accessors `GetNamedCmm()` and `GetSearchCmm()` return null
+once the threaded wrapper is in place — striped apply only fits the
+standard pixel-pipeline use case.
 
 ## See Also
 
 - [IccConnect library](icc-connect.md) — factory that constructs a
-  `Begin()`-ed CMM from JSON config, with `EnableThreading()` for
-  in-place parallel apply.
+  `Begin()`-ed CMM from JSON config, with an `nThreads` parameter on
+  `CreateStandard` for parallel apply.
 - [CLI tool reference](tools-cli-reference.md) — shared option tables for
   the `iccApply*` tools.

--- a/docs/icc-connect-config.schema.json
+++ b/docs/icc-connect-config.schema.json
@@ -141,6 +141,11 @@
           "default": false,
           "description": "Prefer the V5 sub-profile when present"
         },
+        "useD2BxB2Dx": {
+          "type": "boolean",
+          "default": false,
+          "description": "Prefer DToBx/BToDx multi-processing element tags over AToBx/BToAx tags when both are present. Spectral-only profiles (with a populated spectralPCS) automatically use DToBx without this flag."
+        },
         "interpolation": {
           "$ref": "#/$defs/interpolation",
           "default": "tetrahedral",

--- a/docs/icc-connect.md
+++ b/docs/icc-connect.md
@@ -43,9 +43,9 @@ factory methods that load profiles, register hints, attach PCCs, and call
 
 | Factory | Input | Use case |
 |---------|-------|----------|
-| `CreateStandard(profiles, embeddedData=null, embeddedLen=0)` | `CIccCfgProfileSequence` | Standard pixel-pipeline CMM; if `embeddedData` is supplied and the first profile config has an empty `iccFile`, that buffer is loaded as the first xform (e.g. for ICC profiles embedded in TIFF/JPEG). |
-| `CreateNamed(profiles, srcSpace=icSigUnknownData, bInputProfile=true)` | `CIccCfgProfileSequence` | Named-color CMM (`CIccNamedColorCmm`) for named-color workflows. |
-| `CreateSearch(searchApply)` | `CIccCfgSearchApply` | Spectral inverse-search CMM (`CIccCmmSearch`) with weighted PCC attach and optional destination init profile. |
+| `CreateStandard(profiles, embeddedData=null, embeddedLen=0, nThreads=1, pErrorMsg=nullptr)` | `CIccCfgProfileSequence` | Standard pixel-pipeline CMM; if `embeddedData` is supplied and the first profile config has an empty `iccFile`, that buffer is loaded as the first xform (e.g. for ICC profiles embedded in TIFF/JPEG). When `nThreads != 1`, the returned wrapper is a `CIccThreadedCmm` over the underlying CMM. |
+| `CreateNamed(profiles, srcSpace=icSigUnknownData, bInputProfile=true, pErrorMsg=nullptr)` | `CIccCfgProfileSequence` | Named-color CMM (`CIccNamedColorCmm`) for named-color workflows. |
+| `CreateSearch(searchApply, pErrorMsg=nullptr)` | `CIccCfgSearchApply` | Spectral inverse-search CMM (`CIccCmmSearch`) with weighted PCC attach and optional destination init profile. |
 | `Attach(pCmm)` | Any `CIccCmm*` | Wraps an externally constructed CMM; the wrapper takes ownership. |
 
 All factories return `nullptr` on any failure (profile load, hint allocation,
@@ -53,12 +53,34 @@ PCC load, `AddXform`, `Begin`). Loaded PCC profiles are released before
 return whether the call succeeds or fails. Embedded raw profile bytes
 passed to `CreateStandard` are not retained by the library.
 
+### Error Reporting
+
+The library never writes to `stderr`. To learn *why* a factory call
+returned `nullptr`, pass a `std::string*` as the final `pErrorMsg`
+argument. On failure it is populated with a single human-readable line
+describing the first failure encountered, prefixed where applicable with
+the failing stage index. Examples:
+
+```text
+stage 0: unable to open PCC profile 'ICC\Missing.icc' for embedded source profile
+stage 1: unable to open ICC profile 'Data\NotThere.icc'
+stage 2: AddXform failed for 'foo.icc' (status 4)
+Begin() failed (status 14); profile chain is incompatible (srcSpace=0x434d594b dstSpace=0x52474220)
+weighted PCC 0: unable to open or read PCC tags from 'pcc.icc'
+initial-destination: unable to open ICC profile 'final.icc'
+```
+
+The caller decides whether to log the message, surface it in a GUI, or
+discard it. Passing `nullptr` (the default) silently drops the message.
+
 ### Typed accessors
 
 ```cpp
-CIccCmm*           GetCmm()       const;   // wrapped CMM (never null after success)
-CIccNamedColorCmm* GetNamedCmm()  const;   // non-null only for CreateNamed
-CIccCmmSearch*     GetSearchCmm() const;   // non-null only for CreateSearch
+CIccCmm*           GetCmm()         const;   // wrapped CMM (never null after success)
+CIccNamedColorCmm* GetNamedCmm()    const;   // non-null only for CreateNamed
+CIccCmmSearch*     GetSearchCmm()   const;   // non-null only for CreateSearch
+CIccThreadedCmm*   GetThreadedCmm() const;   // non-null when CreateStandard wrapped with nThreads != 1
+bool               IsThreaded()     const;   // shorthand for GetThreadedCmm() != nullptr
 icColorSpaceSignature GetSourceSpace() const;
 icColorSpaceSignature GetDestSpace()   const;
 ```
@@ -66,44 +88,26 @@ icColorSpaceSignature GetDestSpace()   const;
 `~CIccConnectCmm()` deletes the wrapped CMM, so callers own exactly one
 object and free with `delete`.
 
-### Optional Parallel Apply
+### Parallel Apply
 
-After a successful factory call, threading can be enabled in place:
+Threading is selected at construction time via the `nThreads` argument to
+`CreateStandard`. When `nThreads == 0` the factory uses
+`std::thread::hardware_concurrency()`; when `nThreads > 1` it uses that
+many workers; when `nThreads == 1` the underlying CMM is returned without
+the threaded wrapper. See the [threading guide](icc-cmm-threading.md)
+for the apply-time semantics.
 
-```cpp
-bool EnableThreading(int nThreads = 0);   // 0 -> hardware_concurrency
-bool IsThreaded() const;
-```
-
-`EnableThreading` wraps the underlying CMM with `CIccThreadedCmm` (see
-[threading guide](icc-cmm-threading.md)) so subsequent multi-pixel
-`Apply()` calls run in parallel. The wrapper assumes ownership of the
-underlying CMM, so the single-owner contract of `CIccConnectCmm` is
-preserved — callers still free with one `delete`.
-
-Behaviour:
-
-| Condition | Result |
-|-----------|--------|
-| `m_pCmm` is null | Returns `false`. |
-| Already threaded | Returns `true`, no rewrap. |
-| Attach fails | Underlying CMM is destroyed by `CIccThreadedCmm::Attach`, `m_pCmm` becomes null, returns `false`. The connect object should be deleted. |
-| Success | `GetCmm()` returns the threaded wrapper; `IsThreaded()` returns `true`. |
-
-After threading is enabled, `GetNamedCmm()` and `GetSearchCmm()` return
-`nullptr` because the type-specific CMM is hidden behind the wrapper.
-Striped threading is most useful for `CreateStandard` pixel pipelines; if
-you need the named-color or search APIs, call them through the typed
-accessor before enabling threading, or skip `EnableThreading` for those
-factories.
+Because the threaded wrapper hides the type-specific CMM,
+`GetNamedCmm()` and `GetSearchCmm()` return `nullptr` once a threaded
+wrapper is in place. `GetThreadedCmm()` and `IsThreaded()` expose the
+wrapper directly when needed.
 
 For a worked example, see
 [`Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp`](../Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp),
-which builds the CMM with `CreateStandard`, snapshots the underlying
-`CIccCmm*` for metadata queries the wrapper does not forward (e.g.
-`GetLastParentSpace`), calls `EnableThreading(nThreads)`, then drives
-row-batched `Apply(dst, src, nPixels)` calls. The `-threads` CLI flag
-maps straight through to that single argument.
+which calls `CreateStandard(cfgProfiles, pEmbedded, nEmbeddedLen,
+cfgConnect.m_nThreads, &sConnectError)` and drives row-batched
+`Apply(dst, src, nPixels)` calls. The `-threads` CLI flag maps straight
+through to the `nThreads` argument.
 
 ## Per-profile Hints Applied
 
@@ -138,22 +142,26 @@ the appropriate factory. See:
 
 ```cpp
 #include "IccConnect.h"
+#include <string>
 
 CIccCfgApply cfg;
 if (!cfg.fromJson(jsonText)) { /* parse error */ }
 
-CIccConnectCmm *conn = CIccConnectCmm::CreateStandard(cfg.m_profiles);
-if (!conn) { /* failed to build CMM */ }
+std::string sError;
+CIccConnectCmm *conn = CIccConnectCmm::CreateStandard(
+    cfg.m_profiles,
+    /*pEmbeddedData=*/nullptr, /*nEmbeddedLen=*/0,
+    /*nThreads=*/0,                  // 0 = hardware_concurrency, 1 = no wrapper
+    &sError);
 
-// Optional: enable parallel apply.  Ownership stays with conn; the
-// connect object's destructor frees the threaded wrapper, which in turn
-// frees the underlying CMM.
-if (!conn->EnableThreading(/*nThreads=*/0)) {
-  delete conn;
-  /* threading failed; connect is already empty */
+if (!conn) {
+  // sError carries a single human-readable line describing the first
+  // failure (e.g. "stage 1: unable to open ICC profile 'foo.icc'").
+  fprintf(stderr, "%s\n", sError.c_str());
+  return -1;
 }
 
-conn->GetCmm()->Apply(dst, src, nPixels);
+conn->GetCmm()->Apply(dst, src, nPixels);   // threaded path when nThreads != 1
 delete conn;
 ```
 


### PR DESCRIPTION

## PR Summary

In preparing an ICS package for Hybrid Printer Profiles I discovered that it wouldn't correctly apply the spectral sub profile in some instances.  The error messages was less than helpful.  Error Message handling was refactored (so it doesn't use stderr).

## Checklist

- [X] Built locally with the documented build flow in `docs/build.md`
- [X] Ran relevant CTest/profile tests from `docs/ctest.md`
- [X] Added or updated regression coverage for behavior changes
- [ ] Checked sanitizer coverage for memory-safety or parser changes
- [X] Updated documentation for user-visible behavior changes
- [X] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [X] New source files include the ICC copyright and BSD 3-Clause license header
- [X] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
