### PR TITLE
ci: fix PR status labeler completion

### DIFF
--- a/.github/workflows/update-labels.yml
+++ b/.github/workflows/update-labels.yml
@@ -19,6 +19,20 @@ on:
     - cron: '0 */4 * * *'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_run:
+    workflows:
+      - ci-pr-action
+      - ci-json-roundtrip
+      - ci-json-python
+      - ci-docker
+      - ci-regression-checks
+      - ci-risk-analysis
+      - ci-pr-unix
+      - ci-pr-win
+      - ci-pr-wasm
+      - ci-sanitizer-tests
+      - ci-vcpkg-ports
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -27,7 +41,7 @@ permissions:
   checks: read  # Required to evaluate GitHub Actions check runs.
 
 concurrency:
-  group: pr-status-labeler-${{ github.event.pull_request.number || github.event.workflow_run.id || 'batch' }}
+  group: pr-status-labeler-${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id || 'batch' }}
   cancel-in-progress: true
 
 jobs:
@@ -212,7 +226,7 @@ jobs:
                 else
                   [.check_runs[]
                     | select(.name as $name
-                        | ["label-status", "apply-labels", "mark-codeql-ready"]
+                        | ["PR status labeler", "label-status", "apply-labels", "mark-codeql-ready"]
                         | index($name) | not)
                     | if .status != "completed" then "pending"
                       else (.conclusion // "pending") end]


### PR DESCRIPTION
Ignore the status labeler check run when evaluating PR check state, and rerun the labeler after CI workflow completions so pending labels are cleared after checks finish.

## PR Summary

Part of #1022

## Checklist

- [x] Built locally with the documented build flow in `docs/build.md`
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Added or updated regression coverage for behavior changes
- [x] Checked sanitizer coverage for memory-safety or parser changes
- [x] Updated documentation for user-visible behavior changes
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Maintainer Review

Maintainer-owned workflow, release, sanitizer, CTest, CodeQL, or security changes
may receive additional labels and require CODEOWNERS review. If you have
questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
