### PR TITLE
Visualize silent mode, error logging to string

### DIFF
--- a/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
@@ -70,6 +70,7 @@
 #include <cmath>
 #include "MiniPDF.hpp"
 #include "../IccCmdLineUtil.h"
+#include "errorLog.hpp"
 
 
 /******************************************************************************/
@@ -109,7 +110,7 @@ std::ostream& operator<<( std::ostream &os, const point2D &p )
 void PDFWriter::OpenFile( const std::string &filename, float widthPt, float heightPt )
 {
   if (!m_filename.empty()) {
-    fprintf(stderr,"WARNING - PDF file already open!\n");
+    LogAnError(stderr,"WARNING - PDF file already open!\n");
   }
 
   m_filename = filename;
@@ -179,7 +180,7 @@ void PDFWriter::CloseFile()
           // codeql[cpp/path-injection]
           FILE* outFile = icOpenRegularWriteTextFile(m_filename.c_str());
           if (!WritePdfTextFile(outFile, out.str())) {
-            fprintf(stderr, "PDF writing error in '%s': unable to open regular output file\n", m_filename.c_str());
+            LogAnError(stderr, "PDF writing error in '%s': unable to open regular output file\n", m_filename.c_str());
             m_filename.clear();
             return;
           }
@@ -187,10 +188,10 @@ void PDFWriter::CloseFile()
           m_objects.clear();
         }
         catch (const std::exception& e) {
-          fprintf(stderr, "PDF writing error in '%s': '%s'\n", m_filename.c_str(), e.what() );
+          LogAnError(stderr, "PDF writing error in '%s': '%s'\n", m_filename.c_str(), e.what() );
         }
         catch (...) {
-          fprintf(stderr, "PDF writing error in '%s': unknown exception\n", m_filename.c_str());
+          LogAnError(stderr, "PDF writing error in '%s': unknown exception\n", m_filename.c_str());
         }
     }
     m_filename.clear();
