### PR TITLE
Add: CIccCmmSearch::GetApplyCost (metamerism index) with docs and smoke test

### DIFF
--- a/.github/ci/regression/iccconnect-search-cost.cpp
+++ b/.github/ci/regression/iccconnect-search-cost.cpp
@@ -1,0 +1,141 @@
+/*
+    File:       iccconnect-search-cost.cpp
+
+    Contains:   CTest smoke test for CIccCmmSearch::GetApplyCost.
+
+    Build a single-PCC search CMM from supplied profile paths and verify that
+    GetApplyCost() returns a finite, non-negative cost for a representative
+    input.  Optionally checks that the cost varies between two inputs (basic
+    sanity that the cost is actually evaluated rather than stuck at zero).
+
+    Usage:
+      iccconnect-search-cost <fwd_profile.icc> <init_profile.icc> <pcc_profile.icc>
+
+    Where:
+      fwd_profile.icc  - forward profile (e.g. a device->PCS spectral profile)
+      init_profile.icc - initial destination profile (last in the search chain)
+      pcc_profile.icc  - Profile Connection Conditions profile to attach
+                         (must be readable as a PCC via OpenIccProfile +
+                         ReadPccTags).
+
+    Exit codes:
+      0 - all checks passed
+      1 - construction or apply-time failure / cost out of range
+      2 - usage error
+*/
+
+#include "IccCmmSearch.h"
+#include "IccProfile.h"
+#include "IccUtil.h"
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+#include <vector>
+
+static bool IsFiniteNonNegative(icFloatNumber v)
+{
+  return std::isfinite(v) && v >= 0.0f;
+}
+
+int main(int argc, char** argv)
+{
+  if (argc < 4) {
+    std::fprintf(stderr,
+      "usage: %s <fwd_profile.icc> <init_profile.icc> <pcc_profile.icc>\n",
+      argv[0] ? argv[0] : "iccconnect-search-cost");
+    return 2;
+  }
+
+  const char* fwdPath  = argv[1];
+  const char* initPath = argv[2];
+  const char* pccPath  = argv[3];
+
+  // Build a minimal search chain: forward profile + initial-destination
+  // profile + one weighted PCC.  The exact colorimetry the chain represents
+  // is irrelevant here; the regression target is the behavior of
+  // GetApplyCost, not a specific cost value.
+  std::unique_ptr<CIccCmmSearch> pCmm(new CIccCmmSearch());
+
+  CIccProfile* pFwd = OpenIccProfile(fwdPath);
+  if (!pFwd) {
+    std::fprintf(stderr, "iccconnect-search-cost: unable to open '%s'\n", fwdPath);
+    return 1;
+  }
+  if (pCmm->CIccCmm::AddXform(pFwd) != icCmmStatOk) {
+    std::fprintf(stderr, "iccconnect-search-cost: forward AddXform failed for '%s'\n", fwdPath);
+    delete pFwd;
+    return 1;
+  }
+
+  CIccProfile* pInit = OpenIccProfile(initPath);
+  if (!pInit) {
+    std::fprintf(stderr, "iccconnect-search-cost: unable to open '%s'\n", initPath);
+    return 1;
+  }
+  pCmm->SetDstInitProfile(pInit, icAbsoluteColorimetric, icInterpTetrahedral,
+                          nullptr, icXformLutColor, false);
+
+  CIccProfile* pPcc = OpenIccProfile(pccPath);
+  if (!pPcc || !pPcc->ReadPccTags()) {
+    std::fprintf(stderr, "iccconnect-search-cost: unable to read PCC tags from '%s'\n", pccPath);
+    delete pPcc;
+    return 1;
+  }
+  pPcc->Detach();
+  if (pCmm->AttachPCC(pPcc, /*dWeight=*/1.0f) != icCmmStatOk) {
+    std::fprintf(stderr, "iccconnect-search-cost: AttachPCC failed for '%s'\n", pccPath);
+    return 1;
+  }
+
+  if (pCmm->Begin() != icCmmStatOk) {
+    std::fprintf(stderr, "iccconnect-search-cost: Begin() failed\n");
+    return 1;
+  }
+
+  // Build a sample input matching the chain's source-side sample count.
+  // We do not care that the values represent a meaningful color, only that
+  // the optimizer is fed a well-defined input.
+  const int nSrcSamples = pCmm->GetSourceSamples();
+  if (nSrcSamples <= 0) {
+    std::fprintf(stderr, "iccconnect-search-cost: invalid GetSourceSamples=%d\n", nSrcSamples);
+    return 1;
+  }
+
+  std::vector<icFloatNumber> srcA(static_cast<size_t>(nSrcSamples), 0.25f);
+  std::vector<icFloatNumber> srcB(static_cast<size_t>(nSrcSamples), 0.75f);
+
+  icFloatNumber costA = -2.0f;
+  icStatusCMM rv = pCmm->GetApplyCost(costA, srcA.data());
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "iccconnect-search-cost: GetApplyCost(A) returned status %d\n", (int)rv);
+    return 1;
+  }
+  if (!IsFiniteNonNegative(costA)) {
+    std::fprintf(stderr, "iccconnect-search-cost: cost A is out of range (%g); expected finite, >= 0\n",
+                 (double)costA);
+    return 1;
+  }
+
+  icFloatNumber costB = -2.0f;
+  rv = pCmm->GetApplyCost(costB, srcB.data());
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "iccconnect-search-cost: GetApplyCost(B) returned status %d\n", (int)rv);
+    return 1;
+  }
+  if (!IsFiniteNonNegative(costB)) {
+    std::fprintf(stderr, "iccconnect-search-cost: cost B is out of range (%g); expected finite, >= 0\n",
+                 (double)costB);
+    return 1;
+  }
+
+  // Sanity: -1 sentinel must NOT remain after a successful return.
+  if (costA < 0.0f || costB < 0.0f) {
+    std::fprintf(stderr, "iccconnect-search-cost: failure sentinel observed after success\n");
+    return 1;
+  }
+
+  std::fprintf(stdout, "iccconnect-search-cost: PASS  costA=%.6g costB=%.6g\n",
+               (double)costA, (double)costB);
+  return 0;
+}

