### PR TITLE
Fix three tag-allocation leaks on parse-failure paths (#1254, #1255, #1257)

### DIFF
--- a/.github/ci/regression/parser-restore-calls.cpp
+++ b/.github/ci/regression/parser-restore-calls.cpp
@@ -38,7 +38,7 @@ public:
   {
     ++read_count;
     if (nNum >= sizeof(icUInt32Number)) {
-      *((icUInt32Number *)pBuf) = read_count == 1 ? icSigEmbeddedProfileType : 0;
+      *((icUInt32Number *)pBuf) = read_count == 1 ? (icUInt32Number)icSigEmbeddedProfileType : 0u;
       return sizeof(icUInt32Number);
     }
     return 0;

--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1348,6 +1348,7 @@ bool CIccTagArray::Read(icUInt32Number size, CIccIO *pIO)
         CIccTag *pTag = CIccTagCreator::CreateTag(tagSig);
         if (pTag) {
           if (!pTag->Read(tagPos[i].size, pIO)) {
+            delete pTag;
             delete [] tagPos;
             return false;
           }

--- a/IccProfLib/IccTagDict.cpp
+++ b/IccProfLib/IccTagDict.cpp
@@ -790,6 +790,7 @@ bool CIccTagDict::Read(icUInt32Number size, CIccIO *pIO)
         free(pos);
         free(buf);
         delete ptr.ptr;
+        delete pTag;
         return false;
       }
 
@@ -841,6 +842,7 @@ bool CIccTagDict::Read(icUInt32Number size, CIccIO *pIO)
         free(pos);
         free(buf);
         delete ptr.ptr;
+        delete pTag;
         return false;
       }
 

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -752,13 +752,21 @@ bool CIccProfileXml::ParseTag(xmlNode *pNode, std::string &parseStr)
           sscanf(icXmlAttrValue(attr), "%u", &pTag->m_nReserved);
         }
 
+        bool bAttached = false;
         for (xmlNode *tagSigNode = pNode->children; tagSigNode; tagSigNode = tagSigNode->next) {
           if (tagSigNode->type == XML_ELEMENT_NODE && !icXmlStrCmp(tagSigNode->name, "TagSignature")) {
             if ((const icChar*)tagSigNode->children != NULL) {
               sigTag = (icTagSignature)icGetSigVal((const icChar*)tagSigNode->children->content);
               AttachTag(sigTag, pTag);
+              bAttached = true;
             }
           }
+        }
+
+        //No TagSignature node claimed ownership of pTag; free it to avoid a leak
+        if (!bAttached) {
+          delete pTag;
+          return false;
         }
       }
       else {


### PR DESCRIPTION
## Summary

Fixes three LeakSanitizer-reported direct leaks, all the same bug class: a tag object is allocated, then the error path bails out without freeing it.

| Issue | Site | Leak condition |
|---|---|---|
| #1254 | `CIccTagDict::Read` (`IccTagDict.cpp`) | NameLocalized + ValueLocalized blocks `new` a `CIccTagMultiLocalizedUnicode`; when its `Read()` fails the code frees `pos`/`buf`/dict-entry but leaks the tag (2 sites) |
| #1257 | `CIccTagArray::Read` (`IccTagComposite.cpp`) | an array-element tag from `CIccTagCreator::CreateTag` leaks when its `Read()` fails |
| #1255 | `CIccProfileXml::ParseTag` (`IccProfileXml.cpp`) | legacy by-type path: tag is created, `ParseXml` succeeds, but if no valid `TagSignature` child claims it via `AttachTag` the tag is never owned and leaks |

For #1254/#1257 the fix is a `delete pTag;` on the failure branch. For #1255 the fix tracks whether `AttachTag` ever claimed the tag and deletes the orphan otherwise.

## Verification

Built with `-fsanitize=address,undefined` and run against the three fuzz reproducers from `xsscx/fuzz`:

- `iccPawgReport leak-CIccTagDict-Read-…icc` → **0 leaks** (was 32 bytes)
- `iccFromXml leak-CIccTagXmlFactory-CreateTag-…xml` → **0 leaks** (was 48 bytes)
- `iccToJson leak-CIccTagJsonFactory-CreateTag-…icc` → **0 leaks** (was 72 bytes)

All three: zero AddressSanitizer / LeakSanitizer / UBSan findings.

**No regression:** real profiles round-trip cleanly (`iccToXml`→`iccFromXml`, `iccToJson`) with no sanitizer findings. The pre-existing `calcUnderStack_*` MPE XML round-trip failures are byte-for-byte identical with and without this change (verified by reverting the `IccProfileXml.cpp` hunk and re-running).

Closes #1254
Closes #1255
Closes #1257

🤖 Generated with [Claude Code](https://claude.com/claude-code)