### PR TITLE
Additional improvements to named color support with iccApplyNamedCmm

### DIFF
--- a/.github/scripts/iccdev-namedcolor-overprint-regression-tests.sh
+++ b/.github/scripts/iccdev-namedcolor-overprint-regression-tests.sh
@@ -4,20 +4,68 @@
 ###############################################################################
 #
 # Exercises the v5 NamedColor overprint variants surfaced by the
-# CIccCreateNamedColorXformHint::nOverprintType plumbing:
-#   - over-white (default)            -> icSigNmclSpectralDataMbr      ('spec')
-#   - over-black (transform=namedOnBlack / intent +1000000) -> 'spcb'
-#   - over-gray  (transform=namedOnGray  / intent +2000000) -> 'spcg'
+# CIccCreateNamedColorXformHint::nOverprintType plumbing, on both axes:
+#
+# Overprint axis (which spectral array member is read):
+#   - over-white (default)                                  -> 'spec'
+#   - over-black (transform=*OnBlack / intent +1000000)     -> 'spcb'
+#   - over-gray  (transform=*OnGray  / intent +2000000)     -> 'spcg'
+#
+# PCS-side axis (JSON only -- legacy CLI is auto via useD2BxB2Dx):
+#   - named*              -- heuristic: spectralPCS when useD2BxB2Dx and
+#                            spectralPCS is declared, otherwise PCS
+#   - namedSpectral*      -- pinned to the spectral array member chosen
+#                            by the overprint suffix; fails clean with
+#                            icCmmStatBadTintXform if that member is
+#                            absent for the matched entry
+#   - namedColorimetric*  -- pinned to nmclPcsDataMbr; fails clean with
+#                            icCmmStatBadTintXform if that member is
+#                            absent for the matched entry (no silent
+#                            integration from spectral)
+#   - namedDevice         -- pinned to nmclDeviceDataMbr (v5 array) or
+#                            the deviceCoords struct field (v4 NamedColor2);
+#                            fails clean with icCmmStatBadTintXform when
+#                            no device member is available for the entry.
+#                            No overprint suffix is accepted.
 #
 # Test profile: Testing/Named/NamedColor.icc, rebuilt from NamedColor.xml
-# by Testing/CreateAllProfiles.* (the iccdev_profiles fixture).  Its Silver
-# entry carries both 'spec' (mean reflectance ~0.83) and 'spcb' (~0.30)
-# array members but no 'spcg', giving us four distinct assertions:
+# by Testing/CreateAllProfiles.* (the iccdev_profiles fixture).  Two
+# named-color entries cover the cases the script exercises:
+#   - Silver: has 'spec' (~0.83) and 'spcb' (~0.30) spectral members
+#             but NO nmclPcsDataMbr and NO 'spcg'.
+#   - Red:    has nmclPcsDataMbr (last row L=47.9 a=73.5 b=60.6 at tint=1)
+#             plus 'spec'; no 'spcb' or 'spcg'.
+# Together they let the script exercise both halves of the strict
+# semantics: namedSpectral* fails clean on missing spectral members,
+# namedColorimetric* succeeds on Red and fails clean on Silver.
 #
+# Legacy-CLI assertions (intent code, useD2BxB2Dx implicit):
 #   1) over-white succeeds and produces high-reflectance spectrum
 #   2) over-black succeeds and produces low-reflectance spectrum
 #   3) the two spectra differ substantially (delta-mean > 0.3)
 #   4) over-gray fails clean (apply exits non-zero; no silent fallback)
+#
+# JSON-cfg assertions (added after the legacy block):
+#   5) namedSpectral on Silver           -- high-reflectance spectrum (matches #1)
+#   6) namedSpectralOnBlack on Silver    -- low-reflectance spectrum  (matches #2)
+#   7) namedSpectralOnGray on Silver     -- fails clean (no 'spcg' on Silver)
+#   8) namedColorimetric on Silver       -- fails clean (no nmclPcsDataMbr)
+#   9) namedColorimetricOnBlack on Silver-- fails clean (no nmclPcsDataMbr;
+#                                            overprint suffix does not matter
+#                                            for the colorimetric stem)
+#  10) namedColorimetric on Red          -- produces Lab matching the
+#                                            tint=1 row of Red's nmclPcsDataMbr
+#                                            (L ~= 47.9, |L-47.9| < 0.5)
+#  11) namedDevice on Silver             -- fails clean (no nmclDeviceDataMbr
+#                                            on any entry of the v5
+#                                            NamedColor.icc fixture; this
+#                                            guards the v5 array path's
+#                                            BadTintXform surfacing)
+#  12) tint echo in dump (S5/S6/S7 regression) -- the test-5 log must
+#                                            carry a numeric tint token
+#                                            after `;{ "Silver" }`, not
+#                                            silently drop it (used to
+#                                            be suppressed when tint==1).
 #
 # Environment variables (set by CI workflow):
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
@@ -49,7 +97,7 @@ PASS=0
 FAIL=0
 ASAN_FINDINGS=0
 UBSAN_FINDINGS=0
-TOTAL=4
+TOTAL=12
 
 echo "=== iccApplyNamedCmm overprint regression ==="
 
@@ -83,16 +131,20 @@ run_apply() {
   return $ec
 }
 
