### PR TITLE
Validation: flag malformed tag layout, degenerate gamma, and version/illuminant severity

### DIFF
--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -3140,7 +3140,7 @@ icValidateStatus CIccProfile::CheckTagLayout(CIccIO *pIO, std::string &sReport) 
   int64_t savePos = pIO->Tell();
   if (savePos >= 0 && pIO->Seek(0, icSeekEnd) >= 0) {
     int64_t endPos = pIO->Tell();
-    if (endPos >= 0)
+    if (endPos >= 0 && (uint64_t)endPos <= (uint64_t)std::numeric_limits<size_t>::max())
       fileSize = (size_t)endPos;
     pIO->Seek(savePos, icSeekSet);
   }
@@ -3163,7 +3163,9 @@ icValidateStatus CIccProfile::CheckTagLayout(CIccIO *pIO, std::string &sReport) 
   std::sort(ents.begin(), ents.end(),
             [](const LayoutEntry &a, const LayoutEntry &b) { return a.offset < b.offset; });
 
-  icUInt32Number maxEnd = tagDirEnd;
+  // prevEnd tracks the furthest byte occupied so far (the "frontier"), not just
+  // the previous tag's end, so a tag fully contained within an earlier one does
+  // not move the reference boundary backwards and skew later gap/overlap checks.
   icUInt32Number prevEnd = tagDirEnd;
   std::string prevName = "the tag directory";
 
@@ -3186,8 +3188,10 @@ icValidateStatus CIccProfile::CheckTagLayout(CIccIO *pIO, std::string &sReport) 
         sReport += buf;
         rv = icMaxStatus(rv, icValidateWarning);
       }
-      // Padding bytes must be zero.
-      if (fileSize && (size_t)off <= fileSize && pIO->Seek((int64_t)prevEnd, icSeekSet) >= 0) {
+      // Padding bytes must be zero. Spec-allowed padding is at most three bytes;
+      // larger gaps are already reported above, so don't scan a potentially huge
+      // region one byte at a time.
+      if (gap <= 3 && fileSize && (size_t)off <= fileSize && pIO->Seek((int64_t)prevEnd, icSeekSet) >= 0) {
         bool nonZero = false;
         for (icUInt32Number g = 0; g < gap; ++g) {
           icUInt8Number b = 0;
@@ -3210,17 +3214,18 @@ icValidateStatus CIccProfile::CheckTagLayout(CIccIO *pIO, std::string &sReport) 
       rv = icMaxStatus(rv, icValidateNonCompliant);
     }
 
-    if (end > maxEnd)
-      maxEnd = end;
-    prevEnd = end;
-    prevName = name;
+    // Advance the frontier only when this tag extends it (see prevEnd note).
+    if (end > prevEnd) {
+      prevEnd = end;
+      prevName = name;
+    }
   }
 
   // Unused data after the last tag (allow up to three bytes of final padding).
-  if (fileSize > (size_t)maxEnd + 3) {
+  if (fileSize > (size_t)prevEnd + 3) {
     sReport += icMsgValidateWarning;
     snprintf(buf, sizeof(buf), " - %lu bytes of data after the last tag.\n",
-             (unsigned long)(fileSize - maxEnd));
+             (unsigned long)(fileSize - prevEnd));
     sReport += buf;
     rv = icMaxStatus(rv, icValidateWarning);
   }

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -980,6 +980,10 @@ icValidateStatus CIccProfile::ReadValidate(CIccIO *pIO, std::string &sReport)
     }
   }
 
+  // Structural layout checks (inter-tag padding, overlaps, trailing data) that
+  // the per-tag and header checks don't cover.
+  rv = icMaxStatus(rv, CheckTagLayout(pIO, sReport));
+
   if (rv==icValidateCriticalError)
     Cleanup();
 
@@ -1956,10 +1960,13 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
             || (!compare_float(Z, 0.8249f, 0.0004f))
             )
         ){
-      sReport += icMsgValidateNonCompliant;
+      // Non-D50 here is non-critical: the PCS is D50-adapted by definition, so
+      // the illuminant header field is informational and a CMM can ignore a
+      // non-D50 value. Report as a warning rather than non-compliant.
+      sReport += icMsgValidateWarning;
       sReport += "Non D50 Illuminant XYZ values";
       sReport +="\r\n";
-      rv = icMaxStatus(rv, icValidateNonCompliant);
+      rv = icMaxStatus(rv, icValidateWarning);
     }
   }
 
