### PR TITLE
fix size check to include both tag required values

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -1012,7 +1012,7 @@ bool CIccTagUtf8Text::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
 
-  if (size<sizeof(icTagTypeSignature) || !pIO) {
+  if (size < (sizeof(icTagTypeSignature)+ sizeof(icUInt32Number)) || !pIO) {
     m_szText[0] = '\0';
     return false;
   }
@@ -1021,9 +1021,6 @@ bool CIccTagUtf8Text::Read(icUInt32Number size, CIccIO *pIO)
     return false;
 
   if (!pIO->Read32(&m_nReserved))
-    return false;
-
-  if (size < sizeof(icTagTypeSignature) + sizeof(icUInt32Number))
     return false;
 
   size_t nSize = size - sizeof(icTagTypeSignature) - sizeof(icUInt32Number);
@@ -1368,7 +1365,7 @@ bool CIccTagZipUtf8Text::Read(icUInt32Number size, CIccIO *pIO)
 {
   icTagTypeSignature sig;
 
-  if (size<sizeof(icTagTypeSignature) || !pIO) {
+  if (size < (sizeof(icTagTypeSignature) + sizeof(icUInt32Number)) || !pIO) {
     AllocBuffer(0);
     return false;
   }


### PR DESCRIPTION
And fix similarly in another read function
Fixes #1280

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
