### PR TITLE
Fix: leak of CIccPcsXform in CIccCmm::CheckPCSConnections on Connect failure (#1337)

### DIFF
--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -8927,16 +8927,27 @@ icStatusCMM CIccCmm::CheckPCSConnections(bool bUsePCSConversions/*=false*/)
 
         rv = pPcs->Connect(last->ptr, next->ptr);
 
-        if (rv!=icCmmStatOk && rv!=icCmmStatIdentityXform)
+        // A hard Connect() failure aborts CheckPCSConnections.  pPcs is still a
+        // locally-owned allocation that has not been handed to the xform list,
+        // so free it before returning - the sibling CIccPcsXform blocks (the
+        // ConnectFirst case above and the trailing case below) both delete on
+        // their failure paths; this one previously leaked it (#1337).
+        if (rv!=icCmmStatOk && rv!=icCmmStatIdentityXform) {
+          delete pPcs;
           return rv;
+        }
 
         if (rv!=icCmmStatIdentityXform) {
+          // A real conversion is needed: ownership of pPcs passes to the xform
+          // list, which frees it when the CMM is destroyed.
           ptr.ptr = pPcs;
           xforms.push_back(ptr);
 
           bUsesPcsXforms = true;
         }
         else {
+          // Identity conversion: the spaces already match, so the extra
+          // PcsXform is unnecessary - discard it.
           delete pPcs;
         }
       }


### PR DESCRIPTION
## Summary

Fixes the `CIccCmm::CheckPCSConnections` leak surfaced by the iccApplyToLink 200-QA ASan run (#1337):

```
Direct leak of 144 byte(s) in 1 object(s)
  #1 CIccCmm::CheckPCSConnections(bool)  IccProfLib/IccCmm.cpp
  #2 CIccCmm::Begin(bool, bool)
  #3 main  Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
```

`CheckPCSConnections` builds up to three `CIccPcsXform` objects; each is either pushed onto the xform list (ownership transferred) or deleted. The **middle** block returned on a hard `Connect()` failure (`rv != icCmmStatOk && rv != icCmmStatIdentityXform`) **without** deleting the locally-owned `pPcs` — leaking it. The sibling `ConnectFirst` block above and the trailing block below both delete on their failure paths; this one was the outlier.

## Fix

One line — `delete pPcs;` before the failure `return`, with comments documenting the ownership on each branch (transfer-to-list on success, discard on identity, free on failure).

## Verification

- **Code:** the fix makes the middle block consistent with its two siblings (which already delete on failure); ASan log pinpoints this exact allocation site.
- **No regression:** the search `-INIT` success path (which exercises `CheckPCSConnections`' success/identity branches) stays ASan/LSan-clean.
- The specific `Connect()`-hard-failure chain that triggers the leak lives in the 200-QA profile set/script (not in-tree), so no deterministic CTest is added here; the change is a self-evident missing-delete mirroring the adjacent blocks.

> Scope: this addresses the `CheckPCSConnections` library leak (#1337). The separate tool-level `pccList`/`-PCC` drop in `iccApplyToLink.cpp` (#1336) is a different path and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)