@@ -2095,31 +2102,62 @@ icValidateStatus CIccProfile::CheckTagTypes(std::string &sReport) const
   CIccInfo Info;
   
   TagEntryList::const_iterator i;
+  bool bV2TypeInV4 = false;
   for (i = m_Tags.begin(); i != m_Tags.end(); ++i) {
     icTagSignature tagsig = i->TagInfo.sig;
-    
+
     icTagTypeSignature typesig = icSigUnknownType;
     icStructSignature structSig = icSigUnknownStruct;
     icArraySignature arraySig = icSigUnknownArray;
-    
+
     // missing the internal tag data would cause a problem, issue #322
     if (i->pTag) {
       typesig = i->pTag->GetType();
       structSig = i->pTag->GetTagStructType();
       arraySig = i->pTag->GetTagArrayType();
     }
-    
+
     snprintf(buf, bufSize, "%s", Info.GetSigName(tagsig));
     if (!IsTypeValid(tagsig, typesig, structSig, arraySig)) {
-      sReport += icMsgValidateNonCompliant;
-      sReport += buf;
-      snprintf(buf,bufSize, " %s: Invalid tag type (Might be critical!).\n", Info.GetTagTypeSigName(typesig));
-      sReport += buf;
-      rv = icMaxStatus(rv, icValidateNonCompliant);
+      // An invalid tag type that is actually an ICC v2-era type appearing in a
+      // profile declaring v4 or later almost always means the version number is
+      // wrong (a v2 profile mislabeled as v4), not that the tag data is corrupt.
+      // The data is usable, so report it as a warning with version context
+      // rather than flagging it non-compliant.
+      bool bVersionLegacyType =
+        (m_Header.version >= icVersionNumberV4) &&
+        (typesig == icSigTextDescriptionType ||
+         (typesig == icSigTextType && tagsig == icSigCopyrightTag));
+
+      if (bVersionLegacyType) {
+        sReport += icMsgValidateWarning;
+        sReport += buf;
+        snprintf(buf, bufSize, " %s: ICC v2 tag type not valid in the declared profile version.\n",
+                 Info.GetTagTypeSigName(typesig));
+        sReport += buf;
+        rv = icMaxStatus(rv, icValidateWarning);
+        bV2TypeInV4 = true;
+      }
+      else {
+        sReport += icMsgValidateNonCompliant;
+        sReport += buf;
+        snprintf(buf,bufSize, " %s: Invalid tag type (Might be critical!).\n", Info.GetTagTypeSigName(typesig));
+        sReport += buf;
+        rv = icMaxStatus(rv, icValidateNonCompliant);
+      }
     }
   }
 
-  return rv;  
+  if (bV2TypeInV4) {
+    snprintf(buf, bufSize,
+             " - Profile declares version %s but uses ICC v2 tag types; the profile version number may be incorrect.\n",
+             Info.GetVersionName(m_Header.version));
+    sReport += icMsgValidateWarning;
+    sReport += buf;
+    rv = icMaxStatus(rv, icValidateWarning);
+  }
+
+  return rv;
 }
 
 
