### PR TITLE
Fix: Bisect 1f0a9dd CIccMpeXmlCalculator::Flatten()

### DIFF
--- a/.github/instructions/build-system.instructions.md
+++ b/.github/instructions/build-system.instructions.md
@@ -32,20 +32,66 @@ User-facing build details live in `docs/build.md`.
 
 | Option | Default | Purpose |
 |--------|---------|---------|
-| `ENABLE_SANITIZERS` | OFF | ASan + UBSan + IntegerSan combined |
+| `ENABLE_SANITIZERS` | OFF | ASan + UBSan + IntegerSan + float sanitizer combined |
 | `ENABLE_ASAN` | OFF | AddressSanitizer only |
 | `ENABLE_UBSAN` | OFF | UndefinedBehaviorSanitizer only |
 | `ENABLE_INTEGER_SANITIZER` | OFF | IntegerSanitizer for unsigned overflow |
+| `ENABLE_FLOAT_SANITIZER` | OFF | `float-divide-by-zero,float-cast-overflow` |
 | `ENABLE_TSAN` | OFF | ThreadSanitizer |
 | `ENABLE_MSAN` | OFF | MemorySanitizer (Clang only) |
 | `ENABLE_LSAN` | OFF | LeakSanitizer standalone |
+| `ENABLE_COVERAGE` | OFF | Clang source coverage or GCC gcov |
+| `ENABLE_PROFILING` | OFF | gprof/perf `-pg` profiling |
 
 `-fsanitize=undefined` does not catch unsigned overflow or float division by
 zero. For numeric bug hunting, use IntegerSanitizer plus
 `float-divide-by-zero,float-cast-overflow`.
 
-Before changing sanitizer flags in an existing tree, delete
-`Build/CMakeCache.txt` and `Build/CMakeFiles/`.
+Before changing compiler, sanitizer, coverage, or profiling flags in an existing
+tree, delete `Build/CMakeCache.txt` and `Build/CMakeFiles/`. Use `CC=clang`
+and `CXX=clang++` for environment compiler selection; `C=clang` is ignored by
+CMake and can leave a stale `/usr/bin/cc` cache entry after a failed configure.
+
+## Canonical Linux Instrumentation Configure Lines
+
+Run these from the repository root. They intentionally use CMake options instead
+of hand-written sanitizer flags so compile and link flags stay synchronized.
+
+```bash
+# ASan only
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_ASAN=ON
+
+# UBSan + IntSan + float checks, no ASan
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_UBSAN=ON -DENABLE_INTEGER_SANITIZER=ON -DENABLE_FLOAT_SANITIZER=ON
+
+# Security repro default: ASan + UBSan + IntSan + float checks, no coverage
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_ASAN=ON -DENABLE_UBSAN=ON -DENABLE_INTEGER_SANITIZER=ON -DENABLE_FLOAT_SANITIZER=ON
+
+# Equivalent combined security build
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_SANITIZERS=ON
+
+# ThreadSanitizer only; do not combine with ASan, LSan, fuzzing, or ENABLE_SANITIZERS
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_TSAN=ON
+
+# MemorySanitizer only; Clang-only and incompatible with other sanitizers here
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_MSAN=ON
+
+# Source coverage; keep separate from sanitizer reproduction attempts
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_COVERAGE=ON
+
+# gprof/perf profiling; keep separate from sanitizer reproduction attempts
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_PROFILING=ON
+```
+
+Build after configure with:
+
+```bash
+make -j"$(nproc)"
+```
+
+For sanitizer bug reproduction, do not add `-DENABLE_COVERAGE=ON` or
+`-fprofile-instr-generate -fcoverage-mapping`; coverage instrumentation can
+change optimizer and sanitizer behavior enough to mask a finding.
 
 TSan conflicts with ASan, LSan, fuzzing, and `ENABLE_SANITIZERS`. MSan conflicts
 with ASan, TSan, LSan, fuzzing, and `ENABLE_SANITIZERS`. CMake should reject

