### PR TITLE
fix range clipping where comparison was always true

### DIFF
--- a/Tools/CmdLine/IccCmdLineUtil.h
+++ b/Tools/CmdLine/IccCmdLineUtil.h
@@ -142,7 +142,7 @@ inline std::string icSanitizeFileName(const char* szText)
       result += "T";
       break;
     default:
-      if (ch < 0x20 || (ch >= 0x7f && ch <= 0xff)) {
+      if (ch < 0x20 || (ch >= 0x7f)) {  // && <= 0xFF implied by data type
         result += "_";
       }
       else {

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -739,7 +739,7 @@ bool ValidateElf(const RawProfile &raw, size_t offset, size_t end)
 
   // e_type: NONE/REL/EXEC/DYN/CORE (0-4), or the OS/processor-specific reserved
   // ranges (0xfe00-0xffff). e_version must be EV_CURRENT.
-  const bool typeOk = eType <= 4 || (eType >= 0xfe00 && eType <= 0xffff);
+  const bool typeOk = eType <= 4 || (eType >= 0xfe00);  // && eType <= 0xffff implied by data type
   return typeOk && eVersion == 1;
 }
 


### PR DESCRIPTION
Fixes #1279

## PR Summary
simple fix for comparisons always true

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
