### PR TITLE
Issue 1025

### DIFF
--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -85,7 +85,7 @@ static IccJson icJsonGetHeaderFlags(icUInt32Number flags)
   icUInt32Number other = flags & ~(icUInt32Number)(icEmbeddedProfileTrue | icUseWithEmbeddedDataOnly |
                                                    icExtendedRangePCS | icMCSNeedsSubsetTrue);
   if (other) {
-    char buf[16]; snprintf(buf, sizeof(buf), "%08x", other);
+    char buf[16]; snprintf(buf, sizeof(buf), "%08x", (unsigned int) other);
     j["VendorFlags"] = buf;
   }
   return j;

--- a/IccProfLib/IccEncoding.cpp
+++ b/IccProfLib/IccEncoding.cpp
@@ -166,11 +166,12 @@ icStatusEncConvert CIccDefaultEncProfileConverter::ConvertFromParams(CIccProfile
   CIccProfile* pIcc = new CIccProfile;
   pIcc->m_Header = *pHeader;
 
-  struct tm* newtime;
+  struct tm tmStorage;
+  struct tm* newtime = &tmStorage;
   time_t long_time;
 
   time(&long_time);                /* Get time as long integer. */
-  newtime = gmtime(&long_time);
+  newtime = gmtime_r(&long_time, newtime);
 
   pIcc->m_Header.date.year = newtime->tm_year + 1900;
   pIcc->m_Header.date.month = newtime->tm_mon + 1;

--- a/IccProfLib/IccEncoding.cpp
+++ b/IccProfLib/IccEncoding.cpp
@@ -166,12 +166,11 @@ icStatusEncConvert CIccDefaultEncProfileConverter::ConvertFromParams(CIccProfile
   CIccProfile* pIcc = new CIccProfile;
   pIcc->m_Header = *pHeader;
 
-  struct tm tmStorage;
-  struct tm* newtime = &tmStorage;
+  struct tm* newtime;
   time_t long_time;
 
   time(&long_time);                /* Get time as long integer. */
-  newtime = gmtime_r(&long_time, newtime);
+  newtime = gmtime(&long_time);
 
   pIcc->m_Header.date.year = newtime->tm_year + 1900;
   pIcc->m_Header.date.month = newtime->tm_mon + 1;

--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -2259,7 +2259,7 @@ void CIccSampledCalculatorCurve::Describe(std::string &sDescription, int nVerbos
     snprintf(buf, bufSize, "%.8f,", m_lastEntry);
     sDescription += buf;
 
-    snprintf(buf, bufSize, "%u", m_nDesiredSize);
+    snprintf(buf, bufSize, "%u", (unsigned int)m_nDesiredSize);
     sDescription += buf;
 
     snprintf(buf, bufSize, "]\r\n");
@@ -2274,7 +2274,7 @@ void CIccSampledCalculatorCurve::Describe(std::string &sDescription, int nVerbos
     snprintf(buf, bufSize, "%.8f,", m_lastEntry);
     sDescription += buf;
 
-    snprintf(buf, bufSize, "%u", m_nDesiredSize);
+    snprintf(buf, bufSize, "%u", (unsigned int)m_nDesiredSize);
     sDescription += buf;
 
     snprintf(buf, bufSize, "]\r\n");

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -2866,7 +2866,8 @@ bool CIccFuncTokenizer::GetEnvSig(icSigCmmEnvVar &envSig)
 
     icUInt32Number sig = 0;
     if (l==10) {
-      sscanf(szToken+1, "%x", &sig);
+      // this is difficult to format correctly on all platforms, because of pointer and integer size differences
+      sscanf(szToken+1, "%x", &sig );
 
       envSig = (icSigCmmEnvVar)sig;
       return true;
@@ -4761,10 +4762,10 @@ void CIccMpeCalculator::Describe(std::string &sDescription, int nVerboseness)
     if (m_nSubElem && m_SubElem) {
       icUInt32Number i;
       for (i=0; i<m_nSubElem; i++) {
-        snprintf(buf, bufSize, "BEGIN_SUBCALCELEM %u\n", i);
+        snprintf(buf, bufSize, "BEGIN_SUBCALCELEM %u\n", (unsigned int) i);
         sDescription += buf;
         m_SubElem[i]->Describe(sDescription, nVerboseness);
-        snprintf(buf, bufSize, "END_SUBCALCELEM %u\n\n", i);
+        snprintf(buf, bufSize, "END_SUBCALCELEM %u\n\n", (unsigned int) i);
         sDescription += buf;
       }
     }

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1161,7 +1161,7 @@ void CIccProfile::InitHeader()
   m_Header.colorSpace = (icColorSpaceSignature)0;
   m_Header.pcs = icSigLabData;
   
-  struct tm* newtime;
+  struct tm *newtime;
   time_t long_time;
 
   time( &long_time );                /* Get time as long integer. */

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1161,12 +1161,11 @@ void CIccProfile::InitHeader()
   m_Header.colorSpace = (icColorSpaceSignature)0;
   m_Header.pcs = icSigLabData;
   
-  struct tm tmStorage;
-  struct tm* newtime = &tmStorage;
+  struct tm* newtime;
   time_t long_time;
 
   time( &long_time );                /* Get time as long integer. */
-  newtime = gmtime_r( &long_time, newtime ); 
+  newtime = gmtime( &long_time );
 
   m_Header.date.year = newtime->tm_year+1900;
   m_Header.date.month = newtime->tm_mon+1;

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1161,11 +1161,12 @@ void CIccProfile::InitHeader()
   m_Header.colorSpace = (icColorSpaceSignature)0;
   m_Header.pcs = icSigLabData;
   
-  struct tm *newtime;
+  struct tm tmStorage;
+  struct tm* newtime = &tmStorage;
   time_t long_time;
 
   time( &long_time );                /* Get time as long integer. */
-  newtime = gmtime( &long_time ); 
+  newtime = gmtime_r( &long_time, newtime ); 
 
   m_Header.date.year = newtime->tm_year+1900;
   m_Header.date.month = newtime->tm_mon+1;

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -538,7 +538,7 @@ void CIccTagUnknown::Describe(std::string &sDescription, int nVerboseness)
   icChar buf[bufSize];
 
   sDescription = "Unknown Tag Type of ";
-  snprintf(buf, bufSize, "%u Bytes.", m_nSize);
+  snprintf(buf, bufSize, "%u Bytes.", (unsigned int) m_nSize);
   sDescription += buf;
 
   if (nVerboseness > 50) {
@@ -1070,7 +1070,7 @@ void CIccTagUtf8Text::Describe(std::string &sDescription, int nVerboseness)
   if (m_szText && *m_szText) {
     const size_t bufSize = 40;
     char buf[bufSize];
-    snprintf(buf, bufSize, "%u bytes\n", m_nBufSize);
+    snprintf(buf, bufSize, "%u bytes\n", (unsigned int) m_nBufSize);
     sDescription += buf;
   }
   else
@@ -1426,7 +1426,7 @@ void CIccTagZipUtf8Text::Describe(std::string &sDescription, int /* nVerboseness
 #else
   const size_t sizeSize = 30;
   char size[sizeSize];
-  snprintf(size, sizeSize, "%u", m_nBufSize);
+  snprintf(size, sizeSize, "%u", (unsigned int) m_nBufSize);
   sDescription += "BEGIN_COMPESSED_DATA[\"";
   sDescription += size;
   sDescription += "]\n";
@@ -1905,7 +1905,7 @@ void CIccTagUtf16Text::Describe(std::string &sDescription, int nVerboseness)
     if (m_szText && *m_szText) {
         const size_t bufSize = 40;
         char buf[bufSize];
-        snprintf(buf, bufSize, "%u bytes\n", m_nBufSize);
+        snprintf(buf, bufSize, "%u bytes\n", (unsigned int) m_nBufSize);
         sDescription += buf;
     }
     else
@@ -3276,7 +3276,7 @@ void CIccTagNamedColor2::Describe(std::string &sDescription, int /* nVerboseness
 
   sDescription.reserve(sDescription.size() + m_nSize*79);
 
-  snprintf(buf, bufSize, "BEGIN_NAMED_COLORS flags=%08x %u %u\n", m_nVendorFlags, m_nSize, m_nDeviceCoords);
+  snprintf(buf, bufSize, "BEGIN_NAMED_COLORS flags=%08x %u %u\n", (unsigned int)m_nVendorFlags, (unsigned int)m_nSize, (unsigned int)m_nDeviceCoords);
   sDescription += buf;
 
   snprintf(buf, bufSize, "Prefix=\"%s\"\n", m_szPrefix);
@@ -3286,7 +3286,7 @@ void CIccTagNamedColor2::Describe(std::string &sDescription, int /* nVerboseness
   sDescription += buf;
 
   for (i=0; i<m_nSize; i++) {
-    snprintf(buf, bufSize, "Color[%u]: %s :", i, pNamedColor->rootName);
+    snprintf(buf, bufSize, "Color[%u]: %s :", (unsigned int)i, pNamedColor->rootName);
     sDescription += buf;
     
     icFloatNumber pcsCoord[3] ={0};
@@ -3933,7 +3933,7 @@ void CIccTagXYZ::Describe(std::string &sDescription, int /* nVerboseness */)
     sDescription.reserve(sDescription.size() + m_nSize*79);
 
     for (i=0; i<m_nSize; i++) {
-      snprintf(buf, bufSize, "value[%u]: X=%.4lf, Y=%.4lf, Z=%.4lf\n", i, icFtoD(m_XYZ[i].X), icFtoD(m_XYZ[i].Y), icFtoD(m_XYZ[i].Z));
+      snprintf(buf, bufSize, "value[%u]: X=%.4lf, Y=%.4lf, Z=%.4lf\n", (unsigned int) i, icFtoD(m_XYZ[i].X), icFtoD(m_XYZ[i].Y), icFtoD(m_XYZ[i].Z));
       sDescription += buf;
     }
   }
@@ -4214,7 +4214,7 @@ void CIccTagChromaticity::Describe(std::string &sDescription, int /* nVerbosenes
   sDescription += buf;
 
   for (i=0; i<m_nChannels; i++) {
-    snprintf(buf, bufSize, "value[%u]: x=%.3lf, y=%.3lf\n", i, icUFtoD(m_xy[i].x), icUFtoD(m_xy[i].y));
+    snprintf(buf, bufSize, "value[%u]: x=%.3lf, y=%.3lf\n", (unsigned int) i, icUFtoD(m_xy[i].x), icUFtoD(m_xy[i].y));
     sDescription += buf;
   }
 
@@ -5711,9 +5711,9 @@ void CIccTagFixedNum<T, Tsig>::Describe(std::string &sDescription, int /* nVerbo
 
     for (i=0; i<m_nSize; i++) {
       if (Tsig==icSigS15Fixed16ArrayType) 
-        snprintf(buf, bufSize, "Value[%u] = %8.4lf\n", i, icFtoD(m_Num[i]));
+        snprintf(buf, bufSize, "Value[%u] = %8.4lf\n", (unsigned int)i, icFtoD(m_Num[i]));
       else
-        snprintf(buf, bufSize, "Value[%u] = %8.4lf\n", i, icUFtoD(m_Num[i]));
+        snprintf(buf, bufSize, "Value[%u] = %8.4lf\n", (unsigned int)i, icUFtoD(m_Num[i]));
       sDescription += buf;
     }
   }
@@ -6826,7 +6826,7 @@ void CIccTagFloatNum<T, Tsig>::Describe(std::string &sDescription, int /* nVerbo
     icUInt32Number i, n;
     sDescription.reserve(sDescription.size() + m_nSize*79);
 
-    snprintf(buf, bufSize, "Begin_Value_Array[%u]\n", m_nSize);
+    snprintf(buf, bufSize, "Begin_Value_Array[%u]\n", (unsigned int) m_nSize);
     sDescription += buf;
 
     if (sizeof(T)!=8)
@@ -9008,12 +9008,12 @@ void CIccTagColorantOrder::Describe(std::string &sDescription, int /* nVerbosene
   const size_t bufSize = 128;
   icChar buf[bufSize];
 
-  snprintf(buf, bufSize, "Colorant Count : %u\n", m_nCount);
+  snprintf(buf, bufSize, "Colorant Count : %u\n", (unsigned int) m_nCount);
   sDescription += buf;
   sDescription += "Order of Colorants:\n";
   
   for (int i=0; i<(int)m_nCount; i++) {
-    snprintf(buf, bufSize, "%u\n", m_pData[i]);
+    snprintf(buf, bufSize, "%u\n", (unsigned int) m_pData[i]);
     sDescription += buf;
   }
 }
@@ -9299,7 +9299,7 @@ void CIccTagColorantTable::Describe(std::string &sDescription, int /* nVerbosene
   icUInt32Number i, nLen, nMaxLen=0;
   icFloatNumber Lab[3] = {0};
 
-  snprintf(buf, bufSize, "BEGIN_COLORANTS %u\n", m_nCount);
+  snprintf(buf, bufSize, "BEGIN_COLORANTS %u\n", (unsigned int) m_nCount);
   sDescription += buf;
 
   for (i=0; i<m_nCount; i++) {
@@ -9318,7 +9318,7 @@ void CIccTagColorantTable::Describe(std::string &sDescription, int /* nVerbosene
     sDescription += buf;
   }
   for (i=0; i<m_nCount; i++) {
-    snprintf(buf, bufSize, "%2u \"%s\"", i, m_pData[i].name);
+    snprintf(buf, bufSize, "%2u \"%s\"", (unsigned int) i, m_pData[i].name);
     sDescription += buf;
     memset(buf, ' ', 128);
     buf[nMaxLen + 1 - strlen(m_pData[i].name)] ='\0';
@@ -10181,13 +10181,13 @@ void CIccTagProfileSeqDesc::Describe(std::string &sDescription, int nVerboseness
   icChar buf[bufSize], buf2[28];
   icUInt32Number count=0;
 
-  snprintf(buf, bufSize, "Number of Profile Description Structures: %u\n", (icUInt32Number)m_Descriptions->size());
+  snprintf(buf, bufSize, "Number of Profile Description Structures: %zu\n", m_Descriptions->size());
   sDescription += buf;
 
   for (i=m_Descriptions->begin(); i!=m_Descriptions->end(); i++, count++) {
     sDescription += "\n";
 
-    snprintf(buf, bufSize, "Profile Description Structure Number [%u] follows:\n", count+1);
+    snprintf(buf, bufSize, "Profile Description Structure Number [%u] follows:\n", (unsigned int)(count+1));
     sDescription += buf;
 
     snprintf(buf, bufSize, "Device Manufacturer Signature: %s\n", icGetSig(buf2, bufSize, i->m_deviceMfg, false));
@@ -10196,7 +10196,7 @@ void CIccTagProfileSeqDesc::Describe(std::string &sDescription, int nVerboseness
     snprintf(buf, bufSize, "Device Model Signature: %s\n", icGetSig(buf2, bufSize, i->m_deviceModel, false));
     sDescription += buf;
 
-    snprintf(buf, bufSize, "Device Attributes: %08x%08x\n", (icUInt32Number)(i->m_attributes >> 32), (icUInt32Number)(i->m_attributes));
+    snprintf(buf, bufSize, "Device Attributes: %08x%08x\n", (unsigned int)(i->m_attributes >> 32), (unsigned int)(i->m_attributes));
     sDescription += buf;
 
     snprintf(buf, bufSize, "Device Technology Signature: %s\n", icGetSig(buf2, bufSize, i->m_technology, false));
@@ -10574,7 +10574,7 @@ void CIccResponseCurveStruct::Describe(std::string &sDescription, int /* nVerbos
       icFtoD(m_maxColorantXYZ[i].X), icFtoD(m_maxColorantXYZ[i].Y), icFtoD(m_maxColorantXYZ[i].Z));
     sDescription += buf;
 
-    snprintf(buf, bufSize, "Number of Measurements for Channel-%d : %u\n", i+1, (icUInt32Number)nResponseList.size());
+    snprintf(buf, bufSize, "Number of Measurements for Channel-%d : %zu\n", i+1, nResponseList.size());
     sDescription += buf;
 
     snprintf(buf, bufSize, "Measurement Data for Channel-%d follows:\n", i+1);
@@ -10887,7 +10887,7 @@ void CIccTagResponseCurveSet16::Describe(std::string &sDescription, int nVerbose
   snprintf(buf, bufSize, "Number of Channels: %u\n", m_nChannels);
   sDescription += buf;
 
-  snprintf(buf, bufSize, "Number of Measurement Types used: %u\n", (icUInt32Number)m_ResponseCurves->size());
+  snprintf(buf, bufSize, "Number of Measurement Types used: %zu\n", m_ResponseCurves->size() );
   sDescription += buf;
 
   int count = 0;
@@ -12409,7 +12409,7 @@ void CIccTagEmbeddedHeightImage::Describe(std::string &sDescription, int /* nVer
   const size_t bufSize = 128;
   icChar buf[bufSize];
 
-  snprintf(buf, bufSize, "\nSeamlessIndicater: %u\n", m_nSeamlesIndicator);
+  snprintf(buf, bufSize, "\nSeamlessIndicater: %u\n", (unsigned int) m_nSeamlesIndicator);
   sDescription += buf;
 
   switch (m_nEncodingFormat) {
@@ -12420,7 +12420,7 @@ void CIccTagEmbeddedHeightImage::Describe(std::string &sDescription, int /* nVer
     strcpy(buf, "EncodingFormat: TIFF\n");
     break;
   default:
-    snprintf(buf, bufSize, "EncodingFormat: %u", m_nEncodingFormat);
+    snprintf(buf, bufSize, "EncodingFormat: %u", (unsigned int) m_nEncodingFormat);
     break;
   }
   sDescription += buf;
@@ -12712,7 +12712,7 @@ void CIccTagEmbeddedNormalImage::Describe(std::string &sDescription, int /* nVer
   const size_t bufSize = 128;
   icChar buf[bufSize];
 
-  snprintf(buf, bufSize, "\nSeamlessIndicater: %u\n", m_nSeamlesIndicator);
+  snprintf(buf, bufSize, "\nSeamlessIndicater: %u\n", (unsigned int)m_nSeamlesIndicator);
   sDescription += buf;
 
   switch (m_nEncodingFormat) {
@@ -12723,7 +12723,7 @@ void CIccTagEmbeddedNormalImage::Describe(std::string &sDescription, int /* nVer
     strcpy(buf, "EncodingFormat: TIFF\n");
     break;
   default:
-    snprintf(buf, bufSize, "EncodingFormat: %u", m_nEncodingFormat);
+    snprintf(buf, bufSize, "EncodingFormat: %u", (unsigned int)m_nEncodingFormat);
     break;
   }
   sDescription += buf;

--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1198,13 +1198,13 @@ void CIccTagArray::Describe(std::string &sDescription, int nVerboseness)
   for (i=0; i<m_nSize; i++) {
     if (i)
       sDescription += "\n";
-    snprintf(buf, bufSize, "BEGIN INDEX[%u]\n", i);
+    snprintf(buf, bufSize, "BEGIN INDEX[%u]\n", (unsigned int) i);
     sDescription +=  buf;
     
     if (m_TagVals[i].ptr) {
       m_TagVals[i].ptr->Describe(sDescription, nVerboseness);
     }
-    snprintf(buf, bufSize, "END INDEX[%u]\n", i);
+    snprintf(buf, bufSize, "END INDEX[%u]\n", (unsigned int) i);
     sDescription += buf;
   }
 

--- a/IccProfLib/IccTagEmbedIcc.cpp
+++ b/IccProfLib/IccTagEmbedIcc.cpp
@@ -379,7 +379,7 @@ void CIccTagEmbeddedProfile::Describe(std::string& sDescription, int /* nVerbose
     else
       sDescription += "Profile ID:         Profile ID not calculated.\n";
     sDescription += "Size:               ";
-    snprintf(buf, bufSize, "%u(0x%x) bytes\n", pHdr->size, pHdr->size);
+    snprintf(buf, bufSize, "%u(0x%x) bytes\n", (unsigned int) pHdr->size, (unsigned int) pHdr->size);
     sDescription += buf;
     sDescription += "\nHeader\n";
     sDescription += "------\n";
@@ -477,8 +477,8 @@ void CIccTagEmbeddedProfile::Describe(std::string& sDescription, int /* nVerbose
 
       const size_t tempSize = 20;
       char sOffset[tempSize], sSize[tempSize], sPad[tempSize];
-      snprintf(sOffset, tempSize, "%u", i->TagInfo.offset);
-      snprintf(sSize, tempSize, "%u", i->TagInfo.size);
+      snprintf(sOffset, tempSize, "%u", (unsigned int)i->TagInfo.offset);
+      snprintf(sSize, tempSize, "%u", (unsigned int)i->TagInfo.size);
       snprintf(sPad, tempSize, "%d", pad);
       sDescription += fillColumns(Fmt.GetTagSigName(i->TagInfo.sig), icGetSig(sigbuf, bufSize, i->TagInfo.sig, false), sOffset, sSize, sPad) + "\n";
     }

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -6124,10 +6124,10 @@ void CIccTagGamutBoundaryDesc::Describe(std::string &sDescription, int nVerbosen
     const size_t bufSize = 256;
 	icChar buf[bufSize];
 	
-    snprintf(buf, bufSize, "Number Of Vertices = %d, Number of Triangles = %d\n",m_NumberOfVertices,m_NumberOfTriangles);
+    snprintf(buf, bufSize, "Number Of Vertices = %d, Number of Triangles = %d\n", (int) m_NumberOfVertices, (int) m_NumberOfTriangles);
 	sDescription += buf;
 	
-	snprintf(buf,bufSize, "Number Of Inputs = %d, Number of Outputs = %d\n",m_nPCSChannels,m_nDeviceChannels);
+	snprintf(buf,bufSize, "Number Of Inputs = %d, Number of Outputs = %d\n", (int) m_nPCSChannels, (int) m_nDeviceChannels);
 	sDescription += buf;
 	
     if (nVerboseness > 75) {
@@ -6159,7 +6159,10 @@ void CIccTagGamutBoundaryDesc::Describe(std::string &sDescription, int nVerbosen
 	
 	    for (int i=0; i<m_NumberOfTriangles; i++)
 	    {
-            snprintf(buf,bufSize, "V1 = %u\tV2 = %u\tV3 = %u\n",m_Triangles[i].m_VertexNumbers[0],m_Triangles[i].m_VertexNumbers[1],m_Triangles[i].m_VertexNumbers[2]);
+            snprintf(buf,bufSize, "V1 = %u\tV2 = %u\tV3 = %u\n",
+                        (unsigned int)m_Triangles[i].m_VertexNumbers[0],
+                        (unsigned int)m_Triangles[i].m_VertexNumbers[1],
+                        (unsigned int)m_Triangles[i].m_VertexNumbers[2] );
 		        sDescription += buf;
 	    }
     }

--- a/IccProfLib/IccTagMPE.cpp
+++ b/IccProfLib/IccTagMPE.cpp
@@ -289,7 +289,7 @@ void CIccMpeUnknown::Describe(std::string &sDescription, int nVerboseness)
   icChar buf[bufSize], sigbuf[40];
 
   snprintf(buf, bufSize, "Unknown Element(%s) Type of %u Bytes.",
-          icGetSig(sigbuf, 40, m_sig), m_nSize);
+          icGetSig(sigbuf, 40, m_sig), (unsigned int) m_nSize);
   sDescription += buf;
 
   if (nVerboseness > 50) {

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -1089,7 +1089,7 @@ const icChar *icGetSig(icChar *pBuf, size_t bufSize, icUInt32Number nSig, bool b
   }
 
   if (bGetHexVal)
-    snprintf(pBuf+5, bufSize-5, "' = %08X", nSig);  // 17 characcter plus NULL
+    snprintf(pBuf+5, bufSize-5, "' = %08X", (unsigned int) nSig);  // 17 characcter plus NULL
   else
     snprintf(pBuf+5, bufSize-5, "'");   // 6 characters plus NULL
 
@@ -1129,7 +1129,7 @@ const icChar *icGetSigStr(icChar *pBuf, size_t bufSize, icUInt32Number nSig)
   }
 
   if (bGetHexVal)
-    snprintf(pBuf, bufSize, "%08Xh", nSig);
+    snprintf(pBuf, bufSize, "%08Xh", (unsigned int) nSig);
   else
     pBuf[4] = '\0';
 
@@ -1163,7 +1163,7 @@ const icChar *icGetColorSig(icChar *pBuf, size_t bufSize, icUInt32Number nSig, b
       pBuf[0]='\"';
       pBuf[1] = (icUInt8Number)(sig>>24);
       pBuf[2] = (icUInt8Number)(sig>>16);
-      snprintf(pBuf+3, bufSize-3, "%04X\"", icNumColorSpaceChannels(nSig));
+      snprintf(pBuf+3, bufSize-3, "%04X\"", (unsigned int) icNumColorSpaceChannels(nSig));
       return pBuf;
     
     default:
@@ -1184,9 +1184,9 @@ const icChar *icGetColorSig(icChar *pBuf, size_t bufSize, icUInt32Number nSig, b
       }
 
       if (bGetHexVal)
-        snprintf(pBuf+5, bufSize-5, "' = %08X", nSig);
+        snprintf(pBuf+5, bufSize-5, "' = %08X", (unsigned int) nSig);
       else if (bNeedHexVal) {
-        snprintf(pBuf, bufSize, "%08Xh", nSig);
+        snprintf(pBuf, bufSize, "%08Xh", (unsigned int) nSig);
       }
       else
         snprintf(pBuf+5, bufSize-5, "'");
@@ -1222,7 +1222,7 @@ const icChar *icGetColorSigStr(icChar *pBuf, size_t bufSize, icUInt32Number nSig
 
       pBuf[0] = (icUInt8Number)(sig>>24);
       pBuf[1] = (icUInt8Number)(sig>>16);
-      snprintf(pBuf+2, bufSize-2, "%04X", icNumColorSpaceChannels(nSig));
+      snprintf(pBuf+2, bufSize-2, "%04X", (unsigned int) icNumColorSpaceChannels(nSig));
       return pBuf;
 
     default:
@@ -1248,7 +1248,7 @@ const icChar *icGetColorSigStr(icChar *pBuf, size_t bufSize, icUInt32Number nSig
         }
 
         if (bGetHexVal)
-          snprintf(pBuf, bufSize, "%08Xh", nSig);
+          snprintf(pBuf, bufSize, "%08Xh", (unsigned int) nSig);
         else
           pBuf[4] = '\0';
       }
@@ -1359,6 +1359,7 @@ icUInt32Number icGetSigVal(const icChar *pBuf)
                               (((unsigned long)(unsigned char)pBuf[3])));
 
     case 6:  //Channel based color signatures
+      // can't get this format to agree between platforms
       sscanf(pBuf+2, "%x", &v);
 
       return (icUInt32Number)((((unsigned long)(unsigned char)pBuf[0])<<24) +
@@ -1367,6 +1368,7 @@ icUInt32Number icGetSigVal(const icChar *pBuf)
 
     case 8:
     case 9:
+      // can't get this format to agree between platforms
       sscanf(pBuf, "%x", &v);
       return v;
   }
@@ -1507,7 +1509,7 @@ const icChar *CIccInfo::GetVersionName(icUInt32Number val)
 {
   if (!icIsValidBcdByte((val >> 24) & 0xff) ||
       !icIsValidBcdByte((val >> 16) & 0xff)) {
-    snprintf(m_szStr, m_bufSize, "Invalid BCD version 0x%08X", val);
+    snprintf(m_szStr, m_bufSize, "Invalid BCD version 0x%08X", (unsigned int) val);
     return m_szStr;
   }
 
@@ -1523,7 +1525,7 @@ const icChar *CIccInfo::GetSubClassVersionName(icUInt32Number val)
 {
   if (!icIsValidBcdByte((val >> 8) & 0xff) ||
       !icIsValidBcdByte(val & 0xff)) {
-    snprintf(m_szStr, m_bufSize, "Invalid BCD subclass version 0x%04X", val & 0xffff);
+    snprintf(m_szStr, m_bufSize, "Invalid BCD subclass version 0x%04X", (unsigned int) (val & 0xffff) );
     return m_szStr;
   }
 
@@ -1822,33 +1824,33 @@ const icChar *CIccInfo::GetColorSpaceSigName(icColorSpaceSignature sig)
   default:
     switch(icGetColorSpaceType(sig)) {
     case icSigNChannelData:
-      snprintf(m_szStr, m_bufSize, "0x%04XChannelData", icNumColorSpaceChannels(sig));
+      snprintf(m_szStr, m_bufSize, "0x%04XChannelData", (unsigned int) icNumColorSpaceChannels(sig));
       return m_szStr;
 
     case icSigReflectanceSpectralData:
-      snprintf(m_szStr, m_bufSize, "0x%04XChannelReflectanceData", icNumColorSpaceChannels(sig));
+      snprintf(m_szStr, m_bufSize, "0x%04XChannelReflectanceData", (unsigned int) icNumColorSpaceChannels(sig));
       return m_szStr;
 
     case icSigTransmisionSpectralData:
-      snprintf(m_szStr, m_bufSize, "0x%04XChannelTransmissionData", icNumColorSpaceChannels(sig));
+      snprintf(m_szStr, m_bufSize, "0x%04XChannelTransmissionData", (unsigned int) icNumColorSpaceChannels(sig));
       return m_szStr;
 
     case icSigRadiantSpectralData:
-      snprintf(m_szStr, m_bufSize, "0x%04XChannelRadiantData", icNumColorSpaceChannels(sig));
+      snprintf(m_szStr, m_bufSize, "0x%04XChannelRadiantData", (unsigned int) icNumColorSpaceChannels(sig));
       return m_szStr;
 
     case icSigBiSpectralReflectanceData:
-      snprintf(m_szStr, m_bufSize, "0x%04XChannelBiDirReflectanceData", icNumColorSpaceChannels(sig));
+      snprintf(m_szStr, m_bufSize, "0x%04XChannelBiDirReflectanceData", (unsigned int) icNumColorSpaceChannels(sig));
       return m_szStr;
 
     case icSigSparseMatrixReflectanceData:
-      snprintf(m_szStr, m_bufSize, "0x%04XChannelSparseMatrixReflectanceData", icNumColorSpaceChannels(sig));
+      snprintf(m_szStr, m_bufSize, "0x%04XChannelSparseMatrixReflectanceData", (unsigned int) icNumColorSpaceChannels(sig));
       return m_szStr;
 
     default:
       icUInt32Number nChan = icGetSpaceSamples(sig);
       if (nChan>0) {
-        snprintf(m_szStr, m_bufSize, "0x%XColorData", nChan);
+        snprintf(m_szStr, m_bufSize, "0x%XColorData", (unsigned int) nChan);
         return m_szStr;
       }
       return GetUnknownName(sig);
@@ -1863,27 +1865,27 @@ const icChar *CIccInfo::GetSpectralColorSigName(icColorSpaceSignature sig)
     return "NoSpectralData";
 
    case icSigNChannelData:
-     snprintf(m_szStr, m_bufSize, "0x%04XChannelData", icNumColorSpaceChannels(sig));
+     snprintf(m_szStr, m_bufSize, "0x%04XChannelData", (unsigned int) icNumColorSpaceChannels(sig));
      return m_szStr;
 
    case icSigReflectanceSpectralData:
-     snprintf(m_szStr, m_bufSize, "0x%04XChannelReflectanceData", icNumColorSpaceChannels(sig));
+     snprintf(m_szStr, m_bufSize, "0x%04XChannelReflectanceData", (unsigned int) icNumColorSpaceChannels(sig));
      return m_szStr;
 
    case icSigTransmisionSpectralData:
-     snprintf(m_szStr, m_bufSize, "0x%04XChannelTransmissionData", icNumColorSpaceChannels(sig));
+     snprintf(m_szStr, m_bufSize, "0x%04XChannelTransmissionData", (unsigned int) icNumColorSpaceChannels(sig));
      return m_szStr;
 
    case icSigRadiantSpectralData:
-     snprintf(m_szStr, m_bufSize, "0x%04XChannelRadiantData", icNumColorSpaceChannels(sig));
+     snprintf(m_szStr, m_bufSize, "0x%04XChannelRadiantData", (unsigned int) icNumColorSpaceChannels(sig));
      return m_szStr;
 
    case icSigBiSpectralReflectanceData:
-     snprintf(m_szStr, m_bufSize, "0x%04XChannelBiSpectralReflectanceData", icNumColorSpaceChannels(sig));
+     snprintf(m_szStr, m_bufSize, "0x%04XChannelBiSpectralReflectanceData", (unsigned int) icNumColorSpaceChannels(sig));
      return m_szStr;
 
    case icSigSparseMatrixReflectanceData:
-     snprintf(m_szStr, m_bufSize, "0x%04XChannelSparseMatrixReflectanceData", icNumColorSpaceChannels(sig));
+     snprintf(m_szStr, m_bufSize, "0x%04XChannelSparseMatrixReflectanceData", (unsigned int) icNumColorSpaceChannels(sig));
      return m_szStr;
 
   default:

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -2516,11 +2516,12 @@ icValidateStatus CIccInfo::CheckData(std::string &sReport, const icDateTimeNumbe
 {
   icValidateStatus rv = icValidateOK;
 
-  struct tm *newtime;
+  struct tm tmStorage;
+  struct tm *newtime = &tmStorage;
   time_t long_time;
 
   time( &long_time );                /* Get time as long integer. */
-  newtime = localtime( &long_time );
+  newtime = localtime_r( &long_time, newtime );
 
   const size_t bufSize = 128;
   icChar buf[bufSize];
@@ -2929,9 +2930,10 @@ icDateTimeNumber icGetDateTimeValue(const icChar *str)
 
   if (!stricmp(str, "now")) {
     time_t rawtime;
-    struct tm *timeinfo;
+    struct tm tmStorage;
+    struct tm *timeinfo = &tmStorage;
     time(&rawtime);
-    timeinfo = localtime(&rawtime);
+    timeinfo = localtime_r(&rawtime, timeinfo);
     year    = timeinfo->tm_year + 1900;
     month   = timeinfo->tm_mon  + 1;
     day     = timeinfo->tm_mday;

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -2516,12 +2516,11 @@ icValidateStatus CIccInfo::CheckData(std::string &sReport, const icDateTimeNumbe
 {
   icValidateStatus rv = icValidateOK;
 
-  struct tm tmStorage;
-  struct tm *newtime = &tmStorage;
+  struct tm *newtime;
   time_t long_time;
 
   time( &long_time );                /* Get time as long integer. */
-  newtime = localtime_r( &long_time, newtime );
+  newtime = localtime( &long_time );
 
   const size_t bufSize = 128;
   icChar buf[bufSize];
@@ -2930,10 +2929,9 @@ icDateTimeNumber icGetDateTimeValue(const icChar *str)
 
   if (!stricmp(str, "now")) {
     time_t rawtime;
-    struct tm tmStorage;
-    struct tm *timeinfo = &tmStorage;
+    struct tm *timeinfo;
     time(&rawtime);
-    timeinfo = localtime_r(&rawtime, timeinfo);
+    timeinfo = localtime(&rawtime);
     year    = timeinfo->tm_year + 1900;
     month   = timeinfo->tm_mon  + 1;
     day     = timeinfo->tm_mday;

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -142,7 +142,7 @@ bool CIccMpeXmlUnknown::ToXml(std::string &xml, std::string blanks/* = ""*/)
   xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += buf;
   }
   xml += ">\n";
@@ -241,7 +241,7 @@ bool CIccFormulaCurveSegmentXml::ToXml(std::string &xml, std::string blanks)
   xml += line;
 
   if (m_nReserved) {
-    snprintf(line, bufSize, " Reserved=\"%d\"", m_nReserved);
+    snprintf(line, bufSize, " Reserved=\"%d\"", (unsigned int) m_nReserved);
     xml += line;
   }
   if (m_nReserved2) {
@@ -643,11 +643,11 @@ bool CIccSampledCalculatorCurveXml::ToXml(std::string &xml, std::string blanks)
   snprintf(line, lineSize, " ExtensionType=\"%u\"", m_extensionType);
   xml += line;
 
-  snprintf(line, lineSize, " DesiredSize=\"%u\"", m_nDesiredSize);
+  snprintf(line, lineSize, " DesiredSize=\"%u\"", (unsigned int) m_nDesiredSize);
   xml += line;
 
   if (m_nReserved) {
-    snprintf(line, lineSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, lineSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
   if (m_nReserved2) {
@@ -752,7 +752,7 @@ bool CIccSingleSampledCurveXml::ToXml(std::string &xml, std::string blanks)
   xml += line;
 
   if (m_nReserved) {
-    snprintf(line, lineSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, lineSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
   xml += ">\n";
@@ -1232,7 +1232,7 @@ bool CIccMpeXmlCurveSet::ToXml(std::string &xml, std::string blanks/* = ""*/)
   xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, lineSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, lineSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
   xml += ">\n";
@@ -1365,7 +1365,7 @@ bool CIccMpeXmlMatrix::ToXml(std::string &xml, std::string blanks/* = ""*/)
   xml += blanks + buf;
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += buf;
   }
   xml += ">\n";
@@ -1471,7 +1471,7 @@ bool CIccMpeXmlEmissionMatrix::ToXml(std::string &xml, std::string blanks/* = ""
   xml += blanks + buf;
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += buf;
   }
   xml += ">\n";
@@ -1594,7 +1594,7 @@ bool CIccMpeXmlInvEmissionMatrix::ToXml(std::string &xml, std::string blanks/* =
   xml += blanks + buf;
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += buf;
   }
   xml += ">\n";
@@ -1716,7 +1716,7 @@ bool CIccMpeXmlTintArray::ToXml(std::string &xml, std::string blanks/* = ""*/)
   xml += blanks + buf;
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += buf;
   }
   xml += ">\n";
@@ -1839,7 +1839,7 @@ bool CIccXmlToneMapFunc::ToXml(std::string& xml, std::string blanks /* = "" */)
   xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, lineSize, " Reserved=\"%d\"", m_nReserved);
+    snprintf(line, lineSize, " Reserved=\"%d\"", (unsigned int) m_nReserved);
     xml += line;
   }
   if (m_nReserved2) {
@@ -1912,7 +1912,7 @@ bool CIccMpeXmlToneMap::ToXml(std::string& xml, std::string blanks/* = ""*/)
   xml += blanks + buf;
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += buf;
   }
   xml += ">\n";
@@ -2057,7 +2057,7 @@ bool CIccMpeXmlCLUT::ToXml(std::string &xml, std::string blanks/* = ""*/)
   char attrs[bufSize];
 
   if (m_nReserved) {
-    snprintf(attrs, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Reserved=\"%u\"", NumInputChannels(), NumOutputChannels(), m_nReserved);
+    snprintf(attrs, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Reserved=\"%u\"", NumInputChannels(), NumOutputChannels(), (unsigned int) m_nReserved);
   }
   else {
     snprintf(attrs, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\"", NumInputChannels(), NumOutputChannels());
@@ -2093,7 +2093,7 @@ bool CIccMpeXmlExtCLUT::ToXml(std::string &xml, std::string blanks/* = ""*/)
   std::string reserved;
 
   if (m_nReserved) {
-    snprintf(attrs, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(attrs, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     reserved = attrs;
   }
 
@@ -2142,7 +2142,7 @@ bool CIccMpeXmlBAcs::ToXml(std::string &xml, std::string blanks/* = ""*/)
   xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
 
@@ -2198,7 +2198,7 @@ bool CIccMpeXmlEAcs::ToXml(std::string &xml, std::string blanks/* = ""*/)
   xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
 
@@ -2352,7 +2352,7 @@ bool CIccMpeXmlJabToXYZ::ToXml(std::string &xml, std::string blanks/* = ""*/)
   xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, lineSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, lineSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
   xml += ">\n";
@@ -2404,7 +2404,7 @@ bool CIccMpeXmlXYZToJab::ToXml(std::string &xml, std::string blanks/* = ""*/)
     xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, lineSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, lineSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
   xml += ">\n";
@@ -2458,7 +2458,7 @@ bool CIccMpeXmlCalculator::ToXml(std::string &xml, std::string blanks/* = ""*/)
   xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, lineSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(line, lineSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
   xml += ">\n";
@@ -3441,11 +3441,11 @@ bool CIccMpeXmlEmissionCLUT::ToXml(std::string &xml, std::string blanks/* = ""*/
   xml += blanks + "<EmissionCLutElement";
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml +=  buf;
   }
 
-  snprintf(buf, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Flags=\"%d\" StorageType=\"%d\">\n", NumInputChannels(), NumOutputChannels(), m_flags, m_nStorageType);
+  snprintf(buf, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Flags=\"%d\" StorageType=\"%d\">\n", NumInputChannels(), NumOutputChannels(), (unsigned int) m_flags, (unsigned int) m_nStorageType);
   xml += buf;
 
   snprintf(buf, bufSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_Range.start), icF16toF(m_Range.end), m_Range.steps);
@@ -3555,11 +3555,11 @@ bool CIccMpeXmlReflectanceCLUT::ToXml(std::string &xml, std::string blanks/* = "
   xml += blanks + "<ReflectanceCLutElem";
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml +=  buf;
   }
 
-  snprintf(buf, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Flags=\"%d\">\n", NumInputChannels(), NumOutputChannels(), m_flags);
+  snprintf(buf, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Flags=\"%d\">\n", NumInputChannels(), NumOutputChannels(), (unsigned int) m_flags);
   xml += buf;
 
   snprintf(buf, bufSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_Range.start), icF16toF(m_Range.end), m_Range.steps);
@@ -3715,7 +3715,7 @@ bool CIccMpeXmlEmissionObserver::ToXml(std::string &xml, std::string blanks/* = 
   xml += blanks + buf;
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += buf;
   }
   xml += ">\n";
@@ -3798,7 +3798,7 @@ bool CIccMpeXmlReflectanceObserver::ToXml(std::string &xml, std::string blanks/*
   xml += blanks + buf;
 
   if (m_nReserved) {
-    snprintf(buf, bufSize, " Reserved=\"%u\"", m_nReserved);
+    snprintf(buf, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += buf;
   }
   xml += ">\n";

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -240,9 +240,9 @@ bool CIccProfileXml::ToXmlWithBlanks(std::string &xml, std::string blanks)
             // PrivateType - a type that does not belong to the list in the icc specs - custom for vendor.
             if (pTag->m_nReserved) {
               if (!strcmp("PrivateType", tagSig))
-                snprintf(line, bufSize, "<PrivateType type=\"%s\" reserved=\"%08x\">\n", icFixXml(fix, icGetSigStr(buf, bufSize, pTag->GetType())), pTag->m_nReserved);
+                snprintf(line, bufSize, "<PrivateType type=\"%s\" reserved=\"%08x\">\n", icFixXml(fix, icGetSigStr(buf, bufSize, pTag->GetType())), (unsigned int) pTag->m_nReserved);
               else
-                snprintf(line, bufSize, "<%s reserved=\"%08x\">\n", tagSig, pTag->m_nReserved); //parent node is the tag type
+                snprintf(line, bufSize, "<%s reserved=\"%08x\">\n", tagSig, (unsigned int) pTag->m_nReserved); //parent node is the tag type
             }
             else {
               if (!strcmp("PrivateType", tagSig))

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -725,7 +725,7 @@ bool CIccTagXmlNamedColor2::ToXml(std::string &xml, std::string blanks/* = ""*/)
   int i, j;
   std::string str;
 
-  snprintf(line, bufSize, "<NamedColors VendorFlag=\"%08x\" CountOfDeviceCoords=\"%d\" DeviceEncoding=\"int16\"", m_nVendorFlags, m_nDeviceCoords);
+  snprintf(line, bufSize, "<NamedColors VendorFlag=\"%08x\" CountOfDeviceCoords=\"%d\" DeviceEncoding=\"int16\"", (unsigned int) m_nVendorFlags, (unsigned int) m_nDeviceCoords);
   xml += blanks + line;
 
   snprintf(line, bufSize, " Prefix=\"%s\"", icFixXml(fix, icAnsiToUtf8(str, m_szPrefix)));
@@ -1414,7 +1414,7 @@ bool CIccTagXmlNum<T, A, Tsig>::ToXml(std::string &xml, std::string blanks/* = "
     if (sizeof(T)==16)
       snprintf(buf, bufSize, "%llu", (icUInt64Number)this->m_Num[i]);
     else
-      snprintf(buf, bufSize, "%u", (icUInt32Number)this->m_Num[i]);
+      snprintf(buf, bufSize, "%u", (unsigned int) this->m_Num[i]);
     xml += buf;
   }
 
@@ -2625,7 +2625,7 @@ bool CIccTagXmlCurve::ToXml(std::string &xml, icConvertType nType, std::string b
   }
   else if (IsIdentity()) {
     xml += blanks + "<Curve IdentitySize=\"";
-    snprintf(buf, bufSize, "%d", m_nSize);
+    snprintf(buf, bufSize, "%d", (unsigned int) m_nSize);
     xml += buf;
     xml += "\"/>\n";
   }
@@ -5198,7 +5198,10 @@ bool CIccTagXmlGamutBoundaryDesc::ToXml(std::string &xml, std::string blanks/* =
     xml += blanks + "<Triangles>\n";
 
     for (i=0; i<m_NumberOfTriangles; i++) {
-      snprintf(line, lineSize, " <T>%u %u %u</T>\n", m_Triangles[i].m_VertexNumbers[0], m_Triangles[i].m_VertexNumbers[1], m_Triangles[i].m_VertexNumbers[2]);
+      snprintf(line, lineSize, " <T>%u %u %u</T>\n",
+              (unsigned int) m_Triangles[i].m_VertexNumbers[0],
+              (unsigned int) m_Triangles[i].m_VertexNumbers[1],
+              (unsigned int) m_Triangles[i].m_VertexNumbers[2]);
       xml += blanks + line;
     }
 
@@ -5437,10 +5440,10 @@ bool CIccTagXmlEmbeddedHeightImage::ToXml(std::string &xml, std::string blanks/*
   char buf[bufSize];
 
   xml += blanks + "<HeightImage";
-  snprintf(buf, bufSize, " SeamlessIndicator=\"%d\"", m_nSeamlesIndicator);
+  snprintf(buf, bufSize, " SeamlessIndicator=\"%d\"", (unsigned int) m_nSeamlesIndicator);
   xml += buf;
 
-  snprintf(buf, bufSize, " EncodingFormat=\"%d\"", m_nEncodingFormat);
+  snprintf(buf, bufSize, " EncodingFormat=\"%d\"", (unsigned int) m_nEncodingFormat);
   xml += buf;
 
   snprintf(buf, bufSize, " MetersMinPixelValue=\"%.12f\"", m_fMetersMinPixelValue);
@@ -5537,10 +5540,10 @@ bool CIccTagXmlEmbeddedNormalImage::ToXml(std::string &xml, std::string blanks/*
   char buf[bufSize];
 
   xml += blanks + "<NormalImage";
-  snprintf(buf, bufSize, " SeamlessIndicator=\"%d\"", m_nSeamlesIndicator);
+  snprintf(buf, bufSize, " SeamlessIndicator=\"%d\"", (unsigned int) m_nSeamlesIndicator);
   xml += buf;
 
-  snprintf(buf, bufSize, " EncodingFormat=\"%d\"", m_nEncodingFormat);
+  snprintf(buf, bufSize, " EncodingFormat=\"%d\"", (unsigned int) m_nEncodingFormat);
   xml += buf;
 
   if (!m_nSize) {

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -689,7 +689,7 @@ bool CIccXmlArrayType<T, Tsig>::DumpArray(std::string &xml, std::string blanks, 
         break;
 
       case icSigUInt32ArrayType:
-        snprintf(str, strSize, "%u", (icUInt32Number)buf[i]);
+        snprintf(str, strSize, "%u", (unsigned int) buf[i]);
         break;
       
       case icSigUInt64ArrayType:
@@ -760,7 +760,7 @@ icUInt32Number CIccXmlArrayType<T, Tsig>::ParseTextCountNum(const char *szText, 
     else if ( i <= num && !isspace(*szText) ) {
       const size_t lineSize = 100;
       char line[lineSize];
-      snprintf(line, lineSize, "Data '%c' in position %d is not a number. ", *szText, i);
+      snprintf(line, lineSize, "Data '%c' in position %d is not a number. ", *szText, (unsigned int) i );
       parseStr += line;
       return false;
     }
@@ -1219,8 +1219,8 @@ const std::string icGetHeaderFlagsName(icUInt32Number flags, bool bUsesMCS)
   }
 
   if (flags & otherFlags) {
-    snprintf(line, lineSize, " VendorFlags=\"%08x\"", flags & otherFlags);
-    xml += line;  		
+    snprintf(line, lineSize, " VendorFlags=\"%08x\"", (unsigned int) ( flags & otherFlags) );
+    xml += line;
   }
 
   xml += "/>\n";

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -76,7 +76,7 @@
 #include "TiffImg.h"
 
 
-#ifdef _DEBUG
+#if false && defined(_DEBUG)
 #undef THIS_FILE
 static char THIS_FILE[]=__FILE__;
 #define new DEBUG_NEW

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -136,14 +136,14 @@ void DumpTagCore(CIccTag *pTag, icTagSignature sig, int nVerboseness)
       CIccTagMultiProcessElement *pMpe = static_cast<CIccTagMultiProcessElement*>(pTag);
       icUInt32Number nElements = pMpe->NumElements();
       printf("\n  === MPE Element Chain: %u elements, %u->%u channels ===\n",
-             nElements, pMpe->NumInputChannels(), pMpe->NumOutputChannels());
+             (unsigned int) nElements, pMpe->NumInputChannels(), pMpe->NumOutputChannels());
 
       for (icUInt32Number j = 0; j < nElements; j++) {
         CIccMultiProcessElement *pElem = pMpe->GetElement(j);
         if (pElem) {
           icElemTypeSignature elemSig = pElem->GetType();
           printf("  [%u] %s (%s) %u->%u%s\n",
-                 j + 1,
+                 (unsigned int) (j + 1),
                  Fmt.GetElementTypeSigName(elemSig),
                  icGetSig(buf, bufSize, elemSig),
                  pElem->NumInputChannels(),
@@ -411,7 +411,7 @@ int main(int argc, char* argv[])
       printf("Profile ID:         %s\n", Fmt.GetProfileID(&pHdr->profileID));
     else
       printf("Profile ID:         Profile ID not calculated.\n");
-    printf("Size:               %d (0x%x) bytes\n", pHdr->size, pHdr->size);
+    printf("Size:               %d (0x%x) bytes\n", (unsigned int) pHdr->size, (unsigned int) pHdr->size);
 
     // Diagnostic: compare header size vs file stat size
     if (g_bDiagMode) {
@@ -419,7 +419,7 @@ int main(int argc, char* argv[])
       if (stat(argv[nArg], &st) == 0) {
         if ((icUInt32Number)st.st_size != pHdr->size) {
           fprintf(stderr, "[DIAG] *** SIZE MISMATCH: header says %u, file stat says %lld ***\n",
-                  pHdr->size, (long long)st.st_size);
+                  (unsigned int) pHdr->size, (long long)st.st_size);
           if ((icUInt32Number)st.st_size < pHdr->size)
             fprintf(stderr, "[DIAG] File is TRUNCATED (%lld bytes short)\n",
                     (long long)pHdr->size - (long long)st.st_size);
@@ -427,7 +427,7 @@ int main(int argc, char* argv[])
             fprintf(stderr, "[DIAG] File has %lld bytes BEYOND header-declared size\n",
                     (long long)st.st_size - (long long)pHdr->size);
         } else {
-          fprintf(stderr, "[DIAG] Header size matches file stat: %u bytes\n", pHdr->size);
+          fprintf(stderr, "[DIAG] Header size matches file stat: %u bytes\n", (unsigned int) pHdr->size);
         }
       }
       fprintf(stderr, "[DIAG] Load mode: %s | Validation: %s | Verbosity: %d\n",
@@ -535,7 +535,7 @@ int main(int argc, char* argv[])
             pad = closest - i->TagInfo.offset - i->TagInfo.size;
 
         printf("%28s  %s  %8d\t%8d\t%8d\n", Fmt.GetTagSigName(i->TagInfo.sig),
-            icGetSig(buf, bufSize, i->TagInfo.sig, false), i->TagInfo.offset, i->TagInfo.size, pad);
+            icGetSig(buf, bufSize, i->TagInfo.sig, false), (unsigned int) i->TagInfo.offset, (unsigned int) i->TagInfo.size, pad);
     }
 
     printf("\n");
@@ -592,7 +592,7 @@ int main(int argc, char* argv[])
         if ((icUInt64Number)i->TagInfo.offset + i->TagInfo.size > (icUInt64Number)pHdr->size) {
           sReport += icMsgValidateNonCompliant;
           snprintf(str, strSize, "Tag %s (offset %u, size %u) ends beyond EOF.\n",
-                  Fmt.GetTagSigName(i->TagInfo.sig), i->TagInfo.offset, i->TagInfo.size);
+                  Fmt.GetTagSigName(i->TagInfo.sig), (unsigned int) i->TagInfo.offset, (unsigned int) i->TagInfo.size);
           sReport += str;
           nStatus = icMaxStatus(nStatus, icValidateNonCompliant);
         }
@@ -615,7 +615,7 @@ int main(int argc, char* argv[])
         if (((icUInt64Number)i->TagInfo.offset + i->TagInfo.size > (icUInt64Number)closest) && (closest < safeProfileSize)) {
           sReport += icMsgValidateWarning;
           snprintf(str, strSize, "Tag %s (offset %d, size %d) overlaps with following tag data starting at offset %d.\n",
-              Fmt.GetTagSigName(i->TagInfo.sig), i->TagInfo.offset, i->TagInfo.size, closest);
+              Fmt.GetTagSigName(i->TagInfo.sig), (unsigned int) i->TagInfo.offset, (unsigned int) i->TagInfo.size, closest);
           sReport += str;
           nStatus = icMaxStatus(nStatus, icValidateWarning);
         }
@@ -625,7 +625,7 @@ int main(int argc, char* argv[])
           int gapStart = (i->TagInfo.offset + rndup <= (icUInt32Number)INT_MAX) ? (int)(i->TagInfo.offset + rndup) : INT_MAX;
           sReport += icMsgValidateWarning;
           snprintf(str, strSize, "Tag %s (size %d) is followed by %d unnecessary additional bytes (from offset %d).\n",
-              Fmt.GetTagSigName(i->TagInfo.sig), i->TagInfo.size, closest - gapStart, gapStart);
+              Fmt.GetTagSigName(i->TagInfo.sig), (unsigned int) i->TagInfo.size, closest - gapStart, gapStart);
           sReport += str;
           nStatus = icMaxStatus(nStatus, icValidateWarning);
         }
@@ -679,7 +679,7 @@ int main(int argc, char* argv[])
           DIAG("Loading tag %d/%d: %s (offset=%u, size=%u)",
                tagIdx + 1, (int)pIcc->m_Tags.size(),
                Fmt.GetTagSigName(i->TagInfo.sig),
-               i->TagInfo.offset, i->TagInfo.size);
+               (unsigned int) i->TagInfo.offset, (unsigned int) i->TagInfo.size);
           CIccTag *pCheck = pIcc->FindTag(*i);
           if (!pCheck) {
             tagLoadFail++;

--- a/Tools/CmdLine/IccPngDump/iccPngDump.cpp
+++ b/Tools/CmdLine/IccPngDump/iccPngDump.cpp
@@ -644,9 +644,9 @@ void PrintIccProfileInfo(const unsigned char *pProfMem, unsigned int nLen, const
     printf(" Color Space:      %s\n", Fmt.GetColorSpaceSigName(pHdr->colorSpace));
     printf(" Colorimetric PCS: %s\n", Fmt.GetColorSpaceSigName(pHdr->pcs));
     printf(" Profile Version:  %d.%d.%d\n", 
-           (pHdr->version >> 24) & 0xFF,   // Major version
-           (pHdr->version >> 20) & 0x0F,   // Minor version
-           (pHdr->version >> 16) & 0x0F);  // Sub-minor version
+           (unsigned int) ((pHdr->version >> 24) & 0xFF),   // Major version
+           (unsigned int) ((pHdr->version >> 20) & 0x0F),   // Minor version
+           (unsigned int) ((pHdr->version >> 16) & 0x0F));  // Sub-minor version
 
     delete pProfile;
 

--- a/Tools/CmdLine/IccRoundTrip/iccRoundTrip.cpp
+++ b/Tools/CmdLine/IccRoundTrip/iccRoundTrip.cpp
@@ -209,12 +209,12 @@ int main(int argc, char* argv[])
     printf("\nPRMG Interoperability - Round Trip Results\n");
     printf(  "------------------------------------------------------\n");
 
-    printf("DE <= 1.0 (%8u): %5.1f%%\n", prmg.m_nDE1, (float)prmg.m_nDE1/(float)prmg.m_nTotal*100.0); 
-    printf("DE <= 2.0 (%8u): %5.1f%%\n", prmg.m_nDE2, (float)prmg.m_nDE2/(float)prmg.m_nTotal*100.0);
-    printf("DE <= 3.0 (%8u): %5.1f%%\n", prmg.m_nDE3, (float)prmg.m_nDE3/(float)prmg.m_nTotal*100.0);
-    printf("DE <= 5.0 (%8u): %5.1f%%\n", prmg.m_nDE5, (float)prmg.m_nDE5/(float)prmg.m_nTotal*100.0);
-    printf("DE <=10.0 (%8u): %5.1f%%\n", prmg.m_nDE10, (float)prmg.m_nDE10/(float)prmg.m_nTotal*100.0);
-    printf("Total     (%8u)\n", prmg.m_nTotal);
+    printf("DE <= 1.0 (%8u): %5.1f%%\n", (unsigned int) prmg.m_nDE1, (float)prmg.m_nDE1/(float)prmg.m_nTotal*100.0); 
+    printf("DE <= 2.0 (%8u): %5.1f%%\n", (unsigned int) prmg.m_nDE2, (float)prmg.m_nDE2/(float)prmg.m_nTotal*100.0);
+    printf("DE <= 3.0 (%8u): %5.1f%%\n", (unsigned int) prmg.m_nDE3, (float)prmg.m_nDE3/(float)prmg.m_nTotal*100.0);
+    printf("DE <= 5.0 (%8u): %5.1f%%\n", (unsigned int) prmg.m_nDE5, (float)prmg.m_nDE5/(float)prmg.m_nTotal*100.0);
+    printf("DE <=10.0 (%8u): %5.1f%%\n", (unsigned int) prmg.m_nDE10, (float)prmg.m_nDE10/(float)prmg.m_nTotal*100.0);
+    printf("Total     (%8u)\n", (unsigned int) prmg.m_nTotal);
   }
   return 0;
 }

--- a/Tools/wxWidget/wxProfileDump/wxProfileDump.cpp
+++ b/Tools/wxWidget/wxProfileDump/wxProfileDump.cpp
@@ -841,7 +841,7 @@ MyDialog::MyDialog(wxWindow *pParent, const wxString& title, wxString &profilePa
                 if ((icUInt64Number)i->TagInfo.offset + i->TagInfo.size > (icUInt64Number)pHdr->size) {
                     sReport += icMsgValidateNonCompliant;
                     snprintf(str, strSize, "Tag %s (offset %u, size %u) ends beyond EOF.\n",
-                        Fmt.GetTagSigName(i->TagInfo.sig), i->TagInfo.offset, i->TagInfo.size);
+                        Fmt.GetTagSigName(i->TagInfo.sig), (unsigned int) i->TagInfo.offset, (unsigned int) i->TagInfo.size);
                     sReport += str;
                     nStat = icMaxStatus(nStat, icValidateNonCompliant);
                 }
@@ -864,7 +864,7 @@ MyDialog::MyDialog(wxWindow *pParent, const wxString& title, wxString &profilePa
                 if (((icUInt64Number)i->TagInfo.offset + i->TagInfo.size > (icUInt64Number)closest) && (closest < safeProfileSize2)) {
                     sReport += icMsgValidateWarning;
                     snprintf(str, strSize, "Tag %s (offset %u, size %u) overlaps with following tag data starting at offset %d.\n",
-                        Fmt.GetTagSigName(i->TagInfo.sig), i->TagInfo.offset, i->TagInfo.size, closest);
+                        Fmt.GetTagSigName(i->TagInfo.sig), (unsigned int) i->TagInfo.offset, (unsigned int) i->TagInfo.size, closest);
                     sReport += str;
                     nStat = icMaxStatus(nStat, icValidateWarning);
                 }
@@ -877,7 +877,7 @@ MyDialog::MyDialog(wxWindow *pParent, const wxString& title, wxString &profilePa
                     icUInt32Number gapStart = (gapStart64 <= (icUInt64Number)UINT_MAX) ? (icUInt32Number)gapStart64 : UINT_MAX;
                     sReport += icMsgValidateWarning;
                     snprintf(str, strSize, "Tag %s (size %u) is followed by %d unnecessary additional bytes (from offset %u).\n",
-                        Fmt.GetTagSigName(i->TagInfo.sig), i->TagInfo.size, gapBytes, gapStart);
+                        Fmt.GetTagSigName(i->TagInfo.sig), (unsigned int) i->TagInfo.size, gapBytes, (unsigned int) gapStart);
                     sReport += str;
                     nStat = icMaxStatus(nStat, icValidateWarning);
                 }
@@ -891,7 +891,7 @@ MyDialog::MyDialog(wxWindow *pParent, const wxString& title, wxString &profilePa
                 icUInt32Number expectedOffset = (expectedFirstOffset <= (icUInt64Number)UINT_MAX) ? (icUInt32Number)expectedFirstOffset : UINT_MAX;
                 sReport += icMsgValidateNonCompliant;
                 snprintf(str, strSize, "First tag data is at offset %u rather than immediately after tag table (offset %u).\n",
-                    firstOffset, expectedOffset);
+                    (unsigned int) firstOffset, (unsigned int) expectedOffset);
                 sReport += str;
                 nStat = icMaxStatus(nStat, icValidateNonCompliant);
             }


### PR DESCRIPTION
PR#1025 - fix most of the printf format string conflicts from Windows Clang build.

## Checklist

- [x] Signed all Commits in PR - once got signing working
- [x] Performed a Rebase on master
- [x] Confirmed a Linear PR Commit History
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Updated documentation for user-visible behavior changes
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
