### PR TITLE
Add named colors and colorant tables to visualize output

### DIFF
--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -112,7 +112,9 @@ in the same change.
    in automated CI.
 5. If the profile affects automated coverage, update the relevant expected
    counts in `docs/ctest.md`, `Build/Cmake/Testing/CMakeLists.txt`, and the
-   workflows that assert CTest or generated-profile totals.
+   workflows that assert CTest or generated-profile totals. For WASM profile
+   parity, also update `Build/Cmake/wasm-package/regression.js`; workflow
+   inputs alone do not change the packaged fallback count.
 
 ## Maintainer CTest Suite Changes
 

--- a/.github/instructions/workflow-governance.instructions.md
+++ b/.github/instructions/workflow-governance.instructions.md
@@ -206,8 +206,11 @@ Do not mask profile generation, CTest discovery, or regression execution with
 workflow must still have a deterministic pass/fail condition.
 
 When profile generation counts change, update the assertions in
-`docs/ctest.md`, `Build/Cmake/Testing/CMakeLists.txt`, and the workflows that
-validate generated-profile totals.
+`docs/ctest.md`, `Build/Cmake/Testing/CMakeLists.txt`, the generated-profile
+workflows, and packaged regression scripts that validate generated-profile
+totals. For WASM parity, keep `Build/Cmake/wasm-package/regression.js`,
+`.github/workflows/ci-pr-wasm.yml`, `.github/workflows/ci-pr-action.yml`, and
+`.github/workflows/ci-latest-release.yml` in sync.
 
 ## Optional Local Hooks
 

--- a/.github/prompts/maintainer-ci-ctest.prompt.md
+++ b/.github/prompts/maintainer-ci-ctest.prompt.md
@@ -58,6 +58,10 @@ Choose the smallest gate that proves the behavior:
 - When adding cases inside an existing script-backed suite, document that the
   CTest suite count is unchanged and validate both direct script execution and
   the CTest wrapper.
+- When changing generated-profile totals, update every assertion source. For
+  WASM parity this includes `Build/Cmake/wasm-package/regression.js`,
+  `.github/workflows/ci-pr-wasm.yml`, `.github/workflows/ci-pr-action.yml`, and
+  `.github/workflows/ci-latest-release.yml`.
 - For Windows executable tests, keep runtime DLL path handling centralized in
   `Build/Cmake/Testing/WindowsRuntimePaths.cmake`; update docs and skills when
   a test needs vcpkg, Visual Studio LLVM, or MinGW runtime DLLs.

--- a/.github/skills/maintainer-ci-ctest/SKILL.md
+++ b/.github/skills/maintainer-ci-ctest/SKILL.md
@@ -48,9 +48,12 @@ when practical.
 - Adding checks inside `iccdev-tool-coverage-baseline.sh` does not change that
   count; validate the direct script and `ctest -R '^iccdev\.tool-coverage$'`.
 - Windows currently registers 6 CTest suites.
-- Generated-profile gates currently validate 207 ICC profiles.
-- JSON round-trip profile generation validates 129 profile parses.
-- WASM parity currently expects 207 generated ICC profiles.
+- Generated-profile gates currently validate 208 ICC profiles.
+- Windows and JSON profile generation validate 130 profile parses.
+- WASM parity currently expects 208 generated ICC profiles.
+- WASM generated-profile count changes must update both the workflow inputs and
+  `Build/Cmake/wasm-package/regression.js`; the packaged script is the fallback
+  source used by local and release parity runs.
 - Windows batch CTest runs must use the disposable Testing copy under the build
   tree and must not dirty the source `Testing/` directory.
 - Windows executable tests must receive runtime DLL directories through

--- a/.github/workflows/ci-json-roundtrip.yml
+++ b/.github/workflows/ci-json-roundtrip.yml
@@ -129,8 +129,8 @@ jobs:
             bash CreateAllProfiles.sh 2>&1 | tee "$CREATE_LOG"
 
           profile_parse_count="$(grep -c 'Profile parsed and saved correctly' "$CREATE_LOG" || true)"
-          if [ "$profile_parse_count" -ne 129 ]; then
-            echo "[FAIL] Expected 129 generated profiles, got ${profile_parse_count}"
+          if [ "$profile_parse_count" -ne 130 ]; then
+            echo "[FAIL] Expected 130 generated profiles, got ${profile_parse_count}"
             exit 1
           fi
           echo "[OK] Generated ${profile_parse_count} test profiles"

--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -1188,7 +1188,7 @@ jobs:
       - name: Parity gate (Testing/CreateAllProfiles.sh -> regression.js)
         env:
           BASH_ENV: /dev/null
-          ICCDEV_REGRESSION_EXPECTED: '207'
+          ICCDEV_REGRESSION_EXPECTED: '208'
         run: |
           set -euo pipefail
           git config --global credential.helper ""
@@ -1225,7 +1225,7 @@ jobs:
               done
               echo '```'
             } >> "$GITHUB_STEP_SUMMARY"  # elements-sanitized
-            echo "::error::WASM regression.js parity gate failed (expected 207 .icc)"
+            echo "::error::WASM regression.js parity gate failed (expected 208 .icc)"
             exit 1
           fi
 

--- a/.github/workflows/ci-pr-action.yml
+++ b/.github/workflows/ci-pr-action.yml
@@ -602,7 +602,7 @@ jobs:
     needs: [setup, detect-src, validate-inputs]
     uses: ./.github/workflows/ci-pr-wasm.yml
     with:
-      expected-icc-count: '207'
+      expected-icc-count: '208'
 
   #############################################################################
   # Example Consumer Project -- verifies build-tree export works

--- a/.github/workflows/ci-pr-wasm.yml
+++ b/.github/workflows/ci-pr-wasm.yml
@@ -10,7 +10,7 @@
 # Builds Release-only WASM, stages the npm-shaped consumer bundle
 # via Build/Cmake/wasm-package/stage.sh, and runs:
 #   * test_all.js  (16-tool usage smoke)
-#   * regression.js (Testing/CreateAllProfiles.sh -> 207 ICC parity)
+#   * regression.js (Testing/CreateAllProfiles.sh -> 208 ICC parity)
 #
 # Governance: Hoyt shell prologue on every step, sanitize-sed.sh
 # for GITHUB_STEP_SUMMARY, matrix values via env: block, credential
@@ -33,7 +33,7 @@ on:
       expected-icc-count:
         description: "Expected .icc count from CreateAllProfiles.sh (parity gate)"
         required: false
-        default: "207"
+        default: "208"
         type: string
 
 concurrency:

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -173,7 +173,7 @@ if(WIN32)
       300
       "iccdev;windows;setup;profiles"
       "${ICCDEV_TESTING_DIR}/CreateAllProfiles.bat"