--- a/.github/instructions/build-system.instructions.md
+++ b/.github/instructions/build-system.instructions.md
@@ -89,6 +89,26 @@ Build after configure with:
 make -j"$(nproc)"
 ```
 
+Preset equivalents live in `Build/Cmake/CMakePresets.json`:
+
+| Preset | Purpose |
+|--------|---------|
+| `linux-clang-asan` | ASan-only Debug tool build |
+| `linux-clang-ubsan` | UBSan-only Debug tool build |
+| `linux-clang-ubsan-int-float` | UBSan + IntSan + float checks, no ASan |
+| `linux-clang-sanitizers` | ASan + UBSan + IntSan + float checks |
+| `linux-clang-tsan` | TSan-only Debug tool build |
+| `linux-clang-msan` | MSan-only Debug tool build |
+| `linux-clang-coverage` | Clang source coverage |
+| `linux-clang-profiling` | gprof/perf `-pg` profiling |
+
+Example:
+
+```bash
+cmake --preset linux-clang-sanitizers -S Build/Cmake -B out/linux-clang-sanitizers
+cmake --build out/linux-clang-sanitizers -j"$(nproc)"
+```
+
 For sanitizer bug reproduction, do not add `-DENABLE_COVERAGE=ON` or
 `-fprofile-instr-generate -fcoverage-mapping`; coverage instrumentation can
 change optimizer and sanitizer behavior enough to mask a finding.

--- a/.github/prompts/add-new-tool.prompt.md
+++ b/.github/prompts/add-new-tool.prompt.md
@@ -101,7 +101,8 @@ LD_LIBRARY_PATH=IccProfLib:IccXML \
   Tools/IccNewTool/iccNewTool ../Testing/Display/sRGB_D65_MAT.icc
 
 # Test with sanitizers
-cmake Cmake -DCMAKE_CXX_COMPILER=clang++ -DENABLE_SANITIZERS=ON
+rm -rf CMakeCache.txt CMakeFiles/
+CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_SANITIZERS=ON
 make -j"$(nproc)"
 ASAN_OPTIONS=halt_on_error=0,detect_leaks=0 \
 LD_LIBRARY_PATH=IccProfLib:IccXML \

--- a/.github/prompts/bisect-regression.prompt.md
+++ b/.github/prompts/bisect-regression.prompt.md
@@ -18,11 +18,14 @@ ASAN findings, or UBSAN findings that were not present before.
 
 ```bash
 cd Build
-rm -f CMakeCache.txt
-CC=clang CXX=clang++ \
-  CXXFLAGS="-fsanitize=address,undefined,integer -fno-omit-frame-pointer -g -O1" \
-  LDFLAGS="-fsanitize=address,undefined,integer" \
-  cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON
+rm -rf CMakeCache.txt CMakeFiles/
+CC=clang CXX=clang++ cmake Cmake \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DENABLE_TOOLS=ON \
+  -DENABLE_ASAN=ON \
+  -DENABLE_UBSAN=ON \
+  -DENABLE_INTEGER_SANITIZER=ON \
+  -DENABLE_FLOAT_SANITIZER=ON
 make -j"$(nproc)"
 
 # CRITICAL: Verify ASAN is linked (must be > 0)
@@ -38,8 +41,9 @@ cd ../Testing/<test_dir>
 
 ### cmake cache gotcha
 
-cmake retains `ENABLE_SANITIZERS=OFF` from prior builds silently.
-Always delete `CMakeCache.txt` and verify `nm | grep __asan > 0`.
+cmake retains compiler and instrumentation settings from prior builds silently.
+Always delete `CMakeCache.txt` plus `CMakeFiles/`, use `CC=clang` not
+`C=clang`, and verify `nm | grep __asan > 0`.
 Also: `Build/Cmake/` is git-tracked; `rm -rf Build/` requires
 `git checkout -- Build/` to restore cmake sources.
 