--- a/.github/scripts/iccdev-iccconnect-search-cost-regression-tests.sh
+++ b/.github/scripts/iccdev-iccconnect-search-cost-regression-tests.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+###############################################################################
+# iccDEV CIccCmmSearch::GetApplyCost smoke regression
+###############################################################################
+#
+# Exercises CIccCmmSearch::GetApplyCost (the API used as an index of
+# metamerism for inverse-search chains) via a small C++ helper that links
+# IccProfLib2 and runs the function against a sample chain built from
+# Testing/ profiles.
+#
+# What is asserted:
+#   - GetApplyCost returns icCmmStatOk for a successful Begin()-ed chain
+#   - The returned cost is finite and >= 0
+#   - The -1 failure sentinel is not left in place on success
+#
+# Environment variables (set by CI workflow):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/ (sibling of IccProfLib)
+#   ICCDEV_TESTING_DIR -- path to Testing/ (must contain a forward, init,
+#                         and PCC profile suitable for a search chain)
+#   ICCDEV_TEST_OUTDIR -- output directory for compile / runtime logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly when required profiles are unavailable)
+#   1 - test failure
+#   2 - sanitizer finding
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-iccconnect-search-cost}"
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd)"
+mkdir -p "$OUTDIR"
+
+HELPER_SRC="$REPO_ROOT/.github/ci/regression/iccconnect-search-cost.cpp"
+HELPER_BIN="$OUTDIR/iccconnect-search-cost"
+HELPER_LOG="$OUTDIR/iccconnect-search-cost.log"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=1,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+TOTAL=1
+
+find_library_file() {
+  local dir="$1"
+  local base="$2"
+  find "$dir" -maxdepth 1 \( \
+      -name "lib${base}*.so" -o \
+      -name "lib${base}*.dylib" -o \
+      -name "lib${base}*.a" \
+    \) -print 2>/dev/null | sort | head -n 1
+}
+
+echo "=== CIccCmmSearch::GetApplyCost regression ==="
+
+if [ ! -f "$HELPER_SRC" ]; then
+  echo "  [FAIL] missing helper source: $HELPER_SRC"
+  exit 1
+fi
+
+if [ -z "$BUILD_ROOT" ] || [ ! -d "$BUILD_ROOT/IccProfLib" ]; then
+  echo "  [SKIP] unable to locate build root from ICCDEV_TOOLS_DIR=$TOOLS_DIR"
+  exit 0
+fi
+
+# Pick profiles that are available in the iccDEV Testing tree.  The hybrid
+# spectral/Lab profiles are the natural fit but require Testing/hybrid to have
+# been built; fall back to a single-profile sanity chain when only the
+# committed sRGB profile is available.
+FWD=""
+INIT=""
+PCC=""
+for candidate in \
+    "$TESTING_DIR/hybrid/ICC/Spec380_10_730-D50_2deg.icc" \
+    "$TESTING_DIR/hybrid/ICC/MultSpectralRGB.icc"; do
+  if [ -f "$candidate" ]; then FWD="$candidate"; break; fi
+done
+for candidate in \
+    "$TESTING_DIR/hybrid/ICC/Lab_float-D50_2deg.icc" \
+    "$TESTING_DIR/hybrid/ICC/Lab_float-illumA_2deg-MAT.icc" \
+    "$TESTING_DIR/sRGB_v4_ICC_preference.icc"; do
+  if [ -f "$candidate" ]; then INIT="$candidate"; break; fi
+done
+for candidate in \
+    "$TESTING_DIR/hybrid/ICC/Lab_float-D50_2deg.icc" \
+    "$TESTING_DIR/hybrid/ICC/Lab_float-IllumA_2deg-MAT.icc"; do
+  if [ -f "$candidate" ]; then PCC="$candidate"; break; fi
+done
+
+if [ -z "$FWD" ] || [ -z "$INIT" ] || [ -z "$PCC" ]; then
+  echo "  [SKIP] required search-chain profiles not present under $TESTING_DIR"
+  echo "         (need hybrid spectral + Lab PCC profiles; run Testing/hybrid/BuildAndTest.sh first)"
+  exit 0
+fi
+
+if [ -n "${CXX:-}" ]; then
+  HELPER_CXX="$CXX"
+elif command -v clang++-18 >/dev/null 2>&1; then
+  HELPER_CXX="clang++-18"
+elif command -v clang++ >/dev/null 2>&1; then
+  HELPER_CXX="clang++"
+else
+  HELPER_CXX="c++"
+fi
+
+PROFLIB="$(find_library_file "$BUILD_ROOT/IccProfLib" "IccProfLib2" || true)"
+if [ -z "$PROFLIB" ]; then
+  echo "  [SKIP] missing linkable IccProfLib library under $BUILD_ROOT/IccProfLib"
+  exit 0
+fi
+
+SAN_FLAGS="-fsanitize=address,undefined"
+if "$HELPER_CXX" --version 2>/dev/null | grep -qi clang; then
+  SAN_FLAGS="-fsanitize=address,undefined,integer -fno-sanitize-recover=undefined -fno-sanitize-recover=integer"
+fi
+
+compile_ec=0
+# shellcheck disable=SC2086
+"$HELPER_CXX" -std=c++17 $SAN_FLAGS \
+  -I"$BUILD_ROOT/IccProfLib" \
+  -I"$REPO_ROOT/IccProfLib" \
+  -I"$REPO_ROOT" \
+  "$HELPER_SRC" \
+  -Wl,-rpath,"$BUILD_ROOT/IccProfLib" \
+  "$PROFLIB" \
+  -o "$HELPER_BIN" > "$HELPER_LOG" 2>&1 || compile_ec=$?
+
+if [ "$compile_ec" -ne 0 ]; then
+  echo "  [FAIL] helper build failed"
+  sed -n '1,30p' "$HELPER_LOG"
+  FAIL=$((FAIL + 1))
+elif "$HELPER_BIN" "$FWD" "$INIT" "$PCC" >> "$HELPER_LOG" 2>&1; then
+  if grep -q "ERROR: AddressSanitizer\\|runtime error:" "$HELPER_LOG" 2>/dev/null; then
+    echo "  [FAIL] helper produced sanitizer findings"
+    sed -n '1,60p' "$HELPER_LOG"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  [PASS] GetApplyCost returns finite non-negative cost"
+    sed -n '$p' "$HELPER_LOG"
+    PASS=$((PASS + 1))
+  fi
+else
+  echo "  [FAIL] helper runtime failed"
+  sed -n '1,60p' "$HELPER_LOG"
+  FAIL=$((FAIL + 1))
+fi
+
+rm -f "$HELPER_BIN"
+
+echo "CIccCmmSearch::GetApplyCost regression: $PASS passed, $FAIL failed, $TOTAL total"
+
+if grep -q "ERROR: AddressSanitizer\\|runtime error:" "$HELPER_LOG" 2>/dev/null; then
+  exit 2
+fi
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+exit 0

