### PR TITLE
Fix issues in iccapplyprofiles with iccMAX colorimetric encoding profiles

### DIFF
--- a/.github/scripts/iccdev-iccapplyprofiles-lab-roundtrip-tests.sh
+++ b/.github/scripts/iccdev-iccapplyprofiles-lab-roundtrip-tests.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+###############################################################################
+# iccDEV iccApplyProfiles Lab-roundtrip regression tests
+###############################################################################
+#
+# Exercises the TIFF-boundary encoding rule for chains that read from and write
+# to Lab-destination TIFFs via a v5 MPE-based PCC (Profile Connection Conditions)
+# profile that maps standard CIELAB to/from a normalized device-Lab integer
+# encoding. The chain pattern (sRGB -> encoded Lab TIFF -> sRGB) was previously
+# broken because the TIFF boundary applied PCS-encoding conversions intended
+# for v4 chains to values that were already in device-encoded [0,1] form,
+# producing saturated 16-bit pixels and 100x-scaled float pixels.
+#
+# This test guards against future regression of that fix by:
+#   1) Synthesizing a deterministic RGB TIFF with sRGB v4 (Lab PCS) embedded.
+#   2) Building a v5 MPE Lab integer-encoding PCC profile from inline XML.
+#   3) Running a forward apply (RGB -> encoded Lab 16-bit) and a reverse apply
+#      (encoded Lab 16-bit -> RGB) using the same v5 profile.
+#   4) Asserting the RGB round-trip RMS error stays within a generous bound
+#      that any chromaticity-saturation regression would blow through.
+#
+# Environment variables (set by CI workflow):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools (contains tool subdirs)
+#   ICCDEV_TESTING_DIR -- path to Testing/ (contains sRGB_v4_ICC_preference.icc)
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# The test SKIPs cleanly when python3, Pillow, tifffile + imagecodecs, or
+# iccFromXml are unavailable, so it does not false-fail in minimal images.
+#
+# Exit code: 0 = all pass (or skipped), 1 = test failure, 2 = ASAN/UBSAN.
+###############################################################################
+
+set -uo pipefail
+
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:?Set ICCDEV_TOOLS_DIR to iccDEV Build/Tools path}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:?Set ICCDEV_TESTING_DIR to iccDEV Testing path}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-iccapplyprofiles-lab-roundtrip}"
+mkdir -p "$OUTDIR"
+
+APPLY="$TOOLS_DIR/IccApplyProfiles/iccApplyProfiles"
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+ASAN_FINDINGS=0
+UBSAN_FINDINGS=0
+TOTAL=0
+
+echo "=== iccApplyProfiles Lab-roundtrip ==="
+
+if [ ! -x "$APPLY" ]; then
+  echo "  [SKIP] iccApplyProfiles not found at $APPLY"
+  exit 0
+fi
+if [ ! -x "$FROMXML" ]; then
+  echo "  [SKIP] iccFromXml not found at $FROMXML -- cannot build test profile"
+  exit 0
+fi
+
+SRGB_PROFILE=""
+for candidate in \
+  "$TESTING_DIR/sRGB_v4_ICC_preference.icc" \
+  "$TESTING_DIR/../Testing/sRGB_v4_ICC_preference.icc"; do
+  if [ -f "$candidate" ]; then
+    SRGB_PROFILE="$candidate"
+    break
+  fi
+done
+if [ -z "$SRGB_PROFILE" ]; then
+  echo "  [SKIP] sRGB_v4_ICC_preference.icc not found under $TESTING_DIR"
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  [SKIP] python3 not available -- cannot synthesize/verify TIFFs"
+  exit 0
+fi
+
+# Synthesize a deterministic 64x64 RGB TIFF with sRGB v4 (Lab PCS) embedded.
+SRC_TIFF="$OUTDIR/lab-rt-src.tif"
+PY_LOG="$OUTDIR/lab-rt-synth.log"
+python3 - "$SRC_TIFF" "$SRGB_PROFILE" >"$PY_LOG" 2>&1 <<'PY'
+import sys
+try:
+    from PIL import Image
+except Exception as e:
+    print(f"Pillow unavailable: {e}")
+    sys.exit(2)
+
+out_path, icc_path = sys.argv[1], sys.argv[2]
+with open(icc_path, "rb") as f:
+    icc_bytes = f.read()
+
+w, h = 64, 64
+data = bytearray(w * h * 3)
+for y in range(h):
+    base = y * w * 3
+    for x in range(w):
+        i = base + x * 3
+        data[i]     = (x * 4) & 0xFF
+        data[i + 1] = (y * 4) & 0xFF
+        data[i + 2] = ((x + y) * 2) & 0xFF
+
+img = Image.frombytes("RGB", (w, h), bytes(data))
+img.save(out_path, format="TIFF", compression="raw", icc_profile=icc_bytes)
+print(f"wrote {out_path} ({w}x{h})")
+PY
+PY_EC=$?
+if [ "$PY_EC" -ne 0 ] || [ ! -s "$SRC_TIFF" ]; then
+  echo "  [SKIP] Pillow unavailable or source TIFF synthesis failed -- see $PY_LOG"
+  sed -n '1,5p' "$PY_LOG"
+  exit 0
+fi
+
+# Build the v5 MPE PCC Lab integer-encoding profile from inline XML.  The
+# A2B3 matrix decodes device-encoded [0,1] Lab to standard CIELAB
+# (L = L_dev*100, a/b = ab_dev*256-128), and B2A3 encodes the inverse.
+LAB_XML="$OUTDIR/lab-rt-Lab_int_D50.xml"
+LAB_ICC="$OUTDIR/lab-rt-Lab_int_D50.icc"
+cat > "$LAB_XML" <<'XML'
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType></PreferredCMMType>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>spac</ProfileDeviceClass>
+    <DataColourSpace>Lab </DataColourSpace>
+    <PCS>Lab </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
+    </PCSIlluminant>
+    <ProfileCreator></ProfileCreator>
+    <ProfileID>1</ProfileID>
+  </Header>
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Test Lab integer encoding D50 2deg observer]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <multiProcessElementType>
+      <TagSignature>A2B3</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+        <MatrixElement InputChannels="3" OutputChannels="3">
+          <MatrixData>
+            100.0 0 0
+            0 256.0 0
+            0 0 256.0
+          </MatrixData>
+          <OffsetData>0 -128.0 -128.0</OffsetData>
+        </MatrixElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+    <multiProcessElementType>
+      <TagSignature>B2A3</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+        <MatrixElement InputChannels="3" OutputChannels="3">
+          <MatrixData>
+            0.01 0 0
+            0 0.0039062 0
+            0 0 0.0039062
+          </MatrixData>
+          <OffsetData>0 0.5 0.5</OffsetData>
+        </MatrixElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>
+XML
+
+XML_LOG="$OUTDIR/lab-rt-fromxml.log"
+if ! "$FROMXML" "$LAB_XML" "$LAB_ICC" >"$XML_LOG" 2>&1; then
+  echo "  [SKIP] iccFromXml failed to build Lab encoding profile"
+  sed -n '1,10p' "$XML_LOG"
+  exit 0
+fi
+if [ ! -s "$LAB_ICC" ]; then
+  echo "  [SKIP] iccFromXml produced no output"
+  exit 0
+fi
+
+# Forward: embedded sRGB v4 -> encoded Lab 16-bit TIFF.
+FWD_CFG="$OUTDIR/lab-rt-fwd.cfg.json"
+ENC_TIFF="$OUTDIR/lab-rt-encoded.tif"
+cat > "$FWD_CFG" <<EOF
+{
+  "imageFiles": {
+    "srcImageFile": "$SRC_TIFF",
+    "dstImageFile": "$ENC_TIFF",
+    "dstEncoding": "16bit",
+    "dstCompression": false,
+    "dstPlanar": false,
+    "dstEmbedIcc": true
+  },
+  "profileSequence": [
+    { "iccFile": null,       "intent": "relative", "transform": "default" },
+    { "iccFile": "$LAB_ICC", "intent": "relative", "transform": "default" }
+  ]
+}
+EOF
+
+# Reverse: encoded Lab 16-bit TIFF (embedded profile) -> sRGB 8-bit RGB.
+REV_CFG="$OUTDIR/lab-rt-rev.cfg.json"
+RT_TIFF="$OUTDIR/lab-rt-roundtrip.tif"
+cat > "$REV_CFG" <<EOF
+{
+  "imageFiles": {
+    "srcImageFile": "$ENC_TIFF",
+    "dstImageFile": "$RT_TIFF",
+    "dstEncoding": "8bit",
+    "dstCompression": false,
+    "dstPlanar": false,
+    "dstEmbedIcc": false
+  },
+  "profileSequence": [
+    { "iccFile": null,           "intent": "relative", "transform": "default" },
+    { "iccFile": "$SRGB_PROFILE", "intent": "relative", "transform": "default" }
+  ]
+}
+EOF
+
+run_step() {
+  local label="$1"; local cfg="$2"
+  local log="$OUTDIR/lab-rt-${label}.log"
+  local ec=0
+  timeout 60 "$APPLY" -cfg "$cfg" >"$log" 2>&1 || ec=$?
+  if grep -q "ERROR: AddressSanitizer" "$log" 2>/dev/null; then
+    echo "  [ASAN] $label -- AddressSanitizer finding"
+    ASAN_FINDINGS=$((ASAN_FINDINGS + 1))
+    return 1
+  fi
+  if grep -q "runtime error:" "$log" 2>/dev/null; then
+    echo "  [UBSAN] $label -- undefined behavior"
+    UBSAN_FINDINGS=$((UBSAN_FINDINGS + 1))
+    return 1
+  fi
+  if [ "$ec" -ne 0 ]; then
+    echo "  [FAIL] $label exit=$ec"
+    sed -n '1,10p' "$log"
+    return 1
+  fi
+  return 0
+}
+
+TOTAL=$((TOTAL + 1))
+if ! run_step "forward" "$FWD_CFG"; then
+  FAIL=$((FAIL + 1))
+else
+  TOTAL=$((TOTAL + 1))
+  if ! run_step "reverse" "$REV_CFG"; then
+    FAIL=$((FAIL + 1))
+  else
+    # Compare round-trip RGB to source RGB.
+    TOTAL=$((TOTAL + 1))
+    CMP_LOG="$OUTDIR/lab-rt-compare.log"
+    python3 - "$SRC_TIFF" "$RT_TIFF" >"$CMP_LOG" 2>&1 <<'PY'
+import sys
+try:
+    import tifffile
+    import numpy as np
+except Exception as e:
+    print(f"SKIP: tifffile/numpy unavailable ({e})")
+    sys.exit(77)  # treat as skip
+
+src = np.asarray(tifffile.imread(sys.argv[1]), dtype=np.float32)[..., :3]
+rt  = np.asarray(tifffile.imread(sys.argv[2]), dtype=np.float32)[..., :3]
+if src.shape != rt.shape:
+    print(f"FAIL: shape mismatch src={src.shape} rt={rt.shape}")
+    sys.exit(1)
+rms = float(np.sqrt(((src - rt) ** 2).mean()))
+mx  = float(np.abs(src - rt).max())
+print(f"rms={rms:.2f}  max_diff={mx:.0f}")
+
+# Threshold: the fix gives RMS ~9 / max ~30 on this chain. The pre-fix bug
+# saturated chromatic channels to 0 or 65535 producing RMS > 100 and max
+# diff = 255. Set threshold to 35 RMS / 80 max to catch any regression that
+# reintroduces gross encoding errors while tolerating colorimetric loss.
+if rms > 35.0 or mx > 80.0:
+    print("FAIL: RGB round-trip exceeded threshold (rms<=35, max<=80)")
+    sys.exit(1)
+
+print("PASS: RGB round-trip within threshold")
+sys.exit(0)
+PY
+    cmp_ec=$?
+    if [ "$cmp_ec" -eq 77 ]; then
+      echo "  [SKIP] tifffile/numpy unavailable for comparison"
+      sed -n '1,3p' "$CMP_LOG"
+    elif [ "$cmp_ec" -eq 0 ]; then
+      echo "  [PASS] sRGB -> encoded Lab 16-bit -> sRGB ($(sed -n '1p' "$CMP_LOG"))"
+      PASS=$((PASS + 1))
+    else
+      echo "  [FAIL] sRGB -> encoded Lab 16-bit -> sRGB"
+      sed -n '1,5p' "$CMP_LOG"
+      FAIL=$((FAIL + 1))
+    fi
+  fi
+fi
+
+echo "iccApplyProfiles Lab-roundtrip: $PASS passed, $FAIL failed, $TOTAL steps total"
+
+if [ "$ASAN_FINDINGS" -ne 0 ] || [ "$UBSAN_FINDINGS" -ne 0 ]; then
+  exit 2
+fi
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -1448,7 +1448,13 @@ bool CIccMpeXmlMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
     m_nInputChannels = nInputChannels; //Fix m_nInputChannels
   }
 