-# Extract the Silver row's reflectance mean.  Output line shape:
-#   <36 floats>\t;{ "Silver" }
-# Mean = sum of numeric fields / count.  Returns empty if no Silver row was
-# emitted (e.g. because the apply failed before producing output).
+# Extract the Silver row's reflectance mean.  Output line shape (with the
+# tint-echo fix in place):
+#   <36 floats>\t;{ "Silver" }    <tint>
+# Mean = sum of numeric fields / count, stopping at the ';' comment
+# marker so the trailing tint token does not pollute the spectral mean.
+# Returns empty if no Silver row was emitted (e.g. because the apply
+# failed before producing output).
 silver_mean() {
   local logpath="$1"
   awk '
     /Silver/ {
       sum=0; n=0
       for (i = 1; i <= NF; i++) {
+        if ($i ~ /^;/) break
         if ($i ~ /^-?[0-9]+(\.[0-9]+)?$/) { sum += $i; n++ }
       }
       if (n > 0) printf "%.4f\n", sum / n
@@ -152,6 +204,216 @@ if [ "$EC_G" -ne 0 ]; then
 else
   echo "  [FAIL] over-gray   intent=2000003  unexpectedly succeeded (expected fail-clean on missing 'spcg')"
   sed -n '1,10p' "$LOG_G"
+  FAIL=$((FAIL + 1))
+fi
+
+###############################################################################
+# JSON-cfg variants: exercise the new namedSpectral* / namedColorimetric*
+# transform names through iccApplyNamedCmm -cfg.
+###############################################################################
+
+# Build a one-stage config that names $color_name at tint=1.0 and
+# routes it through $PROFILE with the requested transform.
+#   $1: dst encoding ("float" for spectral, "value" for Lab/XYZ)
+#   $2: transform name
+#   $3: named color name (e.g. "Silver", "Red")
+#   $4: output cfg path
+write_cfg() {
+  local dst_encoding="$1"; local transform_name="$2"
+  local color_name="$3"; local cfg_path="$4"
+  cat > "$cfg_path" <<EOF
+{
+ "colorData": {
+  "data": [ { "n": "$color_name", "v": [ 1.0 ] } ],
+  "encoding": "percent",
+  "srcEncoding": "value",
+  "srcSpace": "nmcl"
+ },
+ "dataFiles": {
+  "dstEncoding": "$dst_encoding",
+  "dstType": "legacy",
+  "srcFile": null,
+  "srcType": "colorData"
+ },
+ "profileSequence": [
+  {
+   "iccFile": "$PROFILE",
+   "intent": "absolute",
+   "transform": "$transform_name"
+  }
+ ]
+}
+EOF
+}
+
+# Wraps a JSON-cfg iccApplyNamedCmm invocation; mirrors run_apply's sanitizer
+# bookkeeping so ASAN/UBSAN findings still surface in the script's exit code.
+run_apply_cfg() {
+  local cfg_path="$1"; local logpath="$2"; local ec=0
+  timeout 30 "$APPLY" -cfg "$cfg_path" >"$logpath" 2>&1 || ec=$?
+  if grep -q "ERROR: AddressSanitizer" "$logpath" 2>/dev/null; then
+    ASAN_FINDINGS=$((ASAN_FINDINGS + 1))
+  fi
+  if grep -q "runtime error:" "$logpath" 2>/dev/null; then
+    UBSAN_FINDINGS=$((UBSAN_FINDINGS + 1))
+  fi
+  return $ec
+}
+
+# Extract just the L* of the matched-color row (first numeric token
+# before the ';' comment marker).  Lab output from a one-stage
+# NamedColor profile in icEncodeValue carries Lab directly:
+# "<L>  <a>  <b>  ;{ \"$2\" }    <tint>".
+#   $1: log path
+#   $2: color name (matched as a substring on the row's trailing comment)
+first_value() {
+  local logpath="$1"; local color_name="$2"
+  awk -v color="$color_name" '
+    index($0, color) {
+      for (i = 1; i <= NF; i++) {
+        if ($i ~ /^;/) break
+        if ($i ~ /^-?[0-9]+(\.[0-9]+)?$/) { printf "%.4f\n", $i; exit }
+      }
+      exit
+    }
+  ' "$logpath"
+}
+
+CFG_NS_W="$OUTDIR/cfg-namedSpectral-Silver.json"
+CFG_NS_B="$OUTDIR/cfg-namedSpectralOnBlack-Silver.json"
+CFG_NS_G="$OUTDIR/cfg-namedSpectralOnGray-Silver.json"
+CFG_NC_W="$OUTDIR/cfg-namedColorimetric-Silver.json"
+CFG_NC_B="$OUTDIR/cfg-namedColorimetricOnBlack-Silver.json"
+CFG_NC_R="$OUTDIR/cfg-namedColorimetric-Red.json"
+CFG_ND_S="$OUTDIR/cfg-namedDevice-Silver.json"
+
+LOG_NS_W="$OUTDIR/cfg-namedSpectral-Silver.log"
+LOG_NS_B="$OUTDIR/cfg-namedSpectralOnBlack-Silver.log"
+LOG_NS_G="$OUTDIR/cfg-namedSpectralOnGray-Silver.log"
+LOG_NC_W="$OUTDIR/cfg-namedColorimetric-Silver.log"
+LOG_NC_B="$OUTDIR/cfg-namedColorimetricOnBlack-Silver.log"
+LOG_NC_R="$OUTDIR/cfg-namedColorimetric-Red.log"
+LOG_ND_S="$OUTDIR/cfg-namedDevice-Silver.log"
+
+write_cfg "float" "namedSpectral"            "Silver" "$CFG_NS_W"
+write_cfg "float" "namedSpectralOnBlack"     "Silver" "$CFG_NS_B"
+write_cfg "float" "namedSpectralOnGray"      "Silver" "$CFG_NS_G"
+write_cfg "value" "namedColorimetric"        "Silver" "$CFG_NC_W"
+write_cfg "value" "namedColorimetricOnBlack" "Silver" "$CFG_NC_B"
+write_cfg "value" "namedColorimetric"        "Red"    "$CFG_NC_R"
+write_cfg "value" "namedDevice"              "Silver" "$CFG_ND_S"
+
+run_apply_cfg "$CFG_NS_W" "$LOG_NS_W"; EC_NS_W=$?
+run_apply_cfg "$CFG_NS_B" "$LOG_NS_B"; EC_NS_B=$?
+run_apply_cfg "$CFG_NS_G" "$LOG_NS_G"; EC_NS_G=$?
+run_apply_cfg "$CFG_NC_W" "$LOG_NC_W"; EC_NC_W=$?
+run_apply_cfg "$CFG_NC_B" "$LOG_NC_B"; EC_NC_B=$?
+run_apply_cfg "$CFG_NC_R" "$LOG_NC_R"; EC_NC_R=$?
+run_apply_cfg "$CFG_ND_S" "$LOG_ND_S"; EC_ND_S=$?
+
+MEAN_NS_W="$(silver_mean "$LOG_NS_W")"
+MEAN_NS_B="$(silver_mean "$LOG_NS_B")"
+L_NC_R="$(first_value "$LOG_NC_R" "Red")"
+
+# Test 5: JSON namedSpectral on Silver -- spectral output, high reflectance.
+# Equivalent to legacy intent=3 because both end up reading 'spec'.
+if [ "$EC_NS_W" -eq 0 ] && [ -n "$MEAN_NS_W" ] && \
+   awk -v m="$MEAN_NS_W" 'BEGIN{ exit (m > 0.7) ? 0 : 1 }'; then
+  echo "  [PASS] cfg namedSpectral Silver           mean=$MEAN_NS_W (> 0.7)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] cfg namedSpectral Silver           ec=$EC_NS_W mean=${MEAN_NS_W:-<missing>} (expected ec=0, mean>0.7)"
+  sed -n '1,10p' "$LOG_NS_W"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 6: JSON namedSpectralOnBlack on Silver -- spectral output, low reflectance.
+if [ "$EC_NS_B" -eq 0 ] && [ -n "$MEAN_NS_B" ] && \
+   awk -v m="$MEAN_NS_B" 'BEGIN{ exit (m < 0.5) ? 0 : 1 }'; then
+  echo "  [PASS] cfg namedSpectralOnBlack Silver    mean=$MEAN_NS_B (< 0.5)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] cfg namedSpectralOnBlack Silver    ec=$EC_NS_B mean=${MEAN_NS_B:-<missing>} (expected ec=0, mean<0.5)"
+  sed -n '1,10p' "$LOG_NS_B"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 7: JSON namedSpectralOnGray on Silver -- fail clean (no 'spcg' on Silver).
+if [ "$EC_NS_G" -ne 0 ]; then
+  echo "  [PASS] cfg namedSpectralOnGray Silver     failed cleanly (ec=$EC_NS_G)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] cfg namedSpectralOnGray Silver     unexpectedly succeeded (expected fail-clean on missing 'spcg')"
+  sed -n '1,10p' "$LOG_NS_G"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 8: JSON namedColorimetric on Silver -- fail clean (no nmclPcsDataMbr;
+# the colorimetric stem does not integrate from spectral members).
+if [ "$EC_NC_W" -ne 0 ]; then
+  echo "  [PASS] cfg namedColorimetric Silver       failed cleanly (ec=$EC_NC_W; no nmclPcsDataMbr)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] cfg namedColorimetric Silver       unexpectedly succeeded (expected fail-clean on missing nmclPcsDataMbr)"
+  sed -n '1,10p' "$LOG_NC_W"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 9: JSON namedColorimetricOnBlack on Silver -- fail clean for the
+# same reason as test 8.  The overprint suffix does not change which
+# member the colorimetric stem reads (it still reads nmclPcsDataMbr).
+if [ "$EC_NC_B" -ne 0 ]; then
+  echo "  [PASS] cfg namedColorimetricOnBlack Silver  failed cleanly (ec=$EC_NC_B; no nmclPcsDataMbr)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] cfg namedColorimetricOnBlack Silver  unexpectedly succeeded (expected fail-clean on missing nmclPcsDataMbr)"
+  sed -n '1,10p' "$LOG_NC_B"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 10: JSON namedColorimetric on Red -- read nmclPcsDataMbr and return
+# the tint=1 row directly.  Red's nmclPcsDataMbr last row in NamedColor.xml
+# is L=47.90215 a=73.46014 b=60.61409 -- expect L within +-0.5 of 47.90.
+if [ "$EC_NC_R" -eq 0 ] && [ -n "$L_NC_R" ] && \
+   awk -v l="$L_NC_R" 'BEGIN{ d=l-47.90; if(d<0) d=-d; exit (d < 0.5) ? 0 : 1 }'; then
+  echo "  [PASS] cfg namedColorimetric Red          L*=$L_NC_R (within 0.5 of 47.90)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] cfg namedColorimetric Red          ec=$EC_NC_R L*=${L_NC_R:-<missing>} (expected ec=0, |L-47.90|<0.5)"
+  sed -n '1,10p' "$LOG_NC_R"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 11: JSON namedDevice on Silver -- fail clean.  No entry in the v5
+# NamedColor.icc fixture carries nmclDeviceDataMbr, and the profile
+# header's DataColourSpace is empty, so the v5 array path's
+# GetDeviceTint returns false and Apply surfaces icCmmStatBadTintXform.
+# This is the v5 negative guard; a v4 success case would need a
+# NamedColor2 profile with deviceCoords (e.g. NamedColorV4.icc) and is
+# left for a separate fixture if/when one is part of the iccdev_profiles
+# bundle.
+if [ "$EC_ND_S" -ne 0 ]; then
+  echo "  [PASS] cfg namedDevice Silver             failed cleanly (ec=$EC_ND_S; no nmclDeviceDataMbr)"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] cfg namedDevice Silver             unexpectedly succeeded (expected fail-clean on missing nmclDeviceDataMbr)"
+  sed -n '1,10p' "$LOG_ND_S"
+  FAIL=$((FAIL + 1))
+fi
+
+# Test 12: tint-echo guard (S5/S6/S7 dump regression).  Re-use the test-5
+# log: that run drove namedSpectral on Silver tint=1.0, so the dump row
+# must end with `;{ "Silver" }    <tint>`.  Earlier code suppressed the
+# tint token whenever the value was exactly 1.0, which made S5/S6/S7
+# look as though no tint had been supplied; this assertion fails if that
+# regression returns or if the tool stops copying pData->m_values into
+# the output entry's m_srcValues at all.
+if grep -E 'Silver"[[:space:]]+\}[[:space:]]+[0-9]+\.[0-9]+' "$LOG_NS_W" > /dev/null 2>&1; then
+  echo "  [PASS] tint echo                          { \"Silver\" } row in test-5 log carries a tint token"
+  PASS=$((PASS + 1))
+else
+  echo "  [FAIL] tint echo                          { \"Silver\" } row in test-5 log has no tint token (S5/S6/S7 regression)"
+  sed -n '/Silver/p' "$LOG_NS_W"
   FAIL=$((FAIL + 1))
 fi
 

--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -706,23 +706,48 @@ static const char* icGetRenderingIntentName(int nIntent)
 }
 
 // Transform names exposed by JSON and the (transform, overprint) pair they
-// resolve to.  The "namedOnBlack" / "namedOnGray" variants pick alternate
-// spectral array members on a v5 NamedColor profile; the overprint value is
-// ignored for non-named transforms.  Keep all three arrays in lock-step.
+// resolve to.  The named-color variants come on two axes that mirror the
+// non-named color/colorimetric/spectral triad:
+//
+//  - PCS-side stem:
+//    - "named"             -- auto/legacy: heuristic picks colorimetric or
+//                              spectral based on useD2BxB2Dx and whether
+//                              the profile declares spectralPCS.
+//    - "namedColorimetric" -- pin to nmclPcsDataMbr; fail clean if absent.
+//    - "namedSpectral"     -- pin to the overprint-correct spectral
+//                              member; fail clean if absent.
+//    - "namedDevice"       -- pin to nmclDeviceDataMbr (xform dst is the
+//                              profile's colorSpace); fail clean if absent.
+//
+//  - Overprint suffix (spectral path only -- a no-op on the other stems,
+//    since neither nmclPcsDataMbr nor nmclDeviceDataMbr varies by
+//    substrate): "" / "OnBlack" / "OnGray" selects 'spec' / 'spcb' /
+//    'spcg' from the spectral array.
+//
+// Keep all three arrays in lock-step.
 static const char* icTranNames[] = { "default",
                                      "named", "namedOnBlack", "namedOnGray",
+                                     "namedColorimetric", "namedColorimetricOnBlack", "namedColorimetricOnGray",
+                                     "namedSpectral", "namedSpectralOnBlack", "namedSpectralOnGray",
+                                     "namedDevice",
                                      "colorimetric", "spectral",
                                      "MCS", "preview", "gamut", "brdfParam",
                                      "brdfDirect", "brdfMcsParam" , nullptr };
 
 static icXformLutType icTranValues[] = { icXformLutColor,
                                          icXformLutNamedColor, icXformLutNamedColor, icXformLutNamedColor,
+                                         icXformLutNamedColorimetric, icXformLutNamedColorimetric, icXformLutNamedColorimetric,
+                                         icXformLutNamedSpectral, icXformLutNamedSpectral, icXformLutNamedSpectral,
+                                         icXformLutNamedDevice,
                                          icXformLutColorimetric, icXformLutSpectral,
                                          icXformLutMCS, icXformLutPreview, icXformLutGamut, icXformLutBRDFParam,
                                          icXformLutBRDFDirect, icXformLutBRDFMcsParam, icXformLutColor };
 
 static icNamedColorOverprintType icTranOverprint[] = { icNamedColorOverWhite,
                                                        icNamedColorOverWhite, icNamedColorOverBlack, icNamedColorOverGray,
+                                                       icNamedColorOverWhite, icNamedColorOverBlack, icNamedColorOverGray,
+                                                       icNamedColorOverWhite, icNamedColorOverBlack, icNamedColorOverGray,
+                                                       icNamedColorOverWhite,
                                                        icNamedColorOverWhite, icNamedColorOverWhite,
                                                        icNamedColorOverWhite, icNamedColorOverWhite, icNamedColorOverWhite, icNamedColorOverWhite,
                                                        icNamedColorOverWhite, icNamedColorOverWhite, icNamedColorOverWhite };
@@ -2068,7 +2093,14 @@ fprintf(f, "\n");
 
     if (pData->m_srcName.size() != size_t(0)) {
       fprintf(f,"{ \"%s\" }", pData->m_srcName.c_str());
-      if (pData->m_srcValues.size() > 0 && pData->m_srcValues[0] != 1.0) {
+      // Echo the tint the caller supplied (m_srcValues[0]).  We used to
+      // suppress this when the tint was exactly 1.0, but that hid a
+      // value the caller had explicitly written -- the
+      // hpwos-S5/S6/S7 configs were a concrete example where the
+      // colorData "v" entry of 1.0 disappeared from the dump.  Emit
+      // unconditionally when m_srcValues is populated; an absent "v"
+      // still leaves m_srcValues empty and produces no token.
+      if (pData->m_srcValues.size() > 0) {
         if (!writeFloat(pData->m_srcValues[0])) { if (f != stdout) fclose(f); return false; }
       }
     }

--- a/IccConnect/IccLibConnect/IccConnect.cpp
+++ b/IccConnect/IccLibConnect/IccConnect.cpp
@@ -205,20 +205,23 @@ icStatusCMM CIccConnectCmm::AddXformFromConfig(CIccCmm* pCmm,
   }
 
   // Attach a CIccCreateNamedColorXformHint carrying m_nOverprint whenever
-  // the caller asked for anything other than the OverWhite default.  This
-  // covers both:
-  //  - JSON "namedOnBlack"/"namedOnGray" (which also sets m_transform =
-  //    icXformLutNamedColor)
-  //  - the legacy CLI +1000000/+2000000 high-bit (which leaves m_transform
-  //    at icXformLutColor and relies on the CMM's deviceClass-based
-  //    auto-dispatch to the named-color branch in CIccNamedColorCmm
-  //    or CIccCmm).
-  // The CMM's named-color branch fills in the header-derived color-space
-  // fields after the profile is opened (via the Layer 2 changes that honor
-  // a pre-attached hint).  When the profile turns out not to be a
-  // NamedColor xform, the hint is simply unused.
+  // the caller asked for anything other than the OverWhite default, or
+  // whenever the JSON explicitly selected one of the named-color transform
+  // variants (so the named-color factory path in CIccXform::Create gets a
+  // pre-built hint regardless of profile device class).  Covers:
+  //  - JSON "named*OnBlack"/"named*OnGray" (m_nOverprint != OverWhite)
+  //  - JSON "named", "namedColorimetric", "namedSpectral" (the m_transform
+  //    check below; m_nOverprint is OverWhite)
+  //  - the legacy CLI +1000000/+2000000 high-bit (leaves m_transform at
+  //    icXformLutColor and relies on the CMM's deviceClass-based
+  //    auto-dispatch into the named-color branch).
+  // When the profile turns out not to be a NamedColor xform the hint is
+  // simply unused.
   if (pCfg->m_nOverprint != icNamedColorOverWhite ||
-      pCfg->m_transform == icXformLutNamedColor) {
+      pCfg->m_transform == icXformLutNamedColor ||
+      pCfg->m_transform == icXformLutNamedColorimetric ||
+      pCfg->m_transform == icXformLutNamedSpectral ||
+      pCfg->m_transform == icXformLutNamedDevice) {
     CIccCreateNamedColorXformHint* pNCHint =
         new (std::nothrow) CIccCreateNamedColorXformHint();
     if (!pNCHint) {

--- a/IccProfLib/IccArrayBasic.h
+++ b/IccProfLib/IccArrayBasic.h
@@ -174,9 +174,9 @@ public:
                        icFloatNumber tint=1.0f,
                        icNamedColorlMemberSignature sig=icSigNmclSpectralDataMbr) const;
 
-  icUInt32Number GetDeviceSamples() { return m_nDeviceSamples; }
-  icUInt32Number GetPcsSamples() { return m_nPcsSamples; }
-  icUInt32Number GetSpectralSamples() { return m_nSpectralSamples; }
+  icUInt32Number GetDeviceSamples() const { return m_nDeviceSamples; }
+  icUInt32Number GetPcsSamples() const { return m_nPcsSamples; }
+  icUInt32Number GetSpectralSamples() const { return m_nSpectralSamples; }
 
 protected:
   bool GetTint(icFloatNumber *dstColor,

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -10892,6 +10892,23 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
       break;
   }
 
+  // namedColorimetric / namedSpectral / namedDevice pin which v5 named
+  // array member the name->space apply path reads (nmclPcsDataMbr /
+  // spectral / nmclDeviceDataMbr respectively); plain icXformLutNamedColor
+  // leaves the colorimetric-vs-spectral choice to the bUseD2BxB2Dx /
+  // spectralPCS-presence heuristic below.  Outside the named-color
+  // branch the colorimetric/spectral variants collapse to their non-
+  // named counterparts; namedDevice collapses to icXformLutColor (auto).
+  const bool bExplicitNamed   = (nLutType == icXformLutNamedColor ||
+                                 nLutType == icXformLutNamedColorimetric ||
+                                 nLutType == icXformLutNamedSpectral ||
+                                 nLutType == icXformLutNamedDevice);
+  const bool bWantSpectral    = (nLutType == icXformLutSpectral ||
+                                 nLutType == icXformLutNamedSpectral);
+  const bool bWantColorimetric = (nLutType == icXformLutColorimetric ||
+                                 nLutType == icXformLutNamedColorimetric);
+  const bool bWantDevice      = (nLutType == icXformLutNamedDevice);
+
   Xform.ptr = NULL;
   switch (nUseLutType) {
     //Automatically choose which one
@@ -10899,14 +10916,21 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
     case icXformLutColorimetric:
     case icXformLutSpectral:
     case icXformLutNamedColor:
+    case icXformLutNamedColorimetric:
+    case icXformLutNamedSpectral:
+    case icXformLutNamedDevice:
     {
       CIccTag *pTag = pProfile->FindTag(icSigNamedColor2Tag);
 
-      if (pTag && (pProfile->m_Header.deviceClass==icSigNamedColorClass || nLutType == icXformLutNamedColor)) {
+      if (pTag && (pProfile->m_Header.deviceClass==icSigNamedColorClass || bExplicitNamed)) {
         if (bInput) {
           nSrcSpace = icSigNamedData;
         }
-        else if (nLutType == icXformLutSpectral || ((bUseD2BxB2DxTags || !pProfile->m_Header.pcs) && pProfile->m_Header.spectralPCS && nLutType != icXformLutColorimetric)) {
+        else if (bWantDevice) {
+          // name <- device direction: source is the profile's colorSpace.
+          nSrcSpace = pProfile->m_Header.colorSpace;
+        }
+        else if (bWantSpectral || (!bWantColorimetric && (bUseD2BxB2DxTags || !pProfile->m_Header.pcs) && pProfile->m_Header.spectralPCS)) {
           nSrcSpace = (icColorSpaceSignature)pProfile->m_Header.spectralPCS;
           bUseD2BxB2DxTags = true;
         }
@@ -10932,8 +10956,16 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
         }
 
         if (nSrcSpace==icSigNamedData) {
-          if (nLutType == icXformLutSpectral || (bUseD2BxB2DxTags && pProfile->m_Header.spectralPCS && nLutType != icXformLutColorimetric)) {
-            nDstSpace = (icColorSpaceSignature)pProfile->m_Header.spectralPCS; 
+          if (bWantDevice) {
+            // name -> device direction: dst is the profile's colorSpace.
+            // Apply routes through CIccArrayNamedColor::GetDeviceTint
+            // (v5 array) or memcpy of pTag->GetEntry(j)->deviceCoords
+            // (v4 NamedColor2Tag), both of which surface
+            // icCmmStatBadTintXform if no device member is available.
+            nDstSpace = pProfile->m_Header.colorSpace;
+          }
+          else if (bWantSpectral || (!bWantColorimetric && bUseD2BxB2DxTags && pProfile->m_Header.spectralPCS)) {
+            nDstSpace = (icColorSpaceSignature)pProfile->m_Header.spectralPCS;
             bUseD2BxB2DxTags = true;
           }
           else {
@@ -10961,14 +10993,17 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
       }
       else {
         //It isn't named color so make we will use color lut.
-        if (nUseLutType==icXformLutNamedColor)
+        if (nUseLutType==icXformLutNamedColor ||
+            nUseLutType==icXformLutNamedColorimetric ||
+            nUseLutType==icXformLutNamedSpectral ||
+            nUseLutType==icXformLutNamedDevice)
           nUseLutType = icXformLutColor;
 
         //Check pProfile if nIntent and input can be found.
         if (bInput) {
           nSrcSpace = pProfile->m_Header.colorSpace;
 
-          if (nLutType == icXformLutSpectral || ((bUseD2BxB2DxTags || !pProfile->m_Header.pcs) && pProfile->m_Header.spectralPCS && nLutType != icXformLutColorimetric)) {
+          if (bWantSpectral || (!bWantColorimetric && (bUseD2BxB2DxTags || !pProfile->m_Header.pcs) && pProfile->m_Header.spectralPCS)) {
             nDstSpace = (icColorSpaceSignature)pProfile->m_Header.spectralPCS;
             bUseD2BxB2DxTags = true;
           }
@@ -10984,7 +11019,7 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
             nIntent = icPerceptual; // Note: icPerceptualIntent = 0
           }
 
-          if (nLutType == icXformLutSpectral || ((bUseD2BxB2DxTags || !pProfile->m_Header.pcs) && pProfile->m_Header.spectralPCS && nLutType != icXformLutColorimetric)) {
+          if (bWantSpectral || (!bWantColorimetric && (bUseD2BxB2DxTags || !pProfile->m_Header.pcs) && pProfile->m_Header.spectralPCS)) {
             nSrcSpace = (icColorSpaceSignature)pProfile->m_Header.spectralPCS;
             bUseD2BxB2DxTags = true;
           }

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -131,7 +131,26 @@ typedef enum {
   icXformLutMCS                = 0x8,
   icXformLutColorimetric       = 0x9,
   icXformLutSpectral           = 0xA,
+  icXformLutNamedColorimetric  = 0xB,
+  icXformLutNamedSpectral      = 0xC,
+  icXformLutNamedDevice        = 0xD,
  } icXformLutType;
+
+  // Note: Named-color variants that pin which member of a v5 NamedColor
+  // array the name->space apply path reads:
+  //   icXformLutNamedColorimetric -- reads icSigNmclPcsDataMbr; fails
+  //     with icCmmStatBadTintXform if the matched entry has none.
+  //   icXformLutNamedSpectral     -- reads the spectral member chosen
+  //     by the overprint hint ('spec' / 'spcb' / 'spcg'); fails with
+  //     icCmmStatBadTintXform if that member is absent.
+  //   icXformLutNamedDevice       -- reads icSigNmclDeviceDataMbr; the
+  //     xform's destination is the profile's colorSpace.  Fails with
+  //     icCmmStatBadTintXform if the matched entry has no device
+  //     member, or if the profile declares no colorSpace.
+  // Plain icXformLutNamedColor leaves the colorimetric/spectral choice
+  // to the bUseD2BxB2Dx / spectralPCS-presence heuristic in
+  // CIccNamedColorCmm::AddXform.
+
 
 #define icPerceptualRefBlackX 0.00336
 #define icPerceptualRefBlackY 0.0034731
@@ -339,6 +358,7 @@ public:
 
 //forward reference to CIccXform used by CIccApplyXform
 class CIccApplyXform;
+class CIccMatrixMath;
 
 /**
  **************************************************************************

--- a/Tools/CmdLine/IccApplyNamedCmm/Readme.md
+++ b/Tools/CmdLine/IccApplyNamedCmm/Readme.md
@@ -15,45 +15,108 @@ Example input data files are under `Testing/ApplyDataFiles/`.
 
 ## Named Color Overprint Variants
 
-When a v5 NamedColor profile carries the optional over-black or over-gray
-spectral array members (`icSigNmclSpectralOverBlackMbr 'spcb'` and
-`icSigNmclSpectralOverGrayMbr 'spcg'`), iccApplyNamedCmm can read those
-alternates in place of the default over-white member (`'spec'`). This
-exposes the metameric difference between the named color printed over a
-white substrate, over a black substrate, or over a gray substrate.
+The JSON `transform` field for a NamedColor stage selects on two
+axes that mirror the non-named `color` / `colorimetric` / `spectral`
+triad, plus a `namedDevice` stem that reads the device-side member.
+The **output-side stem** pins which array member the lookup reads;
+the **overprint suffix** picks the spectral substrate variant
+(applies only when the stem is `named` or `namedSpectral`):
 
-Two ways to select the variant:
+| Surface | Over white | Over black | Over gray |
+|---------|------------|------------|-----------|
+| `transform` stem `named` — output side auto (legacy heuristic) | `"named"` | `"namedOnBlack"` | `"namedOnGray"` |
+| `transform` stem `namedColorimetric` — pinned to `nmclPcsDataMbr` (suffix is a no-op) | `"namedColorimetric"` | `"namedColorimetricOnBlack"` | `"namedColorimetricOnGray"` |
+| `transform` stem `namedSpectral` — pinned to the overprint spectral member | `"namedSpectral"` | `"namedSpectralOnBlack"` | `"namedSpectralOnGray"` |
+| `transform` stem `namedDevice` — pinned to `nmclDeviceDataMbr` (no overprint suffix accepted) | `"namedDevice"` | — | — |
+| Legacy CLI intent code (overprint only — stem implicit via `useD2BxB2Dx`) | base intent | `intent + 1000000` | `intent + 2000000` |
 
-| Surface | Default (over white) | Over black | Over gray |
-|---------|---------------------|------------|-----------|
-| JSON `transform` field | `"named"` | `"namedOnBlack"` | `"namedOnGray"` |
-| Legacy CLI intent code | base intent | `intent + 1000000` | `intent + 2000000` |
+`named` is the auto / legacy stem: if `useD2BxB2Dx` is true and the
+profile declares a `spectralPCS`, the named transform's output side is
+the spectralPCS (reads the overprint-correct spectral member);
+otherwise it is the profile's colorimetric PCS (reads `nmclPcsDataMbr`).
+`namedColorimetric` pins reads to `nmclPcsDataMbr` and fails with
+`icCmmStatBadTintXform` when an entry does not carry that member.
+`namedSpectral` pins reads to the spectral array member selected by the
+overprint suffix and fails with `icCmmStatBadTintXform` when that
+member is absent. `namedDevice` pins reads to `nmclDeviceDataMbr` (or
+the legacy `deviceCoords` struct field on a v4 `CIccTagNamedColor2`
+profile) and sets the xform's destination to the profile's
+`colorSpace`; it fails with `icCmmStatBadTintXform` when the device
+member is absent. The overprint suffix is a no-op on
+`namedColorimetric*` and not accepted on `namedDevice`, because neither
+the PCS nor the device member varies by substrate.
 
-Examples — both yield the same chain stage:
+Examples — three transforms that exercise the over-black variant of a
+named color, differing in PCS-side stem:
 
 ```jsonc
-// JSON config (CIccCfgProfile entry)
+// PCS-side auto (legacy heuristic; over-black selected via the
+// overprint suffix).  Whether the lookup reads the spectral member
+// or nmclPcsDataMbr depends on useD2BxB2Dx and whether spectralPCS
+// is declared in the profile header.
 {
-  "iccFile": "Named/NamedColorWithOverPrints.icc",
+  "iccFile": "Named/NamedColor.icc",
   "intent": "absolute",
   "transform": "namedOnBlack"
+}
+
+// Pinned colorimetric -- reads nmclPcsDataMbr only.  Fails if the
+// matched entry has no nmclPcsDataMbr (e.g. the over-black 'spcb'
+// member alone is not sufficient -- there is no spectral integration
+// fall-back).
+{
+  "iccFile": "Named/NamedColor.icc",
+  "intent": "absolute",
+  "transform": "namedColorimetricOnBlack"
+}
+
+// Pinned spectral -- reads icSigNmclSpectralOverBlackMbr ('spcb').
+// Equivalent to "namedOnBlack" + "useD2BxB2Dx": true but does not
+// depend on the legacy heuristic.  Fails if 'spcb' is absent for
+// the matched entry.
+{
+  "iccFile": "Named/NamedColor.icc",
+  "intent": "absolute",
+  "transform": "namedSpectralOnBlack"
 }
 ```
 
 ```sh
 # Legacy CLI: absolute (intent=3) + over-black (+1000000) = 1000003
-iccApplyNamedCmm <data> 0 1 Named/NamedColorWithOverPrints.icc 1000003
+iccApplyNamedCmm <data> 0 1 Named/NamedColor.icc 1000003
 ```
 
-The selection only affects the spectral apply path
-(`CIccArrayNamedColor::GetSpectralTint`). If the profile lacks the
-requested member the apply fails with `icCmmStatBadTintXform` rather than
-silently falling back to the over-white member; this surfaces the
-misconfiguration so it can be corrected. Library API: direct CMM users
-can set the overprint by attaching a `CIccCreateNamedColorXformHint`
-(with `nOverprintType` set to `icNamedColorOverWhite`,
-`icNamedColorOverBlack`, or `icNamedColorOverGray`) to the hint manager
-before calling `CIccCmm::AddXform`.
+If the profile lacks the requested array member for any named color the
+apply hits, `Apply` fails with `icCmmStatBadTintXform` rather than
+silently falling back to a different member; this surfaces the
+misconfiguration so it can be corrected.
+
+Library API: direct CMM users can set the overprint by attaching a
+`CIccCreateNamedColorXformHint` (with `nOverprintType` set to
+`icNamedColorOverWhite`, `icNamedColorOverBlack`, or
+`icNamedColorOverGray`) to the hint manager before calling
+`CIccCmm::AddXform`, and choose the output-side axis via the `nLutType`
+argument (`icXformLutNamedColor`, `icXformLutNamedColorimetric`,
+`icXformLutNamedSpectral`, or `icXformLutNamedDevice`).
+
+## Legacy Dump Format
+
+When the destination is a pixel space, each input data row produces one
+output line:
+
+```
+<applied values...>   ;{ "<source name>" }   <source tint>
+```
+
+The trailing `;{ "name" } tint` comment echoes the input back so the
+mapping between source and applied value is unambiguous. The tint
+token is the value supplied in the colorData `"v"` field (or the
+trailing number on a legacy `{ "Silver" } 0.5`-style data row). An
+absent `"v"` leaves the token off entirely and the apply path uses
+tint=1.0 by default. Tint values of exactly 1.0 are still echoed
+verbatim -- they used to be suppressed, which made the S5/S6/S7
+overprint scenarios for the *Hybrid Printer With Overprint Simulation*
+ICS look as though no tint had been supplied.
 
 ## See Also
 

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -493,11 +493,19 @@ int main(int argc, const char* argv[])
 
       const char* szName = pData->m_name.c_str();
       icFloatNumber tint;
-      
+
       if (pData->m_values.size())
         tint = pData->m_values[0];
       else
         tint = 1.0;
+
+      // For named-color input the tint lives in pData->m_values (the
+      // JSON "v" field), not pData->m_srcValues; mirror the pixel-input
+      // branch below so the dump can echo the tint the caller supplied.
+      // When the caller omitted "v" entirely we leave m_srcValues empty
+      // rather than synthesise a 1.0 the caller did not write.
+      if (pData->m_values.size())
+        out->m_srcValues = pData->m_values;
 
       switch(pNamedCmm->GetInterface()) {
         case icApplyNamed2Pixel:

--- a/docs/icc-connect-config.schema.json
+++ b/docs/icc-connect-config.schema.json
@@ -28,12 +28,19 @@
 
     "transform": {
       "type": "string",
-      "description": "Xform LUT type to use for a profile. The 'namedOnBlack' and 'namedOnGray' variants are NamedColor xforms that read the alternate spectral array members (icSigNmclSpectralOverBlackMbr 'spcb' / icSigNmclSpectralOverGrayMbr 'spcg') of a v5 NamedColor profile instead of the default 'spec' over-white member. They only differ from 'named' for profiles that carry the corresponding member; otherwise the transform fails to bind and AddXform returns icCmmStatBadTintXform.",
+      "description": "Xform LUT type to use for a profile. The named-color variants pin which v5 NamedColor array member the name->space apply path reads, on two axes that mirror the non-named 'color' / 'colorimetric' / 'spectral' triad and add a 'device' stem. PCS-side stem: 'named' is the auto/legacy stem (colorimetric or spectral chosen by useD2BxB2Dx plus whether the profile declares spectralPCS); 'namedColorimetric' pins reads to nmclPcsDataMbr; 'namedSpectral' pins reads to the overprint-correct spectral array member; 'namedDevice' pins reads to nmclDeviceDataMbr and sets the xform's destination to the profile's colorSpace (works against v4 NamedColor2 profiles too, where it reads the entry's deviceCoords struct field). All three pinned stems fail with icCmmStatBadTintXform when the matched entry lacks the requested member -- no silent fall-back between members. Overprint axis (only meaningful for the spectral path -- a no-op on the other stems since neither nmclPcsDataMbr nor nmclDeviceDataMbr varies by substrate): suffix '' / 'OnBlack' / 'OnGray' selects icSigNmclSpectralDataMbr 'spec' / icSigNmclSpectralOverBlackMbr 'spcb' / icSigNmclSpectralOverGrayMbr 'spcg'. namedDevice does not take an overprint suffix.",
       "enum": [
         "default",
         "named",
         "namedOnBlack",
         "namedOnGray",
+        "namedColorimetric",
+        "namedColorimetricOnBlack",
+        "namedColorimetricOnGray",
+        "namedSpectral",
+        "namedSpectralOnBlack",
+        "namedSpectralOnGray",
+        "namedDevice",
         "colorimetric",
         "spectral",
         "MCS",

--- a/docs/icc-connect.md
+++ b/docs/icc-connect.md
@@ -121,34 +121,52 @@ requests them:
 | `adjustPcsLuminance` | `CIccLuminanceMatchingHint` |
 | `iccEnvVars` (non-empty) | `CIccCmmEnvVarHint` |
 | `pccEnvVars` (non-empty) | `CIccCmmPccEnvVarHint` |
-| `transform` ∈ {`namedOnBlack`, `namedOnGray`} *or* `transform = named` | `CIccCreateNamedColorXformHint` with `nOverprintType` set from the JSON `transform` name (or from the legacy CLI's `+1000000`/`+2000000` high-bit) |
+| `transform` ∈ any `named*` variant (`named`, `namedOnBlack`, `namedOnGray`, `namedColorimetric{,OnBlack,OnGray}`, `namedSpectral{,OnBlack,OnGray}`, `namedDevice`) *or* overprint set via the legacy CLI high-bit | `CIccCreateNamedColorXformHint` with `nOverprintType` set from the JSON `transform` name (or from the legacy CLI's `+1000000`/`+2000000` high-bit) |
 
 `pccFile` is opened once per profile entry, passed through as the PCC for
 that xform, and deleted after `Begin()` returns.
 
-### NamedColor Overprint Selection
+### NamedColor Transform Variants
 
-For v5 NamedColor profiles that carry the optional over-black /
-over-gray array members (`icSigNmclSpectralOverBlackMbr` 'spcb',
-`icSigNmclSpectralOverGrayMbr` 'spcg'), the JSON `transform` field
-selects which spectral array member is read by
-`CIccArrayNamedColor::GetSpectralTint`:
+The JSON `transform` field for a NamedColor stage has two independent
+axes that mirror the non-named `color` / `colorimetric` / `spectral`
+triad, plus a `namedDevice` stem for reading the device-side member.
 
-| `transform` value | Array member read | Maps to `icNamedColorOverprintType` |
-|-------------------|-------------------|-------------------------------------|
-| `"named"` (default) | `icSigNmclSpectralDataMbr` ('spec', over-white) | `icNamedColorOverWhite` |
-| `"namedOnBlack"` | `icSigNmclSpectralOverBlackMbr` ('spcb') | `icNamedColorOverBlack` |
-| `"namedOnGray"` | `icSigNmclSpectralOverGrayMbr` ('spcg') | `icNamedColorOverGray` |
+**Output-side axis** — picks which array member the named lookup
+reads (and, equivalently, which space the xform exposes downstream):
 
-The legacy argv form (`CIccCfgProfileSequence::fromArgs`) carries the
-same selection in the millions digit of the intent code:
+| Stem | Member read | Output-side space | Behaviour when the member is absent for an entry |
+|------|-------------|-------------------|--------------------------------------------------|
+| `named` | Auto-selected | Auto-selected | Heuristic: if `useD2BxB2Dx` is true and the profile declares `spectralPCS`, the xform's output space is `spectralPCS` (reads the spectral member); otherwise it is the profile's colorimetric PCS (reads `nmclPcsDataMbr`). Preserves legacy behaviour. |
+| `namedColorimetric` | `nmclPcsDataMbr` | Profile's PCS (XYZ/Lab) | Fail with `icCmmStatBadTintXform`. No silent fall-back to spectral or device. |
+| `namedSpectral` | Spectral member (selected by the overprint axis below) | Profile's `spectralPCS` | Fail with `icCmmStatBadTintXform`. No silent fall-back to the over-white member or to `nmclPcsDataMbr`. |
+| `namedDevice` | `nmclDeviceDataMbr` (v5 array) or `deviceCoords` struct field (v4 `CIccTagNamedColor2`) | Profile's `colorSpace` | Fail with `icCmmStatBadTintXform`. No silent fall-back to PCS or spectral. |
+
+**Overprint axis** — only meaningful on the spectral path. The suffix
+selects which spectral array member is read (neither `nmclPcsDataMbr`
+nor `nmclDeviceDataMbr` varies by substrate, so the suffix is a no-op
+on `namedColorimetric*` and is not accepted on `namedDevice`):
+
+| Suffix | Spectral array member | Maps to `icNamedColorOverprintType` |
+|--------|-----------------------|-------------------------------------|
+| (none) | `icSigNmclSpectralDataMbr` ('spec', over-white) | `icNamedColorOverWhite` |
+| `OnBlack` | `icSigNmclSpectralOverBlackMbr` ('spcb') | `icNamedColorOverBlack` |
+| `OnGray` | `icSigNmclSpectralOverGrayMbr` ('spcg') | `icNamedColorOverGray` |
+
+The two axes combine into the following set of JSON `transform` values:
+`named`, `namedOnBlack`, `namedOnGray`, `namedColorimetric`,
+`namedColorimetricOnBlack`, `namedColorimetricOnGray`, `namedSpectral`,
+`namedSpectralOnBlack`, `namedSpectralOnGray`, `namedDevice`.
+
+The legacy argv form (`CIccCfgProfileSequence::fromArgs`) carries only
+the overprint axis, in the millions digit of the intent code:
 `intent + 1000000` → over-black; `intent + 2000000` → over-gray;
-anything else stays at over-white.
+anything else stays at over-white. The output-side axis is JSON-only.
 
-If the profile lacks the requested member for any named color encountered
-during apply, `CIccArrayNamedColor::GetSpectralTint` returns false and
-the apply fails with `icCmmStatBadTintXform` rather than silently falling
-back to the over-white member. This makes misconfigurations visible.
+If the profile lacks the requested array member for any named color
+encountered during apply (output-side stem or overprint suffix), `Apply`
+fails with `icCmmStatBadTintXform` rather than silently falling back to
+another member. This surfaces misconfigurations.
 See [the iccApplyNamedCmm Readme](../Tools/CmdLine/IccApplyNamedCmm/Readme.md#named-color-overprint-variants)
 for end-to-end usage examples.
 

--- a/docs/tools-cli-reference.md
+++ b/docs/tools-cli-reference.md
@@ -77,8 +77,10 @@ parsed by the shared `CIccCfgProfile::fromArgs` is:
 | `+2000000` | NamedColor over-gray (`icSigNmclSpectralOverGrayMbr`, `'spcg'`) |
 
 The over-black / over-gray flags only affect chains that include a v5
-NamedColor profile. JSON callers prefer the `transform` field values
-`"named"`, `"namedOnBlack"`, `"namedOnGray"` — see
+NamedColor profile. JSON callers prefer the `transform` field values,
+which combine an output-side stem (`named` / `namedColorimetric` /
+`namedSpectral` / `namedDevice`) with an overprint suffix
+(`OnBlack` / `OnGray`, only meaningful on the spectral path) — see
 [`docs/icc-connect-config.schema.json`](icc-connect-config.schema.json)
 and [`Tools/CmdLine/IccApplyNamedCmm/Readme.md`](../Tools/CmdLine/IccApplyNamedCmm/Readme.md).
 


### PR DESCRIPTION
While working to complete proposal for hybrid printer profiles with overprint simulation I encountered problems with adding spectrally based named color tag to sub-profile that caries spectral measurements for additional spot colors.  These have now been addressed.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
