### PR TITLE
Fix leak of identity PCS steps in CIccPcsXform::Optimize

### DIFF
--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -2641,11 +2641,19 @@ icStatusCMM CIccPcsXform::Optimize()
         if (!ptr.ptr->isIdentity()) {
           newSteps.push_back(ptr);
         }
+        else {
+          // Identity steps are dropped from the optimized chain; delete them
+          // so the CIccPcsStep object (and its data buffer) is not leaked.
+          delete ptr.ptr;
+        }
         ptr.ptr = next->ptr;
       }
     }
     if (!ptr.ptr->isIdentity()) {
       newSteps.push_back(ptr);
+    }
+    else {
+      delete ptr.ptr;
     }
 
     steps = newSteps;


### PR DESCRIPTION
Resolves #1240.

### Root cause
`CIccPcsXform::Optimize()` concatenates/removes steps in the PCS transform chain. Steps that reduce to the identity (e.g. a `1,1,1` scale or `0,0,0` offset emitted by `pushScale3`/`pushOffset3` during `Connect`) are intentionally dropped from the rebuilt list:

```cpp
if (!ptr.ptr->isIdentity()) {
  newSteps.push_back(ptr);
}
// else: not pushed... and not deleted -> leak
ptr.ptr = next->ptr;
```

Both the in-loop branch and the post-loop tail skipped an identity step without deleting it, leaking the `CIccPcsStep` object plus its backing `icFloatNumber` data buffer. The function already owns and `delete`s step objects on the `concat` path, so dropped identity steps should be deleted too.

### Fix
Delete identity steps when they are discarded (two spots in `Optimize`).

### Verification (AddressSanitizer)
Reproducer: the hybrid spectral search (`Testing/hybrid/BuildAndTest.sh` Phase 5 — `iccApplySearch` over the CMYK hybrid profile with four `-INIT` PCCs).

| | Before | After |
|---|---|---|
| LeakSanitizer | ~648 B across `CIccPcsStepScale`/`CIccPcsStepOffset` (`pushScale3`/`pushOffset3` → `CheckPCSConnections` → `Begin`) | **clean — 0 leaks** |
| ASAN errors (UAF/double-free) | 0 | **0** |
| `iccApplySearch` output | valid | valid (unchanged) |

Built `-fsanitize=address -O1 -g`; also confirmed a plain Debug build runs the reproducer to completion (exit 0).

This was the pre-existing leak split out of #1239 (the AFL++ leak batch); it is on `master` independently of those fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)