### PR TITLE
Fix two unbounded profile-driven loops (#1246, #1248)

### DIFF
--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -5468,7 +5468,15 @@ CIccApplyMpeCalculator::~CIccApplyMpeCalculator()
   icUInt32Number i;
 
   if (m_SubElem) {
-    for (i=0; i<m_nSubElem; i++) {
+    // CWE-400/CWE-834: m_nSubElem is bounded by MAX_CALC_ELEMENTS in
+    // CIccMpeCalculator::Read and the m_SubElem array is allocated to match
+    // (see GetNewApply). Clamp defensively so a corrupted count can never drive
+    // an unbounded free loop over the array.
+    const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+    icUInt32Number nSubElem = m_nSubElem;
+    if (nSubElem > MAX_CALC_ELEMENTS)
+      nSubElem = MAX_CALC_ELEMENTS;
+    for (i=0; i<nSubElem; i++) {
       delete m_SubElem[i];
     }
     free(m_SubElem);

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -9476,10 +9476,21 @@ void CIccTagColorantTable::Describe(std::string &sDescription, int /* nVerbosene
   icUInt32Number i, nLen, nMaxLen=0;
   icFloatNumber Lab[3] = {0};
 
+  // CWE-400/CWE-834: m_nCount is validated against the tag size and capped at
+  // 0xffff in Read(), and m_pData is allocated to match. Guard here so a
+  // corrupted/directly-constructed table can't drive an unbounded describe loop
+  // or dereference a null array.
+  const icUInt32Number nMaxColorants = 0xffff;
+  icUInt32Number nCount = m_nCount;
+  if (!m_pData)
+    nCount = 0;
+  else if (nCount > nMaxColorants)
+    nCount = nMaxColorants;
+
   snprintf(buf, bufSize, "BEGIN_COLORANTS %u\n", (unsigned int) m_nCount);
   sDescription += buf;
 
-  for (i=0; i<m_nCount; i++) {
+  for (i=0; i<nCount; i++) {
     nLen = (icUInt32Number)strlen(m_pData[i].name);
     if (nLen>nMaxLen)
       nMaxLen =nLen;
@@ -9494,7 +9505,7 @@ void CIccTagColorantTable::Describe(std::string &sDescription, int /* nVerbosene
     snprintf(buf, bufSize, "Lab_L Lab_a Lab_b\n");
     sDescription += buf;
   }
-  for (i=0; i<m_nCount; i++) {
+  for (i=0; i<nCount; i++) {
     snprintf(buf, bufSize, "%2u \"%s\"", (unsigned int) i, m_pData[i].name);
     sDescription += buf;
     memset(buf, ' ', 128);


### PR DESCRIPTION
## Summary

Fixes two CodeQL `iccdev/unbounded-profile-loop` findings (CWE-400/CWE-834) where a loop's iteration count is controlled by a profile-derived field without a bound that static analysis can see.

| Issue | Field | Site | CodeQL alert |
|-------|-------|------|--------------|
| #1246 | `m_nSubElem` | `IccProfLib/IccMpeCalc.cpp:5471` — `CIccApplyMpeCalculator::~CIccApplyMpeCalculator` | 2184 |
| #1248 | `m_nCount` | `IccProfLib/IccTagBasic.cpp:9497` — `CIccTagColorantTable::Describe` | 2183 |

## Root cause

Both counts are in fact validated at read time and the backing arrays are allocated to match:

- **#1246** — `CIccMpeCalculator::Read` rejects `nSubElem >= MAX_CALC_ELEMENTS` and allocates `m_SubElem` to match. But the flagged loop is in the *Apply* class destructor (`CIccApplyMpeCalculator`), whose `m_nSubElem` is copied from the parent in `GetNewApply`; the read-time guard lives on a different type, so dataflow doesn't reach the loop.
- **#1248** — `CIccTagColorantTable::Read` rejects `nCount > 0xffff` / `nNum < nCount` and `SetSize()`s `m_pData` to match. But the guard is on a *local* `nCount`, not the `m_nCount` field used by the `Describe` loop, so the loop appears unbounded.

In both cases the loops are safe for any profile produced through `Read`, but a corrupted/directly-constructed object could over-iterate. The fixes add a real defensive bound.

## Fix

- **#1246** — clamp `m_nSubElem` into a local bounded by `MAX_CALC_ELEMENTS` before the free loop.
- **#1248** — clamp `m_nCount` into a local bounded by `0xffff`, and short-circuit on a null `m_pData`, before the describe loops.

Both iterate the bounded local instead of the field. For valid profiles the bound is never hit, so output/behavior is byte-identical; the loops are now provably bounded.

## Verification

- `IccProfLib2` builds clean (combined ASAN+UBSan `-O1 -g`).
- MPE calc profiles (`Testing/CalcTest/calcUnderStack_*.icc`) dump clean under ASAN + UBSan (no leaks, no runtime errors) — exercises the calculator path.
- Behavior-preserving for valid data: `nCount == m_nCount` whenever `m_nCount <= 0xffff` (always true post-`Read`), and `m_SubElem`/`m_pData` allocations always equal the counts.
- CodeQL on this PR is the authoritative check for alert clearance.

Closes #1246
Closes #1248

🤖 Generated with [Claude Code](https://claude.com/claude-code)