@@ -242,8 +243,8 @@ void PDFWriter::WriteXRefs( std::ostream &out ) {
 
   for( auto &obj : m_objects ) {
     if (obj->m_offset == 0)
-        fprintf(stderr,"WARNING - PDF object referenced but not written yet\n");
-    snprintf( buf, bufSize, "%10.10zu", obj->m_offset );
+        LogAnError(stderr,"WARNING - PDF object referenced but not written yet\n");
+    snprintf( buf, bufSize, "%10.10zu", obj->m_offset );    // must be precisely formatted
     out << buf << " 00000 n \n";  // 20 bytes each, exactly
   }
   out << "\n\n";
@@ -256,7 +257,7 @@ void PDFWriter::WriteFooter( std::ostream &out ) {
   out << "<< /Size " << (m_objects.size()+1) << " /Root 1 0 R>>\n";
   out << "startxref\n";
   if (m_xrefStart == 0)
-    fprintf(stderr,"WARNING - PDF trailer written before xref directory\n");
+    LogAnError(stderr,"WARNING - PDF trailer written before xref directory\n");
   out << m_xrefStart;
   out << "\n%%EOF\n";
 }

--- a/Tools/CmdLine/IccProfileVisualize/MiniSVG.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniSVG.cpp
@@ -69,13 +69,14 @@
 #include <cmath>
 #include "MiniSVG.hpp"
 #include "../IccCmdLineUtil.h"
+#include "errorLog.hpp"
 
 /******************************************************************************/
 
 void SVGOut::OpenFile( const std::string &filename )
 {
   if (!m_filename.empty()) {
-    fprintf(stderr,"WARNING - SVG file already open!\n");
+    LogAnError(stderr,"WARNING - SVG file already open!\n");
   }
   m_GroupLevel = 0;
   m_pageCount = 0;
@@ -95,16 +96,16 @@ void SVGOut::CloseFile()
   }
   
   if (m_GroupLevel > 0)
-    fprintf(stderr,"WARNING - SVG group levels not closed.\n");
+    LogAnError(stderr,"WARNING - SVG group levels not closed.\n");
   if (m_GroupLevel < 0)
-    fprintf(stderr,"WARNING - Too many SVG group levels closed.\n");
+    LogAnError(stderr,"WARNING - Too many SVG group levels closed.\n");
 
   if (!m_filename.empty()) {
     if (m_pageCount > 0) {
       try  {
         FILE* checkFile = icOpenRegularWriteTextFile(m_filename.c_str());
         if (!checkFile || !icFlushAndClose(checkFile)) {
-          fprintf(stderr, "SVG writing error in '%s': unable to open regular output file\n", m_filename.c_str());
+          LogAnError(stderr, "SVG writing error in '%s': unable to open regular output file\n", m_filename.c_str());
           m_filename.clear();
           return;
         }
@@ -118,10 +119,10 @@ void SVGOut::CloseFile()
         out.close();
       }
       catch (const std::exception& e) {
-        fprintf(stderr, "SVG writing error in '%s': '%s'\n", m_filename.c_str(), e.what() );
+        LogAnError(stderr, "SVG writing error in '%s': '%s'\n", m_filename.c_str(), e.what() );
       }
       catch (...) {
-        fprintf(stderr, "SVG writing error in '%s': unknown exception\n", m_filename.c_str());
+        LogAnError(stderr, "SVG writing error in '%s': unknown exception\n", m_filename.c_str());
       }
     }   // if pages > 0
     
@@ -165,7 +166,7 @@ void SVGOut::AddText( const float xCoord, const float yCoord, const std::string 
     else if (align == "right" || align == "Right")
       m_buf << " text-anchor=\"end\"";
     else
-      fprintf(stderr,"WARNING - unknown text alignment %s while exporting SVG\n", align.c_str());
+      LogAnError(stderr,"WARNING - unknown text alignment %s while exporting SVG\n", align.c_str());
     }
 
   float xx = xCoord*mm2point;
@@ -198,7 +199,7 @@ void SVGOut::AddText( const float xCoord, const float yCoord, const std::string 
     else if (style == "Bold Italic")
       m_buf << " font-weight=\"bold\"" << " font-style=\"italic\"";
     else
-      fprintf(stderr,"WARNING - unknown text style %s while exporting SVG\n", style.c_str() );
+      LogAnError(stderr,"WARNING - unknown text style %s while exporting SVG\n", style.c_str() );
     }
 
     m_buf << " font-size=\"" << size << "pt\"";

--- a/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniTIFF.cpp
@@ -74,6 +74,7 @@
 #include <unistd.h>
 #endif
 #include "MiniTIFF.hpp"
+#include "errorLog.hpp"
 
 /******************************************************************************/
 
@@ -215,7 +216,7 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   // see if we can create or update this filename
   outfile = icOpenWriteBinaryFile(name.c_str());
   if(outfile==NULL) {
-    fprintf(stderr,"Could not create output file %s\n", name.c_str());
+    LogAnError(stderr,"Could not create output file %s\n", name.c_str());
     return false;
   }
 
@@ -234,7 +235,7 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
 
   // check for early failure
   if (writeFailed || ferror(outfile)) {
-    fprintf(stderr, "ERROR: I/O error writing TIFF header to %s\n", name.c_str() );
+    LogAnError(stderr, "ERROR: I/O error writing TIFF header to %s\n", name.c_str() );
     fclose(outfile);
     return false;
   }
@@ -301,7 +302,7 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
 
   long byteCountOffset = ftell( outfile );
   if (byteCountOffset < 0) {
-    fprintf(stderr, "ERROR: TIFF ftell failed\n");
+    LogAnError(stderr, "ERROR: TIFF ftell failed\n");
     (void)fclose(outfile);
     return false;
   }
@@ -363,7 +364,7 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   
   // check again after writing the tag directory
   if (writeFailed || ferror(outfile)) {
-    fprintf(stderr, "ERROR: I/O error writing TIFF directory to %s\n", name.c_str() );
+    LogAnError(stderr, "ERROR: I/O error writing TIFF directory to %s\n", name.c_str() );
     fclose(outfile);
     return false;
   }
@@ -390,21 +391,21 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
 
     long stripStart = ftell( outfile );
     if (stripStart < 0 || (unsigned long)stripStart > UINT32_MAX) {
-      fprintf(stderr, "ERROR: TIFF strip offset exceeds 32-bit range\n");
+      LogAnError(stderr, "ERROR: TIFF strip offset exceeds 32-bit range\n");
       fclose(outfile);
       return false;
     }
 
     size_t pixelBytes = (size_t)width * (size_t)channels * (size_t)(depth/8);
     if (fwrite( buffer + offset, pixelBytes, rowCount, outfile ) != rowCount) {
-      fprintf(stderr, "ERROR: TIFF failed to write pixel data\n");
+      LogAnError(stderr, "ERROR: TIFF failed to write pixel data\n");
       fclose(outfile);
       return false;
     }
 
     long stripEnd = ftell( outfile );
     if (stripEnd < 0 || (unsigned long)stripEnd > UINT32_MAX) {
-      fprintf(stderr, "ERROR: TIFF strip end offset exceeds 32-bit range\n");
+      LogAnError(stderr, "ERROR: TIFF strip end offset exceeds 32-bit range\n");
       fclose(outfile);
       return false;
     }
@@ -430,13 +431,13 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   }
 
   if (writeFailed || ferror(outfile)) {
-    fprintf(stderr, "ERROR: I/O error writing TIFF data to %s\n", name.c_str() );
+    LogAnError(stderr, "ERROR: I/O error writing TIFF data to %s\n", name.c_str() );
     fclose(outfile);
     return false;
   }
 
   if (!icFlushAndClose(outfile)) {
-    fprintf(stderr, "ERROR: fclose failed for %s\n", name.c_str() );
+    LogAnError(stderr, "ERROR: fclose failed for %s\n", name.c_str() );
     return false;
   }
 

--- a/Tools/CmdLine/IccProfileVisualize/errorLog.hpp
+++ b/Tools/CmdLine/IccProfileVisualize/errorLog.hpp
@@ -1,0 +1,75 @@
+//
+//  errorLog.hpp
+//
+
+/*
+ * The ICC Software License, Version 0.2
+ *
+ *
+ * Copyright (c) 2003-2026 The International Color Consortium. All rights
+ * reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in
+ *  the documentation and/or other materials provided with the
+ *  distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and "The
+ *  International Color Consortium" must not be used to imply that the
+ *  ICC organization endorses or promotes products derived from this
+ *  software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR
+ * ITS CONTRIBUTING MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the The International Color Consortium.
+ *
+ *
+ * Membership in the ICC is encouraged when this software is used for
+ * commercial purposes.
+ *
+ *
+ * For more information on The International Color Consortium, please
+ * see <http://www.color.org/>.
+ *
+ *
+ */
+
+#ifndef ErrorLog_hpp
+#define ErrorLog_hpp
+
+#include <cstdio>
+#include <cstdarg>
+#include <string>
+
+/******************************************************************************/
+
+void ClearErrorLogs();
+std::string &GetErrorLogs();
+
+void LogAnError(FILE *stream, const char* format, ...);
+
+/******************************************************************************/
+
+
+#endif /* ErrorLog_hpp */

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -119,7 +119,7 @@
 bool gRunSilent = false;
 
 // internal option - should only be used by client code that wants to display errors separately
-bool gLogErrorsToText = false;
+bool gLogErrorsToString = false;
 
 // global storage of accumulated error reports
 // abstracted below because this can easily become more complicated in the future
@@ -152,11 +152,11 @@ void AddErrorStringToLog(const std::string &input)
 
 void LogAnError(FILE *stream, const char* format, ...)
 {
-  if (gLogErrorsToText) {
+  if (gLogErrorsToString) {
     std::va_list args;
     va_start(args, format);
-    size_t bufSize = 4096;      // could also print twice to get size, but this is simpler
-    char buf[bufSize];
+    const size_t bufSize = 4096;      // could also print twice to get size, but this is simpler
+    char buf [ bufSize ];
     auto len = std::vsnprintf(buf, bufSize, format, args);
     if (len > 0)
       AddErrorStringToLog( buf );

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -80,6 +80,7 @@
 #include "MiniSVG.hpp"
 #include "MiniPDF.hpp"
 #include "spectralLocus.hpp"
+#include "errorLog.hpp"
 
 // #define MEMORY_LEAK_CHECK to enable C RTL memory leak checking (slow!)
 #define MEMORY_LEAK_CHECK
@@ -140,6 +141,8 @@ std::string &GetErrorLogs()
 
 /******************************************************************************/
 
+// currently just used by LogAnError, but could be exported if needed
+static
 void AddErrorStringToLog(const std::string &input)
 {
   gErrorLogs += input;
@@ -147,9 +150,7 @@ void AddErrorStringToLog(const std::string &input)
 
 /******************************************************************************/
 
-// this needs to be exported to fileIO code as well!
-
-void ErrorLog(FILE *stream, const char* format, ...)
+void LogAnError(FILE *stream, const char* format, ...)
 {
   if (gLogErrorsToText) {
     std::va_list args;
@@ -1108,7 +1109,7 @@ bool describe1DLUT( CIccTagCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    ErrorLog(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    LogAnError(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "simpleCurve";
     return true;
   }
@@ -1137,7 +1138,7 @@ bool describe1DLUT( CIccTagParametricCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    ErrorLog(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    LogAnError(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "parametric";
     return true;
   }
@@ -1155,7 +1156,7 @@ bool describe1DLUT( CIccTagSegmentedCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    ErrorLog(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    LogAnError(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "segmented";
     return true;
   }
@@ -1173,7 +1174,7 @@ bool describe1DLUT( CIccCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    ErrorLog(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    LogAnError(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "unknown";
     return true;
   }
@@ -1191,7 +1192,7 @@ bool describe3DLUT( CIccMBB *curve, CIccProfile *pIcc, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, pIcc ) > icValidateWarning) {
-    ErrorLog(stderr,"%s: WARNING - 3D table failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    LogAnError(stderr,"%s: WARNING - 3D table failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "MBBLut";
     return true;
   }
@@ -1211,7 +1212,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
   char buf[bufSize];
 
   if (!tag) {
-    ErrorLog(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str() );
+    LogAnError(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str() );
     return 0;
   }
 
@@ -1272,7 +1273,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
       break;
 
     default:
-      ErrorLog(stderr,"%s: Unknown 1D LUT type %s for tag %s\n",
+      LogAnError(stderr,"%s: Unknown 1D LUT type %s for tag %s\n",
          filename.c_str(),
          icGetSig(buf, bufSize, typeSig), sigDesc.c_str() );
       {
@@ -1311,20 +1312,20 @@ int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::stri
   char buf[bufSize];
 
   if (!tag) {
-    ErrorLog(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str());
+    LogAnError(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str());
     return 0;
   }
 
   icTagTypeSignature typeSig = tag->GetType();
   if (typeSig != icSigResponseCurveSet16Type)  {
-    ErrorLog(stderr,"%s: Unknown ResponseCurve type %s for tag %s\n",
+    LogAnError(stderr,"%s: Unknown ResponseCurve type %s for tag %s\n",
          filename.c_str(), icGetSig(buf, bufSize, typeSig), sigDesc.c_str() );
     return 0;
   }
 
   CIccTagResponseCurveSet16 *curves = dynamic_cast<CIccTagResponseCurveSet16*> (tag);
   if (!curves) {
-      ErrorLog(stderr, "%s: Skipping %s: unable to convert response curves\n", filename.c_str(), sigDesc.c_str());
+      LogAnError(stderr, "%s: Skipping %s: unable to convert response curves\n", filename.c_str(), sigDesc.c_str());
       return 0;
   }
   
@@ -1445,7 +1446,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
   int outputCount = 0;
 
   if (!tag) {
-    ErrorLog(stderr, "%s: Skipping %s: unable to load tag\n", basename.c_str(), sigDesc.c_str());
+    LogAnError(stderr, "%s: Skipping %s: unable to load tag\n", basename.c_str(), sigDesc.c_str());
     return 0;
   }
 
@@ -1460,7 +1461,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     {
     CIccMBB *lut = dynamic_cast<CIccMBB*> (tag);
     if (!lut) {
-      ErrorLog(stderr, "%s: Skipping %s: unable to convert LUT\n", basename.c_str(), sigDesc.c_str());
+      LogAnError(stderr, "%s: Skipping %s: unable to convert LUT\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1482,7 +1483,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     bool isInputMatrix = lut->IsInputMatrix();
 
     if (inputChannels <= 0 || outputChannels <= 0) {
-      ErrorLog(stderr, "%s: Skipping %s: invalid channel count\n", basename.c_str(), sigDesc.c_str());
+      LogAnError(stderr, "%s: Skipping %s: invalid channel count\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1530,7 +1531,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       // clut is optional in mAB and mBA tags - only report if it isn't one of those
       if ( !(typeSig == icSigLutAtoBType || typeSig == icSigLutBtoAType) ) {
         std::string typeDesc = icGetSigStr(buf, bufSize, typeSig);
-        ErrorLog(stderr,"%s: ERROR - clut data could not be read for tag '%s' of type '%s'\n",
+        LogAnError(stderr,"%s: ERROR - clut data could not be read for tag '%s' of type '%s'\n",
                 basename.c_str(), sigDesc.c_str(), typeDesc.c_str() );
       }
       return outputCount;
@@ -1542,7 +1543,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     int gridPoints = clut->GridPoints(); // gridSize[0]
     int tiles = gridPoints;
     if (gridPoints <= 0) {
-      ErrorLog(stderr, "%s: Skipping %s: invalid CLUT grid\n", basename.c_str(), sigDesc.c_str());
+      LogAnError(stderr, "%s: Skipping %s: invalid CLUT grid\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1552,7 +1553,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     if (inputChannels >= 2) {
       tileWidth = clut->GridPoint(1);
       if (tileWidth <= 0) {
-        ErrorLog(stderr, "%s: Skipping %s: invalid CLUT width\n", basename.c_str(), sigDesc.c_str());
+        LogAnError(stderr, "%s: Skipping %s: invalid CLUT width\n", basename.c_str(), sigDesc.c_str());
         return outputCount;
       }
     }
@@ -1560,7 +1561,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     if (inputChannels >= 3) {
       tileHeight = clut->GridPoint(2);
       if (tileHeight <= 0) {
-        ErrorLog(stderr, "%s: Skipping %s: invalid CLUT height\n", basename.c_str(), sigDesc.c_str());
+        LogAnError(stderr, "%s: Skipping %s: invalid CLUT height\n", basename.c_str(), sigDesc.c_str());
         return outputCount;
       }
     }
@@ -1569,7 +1570,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       for (int i = 3; i < inputChannels; ++i) {
         int extraGridPoints = clut->GridPoint(i);
         if (extraGridPoints <= 0) {
-          ErrorLog(stderr, "%s: Skipping %s: invalid CLUT tile count\n", basename.c_str(), sigDesc.c_str());
+          LogAnError(stderr, "%s: Skipping %s: invalid CLUT tile count\n", basename.c_str(), sigDesc.c_str());
           return outputCount;
         }
         tiles *= extraGridPoints;
@@ -1591,13 +1592,13 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
 
       // find tile arrangement closest to a square
     if (tiles <= 0) {
-      ErrorLog(stderr,"%s: WARNING - tile count overflow.\n", basename.c_str() );
+      LogAnError(stderr,"%s: WARNING - tile count overflow.\n", basename.c_str() );
       tiles = 1;
     }
 
     auto tempResult = std::sqrt(tiles);
     if (tempResult > std::numeric_limits<int>::max()) {
-      ErrorLog(stderr,"%s: ERROR - sqrt bad result!\n", basename.c_str() );
+      LogAnError(stderr,"%s: ERROR - sqrt bad result!\n", basename.c_str() );
       tempResult = tiles/2;
     }
     int tilesWide = (int)tempResult;
@@ -1619,7 +1620,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     int imageWidth = tilesWide * tileWidth;
     int imageHeight = tilesHigh * tileHeight;
     if (imageWidth <= 0 || imageHeight <= 0 || bytes <= 0) {
-      ErrorLog(stderr, "%s: Skipping %s: invalid image geometry\n", basename.c_str(), sigDesc.c_str());
+      LogAnError(stderr, "%s: Skipping %s: invalid image geometry\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1627,7 +1628,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     size_t bufferSize = (size_t)imageWidth * (size_t)imageHeight * (size_t)outputChannels * bytes;
     // NOTE that bufferSize will usually be greater than clutSize
     if (!bufferSize) {
-      ErrorLog(stderr, "%s: Skipping %s: empty image buffer\n", basename.c_str(), sigDesc.c_str());
+      LogAnError(stderr, "%s: Skipping %s: empty image buffer\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1700,7 +1701,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       int tiffColor = TIFFColorModelFromICCModel( outputSpace );
       if (!WriteTIFF( tiffPath2.c_str(), 100, tiffColor, imageBuf,
                         imageWidth, imageHeight, outputChannels, 8*bytes )) {
-        ErrorLog(stderr, "%s: Failed to write TIFF: %s\n", basename.c_str(), tiffPath2.c_str());
+        LogAnError(stderr, "%s: Failed to write TIFF: %s\n", basename.c_str(), tiffPath2.c_str());
       }
     }
     return ++outputCount;
@@ -1711,7 +1712,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     break;
 
   default:
-    ErrorLog(stderr,"%s: Unknown nD LUT type %s for tag %s\n",
+    LogAnError(stderr,"%s: Unknown nD LUT type %s for tag %s\n",
          basename.c_str(),
          icGetSig(buf, bufSize, typeSig),
          sigDesc.c_str() );
@@ -1890,7 +1891,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   int outputCount = 0;
 
   if (!tag) {
-    ErrorLog(stderr, "%s: Skipping %s: unable to load tag\n", filename.c_str(), sigDesc.c_str());
+    LogAnError(stderr, "%s: Skipping %s: unable to load tag\n", filename.c_str(), sigDesc.c_str());
     return 0;
   }
 
@@ -1902,7 +1903,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   icColorSpaceSignature pcs = pIcc->m_Header.pcs;   // table->GetPCS();
   if (pcs != icSigXYZData && pcs != icSigLabData) {
     if (pcs != icSigNoColorData)                                // TODO - remove this once we can handle spectral data
-      ErrorLog(stderr,"%s: WARNING - unknown pcs for colors: %s\n",
+      LogAnError(stderr,"%s: WARNING - unknown pcs for colors: %s\n",
                         filename.c_str(), icGetSig(buf, bufSize, pcs) );
     return 0;
   }
@@ -1914,7 +1915,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagColorantTable *table = dynamic_cast<CIccTagColorantTable*> (tag);
       if (!table) {
-        ErrorLog(stderr, "%s: Skipping %s: unable to convert colorantTable\n", filename.c_str(), sigDesc.c_str());
+        LogAnError(stderr, "%s: Skipping %s: unable to convert colorantTable\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
 
@@ -1922,7 +1923,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
-        ErrorLog(stderr,"%s: WARNING - colorantTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
+        LogAnError(stderr,"%s: WARNING - colorantTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
 
@@ -1972,7 +1973,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagNamedColor2 *table = dynamic_cast<CIccTagNamedColor2*> (tag);
       if (!table) {
-        ErrorLog(stderr, "%s: Skipping %s: unable to convert namedColorTable\n", filename.c_str(), sigDesc.c_str());
+        LogAnError(stderr, "%s: Skipping %s: unable to convert namedColorTable\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
 
@@ -1980,13 +1981,13 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
-        ErrorLog(stderr,"%s: WARNING - namedColorTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
+        LogAnError(stderr,"%s: WARNING - namedColorTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
       
       icColorSpaceSignature table_pcs = table->GetPCS();
       if (pcs != table_pcs) {
-        ErrorLog(stderr,"%s: WARNING - bad pcs for namedColorTable: %s\n",
+        LogAnError(stderr,"%s: WARNING - bad pcs for namedColorTable: %s\n",
                             filename.c_str(), icGetSig(buf, bufSize, pcs) );
         return 0;
       }
@@ -2032,14 +2033,14 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagArray *array = dynamic_cast<CIccTagArray*> (tag);
       if (!array) {
-        ErrorLog(stderr, "%s: Skipping %s: unable to convert named color array\n", filename.c_str(), sigDesc.c_str());
+        LogAnError(stderr, "%s: Skipping %s: unable to convert named color array\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
       
       icArraySignature arrayType = array->GetTagArrayType();
       if (arrayType != icSigColorantInfoArray
         && arrayType != icSigNamedColorArray) {
-        ErrorLog(stderr,"%s: WARNING - unknown color array type: %s for tag %s\n",
+        LogAnError(stderr,"%s: WARNING - unknown color array type: %s for tag %s\n",
                         filename.c_str(),
                         icGetSig(buf, bufSize, arrayType),
                         sigDesc.c_str() );
@@ -2050,7 +2051,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (array->Validate(path, report, NULL) > icValidateWarning) {
-        ErrorLog(stderr,"%s: WARNING - named color array failed validation:\n%s\n", filename.c_str(), report.c_str() );
+        LogAnError(stderr,"%s: WARNING - named color array failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
 
@@ -2129,7 +2130,7 @@ CIccPcsXform::pushRef2Xyz
                 break;
             
               default:
-                ErrorLog(stderr,"%s: Unknown named color struct data type %s for tag %s\n",
+                LogAnError(stderr,"%s: Unknown named color struct data type %s for tag %s\n",
                         filename.c_str(),
                         icGetSig(buf, bufSize, pcsDataType),
                         sigDesc.c_str() );
@@ -2188,7 +2189,7 @@ CIccPcsXform::pushRef2Xyz
                   break;
                 
                 default:
-                  ErrorLog(stderr,"%s: Unknown named color struct name type %s for tag %s\n",
+                  LogAnError(stderr,"%s: Unknown named color struct name type %s for tag %s\n",
                         filename.c_str(),
                         icGetSig(buf, bufSize, nameDataType),
                         sigDesc.c_str() );
@@ -2229,7 +2230,7 @@ CIccPcsXform::pushRef2Xyz
                     break;
                 
                   default:
-                    ErrorLog(stderr,"%s: Unknown named color tint data type %s for tag %s\n",
+                    LogAnError(stderr,"%s: Unknown named color tint data type %s for tag %s\n",
                             filename.c_str(),
                             icGetSig(buf, bufSize, tintDataType),
                             sigDesc.c_str() );
@@ -2246,7 +2247,7 @@ CIccPcsXform::pushRef2Xyz
             break;
         
           default:
-            ErrorLog(stderr,"%s: Unknown named color struct %s for tag %s\n",
+            LogAnError(stderr,"%s: Unknown named color struct %s for tag %s\n",
                     filename.c_str(),
                     icGetSig(buf, bufSize, structType),
                     sigDesc.c_str() );
@@ -2266,7 +2267,7 @@ CIccPcsXform::pushRef2Xyz
       break;
 
     default:
-      ErrorLog(stderr,"%s: Unknown named color type %s for tag %s\n",
+      LogAnError(stderr,"%s: Unknown named color type %s for tag %s\n",
          filename.c_str(),
          icGetSig(buf, bufSize, typeSig),
          sigDesc.c_str() );
@@ -2500,23 +2501,23 @@ int main(int argc, char* argv[])
       
       CIccProfile *pIcc = OpenIccProfile( file.c_str() );
       if (!pIcc) {
-        ErrorLog(stderr,"Unable to parse '%s' as ICC profile!\n", file.c_str() );
+        LogAnError(stderr,"Unable to parse '%s' as ICC profile!\n", file.c_str() );
         continue;
       }
 
       // DEBUGGING printf("Processing profile '%s'\n", argv[k]);
       auto count = processLuts( pIcc, file );
       if (!count) {
-        ErrorLog(stderr,"Profile %s had no content for output\n", file.c_str()  );
+        LogAnError(stderr,"Profile %s had no content for output\n", file.c_str()  );
       }
 
       delete pIcc;
     }   // end try
     catch (const std::exception& e) {
-      ErrorLog(stderr, "%s: ERROR exception: '%s'\n", file.c_str() , e.what() );
+      LogAnError(stderr, "%s: ERROR exception: '%s'\n", file.c_str() , e.what() );
     }
     catch (...) {
-      ErrorLog(stderr, "%s: ERROR: unknown exception\n", file.c_str()  );
+      LogAnError(stderr, "%s: ERROR: unknown exception\n", file.c_str()  );
     }
     
     // NOTE - consume error logs here if needed, so exceptions are included

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -61,7 +61,6 @@
  *
  */
 
-
 #include <cstdio>
 #include <cstdarg>
 #include <iostream>
@@ -115,20 +114,66 @@
 
 /******************************************************************************/
 
+// command line option
 bool gRunSilent = false;
+
+// internal option - should only be used by client code that wants to display errors separately
+bool gLogErrorsToText = false;
+
+// global storage of accumulated error reports
+// abstracted because this can easily become more complicated in the future
+std::string gErrorLogs;
 
 typedef std::vector<std::string> filename_list;
 
 /******************************************************************************/
 
-// NOTE - this could also have a mode to dump to a text stream for PDF output
-// that would need a reset and final function, plus global storage of the text
+static
+void ClearErrorLogs()
+{
+  gErrorLogs.clear();
+}
+
+/******************************************************************************/
+
+static
+std::string GetErrorLogs()
+{
+  return gErrorLogs;
+}
+
+/******************************************************************************/
+
+static
+void AddErrorString(const std::string &input)
+{
+  gErrorLogs += input;
+}
+
+/******************************************************************************/
+
 static
 void ErrorLog(FILE *stream, const char* format, ...)
 {
+  if (gLogErrorsToText) {
+    std::va_list args;
+    va_start(args, format);
+    size_t bufSize = 4096;      // could also print twice to get size, but this is simpler
+    char buf[bufSize];
+    auto len = std::vsnprintf(buf, bufSize, format, args);
+    if (len > 0)
+      AddErrorString( buf );
+    else
+      AddErrorString( "Error while formatting: " + std::string(format) );
+    va_end(args);
+    return;
+  }
+
+  // are we running silent (but not deep)?
   if (gRunSilent)
     return;
 
+  // else normal output
   std::va_list args;
   va_start(args, format);
   (void)std::vfprintf(stream, format, args);
@@ -2453,6 +2498,8 @@ int main(int argc, char* argv[])
 
   for (auto &file : files) {
     try {
+      ClearErrorLogs();
+      
       CIccProfile *pIcc = OpenIccProfile( file.c_str() );
       if (!pIcc) {
         ErrorLog(stderr,"Unable to parse '%s' as ICC profile!\n", file.c_str() );
@@ -2473,6 +2520,8 @@ int main(int argc, char* argv[])
     catch (...) {
       ErrorLog(stderr, "%s: ERROR: unknown exception\n", file.c_str()  );
     }
+    
+    // consume error logs here if needed
 
   } // end for argc
 

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -114,21 +114,18 @@
 
 /******************************************************************************/
 
-// command line option
+// command line option to disable warning and error reports
 bool gRunSilent = false;
 
 // internal option - should only be used by client code that wants to display errors separately
 bool gLogErrorsToText = false;
 
 // global storage of accumulated error reports
-// abstracted because this can easily become more complicated in the future
+// abstracted below because this can easily become more complicated in the future
 std::string gErrorLogs;
-
-typedef std::vector<std::string> filename_list;
 
 /******************************************************************************/
 
-static
 void ClearErrorLogs()
 {
   gErrorLogs.clear();
@@ -136,23 +133,22 @@ void ClearErrorLogs()
 
 /******************************************************************************/
 
-static
-std::string GetErrorLogs()
+std::string &GetErrorLogs()
 {
   return gErrorLogs;
 }
 
 /******************************************************************************/
 
-static
-void AddErrorString(const std::string &input)
+void AddErrorStringToLog(const std::string &input)
 {
   gErrorLogs += input;
 }
 
 /******************************************************************************/
 
-static
+// this needs to be exported to fileIO code as well!
+
 void ErrorLog(FILE *stream, const char* format, ...)
 {
   if (gLogErrorsToText) {
@@ -162,9 +158,9 @@ void ErrorLog(FILE *stream, const char* format, ...)
     char buf[bufSize];
     auto len = std::vsnprintf(buf, bufSize, format, args);
     if (len > 0)
-      AddErrorString( buf );
+      AddErrorStringToLog( buf );
     else
-      AddErrorString( "Error while formatting: " + std::string(format) );
+      AddErrorStringToLog( "Internal buffer error while formatting: \"" + std::string(format) + "\"\n" );
     va_end(args);
     return;
   }
@@ -2433,6 +2429,8 @@ void printUsage(void)
 
 /******************************************************************************/
 
+typedef std::vector<std::string> filename_list;
+
 static
 filename_list parse_arguments( int argc, char *argv[] )
 {
@@ -2521,7 +2519,7 @@ int main(int argc, char* argv[])
       ErrorLog(stderr, "%s: ERROR: unknown exception\n", file.c_str()  );
     }
     
-    // consume error logs here if needed
+    // NOTE - consume error logs here if needed, so exceptions are included
 
   } // end for argc
 

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -63,6 +63,7 @@
 
 
 #include <cstdio>
+#include <cstdarg>
 #include <iostream>
 #include <fstream>
 #include <cstring>
@@ -90,6 +91,11 @@
 #include <mcheck.h>
 #endif
 
+#ifdef _WIN32
+// work around Windows non-standard headers
+  #define strcasecmp _stricmp
+#endif
+
 /******************************************************************************/
 
 // NOTE - ccox - multipage SVG doesn't work, but we may want to use SVG for UI drawing.
@@ -106,6 +112,28 @@
 #ifndef M_PI
 #define M_PI  3.14159265358979323846264338327950288
 #endif
+
+/******************************************************************************/
+
+bool gRunSilent = false;
+
+typedef std::vector<std::string> filename_list;
+
+/******************************************************************************/
+
+// NOTE - this could also have a mode to dump to a text stream for PDF output
+// that would need a reset and final function, plus global storage of the text
+static
+void ErrorLog(FILE *stream, const char* format, ...)
+{
+  if (gRunSilent)
+    return;
+
+  std::va_list args;
+  va_start(args, format);
+  (void)std::vfprintf(stream, format, args);
+  va_end(args);
+}
 
 /******************************************************************************/
 
@@ -1039,7 +1067,7 @@ bool describe1DLUT( CIccTagCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    ErrorLog(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "simpleCurve";
     return true;
   }
@@ -1068,7 +1096,7 @@ bool describe1DLUT( CIccTagParametricCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    ErrorLog(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "parametric";
     return true;
   }
@@ -1086,7 +1114,7 @@ bool describe1DLUT( CIccTagSegmentedCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    ErrorLog(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "segmented";
     return true;
   }
@@ -1104,7 +1132,7 @@ bool describe1DLUT( CIccCurve *curve, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, NULL) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    ErrorLog(stderr,"%s: WARNING - curve failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "unknown";
     return true;
   }
@@ -1122,7 +1150,7 @@ bool describe3DLUT( CIccMBB *curve, CIccProfile *pIcc, std::string &description,
   path += sigDesc;
   std::string report;
   if (curve->Validate(path, report, pIcc ) > icValidateWarning) {
-    fprintf(stderr,"%s: WARNING - 3D table failed validation:\n%s\n", filename.c_str(), report.c_str() );
+    ErrorLog(stderr,"%s: WARNING - 3D table failed validation:\n%s\n", filename.c_str(), report.c_str() );
     description = "MBBLut";
     return true;
   }
@@ -1142,7 +1170,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
   char buf[bufSize];
 
   if (!tag) {
-    fprintf(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str() );
+    ErrorLog(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str() );
     return 0;
   }
 
@@ -1203,7 +1231,7 @@ int output1DLUT(CIccProfile * /* pIcc */, CIccTag *tag, const std::string &sigDe
       break;
 
     default:
-      fprintf(stderr,"%s: Unknown 1D LUT type %s for tag %s\n",
+      ErrorLog(stderr,"%s: Unknown 1D LUT type %s for tag %s\n",
          filename.c_str(),
          icGetSig(buf, bufSize, typeSig), sigDesc.c_str() );
       {
@@ -1242,20 +1270,20 @@ int outputResponseCurves(CIccProfile * /* pIcc */, CIccTag *tag, const std::stri
   char buf[bufSize];
 
   if (!tag) {
-    fprintf(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str());
+    ErrorLog(stderr, "%s: ERROR - missing data for %s\n", filename.c_str(), sigDesc.c_str());
     return 0;
   }
 
   icTagTypeSignature typeSig = tag->GetType();
   if (typeSig != icSigResponseCurveSet16Type)  {
-    fprintf(stderr,"%s: Unknown ResponseCurve type %s for tag %s\n",
+    ErrorLog(stderr,"%s: Unknown ResponseCurve type %s for tag %s\n",
          filename.c_str(), icGetSig(buf, bufSize, typeSig), sigDesc.c_str() );
     return 0;
   }
 
   CIccTagResponseCurveSet16 *curves = dynamic_cast<CIccTagResponseCurveSet16*> (tag);
   if (!curves) {
-      fprintf(stderr, "%s: Skipping %s: unable to convert response curves\n", filename.c_str(), sigDesc.c_str());
+      ErrorLog(stderr, "%s: Skipping %s: unable to convert response curves\n", filename.c_str(), sigDesc.c_str());
       return 0;
   }
   
@@ -1376,7 +1404,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
   int outputCount = 0;
 
   if (!tag) {
-    fprintf(stderr, "%s: Skipping %s: unable to load tag\n", basename.c_str(), sigDesc.c_str());
+    ErrorLog(stderr, "%s: Skipping %s: unable to load tag\n", basename.c_str(), sigDesc.c_str());
     return 0;
   }
 
@@ -1391,7 +1419,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     {
     CIccMBB *lut = dynamic_cast<CIccMBB*> (tag);
     if (!lut) {
-      fprintf(stderr, "%s: Skipping %s: unable to convert LUT\n", basename.c_str(), sigDesc.c_str());
+      ErrorLog(stderr, "%s: Skipping %s: unable to convert LUT\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1413,7 +1441,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     bool isInputMatrix = lut->IsInputMatrix();
 
     if (inputChannels <= 0 || outputChannels <= 0) {
-      fprintf(stderr, "%s: Skipping %s: invalid channel count\n", basename.c_str(), sigDesc.c_str());
+      ErrorLog(stderr, "%s: Skipping %s: invalid channel count\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1461,7 +1489,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       // clut is optional in mAB and mBA tags - only report if it isn't one of those
       if ( !(typeSig == icSigLutAtoBType || typeSig == icSigLutBtoAType) ) {
         std::string typeDesc = icGetSigStr(buf, bufSize, typeSig);
-        fprintf(stderr,"%s: ERROR - clut data could not be read for tag '%s' of type '%s'\n",
+        ErrorLog(stderr,"%s: ERROR - clut data could not be read for tag '%s' of type '%s'\n",
                 basename.c_str(), sigDesc.c_str(), typeDesc.c_str() );
       }
       return outputCount;
@@ -1473,7 +1501,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     int gridPoints = clut->GridPoints(); // gridSize[0]
     int tiles = gridPoints;
     if (gridPoints <= 0) {
-      fprintf(stderr, "%s: Skipping %s: invalid CLUT grid\n", basename.c_str(), sigDesc.c_str());
+      ErrorLog(stderr, "%s: Skipping %s: invalid CLUT grid\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1483,7 +1511,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     if (inputChannels >= 2) {
       tileWidth = clut->GridPoint(1);
       if (tileWidth <= 0) {
-        fprintf(stderr, "%s: Skipping %s: invalid CLUT width\n", basename.c_str(), sigDesc.c_str());
+        ErrorLog(stderr, "%s: Skipping %s: invalid CLUT width\n", basename.c_str(), sigDesc.c_str());
         return outputCount;
       }
     }
@@ -1491,7 +1519,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     if (inputChannels >= 3) {
       tileHeight = clut->GridPoint(2);
       if (tileHeight <= 0) {
-        fprintf(stderr, "%s: Skipping %s: invalid CLUT height\n", basename.c_str(), sigDesc.c_str());
+        ErrorLog(stderr, "%s: Skipping %s: invalid CLUT height\n", basename.c_str(), sigDesc.c_str());
         return outputCount;
       }
     }
@@ -1500,7 +1528,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       for (int i = 3; i < inputChannels; ++i) {
         int extraGridPoints = clut->GridPoint(i);
         if (extraGridPoints <= 0) {
-          fprintf(stderr, "%s: Skipping %s: invalid CLUT tile count\n", basename.c_str(), sigDesc.c_str());
+          ErrorLog(stderr, "%s: Skipping %s: invalid CLUT tile count\n", basename.c_str(), sigDesc.c_str());
           return outputCount;
         }
         tiles *= extraGridPoints;
@@ -1522,13 +1550,13 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
 
       // find tile arrangement closest to a square
     if (tiles <= 0) {
-      fprintf(stderr,"%s: WARNING - tile count overflow.\n", basename.c_str() );
+      ErrorLog(stderr,"%s: WARNING - tile count overflow.\n", basename.c_str() );
       tiles = 1;
     }
 
     auto tempResult = std::sqrt(tiles);
     if (tempResult > std::numeric_limits<int>::max()) {
-      fprintf(stderr,"%s: ERROR - sqrt bad result!\n", basename.c_str() );
+      ErrorLog(stderr,"%s: ERROR - sqrt bad result!\n", basename.c_str() );
       tempResult = tiles/2;
     }
     int tilesWide = (int)tempResult;
@@ -1550,7 +1578,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     int imageWidth = tilesWide * tileWidth;
     int imageHeight = tilesHigh * tileHeight;
     if (imageWidth <= 0 || imageHeight <= 0 || bytes <= 0) {
-      fprintf(stderr, "%s: Skipping %s: invalid image geometry\n", basename.c_str(), sigDesc.c_str());
+      ErrorLog(stderr, "%s: Skipping %s: invalid image geometry\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1558,7 +1586,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     size_t bufferSize = (size_t)imageWidth * (size_t)imageHeight * (size_t)outputChannels * bytes;
     // NOTE that bufferSize will usually be greater than clutSize
     if (!bufferSize) {
-      fprintf(stderr, "%s: Skipping %s: empty image buffer\n", basename.c_str(), sigDesc.c_str());
+      ErrorLog(stderr, "%s: Skipping %s: empty image buffer\n", basename.c_str(), sigDesc.c_str());
       return outputCount;
     }
 
@@ -1631,7 +1659,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
       int tiffColor = TIFFColorModelFromICCModel( outputSpace );
       if (!WriteTIFF( tiffPath2.c_str(), 100, tiffColor, imageBuf,
                         imageWidth, imageHeight, outputChannels, 8*bytes )) {
-        fprintf(stderr, "%s: Failed to write TIFF: %s\n", basename.c_str(), tiffPath2.c_str());
+        ErrorLog(stderr, "%s: Failed to write TIFF: %s\n", basename.c_str(), tiffPath2.c_str());
       }
     }
     return ++outputCount;
@@ -1642,7 +1670,7 @@ int output3DLUT( CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     break;
 
   default:
-    fprintf(stderr,"%s: Unknown nD LUT type %s for tag %s\n",
+    ErrorLog(stderr,"%s: Unknown nD LUT type %s for tag %s\n",
          basename.c_str(),
          icGetSig(buf, bufSize, typeSig),
          sigDesc.c_str() );
@@ -1821,7 +1849,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   int outputCount = 0;
 
   if (!tag) {
-    fprintf(stderr, "%s: Skipping %s: unable to load tag\n", filename.c_str(), sigDesc.c_str());
+    ErrorLog(stderr, "%s: Skipping %s: unable to load tag\n", filename.c_str(), sigDesc.c_str());
     return 0;
   }
 
@@ -1833,7 +1861,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
   icColorSpaceSignature pcs = pIcc->m_Header.pcs;   // table->GetPCS();
   if (pcs != icSigXYZData && pcs != icSigLabData) {
     if (pcs != icSigNoColorData)                                // TODO - remove this once we can handle spectral data
-      fprintf(stderr,"%s: WARNING - unknown pcs for colors: %s\n",
+      ErrorLog(stderr,"%s: WARNING - unknown pcs for colors: %s\n",
                         filename.c_str(), icGetSig(buf, bufSize, pcs) );
     return 0;
   }
@@ -1845,7 +1873,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagColorantTable *table = dynamic_cast<CIccTagColorantTable*> (tag);
       if (!table) {
-        fprintf(stderr, "%s: Skipping %s: unable to convert colorantTable\n", filename.c_str(), sigDesc.c_str());
+        ErrorLog(stderr, "%s: Skipping %s: unable to convert colorantTable\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
 
@@ -1853,7 +1881,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"%s: WARNING - colorantTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
+        ErrorLog(stderr,"%s: WARNING - colorantTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
 
@@ -1903,7 +1931,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagNamedColor2 *table = dynamic_cast<CIccTagNamedColor2*> (tag);
       if (!table) {
-        fprintf(stderr, "%s: Skipping %s: unable to convert namedColorTable\n", filename.c_str(), sigDesc.c_str());
+        ErrorLog(stderr, "%s: Skipping %s: unable to convert namedColorTable\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
 
@@ -1911,13 +1939,13 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (table->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"%s: WARNING - namedColorTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
+        ErrorLog(stderr,"%s: WARNING - namedColorTable failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
       
       icColorSpaceSignature table_pcs = table->GetPCS();
       if (pcs != table_pcs) {
-        fprintf(stderr,"%s: WARNING - bad pcs for namedColorTable: %s\n",
+        ErrorLog(stderr,"%s: WARNING - bad pcs for namedColorTable: %s\n",
                             filename.c_str(), icGetSig(buf, bufSize, pcs) );
         return 0;
       }
@@ -1963,14 +1991,14 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       {
       CIccTagArray *array = dynamic_cast<CIccTagArray*> (tag);
       if (!array) {
-        fprintf(stderr, "%s: Skipping %s: unable to convert named color array\n", filename.c_str(), sigDesc.c_str());
+        ErrorLog(stderr, "%s: Skipping %s: unable to convert named color array\n", filename.c_str(), sigDesc.c_str());
         return 0;
       }
       
       icArraySignature arrayType = array->GetTagArrayType();
       if (arrayType != icSigColorantInfoArray
         && arrayType != icSigNamedColorArray) {
-        fprintf(stderr,"%s: WARNING - unknown color array type: %s for tag %s\n",
+        ErrorLog(stderr,"%s: WARNING - unknown color array type: %s for tag %s\n",
                         filename.c_str(),
                         icGetSig(buf, bufSize, arrayType),
                         sigDesc.c_str() );
@@ -1981,7 +2009,7 @@ int outputNamedColors(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDes
       path += sigDesc;
       std::string report;
       if (array->Validate(path, report, NULL) > icValidateWarning) {
-        fprintf(stderr,"%s: WARNING - named color array failed validation:\n%s\n", filename.c_str(), report.c_str() );
+        ErrorLog(stderr,"%s: WARNING - named color array failed validation:\n%s\n", filename.c_str(), report.c_str() );
         return 0;
       }
 
@@ -2060,7 +2088,7 @@ CIccPcsXform::pushRef2Xyz
                 break;
             
               default:
-                fprintf(stderr,"%s: Unknown named color struct data type %s for tag %s\n",
+                ErrorLog(stderr,"%s: Unknown named color struct data type %s for tag %s\n",
                         filename.c_str(),
                         icGetSig(buf, bufSize, pcsDataType),
                         sigDesc.c_str() );
@@ -2119,7 +2147,7 @@ CIccPcsXform::pushRef2Xyz
                   break;
                 
                 default:
-                  fprintf(stderr,"%s: Unknown named color struct name type %s for tag %s\n",
+                  ErrorLog(stderr,"%s: Unknown named color struct name type %s for tag %s\n",
                         filename.c_str(),
                         icGetSig(buf, bufSize, nameDataType),
                         sigDesc.c_str() );
@@ -2160,7 +2188,7 @@ CIccPcsXform::pushRef2Xyz
                     break;
                 
                   default:
-                    fprintf(stderr,"%s: Unknown named color tint data type %s for tag %s\n",
+                    ErrorLog(stderr,"%s: Unknown named color tint data type %s for tag %s\n",
                             filename.c_str(),
                             icGetSig(buf, bufSize, tintDataType),
                             sigDesc.c_str() );
@@ -2177,16 +2205,12 @@ CIccPcsXform::pushRef2Xyz
             break;
         
           default:
-            fprintf(stderr,"%s: Unknown named color struct %s for tag %s\n",
+            ErrorLog(stderr,"%s: Unknown named color struct %s for tag %s\n",
                     filename.c_str(),
                     icGetSig(buf, bufSize, structType),
                     sigDesc.c_str() );
             break;
         } // end switch struct type
-        
-        // extract name and PCS value from this struct
-        // if no PCS, bail
-        
         
       } // end loop over items in array
 
@@ -2201,7 +2225,7 @@ CIccPcsXform::pushRef2Xyz
       break;
 
     default:
-      fprintf(stderr,"%s: Unknown named color type %s for tag %s\n",
+      ErrorLog(stderr,"%s: Unknown named color type %s for tag %s\n",
          filename.c_str(),
          icGetSig(buf, bufSize, typeSig),
          sigDesc.c_str() );
@@ -2228,7 +2252,7 @@ std::string remove_extension( const std::string& filename)
 
 // output graphic representation of 1D and nD LUTs
 static
-int processLuts(CIccProfile *pIcc, const char *profilePath )
+int processLuts(CIccProfile *pIcc, const std::string &profilePath )
 {
   const size_t bufSize = 64;
   char buf1[bufSize];
@@ -2356,9 +2380,46 @@ int processLuts(CIccProfile *pIcc, const char *profilePath )
 static
 void printUsage(void)
 {
-  printf("Usage: iccProfileVisualize input_profiles\n");
+  printf("Usage: iccProfileVisualize <args> input_profiles\n");
+  printf("\t-silent         don't output any warnings or errors.\n");
   printf("  output will be TIFF and PDF files next to each input profile.\n");
   printf("iccProfileVisualize built with IccProfLib version " ICCPROFLIBVER "\n\n");
+}
+
+/******************************************************************************/
+
+static
+filename_list parse_arguments( int argc, char *argv[] )
+{
+  filename_list filenames;
+
+  for ( int c = 1; c < argc; ++c ) {
+
+    if ( (strcasecmp( argv[c], "-silent" ) == 0 ) ) {
+      gRunSilent = true;
+    }
+    else if ( strcasecmp( argv[c], "-V" ) == 0
+            || strcasecmp( argv[c], "--V" ) == 0
+            || strcasecmp( argv[c], "-help" ) == 0
+            || strcasecmp( argv[c], "--help" ) == 0
+            || strcasecmp( argv[c], "-version" ) == 0
+            ) {
+      printUsage();
+      exit (0);
+    }
+    else if (argv[c][0] == '-') {
+      // unrecognized switch
+      printUsage();
+      exit (1);
+    }
+    else {
+      // not a switch, treat it as a json input file
+      filenames.push_back( argv[c] );
+    }
+
+  } // end loop over arguments
+
+  return filenames;
 }
 
 /******************************************************************************/
@@ -2388,29 +2449,29 @@ int main(int argc, char* argv[])
     return 0;
   }
 
-// if we need options in the future, then parse -* and add all unknowns to a list of filenames
+  filename_list files = parse_arguments(argc,argv);
 
-  for (int k = 1; k < argc; ++k) {
+  for (auto &file : files) {
     try {
-      CIccProfile *pIcc = OpenIccProfile( argv[k] );
+      CIccProfile *pIcc = OpenIccProfile( file.c_str() );
       if (!pIcc) {
-        fprintf(stderr,"Unable to parse '%s' as ICC profile!\n", argv[k]);
+        ErrorLog(stderr,"Unable to parse '%s' as ICC profile!\n", file.c_str() );
         continue;
       }
 
       // DEBUGGING printf("Processing profile '%s'\n", argv[k]);
-      auto count = processLuts( pIcc, argv[k] );
+      auto count = processLuts( pIcc, file );
       if (!count) {
-        fprintf(stderr,"Profile %s had no content for output\n", argv[k] );
+        ErrorLog(stderr,"Profile %s had no content for output\n", file.c_str()  );
       }
 
       delete pIcc;
     }   // end try
     catch (const std::exception& e) {
-      fprintf(stderr, "%s: ERROR exception: '%s'\n", argv[k], e.what() );
+      ErrorLog(stderr, "%s: ERROR exception: '%s'\n", file.c_str() , e.what() );
     }
     catch (...) {
-      fprintf(stderr, "%s: ERROR: unknown exception\n", argv[k] );
+      ErrorLog(stderr, "%s: ERROR: unknown exception\n", file.c_str()  );
     }
 
   } // end for argc

--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -152,29 +152,35 @@ void AddErrorStringToLog(const std::string &input)
 
 void LogAnError(FILE *stream, const char* format, ...)
 {
-  if (gLogErrorsToString) {
+  try {
+    if (gLogErrorsToString) {
+      std::va_list args;
+      va_start(args, format);
+      const size_t bufSize = 4096;      // could also print twice to get size, but this is simpler
+      char buf [ bufSize ];
+      auto len = std::vsnprintf(buf, bufSize, format, args);
+      if (len > 0)
+        AddErrorStringToLog( buf );
+      else
+        AddErrorStringToLog( "Internal buffer error while formatting: \"" + std::string(format) + "\"\n" );
+      va_end(args);
+      return;
+    }
+
+    // are we running silent (but not deep)?
+    if (gRunSilent)
+      return;
+
+    // else normal output
     std::va_list args;
     va_start(args, format);
-    const size_t bufSize = 4096;      // could also print twice to get size, but this is simpler
-    char buf [ bufSize ];
-    auto len = std::vsnprintf(buf, bufSize, format, args);
-    if (len > 0)
-      AddErrorStringToLog( buf );
-    else
-      AddErrorStringToLog( "Internal buffer error while formatting: \"" + std::string(format) + "\"\n" );
+    (void)std::vfprintf(stream, format, args);
     va_end(args);
-    return;
+  }
+  catch(...) {
+    // don't let any exceptions escape, don't rethrow
   }
 
-  // are we running silent (but not deep)?
-  if (gRunSilent)
-    return;
-
-  // else normal output
-  std::va_list args;
-  va_start(args, format);
-  (void)std::vfprintf(stream, format, args);
-  va_end(args);
 }
 
 /******************************************************************************/
@@ -2424,6 +2430,8 @@ void printUsage(void)
 {
   printf("Usage: iccProfileVisualize <args> input_profiles\n");
   printf("\t-silent         don't output any warnings or errors.\n");
+  printf("\t-V              print usage and version.\n");
+  printf("\t-help           print usage and version.\n");
   printf("  output will be TIFF and PDF files next to each input profile.\n");
   printf("iccProfileVisualize built with IccProfLib version " ICCPROFLIBVER "\n\n");
 }
@@ -2463,6 +2471,12 @@ filename_list parse_arguments( int argc, char *argv[] )
 
   } // end loop over arguments
 
+
+  if (filenames.size() == 0) {
+      printUsage();
+      exit (0);
+  }
+
   return filenames;
 }
 
@@ -2499,16 +2513,16 @@ int main(int argc, char* argv[])
     try {
       ClearErrorLogs();
       
+      // DEBUGGING printf("Processing profile '%s'\n", file.c_str() );
       CIccProfile *pIcc = OpenIccProfile( file.c_str() );
       if (!pIcc) {
         LogAnError(stderr,"Unable to parse '%s' as ICC profile!\n", file.c_str() );
         continue;
       }
 
-      // DEBUGGING printf("Processing profile '%s'\n", argv[k]);
       auto count = processLuts( pIcc, file );
       if (!count) {
-        LogAnError(stderr,"Profile %s had no content for output\n", file.c_str()  );
+        LogAnError(stderr,"Profile %s had no content for output\n", file.c_str() );
       }
 
       delete pIcc;
@@ -2517,7 +2531,7 @@ int main(int argc, char* argv[])
       LogAnError(stderr, "%s: ERROR exception: '%s'\n", file.c_str() , e.what() );
     }
     catch (...) {
-      LogAnError(stderr, "%s: ERROR: unknown exception\n", file.c_str()  );
+      LogAnError(stderr, "%s: ERROR: unknown exception\n", file.c_str() );
     }
     
     // NOTE - consume error logs here if needed, so exceptions are included


### PR DESCRIPTION
## PR Summary

add silent option to profileVisualize
add command line parsing
add internal option to accumulate error reports into a string

## Checklist
- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