-      EXPECTED_PROFILE_PARSE_COUNT 129
+      EXPECTED_PROFILE_PARSE_COUNT 130
     )
     set_tests_properties(iccdev.windows-create-profiles PROPERTIES
       FIXTURES_SETUP iccdev_profiles

--- a/Build/Cmake/wasm-package/regression.js
+++ b/Build/Cmake/wasm-package/regression.js
@@ -5,7 +5,7 @@
 // shims of the 17 published WASM tools, then asserts the produced
 // .icc count matches the native-Linux baseline.
 //
-// Expected baseline (CreateAllProfiles.sh in isolation): 207 .icc
+// Expected baseline (CreateAllProfiles.sh in isolation): 208 .icc
 // Source of truth: native-linux iccDEV/Build/Tools at the same SHA.
 //
 // Exit 0 = parity. Non-zero = drift; prints per-dir distribution diff.
@@ -15,7 +15,7 @@ const path = require('path');
 const os = require('os');
 const cp = require('child_process');
 
-const EXPECTED = parseInt(process.env.ICCDEV_REGRESSION_EXPECTED || '207', 10);
+const EXPECTED = parseInt(process.env.ICCDEV_REGRESSION_EXPECTED || '208', 10);
 const PKG_ROOT = __dirname;
 const TESTING = path.join(PKG_ROOT, 'Testing');
 

--- a/Testing/CreateAllProfiles.bat
+++ b/Testing/CreateAllProfiles.bat
@@ -111,6 +111,7 @@ goto end_Named
 iccFromXml FluorescentNamedColor.xml FluorescentNamedColor.icc
 iccFromXml NamedColor.xml NamedColor.icc
 iccFromXml SparseMatrixNamedColor.xml SparseMatrixNamedColor.icc
+iccFromXml NamedColorV4.xml NamedColorV4.icc
 @echo off
 :end_Named
 

--- a/Testing/CreateAllProfiles.sh
+++ b/Testing/CreateAllProfiles.sh
@@ -150,6 +150,7 @@ then
 	iccFromXml FluorescentNamedColor.xml FluorescentNamedColor.icc
 	iccFromXml NamedColor.xml NamedColor.icc
 	iccFromXml SparseMatrixNamedColor.xml SparseMatrixNamedColor.icc
+	iccFromXml NamedColorV4.xml NamedColorV4.icc
 	set +x
 fi
 

--- a/Testing/Named/NamedColorV4.xml
+++ b/Testing/Named/NamedColorV4.xml
@@ -46,12 +46,12 @@
         <LabNamedColor Name="Violet" L="31.79" a="43.76" b="-43.42">59637 65535 7864 12452</LabNamedColor>
        </NamedColors>
     </namedColor2Type> </namedColor2Tag>
-	
+
 	<XYZType>
       <TagSignature>wtpt</TagSignature>
       <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
     </XYZType>
-	
+
 	<multiLocalizedUnicodeType>
       <TagSignature>cprt</TagSignature>
       <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>

--- a/Testing/Named/NamedColorV4.xml
+++ b/Testing/Named/NamedColorV4.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.20</ProfileVersion>
+    <ProfileDeviceClass>nmcl</ProfileDeviceClass>
+    <DataColourSpace></DataColourSpace>
+	  <PCS>Lab </PCS>
+    <DataColourSpace>CMYK</DataColourSpace>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ccox</ProfileCreator>
+    <ProfileID>1</ProfileID>
+  </Header>
+
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Named Color Example v4]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+
+    <namedColor2Tag> <namedColor2Type>
+      <NamedColors VendorFlag="0" CountOfDeviceCoords="4" DeviceEncoding="int16" Prefix="" Suffix="">
+        <LabNamedColor Name="Violet-Red" L="48" a="74" b="15">3932 65535 29490 1311</LabNamedColor>
+        <LabNamedColor Name="Red" L="46" a="68" b="38">1966 65535 65535 3277</LabNamedColor>
+        <LabNamedColor Name="Red-Orange" L="59" a="66.49" b="59.38">0 58982 65535 0</LabNamedColor>
+        <LabNamedColor Name="Orange" L="69" a="54.07" b="77.99">0 39976 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow-Orange" L="73" a="46.39" b="82.9">0 32768 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow" L="91" a="-4.59" b="97.38">3232 0 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow-Green" L="74.53" a="-41.67" b="69.34">36699 0 65535 0</LabNamedColor>
+        <LabNamedColor Name="Green" L="43.27" a="-57.85" b="21.37">65535 10486 65535 8520</LabNamedColor>
+        <LabNamedColor Name="Aquamarine" L="67.93" a="-43.01" b="-19.61">57671 0 15728 0</LabNamedColor>
+        <LabNamedColor Name="Blue" L="36.9" a="-2.15" b="-58.41">65535 44564 13762 3932</LabNamedColor>
+        <LabNamedColor Name="Indigo" L="25.44" a="27.95" b="-58.05">65535 50462 20316 27525</LabNamedColor>
+        <LabNamedColor Name="Magenta" L="45.65" a="71.53" b="-8.47">17694 65535 5243 0</LabNamedColor>
+        <LabNamedColor Name="Turquoise" L="58.92" a="-39.95" b="-33.66">65535 1311 11796 0</LabNamedColor>
+        <LabNamedColor Name="Goldenrod" L="80.08" a="15.22" b="82.38">1966 15073 65535 0</LabNamedColor>
+        <LabNamedColor Name="Spring Green" L="84.69" a="-15.72" b="63.82">14418 0 58326 0</LabNamedColor>
+        <LabNamedColor Name="Caribbean Green" L="68.37" a="-63.34" b="1.57">63569 0 33423 0</LabNamedColor>
+        <LabNamedColor Name="Ocean Deep Blue" L="38.95" a="-20.88" b="-36.61">65535 38010 17694 9175</LabNamedColor>
+        <LabNamedColor Name="Cerulean" L="40.63" a="-14.9" b="-55.44">65535 36044 9830 2621</LabNamedColor>
+        <LabNamedColor Name="Fuchsia" L="43.64" a="69.35" b="-31.29">31457 65535 0 0</LabNamedColor>
+        <LabNamedColor Name="Violet" L="31.79" a="43.76" b="-43.42">59637 65535 7864 12452</LabNamedColor>
+       </NamedColors>
+    </namedColor2Type> </namedColor2Tag>
+	
+	<XYZType>
+      <TagSignature>wtpt</TagSignature>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZType>
+	
+	<multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+
+  </Tags>
+</IccProfile>

--- a/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
@@ -347,7 +347,7 @@ void PDFGroup::WriteContent( std::ostream &out )
 
 /******************************************************************************/
 
