### PR TITLE
Fix sub-profile IO leak (#1243) and out-of-range encoding UB (#1244)

### DIFF
--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -303,8 +303,15 @@ int CIccCfgDataApply::fromArgs(const char** args, int nArg, bool bReset)
   m_dstType = icCfgLegacy;
   m_dstFile.clear();
 
-  //Setup destination encoding
-  m_dstEncoding = (icFloatColorEncoding)atoi(args[1]);
+  //Setup destination encoding. Validate the parsed value against the valid
+  //enumerator range before storing it: assigning an out-of-range integer to
+  //icFloatColorEncoding is undefined behavior and later loads of that value
+  //(e.g. in toJson) trap under UBSan. Fall back to the reset default when the
+  //argument is malformed or out of range.
+  int nDstEncoding = atoi(args[1]);
+  if (nDstEncoding < icEncodeValue || nDstEncoding > icEncodeUnknown)
+    nDstEncoding = icEncodeValue;
+  m_dstEncoding = (icFloatColorEncoding)nDstEncoding;
 
   const char *colon = strchr(args[1], ':');
   if (colon) {

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -673,6 +673,10 @@ CIccIO* CIccProfile::ConnectSubProfile(CIccIO *pIO, bool bOwnIO) const
         
         if (pEmbedIO->Attach(pIO, i->TagInfo.size - 2 * sizeof(icUInt32Number), bOwnIO))
           return pEmbedIO;
+
+        // Attach failed; release the IO wrapper so it is not leaked. The
+        // CIccEmbedIO destructor handles pIO per the ownership flag set in Attach.
+        delete pEmbedIO;
       }
     }
   }
@@ -870,8 +874,14 @@ bool CIccProfile::Read(CIccIO *pIO, bool bUseSubProfile/*=false*/)
     return false;
   }
 
+  // Transient sub-profile IO wrapper. ConnectSubProfile is called here with
+  // bOwnIO=false, so this wrapper does not own pIO; it only proxies reads while
+  // the (embedded) tags are loaded into memory. It must be deleted before every
+  // return below, otherwise the wrapper object itself is leaked.
+  CIccIO *pSubIO = NULL;
+
   if (bUseSubProfile) {
-    CIccIO *pSubIO = ConnectSubProfile(pIO, false);
+    pSubIO = ConnectSubProfile(pIO, false);
 
     if (pSubIO) {
       icColorSpaceSignature parentColorSpace = m_Header.colorSpace;
@@ -879,6 +889,7 @@ bool CIccProfile::Read(CIccIO *pIO, bool bUseSubProfile/*=false*/)
       m_parentColorSpace = parentColorSpace;
       if (!ReadBasic(pSubIO)) {
         Cleanup();
+        delete pSubIO;
         return false;
       }
       pIO = pSubIO;
@@ -890,10 +901,12 @@ bool CIccProfile::Read(CIccIO *pIO, bool bUseSubProfile/*=false*/)
   for (i=m_Tags.begin(); i!=m_Tags.end(); i++) {
     if (!LoadTag((IccTagEntry*)&(i->TagInfo), pIO)) {
       Cleanup();
+      delete pSubIO;
       return false;
     }
   }
 
+  delete pSubIO;
   return true;
 }
 


### PR DESCRIPTION
Resolves two sanitizer findings handed off in #1243 and #1244. Each is a small, self-contained fix in its own commit.

## #1243 — Leak in `CIccProfile::ConnectSubProfile()` (40 B, ASAN/LSAN)

`CIccProfile::Read` calls `ConnectSubProfile(pIO, false)` to get a transient `CIccEmbedIO` wrapper used while loading an embedded profile's tags into memory. With `bOwnIO=false` the wrapper does not own the underlying IO, but `Read` never freed the **wrapper object itself** on any exit path — leaking 40 bytes for every profile that carries an embedded V5 profile tag.

- Track the wrapper and `delete` it before every return in `Read` (success and both error returns).
- Also harden `ConnectSubProfile` to `delete` the freshly-allocated `CIccEmbedIO` on the `Attach`-failure path; its destructor releases the underlying IO per the ownership flag `Attach` records, so this is correct for both `bOwnIO` values.

**Verification (ASAN+UBSan, `-O1 -g`):** `iccV5DspObsToV4Dsp <embedded-profile-display.icc> ...` reported `40 byte(s) leaked` at `IccProfile.cpp:670` before the fix and is clean after.

## #1244 — UB in `CIccCfgDataApply::toJson()` (UBSan)

`fromArgs` parsed the destination encoding as `(icFloatColorEncoding)atoi(args[1])` with no range check. A malformed argument like `999999999999` overflows into a value outside the enumerator range; storing it into the enum is undefined behavior, and the later load in `toJson` traps under UBSan:

```
IccCmmConfig.cpp:366: runtime error: load of value 3567587327, which is not a valid value for type 'icFloatColorEncoding'
```

Parse into an `int`, validate against `[icEncodeValue, icEncodeUnknown]`, and fall back to the reset default when out of range before storing into the enum. The JSON ingestion path already maps unknown strings to a valid enumerator, so the args path was the only unchecked store.

**Verification (UBSan):** `iccApplyNamedCmm -exportcfganddata ... 999999999999 1 ...` trapped at `IccCmmConfig.cpp:366` before the fix and is clean after.

Closes #1243
Closes #1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)