### PR TITLE
Make sure AddXform takes ownership of profile, or deletes profile on error

### DIFF
--- a/IccProfLib/IccApplyBPC.cpp
+++ b/IccProfLib/IccApplyBPC.cpp
@@ -552,7 +552,6 @@ bool CIccApplyBPC::pixelXfm(icFloatNumber *DstPixel, icFloatNumber *SrcPixel, ic
 
 	// add the xform
 	if (cmm.AddXform(pICC, nIntent, icInterpTetrahedral, NULL, icXformLutColorimetric, pICC->m_Header.version >= icVersionNumberV5 ? false : true)!=icCmmStatOk) {
-		delete pICC;
 		return false;
 	}
 
@@ -593,7 +592,6 @@ CIccCmm* CIccApplyBPC::getBlackXfm(icRenderingIntent nIntent, const CIccProfile 
 
 	// add the xform
 	if (pCmm->AddXform(pICC1, nIntent, icInterpTetrahedral, NULL, icXformLutColor, pICC1->m_Header.version >= icVersionNumberV5 ? false : true)!=icCmmStatOk) {
-		delete pICC1;
 		delete pCmm;
 		return NULL;
 	}
@@ -607,7 +605,6 @@ CIccCmm* CIccApplyBPC::getBlackXfm(icRenderingIntent nIntent, const CIccProfile 
 
 	// add the xform
 	if (pCmm->AddXform(pICC2, icRelativeColorimetric, icInterpTetrahedral, NULL, icXformLutColor, pICC2->m_Header.version >= icVersionNumberV5 ? false : true)!=icCmmStatOk) { // uses the relative intent on the device to Lab side
-		delete pICC2;
 		delete pCmm;
 		return NULL;
 	}

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -8833,10 +8833,16 @@ icStatusCMM CIccCmm::AddXform(CIccProfile &Profile,
 
   //borrow the caller's AttachIO to perform the AddXform
   pProfile->CopyAttach(&Profile, true);
+  
+  // CFL-078: Save deviceClass before AddXform - cenc ownership transfer
+  icProfileClassSignature savedClass = pProfile->m_Header.deviceClass;
 
   icStatusCMM stat = AddXform(pProfile, nIntent, nInterp, pPcc, nLutType, bUseD2BxB2DxTags, pHintManager);
   // AddXform took ownership of the profile pointer, or deleted it if there was an error
-
+  
+  if (stat == icCmmStatOk && savedClass != icSigColorEncodingClass)
+    pProfile->CopyAttach(nullptr);
+    
   return stat;
 }
 

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -8336,14 +8336,8 @@ icStatusCMM CIccCmm::AddXform(const icChar *szProfilePath,
   if (!pProfile) 
     return icCmmStatCantOpenProfile;
 
-  // CFL-078: Save deviceClass before AddXform - CIccXform::Create() deletes
-  // cenc profiles internally (line 546), so caller must NOT double-delete.
-  icProfileClassSignature savedClass = pProfile->m_Header.deviceClass;
-
   icStatusCMM rv = AddXform(pProfile, nIntent, nInterp, pPcc, nLutType, bUseD2BxB2DxTags, pHintManager);
-
-  if (rv != icCmmStatOk && savedClass != icSigColorEncodingClass)
-    delete pProfile;
+  // AddXform took ownership of the profile pointer, or deleted it if there was an error
 
   return rv;
 }
@@ -8396,13 +8390,8 @@ icStatusCMM CIccCmm::AddXform(icUInt8Number *pProfileMem,
     return icCmmStatCantOpenProfile;
   }
 
-  // CFL-078: Save deviceClass before AddXform - cenc ownership transfer
-  icProfileClassSignature savedClass = pProfile->m_Header.deviceClass;
-
   icStatusCMM rv = AddXform(pProfile, nIntent, nInterp, pPcc, nLutType, bUseD2BxB2DxTags, pHintManager);
-
-  if (rv != icCmmStatOk && savedClass != icSigColorEncodingClass)
-    delete pProfile;
+  // AddXform took ownership of the profile pointer, or deleted it if there was an error
 
   return rv;
 }
@@ -8417,6 +8406,7 @@ icStatusCMM CIccCmm::AddXform(icUInt8Number *pProfileMem,
  * 
  * Args: 
  *  pProfile = pointer to the CIccProfile object to be added (profile will be owned by the CMM's added xform),
+ *      AddXform takes ownership of the profile, or deletes the profile on error.
  *  nIntent = rendering intent to be used with the profile,
  *  nInterp = type of interpolation to be used with the profile,
  *  nLutType = selection of which transform lut to use
@@ -8476,6 +8466,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
       }
       else {
         if (pProfile->m_Header.deviceClass == icSigLinkClass) {
+          delete pProfile;
           return icCmmStatBadSpaceLink;
         }
         if (pProfile->m_Header.deviceClass == icSigAbstractClass) {
@@ -8511,24 +8502,30 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
       break;
 
     case icXformLutBRDFParam:
-      if (!bInput)
+      if (!bInput) {
+        delete pProfile;
         return icCmmStatBadSpaceLink;
+      }
       nSrcSpace = pProfile->m_Header.colorSpace;
       nDstSpace = icSigBRDFParameters;
       bInput = true;
       break;
 
     case icXformLutBRDFDirect:
-      if (!bInput)
+      if (!bInput) {
+        delete pProfile;
         return icCmmStatBadSpaceLink;
+      }
       nSrcSpace = icSigBRDFDirect;
       nDstSpace = pProfile->m_Header.pcs;
       bInput = true;
       break;
 
     case icXformLutBRDFMcsParam:
-      if (!bInput)
+      if (!bInput) {
+        delete pProfile;
         return icCmmStatBadSpaceLink;
+      }
       nSrcSpace = (icColorSpaceSignature)pProfile->m_Header.mcs;
       nDstSpace = icSigBRDFParameters;
       break;
@@ -8547,6 +8544,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
           if ((icXformLutType)(prev->ptr->GetXformType()) != icXformLutMCS) {
             //check to see if we can convert previous xform to connect via an MCS
             if (!prev->ptr->GetProfile()->m_Header.mcs) {
+              delete pProfile;
               return icCmmStatBadMCSLink;
             }
 
@@ -8561,6 +8559,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
               // leave the list with a NULL xform that the next Apply
               // dereferences -> SIGSEGV. Leave pPrev in place and
               // surface a clean error status.
+              delete pProfile;
               return icCmmStatBadMCSLink;
             }
 
@@ -8571,6 +8570,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
           }
         }
         else {
+          delete pProfile;
           return icCmmStatBadMCSLink;
         }
 
@@ -8589,12 +8589,14 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
           nParentSpace = pProfile->GetParentColorSpace();
         }
         else {
+          delete pProfile;
           return icCmmStatBadSpaceLink;
         }
       }
       break;
 
     default:
+      delete pProfile;
       return icCmmStatBadLutType;
   }
 
