### PR TITLE
Fix: leak of NamedColor profile in CIccCmmSearch::AddXform (#1332)

### DIFF
--- a/IccProfLib/IccCmmSearch.cpp
+++ b/IccProfLib/IccCmmSearch.cpp
@@ -270,8 +270,16 @@ icStatusCMM CIccCmmSearch::AddXform(CIccProfile* pProfile,
   bool bUseD2BxB2DxTags,
   CIccCreateXformHintManager* /* pHintManager */)
 {
-  if (pProfile->m_Header.deviceClass == icSigNamedColorClass)
+  // This override owns pProfile on every path, matching the base
+  // CIccCmm::AddXform contract (#1327): the successful cases below store it and
+  // ~CIccCmmSearch frees it, while every rejection deletes it here.  Callers
+  // (the filename and reference AddXform overloads) therefore never free it
+  // themselves.  A NamedColor profile has no search LUT, so reject it -- and
+  // free it, as the default case below already does (#1332).
+  if (pProfile->m_Header.deviceClass == icSigNamedColorClass) {
+    delete pProfile;
     return icCmmStatInvalidLut;
+  }
 
   switch (m_nAttached) {
   case 0:


### PR DESCRIPTION
## Summary

Fixes #1332 — a NamedColor profile is leaked by the search CMM. (Regression test in #1334.)

After #1327 made every `CIccCmm::AddXform` overload **own** the profile it is given (store on success, delete on error), the filename and reference overloads stopped freeing it themselves and now rely on `AddXform`. But `CIccCmmSearch::AddXform(CIccProfile*)` rejects a **NamedColor** profile (no search LUT) with `return icCmmStatInvalidLut;` **without** deleting it — while its own `default:` case already deletes. So a NamedColor profile fed through the search forward chain (`CreateSearch` → filename `AddXform` → override) leaks.

## Reproduction (the issue's exact repro, under ASan/LSan)

```
iccApplySearch test-data-rgb-8bit.txt 0 0 leak.icc 1 fidelity.icc 1 -INIT 1
```
`leak.icc` is the NamedColor profile. Pre-fix:
```
SUMMARY: AddressSanitizer: 488 byte(s) leaked in 8 allocation(s)
  ... CIccProfile::ReadBasic(CIccIO*) IccProfLib/IccProfile.cpp:1363
  ... OpenIccProfile -> CIccCmm::AddXform(const char*) -> CIccConnectCmm::CreateSearch
```

## Fix

One line: `delete pProfile;` on the NamedColor rejection path in `CIccCmmSearch::AddXform`, honoring the post-#1327 ownership contract. No double-free — the filename/reference overloads no longer free it. The chain is still correctly rejected (`icCmmStatInvalidLut`); the `-INIT` search success path is unaffected (verified clean under ASan, no double-free). An allocation counter confirms determinism: pre-fix grows 10 allocations/run, post-fix 0.

## Regression test

Submitted as **#1334** (upstream branch — it touches maintainer-owned automation paths that a fork PR cannot modify). It feeds a tracked NamedColor profile through the filename overload and fails pre-fix / passes post-fix under both gcc and clang ASan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)