--- a/.github/prompts/build-and-test.prompt.md
+++ b/.github/prompts/build-and-test.prompt.md
@@ -14,10 +14,13 @@ make -j"$(nproc)"
 
 ```bash
 cd Build && rm -rf CMakeCache.txt CMakeFiles/
-CC=clang CXX=clang++ \
-  CXXFLAGS="-fsanitize=address,undefined,integer -fno-omit-frame-pointer -g -O1" \
-  LDFLAGS="-fsanitize=address,undefined,integer" \
-  cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON
+CC=clang CXX=clang++ cmake Cmake \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DENABLE_TOOLS=ON \
+  -DENABLE_ASAN=ON \
+  -DENABLE_UBSAN=ON \
+  -DENABLE_INTEGER_SANITIZER=ON \
+  -DENABLE_FLOAT_SANITIZER=ON
 make -j"$(nproc)"
 ```
 
@@ -26,7 +29,8 @@ make -j"$(nproc)"
 The `integer` group adds: `unsigned-integer-overflow`,
 `implicit-unsigned-integer-truncation`, `implicit-signed-integer-truncation`,
 `implicit-integer-sign-change`. Issue #769 is ONLY detectable with this flag.
-MSVC does not support `-fsanitize=integer` -- Clang only.
+MSVC does not support `-fsanitize=integer` -- Clang only. Do not enable coverage
+for sanitizer reproduction because coverage instrumentation can mask findings.
 
 Run with sanitizers:
 ```bash
@@ -79,12 +83,15 @@ Testing/RunTests.sh
 | Option | Purpose |
 |--------|---------|
 | `-DENABLE_TESTS=ON` | Build test targets |
-| `-DENABLE_SANITIZERS=ON` | ASan + UBSan + IntSan |
+| `-DENABLE_SANITIZERS=ON` | ASan + UBSan + IntSan + float checks |
 | `-DENABLE_ASAN=ON` | AddressSanitizer only |
 | `-DENABLE_UBSAN=ON` | UBSan only |
 | `-DENABLE_INTEGER_SANITIZER=ON` | IntegerSanitizer (unsigned overflow, Clang only) |
+| `-DENABLE_FLOAT_SANITIZER=ON` | `float-divide-by-zero,float-cast-overflow` |
 | `-DENABLE_TSAN=ON` | ThreadSanitizer (conflicts with ASan) |
+| `-DENABLE_MSAN=ON` | MemorySanitizer (Clang only, conflicts with other sanitizers) |
 | `-DENABLE_COVERAGE=ON` | LLVM source-based coverage |
+| `-DENABLE_PROFILING=ON` | gprof/perf `-pg` profiling |
 | `-DENABLE_FUZZING=ON` | LibFuzzer harnesses |
 | `-DENABLE_ICCXML=ON` | IccXML library |
 
@@ -113,7 +120,8 @@ See `ports/iccdev/portfile.cmake` for the full build configuration.
 ## Coverage Report
 
 ```bash
-cmake Cmake -DCMAKE_CXX_COMPILER=clang++ -DENABLE_COVERAGE=ON
+cd Build && rm -rf CMakeCache.txt CMakeFiles/
+CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_COVERAGE=ON
 make -j"$(nproc)"
 LLVM_PROFILE_FILE=iccdev_%m.profraw Testing/RunTests.sh
 llvm-profdata merge -sparse *.profraw -o merged.profdata

--- a/.github/prompts/code-review-hunting.prompt.md
+++ b/.github/prompts/code-review-hunting.prompt.md
@@ -31,10 +31,13 @@ produce silent NaN corruption (DeltaE=0) instead of UBSAN output.
 Build with float sanitizer:
 ```bash
 cd Build && rm -rf CMakeCache.txt CMakeFiles/
-CC=clang CXX=clang++ \
-  CXXFLAGS="-fsanitize=address,undefined,integer,float-divide-by-zero -fno-omit-frame-pointer -g -O1" \
-  LDFLAGS="-fsanitize=address,undefined,integer,float-divide-by-zero" \
-  cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON
+CC=clang CXX=clang++ cmake Cmake \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DENABLE_TOOLS=ON \
+  -DENABLE_ASAN=ON \
+  -DENABLE_UBSAN=ON \
+  -DENABLE_INTEGER_SANITIZER=ON \
+  -DENABLE_FLOAT_SANITIZER=ON
 make -j"$(nproc)"
 ```
 