+  // Accept either "ConstantData" (canonical, what ToXml writes) or "OffsetData"
+  // (historical alias used by authored profile XML sources). Silent omission of
+  // the offset/constants vector causes the matrix to apply with all-zero offset,
+  // which can change colorimetric results - explicitly read both names.
   pData = icXmlFindNode(pNode->children, "ConstantData");
+  if (!pData)
+    pData = icXmlFindNode(pNode->children, "OffsetData");
   if (pData) {
     if (!CIccFloatArray::ParseArray(m_pConstants, m_nOutputChannels, pData->children))
       return false;

--- a/Tools/CmdLine/IccApplyProfiles/Readme.md
+++ b/Tools/CmdLine/IccApplyProfiles/Readme.md
@@ -12,6 +12,48 @@ Run without arguments to print the current command syntax and supported options:
 iccApplyProfiles
 ```
 
+## TIFF Pixel Encoding
+
+`iccApplyProfiles` treats TIFF pixel values as a *device encoding* regardless
+of color space or TIFF photometric tag. The rule applies symmetrically on
+read and write:
+
+| Pixel format | Decode (read) | Encode (write) |
+|--------------|---------------|----------------|
+| 8-bit integer | `value = pixel / 255` | `pixel = clamp01(value) * 255` |
+| 16-bit integer | `value = pixel / 65535` | `pixel = clamp01(value) * 65535` |
+| 32-bit float | `value = pixel` (pass-through) | `pixel = value` (pass-through) |
+
+No bit-bias adjustments are applied — for example, a/b channels of a 16-bit
+Lab destination are *not* offset by `0x8000` even when the TIFF
+PhotometricInterpretation is `CIELAB` or `ICCLAB`. Consumers of the output
+TIFFs should use the *embedded ICC profile* to interpret pixel values,
+since that profile (not the photometric tag alone) describes the actual
+encoding produced by the final transform.
+
+Any PCS-encoding bridging is the CMM's responsibility: profile xforms whose
+PCS endpoint is `Lab` or `XYZ` apply `icLabToPcs` / `icLabFromPcs` (or the
+XYZ equivalents) at their own entry/exit, so values entering and leaving
+the boundary code here are always in the form the *next* transform stage
+or the destination TIFF expects.
+
+Practical consequences:
+
+- A chain ending in a v5 MPE PCC profile that maps standard CIELAB to a
+  `[0, 1]` device-Lab encoding (e.g. `L_dev = L*/100`,
+  `a_dev = (a*+128)/256`) will produce a 16-bit Lab TIFF where each channel
+  is the device-encoded value scaled to `[0, 65535]`. Round-tripping via
+  the same profile recovers the original colors.
+- A chain ending in a plain Lab PCS output produces values in the CMM's
+  internal PCS-Lab encoding (normalized `[0, 1]`). Writing 32-bit float
+  passes those through unchanged; writing 16-bit scales them to
+  `[0, 65535]`.
+- A TIFF whose `PhotometricInterpretation` is `CIELAB` (TIFF spec) without
+  an embedded ICC profile cannot be read back to its original colors,
+  because the tool does not apply the spec's `±128`-biased decoding. Embed
+  the ICC profile (set `dstEmbedIcc: true` in the JSON config) so the
+  reverse chain can recover the values.
+
 ## See Also
 
 - [CLI tool reference](../../../docs/tools-cli-reference.md)

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -486,7 +486,7 @@ int main(int argc, const char** argv)
     //Fall through - No break here
 
   case icSigLabData:
-    photo = PHOTO_CIELAB;
+    photo = PHOTO_ICCLAB;
     break;
 
   default:
@@ -567,48 +567,35 @@ int main(int argc, const char** argv)
   int lastPer = -1;
   int curper;
 
+  // Boundary rule (per Max Derhak): TIFF pixel values use a *device encoding*
+  // regardless of color space. Integer formats map linearly to [0, 1] via
+  // division/multiplication by the format's full-scale; floating point passes
+  // through unchanged. Any PCS-encoding bridging is handled inside the CMM's
+  // first/last xforms, so the boundary code here is uniform and does not
+  // depend on TIFF photometric or PCS color-space signatures.
   auto decodePixel = [&](icFloatNumber *pPixel, unsigned char *pSrcBytes) -> bool {
     switch(bps) {
-      case 8:
-        if (sphoto==PHOTO_CIELAB) {
-          unsigned char *pSPixel = pSrcBytes;
-          pPixel[0]=(icFloatNumber)pSPixel[0] / 255.0f;
-          pPixel[1]=(icFloatNumber)(pSPixel[1]-128) / 255.0f;
-          pPixel[2]=(icFloatNumber)(pSPixel[2]-128) / 255.0f;
-        }
-        else {
-          unsigned char *pSPixel = pSrcBytes;
-          for (k=0; k<nSrcColorSamples; k++)
-            pPixel[k] = (icFloatNumber)pSPixel[k] / 255.0f;
-        }
+      case 8: {
+        const icUInt8Number *pSPixel = pSrcBytes;
+        for (k=0; k<nSrcColorSamples; k++)
+          pPixel[k] = (icFloatNumber)pSPixel[k] / 255.0f;
         break;
-
-      case 16:
-        if (sphoto==PHOTO_CIELAB) {
-          unsigned short *pSPixel = (unsigned short*)pSrcBytes;
-          pPixel[0]=(icFloatNumber)pSPixel[0] / 65535.0f;
-          pPixel[1]=(icFloatNumber)(pSPixel[1]-0x8000) / 65535.0f;
-          pPixel[2]=(icFloatNumber)(pSPixel[2]-0x8000) / 65535.0f;
-        }
-        else {
-          unsigned short *pSPixel = (unsigned short*)pSrcBytes;
-          for (k=0; k<nSrcColorSamples; k++)
-            pPixel[k] = (icFloatNumber)pSPixel[k] / 65535.0f;
-        }
+      }
+      case 16: {
+        const icUInt16Number *pSPixel = (const icUInt16Number*)pSrcBytes;
+        for (k=0; k<nSrcColorSamples; k++)
+          pPixel[k] = (icFloatNumber)pSPixel[k] / 65535.0f;
         break;
-
+      }
       case 32:
         if (sizeof(icFloatNumber)==sizeof(icFloat32Number)) {
           memcpy(pPixel, pSrcBytes, nSrcColorSamples * sizeof(icFloat32Number));
         }
         else {
-          icFloat32Number *pSPixel = (icFloat32Number*)pSrcBytes;
+          const icFloat32Number *pSPixel = (const icFloat32Number*)pSrcBytes;
           for (k=0; k<nSrcColorSamples; k++)
             pPixel[k] = (icFloatNumber)pSPixel[k];
         }
-
-        if (sphoto==PHOTO_CIELAB || sphoto==PHOTO_ICCLAB)
-          icLabToPcs(pPixel);
         break;
 
       default:
@@ -616,55 +603,24 @@ int main(int argc, const char** argv)
         return false;
     }
 
-    if (sphoto == PHOTO_CIELAB && SrcspaceSig==icSigXYZData) {
-      icLabFromPcs(pPixel);
-      icLabtoXYZ(pPixel);
-      icXyzToPcs(pPixel);
-    }
-
     return true;
   };
 
   auto encodePixel = [&](unsigned char *pDstBytes, icFloatNumber *pPixel) -> bool {
-    if (photo==PHOTO_CIELAB && DestSpaceSig==icSigXYZData) {
-      icXyzFromPcs(pPixel);
-      icXYZtoLab(pPixel);
-      icLabToPcs(pPixel);
-    }
-
     switch(dbps) {
-      case 8:
-        if (photo==PHOTO_CIELAB) {
-          unsigned char *pDPixel = pDstBytes;
-          pDPixel[0] = UnitClipToUInt8(pPixel[0]);
-          pDPixel[1] = static_cast<icUInt8Number>((UnitClipToUInt8(pPixel[1]) + 128) & 0xFF);
-          pDPixel[2] = static_cast<icUInt8Number>((UnitClipToUInt8(pPixel[2]) + 128) & 0xFF);
-        }
-        else {
-          icUInt8Number *pDPixel = pDstBytes;
-          for (k=0; k<nDestSamples; k++)
-            pDPixel[k] = UnitClipToUInt8(pPixel[k]);
-        }
+      case 8: {
+        icUInt8Number *pDPixel = pDstBytes;
+        for (k=0; k<nDestSamples; k++)
+          pDPixel[k] = UnitClipToUInt8(pPixel[k]);
         break;
-
-      case 16:
-        if (photo==PHOTO_CIELAB) {
-          unsigned short *pDPixel = (unsigned short*)pDstBytes;
-          pDPixel[0] = UnitClipToUInt16(pPixel[0]);
-          pDPixel[1] = static_cast<icUInt16Number>((UnitClipToUInt16(pPixel[1]) + 0x8000) & 0xFFFF);
-          pDPixel[2] = static_cast<icUInt16Number>((UnitClipToUInt16(pPixel[2]) + 0x8000) & 0xFFFF);
-        }
-        else {
-          icUInt16Number *pDPixel = (icUInt16Number*)pDstBytes;
-          for (k=0; k<nDestSamples; k++)
-            pDPixel[k] = UnitClipToUInt16(pPixel[k]);
-        }
+      }
+      case 16: {
+        icUInt16Number *pDPixel = (icUInt16Number*)pDstBytes;
+        for (k=0; k<nDestSamples; k++)
+          pDPixel[k] = UnitClipToUInt16(pPixel[k]);
         break;
-
+      }
       case 32:
-        if (photo==PHOTO_CIELAB || photo==PHOTO_ICCLAB)
-          icLabFromPcs(pPixel);
-
         if (sizeof(icFloatNumber)==sizeof(icFloat32Number)) {
           memcpy(pDstBytes, pPixel, dbpp);
         }
@@ -713,139 +669,24 @@ int main(int argc, const char** argv)
     }
     else {
       for (sptr=pSBuf, dptr=pDBuf, j=0; j<(int)SrcImg.GetWidth(); j++, sptr+=sbpp, dptr+=dbpp) {
-
-      //Special conversions need to be made to convert CIELAB and CIEXYZ to internal PCS encoding
-      switch(bps) {
-        case 8:
-          if (sphoto==PHOTO_CIELAB) {
-            unsigned char *pSPixel = sptr;
-            icFloatNumber *pPixel = SrcPixel;
-            pPixel[0]=(icFloatNumber)pSPixel[0] / 255.0f;
-            pPixel[1]=(icFloatNumber)(pSPixel[1]-128) / 255.0f;
-            pPixel[2]=(icFloatNumber)(pSPixel[2]-128) / 255.0f;
-          }
-          else {
-            unsigned char *pSPixel = sptr;
-            icFloatNumber *pPixel = SrcPixel;
-            for (k=0; k<nSrcColorSamples; k++) {
-              pPixel[k] = (icFloatNumber)pSPixel[k] / 255.0f;
-            }
-          }
-          break;
-
-        case 16:
-          if (sphoto==PHOTO_CIELAB) {
-            unsigned short *pSPixel = (unsigned short*)sptr;
-            icFloatNumber *pPixel = SrcPixel;
-            pPixel[0]=(icFloatNumber)pSPixel[0] / 65535.0f;
-            pPixel[1]=(icFloatNumber)(pSPixel[1]-0x8000) / 65535.0f;
-            pPixel[2]=(icFloatNumber)(pSPixel[2]-0x8000) / 65535.0f;
-          }
-          else {
-            unsigned short *pSPixel = (unsigned short*)sptr;
-            icFloatNumber *pPixel = SrcPixel;
-            for (k=0; k<nSrcColorSamples; k++) {
-              pPixel[k] = (icFloatNumber)pSPixel[k] / 65535.0f;
-            }
-          }
-          break;
-
-        case 32:
-          {
-            if (sizeof(icFloatNumber)==sizeof(icFloat32Number)) {
-              memcpy(SrcPixel.get(), sptr, sbpp);
-            }
-            else {
-              icFloat32Number *pSPixel = (icFloat32Number*)sptr;
-              icFloatNumber *pPixel = SrcPixel;
-              for (k=0; k<nSrcColorSamples; k++) {
-                pPixel[k] = (icFloatNumber)pSPixel[k];
-              }
-            }
-
-            if (sphoto==PHOTO_CIELAB || sphoto==PHOTO_ICCLAB) {
-              icLabToPcs(SrcPixel);
-            }
-          }
-          break;
-
-        default:
-          printf("Invalid source bit depth\n");
+        if (!decodePixel(SrcPixel, sptr)) {
+          free(pSBuf);
+          free(pDBuf);
+          free(pSrcRowBuf);
+          free(pDstRowBuf);
           return -1;
-      }
-      if (sphoto == PHOTO_CIELAB && SrcspaceSig==icSigXYZData) {
-        icLabFromPcs(SrcPixel);
-        icLabtoXYZ(SrcPixel);
-        icXyzToPcs(SrcPixel);
-      }
+        }
 
-      //Use CMM to convert SrcPixel to DestPixel
-      pTheCmm->Apply(DestPixel, SrcPixel);
+        //Use CMM to convert SrcPixel to DestPixel
+        pTheCmm->Apply(DestPixel, SrcPixel);
 
-      //Special conversions need to be made to convert from internal PCS encoding CIELAB
-      if (photo==PHOTO_CIELAB && DestSpaceSig==icSigXYZData) {
-        icXyzFromPcs(DestPixel);
-        icXYZtoLab(DestPixel);
-        icLabToPcs(DestPixel);
-      }
-      switch(dbps) {
-        case 8:
-          if (photo==PHOTO_CIELAB) {
-            unsigned char *pDPixel = dptr;
-            icFloatNumber *pPixel = DestPixel;
-            pDPixel[0] = UnitClipToUInt8(pPixel[0]);
-            pDPixel[1] = static_cast<icUInt8Number>((UnitClipToUInt8(pPixel[1]) + 128) & 0xFF);
-            pDPixel[2] = static_cast<icUInt8Number>((UnitClipToUInt8(pPixel[2]) + 128) & 0xFF);
-          }
-          else {
-            icUInt8Number *pDPixel = dptr;
-            icFloatNumber *pPixel = DestPixel;
-            for (k=0; k<nDestSamples; k++) {
-              pDPixel[k] = UnitClipToUInt8(pPixel[k]);
-            }
-          }
-          break;
-
-        case 16:
-          if (photo==PHOTO_CIELAB) {
-            unsigned short *pDPixel = (unsigned short*)dptr;
-            icFloatNumber *pPixel = DestPixel;
-            pDPixel[0] = UnitClipToUInt16(pPixel[0]);
-            pDPixel[1] = static_cast<icUInt16Number>((UnitClipToUInt16(pPixel[1]) + 0x8000) & 0xFFFF);
-            pDPixel[2] = static_cast<icUInt16Number>((UnitClipToUInt16(pPixel[2]) + 0x8000) & 0xFFFF);
-          }
-          else {
-            icUInt16Number *pDPixel = (icUInt16Number*)dptr;
-            icFloatNumber *pPixel = DestPixel;
-            for (k=0; k<nDestSamples; k++) {
-              pDPixel[k] = UnitClipToUInt16(pPixel[k]);
-            }
-          }
-          break;
-
-        case 32:
-          {
-            if (photo==PHOTO_CIELAB || photo==PHOTO_ICCLAB) {
-              icLabFromPcs(SrcPixel);
-            }
-
-            if (sizeof(icFloatNumber)==sizeof(icFloat32Number)) {
-              memcpy(dptr, DestPixel.get(), dbpp);
-            }
-            else {
-              icFloat32Number *pDPixel = (icFloat32Number*)dptr;
-              icFloatNumber *pPixel = DestPixel;
-              for (k=0; k<nDestSamples; k++) {
-                pDPixel[k] = static_cast<icFloat32Number>(pPixel[k]);
-              }
-            }
-          }
-          break;
-
-        default:
-          printf("Invalid source bit depth\n");
+        if (!encodePixel(dptr, DestPixel)) {
+          free(pSBuf);
+          free(pDBuf);
+          free(pSrcRowBuf);
+          free(pDstRowBuf);
           return -1;
-      }
+        }
       }
     }
 


### PR DESCRIPTION
## PR Summary

While working on Colorimetric Encoding ICS package I found that the iccapplyprofiles had problems.  Changes allow round tripping while embedding iccMAX colorimetric encoding profiles.  Small feature added xml parsing to support alternat naming of matrix constant data.

## Checklist

- [X] Built locally with the documented build flow in `docs/build.md`
- [X] Ran relevant CTest/profile tests from `docs/ctest.md`
- [X] Added or updated regression coverage for behavior changes
- [ ] Checked sanitizer coverage for memory-safety or parser changes
- [X] Updated documentation for user-visible behavior changes
- [X] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [X] New source files include the ICC copyright and BSD 3-Clause license header
- [X] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Maintainer Review

Maintainer-owned workflow, release, sanitizer, CTest, CodeQL, or security changes
may receive additional labels and require CODEOWNERS review. If you have
questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
