### PR TITLE
Test: regression for NamedColor profile ownership in CIccCmmSearch (#1332)

### DIFF
--- a/.github/ci/regression/cmmsearch-namedcolor-ownership.cpp
+++ b/.github/ci/regression/cmmsearch-namedcolor-ownership.cpp
@@ -1,0 +1,70 @@
+/*
+    File:       cmmsearch-namedcolor-ownership.cpp
+
+    Contains:   CTest helper for CIccCmmSearch::AddXform profile ownership
+                (issue #1332).
+
+    Post-#1327 every CIccCmm::AddXform overload owns the profile it is given:
+    it stores the profile on success or deletes it on error, so the filename and
+    reference overloads no longer free it themselves.  CIccCmmSearch overrides
+    AddXform(CIccProfile*) and rejects a NamedColor profile (it has no search
+    LUT); that rejection must also delete the profile to honor the contract.
+
+    This helper feeds a NamedColor profile through the inherited
+    AddXform(const char*) overload, which opens the profile internally and hands
+    it to the override.  Because the helper never holds the resulting pointer, a
+    profile that the override failed to free is unreachable and reported by the
+    at-exit LeakSanitizer scan (the iccDEV ASan CI job).  The status check also
+    guards that the NamedColor rejection path is the one exercised.
+
+    Usage:
+      cmmsearch-namedcolor-ownership <namedcolor_profile.icc>
+
+    Exit codes:
+      0 - profile rejected as expected and (under ASan at exit) not leaked
+      1 - unexpected status
+      2 - usage error
+      (non-zero is also forced by LeakSanitizer at exit if the profile leaks)
+*/
+
+#include "IccCmm.h"
+#include "IccCmmSearch.h"
+
+#include <cstdio>
+
+// Contained in its own function so the inherited AddXform(const char*) overload
+// is the only thing that ever holds a pointer to the opened profile; nothing in
+// main() can act as a LeakSanitizer root for it.
+static icStatusCMM add_named_color(const char* profilePath)
+{
+  CIccCmmSearch cmm;
+  // The override hides the inherited filename overload, so qualify it explicitly
+  // (as CIccConnectCmm::CreateSearch does).  It opens the profile and dispatches
+  // back to CIccCmmSearch::AddXform(CIccProfile*) via virtual dispatch.
+  return cmm.CIccCmm::AddXform(profilePath);
+}
+
+int main(int argc, char** argv)
+{
+  if (argc != 2) {
+    std::fprintf(stderr, "usage: %s <namedcolor_profile.icc>\n",
+                 argv[0] ? argv[0] : "cmmsearch-namedcolor-ownership");
+    return 2;
+  }
+
+  icStatusCMM rv = add_named_color(argv[1]);
+
+  // The search CMM has no LUT for a NamedColor profile, so it must reject it.
+  if (rv != icCmmStatInvalidLut) {
+    std::fprintf(stderr,
+      "cmmsearch-namedcolor-ownership: expected InvalidLut (%d), got %d (%s)\n",
+      (int)icCmmStatInvalidLut, (int)rv, CIccCmm::GetStatusText(rv));
+    return 1;
+  }
+
+  std::fprintf(stdout, "cmmsearch-namedcolor-ownership: status=%d (%s)\n",
+               (int)rv, CIccCmm::GetStatusText(rv));
+  // Returns to the runtime; under ASan the at-exit LeakSanitizer check fails the
+  // process if the override left the NamedColor profile unowned (#1332).
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -200,6 +200,47 @@ function(iccdev_add_tag_layout_shared_data_test)
   endif()
 endfunction()
 
+# Guards CIccCmmSearch::AddXform profile ownership (#1332): the search CMM
+# rejects a NamedColor profile (no search LUT) and, like the base AddXform
+# contract (#1327), must free it.  The helper feeds a NamedColor profile through
+# the inherited filename overload, which opens it internally, so a profile the
+# override fails to free is unreachable and reported by the ASan/LSan CI job.
+function(iccdev_add_cmmsearch_namedcolor_ownership_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCmmSearchNamedColorOwnershipTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/cmmsearch-namedcolor-ownership.cpp"
+  )
+  target_link_libraries(iccCmmSearchNamedColorOwnershipTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccCmmSearchNamedColorOwnershipTest)
+
+  add_test(
+    NAME iccdev.cmmsearch-namedcolor-ownership
+    COMMAND "$<TARGET_FILE:iccCmmSearchNamedColorOwnershipTest>"
+      "${ICCDEV_REPO_ROOT}/.github/ci/test-data/fuzz-nmcl-9c09d1e6.icc"
+  )
+  set_tests_properties(iccdev.cmmsearch-namedcolor-ownership PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;iccconnect;search;leak;issue-1332;regression"
+  )
+  if(WIN32)
+    set(_cmmsearch_namedcolor_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCmmSearchNamedColorOwnershipTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _cmmsearch_namedcolor_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.cmmsearch-namedcolor-ownership PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_cmmsearch_namedcolor_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_fileio_getlength_position_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -514,6 +555,7 @@ if(WIN32)
   iccdev_add_fileio_seek_tell_test()
   iccdev_add_parser_restore_calls_test()
   iccdev_add_tag_layout_shared_data_test()
+  iccdev_add_cmmsearch_namedcolor_ownership_test()
 
   return()
 endif()
@@ -570,6 +612,7 @@ iccdev_add_profile_write_failure_test()
 iccdev_add_fileio_seek_tell_test()
 iccdev_add_parser_restore_calls_test()
 iccdev_add_tag_layout_shared_data_test()
+iccdev_add_cmmsearch_namedcolor_ownership_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")


### PR DESCRIPTION
## Summary

Adds a deterministic CTest regression for the NamedColor profile ownership fix in #1332 (code fix in PR #1333). Touches maintainer-owned automation paths (`.github/ci/regression/`, `Build/Cmake/Testing/`), so it is hosted on an upstream branch (the fork-PR automation gate forbids these paths from a fork).

## What it guards

`CIccCmmSearch::AddXform(CIccProfile*)` must free a rejected NamedColor profile (post-#1327 ownership contract). The helper feeds a NamedColor profile through the inherited filename overload (`cmm.CIccCmm::AddXform(path)`, as `CreateSearch` does). Because the helper never holds the opened pointer, a profile the override fails to free is **unreachable** and reliably reported by the at-exit LeakSanitizer scan — avoiding the stack-root flakiness of held-pointer leak tests.

## Verification

- Pre-fix (without #1333): **FAILS** — `LeakSanitizer: ... CIccProfile::ReadBasic IccProfile.cpp:1363`.
- Post-fix (with #1333): **PASSES**.
- Confirmed under **both gcc and clang** ASan via `ctest -R cmmsearch-namedcolor-ownership`.
- Allocation-counter cross-check: pre-fix leaks 10 allocations/run, post-fix 0.

Reuses the tracked `.github/ci/test-data/fuzz-nmcl-9c09d1e6.icc`; no new test assets.

> Note: this test only goes green once #1333 (the one-line fix) is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)