### PR TITLE
Issue 1215 - spectral steps and MPE indices range problems

### DIFF
--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1574,7 +1574,10 @@ bool CIccMpeJsonCalculator::Flatten(std::string &flatStr, std::string macroName,
           CIccFuncTokenizer p2(ref.c_str());
           p2.GetNext();
           icUInt16Number vo = 0, vs = 1;
-          p2.GetIndex(vo, vs, 0, 1);
+          if (!p2.GetIndex(vo, vs, 0, 1)) {
+            parseStr += "Invalid index for local '" + ref + "' in macro '" + macroName + "'\n";
+            return false;
+          }
           voffset = vo; vsize = vs + 1;
         }
         if (voffset + vsize > (int)nLocalSize) {
@@ -1640,7 +1643,10 @@ bool CIccMpeJsonCalculator::Flatten(std::string &flatStr, std::string macroName,
           CIccFuncTokenizer p2(ref.c_str());
           p2.GetNext();
           icUInt16Number vo = 0, vs = 1;
-          p2.GetIndex(vo, vs, 0, 1);
+          if (!p2.GetIndex(vo, vs, 0, 1)) {
+            parseStr += "Invalid index for variable '" + ref + "'\n";
+            return false;
+          }
           voffset = vo; vsize = vs + 1;
         }
         if (voffset + vsize > var->second.m_size) {
@@ -1713,7 +1719,10 @@ bool CIccMpeJsonCalculator::UpdateLocals(std::string &func, std::string sFunc,
       std::string op = parse.GetName();
       CIccFuncTokenizer p2(tok + 4);
       icUInt16Number vo = 0, vs = 1;
-      p2.GetIndex(vo, vs, 0, 1);
+      if (!p2.GetIndex(vo, vs, 0, 1)) {
+        parseStr += "Invalid local variable index\n";
+        return false;
+      }
       int voffset = vo + nLocalsOffset;
       int vsize   = vs + 1;
       if (voffset + vsize > 65535) {
@@ -1826,7 +1835,15 @@ bool CIccMpeJsonCalculator::ParseImport(const IccJson &j, std::string importPath
             return false;
           }
           icUInt16Number msize = 0, extra = 0;
-          parse.GetIndex(msize, extra, 1, 0);
+          const char *idx = parse.GetPos();
+          while (*idx == ' ' || *idx == '\t' || *idx == '\r' || *idx == '\n')
+            idx++;
+          if (*idx == '[' || *idx == '(') {
+            if (!parse.GetIndex(msize, extra, 1, 0)) {
+              parseStr += "Invalid size index for member '" + mname + "' in variable '" + name + "'\n";
+              return false;
+            }
+          }
           msize++;
           if (msize < 1) msize = 1;
           var.m_members.push_back(CIccTempVar(mname, off, msize));
@@ -1876,7 +1893,15 @@ bool CIccMpeJsonCalculator::ParseImport(const IccJson &j, std::string importPath
             return false;
           }
           icUInt16Number lsize = 0, extra = 0;
-          parse.GetIndex(lsize, extra, 1, 0);
+          const char *idx = parse.GetPos();
+          while (*idx == ' ' || *idx == '\t' || *idx == '\r' || *idx == '\n')
+            idx++;
+          if (*idx == '[' || *idx == '(') {
+            if (!parse.GetIndex(lsize, extra, 1, 0)) {
+              parseStr += "Invalid size index for local '" + lname + "' in macro '" + name + "'\n";
+              return false;
+            }
+          }
           lsize++;
           if (lsize < 1) lsize = 1;
           var.m_members.push_back(CIccTempVar(lname, off, lsize));

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -731,7 +731,7 @@ bool CIccTagJsonSpectralViewingConditions::ParseJson(const IccJson &j, std::stri
     jGetValue(obs, "steps", steps);
     unsigned int res2 = 0;
     jGetValue(obs, "Reserved", res2);
-    if (steps < 0 || steps > 0xffff) {
+    if (steps <= 0 || steps > 0xffff) {
       parseStr += "ObserverFuncs steps out of range\n";
       return false;
     }
@@ -782,7 +782,7 @@ bool CIccTagJsonSpectralViewingConditions::ParseJson(const IccJson &j, std::stri
     jGetValue(illum, "steps", steps);
     unsigned int res3 = 0;
     jGetValue(illum, "Reserved", res3);
-    if (steps < 0 || steps > 0xffff) {
+    if (steps <= 0 || steps > 0xffff) {
       parseStr += "IlluminantSPD steps out of range\n";
       return false;
     }

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -129,7 +129,8 @@ static inline icUInt16Number icJsonSafeU16(size_t n)
 
 static bool icJsonIsSafeLocalizedText(const std::string &text)
 {
-  for (unsigned char ch : text) {
+  for (size_t i = 0; i < text.size(); i++) {
+    unsigned char ch = static_cast<unsigned char>(text[i]);
     if (ch < 0x20 && ch != '\n' && ch != '\t')
       return false;
   }

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -2822,6 +2822,7 @@ bool CIccFuncTokenizer::GetIndex(icUInt16Number &v1, icUInt16Number &v2, icUInt1
 {
   unsigned int iv1, iv2;
   const char *pos = GetPos();
+  int nParsed = 0;
 
   if (!GetNext(true))
     return false;
@@ -2831,22 +2832,29 @@ bool CIccFuncTokenizer::GetIndex(icUInt16Number &v1, icUInt16Number &v2, icUInt1
   if (*szToken=='[' || *szToken=='(') {
     if (strchr(szToken, ',')) {
       if (*szToken=='(') 
-        sscanf(m_token->c_str(), "(%u,%u)", &iv1, &iv2);
+        nParsed = sscanf(m_token->c_str(), "(%u,%u)", &iv1, &iv2);
       else 
-        sscanf(m_token->c_str(), "[%u,%u]", &iv1, &iv2);
+        nParsed = sscanf(m_token->c_str(), "[%u,%u]", &iv1, &iv2);
+      if (nParsed != 2)
+        return false;
     }
     else {
       if (*szToken=='(')
-        sscanf(m_token->c_str(), "(%u)", &iv1);
+        nParsed = sscanf(m_token->c_str(), "(%u)", &iv1);
       else 
-        sscanf(m_token->c_str(), "[%u]", &iv1);
+        nParsed = sscanf(m_token->c_str(), "[%u]", &iv1);
+      if (nParsed != 1)
+        return false;
     }
   }
   else {
     SetPos(pos); //Undo get token
   }
-  v1 = (icUInt16Number)iv1 - initV1;
-  v2 = (icUInt16Number)iv2 - initV2;
+  if (iv1 > 0xffff || iv2 > 0xffff || iv1 < initV1 || iv2 < initV2)
+    return false;
+
+  v1 = (icUInt16Number)(iv1 - initV1);
+  v2 = (icUInt16Number)(iv2 - initV2);
 
   return true;
 }

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2643,7 +2643,15 @@ bool CIccMpeXmlCalculator::ParseImport(xmlNode *pNode, std::string importPath, s
                   return false;
                 }
                 size = 0; extra = 0;
-                parse.GetIndex(size, extra, 1, 0);
+                const char *idx = parse.GetPos();
+                while (*idx == ' ' || *idx == '\t' || *idx == '\r' || *idx == '\n')
+                  idx++;
+                if (*idx == '[' || *idx == '(') {
+                  if (!parse.GetIndex(size, extra, 1, 0)) {
+                    parseStr += "Invalid size index for member '" + member + "' in calc element variable '" + name + "'\n";
+                    return false;
+                  }
+                }
                 size++;
                 if (size < 1) 
                   size = 1;
@@ -2708,7 +2716,15 @@ bool CIccMpeXmlCalculator::ParseImport(xmlNode *pNode, std::string importPath, s
                   return false;
                 }
                 size = 0; extra = 0;
-                parse.GetIndex(size, extra, 1, 0);
+                const char *idx = parse.GetPos();
+                while (*idx == ' ' || *idx == '\t' || *idx == '\r' || *idx == '\n')
+                  idx++;
+                if (*idx == '[' || *idx == '(') {
+                  if (!parse.GetIndex(size, extra, 1, 0)) {
+                    parseStr += "Invalid size index for local '" + member + "' in calc element macro '" + name + "'\n";
+                    return false;
+                  }
+                }
                 size++;
                 if (size < 1)
                   size = 1;
@@ -3026,7 +3042,10 @@ bool CIccMpeXmlCalculator::Flatten(std::string &flatStr, std::string macroName, 
           CIccFuncTokenizer p2(ref.c_str());
           p2.GetNext();
           icUInt16Number _voffset = 0, _vsize = 1;
-          p2.GetIndex(_voffset, _vsize, 0, 1);
+          if (!p2.GetIndex(_voffset, _vsize, 0, 1)) {
+            parseStr += "Invalid index for local '" + ref + "' in macro '" + macroName + "'\n";
+            return false;
+          }
           voffset = _voffset;
           vsize = _vsize + 1;
         }
@@ -3121,7 +3140,10 @@ bool CIccMpeXmlCalculator::Flatten(std::string &flatStr, std::string macroName, 
           CIccFuncTokenizer p2(ref.c_str());
           p2.GetNext();
           icUInt16Number _voffset = 0, _vsize = 1;
-          p2.GetIndex(_voffset, _vsize, 0, 1);
+          if (!p2.GetIndex(_voffset, _vsize, 0, 1)) {
+            parseStr += "Invalid index for variable '" + ref + "'\n";
+            return false;
+          }
           voffset = _voffset;
           vsize = _vsize + 1;
         }
@@ -3207,7 +3229,10 @@ bool CIccMpeXmlCalculator::UpdateLocals(std::string &func, std::string sFunc, st
 
       CIccFuncTokenizer p2(tok+4);
       icUInt16Number _voffset = 0, _vsize = 1;
-      p2.GetIndex(_voffset, _vsize, 0, 1);
+      if (!p2.GetIndex(_voffset, _vsize, 0, 1)) {
+        parseStr += "Invalid local variable index\n";
+        return false;
+      }
       voffset = _voffset + nLocalsOffset;
       vsize = _vsize + 1;
 

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -2282,7 +2282,10 @@ bool CIccTagXmlSpectralViewingConditions::ParseXml(xmlNode *pNode, std::string &
     }
     attr = icXmlFindAttr(pChild, "steps");
     if (attr) {
-      m_observerRange.steps = (icUInt16Number)atoi(icXmlAttrValue(attr));
+      int tempSteps = atoi(icXmlAttrValue(attr));
+      if (tempSteps <= 0 || tempSteps > 0xffff)
+        return false;
+      m_observerRange.steps = (icUInt16Number)tempSteps;
     }
     attr = icXmlFindAttr(pChild, "reserved");
     if (attr) {
@@ -2333,7 +2336,10 @@ bool CIccTagXmlSpectralViewingConditions::ParseXml(xmlNode *pNode, std::string &
     }
     attr = icXmlFindAttr(pChild, "steps");
     if (attr) {
-      m_illuminantRange.steps = (icUInt16Number)atoi(icXmlAttrValue(attr));
+      int tempSteps = atoi(icXmlAttrValue(attr));
+      if (tempSteps <= 0 || tempSteps > 0xffff)
+        return false;
+      m_illuminantRange.steps = (icUInt16Number)tempSteps;
     }
     attr = icXmlFindAttr(pChild, "reserved");
     if (attr) {

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -2288,6 +2288,10 @@ bool CIccTagXmlSpectralViewingConditions::ParseXml(xmlNode *pNode, std::string &
     if (attr) {
       m_reserved2 = (icUInt16Number)atoi(icXmlAttrValue(attr));
     }
+    
+    // if these are not set correctly, then later allocations and calculations WILL fail
+    if (m_observerRange.start == 0 || m_observerRange.end == 0 || m_observerRange.steps == 0)
+      return false;
 
     if (pChild->children && pChild->children->content) {
       CIccFloatArray vals;
@@ -2298,6 +2302,8 @@ bool CIccTagXmlSpectralViewingConditions::ParseXml(xmlNode *pNode, std::string &
       if (!m_observer)
         return false;
       icFloatNumber *pBuf = vals.GetBuf();
+      if (!pBuf)
+        return false;
       memcpy(m_observer, pBuf, m_observerRange.steps*3*sizeof(icFloatNumber));
     }
     else {
@@ -2333,8 +2339,12 @@ bool CIccTagXmlSpectralViewingConditions::ParseXml(xmlNode *pNode, std::string &
     if (attr) {
       m_reserved3 = (icUInt16Number)atoi(icXmlAttrValue(attr));
     }
+    
+    // if these are not set correctly, then later allocations and calculations WILL fail
+    if (m_illuminantRange.start == 0 || m_illuminantRange.end == 0 || m_illuminantRange.steps == 0)
+      return false;
 
-    if (pChild->children && pChild->children->content && m_illuminantRange.steps) {
+    if (pChild->children && pChild->children->content) {
       CIccFloatArray vals;
       vals.ParseTextArray((icChar*)pChild->children->content);
       if (vals.GetSize()!=m_illuminantRange.steps)
@@ -2343,6 +2353,8 @@ bool CIccTagXmlSpectralViewingConditions::ParseXml(xmlNode *pNode, std::string &
       if (!m_illuminant)
         return false;
       icFloatNumber *pBuf = vals.GetBuf();
+      if (!pBuf)
+        return false;
       memcpy(m_illuminant, pBuf, m_illuminantRange.steps * sizeof(icFloatNumber));
     }
     else {

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -2046,7 +2046,8 @@ const char *SectionName(char prefix)
 std::string JsonEscape(const std::string &s)
 {
   std::ostringstream oss;
-  for (unsigned char ch : s) {
+  for (size_t i = 0; i < s.size(); i++) {
+    unsigned char ch = static_cast<unsigned char>(s[i]);
     switch (ch) {
       case '\\':
         oss << "\\\\";


### PR DESCRIPTION
## PR Summary
Error check spectral range step reading more carefully in XML and JSON.
Add checks for valid 16 bit range to MPE indices.
Fixes #1215

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members