### PR TITLE
Fix: S8/S12 short-magic false positives in iccPawgReport — gzip, ELF, shebang (#1269)

### DIFF
--- a/.github/scripts/iccdev-pawg-report-regression-tests.sh
+++ b/.github/scripts/iccdev-pawg-report-regression-tests.sh
@@ -43,6 +43,10 @@ GZIP_FALSE_POSITIVE="$OUTDIR/private-invalid-gzip-signature.icc"
 GZIP_TRUE_POSITIVE="$OUTDIR/private-valid-gzip-signature.icc"
 STD_GZIP_FALSE_POSITIVE="$OUTDIR/standard-tag-invalid-gzip-signature.icc"
 STD_GZIP_TRUE_POSITIVE="$OUTDIR/standard-tag-valid-gzip-signature.icc"
+STD_ELF_FALSE_POSITIVE="$OUTDIR/standard-tag-invalid-elf-signature.icc"
+STD_ELF_TRUE_POSITIVE="$OUTDIR/standard-tag-valid-elf-signature.icc"
+STD_SHEBANG_FALSE_POSITIVE="$OUTDIR/standard-tag-invalid-shebang-signature.icc"
+STD_SHEBANG_TRUE_POSITIVE="$OUTDIR/standard-tag-valid-shebang-signature.icc"
 REGISTERED_PRIVATE="$OUTDIR/registered-private-tag.icc"
 
 PASS=0
@@ -742,6 +746,268 @@ run_standard_tag_valid_gzip_signature_profile() {
   pass_case "$name" "valid gzip member in a standard CLUT tag triggers S8 while S12 stays clear"
 }
 
+# Shared builder: writes a minimal RGB profile carrying a single STANDARD 'A2B0'
+# tag whose 256-byte CLUT-like blob has `embed` spliced in at offset 120.
+emit_standard_tag_blob_profile() {
+  python3 - "$1" "$2" <<'PY'
+import pathlib
+import sys
+
+dst = pathlib.Path(sys.argv[1])
+embed = bytes.fromhex(sys.argv[2])
+blob = bytearray((i * 73 + 11) & 0xff for i in range(256))
+blob[120:120 + len(embed)] = embed
+size = 144 + len(blob)
+data = bytearray(size)
+data[0:4] = size.to_bytes(4, "big")
+data[8:12] = bytes.fromhex("04400000")
+data[12:16] = b"mntr"
+data[16:20] = b"RGB "
+data[20:24] = b"XYZ "
+data[36:40] = b"acsp"
+data[68:72] = (0x0000F6D6).to_bytes(4, "big")
+data[72:76] = (0x00010000).to_bytes(4, "big")
+data[76:80] = (0x0000D32D).to_bytes(4, "big")
+data[128:132] = (1).to_bytes(4, "big")
+data[132:136] = b"A2B0"
+data[136:140] = (144).to_bytes(4, "big")
+data[140:144] = len(blob).to_bytes(4, "big")
+data[144:size] = blob
+dst.write_bytes(data)
+PY
+}
+
+generate_standard_tag_invalid_elf_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  # "\x7fELF" magic followed by an invalid e_ident (EI_CLASS/EI_VERSION zero) --
+  # a coincidental 4-byte hit in CLUT data, not a real ELF object.
+  emit_standard_tag_blob_profile "$STD_ELF_FALSE_POSITIVE" \
+    "7f454c4600000000a1b2c3d4e5f60718293a4b5c"
+}
+
+run_standard_tag_invalid_elf_signature_profile() {
+  local name="pawg-standard-tag-invalid-elf-true-negative"
+  local logfile="$OUTDIR/standard-tag-invalid-elf.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$STD_ELF_FALSE_POSITIVE"
+
+  if ! generate_standard_tag_invalid_elf_signature_profile; then
+    fail_case "$name" "failed to generate standard-tag invalid ELF signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$STD_ELF_FALSE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S8" "$logfile"; then
+    fail_case "$name" "invalid ELF ident in standard tag was incorrectly reported in S8"
+    return
+  fi
+  if grep -F -q "ELF executable" "$logfile"; then
+    fail_case "$name" "invalid ELF ident produced ELF detail text"
+    return
+  fi
+
+  pass_case "$name" "ELF magic with invalid ident in a standard CLUT tag did not trigger S8"
+}
+
+generate_standard_tag_valid_elf_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  # Valid ELF identification: \x7fELF, ELFCLASS64, ELFDATA2LSB, EV_CURRENT,
+  # e_type=ET_EXEC, e_machine=EM_X86_64, e_version=EV_CURRENT.
+  emit_standard_tag_blob_profile "$STD_ELF_TRUE_POSITIVE" \
+    "7f454c4602010100000000000000000002003e0001000000"
+}
+
+run_standard_tag_valid_elf_signature_profile() {
+  local name="pawg-standard-tag-valid-elf-true-positive"
+  local logfile="$OUTDIR/standard-tag-valid-elf.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$STD_ELF_TRUE_POSITIVE"
+
+  if ! generate_standard_tag_valid_elf_signature_profile; then
+    fail_case "$name" "failed to generate standard-tag valid ELF signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$STD_ELF_TRUE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "ELF-signature input unexpectedly returned success"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[FAIL] S8" "$logfile"; then
+    fail_case "$name" "valid ELF signature in standard tag was not reported in S8"
+    return
+  fi
+  if ! grep -F -q "ELF executable signature at offset" "$logfile"; then
+    fail_case "$name" "ELF detail text missing expected offset"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S12" "$logfile"; then
+    fail_case "$name" "standard-tag ELF must leave private-tag check S12 clear"
+    return
+  fi
+
+  pass_case "$name" "valid ELF header in a standard CLUT tag triggers S8 while S12 stays clear"
+}
+
+generate_standard_tag_invalid_shebang_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  # "#!/" followed by binary (non-printable) bytes -- a coincidental hit in CLUT
+  # data, not an interpreter line.
+  emit_standard_tag_blob_profile "$STD_SHEBANG_FALSE_POSITIVE" \
+    "23212f00ff01801090a0b0c0d0e0f000"
+}
+
+run_standard_tag_invalid_shebang_signature_profile() {
+  local name="pawg-standard-tag-invalid-shebang-true-negative"
+  local logfile="$OUTDIR/standard-tag-invalid-shebang.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$STD_SHEBANG_FALSE_POSITIVE"
+
+  if ! generate_standard_tag_invalid_shebang_signature_profile; then
+    fail_case "$name" "failed to generate standard-tag invalid shebang signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$STD_SHEBANG_FALSE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S8" "$logfile"; then
+    fail_case "$name" "binary bytes after #!/ in standard tag were incorrectly reported in S8"
+    return
+  fi
+  if grep -F -q "script shebang" "$logfile"; then
+    fail_case "$name" "non-script #!/ produced shebang detail text"
+    return
+  fi
+
+  pass_case "$name" "#!/ followed by binary in a standard CLUT tag did not trigger S8"
+}
+
+generate_standard_tag_valid_shebang_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  # A genuine interpreter line: #!/bin/sh\n
+  emit_standard_tag_blob_profile "$STD_SHEBANG_TRUE_POSITIVE" \
+    "23212f62696e2f73680a"
+}
+
+run_standard_tag_valid_shebang_signature_profile() {
+  local name="pawg-standard-tag-valid-shebang-true-positive"
+  local logfile="$OUTDIR/standard-tag-valid-shebang.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$STD_SHEBANG_TRUE_POSITIVE"
+
+  if ! generate_standard_tag_valid_shebang_signature_profile; then
+    fail_case "$name" "failed to generate standard-tag valid shebang signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$STD_SHEBANG_TRUE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "shebang-signature input unexpectedly returned success"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[FAIL] S8" "$logfile"; then
+    fail_case "$name" "valid shebang in standard tag was not reported in S8"
+    return
+  fi
+  if ! grep -F -q "script shebang signature at offset" "$logfile"; then
+    fail_case "$name" "shebang detail text missing expected offset"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S12" "$logfile"; then
+    fail_case "$name" "standard-tag shebang must leave private-tag check S12 clear"
+    return
+  fi
+
+  pass_case "$name" "valid #!/ interpreter line in a standard CLUT tag triggers S8 while S12 stays clear"
+}
+
 run_json_report() {
   local name="pawg-json-evidence-output"
   local logfile="$OUTDIR/json-report.log"
@@ -887,6 +1153,10 @@ run_invalid_gzip_signature_profile
 run_valid_gzip_signature_profile
 run_standard_tag_invalid_gzip_signature_profile
 run_standard_tag_valid_gzip_signature_profile
+run_standard_tag_invalid_elf_signature_profile
+run_standard_tag_valid_elf_signature_profile
+run_standard_tag_invalid_shebang_signature_profile
+run_standard_tag_valid_shebang_signature_profile
 run_registered_private_profile
 echo "iccPawgReport PAWG regression and security tests: $PASS passed, $FAIL failed, $TOTAL total"
 

--- a/.github/scripts/iccdev-pawg-report-regression-tests.sh
+++ b/.github/scripts/iccdev-pawg-report-regression-tests.sh
@@ -41,6 +41,8 @@ TRUNCATED="$OUTDIR/truncated.icc"
 MALWARE="$OUTDIR/private-pe-signature.icc"
 GZIP_FALSE_POSITIVE="$OUTDIR/private-invalid-gzip-signature.icc"
 GZIP_TRUE_POSITIVE="$OUTDIR/private-valid-gzip-signature.icc"
+STD_GZIP_FALSE_POSITIVE="$OUTDIR/standard-tag-invalid-gzip-signature.icc"
+STD_GZIP_TRUE_POSITIVE="$OUTDIR/standard-tag-valid-gzip-signature.icc"
 REGISTERED_PRIVATE="$OUTDIR/registered-private-tag.icc"
 
 PASS=0
@@ -562,6 +564,184 @@ run_valid_gzip_signature_profile() {
   pass_case "$name" "valid gzip member still triggers S8 and S12"
 }
 
+generate_standard_tag_invalid_gzip_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+
+  python3 - "$STD_GZIP_FALSE_POSITIVE" <<'PY'
+import pathlib
+import struct
+import sys
+
+dst = pathlib.Path(sys.argv[1])
+# 256-byte high-entropy CLUT-like blob carried by a STANDARD 'A2B0' tag, with the
+# exact Fogra51_CF false-positive bytes (1f 8b 08 then invalid FLG 0x86 ...)
+# embedded in the middle -- mirrors a coincidental gzip magic inside lutAToBType
+# CLUT data, as opposed to the private-tag false positive above.
+blob = bytearray((i * 73 + 11) & 0xff for i in range(256))
+blob[120:130] = bytes([0x1f, 0x8b, 0x08, 0x86, 0x97, 0x0b, 0x75, 0x87, 0x7e, 0x87])
+size = 144 + len(blob)
+data = bytearray(size)
+data[0:4] = struct.pack(">I", size)
+data[8:12] = bytes.fromhex("04400000")
+data[12:16] = b"mntr"
+data[16:20] = b"RGB "
+data[20:24] = b"XYZ "
+data[36:40] = b"acsp"
+data[64:68] = struct.pack(">I", 0)
+data[68:72] = struct.pack(">I", 0x0000F6D6)
+data[72:76] = struct.pack(">I", 0x00010000)
+data[76:80] = struct.pack(">I", 0x0000D32D)
+data[128:132] = struct.pack(">I", 1)
+data[132:136] = b"A2B0"
+data[136:140] = struct.pack(">I", 144)
+data[140:144] = struct.pack(">I", len(blob))
+data[144:size] = blob
+dst.write_bytes(data)
+PY
+}
+
+run_standard_tag_invalid_gzip_signature_profile() {
+  local name="pawg-standard-tag-invalid-gzip-true-negative"
+  local logfile="$OUTDIR/standard-tag-invalid-gzip.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$STD_GZIP_FALSE_POSITIVE"
+
+  if ! generate_standard_tag_invalid_gzip_signature_profile; then
+    fail_case "$name" "failed to generate standard-tag invalid gzip signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$STD_GZIP_FALSE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S8" "$logfile"; then
+    fail_case "$name" "invalid gzip header in standard tag was incorrectly reported in S8"
+    return
+  fi
+  if grep -F -q "embedded gzip stream" "$logfile"; then
+    fail_case "$name" "invalid gzip header produced gzip detail text"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S11" "$logfile"; then
+    fail_case "$name" "standard tag was misreported as a private tag in S11"
+    return
+  fi
+
+  pass_case "$name" "invalid gzip-like bytes in a standard CLUT tag did not trigger S8"
+}
+
+generate_standard_tag_valid_gzip_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+
+  python3 - "$STD_GZIP_TRUE_POSITIVE" <<'PY'
+import gzip
+import pathlib
+import struct
+import sys
+
+dst = pathlib.Path(sys.argv[1])
+# Genuine gzip member embedded in the middle of a 256-byte CLUT-like blob carried
+# by a STANDARD 'A2B0' tag. The whole-file S8 scan must still flag it, while the
+# private-tag checks S11/S12 stay clear because no private tag is present -- this
+# is the standard-tag counterpart to the private-tag true positive above.
+member = gzip.compress(b"icc-pawg-clut\n", mtime=0)
+blob = bytearray((i * 73 + 11) & 0xff for i in range(256))
+blob[120:120 + len(member)] = member
+size = 144 + len(blob)
+data = bytearray(size)
+data[0:4] = struct.pack(">I", size)
+data[8:12] = bytes.fromhex("04400000")
+data[12:16] = b"mntr"
+data[16:20] = b"RGB "
+data[20:24] = b"XYZ "
+data[36:40] = b"acsp"
+data[64:68] = struct.pack(">I", 0)
+data[68:72] = struct.pack(">I", 0x0000F6D6)
+data[72:76] = struct.pack(">I", 0x00010000)
+data[76:80] = struct.pack(">I", 0x0000D32D)
+data[128:132] = struct.pack(">I", 1)
+data[132:136] = b"A2B0"
+data[136:140] = struct.pack(">I", 144)
+data[140:144] = struct.pack(">I", len(blob))
+data[144:size] = blob
+dst.write_bytes(data)
+PY
+}
+
+run_standard_tag_valid_gzip_signature_profile() {
+  local name="pawg-standard-tag-valid-gzip-true-positive"
+  local logfile="$OUTDIR/standard-tag-valid-gzip.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$STD_GZIP_TRUE_POSITIVE"
+
+  if ! generate_standard_tag_valid_gzip_signature_profile; then
+    fail_case "$name" "failed to generate standard-tag valid gzip signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$STD_GZIP_TRUE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "gzip-signature input unexpectedly returned success"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[FAIL] S8" "$logfile"; then
+    fail_case "$name" "valid gzip signature in standard tag was not reported in S8"
+    return
+  fi
+  if ! grep -F -q "embedded gzip stream signature at offset" "$logfile"; then
+    fail_case "$name" "gzip detail text missing expected offset"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S12" "$logfile"; then
+    fail_case "$name" "standard-tag gzip must leave private-tag check S12 clear"
+    return
+  fi
+
+  pass_case "$name" "valid gzip member in a standard CLUT tag triggers S8 while S12 stays clear"
+}
+
 run_json_report() {
   local name="pawg-json-evidence-output"
   local logfile="$OUTDIR/json-report.log"
@@ -705,6 +885,8 @@ run_truncated_profile
 run_private_malware_profile
 run_invalid_gzip_signature_profile
 run_valid_gzip_signature_profile
+run_standard_tag_invalid_gzip_signature_profile
+run_standard_tag_valid_gzip_signature_profile
 run_registered_private_profile
 echo "iccPawgReport PAWG regression and security tests: $PASS passed, $FAIL failed, $TOTAL total"
 

--- a/.github/scripts/iccdev-pawg-report-regression-tests.sh
+++ b/.github/scripts/iccdev-pawg-report-regression-tests.sh
@@ -39,6 +39,8 @@ PAWG="$TOOLS_DIR/IccPawgReport/iccPawgReport"
 GOOD_PROFILE="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
 TRUNCATED="$OUTDIR/truncated.icc"
 MALWARE="$OUTDIR/private-pe-signature.icc"
+GZIP_FALSE_POSITIVE="$OUTDIR/private-invalid-gzip-signature.icc"
+GZIP_TRUE_POSITIVE="$OUTDIR/private-valid-gzip-signature.icc"
 REGISTERED_PRIVATE="$OUTDIR/registered-private-tag.icc"
 
 PASS=0
@@ -396,6 +398,170 @@ run_private_malware_profile() {
   pass_case "$name" "private malware signature detected without crash"
 }
 
+generate_private_invalid_gzip_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+
+  python3 - "$GZIP_FALSE_POSITIVE" <<'PY'
+import pathlib
+import struct
+import sys
+
+dst = pathlib.Path(sys.argv[1])
+size = 180
+data = bytearray(size)
+data[0:4] = struct.pack(">I", size)
+data[8:12] = bytes.fromhex("04400000")
+data[12:16] = b"mntr"
+data[16:20] = b"RGB "
+data[20:24] = b"XYZ "
+data[36:40] = b"acsp"
+data[64:68] = struct.pack(">I", 0)
+data[68:72] = struct.pack(">I", 0x0000F6D6)
+data[72:76] = struct.pack(">I", 0x00010000)
+data[76:80] = struct.pack(">I", 0x0000D32D)
+data[128:132] = struct.pack(">I", 1)
+data[132:136] = b"zzzz"
+data[136:140] = struct.pack(">I", 144)
+data[140:144] = struct.pack(">I", 36)
+payload = bytearray(36)
+payload[1:11] = bytes([0x1f, 0x8b, 0x08, 0x86, 0x97, 0x0b, 0x75, 0x87, 0x7e, 0x87])
+data[144:180] = payload
+dst.write_bytes(data)
+PY
+}
+
+run_invalid_gzip_signature_profile() {
+  local name="pawg-invalid-gzip-signature-true-negative"
+  local logfile="$OUTDIR/private-invalid-gzip.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$GZIP_FALSE_POSITIVE"
+
+  if ! generate_private_invalid_gzip_signature_profile; then
+    fail_case "$name" "failed to generate invalid gzip signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$GZIP_FALSE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S8" "$logfile"; then
+    fail_case "$name" "invalid gzip header was incorrectly reported in S8"
+    return
+  fi
+  if grep -F -q "embedded gzip stream" "$logfile"; then
+    fail_case "$name" "invalid gzip header produced gzip detail text"
+    return
+  fi
+
+  pass_case "$name" "invalid gzip-like bytes did not trigger S8"
+}
+
+generate_private_valid_gzip_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+
+  python3 - "$GZIP_TRUE_POSITIVE" <<'PY'
+import gzip
+import pathlib
+import struct
+import sys
+
+dst = pathlib.Path(sys.argv[1])
+payload = gzip.compress(b"icc-pawg\n", mtime=0)
+size = 144 + len(payload)
+data = bytearray(size)
+data[0:4] = struct.pack(">I", size)
+data[8:12] = bytes.fromhex("04400000")
+data[12:16] = b"mntr"
+data[16:20] = b"RGB "
+data[20:24] = b"XYZ "
+data[36:40] = b"acsp"
+data[64:68] = struct.pack(">I", 0)
+data[68:72] = struct.pack(">I", 0x0000F6D6)
+data[72:76] = struct.pack(">I", 0x00010000)
+data[76:80] = struct.pack(">I", 0x0000D32D)
+data[128:132] = struct.pack(">I", 1)
+data[132:136] = b"zzzz"
+data[136:140] = struct.pack(">I", 144)
+data[140:144] = struct.pack(">I", len(payload))
+data[144:size] = payload
+dst.write_bytes(data)
+PY
+}
+
+run_valid_gzip_signature_profile() {
+  local name="pawg-valid-gzip-signature-true-positive"
+  local logfile="$OUTDIR/private-valid-gzip.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$GZIP_TRUE_POSITIVE"
+
+  if ! generate_private_valid_gzip_signature_profile; then
+    fail_case "$name" "failed to generate valid gzip signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$GZIP_TRUE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "gzip-signature input unexpectedly returned success"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[FAIL] S8" "$logfile"; then
+    fail_case "$name" "valid gzip signature was not reported in S8"
+    return
+  fi
+  if ! grep -F -q "embedded gzip stream signature at offset" "$logfile"; then
+    fail_case "$name" "gzip detail text missing expected offset"
+    return
+  fi
+  if ! grep -F -q "[FAIL] S12" "$logfile"; then
+    fail_case "$name" "private gzip signature was not reported in S12"
+    return
+  fi
+
+  pass_case "$name" "valid gzip member still triggers S8 and S12"
+}
+
 run_json_report() {
   local name="pawg-json-evidence-output"
   local logfile="$OUTDIR/json-report.log"
@@ -537,6 +703,8 @@ run_good_profile "pawg-read-option-fidelity" "--read"
 run_json_report
 run_truncated_profile
 run_private_malware_profile
+run_invalid_gzip_signature_profile
+run_valid_gzip_signature_profile
 run_registered_private_profile
 echo "iccPawgReport PAWG regression and security tests: $PASS passed, $FAIL failed, $TOTAL total"
 

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -638,8 +638,80 @@ std::string FirstReportLine(const std::string &report)
   return "validation reported an issue without detail";
 }
 