@@ -8606,15 +8608,19 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
       m_nSrcSpace = nSrcSpace;
     }
     else if (!IsCompatSpace(m_nSrcSpace, nSrcSpace)) {
+      delete pProfile;
       return icCmmStatBadSpaceLink;
     }
   }
   else if (!IsCompatSpace(m_nLastSpace, nSrcSpace)) {
+    delete pProfile;
     return icCmmStatBadSpaceLink;
   }
 
-  if (nSrcSpace==icSigNamedData)
+  if (nSrcSpace==icSigNamedData) {
+    delete pProfile;
     return icCmmStatBadSpaceLink;
+  }
   
   //Automatic creation of intent from header/last profile
   if (nIntent==icUnknownIntent) {
@@ -8638,6 +8644,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
   Xform.ptr = CIccXform::Create(pProfile, bInput, nIntent, nInterp, pPcc, nLutType, bUseD2BxB2DxTags, pHintManager);
 
   if (!Xform.ptr) {
+    // profile was deleted inside CIccXform::Create
     return icCmmStatBadXform;
   }
 
@@ -8664,6 +8671,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
 *
 * Args:
 *  pProfile = pointer to the CIccProfile object to be added,
+*      AddXform takes ownership of the profile, or deletes the profile on error.
 *  nIntent = rendering intent to be used with the profile,
 *  nInterp = type of interpolation to be used with the profile,
 *  nLutType = selection of which transform lut to use
@@ -8692,6 +8700,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
   case icSigMultiplexIdentificationClass:
   case icSigMultiplexVisualizationClass:
   case icSigMultiplexLinkClass:
+    delete pProfile;
     return icCmmStatBadLutType;
 
   default:
@@ -8712,6 +8721,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
   }
   else {
     if (pProfile->m_Header.deviceClass == icSigLinkClass) {
+      delete pProfile;
       return icCmmStatBadSpaceLink;
     }
     if (pProfile->m_Header.deviceClass == icSigAbstractClass) {
@@ -8737,15 +8747,19 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
       m_nSrcSpace = nSrcSpace;
     }
     else if (!IsCompatSpace(m_nSrcSpace, nSrcSpace)) {
+      delete pProfile;
       return icCmmStatBadSpaceLink;
     }
   }
   else if (!IsCompatSpace(m_nLastSpace, nSrcSpace)) {
+    delete pProfile;
     return icCmmStatBadSpaceLink;
   }
 
