### PR TITLE
Fix: leak in XML tag parsing on duplicate tag signatures (#1306)

### DIFF
--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -698,7 +698,16 @@ bool CIccProfileXml::ParseTag(xmlNode *pNode, std::string &parseStr)
           if ((attr = icXmlFindAttr(pTypeNode, "reserved"))) {
             sscanf(icXmlAttrValue(attr), "%x", &pTag->m_nReserved);
           }
-          AttachTag(sigTag, pTag);
+          //AttachTag refuses (and does not take ownership) when a tag with this
+          //signature already exists; free pTag to avoid a leak on duplicates.
+          if (!AttachTag(sigTag, pTag)) {
+            parseStr += "Unable to attach duplicate tag \"";
+            parseStr += nodeName;
+            snprintf(str, strSize, "\" on line %d\n", pTypeNode->line);
+            parseStr += str;
+            delete pTag;
+            return false;
+          }
         }
         else {
           parseStr += "Unable to Parse \"";
@@ -757,8 +766,11 @@ bool CIccProfileXml::ParseTag(xmlNode *pNode, std::string &parseStr)
           if (tagSigNode->type == XML_ELEMENT_NODE && !icXmlStrCmp(tagSigNode->name, "TagSignature")) {
             if ((const icChar*)tagSigNode->children != NULL) {
               sigTag = (icTagSignature)icGetSigVal((const icChar*)tagSigNode->children->content);
-              AttachTag(sigTag, pTag);
-              bAttached = true;
+              //Only flag ownership transfer when AttachTag actually accepts pTag.
+              //It refuses duplicate signatures without taking ownership, so a
+              //blanket bAttached=true here would leak pTag on a duplicate tag.
+              if (AttachTag(sigTag, pTag))
+                bAttached = true;
             }
           }
         }


### PR DESCRIPTION
## Summary

Fixes the LeakSanitizer leak reported in #1306. `iccFromXml` leaks a freshly-created `CIccTag` when the input XML contains a **duplicate tag signature** (the repro has two `<TagSignature>wtpt</TagSignature>` entries).

## Root cause

`CIccProfileXml::ParseTag()` creates a tag with `CIccTag::Create()` and then hands ownership to the profile via `CIccProfile::AttachTag()`. `AttachTag()` **returns `false` and does not take ownership** when a tag with the same signature already exists:

```cpp
IccTagEntry *pEntry = GetTag(sig);
if (pEntry) {
  if (pEntry->pTag == pTag)
    return true;
  return false;          // <-- ownership NOT transferred
}
```

`ParseTag` ignored that result in two places:

- the **legacy by-type** path set `bAttached = true` unconditionally, and
- the **by-name** path discarded the return value entirely.

So on a duplicate signature the new tag was neither attached nor freed → leak. LSan trace: `operator new` at `IccTagXmlFactory.cpp:84` ← `CIccTagXmlFactory::CreateTag` ← `CIccTag::Create` ← `ParseTag` (`IccProfileXml.cpp:738`).

## Fix

Both paths now check the `AttachTag()` return value; on rejection they `delete pTag` and fail the parse, so ownership is always well-defined. Single-file change, `IccXML/IccLibXML/IccProfileXml.cpp`.

## Repro

```
wget https://raw.githubusercontent.com/xsscx/Commodity-Injection-Signatures/refs/heads/master/xml/icc/ub-member-access-null-pointer-struct-xmlnode.xml
iccFromXml ub-member-access-null-pointer-struct-xmlnode.xml oops.icc
```

## Verification (`-fsanitize=address`, `detect_leaks=1`)

| Binary | Result |
|--------|--------|
| pre-fix | `LeakSanitizer: detected memory leaks` — 48-byte direct leak at `IccTagXmlFactory.cpp:84` (matches the issue) |
| post-fix | leak-clean (0 LSan reports), parse fails gracefully |
| `srgbRef.xml` / `argbRef.xml` round-trip (post-fix) | exit 0, valid ICC produced, no leak, no double-free |

Fixes #1306