### PR TITLE
Fix: S8 text-signature false positives in iccPawgReport (#1271)

### DIFF
--- a/.github/scripts/iccdev-pawg-report-regression-tests.sh
+++ b/.github/scripts/iccdev-pawg-report-regression-tests.sh
@@ -47,6 +47,8 @@ STD_ELF_FALSE_POSITIVE="$OUTDIR/standard-tag-invalid-elf-signature.icc"
 STD_ELF_TRUE_POSITIVE="$OUTDIR/standard-tag-valid-elf-signature.icc"
 STD_SHEBANG_FALSE_POSITIVE="$OUTDIR/standard-tag-invalid-shebang-signature.icc"
 STD_SHEBANG_TRUE_POSITIVE="$OUTDIR/standard-tag-valid-shebang-signature.icc"
+STD_TEXTSIG_FALSE_POSITIVE="$OUTDIR/standard-tag-invalid-textsig-signature.icc"
+STD_TEXTSIG_TRUE_POSITIVE="$OUTDIR/standard-tag-valid-textsig-signature.icc"
 REGISTERED_PRIVATE="$OUTDIR/registered-private-tag.icc"
 
 PASS=0
@@ -1008,6 +1010,121 @@ run_standard_tag_valid_shebang_signature_profile() {
   pass_case "$name" "valid #!/ interpreter line in a standard CLUT tag triggers S8 while S12 stays clear"
 }
 
+generate_standard_tag_invalid_textsig_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  # Case-insensitive text signature "iex(" surrounded by binary CLUT bytes -- a
+  # coincidental match with no printable context, as seen on SWOP2013C3_CRPC5.icc.
+  emit_standard_tag_blob_profile "$STD_TEXTSIG_FALSE_POSITIVE" "69657828"
+}
+
+run_standard_tag_invalid_textsig_signature_profile() {
+  local name="pawg-standard-tag-invalid-textsig-true-negative"
+  local logfile="$OUTDIR/standard-tag-invalid-textsig.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$STD_TEXTSIG_FALSE_POSITIVE"
+
+  if ! generate_standard_tag_invalid_textsig_signature_profile; then
+    fail_case "$name" "failed to generate standard-tag invalid text-signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$STD_TEXTSIG_FALSE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S8" "$logfile"; then
+    fail_case "$name" "text signature without printable context was incorrectly reported in S8"
+    return
+  fi
+  if grep -F -q "PowerShell expression invocation" "$logfile"; then
+    fail_case "$name" "binary-context text match produced text-signature detail"
+    return
+  fi
+
+  pass_case "$name" "text signature with no printable context in a standard CLUT tag did not trigger S8"
+}
+
+generate_standard_tag_valid_textsig_signature_profile() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  # A genuine embedded script blob (printable context on both sides):
+  # <html><body><script>invoke-expression('calc.exe');</script></body></html>
+  emit_standard_tag_blob_profile "$STD_TEXTSIG_TRUE_POSITIVE" \
+    "3c68746d6c3e3c626f64793e3c7363726970743e696e766f6b652d65787072657373696f6e282763616c632e65786527293b3c2f7363726970743e3c2f626f64793e3c2f68746d6c3e"
+}
+
+run_standard_tag_valid_textsig_signature_profile() {
+  local name="pawg-standard-tag-valid-textsig-true-positive"
+  local logfile="$OUTDIR/standard-tag-valid-textsig.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile" "$STD_TEXTSIG_TRUE_POSITIVE"
+
+  if ! generate_standard_tag_valid_textsig_signature_profile; then
+    fail_case "$name" "failed to generate standard-tag valid text-signature profile"
+    return
+  fi
+
+  timeout 60 "$PAWG" "$STD_TEXTSIG_TRUE_POSITIVE" > "$logfile" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$logfile"; then
+    fail_case "$name" "sanitizer finding"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "text-signature input unexpectedly returned success"
+    return
+  fi
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,80p' "$logfile"
+    return
+  fi
+  if ! assert_report_truth "$name" "$logfile"; then
+    fail_case "$name" "report count or section mismatch"
+    return
+  fi
+  if ! grep -F -q "[FAIL] S8" "$logfile"; then
+    fail_case "$name" "embedded script markup in standard tag was not reported in S8"
+    return
+  fi
+  if ! grep -F -q "signature at offset" "$logfile"; then
+    fail_case "$name" "text-signature detail text missing expected offset"
+    return
+  fi
+  if ! grep -F -q "[OK  ] S12" "$logfile"; then
+    fail_case "$name" "standard-tag text signature must leave private-tag check S12 clear"
+    return
+  fi
+
+  pass_case "$name" "embedded script markup in a standard CLUT tag triggers S8 while S12 stays clear"
+}
+
 run_json_report() {
   local name="pawg-json-evidence-output"
   local logfile="$OUTDIR/json-report.log"
@@ -1157,6 +1274,8 @@ run_standard_tag_invalid_elf_signature_profile
 run_standard_tag_valid_elf_signature_profile
 run_standard_tag_invalid_shebang_signature_profile
 run_standard_tag_valid_shebang_signature_profile
+run_standard_tag_invalid_textsig_signature_profile
+run_standard_tag_valid_textsig_signature_profile
 run_registered_private_profile
 echo "iccPawgReport PAWG regression and security tests: $PASS passed, $FAIL failed, $TOTAL total"
 

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -812,6 +812,31 @@ bool HasAsciiSignatureCaseInsensitive(const RawProfile &raw, const char *sig,
       }
     }
     if (matched) {
+      // Corroborate: these signatures are dangerous only as text, so a genuine
+      // hit sits inside printable content (embedded script/markup/command line).
+      // A coincidental case-insensitive match inside binary CLUT data has little
+      // or no printable context -- require adjacent printable bytes before/after.
+      const size_t kMinContext = 16;
+      size_t printableBefore = 0;
+      for (size_t k = i; k > begin && printableBefore < kMinContext; --k) {
+        const unsigned char c = raw.data[k - 1];
+        if (c != '\t' && c != '\n' && c != '\r' && (c < 0x20 || c > 0x7e)) {
+          break;
+        }
+        ++printableBefore;
+      }
+      size_t printableAfter = 0;
+      for (size_t k = i + sigLen; k < end && printableAfter < kMinContext; ++k) {
+        const unsigned char c = raw.data[k];
+        if (c != '\t' && c != '\n' && c != '\r' && (c < 0x20 || c > 0x7e)) {
+          break;
+        }
+        ++printableAfter;
+      }
+      if (printableBefore + printableAfter < kMinContext) {
+        continue;
+      }
+
       char msg[96];
       std::snprintf(msg, sizeof(msg), "signature at offset 0x%zx", i);
       detail = msg;


### PR DESCRIPTION
Closes #1271. Approach signed off by @xsscx on the issue.

**Stacks on #1270** (base is `issue-1269`); retarget to `master` once #1270 merges. The text-signature false positive this fixes is only observable after #1270 corroborates the ELF hit that was masking it.

## Problem

`ScanMalwareRange`'s case-insensitive `TextSig` table (`<script`, `<!doctype html`, `<html`, `<?php`, `javascript:`, `vbscript:`, `invoke-expression`, `iex(`, `cmd.exe`, `/bin/sh`), matched by `HasAsciiSignatureCaseInsensitive`, did **no** context validation. A coincidental case-insensitive hit inside high-entropy CLUT data fired S8 — e.g. `PowerShell expression invocation at offset 0x1a2c65` on `SWOP2013C3_CRPC5.icc`, a stray `iex(` inside a `B2A0` lutBToAType CLUT with **zero** printable context on either side. A corpus sweep confirms it is the only text-sig hit across 90 profiles.

## Fix

These signatures are dangerous only as **text**, so a genuine hit sits inside printable content. `HasAsciiSignatureCaseInsensitive` now requires printable bytes (tab/newline/`0x20`–`0x7e`) adjacent to the match, summing to at least 16. A match with little/no printable context (binary on both sides) is rejected; a real embedded script/markup/command payload still fires. Signature-table-local, no new dependency, S8 detail strings unchanged, whole-file coverage preserved.

## Regression coverage

Standard-tag true-negative / true-positive cases added to `iccdev-pawg-report-regression-tests.sh` (CTest `iccdev.pawg-report-regressions`, ASAN+UBSAN), generated in-script:
- **true-negative**: `iex(` surrounded by binary CLUT bytes → S8 stays **OK**.
- **true-positive**: an embedded `<html>…<script>invoke-expression('calc.exe')…</script></html>` blob in printable context → S8 **FAIL**, S12 clear.

**Verification:** 18/18 pass on the patched binary; the text-sig true-negative FAILs on the pre-fix binary, confirming it guards the gate. Corpus: the lone text-sig false positive clears, no true positive lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)