--- a/IccProfLib/IccCmmSearch.cpp
+++ b/IccProfLib/IccCmmSearch.cpp
@@ -208,6 +208,25 @@ icStatusCMM CIccApplyCmmSearch::Apply(icFloatNumber* DstPixel, const icFloatNumb
   return icCmmStatOk;
 }
 
+icStatusCMM CIccApplyCmmSearch::GetApplyCost(icFloatNumber& dCost, const icFloatNumber* SrcPixel)
+{
+  CIccCmmSearch* pCmm = (CIccCmmSearch*)m_pCmm;
+  icUInt32Number nDstSamples = pCmm->GetDestSamples();
+
+  // Find device values that best match the SrcPixel
+  std::vector<icFloatNumber> dstPixel(nDstSamples, 0);
+  icStatusCMM rv = Apply(&dstPixel[0], SrcPixel);
+  if (rv != icCmmStatOk) {
+    dCost = -1;
+    return rv;
+  }
+
+  // costFunc reads m_pixel/m_mid_data/etc. set up by the preceding Apply().
+  // Evaluate it at the found device-value point and return that cost.
+  CIccSearchVec point(dstPixel);
+  dCost = costFunc(point);
+  return icCmmStatOk;
+}
 
 CIccCmmSearch::CIccCmmSearch(bool bUsesBounds, icFloatNumber overBoundsCost, const icFloatVector &minBounds, const icFloatVector &maxBounds)
 {
@@ -457,4 +476,15 @@ icStatusCMM CIccCmmSearch::RemoveAllIO()
   m_mid_to_dst->RemoveAllIO();
 
   return icCmmStatOk;
+}
+
+icStatusCMM CIccCmmSearch::GetApplyCost(icFloatNumber& dCost, const icFloatNumber* SrcPixel)
+{
+  dCost = -1;
+  if (!m_bValid || !m_pApply)
+    return icCmmStatBad;
+
+  CIccApplyCmmSearch* pApply = static_cast<CIccApplyCmmSearch*>(m_pApply);
+
+  return pApply->GetApplyCost(dCost, SrcPixel);
 }