+typedef bool (*SigValidator)(const RawProfile &raw, size_t offset, size_t end);
+
+bool ValidatePe(const RawProfile &raw, size_t offset, size_t end)
+{
+  if (offset > end || end - offset < 64) {
+    return false;
+  }
+
+  uint32_t peOff = (uint32_t)raw.data[offset + 60] |
+                   ((uint32_t)raw.data[offset + 61] << 8) |
+                   ((uint32_t)raw.data[offset + 62] << 16) |
+                   ((uint32_t)raw.data[offset + 63] << 24);
+  return peOff < 1024 && peOff <= end - offset - 4 &&
+         raw.data[offset + peOff] == 'P' && raw.data[offset + peOff + 1] == 'E';
+}
+
+bool ValidateGzipHeader(const RawProfile &raw, size_t offset, size_t end)
+{
+  const size_t kGzipHeaderLen = 10;
+  if (offset > end || end - offset < kGzipHeaderLen) {
+    return false;
+  }
+
+  const unsigned char cm = raw.data[offset + 2];
+  const unsigned char flg = raw.data[offset + 3];
+  const unsigned char xfl = raw.data[offset + 8];
+  const unsigned char os = raw.data[offset + 9];
+  if (cm != 0x08 || (flg & 0xe0) != 0 || !(xfl == 0 || xfl == 2 || xfl == 4) ||
+      !(os <= 13 || os == 255)) {
+    return false;
+  }
+
+  size_t pos = offset + kGzipHeaderLen;
+  if (flg & 0x04) {
+    if (end - pos < 2) {
+      return false;
+    }
+    const size_t extraLen = (size_t)raw.data[pos] | ((size_t)raw.data[pos + 1] << 8);
+    pos += 2;
+    if (extraLen > end - pos) {
+      return false;
+    }
+    pos += extraLen;
+  }
+  if (flg & 0x08) {
+    while (pos < end && raw.data[pos] != 0) {
+      ++pos;
+    }
+    if (pos >= end) {
+      return false;
+    }
+    ++pos;
+  }
+  if (flg & 0x10) {
+    while (pos < end && raw.data[pos] != 0) {
+      ++pos;
+    }
+    if (pos >= end) {
+      return false;
+    }
+    ++pos;
+  }
+  if (flg & 0x02) {
+    if (end - pos < 2) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
 bool HasSignature(const RawProfile &raw, const unsigned char *sig, size_t sigLen,
-                  size_t begin, size_t end, std::string &detail)
+                  SigValidator validate, size_t begin, size_t end,
+                  std::string &detail)
 {
   if (sigLen == 0 || begin >= end || end > raw.data.size()) {
     return false;
@@ -650,18 +722,8 @@ bool HasSignature(const RawProfile &raw, const unsigned char *sig, size_t sigLen
       continue;
     }
 
-    if (sigLen == 2 && sig[0] == 'M') {
-      if (i + 64 > end) {
-        continue;
-      }
-      uint32_t peOff = (uint32_t)raw.data[i + 60] |
-                       ((uint32_t)raw.data[i + 61] << 8) |
-                       ((uint32_t)raw.data[i + 62] << 16) |
-                       ((uint32_t)raw.data[i + 63] << 24);
-      if (peOff >= 1024 || i + peOff + 4 > end ||
-          raw.data[i + peOff] != 'P' || raw.data[i + peOff + 1] != 'E') {
-        continue;
-      }
+    if (validate && !validate(raw, i, end)) {
+      continue;
     }
 
     char msg[96];
@@ -718,25 +780,26 @@ bool ScanMalwareRange(const RawProfile &raw, size_t begin, size_t end,
     const unsigned char *bytes;
     size_t len;
     const char *name;
+    SigValidator validate;
   };
   static const Sig sigs[] = {
-    {elf, sizeof(elf), "ELF executable"},
-    {mz, sizeof(mz), "PE executable"},
-    {macho64, sizeof(macho64), "Mach-O executable"},
-    {macho32, sizeof(macho32), "Mach-O executable"},
-    {shebang, sizeof(shebang), "script shebang"},
-    {pdf, sizeof(pdf), "embedded PDF"},
-    {zip, sizeof(zip), "embedded ZIP archive"},
-    {rar, sizeof(rar), "embedded RAR archive"},
-    {sevenZip, sizeof(sevenZip), "embedded 7z archive"},
-    {gzip, sizeof(gzip), "embedded gzip stream"}
+    {elf, sizeof(elf), "ELF executable", nullptr},
+    {mz, sizeof(mz), "PE executable", ValidatePe},
+    {macho64, sizeof(macho64), "Mach-O executable", nullptr},
+    {macho32, sizeof(macho32), "Mach-O executable", nullptr},
+    {shebang, sizeof(shebang), "script shebang", nullptr},
+    {pdf, sizeof(pdf), "embedded PDF", nullptr},
+    {zip, sizeof(zip), "embedded ZIP archive", nullptr},
+    {rar, sizeof(rar), "embedded RAR archive", nullptr},
+    {sevenZip, sizeof(sevenZip), "embedded 7z archive", nullptr},
+    {gzip, sizeof(gzip), "embedded gzip stream", ValidateGzipHeader}
   };
 
   const size_t kMaxScan = (size_t)10 * 1024 * 1024;
   size_t scanEnd = std::min(end, begin + kMaxScan);
   for (const Sig &sig : sigs) {
     std::string offset;
-    if (HasSignature(raw, sig.bytes, sig.len, begin, scanEnd, offset)) {
+    if (HasSignature(raw, sig.bytes, sig.len, sig.validate, begin, scanEnd, offset)) {
       detail = std::string(sig.name) + " " + offset;
       return true;
     }

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -709,6 +709,65 @@ bool ValidateGzipHeader(const RawProfile &raw, size_t offset, size_t end)
   return true;
 }
 
+bool ValidateElf(const RawProfile &raw, size_t offset, size_t end)
+{
+  // Corroborate a "\x7fELF" hit against the ELF identification fields (e_ident)
+  // plus e_type/e_version, so a coincidental 4-byte match in high-entropy CLUT
+  // data does not fire S8. Need e_ident(16) + e_type(2) + e_machine(2) +
+  // e_version(4) = 24 bytes.
+  if (offset > end || end - offset < 24) {
+    return false;
+  }
+
+  const unsigned char eiClass = raw.data[offset + 4];    // 1=32-bit, 2=64-bit
+  const unsigned char eiData = raw.data[offset + 5];     // 1=little, 2=big endian
+  const unsigned char eiVersion = raw.data[offset + 6];  // EV_CURRENT == 1
+  if (!(eiClass == 1 || eiClass == 2) || !(eiData == 1 || eiData == 2) ||
+      eiVersion != 1) {
+    return false;
+  }
+
+  const bool be = (eiData == 2);
+  const unsigned char *p = raw.data.data() + offset;
+  const uint16_t eType = be ? (uint16_t)((p[16] << 8) | p[17])
+                            : (uint16_t)(p[16] | (p[17] << 8));
+  const uint32_t eVersion = be
+    ? ((uint32_t)p[20] << 24 | (uint32_t)p[21] << 16 |
+       (uint32_t)p[22] << 8 | (uint32_t)p[23])
+    : ((uint32_t)p[20] | (uint32_t)p[21] << 8 |
+       (uint32_t)p[22] << 16 | (uint32_t)p[23] << 24);
+
+  // e_type: NONE/REL/EXEC/DYN/CORE (0-4), or the OS/processor-specific reserved
+  // ranges (0xfe00-0xffff). e_version must be EV_CURRENT.
+  const bool typeOk = eType <= 4 || (eType >= 0xfe00 && eType <= 0xffff);
+  return typeOk && eVersion == 1;
+}
+
+bool ValidateShebang(const RawProfile &raw, size_t offset, size_t end)
+{
+  // The magic is "#!/" (3 bytes). A real shebang continues with a printable
+  // interpreter path terminated by a newline; a coincidental "#!/" inside binary
+  // CLUT data is followed by non-printable bytes well before any newline.
+  const size_t kMaxLine = 256;
+  size_t limit = end;
+  if (limit - offset > kMaxLine) {
+    limit = offset + kMaxLine;
+  }
+  for (size_t pos = offset + 3; pos < limit; ++pos) {
+    const unsigned char c = raw.data[pos];
+    if (c == '\n') {
+      return true;  // a fully-printable interpreter line
+    }
+    if (c == '\t' || c == '\r') {
+      continue;
+    }
+    if (c < 0x20 || c > 0x7e) {
+      return false;  // control/binary byte => not a script line
+    }
+  }
+  return false;  // no newline within a plausible interpreter-line length
+}
+
 bool HasSignature(const RawProfile &raw, const unsigned char *sig, size_t sigLen,
                   SigValidator validate, size_t begin, size_t end,
                   std::string &detail)
@@ -783,11 +842,11 @@ bool ScanMalwareRange(const RawProfile &raw, size_t begin, size_t end,
     SigValidator validate;
   };
   static const Sig sigs[] = {
-    {elf, sizeof(elf), "ELF executable", nullptr},
+    {elf, sizeof(elf), "ELF executable", ValidateElf},
     {mz, sizeof(mz), "PE executable", ValidatePe},
     {macho64, sizeof(macho64), "Mach-O executable", nullptr},
     {macho32, sizeof(macho32), "Mach-O executable", nullptr},
-    {shebang, sizeof(shebang), "script shebang", nullptr},
+    {shebang, sizeof(shebang), "script shebang", ValidateShebang},
     {pdf, sizeof(pdf), "embedded PDF", nullptr},
     {zip, sizeof(zip), "embedded ZIP archive", nullptr},
     {rar, sizeof(rar), "embedded RAR archive", nullptr},


### PR DESCRIPTION
Closes #1269.

## Summary

PAWG check **S8** ("free of known malware signatures?") false-fired on short magic-byte sequences that coincide inside high-entropy CLUT data, with no corroboration of the bytes that follow. The original report was a 3-byte gzip magic (`1f 8b 08`) inside an `mAB ` lutAToBType CLUT in `Fogra51_CF.icc`; the same class also affected ELF (`\x7fELF`) and the `#!/` shebang.

This adds **dependency-free structural validation** of each match before S8/S12 fire (no zlib, no decompression), via a per-signature `SigValidator` hook on the file-local `Sig` table:

- **gzip** — `ValidateGzipHeader`: RFC 1952 (CM=deflate, reserved FLG bits clear, XFL ∈ {0,2,4}, OS ≤ 13 or 255, bounded optional fields).
- **ELF** — `ValidateElf`: `e_ident` (EI_CLASS 1/2, EI_DATA 1/2, EI_VERSION 1) plus a plausible `e_type` and `EV_CURRENT` `e_version`, read with the declared endianness.
- **shebang** — `ValidateShebang`: the `#!/` magic must continue with a printable interpreter line terminated by a newline within a bounded length; binary bytes are rejected.
- **PE** — the existing inline MZ/PE special-case is moved out to `ValidatePe` through the same hook (no behaviour change).

Mach-O / ZIP / RAR / 7z / `%PDF-` keep `nullptr` (magic alone) — unchanged.

## Commits

- `b4bc78d` **Fix: S8/S12 Checks in iccPawgReport** (@xsscx) — the `SigValidator` hook, `ValidatePe`, `ValidateGzipHeader`, and the gzip regression cases.
- `26446c2` **add standard-tag CLUT gzip regression cases** — standard-tag counterpart to the private-tag gzip fixtures.
- `4afa9d8` **corroborate ELF and shebang S8 signatures** — `ValidateElf` + `ValidateShebang` and their standard-tag regression cases.

## Regression coverage

The PAWG regression script (`iccdev-pawg-report-regression-tests.sh`, already gated as CTest `iccdev.pawg-report-regressions` under ASAN+UBSAN on every PR) now carries true-negative / true-positive pairs for **gzip, ELF and shebang**, embedded mid-blob in a standard `A2B0` tag so they exercise S8's whole-file scan while S11/S12 stay clear. Fixtures are generated in-script (no committed binaries).

**Verification:** 16/16 pass on the patched binary; every true-negative case FAILs on the corresponding pre-fix binary (confirming each guards its validator).

## Corpus result (local 90-profile set)

- gzip: **10** S8 verdicts flip FAIL→OK, all confirmed gzip false positives.
- ELF + shebang: clears all **8** remaining production false positives (6 script-shebang, 2 ELF), every one inside lutAToBType/lutBToAType CLUT data. No true positive lost (validators only ever turn FAIL→OK).

## Known follow-up (out of scope here)

Clearing the ELF hit on `SWOP2013C3_CRPC5.icc` unmasks a previously-hidden **text-signature** false positive ("PowerShell expression invocation") in the same CLUT — a different signature family (the `TextSig` table), not addressed in this PR. The `%PDF-` hits remaining in the corpus are crafted/malformed test fixtures, not production false positives.

## Deliberate non-changes

- S8 keeps whole-file coverage; the fixes correct false positives without narrowing detection breadth.
- No zlib / no trial-execution / no decode.
- S8 detail string format unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)