### PR TITLE
Validation: allow shared (linked) tag data in CheckTagLayout

### DIFF
--- a/.github/ci/regression/tag-layout-shared-data.cpp
+++ b/.github/ci/regression/tag-layout-shared-data.cpp
@@ -1,0 +1,138 @@
+// Regression test for shared (linked) tag data in CheckTagLayout.
+//
+// ICC.1:2022 section 7.3.1 permits several tag directory entries to reference one
+// common block of tag data, provided the shared entries carry an identical
+// offset and size ("...both the offset and size of the tag data elements in the
+// tag table shall be the same"). The canonical example is AToB0/AToB1/AToB2 — or
+// BToA0/1/2 — pointing at a single LUT. The structural tag-layout validation
+// added in #1216 walked
+// the offset-sorted directory and reported every entry whose start fell before
+// the running frontier as "<tag> overlaps <prev>" / non-compliant, which
+// misflagged these legitimately shared entries.
+//
+// This test builds a profile that attaches one tag object under three AToB
+// signatures (so Write() emits three directory entries with identical
+// offset+size), reads it back, validates it, and asserts that the layout check
+// does not report an overlap and does not push the status to non-compliant.
+//
+// Pre-fix: validation report contains "overlaps" and status is NonCompliant.
+// Post-fix: no overlap is reported.
+
+#include "IccProfile.h"
+#include "IccTag.h"
+#include "IccTagBasic.h"
+#include "IccTagLut.h"
+#include "IccIO.h"
+#include "IccUtil.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+static CIccTagXYZ *make_xyz(icFloatNumber x, icFloatNumber y, icFloatNumber z)
+{
+  CIccTagXYZ *pTag = new CIccTagXYZ;
+  (*pTag)[0].X = icDtoF(x);
+  (*pTag)[0].Y = icDtoF(y);
+  (*pTag)[0].Z = icDtoF(z);
+  return pTag;
+}
+
+// A small RGB->XYZ 16-bit LUT (mft2), the tag type the real Turquoise_output.icc
+// profile shares across AToB0/AToB1/AToB2.
+static CIccTagLut16 *make_lut16()
+{
+  CIccTagLut16 *pLut = new CIccTagLut16;
+  pLut->Init(3, 3);
+  pLut->SetColorSpaces(icSigRgbData, icSigXYZData);
+
+  LPIccCurve *aCurves = pLut->NewCurvesA();
+  LPIccCurve *bCurves = pLut->NewCurvesB();
+  if (!aCurves || !bCurves) { delete pLut; return nullptr; }
+  for (int i = 0; i < 3; i++) {
+    CIccTagCurve *ca = new CIccTagCurve(); ca->SetSize(2); aCurves[i] = ca;
+    CIccTagCurve *cb = new CIccTagCurve(); cb->SetSize(2); bCurves[i] = cb;
+  }
+  icUInt8Number grid[3] = {2, 2, 2};
+  if (!pLut->NewCLUT(grid, 2)) { delete pLut; return nullptr; }
+  return pLut;
+}
+
+int main()
+{
+  CIccProfile profile;
+
+  // Minimal, well-formed-enough header for a writable RGB display profile.
+  memset(&profile.m_Header, 0, sizeof(profile.m_Header));
+  profile.m_Header.deviceClass    = icSigDisplayClass;
+  profile.m_Header.colorSpace     = icSigRgbData;
+  profile.m_Header.pcs            = icSigXYZData;
+  profile.m_Header.platform       = icSigMacintosh;
+  profile.m_Header.renderingIntent= icPerceptual;
+  profile.m_Header.version        = icVersionNumberV4_3;
+  profile.m_Header.magic          = icMagicNumber;
+  profile.m_Header.illuminant.X   = icDtoF(0.9642f);
+  profile.m_Header.illuminant.Y   = icDtoF(1.0000f);
+  profile.m_Header.illuminant.Z   = icDtoF(0.8249f);
+
+  // Required-ish tags so the profile carries some bulk before the shared block.
+  profile.AttachTag(icSigMediaWhitePointTag, make_xyz(0.9642f, 1.0000f, 0.8249f));
+  profile.AttachTag(icSigRedColorantTag,     make_xyz(0.4361f, 0.2225f, 0.0139f));
+  profile.AttachTag(icSigGreenColorantTag,   make_xyz(0.3851f, 0.7169f, 0.0971f));
+  profile.AttachTag(icSigBlueColorantTag,    make_xyz(0.1431f, 0.0606f, 0.7139f));
+
+  // The crux: one tag object shared across three signatures. AttachTag()
+  // deduplicates by tag pointer, so Write() emits three directory entries that
+  // all point at the same offset with the same size.
+  CIccTagLut16 *pShared = make_lut16();
+  if (!pShared) return 2;
+  if (!profile.AttachTag(icSigAToB0Tag, pShared)) return 3;
+  if (!profile.AttachTag(icSigAToB1Tag, pShared)) return 4;
+  if (!profile.AttachTag(icSigAToB2Tag, pShared)) return 11;
+
+  CIccMemIO io;
+  if (!io.Alloc(256 * 1024, true)) return 5;
+  if (!profile.Write(&io)) return 6;
+
+  icUInt32Number nSize = (icUInt32Number)io.GetLength();
+  if (!nSize) return 7;
+
+  // Read the bytes back and validate via the memory-buffer overload. This both
+  // parses the profile (so we can confirm the shared layout) and runs the
+  // structural tag-layout check under test.
+  std::string report;
+  icValidateStatus status = icValidateOK;
+  CIccProfile *pRead = ValidateIccProfile(io.GetData(), nSize, report, status);
+  if (!pRead) return 8;
+
+  // Sanity: confirm Write() really produced shared entries (identical offset).
+  icUInt32Number off0 = 0, off1 = 0, off2 = 0;
+  for (TagEntryList::const_iterator i = pRead->m_Tags.begin();
+       i != pRead->m_Tags.end(); ++i) {
+    if (i->TagInfo.sig == icSigAToB0Tag) off0 = i->TagInfo.offset;
+    else if (i->TagInfo.sig == icSigAToB1Tag) off1 = i->TagInfo.offset;
+    else if (i->TagInfo.sig == icSigAToB2Tag) off2 = i->TagInfo.offset;
+  }
+  delete pRead;
+  if (!off0 || off0 != off1 || off1 != off2) {
+    // The fixture itself is wrong (no shared layout) — test cannot prove anything.
+    fprintf(stderr, "fixture did not produce shared tag offsets: %u %u %u\n",
+            off0, off1, off2);
+    return 9;
+  }
+
+  // The actual regression assertion: shared tag data must not be reported as an
+  // overlap by the structural tag-layout check. (This synthetic fixture is not a
+  // complete, fully-conformant profile — it intentionally omits the other
+  // required tags — so we assert specifically on the layout/overlap behaviour
+  // rather than on the overall validation status.)
+  (void)status;
+  if (report.find("overlaps") != std::string::npos) {
+    fprintf(stderr, "shared tag data wrongly reported as overlap:\n%s\n",
+            report.c_str());
+    return 1;
+  }
+
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -152,6 +152,41 @@ function(iccdev_add_embedio_read8_bounds_test)
   endif()
 endfunction()
 
+function(iccdev_add_tag_layout_shared_data_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  add_executable(iccTagLayoutSharedDataTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/tag-layout-shared-data.cpp"
+  )
+  target_link_libraries(iccTagLayoutSharedDataTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccTagLayoutSharedDataTest)
+
+  add_test(
+    NAME iccdev.tag-layout-shared-data
+    COMMAND "$<TARGET_FILE:iccTagLayoutSharedDataTest>"
+  )
+  set_tests_properties(iccdev.tag-layout-shared-data PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;validation;layout;regression"
+  )
+  if(WIN32)
+    set(_tag_layout_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccTagLayoutSharedDataTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _tag_layout_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.tag-layout-shared-data PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_tag_layout_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_fileio_getlength_position_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -465,6 +500,7 @@ if(WIN32)
   iccdev_add_profile_write_failure_test()
   iccdev_add_fileio_seek_tell_test()
   iccdev_add_parser_restore_calls_test()
+  iccdev_add_tag_layout_shared_data_test()
 
   return()
 endif()
@@ -520,6 +556,7 @@ iccdev_add_fileio_getlength_position_test()
 iccdev_add_profile_write_failure_test()
 iccdev_add_fileio_seek_tell_test()
 iccdev_add_parser_restore_calls_test()
+iccdev_add_tag_layout_shared_data_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -3207,11 +3207,30 @@ icValidateStatus CIccProfile::CheckTagLayout(CIccIO *pIO, std::string &sReport) 
       }
     }
     else if (off < prevEnd) {
-      // Tag data overlaps the preceding element (or the tag directory).
-      sReport += icMsgValidateNonCompliant;
-      snprintf(buf, sizeof(buf), " - %s overlaps %s.\n", name.c_str(), prevName.c_str());
-      sReport += buf;
-      rv = icMaxStatus(rv, icValidateNonCompliant);
+      // Multiple tag directory entries are permitted to share a single block of
+      // tag data (e.g. AToB0/AToB1/AToB2 pointing at one common LUT). Per
+      // ICC.1:2022 section 7.3.1: "The tag table may contain multiple tags
+      // signatures that all reference the same tag data element offset, allowing
+      // efficient reuse of tag data elements. In such cases, both the offset and
+      // size of the tag data elements in the tag table shall be the same." Such
+      // an entry re-occupies an already-counted extent rather than overlapping a
+      // different one, so it is compliant. A partial overlap (same start but a
+      // different size, or a straddling offset) is not shared data and remains
+      // non-compliant.
+      bool bSharedData = false;
+      for (size_t j = 0; j < k; ++j) {
+        if (ents[j].offset == off && ents[j].size == sz) {
+          bSharedData = true;
+          break;
+        }
+      }
+      if (!bSharedData) {
+        // Tag data overlaps the preceding element (or the tag directory).
+        sReport += icMsgValidateNonCompliant;
+        snprintf(buf, sizeof(buf), " - %s overlaps %s.\n", name.c_str(), prevName.c_str());
+        sReport += buf;
+        rv = icMaxStatus(rv, icValidateNonCompliant);
+      }
     }
 
     // Advance the frontier only when this tag extends it (see prevEnd note).


### PR DESCRIPTION
### Summary
The structural tag-layout validation added in #1216 reports a false-positive *non-compliant* "overlap" for profiles that use **shared (linked) tag data** — multiple tag-directory entries pointing at one common data block with identical offset and size. This is an ICC-permitted and common construction (e.g. `AToB0`/`AToB1`/`AToB2` sharing a single LUT). This PR teaches `CheckTagLayout` to recognize shared data and reserves the non-compliant verdict for genuine overlaps.

### Background / root cause
`CIccProfile::CheckTagLayout` (`IccProfLib/IccProfile.cpp`) walks the offset-sorted tag directory tracking a `prevEnd` frontier. Any entry whose `offset < prevEnd` was unconditionally reported as `"<tag> overlaps <prev>."` and pushed the status to `icValidateNonCompliant`.

But the ICC tag table explicitly permits several tags to *share* one data element. Per **ICC.1:2022 §7.3.1**:

> The tag table may contain multiple tags signatures that all reference the same tag data element offset, allowing efficient reuse of tag data elements. In such cases, both the offset and size of the tag data elements in the tag table shall be the same.

When the encoder writes e.g. `AToB0`/`AToB1`/`AToB2` from one tag object, all three directory entries get the same offset+size. After the first advances the frontier, the second and third have `offset < prevEnd` and were misflagged — so a fully compliant profile is reported non-compliant.

Real-world repro: a CMYK `Turquoise_output.icc` shares `AToB0/1/2` (and `BToA0/1/2`), producing four bogus errors:

```
NonCompliant! - AToB1Tag overlaps AToB0Tag.
NonCompliant! - AToB2Tag overlaps AToB0Tag.
NonCompliant! - BToA1Tag overlaps BToA0Tag.
NonCompliant! - BToA2Tag overlaps BToA0Tag.
```

### The fix
In the `off < prevEnd` branch, treat an entry whose `(offset, size)` **exactly matches** an already-seen entry as permitted shared data and skip the report. A *partial* overlap — same start but a different size, or a straddling offset — is **not** sharing and remains non-compliant, so genuine layout corruption is still caught. (`CIccProfile::AttachTag` already deduplicates by tag pointer, so this exactly mirrors how the library itself emits shared tags.)

### Testing
New regression test `.github/ci/regression/tag-layout-shared-data.cpp`, registered alongside the other IccProfLib CTest regression cases (`iccdev.tag-layout-shared-data`). It builds a profile sharing one `mft2` LUT across `AToB0/1/2`, round-trips it through `Write()`/`ValidateIccProfile()`, asserts the shared layout was actually produced, and asserts the report contains no `overlaps`.

- **Pre-fix:** test fails, emitting the exact `AToB1Tag overlaps AToB0Tag` message.
- **Post-fix:** test passes.

Verified locally (Clang 18 / Linux, `cmake --build … --target check`) and via a downstream WASM build against the real `Turquoise_output.icc` (now reports **valid**).

### Scope / risk
- Single localized change in `CheckTagLayout`; all other layout checks (oversized gaps, non-zero padding, trailing data) are unchanged.
- No change to the genuine-overlap path → no loss of detection for malformed/overlapping profiles.
- O(n²) over tag count inside the already-rare `off < prevEnd` branch; tag counts are small, so negligible.

### Related
Follow-up to #1216 (which introduced `CheckTagLayout`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