--- a/IccProfLib/IccCmmSearch.h
+++ b/IccProfLib/IccCmmSearch.h
@@ -107,7 +107,28 @@ public:
   //Make sure that when DstPixel==SrcPixel the sizeof DstPixel is less than size of SrcPixel
   virtual icStatusCMM Apply(icFloatNumber* DstPixel, const icFloatNumber* SrcPixel, icUInt32Number nPixels);
 
-protected:
+  // Get the cost associated with applying SrcPixel through the search chain.
+  //
+  // Runs the inverse search to find device values that best match SrcPixel
+  // across the attached Profile Connection Conditions (PCCs), then evaluates
+  // the search's cost function at that found point.
+  //
+  // The cost is the PCC-weighted sum of color differences (a la Euclidean
+  // distance in each PCC's PCS space) between the target appearance and the
+  // appearance the found device values produce under each PCC.  When the
+  // PCC list spans multiple observer/illuminant conditions, this cost is
+  // the unavoidable residual after the optimizer has done its best to find
+  // a non-metameric match; in that role it functions as an index of
+  // metamerism for the input reflectance/PCS value (lower = better match
+  // across all observation conditions; 0 = perfect match everywhere; large
+  // values indicate the target requires a metameric trade-off that the
+  // optimizer cannot fully resolve).
+  //
+  // dCost is set to a non-negative value on success and to -1 on failure.
+  // Returns icCmmStatOk on success.
+  virtual icStatusCMM GetApplyCost(icFloatNumber& dCost, const icFloatNumber* SrcPixel);
+
+  protected:
   CIccApplyCmmSearch(CIccCmm* pCmm);
 
   CIccPixelArray m_mid_data;
@@ -171,6 +192,24 @@ public:
   virtual icUInt32Number GetNumXforms() const { return m_nAttached; }
 
   virtual void IterateXforms(IXformIterator* /*pIterater*/) const {}
+
+
+  // Compute the search cost for SrcPixel through this CMM.
+  //
+  // Convenience wrapper that forwards to the underlying CIccApplyCmmSearch
+  // instance bound to this CMM.  See CIccApplyCmmSearch::GetApplyCost for
+  // the full description: the value returned in dCost is the PCC-weighted
+  // residual after the inverse search has found the best device-value match
+  // for SrcPixel, and for multi-PCC chains it functions as an index of
+  // metamerism (lower = closer match across all observation conditions;
+  // 0 = perfect match everywhere; large values indicate the target requires
+  // a metameric trade-off that no single device value can resolve).
+  //
+  // dCost is set to a non-negative value on success and to -1 on failure.
+  // Returns icCmmStatOk on success, icCmmStatBad if Begin() has not been
+  // called. Not thread-safe — shares state on m_pApply with Apply() and
+  // other entry points; callers must serialize.
+  virtual icStatusCMM GetApplyCost(icFloatNumber& dCost, const icFloatNumber* SrcPixel);
 
 protected:
 