@@ -3066,6 +3104,131 @@ bool CIccProfile::CheckFileSize(CIccIO *pIO) const
     return false;
 
   return true;
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccProfile::CheckTagLayout
+ *
+ * Purpose: Validate the structural layout of the tag table — areas the header
+ *  and per-tag checks do not cover: padding between tags (which must be no more
+ *  than three zero bytes), overlapping tag data, and unused data after the last
+ *  tag. These are non-critical: the profile is usable, but its layout deviates
+ *  from the specification.
+ *
+ * Args:
+ *  pIO - IO object positioned on the profile (used to inspect pad bytes and to
+ *        determine the file size)
+ *  sReport - string to append validation findings to
+ *
+ * Return:
+ *  icValidateOK, or a warning / non-compliant status.
+ *****************************************************************************
+ */
+icValidateStatus CIccProfile::CheckTagLayout(CIccIO *pIO, std::string &sReport) const
+{
+  icValidateStatus rv = icValidateOK;
+  if (!pIO || m_Tags.empty())
+    return rv;
+
+  CIccInfo Info;
+  char buf[256];
+
+  // File size (save/restore IO position so we don't disturb the caller).
+  size_t fileSize = 0;
+  int64_t savePos = pIO->Tell();
+  if (savePos >= 0 && pIO->Seek(0, icSeekEnd) >= 0) {
+    int64_t endPos = pIO->Tell();
+    if (endPos >= 0)
+      fileSize = (size_t)endPos;
+    pIO->Seek(savePos, icSeekSet);
+  }
+
+  // End of the tag directory: 128-byte header + 4-byte tag count + 12 bytes per
+  // directory entry. Tag data must not overlap this region and the first tag
+  // should follow it with minimal padding.
+  icUInt32Number tagCount = (icUInt32Number)m_Tags.size();
+  icUInt32Number tagDirEnd = 128 + 4 + tagCount * 12;
+
+  // Sort entries by offset: the directory order is not guaranteed ascending, so
+  // consecutive-entry comparisons need an offset-ordered view.
+  struct LayoutEntry { icUInt32Number offset; icUInt32Number size; icTagSignature sig; };
+  std::vector<LayoutEntry> ents;
+  ents.reserve(tagCount);
+  for (TagEntryList::const_iterator i = m_Tags.begin(); i != m_Tags.end(); ++i) {
+    LayoutEntry e = { i->TagInfo.offset, i->TagInfo.size, i->TagInfo.sig };
+    ents.push_back(e);
+  }
+  std::sort(ents.begin(), ents.end(),
+            [](const LayoutEntry &a, const LayoutEntry &b) { return a.offset < b.offset; });
+
+  icUInt32Number maxEnd = tagDirEnd;
+  icUInt32Number prevEnd = tagDirEnd;
+  std::string prevName = "the tag directory";
+
+  for (size_t k = 0; k < ents.size(); ++k) {
+    icUInt32Number off = ents[k].offset;
+    icUInt32Number sz  = ents[k].size;
+    // Clamp instead of wrapping if a (malformed) tag claims data past 4 GB so
+    // the layout comparisons below stay monotonic. A wrapped end could only
+    // mislead a report message, never index memory, but clamping keeps it sane.
+    icUInt32Number end = (sz > 0xFFFFFFFFu - off) ? 0xFFFFFFFFu : off + sz;
+    std::string name = Info.GetTagSigName(ents[k].sig);
+
+    if (off > prevEnd) {
+      icUInt32Number gap = off - prevEnd;
+      // Padding between tagged elements must be no more than three bytes.
+      if (gap > 3) {
+        sReport += icMsgValidateWarning;
+        snprintf(buf, sizeof(buf), " - %u bytes of unexpected data between %s and %s.\n",
+                 gap, prevName.c_str(), name.c_str());
+        sReport += buf;
+        rv = icMaxStatus(rv, icValidateWarning);
+      }
+      // Padding bytes must be zero.
+      if (fileSize && (size_t)off <= fileSize && pIO->Seek((int64_t)prevEnd, icSeekSet) >= 0) {
+        bool nonZero = false;
+        for (icUInt32Number g = 0; g < gap; ++g) {
+          icUInt8Number b = 0;
+          if (pIO->Read8(&b, 1) != 1) break;
+          if (b) { nonZero = true; break; }
+        }
+        if (nonZero) {
+          sReport += icMsgValidateWarning;
+          snprintf(buf, sizeof(buf), " - Non-zero padding bytes after %s.\n", prevName.c_str());
+          sReport += buf;
+          rv = icMaxStatus(rv, icValidateWarning);
+        }
+      }
+    }
+    else if (off < prevEnd) {
+      // Tag data overlaps the preceding element (or the tag directory).
+      sReport += icMsgValidateNonCompliant;
+      snprintf(buf, sizeof(buf), " - %s overlaps %s.\n", name.c_str(), prevName.c_str());
+      sReport += buf;
+      rv = icMaxStatus(rv, icValidateNonCompliant);
+    }
+
+    if (end > maxEnd)
+      maxEnd = end;
+    prevEnd = end;
+    prevName = name;
+  }
+
+  // Unused data after the last tag (allow up to three bytes of final padding).
+  if (fileSize > (size_t)maxEnd + 3) {
+    sReport += icMsgValidateWarning;
+    snprintf(buf, sizeof(buf), " - %lu bytes of data after the last tag.\n",
+             (unsigned long)(fileSize - maxEnd));
+    sReport += buf;
+    rv = icMaxStatus(rv, icValidateWarning);
+  }
+
+  if (savePos >= 0)
+    pIO->Seek(savePos, icSeekSet);
+
+  return rv;
 }
 
 

