### PR TITLE
Visualize - add V5 named colors, cleanup error reporting

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -6826,7 +6826,7 @@ template <class T, icTagTypeSignature Tsig>
 const icChar *CIccTagFloatNum<T, Tsig>::GetClassName() const
 {
   if (Tsig==icSigFloat16ArrayType)
-    return "CIccFlaot16";
+    return "CIccFloat16";
   if (Tsig==icSigFloat32ArrayType)
     return "CIccFloat32";
   else if (Tsig==icSigFloat64ArrayType)

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -4020,7 +4020,11 @@ icValidateStatus CIccMBB::Validate(std::string sigPath, std::string &sReport, co
       if (m_nInput!=nInput) {
         sReport += icMsgValidateCriticalError;
         sReport += sSigPathName;
-        sReport += " - Incorrect number of input channels.\n";
+        sReport += " - Incorrect number of input channels (";
+        sReport += std::to_string(nInput);
+        sReport += ", expected ";
+        sReport += std::to_string(m_nInput);
+        sReport += " from tag).\n";
         rv = icMaxStatus(rv, icValidateCriticalError);
       }
 
@@ -4028,7 +4032,11 @@ icValidateStatus CIccMBB::Validate(std::string sigPath, std::string &sReport, co
       if (m_nOutput!=nOutput) {
         sReport += icMsgValidateCriticalError;
         sReport += sSigPathName;
-        sReport += " - Incorrect number of output channels.\n";
+        sReport += " - Incorrect number of output channels (";
+        sReport += std::to_string(nOutput);
+        sReport += ", expected ";
+        sReport += std::to_string(m_nOutput);
+        sReport += " from tag).\n";
         rv = icMaxStatus(rv, icValidateCriticalError);
       }
 
@@ -4043,7 +4051,11 @@ icValidateStatus CIccMBB::Validate(std::string sigPath, std::string &sReport, co
       if (m_nInput!=nInput) {
         sReport += icMsgValidateCriticalError;
         sReport += sSigPathName;
-        sReport += " - Incorrect number of input channels.\n";
+        sReport += " - Incorrect number of input channels (";
+        sReport += std::to_string(nInput);
+        sReport += ", expected ";
+        sReport += std::to_string(m_nInput);
+        sReport += " from tag).\n";
         rv = icMaxStatus(rv, icValidateCriticalError);
       }
 
@@ -4051,7 +4063,11 @@ icValidateStatus CIccMBB::Validate(std::string sigPath, std::string &sReport, co
       if (m_nOutput!=nOutput) {
         sReport += icMsgValidateCriticalError;
         sReport += sSigPathName;
-        sReport += " - Incorrect number of output channels.\n";
+        sReport += " - Incorrect number of output channels (";
+        sReport += std::to_string(nOutput);
+        sReport += ", expected ";
+        sReport += std::to_string(m_nOutput);
+        sReport += " from tag).\n";
         rv = icMaxStatus(rv, icValidateCriticalError);
       }
 
@@ -4066,7 +4082,11 @@ icValidateStatus CIccMBB::Validate(std::string sigPath, std::string &sReport, co
     if (m_nInput != nInput) {
       sReport += icMsgValidateCriticalError;
       sReport += sSigPathName;
-      sReport += " - Incorrect number of input channels.\n";
+      sReport += " - Incorrect number of input channels (";
+      sReport += std::to_string(nInput);
+      sReport += ", expected ";
+      sReport += std::to_string(m_nInput);
+      sReport += " from tag).\n";
       rv = icMaxStatus(rv, icValidateCriticalError);
     }
 
@@ -4074,7 +4094,11 @@ icValidateStatus CIccMBB::Validate(std::string sigPath, std::string &sReport, co
     if (m_nOutput != nOutput) {
       sReport += icMsgValidateCriticalError;
       sReport += sSigPathName;
-      sReport += " - Incorrect number of output channels.\n";
+      sReport += " - Incorrect number of output channels (";
+      sReport += std::to_string(nOutput);
+      sReport += ", expected ";
+      sReport += std::to_string(m_nOutput);
+      sReport += " from tag).\n";
       rv = icMaxStatus(rv, icValidateCriticalError);
     }
 
@@ -4086,7 +4110,11 @@ icValidateStatus CIccMBB::Validate(std::string sigPath, std::string &sReport, co
       if (m_nInput!=nInput) {
         sReport += icMsgValidateCriticalError;
         sReport += sSigPathName;
-        sReport += " - Incorrect number of input channels.\n";
+        sReport += " - Incorrect number of input channels (";
+        sReport += std::to_string(nInput);
+        sReport += ", expected ";
+        sReport += std::to_string(m_nInput);
+        sReport += " from tag).\n";
         rv = icMaxStatus(rv, icValidateCriticalError);
       }
 
@@ -4094,7 +4122,11 @@ icValidateStatus CIccMBB::Validate(std::string sigPath, std::string &sReport, co
       if (m_nOutput!=nOutput) {
         sReport += icMsgValidateCriticalError;
         sReport += sSigPathName;
-        sReport += " - Incorrect number of output channels.\n";
+        sReport += " - Incorrect number of output channels (";
+        sReport += std::to_string(nOutput);
+        sReport += ", expected ";
+        sReport += std::to_string(m_nOutput);
+        sReport += " from tag).\n";
         rv = icMaxStatus(rv, icValidateCriticalError);
       }
 
@@ -5802,7 +5834,9 @@ icValidateStatus CIccTagLut16::Validate(std::string sigPath, std::string &sRepor
               if (nCurveEntries < 2 || nCurveEntries > 4096) {
                 sReport += icMsgValidateCriticalError;
                 sReport += sSigPathName;
-                sReport += " - lut16Type input tables require 2 to 4096 entries.\n";
+                sReport += " - lut16Type input tables require 2 to 4096 entries, not ";
+                sReport += std::to_string(nCurveEntries);
+                sReport += "\n";
                 rv = icMaxStatus(rv, icValidateCriticalError);
               }
             }
@@ -5844,7 +5878,9 @@ icValidateStatus CIccTagLut16::Validate(std::string sigPath, std::string &sRepor
               if (nCurveEntries < 2 || nCurveEntries > 4096) {
                 sReport += icMsgValidateCriticalError;
                 sReport += sSigPathName;
-                sReport += " - lut16Type output tables require 2 to 4096 entries.\n";
+                sReport += " - lut16Type output tables require 2 to 4096 entries, not ";
+                sReport += std::to_string(nCurveEntries);
+                sReport += "\n";
                 rv = icMaxStatus(rv, icValidateCriticalError);
               }
             }

--- a/Tools/CmdLine/IccCmdLineUtil.h
+++ b/Tools/CmdLine/IccCmdLineUtil.h
@@ -73,6 +73,8 @@
 #include <unistd.h>
 #endif
 
+/******************************************************************************/
+
 inline std::string icSanitizeConsoleText(const char* szText)
 {
   static const char hex[] = "0123456789ABCDEF";
@@ -115,6 +117,51 @@ inline std::string icSanitizeConsoleText(const std::string& text)
   return icSanitizeConsoleText(text.c_str());
 }
 
+/******************************************************************************/
+
+// NOTE - we cannot filter out path characters /\ without breaking output
+// But we can remove non-ASCII and high ASCII that cause problems
+inline std::string icSanitizeFileName(const char* szText)
+{
+  std::string result;
+
+  if (!szText)
+    return result;
+
+  for (const unsigned char *p = (const unsigned char*)szText; *p; p++) {
+    unsigned char ch = *p;
+
+    switch (ch) {
+    case '\n':
+      result += "N";
+      break;
+    case '\r':
+      result += "R";
+      break;
+    case '\t':
+      result += "T";
+      break;
+    default:
+      if (ch < 0x20 || (ch >= 0x7f && ch <= 0xff)) {
+        result += "_";
+      }
+      else {
+        result += (char)ch;
+      }
+      break;
+    }
+  }
+
+  return result;
+}
+
+inline std::string icSanitizeFileName(const std::string& text)
+{
+  return icSanitizeFileName(text.c_str());
+}
+
+/******************************************************************************/
+
 inline FILE* icOpenRegularWriteFile(const char* szFname, const char* szMode)
 {
   if (!szFname || !szFname[0])
@@ -154,6 +201,8 @@ inline FILE* icOpenRegularWriteTextFile(const char* szFname)
   return icOpenRegularWriteFile(szFname, "wt");
 }
 
+/******************************************************************************/
+
 inline bool icFlushAndClose(FILE* f)
 {
   if (!f)
@@ -169,5 +218,7 @@ inline bool icFlushAndClose(FILE* f)
 
   return !failed;
 }
+
+/******************************************************************************/
 
 #endif

--- a/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
@@ -162,8 +162,8 @@ void PDFWriter::OpenFile( const std::string &filename, float widthPt, float heig
 
 /******************************************************************************/
 
-void PDFWriter::CloseFile() {
-
+void PDFWriter::CloseFile()
+{
   if (!m_filename.empty()) {
     if (PageCount() > 0) {
         try  {

--- a/Tools/CmdLine/IccProfileVisualize/MiniSVG.hpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniSVG.hpp
@@ -77,6 +77,14 @@ const float inch2point = 72.0f;              // 72 points per inch, DTP and W3C 
 struct point2D {
   point2D(float xx, float yy) : x(xx), y(yy) {}
   point2D() : x(0.0), y(0.0) {}
+  
+  bool operator<(const point2D& o) const {
+  if (x == o.x)
+    return y < o.y;
+  else
+    return x < o.x;
+  }
+
   float x, y;
 };
 

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1230,6 +1230,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
 
 /******************************************************************************/
 
+#if 0
 // output graphic representation of response curve 1D LUTs
 //     or would, if I could find any example of profiles using response curves...
 // return number of output items created
@@ -1270,6 +1271,7 @@ int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::stri
   return 0; // no output created
 
 }   // end outputResponseCurves()
+#endif
 
 /******************************************************************************/
 
@@ -2272,15 +2274,19 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
         outputItems += output1DLUT(pIcc, pTag, sigDesc, pdffile, basename );
         }
         break;
-    
+
+#if 0
+// I can't find any examples that use the response tag
+// which makes it difficult to test
       case icSigOutputResponseTag:
         {
-printf("**** Found response curves in %s\n", profilePath );     // DEBUG
+//printf("**** Found response curves in %s\n", profilePath );     // DEBUG
         const char *sigDesc = icGetSigStr(buf1, bufSize, sig);
         CIccTag *pTag = pIcc->FindTag(tag); // load if needed
         outputItems += outputResponseCurves(pIcc, pTag, sigDesc, pdffile, basename );
         }
         break;
+#endif
 
       // nD LUTs
       case icSigAToB0Tag:

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -75,6 +75,7 @@
 #include "IccTag.h"
 #include "IccUtil.h"
 #include "IccProfLibVer.h"
+//#include "IccCmdLineUtil.h"
 #include "MiniTIFF.hpp"
 #include "MiniSVG.hpp"
 #include "MiniPDF.hpp"
@@ -1031,13 +1032,14 @@ void graph1DLUTPDF( CIccCurve *curve, const std::string &name,
 /******************************************************************************/
 
 static
-bool describe1DLUT( CIccTagCurve *curve, std::string &description, const std::string &sigDesc )
+bool describe1DLUT( CIccTagCurve *curve, std::string &description,
+                    const std::string &sigDesc, const std::string &filename )
 {
   std::string path(":");
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"WARNING - curve failed validation: %s\n", report.c_str() );
+    fprintf(stderr,"%s: WARNING - curve failed validation: %s\n", filename.c_str(), report.c_str() );
     description = "simpleCurve";
     return true;
   }
@@ -1059,13 +1061,14 @@ bool describe1DLUT( CIccTagCurve *curve, std::string &description, const std::st
 /******************************************************************************/
 
 static
-bool describe1DLUT( CIccTagParametricCurve *curve, std::string &description, const std::string &sigDesc )
+bool describe1DLUT( CIccTagParametricCurve *curve, std::string &description,
+                    const std::string &sigDesc, const std::string &filename )
 {
   std::string path(":");
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"WARNING - curve failed validation: %s\n", report.c_str() );
+    fprintf(stderr,"%s: WARNING - curve failed validation: %s\n", filename.c_str(), report.c_str() );
     description = "parametric";
     return true;
   }
@@ -1076,13 +1079,14 @@ bool describe1DLUT( CIccTagParametricCurve *curve, std::string &description, con
 /******************************************************************************/
 
 static
-bool describe1DLUT( CIccTagSegmentedCurve *curve, std::string &description, const std::string &sigDesc )
+bool describe1DLUT( CIccTagSegmentedCurve *curve, std::string &description,
+                    const std::string &sigDesc, const std::string &filename )
 {
   std::string path(":");
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"WARNING - curve failed validation: %s\n", report.c_str() );
+    fprintf(stderr,"%s: WARNING - curve failed validation: %s\n", filename.c_str(), report.c_str() );
     description = "segmented";
     return true;
   }
@@ -1093,13 +1097,14 @@ bool describe1DLUT( CIccTagSegmentedCurve *curve, std::string &description, cons
 /******************************************************************************/
 
 static
-bool describe1DLUT( CIccCurve *curve, std::string &description, const std::string &sigDesc )
+bool describe1DLUT( CIccCurve *curve, std::string &description,
+                    const std::string &sigDesc, const std::string &filename )
 {
   std::string path(":");
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"WARNING - curve failed validation: %s\n", report.c_str() );
+    fprintf(stderr,"%s: WARNING - curve failed validation: %s\n", filename.c_str(), report.c_str() );
     description = "unknown";
     return true;
   }
@@ -1110,13 +1115,14 @@ bool describe1DLUT( CIccCurve *curve, std::string &description, const std::strin
 /******************************************************************************/
 
 static
-bool describe3DLUT( CIccMBB *curve, CIccProfile *pIcc, std::string &description, const std::string &sigDesc )
+bool describe3DLUT( CIccMBB *curve, CIccProfile *pIcc, std::string &description,
+                    const std::string &sigDesc, const std::string &filename )
 {
   std::string path(":");
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, pIcc ) > icValidateWarning) {
-    fprintf(stderr,"WARNING - 3D table failed validation: %s\n", report.c_str() );
+    fprintf(stderr,"%s: WARNING - 3D table failed validation: %s\n", filename.c_str(), report.c_str() );
     description = "MBBLut";
     return true;
   }
@@ -1130,13 +1136,13 @@ bool describe3DLUT( CIccMBB *curve, CIccProfile *pIcc, std::string &description,
 // return 1 if output created, 0 if none
 static
 int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDesc,
-        PDFWriter &pdffile )
+        PDFWriter &pdffile, const std::string &filename )
 {
   const size_t bufSize = 64;
   char buf[bufSize];
 
   if (!tag) {
-    fprintf(stderr, "ERROR - missing data for %s\n", sigDesc.c_str());
+    fprintf(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str() );
     return 0;
   }
 
@@ -1148,7 +1154,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
       CIccTagCurve *curve = dynamic_cast<CIccTagCurve*> (tag);
       if (curve) {
         std::string description;
-        if (describe1DLUT(curve, description, sigDesc)) {
+        if (describe1DLUT(curve, description, sigDesc, filename)) {
           return 0;
         }
         int size = curve->GetSize();
@@ -1167,7 +1173,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
       CIccTagParametricCurve *pCurve = dynamic_cast<CIccTagParametricCurve*> (tag);
       if (pCurve) {
         std::string description;
-        if (describe1DLUT(pCurve, description, sigDesc)) {
+        if (describe1DLUT(pCurve, description, sigDesc, filename)) {
           return 0;
         }
 #if USE_SVG
@@ -1184,7 +1190,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
       CIccTagSegmentedCurve *sCurve = dynamic_cast<CIccTagSegmentedCurve*> (tag);
       if (sCurve) {
         std::string description;
-        if (describe1DLUT(sCurve, description, sigDesc)) {
+        if (describe1DLUT(sCurve, description, sigDesc, filename)) {
           return 0;
         }
 #if USE_SVG
@@ -1197,13 +1203,14 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
       break;
 
     default:
-      printf("Unknown 1D LUT type %s for tag %s\n",
+      fprintf(stderr,"%s: Unknown 1D LUT type %s for tag %s\n",
+         filename.c_str(),
          icGetSig(buf, bufSize, typeSig), sigDesc.c_str() );
       {
       CIccCurve *uCurve = dynamic_cast<CIccCurve*> (tag);
       if (uCurve) {
         std::string description;
-        if (describe1DLUT( uCurve, description, sigDesc )) {
+        if (describe1DLUT( uCurve, description, sigDesc, filename)) {
           return 0;
         }
 #if USE_SVG
@@ -1220,6 +1227,36 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
   return 0; // no output created
 
 }   // end output1DLUT()
+
+/******************************************************************************/
+
+// output graphic representation of 1D LUTs
+// return 1 if output created, 0 if none
+static
+int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDesc,
+                        PDFWriter &pdffile, const std::string &filename )
+{
+  const size_t bufSize = 64;
+  char buf[bufSize];
+
+  if (!tag) {
+    fprintf(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str());
+    return 0;
+  }
+
+  icTagTypeSignature typeSig = tag->GetType();
+  if (typeSig != icSigResponseCurveSet16Type)  {
+    fprintf(stderr,"%s: Unknown ResponseCurve type %s for tag %s\n",
+         filename.c_str(), icGetSig(buf, bufSize, typeSig), sigDesc.c_str() );
+    return 0;
+  }
+
+
+// TODO - read and write curves!
+
+  return 0; // no output created
+
+}   // end outputResponseCurves()
 
 /******************************************************************************/
 
@@ -1323,7 +1360,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
   int outputCount = 0;
 
   if (!tag) {
-    fprintf(stderr, "Skipping %s: unable to load tag\n", sigDesc.c_str());
+    fprintf(stderr, "%s: Skipping %s: unable to load tag\n", basename.c_str(), sigDesc.c_str());
     return 0;
   }
 
@@ -1338,12 +1375,12 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     {
     CIccMBB *lut = dynamic_cast<CIccMBB*> (tag);
     if (!lut) {
-      fprintf(stderr, "Skipping %s: unable to convert LUT\n", sigDesc.c_str());
+      fprintf(stderr, "%s: Skipping %s: unable to convert LUT\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
     std::string description;
-    if (describe3DLUT( lut, pIcc, description, sigDesc)) {
+    if (describe3DLUT( lut, pIcc, description, sigDesc, basename)) {
       return outputCount;
     }
 
@@ -1360,7 +1397,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     bool isInputMatrix = lut->IsInputMatrix();
 
     if (inputChannels <= 0 || outputChannels <= 0) {
-      fprintf(stderr, "Skipping %s: invalid channel count\n", sigDesc.c_str());
+      fprintf(stderr, "%s: Skipping %s: invalid channel count\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1371,7 +1408,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
           std::string channel = channelName( i, !isInputMatrix,
                     inputSpace, outputSpace, inputChannels, outputChannels );
           std::string channelDesc = curveDesc + "curveA[ " + channel + " ]";
-          outputCount += output1DLUT( pIcc, curveA[i], channelDesc, pdffile );
+          outputCount += output1DLUT( pIcc, curveA[i], channelDesc, pdffile, basename );
         }
       }
     }
@@ -1383,7 +1420,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
           std::string channel = channelName( i, isInputMatrix,
                     inputSpace, outputSpace, inputChannels, outputChannels );
           std::string channelDesc = curveDesc + "curveB[ " + channel + " ]";
-          outputCount += output1DLUT( pIcc, curveB[i], channelDesc, pdffile );
+          outputCount += output1DLUT( pIcc, curveB[i], channelDesc, pdffile, basename );
         }
       }
     }
@@ -1395,7 +1432,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
           std::string channel = channelName( i, isInputMatrix,
                     inputSpace, outputSpace, inputChannels, outputChannels );
           std::string channelDesc = curveDesc + "curveM[ " + channel + " ]";
-          outputCount += output1DLUT( pIcc, curveM[i], channelDesc, pdffile );
+          outputCount += output1DLUT( pIcc, curveM[i], channelDesc, pdffile, basename );
         }
       }
     }
@@ -1408,8 +1445,8 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       // clut is optional in mAB and mBA tags - only report if it isn't one of those
       if ( !(typeSig == icSigLutAtoBType || typeSig == icSigLutBtoAType) ) {
         std::string typeDesc = icGetSigStr(buf, bufSize, typeSig);
-        fprintf(stderr,"ERROR - clut data could not be read for tag '%s' of type '%s' in file '%s'\n",
-                sigDesc.c_str(), typeDesc.c_str(), basename.c_str() );
+        fprintf(stderr,"%s: ERROR - clut data could not be read for tag '%s' of type '%s'\n",
+                basename.c_str(), sigDesc.c_str(), typeDesc.c_str() );
       }
       return outputCount;
     }
@@ -1420,7 +1457,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     int gridPoints = clut->GridPoints(); // gridSize[0]
     int tiles = gridPoints;
     if (gridPoints <= 0) {
-      fprintf(stderr, "Skipping %s: invalid CLUT grid\n", sigDesc.c_str());
+      fprintf(stderr, "%s: Skipping %s: invalid CLUT grid\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1430,7 +1467,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     if (inputChannels >= 2) {
       tileWidth = clut->GridPoint(1);
       if (tileWidth <= 0) {
-        fprintf(stderr, "Skipping %s: invalid CLUT width\n", sigDesc.c_str());
+        fprintf(stderr, "%s: Skipping %s: invalid CLUT width\n", basename.c_str(), sigDesc.c_str());
         return outputCount;
       }
     }
@@ -1438,7 +1475,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     if (inputChannels >= 3) {
       tileHeight = clut->GridPoint(2);
       if (tileHeight <= 0) {
-        fprintf(stderr, "Skipping %s: invalid CLUT height\n", sigDesc.c_str());
+        fprintf(stderr, "%s: Skipping %s: invalid CLUT height\n", basename.c_str(), sigDesc.c_str());
         return outputCount;
       }
     }
@@ -1447,7 +1484,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       for (int i = 3; i < inputChannels; ++i) {
         int extraGridPoints = clut->GridPoint(i);
         if (extraGridPoints <= 0) {
-          fprintf(stderr, "Skipping %s: invalid CLUT tile count\n", sigDesc.c_str());
+          fprintf(stderr, "%s: Skipping %s: invalid CLUT tile count\n", basename.c_str(), sigDesc.c_str());
           return outputCount;
         }
         tiles *= extraGridPoints;
@@ -1469,13 +1506,13 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
 
       // find tile arrangement closest to a square
     if (tiles <= 0) {
-      fprintf(stderr,"WARNING - tile count overflow.\n");
+      fprintf(stderr,"%s: WARNING - tile count overflow.\n", basename.c_str() );
       tiles = 1;
     }
 
     auto tempResult = std::sqrt(tiles);
     if (tempResult > std::numeric_limits<int>::max()) {
-      fprintf(stderr,"ERROR - sqrt bad result!\n");
+      fprintf(stderr,"%s: ERROR - sqrt bad result!\n", basename.c_str() );
       tempResult = tiles/2;
     }
     int tilesWide = (int)tempResult;
@@ -1497,7 +1534,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     int imageWidth = tilesWide * tileWidth;
     int imageHeight = tilesHigh * tileHeight;
     if (imageWidth <= 0 || imageHeight <= 0 || bytes <= 0) {
-      fprintf(stderr, "Skipping %s: invalid image geometry\n", sigDesc.c_str());
+      fprintf(stderr, "%s: Skipping %s: invalid image geometry\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1505,7 +1542,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     size_t bufferSize = (size_t)imageWidth * (size_t)imageHeight * (size_t)outputChannels * bytes;
     // NOTE that bufferSize will usually be greater than clutSize
     if (!bufferSize) {
-      fprintf(stderr, "Skipping %s: empty image buffer\n", sigDesc.c_str());
+      fprintf(stderr, "%s: Skipping %s: empty image buffer\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1578,7 +1615,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       int tiffColor = TIFFColorModelFromICCModel( outputSpace );
       if (!WriteTIFF( tiffPath2.c_str(), 100, tiffColor, imageBuf,
                         imageWidth, imageHeight, outputChannels, 8*bytes )) {
-        fprintf(stderr, "Failed to write TIFF: %s\n", tiffPath2.c_str());
+        fprintf(stderr, "%s: Failed to write TIFF: %s\n", basename.c_str(), tiffPath2.c_str());
       }
     }
     return ++outputCount;
@@ -1589,7 +1626,8 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     break;
 
   default:
-    printf("Unknown nD LUT type %s for tag %s\n",
+    fprintf(stderr,"%s: Unknown nD LUT type %s for tag %s\n",
+         basename.c_str(),
          icGetSig(buf, bufSize, typeSig),
          sigDesc.c_str() );
     break;
@@ -1758,7 +1796,7 @@ int graphNamedColorsPDF( namedLabList &colorsOut, const std::string &description
 // then plot that
 static
 int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
-        PDFWriter &pdffile )
+        PDFWriter &pdffile, const std::string &filename )
 {
   const size_t bufSize = 64;
   char buf[bufSize];
@@ -1767,7 +1805,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   int outputCount = 0;
 
   if (!tag) {
-    fprintf(stderr, "Skipping %s: unable to load tag\n", sigDesc.c_str());
+    fprintf(stderr, "%s: Skipping %s: unable to load tag\n", filename.c_str(), sigDesc.c_str());
     return 0;
   }
 
@@ -1779,8 +1817,8 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   icColorSpaceSignature pcs = pIcc->m_Header.pcs;   // table->GetPCS();
   if (pcs != icSigXYZData && pcs != icSigLabData) {
     if (pcs != icSigNoColorData)                                // TODO - remove this once we can handle spectral data
-      fprintf(stderr,"WARNING - unknown pcs for colors: %s\n",
-                        icGetSig(buf, bufSize, pcs) );
+      fprintf(stderr,"%s: WARNING - unknown pcs for colors: %s\n",
+                        filename.c_str(), icGetSig(buf, bufSize, pcs) );
     return 0;
   }
 
@@ -1791,7 +1829,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagColorantTable *table = dynamic_cast<CIccTagColorantTable*> (tag);
       if (!table) {
-        fprintf(stderr, "Skipping %s: unable to convert colorantTable\n", sigDesc.c_str());
+        fprintf(stderr, "%s: Skipping %s: unable to convert colorantTable\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
 
@@ -1799,14 +1837,14 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"WARNING - colorantTable failed validation: %s\n", report.c_str() );
+        fprintf(stderr,"%s: WARNING - colorantTable failed validation: %s\n", filename.c_str(), report.c_str() );
         return 0;
       }
       
       icColorSpaceSignature table_pcs = table->GetPCS();
       if (pcs != table_pcs) {
-        fprintf(stderr,"WARNING - bad pcs for colorant table: %s\n",
-                            icGetSig(buf, bufSize, pcs) );
+        fprintf(stderr,"%s: WARNING - bad pcs for colorant table: %s\n",
+                            filename.c_str(), icGetSig(buf, bufSize, pcs) );
         return 0;
       }
 
@@ -1851,7 +1889,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagNamedColor2 *table = dynamic_cast<CIccTagNamedColor2*> (tag);
       if (!table) {
-        fprintf(stderr, "Skipping %s: unable to convert namedColorTable\n", sigDesc.c_str());
+        fprintf(stderr, "%s: Skipping %s: unable to convert namedColorTable\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
 
@@ -1859,14 +1897,14 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"WARNING - namedColorTable failed validation: %s\n", report.c_str() );
+        fprintf(stderr,"%s: WARNING - namedColorTable failed validation: %s\n", filename.c_str(), report.c_str() );
         return 0;
       }
       
       icColorSpaceSignature table_pcs = table->GetPCS();
       if (pcs != table_pcs) {
-        fprintf(stderr,"WARNING - bad pcs for namedColorTable: %s\n",
-                            icGetSig(buf, bufSize, pcs) );
+        fprintf(stderr,"%s: WARNING - bad pcs for namedColorTable: %s\n",
+                            filename.c_str(), icGetSig(buf, bufSize, pcs) );
         return 0;
       }
 
@@ -1911,14 +1949,15 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagArray *array = dynamic_cast<CIccTagArray*> (tag);
       if (!array) {
-        fprintf(stderr, "Skipping %s: unable to convert named color array\n", sigDesc.c_str());
+        fprintf(stderr, "%s: Skipping %s: unable to convert named color array\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
       
       icArraySignature arrayType = array->GetTagArrayType();
       if (arrayType != icSigColorantInfoArray
         && arrayType != icSigNamedColorArray) {
-        fprintf(stderr,"WARNING - unknown color array type: %s for tag %s\n",
+        fprintf(stderr,"%s: WARNING - unknown color array type: %s for tag %s\n",
+                        filename.c_str(),
                         icGetSig(buf, bufSize, arrayType),
                         sigDesc.c_str() );
         return 0;
@@ -1928,7 +1967,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (array->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"WARNING - named color array failed validation: %s\n", report.c_str() );
+        fprintf(stderr,"%s: WARNING - named color array failed validation: %s\n", filename.c_str(), report.c_str() );
         return 0;
       }
 
@@ -2005,7 +2044,8 @@ CIccPcsXform::pushRef2Xyz
                 break;
             
               default:
-                printf("Unknown named color struct data type %s for tag %s\n",
+                fprintf(stderr,"%s: Unknown named color struct data type %s for tag %s\n",
+                        filename.c_str(),
                         icGetSig(buf, bufSize, pcsDataType),
                         sigDesc.c_str() );
                 continue;
@@ -2063,7 +2103,8 @@ CIccPcsXform::pushRef2Xyz
                   break;
                 
                 default:
-                  printf("Unknown named color struct name type %s for tag %s\n",
+                  fprintf(stderr,"%s: Unknown named color struct name type %s for tag %s\n",
+                        filename.c_str(),
                         icGetSig(buf, bufSize, nameDataType),
                         sigDesc.c_str() );
                   break;
@@ -2103,7 +2144,8 @@ CIccPcsXform::pushRef2Xyz
                     break;
                 
                   default:
-                    printf("Unknown named color tint data type %s for tag %s\n",
+                    fprintf(stderr,"%s: Unknown named color tint data type %s for tag %s\n",
+                            filename.c_str(),
                             icGetSig(buf, bufSize, tintDataType),
                             sigDesc.c_str() );
                     // skipping this still allows colors and names, even if we don't have tint percentages
@@ -2120,7 +2162,8 @@ CIccPcsXform::pushRef2Xyz
             break;
         
           default:
-            printf("Unknown named color struct %s for tag %s\n",
+            fprintf(stderr,"%s: Unknown named color struct %s for tag %s\n",
+                    filename.c_str(),
                     icGetSig(buf, bufSize, structType),
                     sigDesc.c_str() );
             break;
@@ -2143,7 +2186,8 @@ CIccPcsXform::pushRef2Xyz
       break;
 
     default:
-      printf("Unknown named color type %s for tag %s\n",
+      fprintf(stderr,"%s: Unknown named color type %s for tag %s\n",
+         filename.c_str(),
          icGetSig(buf, bufSize, typeSig),
          sigDesc.c_str() );
       break;
@@ -2210,12 +2254,19 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
       case icSigGreenTRCTag:
       case icSigBlueTRCTag:
       case icSigGrayTRCTag:
-// response curve struct?
-// response curve array?
         {
         const char *sigDesc = icGetSigStr(buf1, bufSize, sig);
         CIccTag *pTag = pIcc->FindTag(tag); // load if needed
-        outputItems += output1DLUT(pIcc, pTag, sigDesc, pdffile );
+        outputItems += output1DLUT(pIcc, pTag, sigDesc, pdffile, basename );
+        }
+        break;
+    
+      case icSigOutputResponseTag:
+        {
+printf("**** Found response curves in %s\n", profilePath );     // DEBUG
+        const char *sigDesc = icGetSigStr(buf1, bufSize, sig);
+        CIccTag *pTag = pIcc->FindTag(tag); // load if needed
+        outputItems += outputResponseCurves(pIcc, pTag, sigDesc, pdffile, basename );
         }
         break;
 
@@ -2250,7 +2301,7 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
 // TODO - plot named spectra as graphs?
         const char *sigDesc = icGetSigStr(buf1, bufSize, sig);
         CIccTag *pTag = pIcc->FindTag(tag); // load if needed
-        outputItems += outputNamedColors(pIcc, pTag, sigDesc, pdffile );
+        outputItems += outputNamedColors(pIcc, pTag, sigDesc, pdffile, basename );
        }
         break;
 
@@ -2324,23 +2375,23 @@ int main(int argc, char* argv[])
     try {
       CIccProfile *pIcc = OpenIccProfile( argv[k] );
       if (!pIcc) {
-        printf("Unable to parse '%s' as ICC profile!\n", argv[k]);
+        fprintf(stderr,"Unable to parse '%s' as ICC profile!\n", argv[k]);
         continue;
       }
 
       // DEBUGGING printf("Processing profile '%s'\n", argv[k]);
       auto count = processLuts( pIcc, argv[k] );
       if (!count) {
-        printf("Profile %s had no content for output\n", argv[k] );
+        fprintf(stderr,"Profile %s had no content for output\n", argv[k] );
       }
 
       delete pIcc;
     }   // end try
     catch (const std::exception& e) {
-      fprintf(stderr, "ERROR processing '%s': '%s'\n", argv[k], e.what() );
+      fprintf(stderr, "%s: ERROR exception: '%s'\n", argv[k], e.what() );
     }
     catch (...) {
-      fprintf(stderr, "ERROR processing '%s': unknown exception\n", argv[k] );
+      fprintf(stderr, "%s: ERROR: unknown exception\n", argv[k] );
     }
 
   } // end for argc

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1971,8 +1971,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         && arrayType != icSigNamedColorArray) {
         fprintf(stderr,"%s: WARNING - unknown color array type: %s for tag %s\n",
                         filename.c_str(),
-                        icGetSig(buf, bufSize, arrayType),
-                        sigDesc.c_str() );
         return 0;
       }
 

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -2002,7 +2002,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
           case icSigTintZeroStruct:
           case icSigNamedColorStruct:
             {
-            // look for PCS and name info
             CIccTagStruct *structPtr = dynamic_cast<CIccTagStruct*> (thisItem);
             if (!structPtr)
               continue;
@@ -2169,7 +2168,6 @@ CIccPcsXform::pushRef2Xyz
                 }   // end switch by PCS data type
               
             }   // end tint value handling
-            
 
             // add temp values to our list
             if (tempColorValues.size() > 0)

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1915,10 +1915,14 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         return 0;
       }
       
-      auto arrayType = array->GetTagArrayType();
+      icArraySignature arrayType = array->GetTagArrayType();
       if (arrayType != icSigColorantInfoArray
-        && arrayType != icSigNamedColorArray)
+        && arrayType != icSigNamedColorArray) {
+        fprintf(stderr,"WARNING - unknown color array type: %s for tag %s\n",
+                        icGetSig(buf, bufSize, arrayType),
+                        sigDesc.c_str() );
         return 0;
+      }
 
       std::string path(":");
       path += sigDesc;
@@ -1953,7 +1957,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
 CIccPcsXform::pushRef2Xyz
  CIccPcsXform::pushRad2Xyz
  CIccPcsXform::pushBiRef2Xyz
-
  */
             CIccTag *pcsElem = structPtr->FindElem(icSigCinfPcsDataMbr);
             if (!pcsElem)
@@ -2130,7 +2133,7 @@ CIccPcsXform::pushRef2Xyz
         
       } // end loop over items in array
  
-      // make sure we found usable colors and names
+      // make sure we found some usable colors and names
       if (colorsOut.size() == 0)
         return 0;
  
@@ -2245,6 +2248,7 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
       case icSigColorantInfoTag:
       case icSigColorantInfoOutTag:
        {
+// TODO - plot named spectra as graphs?
         const char *sigDesc = icGetSigStr(buf1, bufSize, sig);
         CIccTag *pTag = pIcc->FindTag(tag); // load if needed
         outputItems += outputNamedColors(pIcc, pTag, sigDesc, pdffile );

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1815,7 +1815,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
 {
   const size_t bufSize = 64;
   char buf[bufSize];
-  char buf2[bufSize];
   namedLabList colorsOut;
 
   int outputCount = 0;
@@ -1994,6 +1993,8 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         if (!thisItem)
             continue;
 
+        tempColorValues.clear();
+
         auto structType = thisItem->GetTagStructType();
         
         switch (structType) {
@@ -2001,6 +2002,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
           case icSigTintZeroStruct:
           case icSigNamedColorStruct:
             {
+            // look for PCS and name info
             CIccTagStruct *structPtr = dynamic_cast<CIccTagStruct*> (thisItem);
             if (!structPtr)
               continue;
@@ -2188,7 +2190,7 @@ CIccPcsXform::pushRef2Xyz
         
         
       } // end loop over items in array
- 
+
       // make sure we found some usable colors and names
       if (colorsOut.size() == 0)
         return 0;

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -2106,7 +2106,7 @@ CIccPcsXform::pushRef2Xyz
                     printf("Unknown named color tint data type %s for tag %s\n",
                             icGetSig(buf, bufSize, tintDataType),
                             sigDesc.c_str() );
-                    continue;
+                    // skipping this still allows colors and names, even if we don't have tint percentages
                     break;
                 }   // end switch by PCS data type
               
@@ -2116,7 +2116,6 @@ CIccPcsXform::pushRef2Xyz
             // add temp values to our list
             if (tempColorValues.size() > 0)
               colorsOut.insert( colorsOut.end(), tempColorValues.begin(), tempColorValues.end() );
-            
             }
             break;
         
@@ -2137,7 +2136,7 @@ CIccPcsXform::pushRef2Xyz
       if (colorsOut.size() == 0)
         return 0;
  
-      std::string description("Colorant Array: ");
+      std::string description("Color Array: ");
       outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc,
                         XYZIlluminant, pdffile );
       }
@@ -2258,8 +2257,8 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
 // TODO - embedded height image
 // TODO - embedded normal image
 // TODO - BRDF images?
-// TODO - LUT content from MPE tags
-// TODO - spectral viewing conditions
+// TODO - LUT content from MPE tags?
+// TODO - spectral viewing conditions?
 // TODO - all XYZ type tags?
 // TODO - curveSetElement
 // TODO - singleSampledCurve

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1773,6 +1773,17 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
 
   icTagTypeSignature typeSig = tag->GetType();
 
+  icFloatNumber XYZIlluminant[3];
+  pIcc->getNormIlluminantXYZ( XYZIlluminant );
+  
+  icColorSpaceSignature pcs = pIcc->m_Header.pcs;   // table->GetPCS();
+  if (pcs != icSigXYZData && pcs != icSigLabData) {
+    fprintf(stderr,"WARNING - unknown pcs for colors: %s\n",
+                        icGetSig(buf, bufSize, pcs) );
+    return 0;
+  }
+
+
   switch(typeSig) {
 
     case icSigColorantTableType:    // colorant tables -- name and PCS only
@@ -1790,19 +1801,15 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         fprintf(stderr,"WARNING - colorantTable failed validation: %s\n", report.c_str() );
         return 0;
       }
-
-      icColorSpaceSignature pcs = pIcc->m_Header.pcs; // table->GetPCS();   // never initialized in table!
-
-      if (pcs != icSigXYZData && pcs != icSigLabData) {
-        fprintf(stderr,"WARNING - unknown pcs for colorantTable: %s\n",
+      
+      icColorSpaceSignature table_pcs = table->GetPCS();
+      if (pcs != table_pcs) {
+        fprintf(stderr,"WARNING - bad pcs for colorant table: %s\n",
                             icGetSig(buf, bufSize, pcs) );
         return 0;
       }
 
       icUInt32Number colorCount = table->GetSize();
-
-      icFloatNumber XYZIlluminant[3];
-      pIcc->getNormIlluminantXYZ( XYZIlluminant );
 
       colorsOut.reserve(colorCount);
 
@@ -1854,19 +1861,15 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         fprintf(stderr,"WARNING - namedColorTable failed validation: %s\n", report.c_str() );
         return 0;
       }
-
-      icColorSpaceSignature pcs = table->GetPCS();// pIcc->m_Header.pcs;
-
-      if (pcs != icSigXYZData && pcs != icSigLabData) {
-        fprintf(stderr,"WARNING - unknown pcs for namedColorTable: %s\n",
+      
+      icColorSpaceSignature table_pcs = table->GetPCS();
+      if (pcs != table_pcs) {
+        fprintf(stderr,"WARNING - bad pcs for namedColorTable: %s\n",
                             icGetSig(buf, bufSize, pcs) );
         return 0;
       }
 
       icUInt32Number colorCount = table->GetSize();
-
-      icFloatNumber XYZIlluminant[3];
-      pIcc->getNormIlluminantXYZ( XYZIlluminant );
 
       colorsOut.reserve(colorCount);
 
@@ -1924,7 +1927,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         return 0;
       }
 
-      std::vector<float> tempColorValues;
+      namedLabList tempColorValues;
 
       icUInt32Number items = array->GetSize();
 
@@ -1932,8 +1935,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         CIccTag *thisItem = array->GetIndex(i);
         if (!thisItem)
             continue;
-        
-        tempColorValues.clear();
 
         auto structType = thisItem->GetTagStructType();
         
@@ -1942,7 +1943,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
           case icSigTintZeroStruct:
           case icSigNamedColorStruct:
             {
-            // look for PCS and name info
             CIccTagStruct *structPtr = dynamic_cast<CIccTagStruct*> (thisItem);
             if (!structPtr)
               continue;
@@ -1951,42 +1951,46 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
             CIccTag *pcsElem = structPtr->FindElem(icSigCinfPcsDataMbr);
             if (!pcsElem)
               continue;
+        
+            tempColorValues.clear();
             
             icTagTypeSignature pcsDataType = pcsElem->GetType();
             switch( pcsDataType) {
+              case icSigFloat64ArrayType:
+              case icSigFloat32ArrayType:
               case icSigFloat16ArrayType:
                 {
-                CIccTagFloat16 *flt16 = dynamic_cast<CIccTagFloat16*> (pcsElem);
+                CIccTagNumArray *flt16 = dynamic_cast<CIccTagNumArray*> (pcsElem);
                 if (!flt16)
                   continue;
-                icUInt32Number dataCount = flt16->GetSize();
-                int colorCount = dataCount / 3;
+                icUInt32Number dataCount = flt16->GetNumValues();
+                icUInt32Number colorCount = dataCount / 3; // ignoring any partials
 
-// TODO - store PCS values
+                // loop over count, convert to LAB as needed
+                for (icUInt32Number k = 0; k < colorCount; ++k) {
+                    icFloatNumber valueTemp[3];
+                    icFloatNumber labTemp[3];
+                    
+                    flt16->GetValues(valueTemp, k*3, 3);
+                    
+                    if (pcs == icSigXYZData) {
+                        // XYZ float
+                        icXYZtoLab( labTemp, valueTemp, XYZIlluminant );
+                    } else {
+                        //  LAB float
+                        labTemp[0] = valueTemp[0];
+                        labTemp[1] = valueTemp[1];
+                        labTemp[2] = valueTemp[2];
+                        // assume LAB directly coded as float (as seen in examples)
+                    }
+
+                    namedLAB tempNamed;     // leaving name empty for now
+                    tempNamed.L = labTemp[0];
+                    tempNamed.a = labTemp[1];
+                    tempNamed.b = labTemp[2];
+                    tempColorValues.push_back( tempNamed );
                 }
-                break;
-            
-              case icSigFloat32ArrayType:
-                {
-                CIccTagFloat32 *flt32 = dynamic_cast<CIccTagFloat32*> (pcsElem);
-                if (!flt32)
-                  continue;
-                icUInt32Number dataCount = flt32->GetSize();
-                int colorCount = dataCount / 3;
 
-// TODO - store PCS values
-                }
-                break;
-                
-              case icSigFloat64ArrayType:
-                {
-                CIccTagFloat64 *flt64 = dynamic_cast<CIccTagFloat64*> (pcsElem);
-                if (!flt64)
-                  continue;
-                icUInt32Number dataCount = flt64->GetSize();
-                int colorCount = dataCount / 3;
-
-// TODO - store PCS values
                 }
                 break;
             
@@ -1994,14 +1998,114 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
                 printf("Unknown named color struct data type %s for tag %s\n",
                         icGetSig(buf, bufSize, pcsDataType),
                         sigDesc.c_str() );
+                continue;
                 break;
-            }   // end switch by data type
+            }   // end switch by PCS data type
             
             
-// we have a PCS value list!, now we need name or localized name to go with them
+            // now we try to find names to match the colors
+            CIccTag *nameElem = structPtr->FindElem(icSigCinfNameMbr);
+            if (!nameElem)      // fallback to other tag type
+              nameElem = structPtr->FindElem(icSigCinfLocalizedNameMbr);        // unused so far?
+            
+            // if we don't have names, just skip it and still plot the color valuess
+            if (nameElem) {
+              icTagTypeSignature nameDataType = nameElem->GetType();
+              std::string nameString;
+              switch( nameDataType) {
+                case icSigUtf8TextType:
+                  {
+                  CIccTagUtf8Text *nameUTF8 = dynamic_cast<CIccTagUtf8Text*> (nameElem);
+                  if (nameUTF8)
+                    nameString = std::string( (char *)nameUTF8->GetText() );
+                  }
+                  break;
+                
+                case icSigUtf16TextType:
+                  {
+                  CIccTagUtf16Text *nameUTF16 = dynamic_cast<CIccTagUtf16Text*> (nameElem);
+                  if (nameUTF16) {
+                    std::string buffer;
+                    nameString = std::string( (char *)nameUTF16->GetText(buffer) );   // GetText converts to UTF8
+                    }
+                  }
+                  break;
+                
+                case icSigTextType:
+                  {
+                  CIccTagText *nameText = dynamic_cast<CIccTagText*> (nameElem);
+                  if (nameText)
+                    nameString = std::string( (char *)nameText->GetText() );
+                  }
+                  break;
+                  
+                case icSigDictType: // supposed to be multiLocalizedUnicodeType, but so far unused?
+                case icSigMultiLocalizedUnicodeType:
+                  {
+                  CIccTagMultiLocalizedUnicode *nameDict = dynamic_cast<CIccTagMultiLocalizedUnicode*> (nameElem);
+                  if (nameDict) {
+                        // has language and first entry fallbacks
+                    CIccLocalizedUnicode *uniText = nameDict->Find( icLanguageCodeEnglish, icCountryCodeUSA );
+                    if (uniText)
+                      uniText->GetText(nameString);
+                    }
+                  }
+                  break;
+                
+                default:
+                  printf("Unknown named color struct name type %s for tag %s\n",
+                        icGetSig(buf, bufSize, nameDataType),
+                        sigDesc.c_str() );
+                  break;
+              }
+              
+              if (nameString.size() > 0) {
+                for (auto &color: tempColorValues)
+                  color.name = nameString;
+              }
+            
+            } // end name element handling
 
-// convert PCS value as needed
-// add name and value to list
+
+            // now try to match tint values and append to name, if present
+            CIccTag *tintElem = structPtr->FindElem(icSigNmclTintMbr);
+            if (tintElem) {
+                icTagTypeSignature tintDataType = tintElem->GetType();
+                switch( tintDataType) {
+                  case icSigFloat64ArrayType:
+                  case icSigFloat32ArrayType:
+                  case icSigFloat16ArrayType:
+                    {
+                    CIccTagNumArray *flt16 = dynamic_cast<CIccTagNumArray*> (tintElem);
+                    if (!flt16)
+                      continue;
+                    icUInt32Number dataCount = flt16->GetNumValues();
+                    if (dataCount <= tempColorValues.size()) {
+                      for (icUInt32Number k = 0; k < dataCount; ++k) {
+                        icFloatNumber valueTemp;
+                        flt16->GetValues(&valueTemp, k, 1);
+                        int percent = (int)round(valueTemp * 100.0f);
+                        tempColorValues[k].name += std::string("(") + std::to_string(percent) + std::string("%)");
+                      }
+                    }
+
+                    }
+                    break;
+                
+                  default:
+                    printf("Unknown named color tint data type %s for tag %s\n",
+                            icGetSig(buf, bufSize, tintDataType),
+                            sigDesc.c_str() );
+                    continue;
+                    break;
+                }   // end switch by PCS data type
+              
+            }   // end tint value handling
+            
+
+            // add temp values to our list
+            if (tempColorValues.size() > 0)
+              colorsOut.insert( colorsOut.end(), tempColorValues.begin(), tempColorValues.end() );
             
             }
             break;
@@ -2022,9 +2126,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       // make sure we found usable colors and names
       if (colorsOut.size() == 0)
         return 0;
-
-      icFloatNumber XYZIlluminant[3];
-      pIcc->getNormIlluminantXYZ( XYZIlluminant );
  
       std::string description("Colorant Array: ");
       outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc,

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1234,6 +1234,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
 // output graphic representation of response curve 1D LUTs
 //     or would, if I could find any example of profiles using response curves...
 // return number of output items created
+
 static
 int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDesc,
                         PDFWriter &pdffile, const std::string &filename )
@@ -1267,6 +1268,7 @@ int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::stri
 
     curveIter = curves->GetNextCurves();
   }
+
 
   return 0; // no output created
 
@@ -1971,6 +1973,8 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         && arrayType != icSigNamedColorArray) {
         fprintf(stderr,"%s: WARNING - unknown color array type: %s for tag %s\n",
                         filename.c_str(),
+                        icGetSig(buf, bufSize, arrayType),
+                        sigDesc.c_str() );
         return 0;
       }
 

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1234,7 +1234,6 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
 // output graphic representation of response curve 1D LUTs
 //     or would, if I could find any example of profiles using response curves...
 // return number of output items created
-
 static
 int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDesc,
                         PDFWriter &pdffile, const std::string &filename )

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -108,6 +108,54 @@
 
 /******************************************************************************/
 
+// Cross product 2 vectors from O to A and B
+// Returns a positive value, if OAB makes a counter-clockwise turn,
+// negative for clockwise turn, and zero if the points are collinear.
+float cross(const point2D &O, const point2D &A, const point2D &B)
+{
+  return (A.x - O.x) * (B.y - O.y) - (A.y - O.y) * (B.x - O.x);
+}
+
+/******************************************************************************/
+
+// Returns a list of points on the convex hull from the set of input points.
+// Duplicate points and colinear points are removed.
+// Monotone chain algorithm  O(NlogN+2N)
+// NOTE - Could be abstracted to any random access container
+template <typename P>
+std::vector<P> convex_hull2D(std::vector<P> points_in)
+{
+  size_t n = points_in.size();
+
+  if (n <= 3)
+    return points_in;
+
+  std::vector<P> result(2*n); // worst case storage
+
+  // Sort points
+  std::sort( points_in.begin(), points_in.end() );
+
+  // Build lower hull
+  size_t k = 0;
+  for (size_t i = 0; i < n; ++i) {
+    while (k >= 2 && cross(result[k-2], result[k-1], points_in[i]) <= 0)
+      k--;
+    result[k++] = points_in[i];
+  }
+
+  // Build upper hull
+  for (size_t i = n-1, t = k+1; i > 0; --i) {
+    while (k >= t && cross(result[k-2], result[k-1], points_in[i-1]) <= 0)
+      k--;
+    result[k++] = points_in[i-1];
+  }
+
+  result.resize(k-1);
+  return result;
+}
+
+/******************************************************************************/
+
 #if USE_SVG
 static
 void DrawAxisSVG( SVGOut &svgfile, const point2D &basepoint, const point2D &range,
@@ -305,11 +353,26 @@ void CreateAxesXobject( PDFWriter &pdfout )
 
 struct XYColor
 {
-    XYColor (float xx, float yy) : x(xx), y(yy) {}
+  XYColor (float xx, float yy) : x(xx), y(yy) {}
 
-    float x;
-    float y;
+  bool operator<(const XYColor& o) const {
+    if (x == o.x)
+      return y < o.y;
+    else
+      return x < o.x;
+  }
+
+public:
+  float x;
+  float y;
 };
+
+float cross(const XYColor &O, const XYColor &A, const XYColor &B)
+{
+  return (A.x - O.x) * (B.y - O.y) - (A.y - O.y) * (B.x - O.x);
+}
+
+/******************************************************************************/
 
 // https://en.wikipedia.org/wiki/Planckian_locus
 // Bongsoon Kang; Ohak Moon; Changhee Hong; Honam Lee; Bonghwan Cho; Youngsun Kim (December 2002).
@@ -318,56 +381,56 @@ struct XYColor
 static
 XYColor approx_planck( double t )
 {
-    const double c3a = -0.2661239;
-    const double c2a = -0.2343589;
-    const double c1a =  0.8776956;
-    const double c0a =  0.179910;
+  const double c3a = -0.2661239;
+  const double c2a = -0.2343589;
+  const double c1a =  0.8776956;
+  const double c0a =  0.179910;
 
-    const double c3b = -3.0258469;
-    const double c2b =  2.1070379;
-    const double c1b =  0.2226347;
-    const double c0b =  0.240390;
+  const double c3b = -3.0258469;
+  const double c2b =  2.1070379;
+  const double c1b =  0.2226347;
+  const double c0b =  0.240390;
 
-    const double k3a = -1.1063814;
-    const double k2a = -1.34811020;
-    const double k1a =  2.18555832;
-    const double k0a = -0.20219683;
+  const double k3a = -1.1063814;
+  const double k2a = -1.34811020;
+  const double k1a =  2.18555832;
+  const double k0a = -0.20219683;
 
-    const double k3b = -0.9549476;
-    const double k2b = -1.37418593;
-    const double k1b =  2.09137015;
-    const double k0b = -0.16748867;
+  const double k3b = -0.9549476;
+  const double k2b = -1.37418593;
+  const double k1b =  2.09137015;
+  const double k0b = -0.16748867;
 
-    const double k3c =  3.0817580;
-    const double k2c = -5.87338670;
-    const double k1c =  3.75112997;
-    const double k0c = -0.37001483;
+  const double k3c =  3.0817580;
+  const double k2c = -5.87338670;
+  const double k1c =  3.75112997;
+  const double k0c = -0.37001483;
 
-    double t2 = t*t;
-    double t3 = t*t*t;
+  double t2 = t*t;
+  double t3 = t*t*t;
 
-    double x = 0.0;
+  double x = 0.0;
 
-    if (t < 4000.0) {
-        x = c3a*(1e9/t3) + c2a*(1e6/t2) + c1a*(1e3/t) + c0a;
-    } else {
-        x = c3b*(1e9/t3) + c2b*(1e6/t2) + c1b*(1e3/t) + c0b;
-    }
+  if (t < 4000.0) {
+    x = c3a*(1e9/t3) + c2a*(1e6/t2) + c1a*(1e3/t) + c0a;
+  } else {
+    x = c3b*(1e9/t3) + c2b*(1e6/t2) + c1b*(1e3/t) + c0b;
+  }
 
-    double x2 = x*x;
-    double x3 = x*x*x;
+  double x2 = x*x;
+  double x3 = x*x*x;
 
-    double y = 0.0;
+  double y = 0.0;
 
-    if (t < 2222.0) {
-        y = k3a*x3 + k2a*x2 + k1a*x + k0a;
-    } else if (t < 4000.0) {
-        y = k3b*x3 + k2b*x2 + k1b*x + k0b;
-    } else {
-        y = k3c*x3 + k2c*x2 + k1c*x + k0c;
-    }
+  if (t < 2222.0) {
+    y = k3a*x3 + k2a*x2 + k1a*x + k0a;
+  } else if (t < 4000.0) {
+    y = k3b*x3 + k2b*x2 + k1b*x + k0b;
+  } else {
+    y = k3c*x3 + k2c*x2 + k1c*x + k0c;
+  }
 
-    return XYColor(x,y);
+  return XYColor(x,y);
 }
 
 /******************************************************************************/
@@ -378,12 +441,12 @@ sorta, kinda evenly spaced, plus endpoints
  */
 std::vector<int> locusLabelWavelengths =
 {
-    360,
-    460, 450,
-    470, 475, 480, 485, 490, 495, 500, 505, 510, 515,
-    520, 530, 540, 550, 560, 570, 580, 590, 600, 610, 620,
-    640,
-    700
+  360,
+  460, 450,
+  470, 475, 480, 485, 490, 495, 500, 505, 510, 515,
+  520, 530, 540, 550, 560, 570, 580, 590, 600, 610, 620,
+  640,
+  700
 };
 
 /******************************************************************************/
@@ -394,21 +457,21 @@ point2D spectrumLabelOffset( int nm, float textSize, TextAlignment &align )
 // NOTE - Yes, I could create normal vectors from the locus points, etc.
 // but this looks better with less math, and is much easier to debug.
 
-    if (nm < 515) {
-        // go left
-        align = kTextAlignRight;
-        return point2D( -2.0f, 0.0f );
-    } else if (nm <= 520) {
-        // go up
-        align = kTextAlignCenter;
-        return point2D( -3.0f, textSize*1.55f );
-    } else {
-        // go right
-        align = kTextAlignLeft;
-        return point2D( textSize*0.5, textSize );
-    }
+  if (nm < 515) {
+    // go left
+    align = kTextAlignRight;
+    return point2D( -2.0f, 0.0f );
+  } else if (nm <= 520) {
+    // go up
+    align = kTextAlignCenter;
+    return point2D( -3.0f, textSize*1.55f );
+  } else {
+    // go right
+    align = kTextAlignLeft;
+    return point2D( textSize*0.5, textSize );
+  }
 
-    // unreachable
+  // unreachable
 }
 
 /******************************************************************************/
@@ -503,9 +566,9 @@ void CreateXYPlotXobject( PDFWriter &pdfout )
   firstPoint = basepoint + scaling * point2D( firstXY.x, firstXY.y );
   commands << firstPoint << " m\n";
   for (float temp = start_temp+temp_step; temp <= end_temp; temp += temp_step ) {
-        XYColor thisXY = approx_planck( temp );
-        point2D thispoint = basepoint + scaling * point2D( thisXY.x, thisXY.y );
-        commands << thispoint << " l\n";
+    XYColor thisXY = approx_planck( temp );
+    point2D thispoint = basepoint + scaling * point2D( thisXY.x, thisXY.y );
+    commands << thispoint << " l\n";
   }
   // stroke the curve
   commands << "S\n";
@@ -629,18 +692,18 @@ void CreateABPlotXobject( PDFWriter &pdfout )
 static
 XYColor xyFromICCXYZ( const icXYZNumber *xyz )
 {
-    // integers, so don't have to test for NaN or Inf
-    float X = xyz->X / 65535.0f;
-    float Y = xyz->Y / 65535.0f;
-    float Z = xyz->Z / 65535.0f;
+// integers, so don't have to test for NaN or Inf
+  float X = xyz->X / 65535.0f;
+  float Y = xyz->Y / 65535.0f;
+  float Z = xyz->Z / 65535.0f;
 
-    float sum = X + Y + Z;
-    if (sum <= 1e-8)
-        return XYColor(0,0);
+  float sum = X + Y + Z;
+  if (sum <= 1e-8)
+    return XYColor(0,0);
 
-    float x = X / sum;
-    float y = Y / sum;
-    return XYColor(x,y);
+  float x = X / sum;
+  float y = Y / sum;
+  return XYColor(x,y);
 }
 
 /******************************************************************************/
@@ -648,17 +711,17 @@ XYColor xyFromICCXYZ( const icXYZNumber *xyz )
 static
 XYColor xyFromICCXYZFloat( const icFloatNumber *xyz )
 {
-    float X = xyz[0];
-    float Y = xyz[1];
-    float Z = xyz[2];
+  float X = xyz[0];
+  float Y = xyz[1];
+  float Z = xyz[2];
 
-    float sum = X + Y + Z;
-    if (sum <= 1e-8)
-        return XYColor(0,0);
+  float sum = X + Y + Z;
+  if (sum <= 1e-8)
+    return XYColor(0,0);
 
-    float x = X / sum;
-    float y = Y / sum;
-    return XYColor(x,y);
+  float x = X / sum;
+  float y = Y / sum;
+  return XYColor(x,y);
 }
 
 /******************************************************************************/
@@ -1847,9 +1910,125 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
         fprintf(stderr, "Skipping %s: unable to convert named color array\n", sigDesc.c_str());
         return 0;
       }
+      
+      auto arrayType = array->GetTagArrayType();
+      if (arrayType != icSigColorantInfoArray
+        && arrayType != icSigNamedColorArray)
+        return 0;
 
-// TODO - dissect structure, figure out LAB values for colors
+      std::string path(":");
+      path += sigDesc;
+      std::string report;
+      if (array->Validate(path, report, NULL) > icValidateWarning) {
+        fprintf(stderr,"WARNING - named color array failed validation: %s\n", report.c_str() );
+        return 0;
+      }
 
+      std::vector<float> tempColorValues;
+
+      icUInt32Number items = array->GetSize();
+
+      for (icUInt32Number i = 0; i < items; ++i) {
+        CIccTag *thisItem = array->GetIndex(i);
+        if (!thisItem)
+            continue;
+        
+        tempColorValues.clear();
+
+        auto structType = thisItem->GetTagStructType();
+        
+        switch (structType) {
+          case icSigColorantInfoStruct:
+          case icSigTintZeroStruct:
+          case icSigNamedColorStruct:
+            {
+            // look for PCS and name info
+            CIccTagStruct *structPtr = dynamic_cast<CIccTagStruct*> (thisItem);
+            if (!structPtr)
+              continue;
+
+// TODO - can we easily convert spectra to PCS? Probably not without specifying viewing conditions.
+            CIccTag *pcsElem = structPtr->FindElem(icSigCinfPcsDataMbr);
+            if (!pcsElem)
+              continue;
+            
+            icTagTypeSignature pcsDataType = pcsElem->GetType();
+            switch( pcsDataType) {
+              case icSigFloat16ArrayType:
+                {
+                CIccTagFloat16 *flt16 = dynamic_cast<CIccTagFloat16*> (pcsElem);
+                if (!flt16)
+                  continue;
+                icUInt32Number dataCount = flt16->GetSize();
+                int colorCount = dataCount / 3;
+
+// TODO - store PCS values
+                }
+                break;
+            
+              case icSigFloat32ArrayType:
+                {
+                CIccTagFloat32 *flt32 = dynamic_cast<CIccTagFloat32*> (pcsElem);
+                if (!flt32)
+                  continue;
+                icUInt32Number dataCount = flt32->GetSize();
+                int colorCount = dataCount / 3;
+
+// TODO - store PCS values
+                }
+                break;
+                
+              case icSigFloat64ArrayType:
+                {
+                CIccTagFloat64 *flt64 = dynamic_cast<CIccTagFloat64*> (pcsElem);
+                if (!flt64)
+                  continue;
+                icUInt32Number dataCount = flt64->GetSize();
+                int colorCount = dataCount / 3;
+
+// TODO - store PCS values
+                }
+                break;
+            
+              default:
+                printf("Unknown named color struct data type %s for tag %s\n",
+                        icGetSig(buf, bufSize, pcsDataType),
+                        sigDesc.c_str() );
+                break;
+            }   // end switch by data type
+            
+            
+// we have a PCS value list!, now we need name or localized name to go with them
+
+// convert PCS value as needed
+// add name and value to list
+            
+            }
+            break;
+        
+          default:
+            printf("Unknown named color struct %s for tag %s\n",
+                    icGetSig(buf, bufSize, structType),
+                    sigDesc.c_str() );
+            break;
+        } // end switch struct type
+        
+        // extract name and PCS value from this struct
+        // if no PCS, bail
+        
+        
+      } // end loop over items in array
+ 
+      // make sure we found usable colors and names
+      if (colorsOut.size() == 0)
+        return 0;
+
+      icFloatNumber XYZIlluminant[3];
+      pIcc->getNormIlluminantXYZ( XYZIlluminant );
+ 
+      std::string description("Colorant Array: ");
+      outputCount += graphNamedColorsPDF( colorsOut, description + sigDesc,
+                        XYZIlluminant, pdffile );
       }
       break;
 
@@ -1863,7 +2042,6 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
 
   return outputCount;
 }
-
 
 /******************************************************************************/
 
@@ -1956,12 +2134,24 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
       case icSigNamedColor2Tag:
       case icSigColorantTableTag:
       case icSigColorantTableOutTag:
+      case icSigColorantInfoTag:
+      case icSigColorantInfoOutTag:
        {
         const char *sigDesc = icGetSigStr(buf1, bufSize, sig);
         CIccTag *pTag = pIcc->FindTag(tag); // load if needed
         outputItems += outputNamedColors(pIcc, pTag, sigDesc, pdffile );
        }
         break;
+
+// TODO - embedded height image
+// TODO - embedded normal image
+// TODO - BRDF images?
+// TODO - LUT content from MPE tags
+// TODO - spectral viewing conditions
+// TODO - all XYZ type tags?
+// TODO - curveSetElement
+// TODO - singleSampledCurve
+// TODO - segmentedCurve
 
       // ignore everything else
       default:

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -75,7 +75,7 @@
 #include "IccTag.h"
 #include "IccUtil.h"
 #include "IccProfLibVer.h"
-//#include "IccCmdLineUtil.h"
+#include "../IccCmdLineUtil.h"
 #include "MiniTIFF.hpp"
 #include "MiniSVG.hpp"
 #include "MiniPDF.hpp"
@@ -1039,7 +1039,7 @@ bool describe1DLUT( CIccTagCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - curve failed validation: %s\n", filename.c_str(), report.c_str() );
+    fprintf(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "simpleCurve";
     return true;
   }
@@ -1068,7 +1068,7 @@ bool describe1DLUT( CIccTagParametricCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - curve failed validation: %s\n", filename.c_str(), report.c_str() );
+    fprintf(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "parametric";
     return true;
   }
@@ -1086,7 +1086,7 @@ bool describe1DLUT( CIccTagSegmentedCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - curve failed validation: %s\n", filename.c_str(), report.c_str() );
+    fprintf(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "segmented";
     return true;
   }
@@ -1104,7 +1104,7 @@ bool describe1DLUT( CIccCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - curve failed validation: %s\n", filename.c_str(), report.c_str() );
+    fprintf(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "unknown";
     return true;
   }
@@ -1122,7 +1122,7 @@ bool describe3DLUT( CIccMBB *curve, CIccProfile *pIcc, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, pIcc ) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - 3D table failed validation: %s\n", filename.c_str(), report.c_str() );
+    fprintf(stderr,"%s: WARNING - 3D table failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "MBBLut";
     return true;
   }
@@ -1230,8 +1230,9 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
 
 /******************************************************************************/
 
-// output graphic representation of 1D LUTs
-// return 1 if output created, 0 if none
+// output graphic representation of response curve 1D LUTs
+//     or would, if I could find any example of profiles using response curves...
+// return number of output items created
 static
 int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDesc,
                         PDFWriter &pdffile, const std::string &filename )
@@ -1251,8 +1252,20 @@ int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::stri
     return 0;
   }
 
+  CIccTagResponseCurveSet16 *curves = dynamic_cast<CIccTagResponseCurveSet16*> (tag);
+  if (!curves) {
+      fprintf(stderr, "%s: Skipping %s: unable to convert response curves\n", filename.c_str(), sigDesc.c_str());
+      return 0;
+  }
+  
+  //icUInt16Number channels = curves->GetNumChannels();
+  CIccResponseCurveStruct *curveIter = curves->GetFirstCurves();
+  while (curveIter != NULL) {
 
-// TODO - read and write curves!
+// TODO - read and output
+
+    curveIter = curves->GetNextCurves();
+  }
 
   return 0; // no output created
 
@@ -1800,6 +1813,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
 {
   const size_t bufSize = 64;
   char buf[bufSize];
+  char buf2[bufSize];
   namedLabList colorsOut;
 
   int outputCount = 0;
@@ -1837,16 +1851,14 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"%s: WARNING - colorantTable failed validation: %s\n", filename.c_str(), report.c_str() );
+        fprintf(stderr,"%s: WARNING - colorantTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
-      
-      icColorSpaceSignature table_pcs = table->GetPCS();
-      if (pcs != table_pcs) {
-        fprintf(stderr,"%s: WARNING - bad pcs for colorant table: %s\n",
-                            filename.c_str(), icGetSig(buf, bufSize, pcs) );
-        return 0;
-      }
+
+/*
+    CIccTagColorantTable::m_PCS is never set, so testing the value always fails.
+    This value is not written, or read as part of the table -- so we must assume that data PCS == profile PCS
+*/
 
       icUInt32Number colorCount = table->GetSize();
 
@@ -1897,7 +1909,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"%s: WARNING - namedColorTable failed validation: %s\n", filename.c_str(), report.c_str() );
+        fprintf(stderr,"%s: WARNING - namedColorTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
       
@@ -1967,7 +1979,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (array->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"%s: WARNING - named color array failed validation: %s\n", filename.c_str(), report.c_str() );
+        fprintf(stderr,"%s: WARNING - named color array failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
 
@@ -2219,8 +2231,8 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
   char buf1[bufSize];
   int outputItems = 0;
 
-  std::string basename = remove_extension( profilePath );
-
+  std::string tmpName = remove_extension( profilePath );
+  std::string basename = icSanitizeFileName( tmpName );
 
 // write next to input file
 // write output to basename + _luts.pdf

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1778,7 +1778,8 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   
   icColorSpaceSignature pcs = pIcc->m_Header.pcs;   // table->GetPCS();
   if (pcs != icSigXYZData && pcs != icSigLabData) {
-    fprintf(stderr,"WARNING - unknown pcs for colors: %s\n",
+    if (pcs != icSigNoColorData)                                // TODO - remove this once we can handle spectral data
+      fprintf(stderr,"WARNING - unknown pcs for colors: %s\n",
                         icGetSig(buf, bufSize, pcs) );
     return 0;
   }
@@ -1948,6 +1949,12 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
               continue;
 
 // TODO - can we easily convert spectra to PCS? Probably not without specifying viewing conditions.
+/*
+CIccPcsXform::pushRef2Xyz
+ CIccPcsXform::pushRad2Xyz
+ CIccPcsXform::pushBiRef2Xyz
+
+ */
             CIccTag *pcsElem = structPtr->FindElem(icSigCinfPcsDataMbr);
             if (!pcsElem)
               continue;


### PR DESCRIPTION
## PR Summary
Add V5 named colors
cleanup error/warning reporting
fix several issues found along the way
Add convex hull code for ongoing work to draw profile gamuts
expand validation reports for tables with wrong counts to be more useful
And started to process responsecurves, but never found a profile that used them.

## Checklist
- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