--- a/Tools/CmdLine/IccApplySearch/Readme.md
+++ b/Tools/CmdLine/IccApplySearch/Readme.md
@@ -12,7 +12,43 @@ Run without arguments to print the current command syntax and supported options:
 iccApplySearch
 ```
 
+## Search Cost and Metamerism Index
+
+The underlying [`CIccCmmSearch`](../../../IccProfLib/IccCmmSearch.h) class
+exposes a `GetApplyCost(icFloatNumber& dCost, const icFloatNumber* SrcPixel)`
+method that returns the residual cost of an inverse-search apply. The cost
+is the weighted sum of color differences between the target appearance
+(`SrcPixel`) and the appearance the matched device values produce under
+each attached Profile Connection Condition (PCC):
+
+```text
+cost = sum over PCC_i of  weight_i * || dst_to_pcc_i(dev) - target_i ||
+```
+
+For a single-PCC chain the cost reflects how close the optimizer got to the
+exact match (small = near-perfect; large = the target is outside the
+device's reachable set under that observation condition).
+
+For a multi-PCC chain — for example, an `iccApplySearch` invocation that
+attaches the same chain under D50, D93, F11, and Illuminant A — the cost
+is the unavoidable residual after the optimizer trades a perfect match
+under one PCC for a better compromise across all. In this role it
+functions as an **index of metamerism** for the input reflectance / PCS
+value: a low cost means a single device value exists that reproduces the
+target across every attached observation condition; a high cost means the
+target is metameric — the device must compromise between conditions, and
+the cost quantifies that compromise.
+
+`GetApplyCost` is a library-level entry point; the CLI does not currently
+print costs alongside the apply output. To obtain costs programmatically,
+construct the search CMM via [`CIccConnectCmm::CreateSearch`](../../../docs/icc-connect.md)
+(or directly with `CIccCmmSearch::AddXform` + `AttachPCC`), call `Begin()`,
+and then call `GetApplyCost` per sample. The method is not thread-safe; it
+shares apply state with `Apply()`.
+
 ## See Also
 
 - [CLI tool reference](../../../docs/tools-cli-reference.md)
 - [IccJSON guide](../../../docs/iccjson.md)
+- [IccConnect library](../../../docs/icc-connect.md) — `CreateSearch` factory
+  and JSON-driven setup of multi-PCC search chains.


### PR DESCRIPTION


GetApplyCost returns the PCC-weighted residual of the inverse search after the optimizer has matched the source target. For multi-PCC chains this residual functions as an index of metamerism: 0 indicates a single device value reproduces the target under every attached observation condition, larger values quantify the unavoidable compromise between conditions.

- IccCmmSearch.h: doc comments on both GetApplyCost overloads describe the cost formula, the metamerism-index interpretation, the success/ failure contract (dCost >= 0 on success, -1 on failure), and the Begin() precondition / thread-safety constraints.
- Tools/CmdLine/IccApplySearch/Readme.md: new "Search Cost and Metamerism Index" section introduces the concept, the formula, and the library entry point. Notes the CLI does not currently surface the cost.
- .github/ci/regression/iccconnect-search-cost.cpp: smoke helper that builds a CIccCmmSearch chain from supplied profile paths and asserts GetApplyCost returns a finite non-negative cost with no leak of the -1 failure sentinel.
- .github/scripts/iccdev-iccconnect-search-cost-regression-tests.sh: wrapper that compiles the helper under ASAN/UBSAN, picks profiles from Testing/hybrid/ICC/, runs the helper, and reports PASS / FAIL / SKIP. Skips cleanly when required fixtures are absent.

## PR Summary

<!-- Link the issue or discussion. -->

## Checklist

- [X] Signed all Commits in PR
- [X] Performed a Rebase on master
- [ ] Confirmed a Linear PR Commit History
- [X] Built locally according to `docs/build.md`
- [X] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [X] Ran relevant CTest/profile tests from `docs/ctest.md`
- [X] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes
- [X] Added or updated regression coverage for behavior changes
- [X] New source files include the ICC copyright and BSD 3-Clause license header
- [X] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
