### PR TITLE
Fix: signed->unsigned SeamlessIndicator conversion in image ParseXml (#1342, #1343)

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -5545,7 +5545,14 @@ bool CIccTagXmlEmbeddedHeightImage::ParseXml(xmlNode *pNode, std::string &parseS
   if (!tagNode)
     return false;
 
-  m_nSeamlesIndicator = atoi(icXmlAttrValue(tagNode, "SeamlessIndicator", "0"));
+  // SeamlessIndicator is stored as an unsigned 32-bit indicator (the binary
+  // Read() path uses Read32).  atoi() returns a signed int, so a negative XML
+  // attribute used to wrap to a huge unsigned value through the implicit
+  // int -> icUInt32Number conversion (#1342).  The value is now parsed into a
+  // signed temporary and any negative (invalid) input is floored to 0, so the
+  // stored indicator is always a well-defined non-negative number.
+  int nSeamlessIndicator = atoi(icXmlAttrValue(tagNode, "SeamlessIndicator", "0"));
+  m_nSeamlesIndicator = nSeamlessIndicator < 0 ? 0 : (icUInt32Number)nSeamlessIndicator;
   m_nEncodingFormat = (icImageEncodingType)atoi(icXmlAttrValue(tagNode, "EncodingFormat", "0"));
   m_fMetersMinPixelValue = (icFloatNumber)atof(icXmlAttrValue(tagNode, "MetersMinPixelValue", "0.0"));
   m_fMetersMaxPixelValue = (icFloatNumber)atof(icXmlAttrValue(tagNode, "MetersMaxPixelValue", "0.0"));
@@ -5648,7 +5655,14 @@ bool CIccTagXmlEmbeddedNormalImage::ParseXml(xmlNode *pNode, std::string &parseS
   if (!tagNode)
     return false;
 
-  m_nSeamlesIndicator = atoi(icXmlAttrValue(tagNode, "SeamlessIndicator", "0"));
+  // SeamlessIndicator is stored as an unsigned 32-bit indicator (the binary
+  // Read() path uses Read32).  atoi() returns a signed int, so a negative XML
+  // attribute used to wrap to a huge unsigned value through the implicit
+  // int -> icUInt32Number conversion (#1343).  The value is now parsed into a
+  // signed temporary and any negative (invalid) input is floored to 0, so the
+  // stored indicator is always a well-defined non-negative number.
+  int nSeamlessIndicator = atoi(icXmlAttrValue(tagNode, "SeamlessIndicator", "0"));
+  m_nSeamlesIndicator = nSeamlessIndicator < 0 ? 0 : (icUInt32Number)nSeamlessIndicator;
   m_nEncodingFormat = (icImageEncodingType)atoi(icXmlAttrValue(tagNode, "EncodingFormat", "0"));
 
   xmlNode *pImageNode;


### PR DESCRIPTION
## Summary

Fixes **#1342** and **#1343** (same root cause, same fix pattern), both UBSan `implicit-integer-sign-change` findings from the xsscx fuzz/QA wave (bisected to `bab6678`).

`CIccTagXmlEmbeddedHeightImage::ParseXml()` (`IccTagXml.cpp:5548`, #1342) and `CIccTagXmlEmbeddedNormalImage::ParseXml()` (`IccTagXml.cpp:5651`, #1343) read the `SeamlessIndicator` XML attribute with `atoi()` (signed `int`) and assigned it directly to the unsigned 32-bit member `m_nSeamlesIndicator`. A negative attribute value wrapped to a huge unsigned value via the implicit `int -> icUInt32Number` conversion:

```
IccTagXml.cpp:5548:25: runtime error: implicit conversion from type 'int' of value
-98 (32-bit, signed) to type 'icUInt32Number' (aka 'unsigned int') changed the value
to 4294967198 (32-bit, unsigned)
```

## Fix

Both sites parse into a signed temporary and floor any negative (invalid) value to 0 before the unsigned assignment, so the stored indicator is always a well-defined non-negative number. Positive values pass through unchanged — `atoi` already capped at `int` range, so the XML path could never represent a value above `INT_MAX`; only the previously-UB negative case now resolves to 0. The binary `Read()` path (`Read32`) is unaffected.

## Verification

Built `iccFromXml` with `-fsanitize=implicit-conversion -fno-sanitize-recover=all` (clang-18):

| PoC | Pre-fix | Post-fix |
|-----|---------|----------|
| `...EmbeddedHeightImage-...Line5548.xml` (`SeamlessIndicator="-98"`) | UBSan runtime error | clean, normal compliance reporting |
| `...EmbeddedNormalImage-...Line5651.xml` (`SeamlessIndicator="-5655"`) | UBSan runtime error | clean |

A valid positive `SeamlessIndicator` (e.g. `7`) still parses and stores unchanged.

## Notes

- Library-only change (`IccXML/`), no fork-gate split needed.
- The deterministic CTest regression for both issues is filed separately as an upstream PR (it touches `.github/` + `Build/Cmake`, which the fork-PR automation gate blocks). Merge **this fix first**; the test PR goes green once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)