-  if (nSrcSpace == icSigNamedData)
+  if (nSrcSpace == icSigNamedData) {
+    delete pProfile;
     return icCmmStatBadSpaceLink;
+  }
 
   //Automatic creation of intent from header/last profile
   if (nIntent == icUnknownIntent) {
@@ -8764,6 +8778,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
   Xform.ptr = CIccXform::Create(pProfile, pXformTag, bInput, nIntent, nInterp, pPcc, bUseSpectralPCS, pHintManager);
 
   if (!Xform.ptr) {
+    // CIccXform::Create has already deleted the profile
     return icCmmStatBadXform;
   }
 
@@ -8786,6 +8801,7 @@ icStatusCMM CIccCmm::AddXform(CIccProfile *pProfile,
  * 
  * Args: 
  *  Profile = reference a CIccProfile object that will be copies and added,
+ *      AddXform takes ownership of the profile, or deletes the profile on error.
  *  nIntent = rendering intent to be used with the profile,
  *  nInterp = type of interpolation to be used with the profile,
  *  nLutType = selection of which transform lut to use
@@ -8818,17 +8834,8 @@ icStatusCMM CIccCmm::AddXform(CIccProfile &Profile,
   //borrow the caller's AttachIO to perform the AddXform
   pProfile->CopyAttach(&Profile, true);
 
-  // CFL-078: Save deviceClass before AddXform - cenc ownership transfer
-  icProfileClassSignature savedClass = pProfile->m_Header.deviceClass;
-
   icStatusCMM stat = AddXform(pProfile, nIntent, nInterp, pPcc, nLutType, bUseD2BxB2DxTags, pHintManager);
-
-  //Now that we have added the xform disconnect from the callers AttachIO
-  if (savedClass != icSigColorEncodingClass)
-    pProfile->CopyAttach(nullptr);
-
-  if (stat != icCmmStatOk && savedClass != icSigColorEncodingClass)
-    delete pProfile;
+  // AddXform took ownership of the profile pointer, or deleted it if there was an error
 
   return stat;
 }
@@ -10877,13 +10884,8 @@ icStatusCMM CIccNamedColorCmm::AddXform(const icChar *szProfilePath,
   if (!pProfile) 
     return icCmmStatCantOpenProfile;
 
-  // CFL-078: Save deviceClass before AddXform - cenc ownership transfer (CWE-416)
-  icProfileClassSignature savedClass = pProfile->m_Header.deviceClass;
-
   icStatusCMM rv = AddXform(pProfile, nIntent, nInterp, pPcc, nLutType, bUseD2BxB2DxTags, pHintManager);
-
-  if (rv != icCmmStatOk && savedClass != icSigColorEncodingClass)
-    delete pProfile;
+  // AddXform took ownership of the profile pointer, or deleted it if there was an error
 
   return rv;
 }
@@ -10897,6 +10899,7 @@ icStatusCMM CIccNamedColorCmm::AddXform(const icChar *szProfilePath,
  * 
  * Args: 
  *  pProfile = pointer to the CIccProfile object to be added,
+ *      AddXform takes ownership of the profile, or deletes the profile on error.
  *  nIntent = rendering intent to be used with the profile,
  *  nInterp = type of interpolation to be used with the profile
  *  nLutType = type of lut to use from the profile
@@ -11023,16 +11026,21 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
 
         Xform.ptr = CIccXform::Create(pProfile, bInput, nIntent, nInterp, pPcc, icXformLutNamedColor, bUseD2BxB2DxTags, pHintManager);
         if (!Xform.ptr) {
+          // CIccXform::Create has already deleted the profile
           return icCmmStatBadXform;
         }
         CIccXformNamedColor *pXform = (CIccXformNamedColor *)Xform.ptr;
         rv = pXform->SetSrcSpace(nSrcSpace);
-        if (rv)
+        if (rv) {
+          delete Xform.ptr;
           return rv;
+        }
 
         rv = pXform->SetDestSpace(nDstSpace);
-        if (rv)
+        if (rv) {
+          delete Xform.ptr;
           return rv;
+        }
       }
       else {
         //It isn't named color so make we will use color lut.
@@ -11055,6 +11063,7 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
         }
         else {
           if (pProfile->m_Header.deviceClass == icSigLinkClass) {
+            delete pProfile;
             return icCmmStatBadSpaceLink;
           }
           if (pProfile->m_Header.deviceClass == icSigAbstractClass) {
@@ -11122,11 +11131,13 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
           break;
 
         default:
+          delete pProfile;
           return icCmmStatBadLutType;
       }
       break;
 
     default:
+      delete pProfile;
       return icCmmStatBadLutType;
   }
 
@@ -11137,10 +11148,14 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
       m_nSrcSpace = nSrcSpace;
     }
     else if (!IsCompatSpace(m_nSrcSpace, nSrcSpace) && !IsNChannelCompat(m_nSrcSpace, nSrcSpace)) {
+      if (!Xform.ptr)
+        delete pProfile;
       return icCmmStatBadSpaceLink;
     }
   }
   else if (!IsCompatSpace(m_nLastSpace, nSrcSpace) && !IsNChannelCompat(m_nSrcSpace, nSrcSpace))  {
+      if (!Xform.ptr)
+        delete pProfile;
       return icCmmStatBadSpaceLink;
   }
 
@@ -11168,6 +11183,7 @@ icStatusCMM CIccNamedColorCmm::AddXform(CIccProfile *pProfile,
     Xform.ptr = CIccXform::Create(pProfile, bInput, nIntent, nInterp, pPcc, nUseLutType, bUseD2BxB2DxTags, pHintManager);
 
   if (!Xform.ptr) {
+    // CIccXform::Create has already deleted the profile
     return icCmmStatBadXform;
   }
 


### PR DESCRIPTION
Make sure AddXform deletes the profile when there is an error, similar to CreatXform.
Adjust callers to deal with that change.
Add comments about how AddXform takes ownership, or deletes the profile on error.
Fixes #1310 and related bugs.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