-void PDFWriter::AddXObject( Rect2D &bounds, std::string &content, std::string name,
+void PDFWriter::AddXObject( const Rect2D &bounds, std::string &content, std::string name,
                 size_t group, size_t font, size_t procSet )
 {
   if (group == 0)

--- a/Tools/CmdLine/IccProfileVisualize/MiniPDF.hpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniPDF.hpp
@@ -237,7 +237,7 @@ public:
 class PDFXObject : public PDFObject
 {
 public:
-  PDFXObject( const std::string &buf, Rect2D &bounds,
+  PDFXObject( const std::string &buf, const Rect2D &bounds,
             size_t group = 0, size_t font = 0, size_t procSet = 0 ) :
     PDFObject(), m_buf(buf), m_bounds(bounds), m_procset(procSet),
     m_font(font), m_group(group)
@@ -279,7 +279,7 @@ public:
 
 public:
 
-  void AddXObject( Rect2D &bounds, std::string &content, std::string name,
+  void AddXObject( const Rect2D &bounds, std::string &content, std::string name,
                 size_t group = 0, size_t font = 0, size_t procSet = 0 );
 
   size_t PageCount() const { return m_pageCount; }

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -275,27 +275,27 @@ std::string DrawAxisPDF( const point2D &basepoint, const point2D &range,
 void CreateAxesXobject( PDFWriter &pdfout )
 {
   std::string commands;
-  float margin = 0.5*inch2point;
-  float tickLength = 12.0f; // pt
+  const float margin = 0.5*inch2point;
+  const float tickLength = 12.0f; // pt
 
-  float bottom = 0.0f;
-  float left = 0.0f;
-  float top = pdfout.PageHeight();
-  float right = pdfout.PageWidth();
-  Rect2D bounds ( left, right, bottom, top );
+  const float bottom = 0.0f;
+  const float left = 0.0f;
+  const float top = pdfout.PageHeight();
+  const float right = pdfout.PageWidth();
+  const Rect2D bounds ( left, right, bottom, top );
 
   // draw axes
   // horizontal
-  point2D basepoint( margin, bottom+margin );
-  point2D rangeX( right-2*margin, 0.0 );
-  point2D tickLengthX( 0, -tickLength );
-  point2D fullLengthX( 0, (top-margin) - (bottom+margin) );
+  const point2D basepoint( margin, bottom+margin );
+  const point2D rangeX( right-2*margin, 0.0 );
+  const point2D tickLengthX( 0, -tickLength );
+  const point2D fullLengthX( 0, (top-margin) - (bottom+margin) );
   commands += DrawAxisPDF( basepoint, rangeX, tickLengthX, fullLengthX, 12.0, "Input" );
 
   // vertical
-  point2D rangeY( 0.0, (top-2*margin) );
-  point2D tickLengthY( -tickLength, 0 );
-  point2D fullLengthY( (right-margin) - (left+margin), 0 );
+  const point2D rangeY( 0.0, (top-2*margin) );
+  const point2D tickLengthY( -tickLength, 0 );
+  const point2D fullLengthY( (right-margin) - (left+margin), 0 );
   commands += DrawAxisPDF( basepoint, rangeY, tickLengthY, fullLengthY, 12.0, "Output" );
 
   pdfout.AddXObject( bounds, commands, "Axes" );
@@ -423,14 +423,14 @@ void CreateXYPlotXobject( PDFWriter &pdfout )
   const float fineIncrement = 0.01f;
   const float coarseIncrement = 0.1f;
 
-  float bottom = 0.0f;
-  float left = 0.0f;
-  float top = pdfout.PageHeight();
-  float right = pdfout.PageWidth();
-  Rect2D bounds ( left, right, bottom, top );
-  point2D basepoint( left+margin, bottom+margin );
-  point2D rangeX( right-left-2*margin, 0 );
-  point2D rangeY( 0, top-bottom-2*margin );
+  const float bottom = 0.0f;
+  const float left = 0.0f;
+  const float top = pdfout.PageHeight();
+  const float right = pdfout.PageWidth();
+  const Rect2D bounds ( left, right, bottom, top );
+  const point2D basepoint( left+margin, bottom+margin );
+  const point2D rangeX( right-left-2*margin, 0 );
+  const point2D rangeY( 0, top-bottom-2*margin );
 
 
   // draw grid
@@ -465,7 +465,7 @@ void CreateXYPlotXobject( PDFWriter &pdfout )
 
   // spectral locus
   commands << "0.5 0.5 0 0 K\n";
-  point2D scaling = (rangeX + rangeY) / chromaticityChartScale;
+  const point2D scaling = (rangeX + rangeY) / chromaticityChartScale;
   point2D firstPoint = basepoint + scaling * point2D( spectralLocus2degree[0].x , spectralLocus2degree[0].y );
   commands << firstPoint << " m\n";
   for (size_t k = 1; k < spectralLocus2degree.size(); ++k ) {
@@ -477,8 +477,8 @@ void CreateXYPlotXobject( PDFWriter &pdfout )
 
   // labels for spectral locus
   commands << "0.5 0.5 0 0 k\n";
-  float labelSize = 9.0f;
-  int wavelengthOffset = spectralLocus2degree[0].wavelength;
+  const float labelSize = 9.0f;
+  const int wavelengthOffset = spectralLocus2degree[0].wavelength;
   for (auto &nm : locusLabelWavelengths ) {
     TextAlignment align;
     point2D offset = spectrumLabelOffset( nm,labelSize, align );
@@ -521,10 +521,10 @@ std::string plotCirclePDF( const point2D &center, float radius )
 
   const float handle_factor = (4.0f * (M_SQRT2 - 1.0f) / 3.0f);
   const float K = radius * handle_factor;
-  point2D rx(radius,0);
-  point2D kx(K,0);
-  point2D ry(0,radius);
-  point2D ky(0,K);
+  const point2D rx(radius,0);
+  const point2D kx(K,0);
+  const point2D ry(0,radius);
+  const point2D ky(0,K);
 
   commands << center+rx << " m\n";
   commands << center+rx-ky << " " << center+kx-ry << " " << center-ry << " c\n";
@@ -547,24 +547,29 @@ void CreateABPlotXobject( PDFWriter &pdfout )
   const float abChartScale = 2 * 130.0f;
   const float coarseIncrement = 10.0f;
 
-  float bottom = 0.0f;
-  float left = 0.0f;
-  float top = pdfout.PageHeight();
-  float right = pdfout.PageWidth();
-  Rect2D bounds ( left, right, bottom, top );
-  point2D basepoint( left+margin, bottom+margin );
-  point2D rangeX( right-left-2*margin, 0 );
-  point2D rangeY( 0, top-bottom-2*margin );
-  point2D center = 0.5f * (basepoint + point2D(right-margin,top-margin));
-  float maxRadius = std::max( right-left-2*margin, top-bottom-2*margin );
+  const float bottom = 0.0f;
+  const float left = 0.0f;
+  const float top = pdfout.PageHeight();
+  const float right = pdfout.PageWidth();
+  const Rect2D bounds ( left, right, bottom, top );
+  const point2D basepoint( left+margin, bottom+margin );
+  const point2D rangeX( right-left-2*margin, 0 );
+  const point2D rangeY( 0, top-bottom-2*margin );
+  const point2D center = 0.5f * (basepoint + point2D(right-margin,top-margin));
+  const float maxRadius = std::max( right-left-2*margin, top-bottom-2*margin );
 
 
   // draw grid
   commands << "q\n";
+  
+  // clip to chart area
+  commands << basepoint << " m " << (basepoint+rangeY) << " l\n";
+  commands << (basepoint+rangeY+rangeX) << " l\n";
+  commands << (basepoint+rangeX) << " l h W n\n";
 
   // vertical grid
   commands << "0.1 0 0 0 K\n";
-  point2D centerX(center.x,bottom+margin);
+  const point2D centerX(center.x,bottom+margin);
   for (float i = coarseIncrement; i <= abChartScale; i += coarseIncrement) {
     point2D startN = centerX + i/abChartScale * rangeX;
     commands << startN << " m " << (startN+rangeY) << " l S\n";
@@ -572,7 +577,7 @@ void CreateABPlotXobject( PDFWriter &pdfout )
     commands << start2 << " m " << (start2+rangeY) << " l S\n";
   }
   // horizontal grid
-  point2D centerY(left+margin,center.y);
+  const point2D centerY(left+margin,center.y);
   for (float i = coarseIncrement; i <= abChartScale; i += coarseIncrement) {
     point2D startN = centerY + i/abChartScale * rangeY;
     commands << startN << " m " << (startN+rangeX) << " l S\n";
@@ -581,8 +586,8 @@ void CreateABPlotXobject( PDFWriter &pdfout )
   }
 
   // constant chroma circles are helpful
-  float chromaIncrement = 30.0f;
-  float chromaMax = 120.0f;
+  const float chromaIncrement = 30.0f;
+  const float chromaMax = 150.0f;
   for (float i = chromaIncrement; i <= chromaMax; i += chromaIncrement) {
     commands << plotCirclePDF( center, i*maxRadius/abChartScale );
   }
@@ -733,8 +738,8 @@ int graphChromaticityPDF( CIccProfile *pIcc, PDFWriter &pdffile )
   point2D rangeX( right-bottom-2*margin, 0 );
   point2D rangeY( 0, top-bottom-2*margin );
   point2D scaling = (rangeX + rangeY) / chromaticityChartScale;
-  float markSize = 4;
-  float textSize = 10;
+  float markSize = 4.0f;
+  float textSize = 10.0f;
 
 
 // TODO - determine approximate CCT and add that to label
@@ -1467,6 +1472,257 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
 
 /******************************************************************************/
 
+struct namedLAB {
+    namedLAB() : L(0), a(0), b(0) {}
+    
+    namedLAB( std::string nn, float LL, float aa, float bb ) :
+        name(nn), L(LL), a(aa), b(bb) {}
+
+    std::string name;
+    float L, a, b;
+};
+
+typedef std::vector<namedLAB> namedLabList;
+
+/******************************************************************************/
+
+int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description,
+                        PDFWriter &pdffile )
+{
+  std::ostringstream commands;
+
+  const float bottom = 0.0f;
+  const float left = 0.0f;
+  const float top = pdffile.PageHeight();
+  const float right = pdffile.PageWidth();
+  Rect2D bounds ( left, right, bottom, top );
+  const float margin = 0.25*inch2point;
+  const point2D basepoint( left+margin, bottom+margin );
+  const point2D rangeX( right-left-2*margin, 0 );
+  const point2D rangeY( 0, top-bottom-2*margin );
+  const point2D center = 0.5f * (basepoint + point2D(right-margin,top-margin));
+  float maxRadius = std::max( right-left-2*margin, top-bottom-2*margin );
+
+// TODO  - full 128+ range is probably excessive for real world use
+// what is an appropriate limit?
+  const float abChartScale = 2 * 130.0f;
+
+    // plot on AB grid
+  // if the xyPlot xobject doesn't exist, create it now
+  if (!pdffile.xobjectExists("abPlot"))
+    CreateABPlotXobject( pdffile );
+
+  // add the common axes
+  commands << "/abPlot Do\n";
+
+  // add label
+  point2D range( right - left, 0 );
+  point2D labelBase( left, top );
+  point2D tickLength(0,0);
+  commands << AddGraphLabels( labelBase + range*0.5, false, tickLength, 12, description );
+
+
+  float symbolSize = 4.0f;
+  float labelSize = 10.0f;
+  point2D labelOffset( 0, symbolSize + 2 + labelSize );
+  for (auto &sample : colorsOut) {
+    point2D colorPt( sample.a*maxRadius/abChartScale, sample.b*maxRadius/abChartScale );
+    point2D plotCenter = center + colorPt;
+    commands << plotSquarePDF( plotCenter, symbolSize);
+// TODO - names?
+    commands << AddGraphLabels( plotCenter+labelOffset, false, point2D(0,0),
+                                labelSize, sample.name, kTextAlignLeft );
+  }
+
+// TODO - xyPlot as well?
+// TODO - CIECAM16 plot as well?
+
+
+  // and finally create the graphics object and page
+  PDFGraphic *graphics = new PDFGraphic( commands.str() );
+  pdffile.AddObject( graphics );
+  size_t content = pdffile.ObjectCount();
+
+  pdffile.AddPage( content, "abPlot" );
+
+  return 1;
+}
+
+/******************************************************************************/
+
+// convert all types of color lists to a known vector of names and LAB or XYZ colors
+// then plot that
+static
+int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
+        PDFWriter &pdffile )
+{
+  const size_t bufSize = 64;
+  char buf[bufSize];
+  namedLabList colorsOut;
+
+  int outputCount = 0;
+
+  if (!tag) {
+    fprintf(stderr, "Skipping %s: unable to load tag\n", sigDesc.c_str());
+    return 0;
+  }
+
+  icTagTypeSignature typeSig = tag->GetType();
+  
+  switch(typeSig) {
+  
+    case icSigColorantTableType:    // colorant tables -- name and PCS only
+      {
+      CIccTagColorantTable *table = dynamic_cast<CIccTagColorantTable*> (tag);
+      if (!table) {
+        fprintf(stderr, "Skipping %s: unable to convert colorantTable\n", sigDesc.c_str());
+        return 0;
+      }
+      
+      std::string path("colorantTable");
+      std::string report;
+      if (table->Validate(path, report, NULL) > icValidateWarning) {
+        fprintf(stderr,"WARNING - colorantTable failed validation: %s\n", report.c_str() );
+        return 0;
+      }
+      
+      icColorSpaceSignature pcs = pIcc->m_Header.pcs; // table->GetPCS();   // never initialized in table!
+      
+      if (pcs != icSigXYZData && pcs != icSigLabData) {
+        fprintf(stderr,"WARNING - unknown pcs for colorantTable: %s\n",
+                            icGetSig(buf, bufSize, pcs) );
+        return 0;
+      }
+      
+      icUInt32Number colorCount = table->GetSize();
+      
+      icFloatNumber XYZIlluminant[3];
+      pIcc->getNormIlluminantXYZ( XYZIlluminant );
+      
+      colorsOut.reserve(colorCount);
+      
+      for (icUInt32Number i = 0; i < colorCount; ++i) {
+        icFloatNumber labTemp[3];
+        icColorantTableEntry *entry = table->GetEntry( i );
+        namedLAB tempNamed;
+        tempNamed.name = entry->name;
+        if (pcs == icSigXYZData) {
+            // XYZ 16 bit integer
+            icFloatNumber xyzTemp[3];
+            xyzTemp[0] = icU16toF( entry->data[0] );
+            xyzTemp[1] = icU16toF( entry->data[1] );
+            xyzTemp[2] = icU16toF( entry->data[2] );
+            icXYZtoLab( labTemp, xyzTemp, XYZIlluminant );
+        } else {
+            //  LAB 16bit integer
+            labTemp[0] = icU16toF( entry->data[0] );
+            labTemp[1] = icU16toF( entry->data[1] );
+            labTemp[2] = icU16toF( entry->data[2] );
+            icLabFromPcs( labTemp );
+        }
+        
+        tempNamed.L = labTemp[0];
+        tempNamed.a = labTemp[1];
+        tempNamed.b = labTemp[2];
+
+        colorsOut.push_back(tempNamed);
+      }
+      
+      std::string description("Colorant Table: ");
+      outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc, pdffile );
+      }
+      break;
+  
+    case icSigNamedColor2Type:      // named color - PCS and colorspace (PCS optional?)
+      {
+      CIccTagNamedColor2 *table = dynamic_cast<CIccTagNamedColor2*> (tag);
+      if (!table) {
+        fprintf(stderr, "Skipping %s: unable to convert namedColorTable\n", sigDesc.c_str());
+        return 0;
+      }
+      
+      std::string path("namedColorTable");
+      std::string report;
+      if (table->Validate(path, report, NULL) > icValidateWarning) {
+        fprintf(stderr,"WARNING - namedColorTable failed validation: %s\n", report.c_str() );
+        return 0;
+      }
+      
+      icColorSpaceSignature pcs = table->GetPCS();// pIcc->m_Header.pcs;
+      
+      if (pcs != icSigXYZData && pcs != icSigLabData) {
+        fprintf(stderr,"WARNING - unknown pcs for namedColorTable: %s\n",
+                            icGetSig(buf, bufSize, pcs) );
+        return 0;
+      }
+      
+      icUInt32Number colorCount = table->GetSize();
+      
+      icFloatNumber XYZIlluminant[3];
+      pIcc->getNormIlluminantXYZ( XYZIlluminant );
+      
+      colorsOut.reserve(colorCount);
+      
+      std::string prefix = table->GetPrefix();
+      std::string suffix = table->GetSufix();
+      for (icUInt32Number i = 0; i < colorCount; ++i) {
+        icFloatNumber labTemp[3];
+        SIccNamedColorEntry *entry = table->GetEntry( i );
+        namedLAB tempNamed;
+        tempNamed.name = prefix + std::string(entry->rootName) + suffix;
+        if (pcs == icSigXYZData) {
+            // XYZ float
+            icXYZtoLab( labTemp, entry->pcsCoords, XYZIlluminant );
+        } else {
+            //  LAB float
+            icFloatNumber labTemp2[3];
+            labTemp2[0] = entry->pcsCoords[0];
+            labTemp2[1] = entry->pcsCoords[1];
+            labTemp2[2] = entry->pcsCoords[2];
+            table->Lab2ToLab4(labTemp,labTemp2);
+            icLabFromPcs( labTemp );
+        }
+        
+        tempNamed.L = labTemp[0];
+        tempNamed.a = labTemp[1];
+        tempNamed.b = labTemp[2];
+
+        colorsOut.push_back(tempNamed);
+      }
+      
+      std::string description("Named Color Table: ");
+      outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc, pdffile );
+      }
+      break;
+    
+    case icSigTagArrayType:         // v5 only
+      {
+      CIccTagArray *array = dynamic_cast<CIccTagArray*> (tag);
+      if (!array) {
+        fprintf(stderr, "Skipping %s: unable to convert named color array\n", sigDesc.c_str());
+        return 0;
+      }
+
+// TODO - dissect structure, figure out LAB values for colors
+
+      }
+      break;
+  
+    default:
+      printf("Unknown named color type %s for tag %s\n",
+         icGetSig(buf, bufSize, typeSig),
+         sigDesc.c_str() );
+      break;
+  }
+
+
+      
+  return outputCount;
+}
+
+
+/******************************************************************************/
+
 static
 std::string remove_extension( const std::string& filename)
 {
@@ -1504,7 +1760,7 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
   PDFWriter pdffile( pdfPath, 8*inch2point, 8*inch2point );
 
 
-    // plot white point, RGB chromaticities
+  // plot RGB chromaticities, white point
   outputItems += graphChromaticityPDF( pIcc, pdffile );
 
 
@@ -1550,6 +1806,17 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
         outputItems += output3DLUT(pIcc, pTag, sigDesc, basename, pdffile );
 // TODO - plot gamut from A2B and B2A tags into xy and LAB plots
         }
+        break;
+
+      case icSigNamedColorTag:
+      case icSigNamedColor2Tag:
+      case icSigColorantTableTag:
+      case icSigColorantTableOutTag:
+       {
+        const char *sigDesc = icGetSigStr(buf1, bufSize, sig);
+        CIccTag *pTag = pIcc->FindTag(tag); // load if needed
+        outputItems += outputNamedColors(pIcc, pTag, sigDesc, pdffile );
+       }
         break;
 
       // ignore everything else

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1529,10 +1529,10 @@ int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description
     point2D colorPt( sample.a*maxRadius/abChartScale, sample.b*maxRadius/abChartScale );
     point2D plotCenter = center + colorPt;
     commands << plotSquarePDF( plotCenter, symbolSize);
-// TODO - names?
     commands << AddGraphLabels( plotCenter+labelOffset, false, point2D(0,0),
                                 labelSize, sample.name, kTextAlignLeft );
   }
+
 
 // TODO - xyPlot as well?
 // TODO - CIECAM16 plot as well?
@@ -1605,7 +1605,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         icFloatNumber labTemp[3];
         icColorantTableEntry *entry = table->GetEntry( i );
         namedLAB tempNamed;
-        tempNamed.name = entry->name;
+        tempNamed.name = std::to_string(i+1) + std::string(" ") + std::string(entry->name);
         if (pcs == icSigXYZData) {
             // XYZ 16 bit integer
             icFloatNumber xyzTemp[3];

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -567,7 +567,7 @@ void CreateABPlotXobject( PDFWriter &pdfout )
 
   // draw grid
   commands << "q\n";
-  
+
   // clip to chart area
   commands << basepoint << " m " << (basepoint+rangeY) << " l\n";
   commands << (basepoint+rangeY+rangeX) << " l\n";
@@ -1513,7 +1513,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
 
 struct namedLAB {
     namedLAB() : L(0), a(0), b(0) {}
-    
+
     namedLAB( std::string nn, float LL, float aa, float bb ) :
         name(nn), L(LL), a(aa), b(bb) {}
 
@@ -1567,7 +1567,7 @@ int graphNamedColorsXYPDF( namedLabList &colorsOut, const std::string &descripti
     icLAB[2] = sample.b;
     icLabtoXYZ( xyzOut, icLAB, XYZIlluminant );
     XYColor theXY = xyFromICCXYZFloat( xyzOut );
-  
+
     point2D plotCenter = basepoint + scaling * point2D( theXY.x, theXY.y );
     commands << plotSquarePDF( plotCenter, markSize);
     commands << AddGraphLabels( plotCenter+labelOffset, false, point2D(0,0),
@@ -1649,15 +1649,15 @@ int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description
 {
   std::ostringstream commands;
   int outputObjects = 0;
-  
+
   outputObjects += graphNamedColorsABPDF( colorsOut, description, XYZIlluminant, pdffile );
-  
+
   outputObjects += graphNamedColorsXYPDF( colorsOut, description, XYZIlluminant, pdffile );
 
 // TODO - CIECAM16 plot as well?
     //#include "IccCAM.h" -- is CIECAM02
     // would have to add CAM16 code
-    
+
   return outputObjects;
 }
 
@@ -1681,9 +1681,9 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   }
 
   icTagTypeSignature typeSig = tag->GetType();
-  
+
   switch(typeSig) {
-  
+
     case icSigColorantTableType:    // colorant tables -- name and PCS only
       {
       CIccTagColorantTable *table = dynamic_cast<CIccTagColorantTable*> (tag);
@@ -1691,29 +1691,29 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         fprintf(stderr, "Skipping %s: unable to convert colorantTable\n", sigDesc.c_str());
         return 0;
       }
-      
+
       std::string path("colorantTable");
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
         fprintf(stderr,"WARNING - colorantTable failed validation: %s\n", report.c_str() );
         return 0;
       }
-      
+
       icColorSpaceSignature pcs = pIcc->m_Header.pcs; // table->GetPCS();   // never initialized in table!
-      
+
       if (pcs != icSigXYZData && pcs != icSigLabData) {
         fprintf(stderr,"WARNING - unknown pcs for colorantTable: %s\n",
                             icGetSig(buf, bufSize, pcs) );
         return 0;
       }
-      
+
       icUInt32Number colorCount = table->GetSize();
-      
+
       icFloatNumber XYZIlluminant[3];
       pIcc->getNormIlluminantXYZ( XYZIlluminant );
-      
+
       colorsOut.reserve(colorCount);
-      
+
       for (icUInt32Number i = 0; i < colorCount; ++i) {
         icFloatNumber labTemp[3];
         icColorantTableEntry *entry = table->GetEntry( i );
@@ -1733,20 +1733,20 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
             labTemp[2] = icU16toF( entry->data[2] );
             icLabFromPcs( labTemp );
         }
-        
+
         tempNamed.L = labTemp[0];
         tempNamed.a = labTemp[1];
         tempNamed.b = labTemp[2];
 
         colorsOut.push_back(tempNamed);
       }
-      
+
       std::string description("Colorant Table: ");
       outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc,
                         XYZIlluminant, pdffile );
       }
       break;
-  
+
     case icSigNamedColor2Type:      // named color - PCS and colorspace (PCS optional?)
       {
       CIccTagNamedColor2 *table = dynamic_cast<CIccTagNamedColor2*> (tag);
@@ -1754,29 +1754,29 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         fprintf(stderr, "Skipping %s: unable to convert namedColorTable\n", sigDesc.c_str());
         return 0;
       }
-      
+
       std::string path("namedColorTable");
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
         fprintf(stderr,"WARNING - namedColorTable failed validation: %s\n", report.c_str() );
         return 0;
       }
-      
+
       icColorSpaceSignature pcs = table->GetPCS();// pIcc->m_Header.pcs;
-      
+
       if (pcs != icSigXYZData && pcs != icSigLabData) {
         fprintf(stderr,"WARNING - unknown pcs for namedColorTable: %s\n",
                             icGetSig(buf, bufSize, pcs) );
         return 0;
       }
-      
+
       icUInt32Number colorCount = table->GetSize();
-      
+
       icFloatNumber XYZIlluminant[3];
       pIcc->getNormIlluminantXYZ( XYZIlluminant );
-      
+
       colorsOut.reserve(colorCount);
-      
+
       std::string prefix = table->GetPrefix();
       std::string suffix = table->GetSufix();
       for (icUInt32Number i = 0; i < colorCount; ++i) {
@@ -1796,20 +1796,20 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
             table->Lab2ToLab4(labTemp,labTemp2);
             icLabFromPcs( labTemp );
         }
-        
+
         tempNamed.L = labTemp[0];
         tempNamed.a = labTemp[1];
         tempNamed.b = labTemp[2];
 
         colorsOut.push_back(tempNamed);
       }
-      
+
       std::string description("Named Color Table: ");
       outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc,
                             XYZIlluminant, pdffile );
       }
       break;
