### PR TITLE
More codeQL fixes, part 4

### DIFF
--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -1404,7 +1404,7 @@ public:
       if (c < 0) {
         if (str.size() != size_t(0))
           line.push_back(str);
-        if (!line.size())
+        if (line.size() == size_t(0))
           return false;
         break;
       }

--- a/IccJSON/IccLibJSON/IccIoJson.cpp
+++ b/IccJSON/IccLibJSON/IccIoJson.cpp
@@ -58,6 +58,7 @@ Copyright:  (c) see Software License
  */
 
 #include "IccIoJson.h"
+#include <new>
 
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
@@ -65,8 +66,8 @@ namespace iccDEV {
 
 CIccIO *CIccJsonStandardFileIO::OpenFile(const icChar *szFilename, const char *szAttr)
 {
-  CIccFileIO *file = new CIccFileIO();
-  if (!file->Open(szFilename, szAttr)) {
+  CIccFileIO *file = new (std::nothrow) CIccFileIO();
+  if (file && !file->Open(szFilename, szAttr)) {
     delete file;
     return nullptr;
   }

--- a/IccJSON/IccLibJSON/IccMpeJsonFactory.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJsonFactory.cpp
@@ -70,24 +70,24 @@ namespace iccDEV {
 CIccMultiProcessElement* CIccMpeJsonFactory::CreateElement(icElemTypeSignature elemTypeSig)
 {
   switch (elemTypeSig) {
-  case icSigMatrixElemType:             return new CIccMpeJsonMatrix();
-  case icSigCurveSetElemType:           return new CIccMpeJsonCurveSet();
-  case icSigCLutElemType:               return new CIccMpeJsonCLUT();
-  case icSigExtCLutElemType:            return new CIccMpeJsonExtCLUT();
-  case icSigCalculatorElemType:         return new CIccMpeJsonCalculator();
-  case icSigTintArrayElemType:          return new CIccMpeJsonTintArray();
-  case icSigToneMapElemType:            return new CIccMpeJsonToneMap();
-  case icSigXYZToJabElemType:           return new CIccMpeJsonXYZToJab();
-  case icSigJabToXYZElemType:           return new CIccMpeJsonJabToXYZ();
-  case icSigEmissionMatrixElemType:     return new CIccMpeJsonEmissionMatrix();
-  case icSigInvEmissionMatrixElemType:  return new CIccMpeJsonInvEmissionMatrix();
-  case icSigEmissionCLUTElemType:       return new CIccMpeJsonEmissionCLUT();
-  case icSigReflectanceCLUTElemType:    return new CIccMpeJsonReflectanceCLUT();
-  case icSigEmissionObserverElemType:   return new CIccMpeJsonEmissionObserver();
-  case icSigReflectanceObserverElemType: return new CIccMpeJsonReflectanceObserver();
-  case icSigBAcsElemType:               return new CIccMpeJsonBAcs();
-  case icSigEAcsElemType:               return new CIccMpeJsonEAcs();
-  default:                              return new CIccMpeJsonUnknown();
+  case icSigMatrixElemType:             return new (std::nothrow) CIccMpeJsonMatrix();
+  case icSigCurveSetElemType:           return new (std::nothrow) CIccMpeJsonCurveSet();
+  case icSigCLutElemType:               return new (std::nothrow) CIccMpeJsonCLUT();
+  case icSigExtCLutElemType:            return new (std::nothrow) CIccMpeJsonExtCLUT();
+  case icSigCalculatorElemType:         return new (std::nothrow) CIccMpeJsonCalculator();
+  case icSigTintArrayElemType:          return new (std::nothrow) CIccMpeJsonTintArray();
+  case icSigToneMapElemType:            return new (std::nothrow) CIccMpeJsonToneMap();
+  case icSigXYZToJabElemType:           return new (std::nothrow) CIccMpeJsonXYZToJab();
+  case icSigJabToXYZElemType:           return new (std::nothrow) CIccMpeJsonJabToXYZ();
+  case icSigEmissionMatrixElemType:     return new (std::nothrow) CIccMpeJsonEmissionMatrix();
+  case icSigInvEmissionMatrixElemType:  return new (std::nothrow) CIccMpeJsonInvEmissionMatrix();
+  case icSigEmissionCLUTElemType:       return new (std::nothrow) CIccMpeJsonEmissionCLUT();
+  case icSigReflectanceCLUTElemType:    return new (std::nothrow) CIccMpeJsonReflectanceCLUT();
+  case icSigEmissionObserverElemType:   return new (std::nothrow) CIccMpeJsonEmissionObserver();
+  case icSigReflectanceObserverElemType: return new (std::nothrow) CIccMpeJsonReflectanceObserver();
+  case icSigBAcsElemType:               return new (std::nothrow) CIccMpeJsonBAcs();
+  case icSigEAcsElemType:               return new (std::nothrow) CIccMpeJsonEAcs();
+  default:                              return new (std::nothrow) CIccMpeJsonUnknown();
   }
 }
 

--- a/IccJSON/IccLibJSON/IccTagJsonFactory.cpp
+++ b/IccJSON/IccLibJSON/IccTagJsonFactory.cpp
@@ -70,59 +70,59 @@ namespace iccDEV {
 CIccTag* CIccTagJsonFactory::CreateTag(icTagTypeSignature tagSig)
 {
   switch (tagSig) {
-  case icSigSignatureType:           return new CIccTagJsonSignature;
-  case icSigTextType:                return new CIccTagJsonText;
-  case icSigXYZArrayType:            return new CIccTagJsonXYZ;
-  case icSigCicpType:                return new CIccTagJsonCicp;
-  case icSigUInt8ArrayType:          return new CIccTagJsonUInt8;
-  case icSigUInt16ArrayType:         return new CIccTagJsonUInt16;
-  case icSigUInt32ArrayType:         return new CIccTagJsonUInt32;
-  case icSigUInt64ArrayType:         return new CIccTagJsonUInt64;
-  case icSigS15Fixed16ArrayType:     return new CIccTagJsonS15Fixed16;
-  case icSigFloat16ArrayType:        return new CIccTagJsonFloat16;
-  case icSigFloat32ArrayType:        return new CIccTagJsonFloat32;
-  case icSigFloat64ArrayType:        return new CIccTagJsonFloat64;
-  case icSigGamutBoundaryDescType:   return new CIccTagJsonGamutBoundaryDesc;
-  case icSigCurveType:               return new CIccTagJsonCurve;
-  case icSigSegmentedCurveType:      return new CIccTagJsonSegmentedCurve;
-  case icSigMeasurementType:         return new CIccTagJsonMeasurement;
-  case icSigMultiLocalizedUnicodeType: return new CIccTagJsonMultiLocalizedUnicode;
-  case icSigMultiProcessElementType: return new CIccTagJsonMultiProcessElement;
-  case icSigParametricCurveType:     return new CIccTagJsonParametricCurve;
-  case icSigLutAtoBType:             return new CIccTagJsonLutAtoB;
-  case icSigLutBtoAType:             return new CIccTagJsonLutBtoA;
-  case icSigLut16Type:               return new CIccTagJsonLut16;
-  case icSigLut8Type:                return new CIccTagJsonLut8;
-  case icSigTextDescriptionType:     return new CIccTagJsonTextDescription;
-  case icSigNamedColor2Type:         return new CIccTagJsonNamedColor2;
-  case icSigChromaticityType:        return new CIccTagJsonChromaticity;
-  case icSigDataType:                return new CIccTagJsonTagData;
-  case icSigDateTimeType:            return new CIccTagJsonDateTime;
-  case icSigColorantOrderType:       return new CIccTagJsonColorantOrder;
-  case icSigColorantTableType:       return new CIccTagJsonColorantTable;
-  case icSigSparseMatrixArrayType:   return new CIccTagJsonSparseMatrixArray;
-  case icSigViewingConditionsType:   return new CIccTagJsonViewingConditions;
-  case icSigSpectralViewingConditionsType: return new CIccTagJsonSpectralViewingConditions;
-  case icSigSpectralDataInfoType:    return new CIccTagJsonSpectralDataInfo;
-  case icSigProfileSequenceDescType: return new CIccTagJsonProfileSeqDesc;
-  case icSigResponseCurveSet16Type:  return new CIccTagJsonResponseCurveSet16;
-  case icSigProfileSequceIdType:     return new CIccTagJsonProfileSequenceId;
-  case icSigDictType:                return new CIccTagJsonDict;
-  case icSigTagStructType:           return new CIccTagJsonStruct;
-  case icSigTagArrayType:            return new CIccTagJsonArray;
-  case icSigUtf8TextType:            return new CIccTagJsonUtf8Text;
-  case icSigZipUtf8TextType:         return new CIccTagJsonZipUtf8Text;
-  case icSigZipXmlType:              return new CIccTagJsonZipXml;
-  case icSigUtf16TextType:           return new CIccTagJsonUtf16Text;
-  case icSigEmbeddedProfileType:     return new CIccTagJsonEmbeddedProfile;
-  case icSigEmbeddedHeightImageType: return new CIccTagJsonEmbeddedHeightImage;
-  case icSigEmbeddedNormalImageType: return new CIccTagJsonEmbeddedNormalImage;
+  case icSigSignatureType:           return new (std::nothrow) CIccTagJsonSignature;
+  case icSigTextType:                return new (std::nothrow) CIccTagJsonText;
+  case icSigXYZArrayType:            return new (std::nothrow) CIccTagJsonXYZ;
+  case icSigCicpType:                return new (std::nothrow) CIccTagJsonCicp;
+  case icSigUInt8ArrayType:          return new (std::nothrow) CIccTagJsonUInt8;
+  case icSigUInt16ArrayType:         return new (std::nothrow) CIccTagJsonUInt16;
+  case icSigUInt32ArrayType:         return new (std::nothrow) CIccTagJsonUInt32;
+  case icSigUInt64ArrayType:         return new (std::nothrow) CIccTagJsonUInt64;
+  case icSigS15Fixed16ArrayType:     return new (std::nothrow) CIccTagJsonS15Fixed16;
+  case icSigFloat16ArrayType:        return new (std::nothrow) CIccTagJsonFloat16;
+  case icSigFloat32ArrayType:        return new (std::nothrow) CIccTagJsonFloat32;
+  case icSigFloat64ArrayType:        return new (std::nothrow) CIccTagJsonFloat64;
+  case icSigGamutBoundaryDescType:   return new (std::nothrow) CIccTagJsonGamutBoundaryDesc;
+  case icSigCurveType:               return new (std::nothrow) CIccTagJsonCurve;
+  case icSigSegmentedCurveType:      return new (std::nothrow) CIccTagJsonSegmentedCurve;
+  case icSigMeasurementType:         return new (std::nothrow) CIccTagJsonMeasurement;
+  case icSigMultiLocalizedUnicodeType: return new (std::nothrow) CIccTagJsonMultiLocalizedUnicode;
+  case icSigMultiProcessElementType: return new (std::nothrow) CIccTagJsonMultiProcessElement;
+  case icSigParametricCurveType:     return new (std::nothrow) CIccTagJsonParametricCurve;
+  case icSigLutAtoBType:             return new (std::nothrow) CIccTagJsonLutAtoB;
+  case icSigLutBtoAType:             return new (std::nothrow) CIccTagJsonLutBtoA;
+  case icSigLut16Type:               return new (std::nothrow) CIccTagJsonLut16;
+  case icSigLut8Type:                return new (std::nothrow) CIccTagJsonLut8;
+  case icSigTextDescriptionType:     return new (std::nothrow) CIccTagJsonTextDescription;
+  case icSigNamedColor2Type:         return new (std::nothrow) CIccTagJsonNamedColor2;
+  case icSigChromaticityType:        return new (std::nothrow) CIccTagJsonChromaticity;
+  case icSigDataType:                return new (std::nothrow) CIccTagJsonTagData;
+  case icSigDateTimeType:            return new (std::nothrow) CIccTagJsonDateTime;
+  case icSigColorantOrderType:       return new (std::nothrow) CIccTagJsonColorantOrder;
+  case icSigColorantTableType:       return new (std::nothrow) CIccTagJsonColorantTable;
+  case icSigSparseMatrixArrayType:   return new (std::nothrow) CIccTagJsonSparseMatrixArray;
+  case icSigViewingConditionsType:   return new (std::nothrow) CIccTagJsonViewingConditions;
+  case icSigSpectralViewingConditionsType: return new (std::nothrow) CIccTagJsonSpectralViewingConditions;
+  case icSigSpectralDataInfoType:    return new (std::nothrow) CIccTagJsonSpectralDataInfo;
+  case icSigProfileSequenceDescType: return new (std::nothrow) CIccTagJsonProfileSeqDesc;
+  case icSigResponseCurveSet16Type:  return new (std::nothrow) CIccTagJsonResponseCurveSet16;
+  case icSigProfileSequceIdType:     return new (std::nothrow) CIccTagJsonProfileSequenceId;
+  case icSigDictType:                return new (std::nothrow) CIccTagJsonDict;
+  case icSigTagStructType:           return new (std::nothrow) CIccTagJsonStruct;
+  case icSigTagArrayType:            return new (std::nothrow) CIccTagJsonArray;
+  case icSigUtf8TextType:            return new (std::nothrow) CIccTagJsonUtf8Text;
+  case icSigZipUtf8TextType:         return new (std::nothrow) CIccTagJsonZipUtf8Text;
+  case icSigZipXmlType:              return new (std::nothrow) CIccTagJsonZipXml;
+  case icSigUtf16TextType:           return new (std::nothrow) CIccTagJsonUtf16Text;
+  case icSigEmbeddedProfileType:     return new (std::nothrow) CIccTagJsonEmbeddedProfile;
+  case icSigEmbeddedHeightImageType: return new (std::nothrow) CIccTagJsonEmbeddedHeightImage;
+  case icSigEmbeddedNormalImageType: return new (std::nothrow) CIccTagJsonEmbeddedNormalImage;
 
   case icSigScreeningType:
   case icSigUcrBgType:
   case icSigCrdInfoType:
   default:
-    return new CIccTagJsonUnknown(tagSig);
+    return new (std::nothrow) CIccTagJsonUnknown(tagSig);
   }
 }
 

--- a/IccProfLib/IccArrayFactory.cpp
+++ b/IccProfLib/IccArrayFactory.cpp
@@ -84,13 +84,13 @@ IIccArray* CIccBasicArrayFactory::CreateArray(icArraySignature arrayTypeSig, CIc
 {
   switch(arrayTypeSig) {
     case icSigNamedColorArray:
-      return new CIccArrayNamedColor(pTagArray);
+      return new (std::nothrow) CIccArrayNamedColor(pTagArray);
 
     case icSigColorantInfoArray:
-      return new CIccArrayColorantInfo(pTagArray);
+      return new (std::nothrow) CIccArrayColorantInfo(pTagArray);
 
     default:
-      return new CIccArrayUnknown(pTagArray, arrayTypeSig);
+      return new (std::nothrow) CIccArrayUnknown(pTagArray, arrayTypeSig);
   }
 }
 

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -3181,7 +3181,12 @@ icStatusCMM CIccPcsXform::pushXYZConvert(CIccXform *pFromXform, CIccXform *pToXf
 
 void CIccPcsXform::pushXYZNormalize(IIccProfileConnectionConditions *pPcc, const icSpectralRange &srcRange, const icSpectralRange &dstRange)
 {
+  if (!pPcc)
+    return;
+
   const CIccTagSpectralViewingConditions *pView = pPcc->getPccViewingConditions();
+  if (!pView)
+    return; // need a way to report errors
 
   CIccPcsXform tmp;
 

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -838,6 +838,7 @@ CIccXform *CIccXform::Create(CIccProfile *pProfile,
           if (!pNamedColorHint)
             return NULL;
         }
+
         pNamedColorHint->csPcs = pProfile->m_Header.pcs;
         pNamedColorHint->csDevice = pProfile->m_Header.colorSpace;
         pNamedColorHint->csSpectralPcs = pProfile->m_Header.spectralPCS;
@@ -1400,9 +1401,11 @@ CIccXform *CIccXform::Create(CIccProfile &Profile,
 														 bool bUseD2BxB2DxTags/* =true */,
                              CIccCreateXformHintManager *pHintManager/* =NULL */)
 {
-  CIccProfile *pProfile = new CIccProfile(Profile);
-  CIccXform *pXform = Create(pProfile, bInput, nIntent, nInterp, pPcc, nLutType, bUseD2BxB2DxTags, pHintManager);
+  CIccProfile *pProfile = new (std::nothrow) CIccProfile(Profile);
+  if (!pProfile)
+    return NULL;
 
+  CIccXform *pXform = Create(pProfile, bInput, nIntent, nInterp, pPcc, nLutType, bUseD2BxB2DxTags, pHintManager);
   if (!pXform)
     delete pProfile;
 
@@ -3653,7 +3656,7 @@ void CIccPcsXform::Apply(CIccApplyXform *pXform, icFloatNumber *DstPixel, const 
 */
 CIccApplyPcsStep* CIccPcsStep::GetNewApply()
 {
-  return new CIccApplyPcsStep(this);
+  return new (std::nothrow) CIccApplyPcsStep(this);
 }
 
 
@@ -3892,12 +3895,12 @@ CIccPcsStep *CIccPcsStepLabToXYZ::concat(CIccPcsStep *pNext) const
     if (pNext->GetType() == icPcsStepXYZToLab) {
       CIccPcsLabStep* pStep = (CIccPcsLabStep*)pNext;
       if (pStep->isSameWhite(m_xyzWhite))
-        return new CIccPcsStepIdentity(3);
+        return new (std::nothrow) CIccPcsStepIdentity(3);
     }
     else if (pNext->GetType() == icPcsStepXYZToLab2) {
       CIccPcsLabStep* pStep = (CIccPcsLabStep*)pNext;
       if (pStep->isSameWhite(m_xyzWhite))
-        return new CIccPcsStepLabToLab2();
+        return new (std::nothrow) CIccPcsStepLabToLab2();
     }
   }
   return NULL;
@@ -3971,7 +3974,7 @@ CIccPcsStep *CIccPcsStepXYZToLab::concat(CIccPcsStep *pNext) const
   if (pNext && pNext->GetType()==icPcsStepLabToXYZ) {
     CIccPcsLabStep *pStep = (CIccPcsLabStep *)pNext;
     if (pStep->isSameWhite(m_xyzWhite))
-      return new CIccPcsStepIdentity(3);
+      return new (std::nothrow) CIccPcsStepIdentity(3);
   }
   return NULL;
 }
@@ -4046,12 +4049,12 @@ CIccPcsStep *CIccPcsStepLab2ToXYZ::concat(CIccPcsStep *pNext) const
     if (pNext->GetType() == icPcsStepXYZToLab2) {
       CIccPcsLabStep* pStep = (CIccPcsLabStep*)pNext;
       if (pStep->isSameWhite(m_xyzWhite))
-        return new CIccPcsStepIdentity(3);
+        return new (std::nothrow) CIccPcsStepIdentity(3);
     }
     else if (pNext->GetType() == icPcsStepXYZToLab) {
       CIccPcsLabStep* pStep = (CIccPcsLabStep*)pNext;
       if (pStep->isSameWhite(m_xyzWhite))
-        return new CIccPcsStepLab2ToLab();
+        return new (std::nothrow) CIccPcsStepLab2ToLab();
     }
   }
 
@@ -4126,7 +4129,7 @@ CIccPcsStep *CIccPcsStepXYZToLab2::concat(CIccPcsStep *pNext) const
   if (pNext && pNext->GetType()==icPcsStepLab2ToXYZ) {
     CIccPcsLabStep *pStep = (CIccPcsLabStep *)pNext;
     if (pStep->isSameWhite(m_xyzWhite))
-      return new CIccPcsStepIdentity(3);
+      return new (std::nothrow) CIccPcsStepIdentity(3);
   }
   return NULL;
 }
@@ -4174,7 +4177,7 @@ void CIccPcsStepLabToLab2::dump(std::string& str) const
 CIccPcsStep* CIccPcsStepLabToLab2::concat(CIccPcsStep* pNext) const
 {
   if (pNext && pNext->GetType() == icPcsStepLab2ToLab) {
-    return new CIccPcsStepIdentity(3);
+    return new (std::nothrow) CIccPcsStepIdentity(3);
   }
   return NULL;
 }
@@ -4223,7 +4226,7 @@ void CIccPcsStepLab2ToLab::dump(std::string& str) const
 CIccPcsStep* CIccPcsStepLab2ToLab::concat(CIccPcsStep* pNext) const
 {
   if (pNext && pNext->GetType() == icPcsStepLabToLab2) {
-    return new CIccPcsStepIdentity(3);
+    return new (std::nothrow) CIccPcsStepIdentity(3);
   }
   return NULL;
 }
@@ -4764,7 +4767,7 @@ CIccPcsStepMpe::~CIccPcsStepMpe()
 */
 CIccApplyPcsStep* CIccPcsStepMpe::GetNewApply()
 {
-  CIccApplyPcsStepMpe *rv = new CIccApplyPcsStepMpe(this, m_pMpe->GetNewApply());
+  CIccApplyPcsStepMpe *rv = new (std::nothrow) CIccApplyPcsStepMpe(this, m_pMpe->GetNewApply());
 
   return rv;
 }
@@ -5338,9 +5341,11 @@ LPIccCurve* CIccXformMonochrome::ExtractInputCurves()
 {
 	if (m_bInput) {
 		if (m_Curve) {
-			LPIccCurve* Curve = new LPIccCurve[1];
-			Curve[0] = (LPIccCurve)(m_Curve->NewCopy());
-			m_ApplyCurvePtr = NULL;
+			LPIccCurve* Curve = new (std::nothrow) LPIccCurve[1];
+            if (Curve) {
+			  Curve[0] = (LPIccCurve)(m_Curve->NewCopy());
+			  m_ApplyCurvePtr = NULL;
+            }
 			return Curve;
 		}
 	}
@@ -5366,9 +5371,11 @@ LPIccCurve* CIccXformMonochrome::ExtractOutputCurves()
 {
 	if (!m_bInput) {
 		if (m_Curve) {
-			LPIccCurve* Curve = new LPIccCurve[1];
-			Curve[0] = (LPIccCurve)(m_Curve->NewCopy());
-			m_ApplyCurvePtr = NULL;
+			LPIccCurve* Curve = new (std::nothrow) LPIccCurve[1];
+            if (Curve) {
+			  Curve[0] = (LPIccCurve)(m_Curve->NewCopy());
+			  m_ApplyCurvePtr = NULL;
+            }
 			return Curve;
 		}
 	}
@@ -5691,11 +5698,13 @@ LPIccCurve* CIccXformMatrixTRC::ExtractInputCurves()
 {
   if (m_bInput) {
     if (m_Curve[0]) {
-			LPIccCurve* Curve = new LPIccCurve[3];
-			Curve[0] = (LPIccCurve)(m_Curve[0]->NewCopy());
-			Curve[1] = (LPIccCurve)(m_Curve[1]->NewCopy());
-			Curve[2] = (LPIccCurve)(m_Curve[2]->NewCopy());
-      m_ApplyCurvePtr = NULL;
+      LPIccCurve* Curve = new (std::nothrow) LPIccCurve[3];
+      if (Curve) {
+        Curve[0] = (LPIccCurve)(m_Curve[0]->NewCopy());
+        Curve[1] = (LPIccCurve)(m_Curve[1]->NewCopy());
+        Curve[2] = (LPIccCurve)(m_Curve[2]->NewCopy());
+        m_ApplyCurvePtr = NULL;
+      }
       return Curve;
     }
   }
@@ -5721,11 +5730,13 @@ LPIccCurve* CIccXformMatrixTRC::ExtractOutputCurves()
 {
   if (!m_bInput) {
     if (m_Curve[0]) {
-			LPIccCurve* Curve = new LPIccCurve[3];
-			Curve[0] = (LPIccCurve)(m_Curve[0]->NewCopy());
-			Curve[1] = (LPIccCurve)(m_Curve[1]->NewCopy());
-			Curve[2] = (LPIccCurve)(m_Curve[2]->NewCopy());
-      m_ApplyCurvePtr = NULL;
+      LPIccCurve* Curve = new (std::nothrow) LPIccCurve[3];
+      if (Curve) {
+        Curve[0] = (LPIccCurve)(m_Curve[0]->NewCopy());
+        Curve[1] = (LPIccCurve)(m_Curve[1]->NewCopy());
+        Curve[2] = (LPIccCurve)(m_Curve[2]->NewCopy());
+        m_ApplyCurvePtr = NULL;
+      }
       return Curve;
     }
   }
@@ -6037,21 +6048,25 @@ LPIccCurve* CIccXform3DLut::ExtractInputCurves()
   if (m_bInput) {
     if (m_pTag->m_bInputMatrix) {
       if (m_pTag->m_CurvesB) {
-        LPIccCurve* Curve = new LPIccCurve[3];
-				Curve[0] = (LPIccCurve)(m_pTag->m_CurvesB[0]->NewCopy());
-				Curve[1] = (LPIccCurve)(m_pTag->m_CurvesB[1]->NewCopy());
-				Curve[2] = (LPIccCurve)(m_pTag->m_CurvesB[2]->NewCopy());
-        m_ApplyCurvePtrB = NULL;
+        LPIccCurve* Curve = new (std::nothrow) LPIccCurve[3];
+        if (Curve) {
+          Curve[0] = (LPIccCurve)(m_pTag->m_CurvesB[0]->NewCopy());
+          Curve[1] = (LPIccCurve)(m_pTag->m_CurvesB[1]->NewCopy());
+          Curve[2] = (LPIccCurve)(m_pTag->m_CurvesB[2]->NewCopy());
+          m_ApplyCurvePtrB = NULL;
+        }
         return Curve;
       }
     }
     else {
       if (m_pTag->m_CurvesA) {
-        LPIccCurve* Curve = new LPIccCurve[3];
-				Curve[0] = (LPIccCurve)(m_pTag->m_CurvesA[0]->NewCopy());
-				Curve[1] = (LPIccCurve)(m_pTag->m_CurvesA[1]->NewCopy());
-				Curve[2] = (LPIccCurve)(m_pTag->m_CurvesA[2]->NewCopy());
-        m_ApplyCurvePtrA = NULL;
+        LPIccCurve* Curve = new (std::nothrow) LPIccCurve[3];
+        if (Curve) {
+          Curve[0] = (LPIccCurve)(m_pTag->m_CurvesA[0]->NewCopy());
+          Curve[1] = (LPIccCurve)(m_pTag->m_CurvesA[1]->NewCopy());
+          Curve[2] = (LPIccCurve)(m_pTag->m_CurvesA[2]->NewCopy());
+          m_ApplyCurvePtrA = NULL;
+        }
         return Curve;
       }
     }
@@ -6079,21 +6094,25 @@ LPIccCurve* CIccXform3DLut::ExtractOutputCurves()
   if (!m_bInput) {
     if (m_pTag->m_bInputMatrix) {
       if (m_pTag->m_CurvesA) {
-        LPIccCurve* Curve = new LPIccCurve[m_pTag->m_nOutput];
-				for (int i=0; i<m_pTag->m_nOutput; i++) {
-					Curve[i] = (LPIccCurve)(m_pTag->m_CurvesA[i]->NewCopy());
-				}
-        m_ApplyCurvePtrA = NULL;
+        LPIccCurve* Curve = new (std::nothrow) LPIccCurve[m_pTag->m_nOutput];
+        if (Curve) {
+          for (int i=0; i<m_pTag->m_nOutput; i++) {
+            Curve[i] = (LPIccCurve)(m_pTag->m_CurvesA[i]->NewCopy());
+          }
+          m_ApplyCurvePtrA = NULL;
+        }
         return Curve;
       }
     }
     else {
       if (m_pTag->m_CurvesB) {
-        LPIccCurve* Curve = new LPIccCurve[m_pTag->m_nOutput];
-				for (int i=0; i<m_pTag->m_nOutput; i++) {
-					Curve[i] = (LPIccCurve)(m_pTag->m_CurvesB[i]->NewCopy());
-				}
-        m_ApplyCurvePtrB = NULL;
+        LPIccCurve* Curve = new (std::nothrow) LPIccCurve[m_pTag->m_nOutput];
+        if (Curve) {
+          for (int i=0; i<m_pTag->m_nOutput; i++) {
+            Curve[i] = (LPIccCurve)(m_pTag->m_CurvesB[i]->NewCopy());
+          }
+          m_ApplyCurvePtrB = NULL;
+        }
         return Curve;
       }
     }
@@ -6378,30 +6397,34 @@ void CIccXform4DLut::Apply(CIccApplyXform* pApply, icFloatNumber *DstPixel, cons
 */
 LPIccCurve* CIccXform4DLut::ExtractInputCurves()
 {
-	if (m_bInput) {
-		if (m_pTag->m_bInputMatrix) {
-			if (m_pTag->m_CurvesB) {
-				LPIccCurve* Curve = new LPIccCurve[4];
-				Curve[0] = (LPIccCurve)(m_pTag->m_CurvesB[0]->NewCopy());
-				Curve[1] = (LPIccCurve)(m_pTag->m_CurvesB[1]->NewCopy());
-				Curve[2] = (LPIccCurve)(m_pTag->m_CurvesB[2]->NewCopy());
-				Curve[3] = (LPIccCurve)(m_pTag->m_CurvesB[3]->NewCopy());
-				m_ApplyCurvePtrB = NULL;
-				return Curve;
-			}
-		}
-		else {
-			if (m_pTag->m_CurvesA) {
-				LPIccCurve* Curve = new LPIccCurve[4];
-				Curve[0] = (LPIccCurve)(m_pTag->m_CurvesA[0]->NewCopy());
-				Curve[1] = (LPIccCurve)(m_pTag->m_CurvesA[1]->NewCopy());
-				Curve[2] = (LPIccCurve)(m_pTag->m_CurvesA[2]->NewCopy());
-				Curve[3] = (LPIccCurve)(m_pTag->m_CurvesA[3]->NewCopy());
-				m_ApplyCurvePtrA = NULL;
-				return Curve;
-			}
-		}
-	}
+  if (m_bInput) {
+    if (m_pTag->m_bInputMatrix) {
+      if (m_pTag->m_CurvesB) {
+        LPIccCurve* Curve = new (std::nothrow) LPIccCurve[4];
+        if (Curve) {
+          Curve[0] = (LPIccCurve)(m_pTag->m_CurvesB[0]->NewCopy());
+          Curve[1] = (LPIccCurve)(m_pTag->m_CurvesB[1]->NewCopy());
+          Curve[2] = (LPIccCurve)(m_pTag->m_CurvesB[2]->NewCopy());
+          Curve[3] = (LPIccCurve)(m_pTag->m_CurvesB[3]->NewCopy());
+          m_ApplyCurvePtrB = NULL;
+        }
+      return Curve;
+      }
+    }
+    else {
+      if (m_pTag->m_CurvesA) {
+        LPIccCurve* Curve = new (std::nothrow) LPIccCurve[4];
+        if (Curve) {
+          Curve[0] = (LPIccCurve)(m_pTag->m_CurvesA[0]->NewCopy());
+          Curve[1] = (LPIccCurve)(m_pTag->m_CurvesA[1]->NewCopy());
+          Curve[2] = (LPIccCurve)(m_pTag->m_CurvesA[2]->NewCopy());
+          Curve[3] = (LPIccCurve)(m_pTag->m_CurvesA[3]->NewCopy());
+          m_ApplyCurvePtrA = NULL;
+        }
+        return Curve;
+      }
+    }
+  }
 
   return NULL;
 }
@@ -6425,21 +6448,25 @@ LPIccCurve* CIccXform4DLut::ExtractOutputCurves()
 	if (!m_bInput) {
 		if (m_pTag->m_bInputMatrix) {
 			if (m_pTag->m_CurvesA) {
-				LPIccCurve* Curve = new LPIccCurve[m_pTag->m_nOutput];
-				for (int i=0; i<m_pTag->m_nOutput; i++) {
-					Curve[i] = (LPIccCurve)(m_pTag->m_CurvesA[i]->NewCopy());
-				}
-				m_ApplyCurvePtrA = NULL;
+				LPIccCurve* Curve = new (std::nothrow) LPIccCurve[m_pTag->m_nOutput];
+                if (Curve) {
+                    for (int i=0; i<m_pTag->m_nOutput; i++) {
+                        Curve[i] = (LPIccCurve)(m_pTag->m_CurvesA[i]->NewCopy());
+                    }
+                    m_ApplyCurvePtrA = NULL;
+                }
 				return Curve;
 			}
 		}
 		else {
 			if (m_pTag->m_CurvesB) {
-				LPIccCurve* Curve = new LPIccCurve[m_pTag->m_nOutput];
-				for (int i=0; i<m_pTag->m_nOutput; i++) {
-					Curve[i] = (LPIccCurve)(m_pTag->m_CurvesB[i]->NewCopy());
-				}
-				m_ApplyCurvePtrB = NULL;
+				LPIccCurve* Curve = new (std::nothrow) LPIccCurve[m_pTag->m_nOutput];
+                if (Curve) {
+                    for (int i=0; i<m_pTag->m_nOutput; i++) {
+                        Curve[i] = (LPIccCurve)(m_pTag->m_CurvesB[i]->NewCopy());
+                    }
+                    m_ApplyCurvePtrB = NULL;
+                }
 				return Curve;
 			}
 		}
@@ -6793,21 +6820,25 @@ LPIccCurve* CIccXformNDLut::ExtractInputCurves()
 	if (m_bInput) {
 		if (m_pTag->m_bInputMatrix) {
 			if (m_pTag->m_CurvesB) {
-				LPIccCurve* Curve = new LPIccCurve[m_pTag->m_nInput];
-				for (int i=0; i<m_pTag->m_nInput; i++) {
-					Curve[i] = (LPIccCurve)(m_pTag->m_CurvesB[i]->NewCopy());
-				}
-				m_ApplyCurvePtrB = NULL;
+				LPIccCurve* Curve = new (std::nothrow) LPIccCurve[m_pTag->m_nInput];
+                if (Curve) {
+                    for (int i=0; i<m_pTag->m_nInput; i++) {
+                        Curve[i] = (LPIccCurve)(m_pTag->m_CurvesB[i]->NewCopy());
+                    }
+                    m_ApplyCurvePtrB = NULL;
+                }
 				return Curve;
 			}
 		}
 		else {
 			if (m_pTag->m_CurvesA) {
-				LPIccCurve* Curve = new LPIccCurve[m_pTag->m_nInput];
-				for (int i=0; i<m_pTag->m_nInput; i++) {
-					Curve[i] = (LPIccCurve)(m_pTag->m_CurvesA[i]->NewCopy());
-				}
-				m_ApplyCurvePtrA = NULL;
+				LPIccCurve* Curve = new (std::nothrow) LPIccCurve[m_pTag->m_nInput];
+                if (Curve) {
+                    for (int i=0; i<m_pTag->m_nInput; i++) {
+                        Curve[i] = (LPIccCurve)(m_pTag->m_CurvesA[i]->NewCopy());
+                    }
+                    m_ApplyCurvePtrA = NULL;
+                }
 				return Curve;
 			}
 		}
@@ -6835,21 +6866,25 @@ LPIccCurve* CIccXformNDLut::ExtractOutputCurves()
 	if (!m_bInput) {
 		if (m_pTag->m_bInputMatrix) {
 			if (m_pTag->m_CurvesA) {
-				LPIccCurve* Curve = new LPIccCurve[m_pTag->m_nOutput];
-				for (int i=0; i<m_pTag->m_nOutput; i++) {
-					Curve[i] = (LPIccCurve)(m_pTag->m_CurvesA[i]->NewCopy());
-				}
-				m_ApplyCurvePtrA = NULL;
+				LPIccCurve* Curve = new (std::nothrow) LPIccCurve[m_pTag->m_nOutput];
+                if (Curve) {
+                    for (int i=0; i<m_pTag->m_nOutput; i++) {
+                        Curve[i] = (LPIccCurve)(m_pTag->m_CurvesA[i]->NewCopy());
+                    }
+                    m_ApplyCurvePtrA = NULL;
+                }
 				return Curve;
 			}
 		}
 		else {
 			if (m_pTag->m_CurvesB) {
-				LPIccCurve* Curve = new LPIccCurve[m_pTag->m_nOutput];
-				for (int i=0; i<m_pTag->m_nOutput; i++) {
-					Curve[i] = (LPIccCurve)(m_pTag->m_CurvesB[i]->NewCopy());
-				}
-				m_ApplyCurvePtrB = NULL;
+				LPIccCurve* Curve = new (std::nothrow) LPIccCurve[m_pTag->m_nOutput];
+                if (Curve) {
+                    for (int i=0; i<m_pTag->m_nOutput; i++) {
+                        Curve[i] = (LPIccCurve)(m_pTag->m_CurvesB[i]->NewCopy());
+                    }
+                    m_ApplyCurvePtrB = NULL;
+                }
 				return Curve;
 			}
 		}
@@ -7403,13 +7438,13 @@ CIccXform *CIccXformMpe::Create(CIccProfile *pProfile, bool bInput/* =true */, i
 
         if (!pTag) {
           if (bUseColorimeticTags && pProfile->m_Header.colorSpace == icSigRgbData && pProfile->m_Header.version < icVersionNumberV5) {
-            rv = new CIccXformMatrixTRC();
+            rv = new (std::nothrow) CIccXformMatrixTRC();
           }
           else
             return NULL;
         }
         else if (pTag->GetType()==icSigMultiProcessElementType) {
-          rv = new CIccXformMpe(pTag);
+          rv = new (std::nothrow) CIccXformMpe(pTag);
         }
         else {
           switch(pProfile->m_Header.colorSpace) {
@@ -7423,16 +7458,16 @@ CIccXform *CIccXformMpe::Create(CIccProfile *pProfile, bool bInput/* =true */, i
             case icSigHlsData:
             case icSigCmyData:
             case icSig3colorData:
-              rv = new CIccXform3DLut(pTag);
+              rv = new (std::nothrow) CIccXform3DLut(pTag);
               break;
 
             case icSigCmykData:
             case icSig4colorData:
-              rv = new CIccXform4DLut(pTag);
+              rv = new (std::nothrow) CIccXform4DLut(pTag);
               break;
 
             default:
-              rv = new CIccXformNDLut(pTag);
+              rv = new (std::nothrow) CIccXformNDLut(pTag);
               break;
           }
         }
@@ -7479,20 +7514,20 @@ CIccXform *CIccXformMpe::Create(CIccProfile *pProfile, bool bInput/* =true */, i
 
         if (!pTag) {
           if (bUseColorimeticTags && pProfile->m_Header.colorSpace == icSigRgbData && pProfile->m_Header.version<icVersionNumberV5) {
-            rv = new CIccXformMatrixTRC();
+            rv = new (std::nothrow) CIccXformMatrixTRC();
           }
           else
             return NULL;
         }
 
         if (pTag && pTag->GetType()==icSigMultiProcessElementType) {
-          rv = new CIccXformMpe(pTag);
+          rv = new (std::nothrow) CIccXformMpe(pTag);
         }
         else {
           switch(pProfile->m_Header.pcs) {
             case icSigXYZData:
             case icSigLabData:
-              rv = new CIccXform3DLut(pTag);
+              rv = new (std::nothrow) CIccXform3DLut(pTag);
               break;
 
             default:
@@ -7508,7 +7543,7 @@ CIccXform *CIccXformMpe::Create(CIccProfile *pProfile, bool bInput/* =true */, i
         if (!pTag)
           return NULL;
 
-        rv = new CIccXformNamedColor(pTag, pProfile->m_Header.pcs, pProfile->m_Header.colorSpace,
+        rv = new (std::nothrow) CIccXformNamedColor(pTag, pProfile->m_Header.pcs, pProfile->m_Header.colorSpace,
                                      pProfile->m_Header.spectralPCS,
                                      &pProfile->m_Header.spectralRange,
                                      &pProfile->m_Header.biSpectralRange);
@@ -7529,7 +7564,7 @@ CIccXform *CIccXformMpe::Create(CIccProfile *pProfile, bool bInput/* =true */, i
           switch(pProfile->m_Header.pcs) {
             case icSigXYZData:
             case icSigLabData:
-              rv = new CIccXform3DLut(pTag);
+              rv = new (std::nothrow) CIccXform3DLut(pTag);
               break;
 
             default:
@@ -7550,7 +7585,7 @@ CIccXform *CIccXformMpe::Create(CIccProfile *pProfile, bool bInput/* =true */, i
           switch(pProfile->m_Header.pcs) {
             case icSigXYZData:
             case icSigLabData:
-              rv = new CIccXform3DLut(pTag);
+              rv = new (std::nothrow) CIccXform3DLut(pTag);
               break;
 
             default:
@@ -11142,22 +11177,21 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
  */
  CIccApplyCmm *CIccNamedColorCmm::GetNewApplyCmm(icStatusCMM &status)
  {
-  CIccApplyCmm *pApply = new CIccApplyNamedColorCmm(this);
+  CIccApplyCmm *pApply = new (std::nothrow) CIccApplyNamedColorCmm(this);
 
-  CIccXformList::iterator i;
-
-  for (i=m_Xforms->begin(); i!=m_Xforms->end(); i++) {
-    CIccApplyXform *pXform = i->ptr->GetNewApply(status);
-    if (status != icCmmStatOk || !pXform) {
-      delete pApply;
-      return NULL;
+  if (pApply) {
+    for (CIccXformList::iterator i=m_Xforms->begin(); i!=m_Xforms->end(); i++) {
+      CIccApplyXform *pXform = i->ptr->GetNewApply(status);
+      if (status != icCmmStatOk || !pXform) {
+        delete pApply;
+        return NULL;
+      }
+      pApply->AppendApplyXform(pXform);
     }
-    pApply->AppendApplyXform(pXform);
+
+    m_bValid = true;
+    status = icCmmStatOk;
   }
-
-  m_bValid = true;
-
-  status = icCmmStatOk;
   return pApply;
 }
 

--- a/IccProfLib/IccMpeCalc.h
+++ b/IccProfLib/IccMpeCalc.h
@@ -251,7 +251,7 @@ public:
 #endif
     } select;
   }data;
-  unsigned long extra;
+  icUInt32Number extra;
   IIccOpDef *def;
 
   void Describe(std::string &desc, int nVerboseness=100);

--- a/IccProfLib/IccMpeFactory.cpp
+++ b/IccProfLib/IccMpeFactory.cpp
@@ -86,58 +86,58 @@ CIccMultiProcessElement* CIccBasicMpeFactory::CreateElement(icElemTypeSignature 
 {
   switch(elemTypeSig) {
     case icSigCurveSetElemType:
-      return new CIccMpeCurveSet();
+      return new (std::nothrow) CIccMpeCurveSet();
 
     case icSigMatrixElemType:
-      return new CIccMpeMatrix();
+      return new (std::nothrow) CIccMpeMatrix();
 
     case icSigCLutElemType:
-      return new CIccMpeCLUT();
+      return new (std::nothrow) CIccMpeCLUT();
 
     case icSigExtCLutElemType:
-      return new CIccMpeExtCLUT();
+      return new (std::nothrow) CIccMpeExtCLUT();
 
     case icSigCalculatorElemType:
-      return new CIccMpeCalculator();
+      return new (std::nothrow) CIccMpeCalculator();
 
     case icSigTintArrayElemType:
-      return new CIccMpeTintArray();
+      return new (std::nothrow) CIccMpeTintArray();
 
     case icSigToneMapElemType:
-      return new CIccMpeToneMap();
+      return new (std::nothrow) CIccMpeToneMap();
 
     case icSigJabToXYZElemType:
-      return new CIccMpeJabToXYZ();
+      return new (std::nothrow) CIccMpeJabToXYZ();
 
     case icSigXYZToJabElemType:
-      return new CIccMpeXYZToJab();
+      return new (std::nothrow) CIccMpeXYZToJab();
 
     case icSigEmissionMatrixElemType:
-      return new CIccMpeEmissionMatrix();
+      return new (std::nothrow) CIccMpeEmissionMatrix();
 
     case icSigInvEmissionMatrixElemType:
-      return new CIccMpeInvEmissionMatrix();
+      return new (std::nothrow) CIccMpeInvEmissionMatrix();
 
     case icSigEmissionCLUTElemType:
-      return new CIccMpeEmissionCLUT();
+      return new (std::nothrow) CIccMpeEmissionCLUT();
 
     case icSigReflectanceCLUTElemType:
-      return new CIccMpeReflectanceCLUT();
+      return new (std::nothrow) CIccMpeReflectanceCLUT();
 
     case icSigEmissionObserverElemType:
-      return new CIccMpeEmissionObserver();
+      return new (std::nothrow) CIccMpeEmissionObserver();
 
     case icSigReflectanceObserverElemType:
-      return new CIccMpeReflectanceObserver();
+      return new (std::nothrow) CIccMpeReflectanceObserver();
 
     case icSigBAcsElemType:
-      return new CIccMpeBAcs();
+      return new (std::nothrow) CIccMpeBAcs();
 
     case icSigEAcsElemType:
-      return new CIccMpeEAcs();
+      return new (std::nothrow) CIccMpeEAcs();
 
     default:
-      return new CIccMpeUnknown();
+      return new (std::nothrow) CIccMpeUnknown();
   }
 }
 

--- a/IccProfLib/IccStructFactory.cpp
+++ b/IccProfLib/IccStructFactory.cpp
@@ -84,28 +84,28 @@ IIccStruct* CIccBasicStructFactory::CreateStruct(icStructSignature structTypeSig
 {
   switch(structTypeSig) {
     case icSigBRDFStruct:
-      return new CIccStructBRDF(pTagStruct);
+      return new (std::nothrow) CIccStructBRDF(pTagStruct);
 
     case icSigColorantInfoStruct:
-      return new CIccStructColorantInfo(pTagStruct);
+      return new (std::nothrow) CIccStructColorantInfo(pTagStruct);
 
     case icSigColorEncodingParamsSruct:
-      return new CIccStructColorEncodingParams(pTagStruct);
+      return new (std::nothrow) CIccStructColorEncodingParams(pTagStruct);
 
     case icSigMeasurementInfoStruct:
-      return new CIccStructMeasurementInfo(pTagStruct);
+      return new (std::nothrow) CIccStructMeasurementInfo(pTagStruct);
 
     case icSigNamedColorStruct:
-      return new CIccStructNamedColor(pTagStruct);
+      return new (std::nothrow) CIccStructNamedColor(pTagStruct);
 
     case icSigProfileInfoStruct:
-      return new CIccStructProfileInfo(pTagStruct);
+      return new (std::nothrow) CIccStructProfileInfo(pTagStruct);
 
     case icSigTintZeroStruct:
-      return new CIccStructTintZero(pTagStruct);
+      return new (std::nothrow) CIccStructTintZero(pTagStruct);
 
     default:
-      return new CIccStructUnknown(pTagStruct);
+      return new (std::nothrow) CIccStructUnknown(pTagStruct);
   }
 }
 

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -792,10 +792,10 @@ void CIccTagText::SetText(const icChar *szText)
  * Return: A pointer to the string assigned to the tag.
  *****************************************************************************
  */
-const icChar *CIccTagText::operator=(const icChar *szText)
+CIccTagText &CIccTagText::operator=(const icChar *szText)
 {
   SetText(szText);
-  return m_szText;
+  return *this;
 }
 
 /**
@@ -1187,10 +1187,10 @@ void CIccTagUtf8Text::SetText(const icUChar16 *szText)
  * Return: A pointer to the string assigned to the tag.
  *****************************************************************************
  */
-const icUChar *CIccTagUtf8Text::operator=(const icUChar *szText)
+CIccTagUtf8Text& CIccTagUtf8Text::operator=(const icUChar *szText)
 {
   SetText(szText);
-  return (icUChar*)m_szText;
+  return *this;
 }
 
 /**
@@ -2077,10 +2077,10 @@ void CIccTagUtf16Text::SetText(const icUChar *szText)
  * Return: A pointer to the string assigned to the tag.
  *****************************************************************************
  */
-const icUChar16 *CIccTagUtf16Text::operator=(const icUChar16 *szText)
+CIccTagUtf16Text& CIccTagUtf16Text::operator=(const icUChar16 *szText)
 {
   SetText(szText);
-  return (icUChar16*)m_szText;
+  return *this;
 }
 
 /**
@@ -2572,10 +2572,10 @@ void CIccTagTextDescription::SetText(const icChar *szText)
  * Return: A pointer to the string assigned to the tag.
  *****************************************************************************
  */
-const icChar *CIccTagTextDescription::operator=(const icChar *szText)
+CIccTagTextDescription& CIccTagTextDescription::operator=(const icChar *szText)
 {
   SetText(szText);
-  return m_szText;
+  return *this;
 }
 
 /**

--- a/IccProfLib/IccTagBasic.h
+++ b/IccProfLib/IccTagBasic.h
@@ -413,7 +413,7 @@ public:
 
   const icChar *GetText() const { return m_szText; }
   void SetText(const icChar *szText);
-  const icChar *operator=(const icChar *szText);
+  CIccTagText &operator=(const icChar *szText);
 
   icChar *GetBuffer(icUInt32Number nSize);
   void Release();
@@ -455,8 +455,8 @@ public:
   void SetText(const icUChar *szText);
   void SetText(const icChar *szText) { SetText((icUChar*)szText); }
   
-  const icUChar *operator=(const icUChar *szText);
-  const icChar *operator=(const icChar *szText) { return (const icChar*)operator=((icUChar*)szText); }
+  CIccTagUtf8Text& operator=(const icUChar *szText);
+  CIccTagUtf8Text& operator=(const icChar *szText) { return operator=((icUChar*)szText); }
 
   icUChar *GetBuffer(icUInt32Number nSize);
   void Release();
@@ -570,7 +570,7 @@ public:
 
   icUInt32Number GetLength() const;
 
-  const icUChar16 *operator=(const icUChar16 *szText);
+  CIccTagUtf16Text& operator=(const icUChar16 *szText);
 
   icUChar16 *GetBuffer(icUInt32Number nSize);
   void Release();
@@ -610,7 +610,7 @@ public:
 
   const icChar *GetText() const { return m_szText; }
   void SetText(const icChar *szText);
-  const icChar *operator=(const icChar *szText);
+  CIccTagTextDescription& operator=(const icChar *szText);
 
   icChar *GetBuffer(icUInt32Number nSize);
   void Release();
@@ -667,7 +667,7 @@ public:
 
   icUInt32Number GetValue() const { return m_nSig; }
   void SetValue(icUInt32Number sig) { m_nSig = sig; }
-  icUInt32Number operator=(icUInt32Number sig) { SetValue(sig); return m_nSig; }
+  CIccTagSignature& operator=(icUInt32Number sig) { SetValue(sig); return *this; }
   virtual icValidateStatus Validate(std::string sigPath, std::string &sReport, const CIccProfile* pProfile=NULL) const;
 
 protected:
@@ -1311,9 +1311,9 @@ public: //member functions
                icLanguageCode nLanguageCode = icLanguageCodeEnglish,
                icCountryCode nRegionCode = icCountryCodeUSA);
 
-  const icChar *operator=(const icChar *szText) { SetText(szText); return szText; }
-  const icUInt16Number *operator=(const icUInt16Number *sszText) { SetText(sszText); return sszText; }
-  const icUInt32Number *operator=(const icUInt32Number *sszText) { SetText(sszText); return sszText; }
+  CIccLocalizedUnicode& operator=(const icChar *szText) { SetText(szText); return *this; }
+  CIccLocalizedUnicode& operator=(const icUInt16Number *sszText) { SetText(sszText); return *this; }
+  CIccLocalizedUnicode& operator=(const icUInt32Number *sszText) { SetText(sszText); return *this; }
 
   //Data
   icLanguageCode m_nLanguageCode;

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -383,8 +383,11 @@ int main(int argc, const char* argv[])
         cfgJson["profileSequence"] = profilesJson;
 
         std::string jsonText = cfgJson.dump(1);
-        fwrite(jsonText.c_str(), 1, jsonText.size(), f);
-        fclose(f);
+        size_t n = fwrite(jsonText.c_str(), 1, jsonText.size(), f);
+        if (n != jsonText.size()) {
+          printf("Error writing json config file '%s'\n", exportFile.c_str());
+        }
+        (void)fclose(f);
       }
       else {
         printf("Unable to export config file '%s'\n", exportFile.c_str());

--- a/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
+++ b/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
@@ -380,8 +380,11 @@ int main(int argc, const char* argv[])
 
 
         std::string jsonText = cfgJson.dump(1);
-        fwrite(jsonText.c_str(), 1, jsonText.size(), f);
-        fclose(f);
+        size_t n = fwrite(jsonText.c_str(), 1, jsonText.size(), f);
+        if (n != jsonText.size()) {
+          printf("Error writing json config file '%s'\n", exportFile.c_str());
+        }
+        (void)fclose(f);
       }
       else {
         printf("Unable to export config file '%s'\n", exportFile.c_str());

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -159,7 +159,7 @@ void DumpTagCore(CIccTag *pTag, icTagSignature sig, int nVerboseness)
       contents = validateReport;
     else
       pTag->Describe(contents, nVerboseness);
-    fwrite(contents.c_str(), contents.length(), 1, stdout);
+    (void)fwrite(contents.c_str(), contents.length(), 1, stdout);
   }
   else {
     printf("Tag (%s) not found in profile\n", icGetSig(buf, bufSize, sig));
@@ -734,7 +734,7 @@ int main(int argc, char* argv[])
   printf("\n\n");
 
   sReport += "\n";
-  fwrite(sReport.c_str(), sReport.length(), 1, stdout);
+  (void)fwrite(sReport.c_str(), sReport.length(), 1, stdout);
 
   delete pIcc;
 

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -532,7 +532,7 @@ int main(int argc, char* argv[])
             pad = (overlap > (icUInt64Number)INT_MAX) ? INT_MIN : -(int)overlap;
         }
         else
-            pad = closest - i->TagInfo.offset - i->TagInfo.size;
+            pad = (int)(closest - tagEnd);
 
         printf("%28s  %s  %8d\t%8d\t%8d\n", Fmt.GetTagSigName(i->TagInfo.sig),
             icGetSig(buf, bufSize, i->TagInfo.sig, false), (unsigned int) i->TagInfo.offset, (unsigned int) i->TagInfo.size, pad);

--- a/Tools/CmdLine/IccFromCube/iccFromCube.cpp
+++ b/Tools/CmdLine/IccFromCube/iccFromCube.cpp
@@ -109,6 +109,10 @@ public:
     bool bAddBlankLine = false;
     while (!isEOF()) {
       long pos = ftell(m_f);
+      if (pos < 0) {
+        printf("header parsing error\n");
+        return false;
+      }
       std::string line = getNextLine();
 
       if (line.empty()) {
@@ -118,7 +122,11 @@ public:
       }
       else if (line[0] == '-' || line[0] == '.' || (line[0] >= '0' && line[0] <= '9')) {
         //undo getNextLine so it can be 3D table can be parsed
-        fseek(m_f, pos, SEEK_SET);
+        int result = fseek(m_f, pos, SEEK_SET);
+        if (result < 0) {
+          printf("header parsing error\n");
+          return false;
+        }
         break;
       }
       else if (line.substr(0, 6) == "TITLE ") {
@@ -264,7 +272,9 @@ protected:
       m_f = fopen(m_sFilename.c_str(), "rb");
     }
     else {
-      fseek(m_f, 0, SEEK_SET);
+      int result = fseek(m_f, 0, SEEK_SET);
+      if (result < 0)
+        return false;
     }
     return m_f != nullptr;
   }

--- a/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
@@ -314,6 +314,11 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   writeFailed |= putIFDLong( TIFF_ROWSPERSTRIP, TIFF_LONG, 1, uint32_t(rowsPerStrip), outfile );
 
   long byteCountOffset = ftell( outfile );
+  if (byteCountOffset < 0) {
+    fprintf(stderr, "ERROR: TIFF ftell failed\n");
+    (void)fclose(outfile);
+    return false;
+  }
   if (stripCount > 1)
     writeFailed |= putIFDLong( TIFF_STRIPBYTECOUNTS, TIFF_LONG, uint32_t(stripCount), stripByteCount_offset, outfile );
   else


### PR DESCRIPTION
Part of #1063

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members