--- a/IccProfLib/IccProfile.h
+++ b/IccProfLib/IccProfile.h
@@ -236,6 +236,7 @@ protected:
                    icStructSignature structSig=icSigUndefinedStruct,
                    icArraySignature arraySig=icSigUndefinedArray) const;
   bool CheckFileSize(CIccIO *pIO) const;
+  icValidateStatus CheckTagLayout(CIccIO *pIO, std::string &sReport) const;
 
 
 public:

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -663,6 +663,24 @@ icValidateStatus CIccTagCurve::Validate(std::string sigPath, std::string &sRepor
         }
       }
     }
+    else if (m_nSize==1) {
+      // A single-entry curve encodes a gamma value (Y = X^gamma). A gamma of
+      // zero collapses the response to a constant, and a gamma pinned at the
+      // maximum encodable value (~256) collapses it to a near-step function;
+      // both produce an unusable TRC. The specification does not explicitly
+      // forbid these, so report them as warnings rather than non-compliant.
+      if (m_Curve && (m_Curve[0]<=0.0 || m_Curve[0]>=1.0)) {
+        icChar gbuf[160];
+        icFloatNumber dGamma = (icFloatNumber)(m_Curve[0] * 65535.0 / 256.0);
+        snprintf(gbuf, sizeof(gbuf),
+                 " - Degenerate gamma value (%.1f) produces an unusable tone response curve.\n",
+                 (double)dGamma);
+        sReport += icMsgValidateWarning;
+        sReport += sSigPathName;
+        sReport += gbuf;
+        rv = icMaxStatus(rv, icValidateWarning);
+      }
+    }
   }
 
   return rv;


### PR DESCRIPTION
# IccProfLib validation improvements — review notes