-    
+
     case icSigTagArrayType:         // v5 only
       {
       CIccTagArray *array = dynamic_cast<CIccTagArray*> (tag);
@@ -1822,7 +1822,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
 
       }
       break;
-  
+
     default:
       printf("Unknown named color type %s for tag %s\n",
          icGetSig(buf, bufSize, typeSig),

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -124,8 +124,6 @@ void DrawAxisSVG( SVGOut &svgfile, const point2D &basepoint, const point2D &rang
   point2D start2 = basepoint + range*0.5;
   svgfile.AddLine( start2, start2+tickLength );
 
-// TODO - values???  0.1 increments?
-
   // small marks for each tenth that isn't 0.5
   for (int i = 1; i < 10; ++i) {
     if (i == 5) continue;
@@ -396,11 +394,11 @@ point2D spectrumLabelOffset( int nm, float textSize, TextAlignment &align )
     if (nm < 515) {
         // go left
         align = kTextAlignRight;
-        return point2D( -2, 0 );
+        return point2D( -2.0f, 0.0f );
     } else if (nm <= 520) {
         // go up
         align = kTextAlignCenter;
-        return point2D( -3, textSize*1.55 );
+        return point2D( -3.0f, textSize*1.55f );
     } else {
         // go right
         align = kTextAlignLeft;
@@ -412,14 +410,15 @@ point2D spectrumLabelOffset( int nm, float textSize, TextAlignment &align )
 
 /******************************************************************************/
 
+// x range [ 0.00364, 0.73469 ]   for 2degree 1931 observer
+// y range [ 0.00529, 0.83409 ]
+const float chromaticityChartScale = 0.85f;
+
 void CreateXYPlotXobject( PDFWriter &pdfout )
 {
   std::ostringstream commands;
   float margin = 0.25*inch2point;
 
-  // x range [ 0.00364, 0.73469 ]   for 2degree 1931 observer
-  // y range [ 0.00529, 0.83409 ]
-  const float chromaticityChartScale = 0.85f;
   const float fineIncrement = 0.01f;
   const float coarseIncrement = 0.1f;
 
@@ -537,14 +536,15 @@ std::string plotCirclePDF( const point2D &center, float radius )
 
 /******************************************************************************/
 
+// DEFERRED - full 128+ range is probably excessive for real world use
+// what is an appropriate limit?        So far 130 looks fine.
+const float abChartScale = 2 * 130.0f;
+  
 void CreateABPlotXobject( PDFWriter &pdfout )
 {
   std::ostringstream commands;
   float margin = 0.25*inch2point;
 
-// TODO  - full 128+ range is probably excessive for real world use
-// what is an appropriate limit?
-  const float abChartScale = 2 * 130.0f;
   const float coarseIncrement = 10.0f;
 
   const float bottom = 0.0f;
@@ -592,8 +592,6 @@ void CreateABPlotXobject( PDFWriter &pdfout )
     commands << plotCirclePDF( center, i*maxRadius/abChartScale );
   }
 
-// TODO - 30 degree hue angles?
-
   // axes
   commands << "0.4 0 0 0 K\n";
   commands << centerX << " m " << (centerX+rangeY) << " l S\n";
@@ -629,6 +627,24 @@ XYColor xyFromICCXYZ( const icXYZNumber *xyz )
     float X = xyz->X / 65535.0;
     float Y = xyz->Y / 65535.0;
     float Z = xyz->Z / 65535.0;
+
+    float sum = X + Y + Z;
+    if (sum <= 1e-8)
+        return XYColor(0,0);
+
+    float x = X / sum;
+    float y = Y / sum;
+    return XYColor(x,y);
+}
+
+/******************************************************************************/
+
+static
+XYColor xyFromICCXYZ( const icFloatNumber *xyz )
+{
+    float X = xyz[0];
+    float Y = xyz[1];
+    float Z = xyz[2];
 
     float sum = X + Y + Z;
     if (sum <= 1e-8)
@@ -733,7 +749,6 @@ int graphChromaticityPDF( CIccProfile *pIcc, PDFWriter &pdffile )
   // gsave, color black
   commands << "q 0 0 0 1 K\n";
 
-  const float chromaticityChartScale = 0.85f;   // must match CreateXYPlotXobject
   point2D basepoint( left+margin, bottom+margin );
   point2D rangeX( right-bottom-2*margin, 0 );
   point2D rangeY( 0, top-bottom-2*margin );
@@ -936,7 +951,7 @@ void describe1DLUT( CIccTagCurve *curve, std::string &description )
   } else if (size == 1) {
     icFloatNumber value0 = (*curve)[0];
     icFloatNumber dGamma = (icFloatNumber)(value0 * 256.0);
-    description += "Y = X ^ " + std::to_string(dGamma);   // TODO - truncate to 4 decimal places
+    description += "Y = X ^ " + std::to_string(dGamma);
   } else {
     description += "LookupTable[" + std::to_string(size) + "]";
   }
@@ -1038,7 +1053,6 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
       }
       break;
 
-    // TODO - might merge below
     case icSigParametricCurveType:
       {
       CIccTagParametricCurve *pCurve = dynamic_cast<CIccTagParametricCurve*> (tag);
@@ -1054,7 +1068,6 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
       }
       break;
 
-    // TODO - might merge below
     case icSigSegmentedCurveType:
       {
       CIccTagSegmentedCurve *sCurve = dynamic_cast<CIccTagSegmentedCurve*> (tag);
@@ -1486,8 +1499,68 @@ typedef std::vector<namedLAB> namedLabList;
 
 /******************************************************************************/
 
-int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description,
-                        PDFWriter &pdffile )
+int graphNamedColorsXYPDF( namedLabList &colorsOut, const std::string &description,
+                        icFloatNumber *XYZIlluminant, PDFWriter &pdffile )
+{
+  std::ostringstream commands;
+
+  const float bottom = 0.0f;
+  const float left = 0.0f;
+  const float top = pdffile.PageHeight();
+  const float right = pdffile.PageWidth();
+  Rect2D bounds ( left, right, bottom, top );
+  const float margin = 0.25*inch2point;
+  const point2D basepoint( left+margin, bottom+margin );
+  const point2D rangeX( right-left-2*margin, 0 );
+  const point2D rangeY( 0, top-bottom-2*margin );
+  point2D scaling = (rangeX + rangeY) / chromaticityChartScale;
+  float markSize = 4.0f;
+  float textSize = 10.0f;
+
+  // plot on AB grid
+  // if the xyPlot xobject doesn't exist, create it now
+  if (!pdffile.xobjectExists("xyPlot"))
+    CreateXYPlotXobject( pdffile );
+
+  // add the common axes
+  commands << "/xyPlot Do\n";
+
+  // add label
+  point2D range( right - left, 0 );
+  point2D labelBase( left, top );
+  point2D tickLength(0,0);
+  commands << AddGraphLabels( labelBase + range*0.5, false, tickLength, 12, description );
+
+  point2D labelOffset( 0, markSize + 2 + textSize );
+  for (auto &sample : colorsOut) {
+    icFloatNumber icLAB[3];
+    icFloatNumber xyzOut[3];
+    icLAB[0] = sample.L;
+    icLAB[1] = sample.a;
+    icLAB[2] = sample.b;
+    icLabtoXYZ( xyzOut, icLAB, XYZIlluminant );
+    XYColor theXY = xyFromICCXYZ( xyzOut );
+  
+    point2D plotCenter = basepoint + scaling * point2D( theXY.x, theXY.y );
+    commands << plotSquarePDF( plotCenter, markSize);
+    commands << AddGraphLabels( plotCenter+labelOffset, false, point2D(0,0),
+                                textSize, sample.name, kTextAlignLeft );
+  }
+
+  // and finally create the graphics object and page
+  PDFGraphic *graphics = new PDFGraphic( commands.str() );
+  pdffile.AddObject( graphics );
+  size_t content = pdffile.ObjectCount();
+
+  pdffile.AddPage( content, "xyPlot" );
+
+  return 1;
+}
+
+/******************************************************************************/
+
+int graphNamedColorsABPDF( namedLabList &colorsOut, const std::string &description,
+                        icFloatNumber * /*XYZIlluminant*/, PDFWriter &pdffile )
 {
   std::ostringstream commands;
 
@@ -1503,12 +1576,8 @@ int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description
   const point2D center = 0.5f * (basepoint + point2D(right-margin,top-margin));
   float maxRadius = std::max( right-left-2*margin, top-bottom-2*margin );
 
-// TODO  - full 128+ range is probably excessive for real world use
-// what is an appropriate limit?
-  const float abChartScale = 2 * 130.0f;
-
-    // plot on AB grid
-  // if the xyPlot xobject doesn't exist, create it now
+  // plot on AB grid
+  // if the abPlot xobject doesn't exist, create it now
   if (!pdffile.xobjectExists("abPlot"))
     CreateABPlotXobject( pdffile );
 
@@ -1534,10 +1603,6 @@ int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description
   }
 
 
-// TODO - xyPlot as well?
-// TODO - CIECAM16 plot as well?
-
-
   // and finally create the graphics object and page
   PDFGraphic *graphics = new PDFGraphic( commands.str() );
   pdffile.AddObject( graphics );
@@ -1546,6 +1611,24 @@ int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description
   pdffile.AddPage( content, "abPlot" );
 
   return 1;
+}
+
+/******************************************************************************/
+
+int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description,
+                        icFloatNumber *XYZIlluminant, PDFWriter &pdffile )
+{
+  std::ostringstream commands;
+  int outputObjects = 0;
+  
+  outputObjects += graphNamedColorsABPDF( colorsOut, description, XYZIlluminant, pdffile );
+  
+  outputObjects += graphNamedColorsXYPDF( colorsOut, description, XYZIlluminant, pdffile );
+
+// TODO - CIECAM16 plot as well?
+    //#include "IccCAM.h" -- is CIECAM02
+    
+  return outputObjects;
 }
 
 /******************************************************************************/
@@ -1629,7 +1712,8 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       }
       
       std::string description("Colorant Table: ");
