### PR TITLE
Fix: leak of -PCC profiles in iccApplyToLink on error exit paths (#1336)

### DIFF
--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -660,6 +660,18 @@ void Usage()
 
 //===================================================
 
+// The tool owns every -PCC profile it opens until cmm.Begin() has consumed the
+// connection conditions; they are tracked in pccList and must be released on
+// every exit path.  Centralizing the release here keeps the early-return error
+// paths from stranding them (#1336).
+static void releasePccList(IccProfilePtrList& pccList)
+{
+  for (IccProfilePtrList::iterator pcc = pccList.begin(); pcc != pccList.end(); pcc++) {
+    delete *pcc;
+  }
+  pccList.clear();
+}
+
 int main(int argc, icChar* argv[])
 {
   int minargs = 10; // minimum number of arguments
@@ -782,6 +794,8 @@ int main(int argc, icChar* argv[])
         pPccProfile = OpenIccProfile(argv[nCount+3]);
         if (!pPccProfile) {
           printf("Unable to open Profile Connections Conditions from '%s'\n", argv[nCount+3]);
+          // Free any -PCC profiles opened on earlier loop iterations (#1336).
+          releasePccList(pccList);
           return -1;
         }
         //Keep track of pPccProfile for until after cmm.Begin is called
@@ -814,6 +828,10 @@ int main(int argc, icChar* argv[])
         if (stat == icCmmStatBadSpaceLink) {
           printf("The profile's color spaces do not connect with the previous transform in the chain.\n");
         }
+        // AddXform already owns/frees pXformProfile on failure (#1327); the
+        // tool still owns the accumulated -PCC profiles, so release them before
+        // bailing out instead of leaking them (#1336).
+        releasePccList(pccList);
         return -1;
       }
       sigMap.clear();
@@ -829,18 +847,17 @@ int main(int argc, icChar* argv[])
     // Decode the status code into text (issue #1322 follow-through) instead
     // of printing a bare number.
     printf("Error - Unable to begin profile application (status %d: %s) - Possibly invalid or incompatible profiles\n", stat, CIccCmm::GetStatusText(stat));
+    // Begin() failed after the chain was assembled; the -PCC profiles are still
+    // tool-owned at this point, so release them rather than leak them (#1336).
+    releasePccList(pccList);
     return -1;
   }
 
   pWriter->setCmm(&theCmm);
 
-  //Now we can release the pccProfile nodes.
-  IccProfilePtrList::iterator pcc;
-  for (pcc=pccList.begin(); pcc!=pccList.end(); pcc++) {
-    CIccProfile *pPccProfile = *pcc;
-    delete pPccProfile;
-  }
-  pccList.clear();
+  //Now that Begin() has consumed the connection conditions we can release the
+  //-PCC profile nodes.
+  releasePccList(pccList);
 
   if (!pWriter->begin(theCmm.GetSourceSpace(), theCmm.GetDestSpace())) {
     printf("Unable to begin writing LUT\n");


### PR DESCRIPTION
## Summary

Fixes #1336 — `iccApplyToLink` leaks its `-PCC` profiles when the chain fails to assemble.

The tool opens each `-PCC` profile and tracks it in `pccList`, releasing the list only **after** `cmm.Begin()` consumes the connection conditions. Three error-exit paths before that point returned **without** freeing `pccList`:
- `-PCC` open failure (leaks earlier-iteration entries)
- **`AddXform` failure** — e.g. `icCmmStatBadSpaceLink` when a profile doesn't connect to the chain (the path the issue's repro hits)
- `Begin()` failure

## Reproduction (issue's exact command, under ASan/LSan)

```
iccApplyToLink Results/qa_link_pcc.icc 0 17 1 QA_Link_PCC 0.0 1.0 0 1 \
  ICC/Spec380_10_730-D50_2deg.icc 3 -PCC ICC/Spec400_10_700-IllumA_2deg-Abs.icc \
  ../sRGB_v4_ICC_preference.icc 1
```
The `sRGB` profile doesn't connect to the spectral chain → `AddXform` returns `BadSpaceLink` → early `return -1` strands the `-PCC` `Spec400` profile:
```
Indirect leak of ... CIccProfile::ReadBasic(CIccIO*) IccProfile.cpp:1363
  ... OpenIccProfile -> main iccApplyToLink.cpp  (the -PCC open)
SUMMARY: AddressSanitizer: 608 byte(s) leaked
```
(The tool's error message looked "silent" only because LeakSanitizer's `_exit` discards the buffered stdout; with leak detection off it prints `Error - Unable to add '…' (status 2: Invalid space link)`.)

## Fix

Centralize the release in a `releasePccList()` helper and call it on every exit path. The main (non-`-PCC`) profiles are unaffected — `AddXform` owns and frees them on failure (#1327).

## Verification

- The repro is now **LSan-clean** and prints its real error (tool exit 255, no leak summary).
- **No regression:** valid links **with and without `-PCC`** still succeed (LUT written) and stay ASan/LSan-clean — the success-path cleanup is the same delete loop, just factored into the helper.

> Related: #1337 (the `CIccCmm::CheckPCSConnections` `CIccPcsXform` leak, PR #1338) is a different path reached only once `Begin()` runs; this `iccApplyToLink` command fails earlier at `AddXform`, so the two leaks are independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)