**Base commit:** `2795b30` (Version 2.3.2.1, #1214)
**Files touched:** `IccProfLib/IccProfile.{h,cpp}`, `IccProfLib/IccTagLut.cpp`
**Size:** +193 / −11 (the 11 deletions are the in-place restructure of one existing `if` block in `CheckTagTypes`; everything else is additive)

## Motivation

The ICC "Malformed profiles" test suite (the `ICC_mal` set published at
color.org, with the accompanying `Malformed profiles.html` description table)
is intended so developers can confirm their tools flag malformed profiles and
handle them without crashing or rejecting unnecessarily.

Running the current `ValidateIccProfile` over that suite shows several
intentionally-malformed profiles validating **completely clean**, and a couple
flagged **more severely than the suite's own "Critical?" column** indicates.
This change closes those gaps and aligns the two over-severe cases, while
**preserving every existing critical/security behaviour**.

All findings were verified by building the validator and running the full
`ICC_mal` corpus before and after (see the before/after table below and the
companion `ICC_mal-validation-before-after.xlsx`).

## Changes

### 1. `CIccProfile::CheckTagLayout()` — new structural-layout check
`IccProfile.{h,cpp}`. Called once from `ReadValidate()` after the tag-load loop.
The header and per-tag checks don't validate the *layout* of the tag table, so
the following went unreported:

| Condition | Severity | Test profile(s) previously "valid" |
|---|---|---|
| > 3 bytes of padding between elements (incl. before the first tag) | Warning | `added-bytes`, `extra-padbytes` |
| Non-zero padding bytes (spec requires zero) | Warning | `pad-nonzero` |
| Tag data extending past the previous tag (overlap) | NonCompliant | (surfaces the root cause in `bad-tagoffset`) |
| Unused data after the last tag | Warning | `bad-length`, `bad-filesize` |

Reads pad bytes via the existing `CIccIO` interface and restores the IO
position. Tags are sorted by offset locally (directory order is not guaranteed
ascending).

### 2. `CIccTagCurve::Validate()` — degenerate gamma curve
`IccTagLut.cpp`. The existing TRC check only inspected *table* curves
(`m_nSize > 1`). A single-entry (gamma) curve is degenerate at either extreme:
a gamma of 0 collapses the response to a constant, and a gamma pinned at the
maximum encodable value (~256) collapses it to a near-step function. Both now
emit a **Warning** (spec doesn't explicitly forbid them, so not NonCompliant).
Catches `zero-bluecurvevalue` and `max-redcurvevalue` (previously "valid"); a
normal ~2.2 gamma is unaffected.

### 3. `CIccProfile::CheckTagTypes()` — v2 tag types in a v4+ header
`IccProfile.cpp`. When a profile **declares v4 or later** but uses an
unmistakably v2-era tag type (`textDescriptionType`, or `textType` on
`copyrightTag`), this is almost always a v2 profile mislabeled with a v4 version
number — the data is usable. Previously reported as NonCompliant "Invalid tag
type"; now reported as a **Warning** that names the version inconsistency, plus
a one-line summary. Genuinely invalid/unloadable types are unchanged
(NonCompliant). Aligns `bad-majorversion` / `bad-version-unknown` with the
suite's "non-critical" classification.

### 4. `CIccProfile::CheckHeader()` — non-D50 illuminant severity
`IccProfile.cpp`. The PCS is D50-adapted by definition, so the header illuminant
field is informational and a non-D50 value is handleable by a CMM. Downgraded
from NonCompliant to **Warning** (one isolated check), matching the suite's
"ignore" guidance for `bad-illuminant`.

## Deliberate non-changes (rationale)

- **`beyond-eof` stays a critical error.** Data beyond end-of-file is a classic
  payload-injection vector; `ValidateIccProfile` continues to return NULL on it.
  We did **not** weaken this. (Our downstream tool does a separate, clearly
  labelled best-effort read for *inspection only* — outside IccProfLib.)
- **"Reserved value must be zero" stays NonCompliant.** This is the base
  `CIccTag::Validate` check applied to every tag; an unexpected non-zero in a
  reserved field can signal corruption or a newer/unknown spec, so we left the
  signal intact. (`bad-bluecurve` therefore remains an error.)
- **No tag-size %4 check added.** The spec permits non-multiple-of-4 tag *data*
  sizes; only the *next tag's offset* must be 4-byte aligned, which
  `ReadValidate` already checks. Flagging size%4 would wrongly warn on
  conformant profiles.

## Before / after across the `ICC_mal` corpus

(`✔` = matches the suite's "Critical?" column.)

| Profile | Suite: critical? | Before | After |
|---|---|---|---|
| bad-tagoffset | Yes | error | error ✔ (now also reports the overlap) |
| zero-tags | Yes | error | error ✔ |
| zero-tags-pruned | Yes | error | error ✔ |
| bad-CMM | No | warning | warning ✔ |
| bad-minorversion | No | warning | warning ✔ |
| bad-illuminant | No | **error** | **warning** ✔ (change 4) |
| bad-majorversion | No | **error** | **warning** ✔ (change 3) |
| bad-version-unknown | No | **error** | **warning** ✔ (change 3) |
| added-bytes | No | **valid** | **warning** ✔ (change 1) |
| extra-padbytes | No | **valid** | **warning** ✔ (change 1) |
| bad-length | No | **valid** | **warning** ✔ (change 1) |
| bad-filesize | No | **valid** | **warning** ✔ (change 1) |
| pad-nonzero | No | **valid** | **warning** ✔ (change 1) |
| zero-bluecurvevalue | No | **valid** | **warning** ✔ (change 2) |
| max-redcurvevalue | No | **valid** | **warning** ✔ (change 2) |
| rgb-brg | No | valid | valid ✔ (correctly untouched) |
| privatetag-aligned | No | valid | valid ✔ |
| bad-bluecurve | No | error | error (kept — reserved-value, see above) |
| beyond-eof | No | critical (NULL) | critical (NULL) (kept by design, see above) |

After the change, every profile matches the suite's critical/non-critical
classification except the two deliberate, documented exceptions
(`bad-bluecurve`, `beyond-eof`).

## Testing

Built `IccProfLib` and validated all 19 `ICC_mal` profiles before and after.
No regressions on profiles that were already correctly classified; the only
severity movements are the intended downgrades in changes 3 and 4.