-      outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc, pdffile );
+      outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc,
+                        XYZIlluminant, pdffile );
       }
       break;
   
@@ -1691,7 +1775,8 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       }
       
       std::string description("Named Color Table: ");
-      outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc, pdffile );
+      outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc,
+                            XYZIlluminant, pdffile );
       }
       break;
     
@@ -1716,7 +1801,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   }
 
 
-      
   return outputCount;
 }
 

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -640,7 +640,7 @@ XYColor xyFromICCXYZ( const icXYZNumber *xyz )
 /******************************************************************************/
 
 static
-XYColor xyFromICCXYZ( const icFloatNumber *xyz )
+XYColor xyFromICCXYZFloat( const icFloatNumber *xyz )
 {
     float X = xyz[0];
     float Y = xyz[1];
@@ -756,14 +756,33 @@ int graphChromaticityPDF( CIccProfile *pIcc, PDFWriter &pdffile )
   float markSize = 4.0f;
   float textSize = 10.0f;
 
+  if (hasWhite) {
+    std::string CCTText;
+#if 0
+// not working correctly with 9300 whitepoint displays, gives 3175K
+    auto theXYZTag = dynamic_cast<CIccTagXYZ*>(whiteTag);
+    if (theXYZTag) {
+      auto theXYZ = theXYZTag->GetXYZ(0);
+      if (theXYZ) {
+        auto theXY = xyFromICCXYZ( theXYZ );
+        // McCamy's forumula
+        // McCamy, Calvin S. (April 1992).
+        // "Correlated color temperature as an explicit function of chromaticity coordinates"
+        float n = (theXY.x - 0.3320f) / (0.1858f - theXY.y);
+        float n2 = n*n;
+        float n3 = n*n*n;
+        //float cct = -437.0f *n3 + 3601.0f *n2 - 6861.0f *n + 5514.31f;    // first eq.
+        float cct = -449.0f *n3 + 3525.0f *n2 - 6823.3f *n + 5520.33f;  // second eq.
+        int32_t cctI = (int32_t)cct; // we want the integer part, don't need precision
+        CCTText = std::string("( ~") + std::to_string(cctI) + std::string("K)");
+#endif
+      }
+    }
 
-// TODO - determine approximate CCT and add that to label
-// McCamy's approximation may not be good enough
-
-
-  if (hasWhite)
-    commands << plotXYZTag( whiteTag, "White", basepoint,
+    std::string label = std::string("White") + CCTText;
+    commands << plotXYZTag( whiteTag, label, basepoint,
                         scaling, markSize, textSize );
+  }
 
   if (hasRGB) {
     point2D redPt, greenPt, bluePt;

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -121,28 +121,28 @@ void DrawAxisSVG( SVGOut &svgfile, const point2D &basepoint, const point2D &rang
   svgfile.AddLine( start0, start0+tickLength );
   point2D start1 = basepoint + range;
   svgfile.AddLine( start1, start1+tickLength );
-  point2D start2 = basepoint + range*0.5;
+  point2D start2 = basepoint + range*0.5f;
   svgfile.AddLine( start2, start2+tickLength );
 
   // small marks for each tenth that isn't 0.5
   for (int i = 1; i < 10; ++i) {
     if (i == 5) continue;
-    point2D startN = basepoint + range*(i/10.0);
-    svgfile.AddLine( startN, startN+tickLength*0.5);
+    point2D startN = basepoint + range*(i/10.0f);
+    svgfile.AddLine( startN, startN+tickLength*0.5f);
   }
 
   // small marks for each hundredth
   for (int i = 1; i < 100; ++i) {
     if ((i % 10) == 0) continue;
-    point2D startN = basepoint + range*(i/100.0);
-    svgfile.AddLine( startN, startN+tickLength*0.25);
+    point2D startN = basepoint + range*(i/100.0f);
+    svgfile.AddLine( startN, startN+tickLength*0.25f);
   }
 
   // label near halfway
   std::string font = "Arial";
   std::string style = "Regular";
   std::string align = "Center";
-  point2D labelPt = basepoint + range*0.5 + tickLength*2.0;
+  point2D labelPt = basepoint + range*0.5f + tickLength*2.0f;
   float rotation = (range.x == 0.0) ? 90 : 0;   // horiz or vertical
   svgfile.AddText( labelPt.x, labelPt.y, label, 14, font, style, align, rotation );
 }
@@ -156,6 +156,7 @@ enum TextAlignment {
     kTextAlignRight = 2
 };
 
+static
 std::string AddGraphLabels( const point2D &basepoint, bool isVertical,
         const point2D &tickLength, float labelSize, const std::string &text,
         TextAlignment align = kTextAlignCenter )
@@ -163,7 +164,7 @@ std::string AddGraphLabels( const point2D &basepoint, bool isVertical,
   std::ostringstream commands;
 
   float textWidth = labelSize * 0.6f * text.size(); // very approximate, not using font metrics
-  float textHalf = 0.5 * textWidth;
+  float textHalf = 0.5f * textWidth;
 
   point2D position(0,0);
   switch(align) {
@@ -212,12 +213,12 @@ std::string DrawAxisPDF( const point2D &basepoint, const point2D &range,
   commands << "0.05 0 0 0 K\n";
   for (int i = 1; i <= 100; ++i) {
     if ((i % 10) == 0) continue;
-    point2D startN = basepoint + range*(i/100.0);
+    point2D startN = basepoint + range*(i/100.0f);
     commands << startN << " m " << (startN+fullLength) << " l S\n";
   }
   commands << "0.1 0 0 0 K\n";
   for (int i = 1; i <= 10; ++i) {
-    point2D startN = basepoint + range*(i/10.0);
+    point2D startN = basepoint + range*(i/10.0f);
     commands << startN << " m " << (startN+fullLength) << " l S\n";
   }
   // identity line
@@ -233,20 +234,20 @@ std::string DrawAxisPDF( const point2D &basepoint, const point2D &range,
   commands << start0 << " m " << (start0+tickLength) << " l S\n";
   point2D start1 = basepoint + range;
   commands << start1 << " m " << (start1+tickLength) << " l S\n";
-  point2D start2 = basepoint + range*0.5;
+  point2D start2 = basepoint + range*0.5f;
   commands << start2 << " m " << (start2+tickLength) << " l S\n";
 
   // small marks for each tenth that isn't 0.5
   for (int i = 1; i < 10; ++i) {
     if (i == 5) continue;
-    point2D startN = basepoint + range*(i/10.0);
+    point2D startN = basepoint + range*(i/10.0f);
     commands << startN << " m " << (startN+tickLength*0.5) << " l S\n";
   }
 
   // small marks for each hundredth
   for (int i = 1; i < 100; ++i) {
     if ((i % 10) == 0) continue;
-    point2D startN = basepoint + range*(i/100.0);
+    point2D startN = basepoint + range*(i/100.0f);
     commands << startN << " m " << (startN+tickLength*0.25) << " l S\n";
   }
 
@@ -256,7 +257,7 @@ std::string DrawAxisPDF( const point2D &basepoint, const point2D &range,
   std::string full("100%");
   bool isVertical = (range.x == 0);
   commands << AddGraphLabels( basepoint, isVertical, tickLength, labelSize, zero );
-  commands << AddGraphLabels( basepoint+0.5*range, isVertical, tickLength, labelSize, half );
+  commands << AddGraphLabels( basepoint+0.5f*range, isVertical, tickLength, labelSize, half );
   commands << AddGraphLabels( basepoint+range, isVertical, tickLength, labelSize, full, kTextAlignRight );
 
   // IO label near 2/3
@@ -270,10 +271,11 @@ std::string DrawAxisPDF( const point2D &basepoint, const point2D &range,
 
 /******************************************************************************/
 
+static
 void CreateAxesXobject( PDFWriter &pdfout )
 {
   std::string commands;
-  const float margin = 0.5*inch2point;
+  const float margin = 0.5f*inch2point;
   const float tickLength = 12.0f; // pt
 
   const float bottom = 0.0f;
@@ -285,16 +287,16 @@ void CreateAxesXobject( PDFWriter &pdfout )
   // draw axes
   // horizontal
   const point2D basepoint( margin, bottom+margin );
-  const point2D rangeX( right-2*margin, 0.0 );
+  const point2D rangeX( right-2*margin, 0.0f );
   const point2D tickLengthX( 0, -tickLength );
   const point2D fullLengthX( 0, (top-margin) - (bottom+margin) );
-  commands += DrawAxisPDF( basepoint, rangeX, tickLengthX, fullLengthX, 12.0, "Input" );
+  commands += DrawAxisPDF( basepoint, rangeX, tickLengthX, fullLengthX, 12.0f, "Input" );
 
   // vertical
   const point2D rangeY( 0.0, (top-2*margin) );
   const point2D tickLengthY( -tickLength, 0 );
   const point2D fullLengthY( (right-margin) - (left+margin), 0 );
-  commands += DrawAxisPDF( basepoint, rangeY, tickLengthY, fullLengthY, 12.0, "Output" );
+  commands += DrawAxisPDF( basepoint, rangeY, tickLengthY, fullLengthY, 12.0f, "Output" );
 
   pdfout.AddXObject( bounds, commands, "Axes" );
 }
@@ -386,6 +388,7 @@ std::vector<int> locusLabelWavelengths =
 
 /******************************************************************************/
 
+static
 point2D spectrumLabelOffset( int nm, float textSize, TextAlignment &align )
 {
 // NOTE - Yes, I could create normal vectors from the locus points, etc.
@@ -414,6 +417,7 @@ point2D spectrumLabelOffset( int nm, float textSize, TextAlignment &align )
 // y range [ 0.00529, 0.83409 ]
 const float chromaticityChartScale = 0.85f;
 
+static
 void CreateXYPlotXobject( PDFWriter &pdfout )
 {
   std::ostringstream commands;
@@ -437,24 +441,24 @@ void CreateXYPlotXobject( PDFWriter &pdfout )
 
   // vertical fine grid
   commands << "0.05 0 0 0 K\n";
-  for (float i = 0.0; i <= chromaticityChartScale; i += fineIncrement) {
+  for (float i = 0.0f; i <= chromaticityChartScale; i += fineIncrement) {
     point2D startN = basepoint + i/chromaticityChartScale * rangeX;
     commands << startN << " m " << (startN+rangeY) << " l S\n";
   }
   // horizontal fine grid
-  for (float i = 0.0; i <= chromaticityChartScale; i += fineIncrement) {
+  for (float i = 0.0f; i <= chromaticityChartScale; i += fineIncrement) {
     point2D startN = basepoint + i/chromaticityChartScale * rangeY;
     commands << startN << " m " << (startN+rangeX) << " l S\n";
   }
 
   // vertical coarse grid
   commands << "0.1 0 0 0 K\n";
-  for (float i = 0.0; i <= chromaticityChartScale; i += coarseIncrement) {
+  for (float i = 0.0f; i <= chromaticityChartScale; i += coarseIncrement) {
     point2D startN = basepoint + i/chromaticityChartScale * rangeX;
     commands << startN << " m " << (startN+rangeY) << " l S\n";
   }
   // horizontal coarse grid
-  for (float i = 0.0; i <= chromaticityChartScale; i += coarseIncrement) {
+  for (float i = 0.0f; i <= chromaticityChartScale; i += coarseIncrement) {
     point2D startN = basepoint + i/chromaticityChartScale * rangeY;
     commands << startN << " m " << (startN+rangeX) << " l S\n";
   }
@@ -482,16 +486,17 @@ void CreateXYPlotXobject( PDFWriter &pdfout )
     TextAlignment align;
     point2D offset = spectrumLabelOffset( nm,labelSize, align );
     size_t index = nm - wavelengthOffset;
-    point2D thispoint = basepoint + scaling * point2D( spectralLocus2degree[index].x , spectralLocus2degree[index].y );
+    point2D thispoint = basepoint + scaling * point2D( spectralLocus2degree[index].x,
+                                                       spectralLocus2degree[index].y );
     std::string number = std::to_string(nm);
     commands << AddGraphLabels( thispoint + offset, false, point2D(0,0), labelSize, number, align );
   }
 
   // plankian white curve
   commands << "0 0.25 0.25 0 K\n";
-  const float start_temp = 1500.0;   // degrees Kelvin
-  const float end_temp = 20000.0;
-  const float temp_step = 200.0;
+  const float start_temp = 1500.0f;   // degrees Kelvin
+  const float end_temp = 20000.0f;
+  const float temp_step = 200.0f;
 
   // scan over the planck curve and plot the lines
   XYColor firstXY = approx_planck( start_temp );
@@ -518,7 +523,7 @@ std::string plotCirclePDF( const point2D &center, float radius )
 {
   std::ostringstream commands;
 
-  const float handle_factor = (4.0f * (M_SQRT2 - 1.0f) / 3.0f);
+  const float handle_factor = float(4.0 * (M_SQRT2 - 1.0) / 3.0);
   const float K = radius * handle_factor;
   const point2D rx(radius,0);
   const point2D kx(K,0);
@@ -539,11 +544,12 @@ std::string plotCirclePDF( const point2D &center, float radius )
 // DEFERRED - full 128+ range is probably excessive for real world use
 // what is an appropriate limit?        So far 130 looks fine.
 const float abChartScale = 2 * 130.0f;
-  
+
+static
 void CreateABPlotXobject( PDFWriter &pdfout )
 {
   std::ostringstream commands;
-  float margin = 0.25*inch2point;
+  float margin = 0.25f*inch2point;
 
   const float coarseIncrement = 10.0f;
 
@@ -624,9 +630,9 @@ static
 XYColor xyFromICCXYZ( const icXYZNumber *xyz )
 {
     // integers, so don't have to test for NaN or Inf
-    float X = xyz->X / 65535.0;
-    float Y = xyz->Y / 65535.0;
-    float Z = xyz->Z / 65535.0;
+    float X = xyz->X / 65535.0f;
+    float Y = xyz->Y / 65535.0f;
+    float Z = xyz->Z / 65535.0f;
 
     float sum = X + Y + Z;
     if (sum <= 1e-8)
@@ -715,7 +721,7 @@ int graphChromaticityPDF( CIccProfile *pIcc, PDFWriter &pdffile )
   float top = pdffile.PageHeight();
   float right = pdffile.PageWidth();
   Rect2D bounds ( left, right, bottom, top );
-  float margin = 0.25*inch2point;
+  float margin = 0.25f*inch2point;
 
     // icSigMediaBlackPointTag ????
   auto whiteTag = pIcc->FindTag( icSigMediaWhitePointTag );
@@ -743,7 +749,7 @@ int graphChromaticityPDF( CIccProfile *pIcc, PDFWriter &pdffile )
   point2D range( right - left, 0 );
   point2D labelBase( left, top );
   point2D tickLength(0,0);
-  commands << AddGraphLabels( labelBase + range*0.5, false, tickLength, 12, "Chromaticity xy" );
+  commands << AddGraphLabels( labelBase + range*0.5, false, tickLength, 12.0f, "Chromaticity xy" );
 
 
   // gsave, color black
@@ -775,9 +781,9 @@ int graphChromaticityPDF( CIccProfile *pIcc, PDFWriter &pdffile )
         float cct = -449.0f *n3 + 3525.0f *n2 - 6823.3f *n + 5520.33f;  // second eq.
         int32_t cctI = (int32_t)cct; // we want the integer part, don't need precision
         CCTText = std::string("( ~") + std::to_string(cctI) + std::string("K)");
-#endif
       }
     }
+#endif
 
     std::string label = std::string("White") + CCTText;
     commands << plotXYZTag( whiteTag, label, basepoint,
@@ -832,11 +838,11 @@ void graph1DLUTSVG( CIccCurve *curve, const std::string &name,
   std::replace( clean_description.begin(), clean_description.end(), '\n', ' ');
   // and wrap our text in CDATA, because SVG doesn't like < > &
   std::string outdescription = "<![CDATA[" + name + " " + clean_description + "]]>";
-  svgfile.AddText( 8*0.5*inch2mm, 0.25*inch2mm, outdescription, 14, font, style, align );
+  svgfile.AddText( 8*0.5*inch2mm, 0.25f*inch2mm, outdescription, 14.0f, font, style, align );
 
   // draw axes
-  point2D basepoint( 0.5*inch2mm, 7.5*inch2mm );
-  point2D rangeX( 7.0*inch2mm, 0.0 );
+  point2D basepoint( 0.5f*inch2mm, 7.5f*inch2mm );
+  point2D rangeX( 7.0f*inch2mm, 0.0f );
   point2D tickLengthX( 0, 5 );
   DrawAxisSVG( svgfile, basepoint, rangeX, tickLengthX, "Input" );
 
@@ -846,15 +852,15 @@ void graph1DLUTSVG( CIccCurve *curve, const std::string &name,
 
   // draw the curve
   pointList points(steps+1);
-  float scale = (7.5-0.5)*inch2mm;
-  point2D base( 0.5*inch2mm, 7.5*inch2mm );
+  float scale = (7.5f-0.5f)*inch2mm;
+  point2D base( 0.5f*inch2mm, 7.5f*inch2mm );
   for (int i = 0; i <= steps; ++i ) {
     float input = i / (float)steps;
     float output = curve->Apply( input );
     if (std::isnan(output)) output = 0.0;
     if (std::isinf(output)) output = 1.0;
-    if (output > 1.0) output = 1.0;
-    if (output < 0.0) output = 0.0;
+    if (output > 1.0f) output = 1.0f;
+    if (output < 0.0f) output = 0.0f;
     points[i] = point2D( input*scale, -output*scale ) + base;
   }
   svgfile.AddPolyLine( points, false, false );
@@ -865,6 +871,7 @@ void graph1DLUTSVG( CIccCurve *curve, const std::string &name,
 
 /******************************************************************************/
 
+static
 std::vector<std::string> splitTextLines(const std::string& str)
 {
   const char newline = '\n';
@@ -905,7 +912,7 @@ void graph1DLUTPDF( CIccCurve *curve, const std::string &name,
 
   // label (may be a couple of lines)
   std::vector<std::string> lines = splitTextLines( description );
-  float labelSize = 12;     // points
+  float labelSize = 12.0f;     // points
   float leading = labelSize * 1.1f;
   float indent = 0.5f * inch2point;
   commands << "BT /F1 " << labelSize << " Tf ";
@@ -969,7 +976,7 @@ void describe1DLUT( CIccTagCurve *curve, std::string &description )
     description += "Y = X";
   } else if (size == 1) {
     icFloatNumber value0 = (*curve)[0];
-    icFloatNumber dGamma = (icFloatNumber)(value0 * 256.0);
+    icFloatNumber dGamma = (icFloatNumber)(value0 * 256.0f);
     description += "Y = X ^ " + std::to_string(dGamma);
   } else {
     description += "LookupTable[" + std::to_string(size) + "]";
@@ -1518,6 +1525,7 @@ typedef std::vector<namedLAB> namedLabList;
 
 /******************************************************************************/
 
+static
 int graphNamedColorsXYPDF( namedLabList &colorsOut, const std::string &description,
                         icFloatNumber *XYZIlluminant, PDFWriter &pdffile )
 {
@@ -1528,7 +1536,7 @@ int graphNamedColorsXYPDF( namedLabList &colorsOut, const std::string &descripti
   const float top = pdffile.PageHeight();
   const float right = pdffile.PageWidth();
   Rect2D bounds ( left, right, bottom, top );
-  const float margin = 0.25*inch2point;
+  const float margin = 0.25f*inch2point;
   const point2D basepoint( left+margin, bottom+margin );
   const point2D rangeX( right-left-2*margin, 0 );
   const point2D rangeY( 0, top-bottom-2*margin );
@@ -1558,7 +1566,7 @@ int graphNamedColorsXYPDF( namedLabList &colorsOut, const std::string &descripti
     icLAB[1] = sample.a;
     icLAB[2] = sample.b;
     icLabtoXYZ( xyzOut, icLAB, XYZIlluminant );
-    XYColor theXY = xyFromICCXYZ( xyzOut );
+    XYColor theXY = xyFromICCXYZFloat( xyzOut );
   
     point2D plotCenter = basepoint + scaling * point2D( theXY.x, theXY.y );
     commands << plotSquarePDF( plotCenter, markSize);
@@ -1578,6 +1586,7 @@ int graphNamedColorsXYPDF( namedLabList &colorsOut, const std::string &descripti
 
 /******************************************************************************/
 
+static
 int graphNamedColorsABPDF( namedLabList &colorsOut, const std::string &description,
                         icFloatNumber * /*XYZIlluminant*/, PDFWriter &pdffile )
 {
@@ -1634,6 +1643,7 @@ int graphNamedColorsABPDF( namedLabList &colorsOut, const std::string &descripti
 
 /******************************************************************************/
 
+static
 int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description,
                         icFloatNumber *XYZIlluminant, PDFWriter &pdffile )
 {
@@ -1646,6 +1656,7 @@ int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description
 
 // TODO - CIECAM16 plot as well?
     //#include "IccCAM.h" -- is CIECAM02
+    // would have to add CAM16 code
     
   return outputObjects;
 }

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -228,7 +228,11 @@ For repeatable agent-assisted work, use
    - Linux CTest count in `.github/workflows/ci-iccdev-tool-tests.yml`.
    - Windows profile parse count in `Build/Cmake/Testing/CMakeLists.txt`.
    - JSON profile parse count in `.github/workflows/ci-json-roundtrip.yml`.
-   - WASM expected ICC count in `.github/workflows/ci-tool-tests.yml` when
+     Keep these in sync with `Testing/CreateAllProfiles.sh` and
+     `Testing/CreateAllProfiles.bat`.
+   - WASM expected ICC count in `Build/Cmake/wasm-package/regression.js`,
+     `.github/workflows/ci-pr-wasm.yml`, `.github/workflows/ci-pr-action.yml`,
+     and `.github/workflows/ci-latest-release.yml` when
      `Testing/CreateAllProfiles.sh` changes the generated-profile set.
 4. Validate locally with CMake configure, build, `ctest -N --no-tests=error`,
    `ctest --output-on-failure --no-tests=error`, and `git diff --check`.


### PR DESCRIPTION
Also add a v4 named profile to our test files, because we didn't have one - and most named profiles I found in the wild are bad/corrupt.

## Checklist

- [x] Signed all Commits in PR
- [x] Performed a Rebase on master
- [x] Confirmed a Linear PR Commit History
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Updated documentation for user-visible behavior changes
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
