### PR TITLE
Add IccProfilePlot: data-first profile visualization API + CLI

### DIFF
--- a/Build/Cmake/CMakeLists.txt
+++ b/Build/Cmake/CMakeLists.txt
@@ -1472,6 +1472,7 @@ IF(ENABLE_TOOLS)
   ADD_SUBDIRECTORY(Tools/IccApplyToLink)
   ADD_SUBDIRECTORY(Tools/IccApplySearch)
   ADD_SUBDIRECTORY(Tools/IccProfileVisualize)
+  ADD_SUBDIRECTORY(Tools/IccProfilePlot)
 
   # Ensure IccXML-dependent tools are built after IccXML library (safety net)
   IF(ENABLE_ICCXML)

--- a/Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt
+++ b/Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt
@@ -1,0 +1,45 @@
+#
+# IccProfilePlot CMakeLists.txt | iccDEV Project
+# Copyright (c) 2026 The International Color Consortium. All rights reserved.
+#
+# iccProfilePlot exposes IccVizModel — the data-first profile visualization
+# API. IccVizModel.cpp depends only on IccProfLib + spectralLocus.hpp (shared
+# with IccProfileVisualize), no PDF/TIFF writers, so it is reusable as a small
+# library component by other iccDEV consumers.
+#
+
+set(TARGET_NAME iccProfilePlot)
+set(SRC_PATH ../../../.. )
+set(SRC_ROOT ${SRC_PATH}/Tools/CmdLine/IccProfilePlot )
+set(VIZ_ROOT ${SRC_PATH}/Tools/CmdLine/IccProfileVisualize )
+set(SOURCES
+	"${SRC_ROOT}/iccProfilePlot.cpp"
+	"${SRC_ROOT}/IccVizModel.cpp"
+)
+
+add_executable(${TARGET_NAME} ${SOURCES})
+
+set_target_properties(${TARGET_NAME} PROPERTIES
+  OUTPUT_NAME "iccProfilePlot"
+)
+
+target_link_libraries(${TARGET_NAME}
+  PRIVATE
+    ${TARGET_LIB_ICCPROFLIB}
+)
+
+target_include_directories(${TARGET_NAME}
+  PRIVATE
+    ${PROJECT_ROOT_DIR}/IccProfLib
+    ${VIZ_ROOT}      # spectralLocus.hpp
+)
+
+install(TARGETS ${TARGET_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Emscripten WASM support
+if(EMSCRIPTEN)
+  set_target_properties(${TARGET_NAME} PROPERTIES
+    SUFFIX ".js"
+    LINK_FLAGS "-sMODULARIZE=1 -sINVOKE_RUN=0 -sEXPORTED_RUNTIME_METHODS=callMain,FS -sALLOW_MEMORY_GROWTH=1"
+  )
+endif()

--- a/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
+++ b/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
@@ -1,0 +1,605 @@
+/**
+ * IccVizModel implementation — see IccVizModel.hpp.
+ *
+ * The producers below mirror, in math, the plots iccProfileVisualize.cpp draws
+ * into PDF/TIFF, but emit data structures instead of drawing commands. Kept
+ * intentionally independent of that file so the two can be diffed.
+ */
+
+#include "IccVizModel.hpp"
+
+#include "IccProfile.h"
+#include "IccTag.h"
+#include "IccTagBasic.h"
+#include "IccTagLut.h"
+#include "IccUtil.h"
+
+#include "spectralLocus.hpp"   // const spectralLocus2degree (internal linkage)
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+namespace iccviz {
+namespace {
+
+constexpr float kChromaScale = 0.85f;   // matches chromaticityChartScale
+constexpr float kAbHalfRange = 130.0f;  // matches abChartScale/2
+const float kNaN = std::numeric_limits<float>::quiet_NaN();
+
+std::string sigStr(icTagSignature sig) {
+  char buf[64];
+  return std::string(icGetSigStr(buf, sizeof buf, static_cast<icUInt32Number>(sig)));
+}
+
+// ── colour helpers (ported verbatim from iccProfileVisualize.cpp) ────────────
+
+struct XY { float x, y; };
+
+XY xyFromICCXYZ(const icXYZNumber* xyz) {
+  float X = xyz->X / 65535.0f, Y = xyz->Y / 65535.0f, Z = xyz->Z / 65535.0f;
+  float sum = X + Y + Z;
+  if (sum <= 1e-8f) return {0.0f, 0.0f};
+  return {X / sum, Y / sum};
+}
+
+XY xyFromXYZFloat(const icFloatNumber* xyz) {
+  float sum = xyz[0] + xyz[1] + xyz[2];
+  if (sum <= 1e-8f) return {0.0f, 0.0f};
+  return {xyz[0] / sum, xyz[1] / sum};
+}
+
+// Planckian locus approximation (Kang et al. 2002), ported verbatim.
+XY approxPlanck(double t) {
+  const double c3a=-0.2661239,c2a=-0.2343589,c1a=0.8776956,c0a=0.179910;
+  const double c3b=-3.0258469,c2b=2.1070379,c1b=0.2226347,c0b=0.240390;
+  const double k3a=-1.1063814,k2a=-1.34811020,k1a=2.18555832,k0a=-0.20219683;
+  const double k3b=-0.9549476,k2b=-1.37418593,k1b=2.09137015,k0b=-0.16748867;
+  const double k3c=3.0817580,k2c=-5.87338670,k1c=3.75112997,k0c=-0.37001483;
+  double t2=t*t, t3=t*t*t, x;
+  if (t < 4000.0) x = c3a*(1e9/t3)+c2a*(1e6/t2)+c1a*(1e3/t)+c0a;
+  else            x = c3b*(1e9/t3)+c2b*(1e6/t2)+c1b*(1e3/t)+c0b;
+  double x2=x*x, x3=x*x*x, y;
+  if (t < 2222.0)      y = k3a*x3+k2a*x2+k1a*x+k0a;
+  else if (t < 4000.0) y = k3b*x3+k2b*x2+k1b*x+k0b;
+  else                 y = k3c*x3+k2c*x2+k1c*x+k0c;
+  return {static_cast<float>(x), static_cast<float>(y)};
+}
+
+// Curated wavelength labels along the spectral locus (from iccProfileVisualize).
+const int kLocusLabels[] = {
+  360, 460, 450, 470, 475, 480, 485, 490, 495, 500, 505, 510, 515,
+  520, 530, 540, 550, 560, 570, 580, 590, 600, 610, 620, 640, 700
+};
+
+std::string channelName(int index, bool useInput, icColorSpaceSignature inSpace,
+                        icColorSpaceSignature outSpace, int inCh, int outCh) {
+  char buf[128];
+  icColorIndexName(buf, 128, useInput ? inSpace : outSpace, index,
+                   useInput ? inCh : outCh, useInput ? "In" : "Out");
+  return std::string(buf);
+}
+
+unsigned char clipU8(icFloatNumber v) {
+  if (std::isnan(v)) return 0;
+  if (std::isinf(v)) return 255;
+  if (v < 0) return 0;
+  if (v > 255) return 255;
+  return static_cast<unsigned char>(v);
+}
+unsigned short clipU16(icFloatNumber v) {
+  if (std::isnan(v)) return 0;
+  if (std::isinf(v)) return 65535;
+  if (v < 0) return 0;
+  if (v > 65535) return 65535;
+  return static_cast<unsigned short>(v);
+}
+
+int photometricFromSpace(icColorSpaceSignature s) {
+  switch (s) {
+    case icSigRgbData: case icSigCmyData: case icSigXYZData: case icSigLuvData:
+    case icSigYCbCrData: case icSigYxyData: case icSigHsvData: case icSigHlsData:
+      return 2;  // RGB
+    case icSigCmykData: return 5;            // CMYK
+    case icSigLabData:  return 8;            // CIELAB
+    case icSigGrayData: case icSigGamutData: return 1;  // BlackIsZero
+    default: return 0;                        // WhiteIsZero (N-ink fallback)
+  }
+}
+
+// ── curve description + validation gate (mirrors describe1DLUT) ──────────────
+
+bool curvePasses(CIccCurve* curve, const std::string& sigDesc) {
+  std::string path = ":" + sigDesc, report;
+  return curve->Validate(path, report, nullptr) <= icValidateWarning;
+}
+
+std::string describeCurve(CIccCurve* curve) {
+  if (auto* tc = dynamic_cast<CIccTagCurve*>(curve)) {
+    icUInt32Number size = tc->GetSize();
+    if (size == 0) return "Y = X";
+    if (size == 1) {
+      icFloatNumber g = (*tc)[0] * 256.0f;
+      return "Y = X ^ " + std::to_string(g);
+    }
+    return "LookupTable[" + std::to_string(size) + "]";
+  }
+  std::string desc;
+  curve->Describe(desc, 100);
+  return desc;
+}
+
+// ── producers ────────────────────────────────────────────────────────────────
+
+Graph buildCurveGraph(CIccCurve* curve, const std::string& title) {
+  Graph g;
+  g.title = title;
+  g.description = describeCurve(curve);
+  g.xAxis = Axis{"Input", 0.0f, 1.0f, false};
+  g.yAxis = Axis{"Output", 0.0f, 1.0f, false};
+
+  int steps = 1000;
+  if (auto* tc = dynamic_cast<CIccTagCurve*>(curve))
+    steps = std::max(1000, static_cast<int>(tc->GetSize()));
+  if (curve->IsIdentity()) steps = 2;
+
+  Series data;
+  data.id = "curve"; data.name = title; data.role = Role::Primary;
+  data.shape = Shape::Polyline; data.colorHint = "neutral";
+  data.verts.reserve(steps + 1);
+  for (int i = 0; i <= steps; ++i) {
+    float in = i / static_cast<float>(steps);
+    float out = curve->Apply(in);
+    if (std::isnan(out)) out = 0.0f;
+    if (std::isinf(out)) out = 1.0f;
+    out = std::min(1.0f, std::max(0.0f, out));
+    data.verts.push_back(Vertex{in, out, "", kNaN});
+  }
+  g.series.push_back(std::move(data));
+
+  Series ident;
+  ident.id = "identity"; ident.name = "Identity"; ident.role = Role::Hint;
+  ident.shape = Shape::Polyline; ident.colorHint = "neutral";
+  ident.verts = {Vertex{0, 0, "", kNaN}, Vertex{1, 1, "", kNaN}};
+  g.series.push_back(std::move(ident));
+  return g;
+}
+
+void addPrimaryPoint(Graph& g, Series& s, CIccTag* tag, const char* label,
+                     const char* colorHint) {
+  auto* xyzTag = dynamic_cast<CIccTagXYZ*>(tag);
+  if (!xyzTag) return;
+  const icXYZNumber* xyz = xyzTag->GetXYZ(0);
+  if (!xyz) return;
+  XY p = xyFromICCXYZ(xyz);
+  s.verts.push_back(Vertex{p.x, p.y, label, kNaN});
+  (void)g;
+}
+
+Graph buildChromaticityGraph(CIccProfile* pIcc) {
+  Graph g;
+  g.title = "Chromaticity xy";
+  g.xAxis = Axis{"x (CIE 1931)", 0.0f, kChromaScale, true};
+  g.yAxis = Axis{"y (CIE 1931)", 0.0f, kChromaScale, true};
+
+  // Spectral locus (Hint, closed horseshoe).
+  Series locus;
+  locus.id = "locus"; locus.name = "Spectral locus"; locus.role = Role::Hint;
+  locus.shape = Shape::ClosedPath; locus.colorHint = "locus";
+  locus.verts.reserve(spectralLocus2degree.size());
+  for (const auto& p : spectralLocus2degree)
+    locus.verts.push_back(Vertex{static_cast<float>(p.x), static_cast<float>(p.y), "", kNaN});
+  g.series.push_back(std::move(locus));
+
+  // Wavelength number labels along the locus (Hint).
+  Series labels;
+  labels.id = "locusLabels"; labels.name = "Wavelengths"; labels.role = Role::Hint;
+  labels.shape = Shape::Scatter; labels.auxKind = "nm"; labels.colorHint = "locus";
+  int wlOffset = spectralLocus2degree.front().wavelength;
+  for (int nm : kLocusLabels) {
+    size_t idx = static_cast<size_t>(nm - wlOffset);
+    if (idx >= spectralLocus2degree.size()) continue;
+    const auto& p = spectralLocus2degree[idx];
+    labels.verts.push_back(Vertex{static_cast<float>(p.x), static_cast<float>(p.y),
+                                  std::to_string(nm), static_cast<float>(nm)});
+  }
+  g.series.push_back(std::move(labels));
+
+  // Planckian (blackbody) locus (Hint).
+  Series planck;
+  planck.id = "planckian"; planck.name = "Planckian locus"; planck.role = Role::Hint;
+  planck.shape = Shape::Polyline; planck.auxKind = "kelvin"; planck.colorHint = "neutral";
+  for (float t = 1500.0f; t <= 20000.0f; t += 200.0f) {
+    XY p = approxPlanck(t);
+    planck.verts.push_back(Vertex{p.x, p.y, "", t});
+  }
+  g.series.push_back(std::move(planck));
+
+  // Primaries + white (Primary).
+  Series prim;
+  prim.id = "primaries"; prim.name = "Primaries"; prim.role = Role::Primary;
+  prim.shape = Shape::Scatter;
+  CIccTag* w = pIcc->FindTag(icSigMediaWhitePointTag);
+  if (w) addPrimaryPoint(g, prim, w, "White", "white");
+  CIccTag* r = pIcc->FindTag(icSigRedColorantTag);
+  CIccTag* gr = pIcc->FindTag(icSigGreenColorantTag);
+  CIccTag* b = pIcc->FindTag(icSigBlueColorantTag);
+  Series gamut;
+  gamut.id = "gamut"; gamut.name = "Gamut"; gamut.role = Role::Primary;
+  gamut.shape = Shape::ClosedPath; gamut.colorHint = "neutral";
+  if (r && gr && b) {
+    size_t base = prim.verts.size();
+    addPrimaryPoint(g, prim, r, "R", "R");
+    addPrimaryPoint(g, prim, gr, "G", "G");
+    addPrimaryPoint(g, prim, b, "B", "B");
+    for (size_t i = base; i < prim.verts.size(); ++i)
+      gamut.verts.push_back(Vertex{prim.verts[i].x, prim.verts[i].y, "", kNaN});
+  }
+  g.series.push_back(std::move(prim));
+  if (!gamut.verts.empty()) g.series.push_back(std::move(gamut));
+  return g;
+}
+
+struct NamedLab { std::string name; float L, a, b; };
+
+// Collect named/colorant colours as Lab + name (mirrors outputNamedColors).
+bool collectNamedColors(CIccProfile* pIcc, CIccTag* tag,
+                        std::vector<NamedLab>& out, std::string& title) {
+  icTagTypeSignature type = tag->GetType();
+  icFloatNumber illum[3];
+  pIcc->getNormIlluminantXYZ(illum);
+
+  if (type == icSigColorantTableType) {
+    auto* table = dynamic_cast<CIccTagColorantTable*>(tag);
+    if (!table) return false;
+    std::string path = ":colorantTable", report;
+    if (table->Validate(path, report, nullptr) > icValidateWarning) return false;
+    icColorSpaceSignature pcs = pIcc->m_Header.pcs;
+    if (pcs != icSigXYZData && pcs != icSigLabData) return false;
+    icUInt32Number n = table->GetSize();
+    for (icUInt32Number i = 0; i < n; ++i) {
+      icColorantTableEntry* e = table->GetEntry(i);
+      icFloatNumber lab[3];
+      if (pcs == icSigXYZData) {
+        icFloatNumber xyz[3] = {icU16toF(e->data[0]), icU16toF(e->data[1]), icU16toF(e->data[2])};
+        icXYZtoLab(lab, xyz, illum);
+      } else {
+        lab[0]=icU16toF(e->data[0]); lab[1]=icU16toF(e->data[1]); lab[2]=icU16toF(e->data[2]);
+        icLabFromPcs(lab);
+      }
+      out.push_back(NamedLab{std::to_string(i+1) + " " + std::string(e->name), lab[0], lab[1], lab[2]});
+    }
+    title = "Colorant Table";
+    return !out.empty();
+  }
+
+  if (type == icSigNamedColor2Type) {
+    auto* table = dynamic_cast<CIccTagNamedColor2*>(tag);
+    if (!table) return false;
+    std::string path = ":namedColor2", report;
+    if (table->Validate(path, report, nullptr) > icValidateWarning) return false;
+    icColorSpaceSignature pcs = table->GetPCS();
+    if (pcs != icSigXYZData && pcs != icSigLabData) return false;
+    icUInt32Number n = table->GetSize();
+    std::string prefix = table->GetPrefix(), suffix = table->GetSufix();
+    for (icUInt32Number i = 0; i < n; ++i) {
+      SIccNamedColorEntry* e = table->GetEntry(i);
+      icFloatNumber lab[3];
+      if (pcs == icSigXYZData) {
+        icXYZtoLab(lab, e->pcsCoords, illum);
+      } else {
+        icFloatNumber lab2[3] = {e->pcsCoords[0], e->pcsCoords[1], e->pcsCoords[2]};
+        table->Lab2ToLab4(lab, lab2);
+        icLabFromPcs(lab);
+      }
+      out.push_back(NamedLab{prefix + std::string(e->rootName) + suffix, lab[0], lab[1], lab[2]});
+    }
+    title = "Named Color Table";
+    return !out.empty();
+  }
+
+  return false;  // tagArray (v5) not yet dissected, like upstream
+}
+
+Graph buildNamedAB(const std::vector<NamedLab>& colors, const std::string& title) {
+  Graph g;
+  g.title = title + " — a*b*";
+  g.xAxis = Axis{"a*", -kAbHalfRange, kAbHalfRange, true};
+  g.yAxis = Axis{"b*", -kAbHalfRange, kAbHalfRange, true};
+
+  // Constant-chroma circles (Hint).
+  for (float radius = 30.0f; radius <= 150.0f; radius += 30.0f) {
+    Series circ;
+    circ.id = "chroma" + std::to_string(static_cast<int>(radius));
+    circ.name = "C* = " + std::to_string(static_cast<int>(radius));
+    circ.role = Role::Hint; circ.shape = Shape::ClosedPath; circ.colorHint = "neutral";
+    for (int k = 0; k < 72; ++k) {
+      float th = static_cast<float>(k) / 72.0f * 6.28318530718f;
+      circ.verts.push_back(Vertex{radius * std::cos(th), radius * std::sin(th), "", kNaN});
+    }
+    g.series.push_back(std::move(circ));
+  }
+  // Quadrant labels (Hint) — match the PDF's +a Magenta / -a Green / etc.
+  Series ax;
+  ax.id = "axisLabels"; ax.name = "Axes"; ax.role = Role::Hint; ax.shape = Shape::Scatter;
+  ax.colorHint = "neutral";
+  ax.verts = {
+    Vertex{ kAbHalfRange, 0, "+a Magenta", kNaN}, Vertex{-kAbHalfRange, 0, "-a Green", kNaN},
+    Vertex{0,  kAbHalfRange, "+b Yellow", kNaN},  Vertex{0, -kAbHalfRange, "-b Blue", kNaN},
+  };
+  g.series.push_back(std::move(ax));
+
+  Series data;
+  data.id = "colors"; data.name = title; data.role = Role::Primary;
+  data.shape = Shape::Scatter; data.auxKind = "Lstar";
+  for (const auto& c : colors)
+    data.verts.push_back(Vertex{c.a, c.b, c.name, c.L});
+  g.series.push_back(std::move(data));
+  return g;
+}
+
+Graph buildNamedXY(CIccProfile* pIcc, const std::vector<NamedLab>& colors,
+                   const std::string& title) {
+  Graph g;
+  g.title = title + " — xy";
+  g.xAxis = Axis{"x (CIE 1931)", 0.0f, kChromaScale, true};
+  g.yAxis = Axis{"y (CIE 1931)", 0.0f, kChromaScale, true};
+
+  // Reuse the locus + planckian reference geometry.
+  Graph chrom = buildChromaticityGraph(pIcc);
+  for (auto& s : chrom.series)
+    if (s.role == Role::Hint) g.series.push_back(std::move(s));
+
+  icFloatNumber illum[3];
+  pIcc->getNormIlluminantXYZ(illum);
+  Series data;
+  data.id = "colors"; data.name = title; data.role = Role::Primary;
+  data.shape = Shape::Scatter; data.auxKind = "Lstar";
+  for (const auto& c : colors) {
+    icFloatNumber lab[3] = {c.L, c.a, c.b}, xyz[3];
+    icLabtoXYZ(xyz, lab, illum);
+    XY p = xyFromXYZFloat(xyz);
+    data.verts.push_back(Vertex{p.x, p.y, c.name, c.L});
+  }
+  g.series.push_back(std::move(data));
+  return g;
+}
+
+// CLUT lattice → raster (ported from output3DLUT's flatten).
+bool buildClutRaster(CIccTag* tag, Raster& out) {
+  auto* lut = dynamic_cast<CIccMBB*>(tag);
+  if (!lut) return false;
+  CIccCLUT* clut = lut->GetCLUT();
+  if (!clut) return false;
+
+  int bytes = lut->GetPrecision();
+  int inputChannels = lut->InputChannels();
+  int outputChannels = lut->OutputChannels();
+  if (inputChannels <= 0 || outputChannels <= 0 || bytes <= 0) return false;
+
+  clut->Begin();
+  int gridPoints = clut->GridPoints();
+  if (gridPoints <= 0) return false;
+
+  int tiles = gridPoints, tileWidth = 1, tileHeight = 1;
+  if (inputChannels >= 2) { tileWidth = clut->GridPoint(1); if (tileWidth <= 0) return false; }
+  if (inputChannels >= 3) { tileHeight = clut->GridPoint(2); if (tileHeight <= 0) return false; }
+  if (inputChannels > 3)
+    for (int i = 3; i < inputChannels; ++i) {
+      int g = clut->GridPoint(i); if (g <= 0) return false; tiles *= g;
+    }
+  if (inputChannels == 1) { tileWidth = tiles; tiles = 1; tileHeight = 1; }
+  if (inputChannels == 2) { tileHeight = tiles; tiles = 1; }
+  if (tiles <= 0) tiles = 1;
+
+  double sq = std::sqrt(static_cast<double>(tiles));
+  int tilesWide = static_cast<int>(sq);
+  if (tilesWide <= 0) tilesWide = 1;
+  if (inputChannels > 3 && (inputChannels & 1)) {
+    int old = tilesWide;
+    tilesWide -= (tilesWide % (gridPoints * tileWidth));
+    if (tilesWide == 0) tilesWide = old;
+  }
+  int tilesHigh = (tiles + (tilesWide - 1)) / tilesWide;
+  int imageWidth = tilesWide * tileWidth;
+  int imageHeight = tilesHigh * tileHeight;
+  if (imageWidth <= 0 || imageHeight <= 0) return false;
+
+  size_t bufferSize = static_cast<size_t>(imageWidth) * imageHeight * outputChannels * bytes;
+  if (!bufferSize) return false;
+
+  out.samples.assign(bufferSize, 0);
+  unsigned char* buf = out.samples.data();
+  unsigned short* buf16 = reinterpret_cast<unsigned short*>(buf);
+  float* buf32 = reinterpret_cast<float*>(buf);
+  icFloatNumber* clutData = clut->GetData(0);
+
+  size_t n001 = static_cast<size_t>(tileWidth) * tileHeight * outputChannels;
+  size_t n010 = static_cast<size_t>(tileWidth) * outputChannels;
+  size_t n100 = static_cast<size_t>(outputChannels);
+  if (inputChannels < 2) std::swap(n010, n100);
+  size_t outTileStepV = static_cast<size_t>(imageWidth) * tileHeight * outputChannels;
+  size_t outTileStepH = static_cast<size_t>(tileWidth) * outputChannels;
+  size_t outColStep = static_cast<size_t>(outputChannels);
+  size_t outRowStep = static_cast<size_t>(imageWidth) * outputChannels;
+
+  for (int z = 0; z < tiles; ++z) {
+    int z2 = z % tilesWide, z3 = z / tilesWide;
+    for (int x = 0; x < tileWidth; ++x)
+      for (int y = 0; y < tileHeight; ++y) {
+        size_t in = z * n001 + x * n010 + (tileHeight - 1 - y) * n100;
+        size_t o = z3 * outTileStepV + z2 * outTileStepH + y * outRowStep + x * outColStep;
+        if (bytes == 4 || bytes == 8)
+          for (int c = 0; c < outputChannels; ++c) buf32[o + c] = clutData[in + c];
+        else if (bytes == 2)
+          for (int c = 0; c < outputChannels; ++c) buf16[o + c] = clipU16(clutData[in + c] * 65535.0f);
+        else
+          for (int c = 0; c < outputChannels; ++c) buf[o + c] = clipU8(clutData[in + c] * 255.0f);
+      }
+  }
+
+  out.width = imageWidth; out.height = imageHeight;
+  out.channels = outputChannels; out.bitsPerChannel = 8 * bytes;
+  out.photometric = photometricFromSpace(lut->GetCsOutput());
+  out.normalizedICC = true;
+  return true;
+}
+
+// Append LUT sub-curve descriptors in the A→B→M order output3DLUT uses.
+void enumerateLutCurves(CIccProfile* pIcc, icTagSignature sig, CIccMBB* lut,
+                        std::vector<Descriptor>& out) {
+  std::string base = sigStr(sig);
+  int inCh = lut->InputChannels(), outCh = lut->OutputChannels();
+  icColorSpaceSignature inSp = lut->GetCsInput(), outSp = lut->GetCsOutput();
+  bool inMtx = lut->IsInputMatrix();
+  struct Grp { char g; CIccCurve** arr; int count; bool useInput; };
+  Grp groups[] = {
+    {'A', lut->GetCurvesA(), inMtx ? outCh : inCh, !inMtx},
+    {'B', lut->GetCurvesB(), inMtx ? inCh : outCh, inMtx},
+    {'M', lut->GetCurvesM(), inMtx ? inCh : outCh, inMtx},
+  };
+  for (const Grp& grp : groups) {
+    if (!grp.arr) continue;
+    for (int i = 0; i < grp.count; ++i) {
+      CIccCurve* c = grp.arr[i];
+      if (!c) continue;
+      std::string ch = channelName(i, grp.useInput, inSp, outSp, inCh, outCh);
+      std::string label = base + ": curve" + grp.g + "[ " + ch + " ]";
+      if (!curvePasses(c, label)) continue;
+      Descriptor d;
+      d.kind = Kind::Curve1D; d.output = Output::Graph;
+      d.id = "curve:" + base + ":" + grp.g + ":" + std::to_string(i);
+      d.title = label; d.tag = sig; d.grp = grp.g; d.idx = i;
+      out.push_back(std::move(d));
+    }
+  }
+  (void)pIcc;
+}
+
+CIccCurve* lutCurveFor(CIccMBB* lut, char grp, int idx) {
+  CIccCurve** arr = grp == 'A' ? lut->GetCurvesA()
+                  : grp == 'B' ? lut->GetCurvesB()
+                  : grp == 'M' ? lut->GetCurvesM() : nullptr;
+  return arr ? arr[idx] : nullptr;
+}
+
+} // namespace
+
+// ── public API ───────────────────────────────────────────────────────────────
+
+std::vector<Descriptor> Enumerate(CIccProfile* pIcc) {
+  std::vector<Descriptor> out;
+  if (!pIcc) return out;
+
+  // NOTE: we deliberately do NOT iterate pIcc->m_Tags here. m_Tags is a
+  // std::list owned by the IccProfLib translation unit; iterating it from this
+  // TU walks off the end into the circular list (cross-TU std::list iterator
+  // mismatch). CIccProfile::FindTag (which lives in IccProfLib) is safe, so we
+  // probe a fixed, canonically-ordered signature list instead. This also gives
+  // deterministic ordering — close to, though not byte-identical with, the
+  // file-order iccProfileVisualize uses.
+
+  // Chromaticity first (only when RGB colorants are present, like upstream).
+  if (pIcc->FindTag(icSigRedColorantTag) && pIcc->FindTag(icSigGreenColorantTag) &&
+      pIcc->FindTag(icSigBlueColorantTag)) {
+    Descriptor d;
+    d.kind = Kind::ChromaticityXY; d.output = Output::Graph;
+    d.id = "chroma:xy"; d.title = "Chromaticity xy";
+    out.push_back(std::move(d));
+  }
+
+  static const icTagSignature kTrcSigs[] = {
+    icSigRedTRCTag, icSigGreenTRCTag, icSigBlueTRCTag, icSigGrayTRCTag };
+  for (icTagSignature sig : kTrcSigs) {
+    auto* c = dynamic_cast<CIccCurve*>(pIcc->FindTag(sig));
+    if (!c || !curvePasses(c, sigStr(sig))) continue;
+    Descriptor d;
+    d.kind = Kind::Curve1D; d.output = Output::Graph;
+    d.id = "curve:" + sigStr(sig); d.title = sigStr(sig); d.tag = sig;
+    out.push_back(std::move(d));
+  }
+
+  static const icTagSignature kLutSigs[] = {
+    icSigAToB0Tag, icSigAToB1Tag, icSigAToB2Tag, icSigAToB3Tag,
+    icSigBToA0Tag, icSigBToA1Tag, icSigBToA2Tag, icSigBToA3Tag,
+    icSigGamutTag, icSigPreview0Tag, icSigPreview1Tag, icSigPreview2Tag };
+  for (icTagSignature sig : kLutSigs) {
+    CIccTag* t = pIcc->FindTag(sig);
+    auto* lut = dynamic_cast<CIccMBB*>(t);
+    if (!lut) continue;
+    enumerateLutCurves(pIcc, sig, lut, out);
+    Raster probe;
+    if (buildClutRaster(t, probe)) {
+      Descriptor d;
+      d.kind = Kind::ClutImage; d.output = Output::Raster;
+      d.id = "clut:" + sigStr(sig); d.title = sigStr(sig) + " CLUT"; d.tag = sig;
+      out.push_back(std::move(d));
+    }
+  }
+
+  static const icTagSignature kNamedSigs[] = {
+    icSigNamedColorTag, icSigNamedColor2Tag, icSigColorantTableTag, icSigColorantTableOutTag };
+  for (icTagSignature sig : kNamedSigs) {
+    CIccTag* t = pIcc->FindTag(sig);
+    if (!t) continue;
+    std::vector<NamedLab> colors; std::string title;
+    if (!collectNamedColors(pIcc, t, colors, title)) continue;
+    Descriptor ab;
+    ab.kind = Kind::NamedColorsAB; ab.output = Output::Graph;
+    ab.id = "named:ab:" + sigStr(sig); ab.title = title + " — a*b* (" + sigStr(sig) + ")";
+    ab.tag = sig; out.push_back(std::move(ab));
+    Descriptor xy;
+    xy.kind = Kind::NamedColorsXY; xy.output = Output::Graph;
+    xy.id = "named:xy:" + sigStr(sig); xy.title = title + " — xy (" + sigStr(sig) + ")";
+    xy.tag = sig; out.push_back(std::move(xy));
+  }
+  return out;
+}
+
+GraphResult RenderGraph(CIccProfile* pIcc, const std::string& id) {
+  GraphResult res;
+  if (!pIcc) { res.error = "null profile"; return res; }
+  for (const Descriptor& d : Enumerate(pIcc)) {
+    if (d.id != id) continue;
+    if (d.output != Output::Graph) { res.error = "descriptor is not a graph"; return res; }
+    if (d.kind == Kind::ChromaticityXY) {
+      res.graph = buildChromaticityGraph(pIcc); res.ok = true; return res;
+    }
+    if (d.kind == Kind::Curve1D) {
+      CIccTag* t = pIcc->FindTag(d.tag);
+      CIccCurve* c = nullptr;
+      if (d.grp) { auto* lut = dynamic_cast<CIccMBB*>(t); if (lut) c = lutCurveFor(lut, d.grp, d.idx); }
+      else c = dynamic_cast<CIccCurve*>(t);
+      if (!c) { res.error = "curve not found"; return res; }
+      res.graph = buildCurveGraph(c, d.title); res.ok = true; return res;
+    }
+    if (d.kind == Kind::NamedColorsAB || d.kind == Kind::NamedColorsXY) {
+      CIccTag* t = pIcc->FindTag(d.tag);
+      std::vector<NamedLab> colors; std::string title;
+      if (!t || !collectNamedColors(pIcc, t, colors, title)) { res.error = "no colours"; return res; }
+      res.graph = (d.kind == Kind::NamedColorsAB) ? buildNamedAB(colors, title)
+                                                  : buildNamedXY(pIcc, colors, title);
+      res.ok = true; return res;
+    }
+    res.error = "unsupported graph kind"; return res;
+  }
+  res.error = "unknown visualization id: " + id;
+  return res;
+}
+
+RasterResult RenderRaster(CIccProfile* pIcc, const std::string& id) {
+  RasterResult res;
+  if (!pIcc) { res.error = "null profile"; return res; }
+  for (const Descriptor& d : Enumerate(pIcc)) {
+    if (d.id != id) continue;
+    if (d.output != Output::Raster) { res.error = "descriptor is not a raster"; return res; }
+    CIccTag* t = pIcc->FindTag(d.tag);
+    if (!t || !buildClutRaster(t, res.raster)) { res.error = "could not build raster"; return res; }
+    res.ok = true; return res;
+  }
+  res.error = "unknown visualization id: " + id;
+  return res;
+}
+
+} // namespace iccviz

--- a/Tools/CmdLine/IccProfilePlot/IccVizModel.hpp
+++ b/Tools/CmdLine/IccProfilePlot/IccVizModel.hpp
@@ -1,0 +1,128 @@
+/**
+ * IccVizModel — data-first profile visualization model.
+ *
+ * A standalone, dependency-light re-implementation of the visualizations that
+ * iccDEV's iccProfileVisualize tool draws into a single PDF/TIFF report. Where
+ * iccProfileVisualize *renders* (it emits finished PDF pages and TIFF rasters),
+ * this model *returns the underlying data*:
+ *
+ *   - Graph visualizations (tone curves, chromaticity, named-colour scatters)
+ *     come back as IccVizGraph: 2-D point series plus axis range hints, so the
+ *     caller draws/rasterizes them in its own look-and-feel. NO raster is
+ *     produced for graph types.
+ *   - Genuine images (the nD CLUT lattice) come back as IccVizRaster: the same
+ *     ICC-normalized samples iccProfileVisualize would have written to TIFF,
+ *     plus geometry — the caller decides how to colour-manage/display them.
+ *
+ * Series carry a role: Primary (the profile's own data — primaries, white,
+ * curve, named colours) vs Hint (reference geometry the caller may draw or
+ * ignore — spectral locus, planckian curve, wavelength labels, chroma circles,
+ * identity line). No ticks/grid are shipped: those are a caller-side decision;
+ * only an axis range *hint* is provided.
+ *
+ * Design intent: this file depends ONLY on IccProfLib + spectralLocus.hpp + the
+ * C++ standard library — no embind, no nlohmann, no PDF/TIFF writers — so it can
+ * be lifted into iccDEV verbatim once the profiletool proof-of-concept is
+ * approved. iccProfileVisualize.cpp is deliberately left untouched; the math is
+ * duplicated here on purpose so the two can be diffed independently.
+ */
+
+#ifndef ICC_VIZ_MODEL_HPP
+#define ICC_VIZ_MODEL_HPP
+
+#include "IccProfLibConf.h"    // required before icProfileHeader.h (uint types/config)
+#include "icProfileHeader.h"   // icTagSignature, icColorSpaceSignature
+#include <string>
+#include <vector>
+#include <limits>
+
+class CIccProfile;
+
+namespace iccviz {
+
+// Stable identity for a visualization category. Append-only: existing values
+// never change, so they are safe to use as a persistent wire identifier.
+enum class Kind : unsigned int {
+  Curve1D        = 1,   // 1-D tone curve (TRC, or an A/B/M curve of a LUT tag)
+  ChromaticityXY = 2,   // RGB primaries + white on the CIE 1931 xy chart
+  NamedColorsAB  = 3,   // named/colorant colours on a CIELAB a*b* chart
+  NamedColorsXY  = 4,   // named/colorant colours on the xy chart
+  ClutImage      = 5,   // nD CLUT lattice flattened to an image (raster)
+  // SmoothnessLattice = 6,  // reserved — deferred to a later phase
+};
+
+enum class Output : unsigned char { Graph, Raster };
+
+// What a series represents, so the caller can style data vs reference geometry.
+enum class Role : unsigned char { Primary, Hint };
+
+enum class Shape : unsigned char { Polyline, ClosedPath, Scatter };
+
+struct Vertex {
+  float x = 0.0f;
+  float y = 0.0f;
+  std::string label;                                  // "" when unlabelled
+  float aux = std::numeric_limits<float>::quiet_NaN(); // NaN when no aux scalar
+};
+
+struct Series {
+  std::string id;          // "curve","identity","locus","planckian","chroma30",…
+  std::string name;        // human/legend label
+  Role  role  = Role::Primary;
+  Shape shape = Shape::Polyline;
+  std::string auxKind;     // "", "Lstar", "nm", "kelvin" — meaning of Vertex.aux
+  std::string colorHint;   // optional: "R","G","B","white","neutral","locus"
+  std::vector<Vertex> verts;
+};
+
+struct Axis {
+  std::string label;       // "Input", "a*", "x (CIE 1931)"
+  float minHint = 0.0f;    // suggested range only — caller may recompute/override
+  float maxHint = 1.0f;
+  bool  equalAspect = false;  // chart wants square aspect (xy / ab plots)
+};
+
+struct Graph {
+  std::string title;
+  std::string description;   // e.g. curve Describe() text
+  Axis xAxis, yAxis;
+  std::vector<Series> series;  // mixed Primary + Hint
+};
+
+struct Raster {
+  int  width = 0, height = 0, channels = 0, bitsPerChannel = 0;
+  int  photometric = 1;       // TIFF-style hint: 0/1 gray, 2 RGB, 5 CMYK, 8 CIELAB
+  bool normalizedICC = true;  // samples are ICC-normalized (not TIFF-standard Lab)
+  std::vector<unsigned char> samples;  // row-major, channels interleaved
+};
+
+// One available visualization. `id` is stable and is what callers pass back to
+// render(). Internal addressing fields (tag/group/index) let render() rebuild
+// the exact source object without re-parsing the id string.
+struct Descriptor {
+  Kind   kind;
+  Output output;
+  std::string id;
+  std::string title;
+  icTagSignature tag = static_cast<icTagSignature>(0);  // owning tag (0 = whole profile)
+  char grp = 0;          // 'A' | 'B' | 'M' for LUT sub-curves, else 0
+  int  idx = -1;         // channel index within grp, else -1
+};
+
+struct GraphResult  { bool ok = false; std::string error; Graph  graph;  };
+struct RasterResult { bool ok = false; std::string error; Raster raster; };
+
+// List every visualization available for the profile, in the SAME order
+// iccProfileVisualize emits them (chromaticity first, then per-tag in tag-table
+// order: TRC curves, then each LUT's A/B/M curves followed by its CLUT image,
+// then named/colorant tables as a*b* then xy).
+std::vector<Descriptor> Enumerate(CIccProfile* pIcc);
+
+// Render one graph / raster by descriptor id. render*ById re-enumerates to find
+// the descriptor (cheap; callers should cache the parsed profile).
+GraphResult  RenderGraph (CIccProfile* pIcc, const std::string& id);
+RasterResult RenderRaster(CIccProfile* pIcc, const std::string& id);
+
+} // namespace iccviz
+
+#endif // ICC_VIZ_MODEL_HPP

--- a/Tools/CmdLine/IccProfilePlot/Readme.md
+++ b/Tools/CmdLine/IccProfilePlot/Readme.md
@@ -1,0 +1,178 @@
+# IccProfilePlot / IccVizModel — data-first profile visualization
+
+`IccVizModel` turns an ICC profile's plottable content into **data** instead of a
+finished picture. Where [`IccProfileVisualize`](../IccProfileVisualize) renders a
+profile into a single PDF (tone curves, chromaticity, named-colour scatters) plus
+per-tag TIFFs, `IccVizModel` lets a caller **enumerate** the available
+visualizations and **render each one individually**:
+
+- **Graphs** (tone curves, chromaticity, named-colour scatters) come back as 2-D
+  point series + axis range hints. No raster is produced — the caller draws and
+  styles them however it likes.
+- **Genuine images** (the nD CLUT lattice) come back as ICC-normalized raster
+  samples + geometry. The caller decides how to colour-manage / display them.
+
+It depends only on **IccProfLib** + `spectralLocus.hpp` — no PDF/TIFF/SVG
+writers, no third-party libraries — so `IccVizModel.{hpp,cpp}` can be compiled
+directly into any consumer (it is, for example, compiled into a WebAssembly
+module by the [profiletool](https://github.com/colourbill-ctrl/profiletool) web
+front-end). `iccProfileVisualize` is left untouched; the maths is reimplemented
+here independently.
+
+---
+
+## Two ways to use it
+
+### 1. The C++ library API (`IccVizModel.hpp`)
+
+Everything lives in namespace `iccviz`. Parse a profile once, then enumerate and
+render against it.
+
+```cpp
+#include "IccVizModel.hpp"
+#include "IccProfile.h"
+
+CIccProfile* p = OpenIccProfile("photo.icc");          // your own parse
+
+for (const iccviz::Descriptor& d : iccviz::Enumerate(p)) {
+  if (d.output == iccviz::Output::Graph) {
+    iccviz::GraphResult g = iccviz::RenderGraph(p, d.id);
+    // g.ok, g.graph.series → draw / restyle however you like
+  } else {                                             // Output::Raster
+    iccviz::RasterResult r = iccviz::RenderRaster(p, d.id);
+    // r.ok, r.raster.samples + geometry → your own display path
+  }
+}
+delete p;
+```
+
+#### The three calls
+
+```cpp
+std::vector<Descriptor> Enumerate    (CIccProfile* pIcc);
+GraphResult             RenderGraph  (CIccProfile* pIcc, const std::string& id);
+RasterResult            RenderRaster (CIccProfile* pIcc, const std::string& id);
+```
+
+`RenderGraph` / `RenderRaster` re-enumerate internally to resolve the `id`, so
+callers that render many graphs should keep the parsed `CIccProfile` alive (the
+parse is the expensive part, not enumeration).
+
+#### The data model
+
+```cpp
+enum class Kind   { Curve1D=1, ChromaticityXY=2, NamedColorsAB=3,
+                    NamedColorsXY=4, ClutImage=5 };   // stable, append-only
+enum class Output { Graph, Raster };
+enum class Role   { Primary, Hint };                  // profile data vs reference geometry
+enum class Shape  { Polyline, ClosedPath, Scatter };
+
+struct Vertex { float x, y; std::string label; float aux; };   // aux = NaN when none
+struct Series {
+  std::string id, name;        // "curve","identity","locus","planckian","chroma30",…
+  Role  role;  Shape shape;
+  std::string auxKind;         // "", "Lstar", "nm", "kelvin"  (meaning of Vertex.aux)
+  std::string colorHint;       // "R","G","B","white","neutral","locus"  (optional)
+  std::vector<Vertex> verts;
+};
+struct Axis  { std::string label; float minHint, maxHint; bool equalAspect; };
+struct Graph { std::string title, description; Axis xAxis, yAxis;
+               std::vector<Series> series; };
+
+struct Raster {
+  int  width, height, channels, bitsPerChannel;
+  int  photometric;            // TIFF-style: 0/1 gray · 2 RGB · 5 CMYK · 8 CIELAB
+  bool normalizedICC;          // samples are ICC-normalized (see note below)
+  std::vector<unsigned char> samples;   // row-major, channels interleaved
+};
+
+struct Descriptor { Kind kind; Output output; std::string id, title;
+                    icTagSignature tag; char grp; int idx; };
+```
+
+#### Contract
+
+- **`id` is the stable handle.** Enumerate returns ids like `chroma:xy`,
+  `curve:rTRC`, `curve:A2B0:B:1`, `clut:A2B0`, `named:ab:ncl2`. Titles may
+  change; ids do not. Pass an `id` back to `RenderGraph`/`RenderRaster`.
+- **Graphs are pure data.** Each plot is point series split into **Primary** (the
+  profile's own values — primaries, white, gamut, the curve, named colours) and
+  **Hint** (reference geometry you may draw or ignore — spectral locus, Planckian
+  curve, wavelength labels, constant-chroma circles, the identity line). Only an
+  **axis range hint** is provided — no ticks, no grid (those are caller choices).
+- **Rasters stay rasters.** The nD CLUT lattice is returned as samples +
+  geometry, never coerced into a graph.
+- **No drawing dependency.** Want a PDF? Use `iccProfileVisualize`. Want your own
+  charts? Use this.
+
+#### What each `Kind` returns
+
+| Kind | Output | Primary series | Hint series |
+|---|---|---|---|
+| `Curve1D` (TRC, and A/B/M curves of a LUT tag) | Graph | `curve` (input,output) sampled at `max(1000, tableSize)` | `identity` (0,0)→(1,1) |
+| `ChromaticityXY` (RGB primaries + white) | Graph | `primaries` R/G/B + `white`; `gamut` triangle | `locus` (closed, with `locusLabels` aux=nm) + `planckian` (aux=kelvin) |
+| `NamedColorsAB` (colorantTable / namedColor2) | Graph | `colors` (a\*,b\*), aux=L\* | constant-chroma circles + quadrant labels |
+| `NamedColorsXY` (same tags) | Graph | `colors` (x,y), aux=L\* | `locus` + `planckian` |
+| `ClutImage` (AToB\*/BToA\*/gamut/preview CLUTs) | Raster | — | — |
+
+### 2. The CLI tool (`iccProfilePlot`)
+
+A thin command-line wrapper, for scripting and inspection:
+
+```
+iccProfilePlot <profile.icc> list
+iccProfilePlot <profile.icc> graph  <id>
+iccProfilePlot <profile.icc> raster <id> [out.raw]
+```
+
+- **`list`** → JSON array of descriptors:
+  ```json
+  [ {"kind":2,"output":"graph","id":"chroma:xy","title":"Chromaticity xy"},
+    {"kind":1,"output":"graph","id":"curve:rTRC","title":"rTRC"},
+    {"kind":5,"output":"raster","id":"clut:A2B0","title":"A2B0 CLUT"} ]
+  ```
+- **`graph <id>`** → one graph as JSON:
+  ```json
+  {"title":"…","description":"…",
+   "xAxis":{"label":"Input","min":0,"max":1,"equalAspect":false},
+   "yAxis":{…},
+   "series":[{"id":"curve","name":"…","role":"primary","shape":"polyline",
+              "colorHint":"neutral","auxKind":"",
+              "points":[x,y,x,y,…],
+              "labels":[{"i":12,"t":"520","a":520}]}]}
+  ```
+  Geometry is a flat `points:[x,y,…]` array; labels are listed **sparsely**
+  (`{i: vertexIndex, t: text, a: aux}`) so a 1000-point curve isn't bloated.
+- **`raster <id> [out.raw]`** → JSON geometry; with `out.raw`, writes the
+  row-major, channel-interleaved ICC-normalized samples.
+
+---
+
+## Important: raster sample encoding
+
+`Raster.samples` are **ICC-normalized** (`normalizedICC == true`): each channel
+is the profile's internal 0…1 value scaled to the integer range (8- or 16-bit,
+per `bitsPerChannel`). For a CIELAB CLUT this means:
+
+```
+L* = (sample / maxVal) * 100
+a* = (sample / maxVal) * 255 - 128
+b* = (sample / maxVal) * 255 - 128
+```
+
+These are **not** the TIFF-standard *signed* CIELAB encoding. `iccProfileVisualize`
+writes its TIFFs through `MiniTIFF::WriteTIFF`, whose `shiftTIFFLAB()` step
+rewrites a\*/b\* into the signed convention (subtract half-range, i.e. flip the
+top bit). `IccVizModel` does **not** do that — it hands back the raw
+ICC-normalized samples. A consumer that expects signed-CIELAB input must apply
+that shift itself; a consumer using the formulas above must not.
+
+---
+
+## Building
+
+Built as part of the iccDEV CMake tree (registered in `Build/Cmake/CMakeLists.txt`
+as `Tools/IccProfilePlot`). To reuse just the library in another project,
+compile `IccVizModel.cpp` and add both this directory and
+`Tools/CmdLine/IccProfileVisualize` (for `spectralLocus.hpp`) to the include
+path; link against IccProfLib.

--- a/Tools/CmdLine/IccProfilePlot/iccProfilePlot.cpp
+++ b/Tools/CmdLine/IccProfilePlot/iccProfilePlot.cpp
@@ -1,0 +1,249 @@
+/*
+  File:     iccProfilePlot.cpp
+
+  Contains: Console app that exposes IccVizModel — the data-first profile
+            visualization API. Where iccProfileVisualize renders a single
+            PDF + per-tag TIFFs, this lists the visualizations a profile
+            supports and emits each one as DATA (graphs as 2-D point series +
+            axis hints; the nD CLUT lattice as ICC-normalized raster samples),
+            so a caller can draw/colour-manage them however it likes.
+
+  Version:  V1
+
+  Copyright:  (c) see below
+*/
+
+/*
+ * The ICC Software License, Version 0.2
+ *
+ *
+ * Copyright (c) 2003-2026 The International Color Consortium. All rights
+ * reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in
+ *  the documentation and/or other materials provided with the
+ *  distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and "The
+ *  International Color Consortium" must not be used to imply that the
+ *  ICC organization endorses or promotes products derived from this
+ *  software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR
+ * ITS CONTRIBUTING MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the The International Color Consortium.
+ *
+ *
+ * Membership in the ICC is encouraged when this software is used for
+ * commercial purposes.
+ *
+ *
+ * For more information on The International Color Consortium, please
+ * see <http://www.color.org/>.
+ *
+ *
+ */
+
+#include "IccVizModel.hpp"
+#include "IccProfile.h"
+#include "IccProfLibVer.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+// ── tiny hand-rolled JSON emitter (no third-party deps, like IccPawgReport) ──
+
+static void jsonEscape(const std::string& s, std::string& out) {
+  for (char ch : s) {
+    unsigned char c = static_cast<unsigned char>(ch);
+    switch (c) {
+      case '"':  out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\b': out += "\\b";  break;
+      case '\f': out += "\\f";  break;
+      case '\n': out += "\\n";  break;
+      case '\r': out += "\\r";  break;
+      case '\t': out += "\\t";  break;
+      default:
+        if (c < 0x20) { char buf[8]; std::snprintf(buf, sizeof buf, "\\u%04x", c); out += buf; }
+        else out += ch;
+    }
+  }
+}
+
+static std::string jstr(const std::string& s) {
+  std::string out = "\"";
+  jsonEscape(s, out);
+  out += "\"";
+  return out;
+}
+
+static std::string jnum(double v) {
+  if (std::isnan(v) || std::isinf(v)) return "null";
+  char buf[32];
+  std::snprintf(buf, sizeof buf, "%g", v);
+  return std::string(buf);
+}
+
+static const char* outputStr(iccviz::Output o) {
+  return o == iccviz::Output::Raster ? "raster" : "graph";
+}
+static const char* roleStr(iccviz::Role r) {
+  return r == iccviz::Role::Hint ? "hint" : "primary";
+}
+static const char* shapeStr(iccviz::Shape s) {
+  switch (s) {
+    case iccviz::Shape::ClosedPath: return "closedPath";
+    case iccviz::Shape::Scatter:    return "scatter";
+    default:                        return "polyline";
+  }
+}
+
+// ── emitters ─────────────────────────────────────────────────────────────────
+
+static void printList(const std::vector<iccviz::Descriptor>& descs) {
+  std::printf("[");
+  for (size_t i = 0; i < descs.size(); ++i) {
+    const auto& d = descs[i];
+    std::printf("%s{\"kind\":%u,\"output\":\"%s\",\"id\":%s,\"title\":%s}",
+                i ? "," : "",
+                static_cast<unsigned>(d.kind), outputStr(d.output),
+                jstr(d.id).c_str(), jstr(d.title).c_str());
+  }
+  std::printf("]\n");
+}
+
+static void printGraph(const iccviz::Graph& g) {
+  std::string s = "{";
+  s += "\"title\":" + jstr(g.title);
+  s += ",\"description\":" + jstr(g.description);
+  auto axis = [](const iccviz::Axis& a) {
+    return std::string("{\"label\":") + jstr(a.label) +
+           ",\"min\":" + jnum(a.minHint) + ",\"max\":" + jnum(a.maxHint) +
+           ",\"equalAspect\":" + (a.equalAspect ? "true" : "false") + "}";
+  };
+  s += ",\"xAxis\":" + axis(g.xAxis);
+  s += ",\"yAxis\":" + axis(g.yAxis);
+  s += ",\"series\":[";
+  for (size_t si = 0; si < g.series.size(); ++si) {
+    const auto& ser = g.series[si];
+    if (si) s += ",";
+    s += "{\"id\":" + jstr(ser.id) + ",\"name\":" + jstr(ser.name);
+    s += ",\"role\":\"" + std::string(roleStr(ser.role)) + "\"";
+    s += ",\"shape\":\"" + std::string(shapeStr(ser.shape)) + "\"";
+    s += ",\"colorHint\":" + jstr(ser.colorHint);
+    s += ",\"auxKind\":" + jstr(ser.auxKind);
+    s += ",\"points\":[";
+    for (size_t i = 0; i < ser.verts.size(); ++i) {
+      if (i) s += ",";
+      s += jnum(ser.verts[i].x) + "," + jnum(ser.verts[i].y);
+    }
+    s += "],\"labels\":[";
+    bool firstLabel = true;
+    for (size_t i = 0; i < ser.verts.size(); ++i) {
+      const auto& v = ser.verts[i];
+      if (v.label.empty() && std::isnan(v.aux)) continue;
+      if (!firstLabel) s += ",";
+      firstLabel = false;
+      s += "{\"i\":" + std::to_string(i);
+      if (!v.label.empty()) s += ",\"t\":" + jstr(v.label);
+      if (!std::isnan(v.aux)) s += ",\"a\":" + jnum(v.aux);
+      s += "}";
+    }
+    s += "]}";
+  }
+  s += "]}";
+  std::printf("%s\n", s.c_str());
+}
+
+static void printRaster(const iccviz::Raster& r, const char* outFile) {
+  std::printf("{\"width\":%d,\"height\":%d,\"channels\":%d,\"bitsPerChannel\":%d,"
+              "\"photometric\":%d,\"normalizedICC\":%s",
+              r.width, r.height, r.channels, r.bitsPerChannel, r.photometric,
+              r.normalizedICC ? "true" : "false");
+  if (outFile) {
+    FILE* f = std::fopen(outFile, "wb");
+    if (f) {
+      std::fwrite(r.samples.data(), 1, r.samples.size(), f);
+      std::fclose(f);
+      std::printf(",\"samplesFile\":%s,\"sampleBytes\":%zu",
+                  jstr(outFile).c_str(), r.samples.size());
+    } else {
+      std::printf(",\"error\":\"could not open output file\"");
+    }
+  } else {
+    std::printf(",\"sampleBytes\":%zu", r.samples.size());
+  }
+  std::printf("}\n");
+}
+
+static void usage() {
+  std::printf(
+    "Usage:\n"
+    "  iccProfilePlot <profile.icc> list\n"
+    "  iccProfilePlot <profile.icc> graph  <id>\n"
+    "  iccProfilePlot <profile.icc> raster <id> [out.raw]\n"
+    "\n"
+    "  list   - JSON array of available visualizations {kind,output,id,title}\n"
+    "  graph  - JSON for one graph (2-D point series + axis hints)\n"
+    "  raster - JSON geometry for one CLUT image; with out.raw, writes the\n"
+    "           row-major, channel-interleaved ICC-normalized samples.\n"
+    "iccProfilePlot built with IccProfLib version " ICCPROFLIBVER "\n");
+}
+
+int main(int argc, char* argv[]) {
+  if (argc < 3) { usage(); return argc < 2 ? 0 : 1; }
+
+  const char* path = argv[1];
+  const std::string cmd = argv[2];
+
+  CIccProfile* pIcc = OpenIccProfile(path);
+  if (!pIcc) {
+    std::fprintf(stderr, "Unable to parse '%s' as an ICC profile.\n", path);
+    return 2;
+  }
+
+  int rc = 0;
+  if (cmd == "list") {
+    printList(iccviz::Enumerate(pIcc));
+  } else if (cmd == "graph" && argc >= 4) {
+    auto res = iccviz::RenderGraph(pIcc, argv[3]);
+    if (!res.ok) { std::fprintf(stderr, "%s\n", res.error.c_str()); rc = 3; }
+    else printGraph(res.graph);
+  } else if (cmd == "raster" && argc >= 4) {
+    auto res = iccviz::RenderRaster(pIcc, argv[3]);
+    if (!res.ok) { std::fprintf(stderr, "%s\n", res.error.c_str()); rc = 3; }
+    else printRaster(res.raster, argc >= 5 ? argv[4] : nullptr);
+  } else {
+    usage();
+    rc = 1;
+  }
+
+  delete pIcc;
+  return rc;
+}


### PR DESCRIPTION
## What
Adds `IccProfilePlot` — a data-first companion to `IccProfileVisualize`.

`IccVizModel` exposes an ICC profile's plottable content as **data** rather than
a fixed picture: 2-D point series + axis hints for graphs (tone curves,
chromaticity, named-colour scatters), and ICC-normalized samples for the nD
CLUT lattice. It enumerates the visualizations a profile supports and renders
each individually, so a caller can draw/colour-manage them in its own style.

## Why
`IccProfileVisualize` emits one combined PDF + per-tag TIFFs — great for a quick
look, but a consumer that wants to style/lay out individual plots (a GUI, a web
front-end) has to scrape a finished document. This returns the underlying data.

## Contents
- `Tools/CmdLine/IccProfilePlot/IccVizModel.{hpp,cpp}` — the API. Depends only on
  IccProfLib + `spectralLocus.hpp` (no PDF/TIFF/SVG writers, no third-party
  libraries), so it's reusable as a small library component.
- `Tools/CmdLine/IccProfilePlot/iccProfilePlot.cpp` — CLI (`list` / `graph <id>` /
  `raster <id> [out.raw]`), hand-rolled JSON output (no deps, like IccPawgReport).
- `Tools/CmdLine/IccProfilePlot/Readme.md` — API + CLI guide.
- `Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt` + `ADD_SUBDIRECTORY` registration.

## Non-breaking
`iccProfileVisualize.cpp` is **untouched**. `IccVizModel` is an independent
re-implementation of the same plots; it was verified to reproduce
`iccProfileVisualize`'s output (graph data and CLUT samples) across matrix/TRC,
LUT (A2B/B2A), and CMYK/named-colour profiles.

---

## Roadmap — this is phase one of a larger refactor

This PR is intentionally **non-destructive**: it stands `IccVizModel` up
*alongside* the existing tool so it can be reviewed and verified on its own. But
the goal is **not** to keep two copies of the math — it's to make
`iccProfileVisualize` render *from* this model, so the visualization logic has a
single home. Per @ChrisCoxArt's review note:

> Can we find some way to share the code in profileVisualize, and just output to
> different targets (PDF, JSON, images, etc.)? That way the code will remain in
> sync, and it'll be a LOT easier to track bugs and new features.

That is exactly the plan. The work is staged so each step is small and
**byte-identical-verifiable** against the current tool:

| Phase | What | Where |
|-------|------|-------|
| **1 — this PR** | Stand up `IccVizModel` as a data-first API + `iccProfilePlot` CLI, non-destructively, verified to reproduce the existing output. | #1253 |
| **A** | Extract `IccVizModel` into a shared **static library** that both `iccProfilePlot` (JSON) and `iccProfileVisualize` (PDF/TIFF) link — one home for the math. | #1259 |
| **B** | Re-seat `iccProfileVisualize` onto the model: CLUT lattice via `RenderRaster()`, named/colorant colours via `RenderGraph()`. Bespoke PDF/TIFF drawing untouched; only the data source changes. | #1259 |
| **C** | Delete the now-duplicated math from `iccProfileVisualize.cpp` (CLUT flatten, named-colour extraction, dead clamp helpers). | #1259 |
| **B2** | Re-seat the remaining chromaticity/curve helpers (small; bulk spectral-locus data already shared via header in Phase A). | follow-up |
| **D** | Comprehensive report wrap-up — a summary/index page driven off `Enumerate()`. | follow-up |

**Phases A–C are already implemented and verified byte-identical** (PDF + TIFF,
bit-for-bit) on a matrix/TRC + A2B/B2A LUT + named-colour corpus — see the
stacked PR **#1259**, which builds directly on this branch. Merging #1253 first
lets #1259 rebase cleanly onto `master`.

So: #1253 is the foundation; the end state is a single visualization code path
that emits to PDF, TIFF, **and** JSON from the same model.
