### PR TITLE
use unordered_map to try and work around gcc bug in basic_string.h

### DIFF
--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -378,7 +378,7 @@ bool CIccProfileJson::ParseBasic(const IccJson &header, std::string & /*parseStr
 }
 
 bool CIccProfileJson::ParseTag(const std::string &key, const IccJson &tagValue,
-                               std::map<std::string, icTagSignature> &keyToSig,
+                               KeyToSignatureMap &keyToSig,
                                std::string &parseStr)
 {
   // Determine tag signature from the key name
@@ -521,7 +521,7 @@ bool CIccProfileJson::ParseJson(const IccJson &root, std::string &parseStr)
       return false;
     }
 
-    std::map<std::string, icTagSignature> keyToSig;
+    KeyToSignatureMap keyToSig;
     for (const auto &entry : tags) {
       if (!entry.is_object() || entry.size() != 1) {
         parseStr += "Warning: tag entry must be a single-member object, skipping\n";

--- a/IccJSON/IccLibJSON/IccProfileJson.h
+++ b/IccJSON/IccLibJSON/IccProfileJson.h
@@ -63,9 +63,15 @@ Copyright:  (c) see Software License
 #include "IccProfile.h"
 #include <nlohmann/json.hpp>
 #include <map>
+#include <unordered_map>
 #include <string>
 
 using IccJson = nlohmann::ordered_json;
+
+// currently breaking on GCC due to difference bug in basic_string.h line 495
+// unordered_map doesn't use a signed comparison
+//typedef std::map<std::string, icTagSignature>  KeyToSignatureMap;
+typedef std::unordered_map<std::string, icTagSignature>  KeyToSignatureMap;
 
 class CIccProfileJson : public CIccProfile
 {
@@ -87,7 +93,7 @@ public:
 protected:
   bool ParseBasic(const IccJson &j, std::string &parseStr);
   bool ParseTag(const std::string &key, const IccJson &tagValue,
-                std::map<std::string, icTagSignature> &keyToSig,
+                KeyToSignatureMap &keyToSig,
                 std::string &parseStr);
 };
 


### PR DESCRIPTION
## PR Summary

Work around GCC issue in basic_string.h that causes UBSan errors.
By using unordered_map which won't do comparisons, just hashes.
Works around #1256

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