--- a/.github/prompts/reproduce-security-issue.prompt.md
+++ b/.github/prompts/reproduce-security-issue.prompt.md
@@ -21,10 +21,13 @@ gh api "repos/InternationalColorConsortium/iccDEV/security-advisories/GHSA-xxxx-
 
 ```bash
 cd Build && rm -rf CMakeCache.txt CMakeFiles/
-CC=clang CXX=clang++ \
-  CXXFLAGS="-fsanitize=address,undefined,integer -fno-omit-frame-pointer -g -O1" \
-  LDFLAGS="-fsanitize=address,undefined,integer" \
-  cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON
+CC=clang CXX=clang++ cmake Cmake \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DENABLE_TOOLS=ON \
+  -DENABLE_ASAN=ON \
+  -DENABLE_UBSAN=ON \
+  -DENABLE_INTEGER_SANITIZER=ON \
+  -DENABLE_FLOAT_SANITIZER=ON
 make -j"$(nproc)"
 
 # CRITICAL: Verify ASAN is linked (must be > 0)
@@ -33,7 +36,9 @@ nm Tools/IccDumpProfile/iccDumpProfile | grep -c __asan
 
 **Note**: `-fsanitize=integer` detects unsigned integer overflow (wrapping),
 which is well-defined per C/C++ standard and NOT caught by `undefined` alone.
-Issue #769 required this flag. MSVC does not support it.
+Issue #769 required this flag. MSVC does not support it. Do not add coverage
+flags or `-DENABLE_COVERAGE=ON` when reproducing sanitizer findings; coverage
+instrumentation can mask a bug.
 
 ## Step 3: Reproduce
 

--- a/.github/skills/sanitizer-repro/SKILL.md
+++ b/.github/skills/sanitizer-repro/SKILL.md
@@ -36,13 +36,14 @@ manual findings involving iccDEV command-line tools.
 
 ```bash
 cd Build && rm -rf CMakeCache.txt CMakeFiles/
-CC=clang CXX=clang++ CXXFLAGS="-fsanitize=address,undefined,integer -fno-omit-frame-pointer -g -O1" LDFLAGS="-fsanitize=address,undefined,integer" cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON
+CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_ASAN=ON -DENABLE_UBSAN=ON -DENABLE_INTEGER_SANITIZER=ON -DENABLE_FLOAT_SANITIZER=ON
 make -j"$(nproc)"
 nm Tools/IccDumpProfile/iccDumpProfile | grep -c __asan
 ```
 
-Add `float-divide-by-zero,float-cast-overflow` when investigating floating-point
-semantic bugs; those are not covered by `undefined`.
+Use `CC=clang`, not `C=clang`; after any failed compiler configure, delete both
+`CMakeCache.txt` and `CMakeFiles/` before retrying. Do not enable coverage for a
+sanitizer reproduction because coverage instrumentation can mask findings.
 
 ## References
 

--- a/Build/Cmake/CMakePresets.json
+++ b/Build/Cmake/CMakePresets.json
@@ -97,7 +97,7 @@
       "displayName": "Linux GCC with AddressSanitizer",
       "cacheVariables": {
         "ENABLE_ASAN": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -106,7 +106,27 @@
       "displayName": "Linux Clang with AddressSanitizer",
       "cacheVariables": {
         "ENABLE_ASAN": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-clang-sanitizers",
+      "inherits": "linux-clang",
+      "displayName": "Linux Clang with ASan, UBSan, IntSan, and float sanitizers",
+      "cacheVariables": {
+        "ENABLE_SANITIZERS": "ON",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-clang-ubsan-int-float",
+      "inherits": "linux-clang",
+      "displayName": "Linux Clang with UBSan, IntSan, and float sanitizers",
+      "cacheVariables": {
+        "ENABLE_UBSAN": "ON",
+        "ENABLE_INTEGER_SANITIZER": "ON",
+        "ENABLE_FLOAT_SANITIZER": "ON",
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -115,7 +135,7 @@
       "displayName": "Linux Clang with ThreadSanitizer",
       "cacheVariables": {
         "ENABLE_TSAN": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -124,7 +144,7 @@
       "displayName": "Linux Clang with MemorySanitizer",
       "cacheVariables": {
         "ENABLE_MSAN": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {
@@ -133,7 +153,25 @@
       "displayName": "Linux Clang with UBSanitizer",
       "cacheVariables": {
         "ENABLE_UBSAN": "ON",
-        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-clang-coverage",
+      "inherits": "linux-clang",
+      "displayName": "Linux Clang with source coverage",
+      "cacheVariables": {
+        "ENABLE_COVERAGE": "ON",
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "linux-clang-profiling",
+      "inherits": "linux-clang",
+      "displayName": "Linux Clang with gprof/perf profiling",
+      "cacheVariables": {
+        "ENABLE_PROFILING": "ON",
+        "CMAKE_BUILD_TYPE": "Debug"
       }
     },
     {

--- a/docs/bisect.md
+++ b/docs/bisect.md
@@ -15,6 +15,13 @@ generation, validation, conversion, or tool behavior.
 Build instructions are in [build.md](build.md). Maintainer sanitizer details are
 in `.github/instructions/build-system.instructions.md`.
 
+For sanitizer bisects, configure without coverage instrumentation:
+
+```bash
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_ASAN=ON -DENABLE_UBSAN=ON -DENABLE_INTEGER_SANITIZER=ON -DENABLE_FLOAT_SANITIZER=ON
+make -j"$(nproc)"
+```
+
 ## Reproduce
 
 Run the smallest command that demonstrates the failure. For profile-suite

--- a/docs/build.md
+++ b/docs/build.md
@@ -187,6 +187,38 @@ cmake --build out/vs2022-x64 --config Release --target check
 See [CTest tool suites](ctest.md) for the registered tests, fixtures, logs, and
 add-test process.
 
+## Instrumentation Builds
+
+Use CMake options instead of hand-written sanitizer flags. Clean the cache when
+changing compiler or instrumentation mode, and use `CC=clang` plus `CXX=clang++`
+for environment compiler selection.
+
+```bash
+# Security repro default: ASan + UBSan + IntSan + float checks, no coverage
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_ASAN=ON -DENABLE_UBSAN=ON -DENABLE_INTEGER_SANITIZER=ON -DENABLE_FLOAT_SANITIZER=ON
+make -j"$(nproc)"
+
+# Coverage build; keep separate from sanitizer reproductions
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_COVERAGE=ON
+make -j"$(nproc)"
+
+# Profiling build
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_PROFILING=ON
+make -j"$(nproc)"
+```
+
+For ThreadSanitizer and MemorySanitizer, use one sanitizer family per build:
+
+```bash
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_TSAN=ON
+cd Build && rm -rf CMakeCache.txt CMakeFiles && CC=clang CXX=clang++ cmake Cmake -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=ON -DENABLE_MSAN=ON
+```
+
+Do not enable coverage while reproducing sanitizer findings; coverage
+instrumentation can change optimizer and sanitizer behavior enough to mask a
+bug. Maintainer-level details live in
+`.github/instructions/build-system.instructions.md`.
+
 ## Maintainer Dockerfiles
 
 `Dockerfile*` files are maintainer-owned release and CI infrastructure. General

--- a/docs/build.md
+++ b/docs/build.md
@@ -219,6 +219,17 @@ instrumentation can change optimizer and sanitizer behavior enough to mask a
 bug. Maintainer-level details live in
 `.github/instructions/build-system.instructions.md`.
 
+Preset equivalents are available for the same modes:
+
+```bash
+cmake --preset linux-clang-sanitizers -S Build/Cmake -B out/linux-clang-sanitizers
+cmake --preset linux-clang-ubsan-int-float -S Build/Cmake -B out/linux-clang-ubsan-int-float
+cmake --preset linux-clang-tsan -S Build/Cmake -B out/linux-clang-tsan
+cmake --preset linux-clang-msan -S Build/Cmake -B out/linux-clang-msan
+cmake --preset linux-clang-coverage -S Build/Cmake -B out/linux-clang-coverage
+cmake --preset linux-clang-profiling -S Build/Cmake -B out/linux-clang-profiling
+```
+
 ## Maintainer Dockerfiles
 
 `Dockerfile*` files are maintainer-owned release and CI infrastructure. General


### PR DESCRIPTION
## PR Summary

#1185 

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
