### PR TITLE
Test: regression for signed->unsigned SeamlessIndicator conversion (#1342, #1343)

### DIFF
--- a/.github/ci/test-data/ub-heightimage-parsexml-1342.xml
+++ b/.github/ci/test-data/ub-heightimage-parsexml-1342.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType>E98CE9E9h</PreferredCMMType>
+    <ProfileVersion>Invalid BCD version 0xE9E9E9E9</ProfileVersion>
+    <ProfileSubClassVersion>Invalid BCD subclass version 0xE9E9</ProfileSubClassVersion>
+    <ProfileDeviceClass>6393919Ch</ProfileDeviceClass>
+    <ProfileDeviceSubClass>E9E9F9E9h</ProfileDeviceSubClass>
+    <DataColourSpace>16161616h</DataColourSpace>
+    <PCS>1649E9F1h</PCS>
+    <CreationDateTime>59881-59881-59881T59881:57833:59881</CreationDateTime>
+    <PrimaryPlatform>F1380020h</PrimaryPlatform>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false" MCSNeedsSubset="false" VendorFlags="01000000"/>
+    <DeviceManufacturer>0000095Ch</DeviceManufacturer>
+    <DeviceModel>ADADADADh</DeviceModel>
+    <DeviceAttributes ReflectiveOrTransparency="transparency" GlossyOrMatte="glossy" MediaPolarity="negative" MediaColour="blackAndwhite" VendorSpecific="adadadadadadada0"/>
+    <RenderingIntent>Unknown Intent '1397903885'</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="-5654.760253906250" Y="28222.892578125000" Z="-19195.751953125000"/>
+    </PCSIlluminant>
+    <ProfileCreator>9179D334h</ProfileCreator>
+    <ProfileID>FFE9E9E9E9E9E9E9E9E9E9E9DAE9E9E9</ProfileID>
+    <SpectralPCS>E9000051h</SpectralPCS>
+    <SpectralRange>
+     <Wavelengths start="-0.00048828" end="0.01029968" steps="46569"/>
+    </SpectralRange>
+    <BiSpectralRange>
+     <Wavelengths start="-3026.00000000" end="-3026.00000000" steps="59881"/>
+)    </BiSpectralRange>
+    <MCS>E9E9E9E9h</MCS>
+    <Reserved>FFFFFF2F</Reserved>
+  </Header>
+  <Tags>
+    <AToB0Tag> <embeddedHeightImageType reserved="aaffffff">
+      <HeightImage SeamlessIndicator="-98" EncodingFormat="-12623518" MetersMinPixelValue="16967925094473982598447104.000000000000" MetersMaxPixelValue="-0.000000000000">
+       <Image>
+        919191919191919191adadad53525216e9e93d6f6e3e000003ff00fcffffe9e9
+        e9e9e9e9e9e9e9e9e9e9e9e9e9e9
+       </Image>
+      </HeightImage>
+    </embeddedHeightImageType> </AToB0Tag>
+
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-normalimage-parsexml-1343.xml
+++ b/.github/ci/test-data/ub-normalimage-parsexml-1343.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType>E98CE9E9h</PreferredCMMType>
+    <ProfileVersion>0.00</ProfileVersion>
+    <ProfileSubClassVersion>61.63</ProfileSubClassVersion>
+    <ProfileDeviceClass>7370F9F9h</ProfileDeviceClass>
+    <ProfileDeviceSubClass>E9E9E9E9h</ProfileDeviceSubClass>
+    <DataColourSpace>B9F9F9FFh</DataColourSpace>
+    <PCS>FFFFE9E9h</PCS>
+    <CreationDateTime>59881-59-00T00:00:00</CreationDateTime>
+    <PrimaryPlatform>F9380020h</PrimaryPlatform>
+    <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false" ExtendedRangePCS="true" MCSNeedsSubset="true" VendorFlags="adadada0"/>
+    <DeviceManufacturer>ADADADADh</DeviceManufacturer>
+    <DeviceModel>ADADADADh</DeviceModel>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="matte" MediaPolarity="positive" MediaColour="colour" VendorSpecific="adadadadadade950"/>
+    <RenderingIntent>Unknown Intent '16318208'</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="-5714.565429687500" Y="-28354.525390625000" Z="-6986.506835937500"/>
+    </PCSIlluminant>
+    <ProfileCreator>BF04D334h</ProfileCreator>
+    <ProfileID>BBB350F092AAAF6BC31332C414A873D1</ProfileID>
+    <SpectralPCS>E9E9E9E9h</SpectralPCS>
+    <SpectralRange>
+     <Wavelengths start="-3026.00000000" end="-3026.00000000" steps="59881"/>
+    </SpectralRange>
+    <BiSpectralRange>
+     <Wavelengths start="-3026.00000000" end="-3026.00000000" steps="59881"/>
+)    </BiSpectralRange>
+    <MCS>E9E9E9E9h</MCS>
+  </Header>
+  <Tags>
+    <PrivateTag TagSignature="2B2A"> <embeddedNormalImageType reserved="6568f9ff">
+      <NormalImage SeamlessIndicator="-5655" EncodingFormat="-370606021">
+       <Image>
+        0000000000000000
+       </Image>
+      </NormalImage>
+    </embeddedNormalImageType> </PrivateTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh
+++ b/.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issues #1342 / #1343 - signed->unsigned conversion in image ParseXml
+###############################################################################
+#
+# CIccTagXmlEmbeddedHeightImage::ParseXml() and
+# CIccTagXmlEmbeddedNormalImage::ParseXml() read the "SeamlessIndicator"
+# attribute with atoi() (a signed int) and assigned it to the unsigned 32-bit
+# member m_nSeamlesIndicator.  A negative attribute value wrapped to a huge
+# unsigned value through the implicit int -> icUInt32Number conversion, which
+# UBSan's implicit-integer-sign-change check (part of the "integer" group)
+# flags as a runtime error:
+#
+#   IccTagXml.cpp:5548:25: runtime error: implicit conversion from type 'int'
+#   of value -98 ... to type 'icUInt32Number' ... changed the value to ...
+#
+# The fix parses into a signed temporary and floors negatives to 0, so no
+# signed->unsigned wrap occurs.  This test replays the two fuzz PoCs through
+# iccFromXml and fails if the implicit-conversion runtime error reappears.
+#
+# This check is only meaningful when iccFromXml was built with the UBSan
+# integer / implicit-conversion sanitizer (the ci-iccdev-tool-tests workflow
+# builds with ENABLE_UBSAN=ON ENABLE_INTEGER_SANITIZER=ON).  On a plain build
+# the conversion check is absent, so the test SKIPS rather than report a
+# misleading pass.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (no sign-change error) or skipped cleanly
+#   2 - UBSan implicit-conversion finding (regression)
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1342-1343}"
+DATA_DIR="$REPO_ROOT/.github/ci/test-data"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+
+# Only meaningful under a build instrumented with the integer / implicit
+# conversion sanitizer.  Inspect the build's CMakeCache.txt (walk up from the
+# tool location) for either the ENABLE_* options or an explicit -fsanitize flag
+# covering integer/undefined/implicit conversions.
+CACHE=""
+probe="$(dirname "$FROMXML")"
+for _ in 1 2 3 4 5; do
+  if [ -f "$probe/CMakeCache.txt" ]; then CACHE="$probe/CMakeCache.txt"; break; fi
+  probe="$(dirname "$probe")"
+done
+sanitized=0
+if [ -n "$CACHE" ]; then
+  if grep -qiE "ENABLE_INTEGER_SANITIZER:BOOL=ON|ENABLE_UBSAN:BOOL=ON" "$CACHE"; then
+    sanitized=1
+  elif grep -iE "CMAKE_(CXX|C)_FLAGS" "$CACHE" | grep -qiE "fsanitize=[^ ]*(integer|undefined|implicit)"; then
+    sanitized=1
+  fi
+fi
+if [ "$sanitized" -ne 1 ]; then
+  echo "[SKIP] iccFromXml not built with the integer/implicit-conversion sanitizer (CMakeCache: ${CACHE:-none})"
+  exit 0
+fi
+
+HEIGHT_XML="$DATA_DIR/ub-heightimage-parsexml-1342.xml"
+NORMAL_XML="$DATA_DIR/ub-normalimage-parsexml-1343.xml"
+
+status=0
+run_case() {
+  local issue="$1" xml="$2"
+  if [ ! -f "$xml" ]; then
+    echo "[SKIP] PoC XML missing: $xml"
+    return
+  fi
+  local log="$OUTDIR/$(basename "$xml").log"
+  # The PoC profile is intentionally invalid, so iccFromXml exits non-zero
+  # regardless of the fix; the pass/fail signal is the UBSan runtime error, not
+  # the tool exit code.  Keep ASan quiet about unrelated leaks on this invalid
+  # input so UBSan's conversion diagnostic is the only thing we key on.
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$FROMXML" "$xml" "$OUTDIR/$(basename "$xml").out" > "$log" 2>&1
+
+  if grep -qE "runtime error: implicit conversion" "$log"; then
+    echo "[FAIL] #$issue: signed->unsigned conversion of SeamlessIndicator reappeared"
+    grep -E "runtime error: implicit conversion|SeamlessIndicator|ParseXml" "$log" | head
+    status=2
+  else
+    echo "[PASS] #$issue: SeamlessIndicator parsed without signed->unsigned conversion"
+  fi
+}
+
+run_case 1342 "$HEIGHT_XML"
+run_case 1343 "$NORMAL_XML"
+
+exit "$status"

--- a/.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh
+++ b/.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh
@@ -81,7 +81,10 @@ run_case() {
     echo "[SKIP] PoC XML missing: $xml"
     return
   fi
-  local log="$OUTDIR/$(basename "$xml").log"
+  # Declare then assign separately so the $(basename ...) exit status is not
+  # masked by `local` (shellcheck SC2155).
+  local log
+  log="$OUTDIR/$(basename "$xml").log"
   # The PoC profile is intentionally invalid, so iccFromXml exits non-zero
   # regardless of the fix; the pass/fail signal is the UBSan runtime error, not
   # the tool exit code.  Keep ASan quiet about unrelated leaks on this invalid

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1029,6 +1029,20 @@ set_tests_properties(iccdev.profile-visualize-regressions PROPERTIES
   FIXTURES_REQUIRED iccdev_profiles
 )
 
+# Replays the #1342 / #1343 fuzz PoCs (negative SeamlessIndicator) through
+# iccFromXml and fails if the signed->unsigned implicit conversion in the
+# Embedded Height/Normal image ParseXml() handlers reappears.  Meaningful only
+# under the integer/implicit-conversion sanitizer build (the script skips
+# cleanly otherwise), so it carries the ubsan label.  No profile fixture needed
+# -- the trigger XML files are committed test data.
+iccdev_add_script_test(
+  iccdev.issue-1342-1343-imageparse-signed-unsigned-regression
+  120
+  "iccdev;imageparse;signed-unsigned;regression;ubsan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh"
+)
+
 # Describe sink + options API smoke test. Verifies byte-equivalence
 # between the legacy std::string Describe() and the new
 # Describe(IDescribeSink&, const DescribeOptions&) virtual, plus


### PR DESCRIPTION
## Summary

Deterministic CTest regression for **#1342** and **#1343** — the signed→unsigned `SeamlessIndicator` conversion in the Embedded Height/Normal image XML parsers. Pairs with fix PR #1344.

Replays the two fuzz PoCs (negative `SeamlessIndicator`) through `iccFromXml` and fails if the UBSan `implicit-integer-sign-change` finding reappears at `CIccTagXmlEmbeddedHeightImage::ParseXml` (#1342) or `CIccTagXmlEmbeddedNormalImage::ParseXml` (#1343).

## What's added

- `.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh`
- `.github/ci/test-data/ub-heightimage-parsexml-1342.xml` and `ub-normalimage-parsexml-1343.xml` (the committed trigger PoCs)
- CTest registration `iccdev.issue-1342-1343-imageparse-signed-unsigned-regression` (label `ubsan`)

## How it signals

The check is only meaningful under a build instrumented with the integer / implicit-conversion sanitizer. `ci-iccdev-tool-tests` builds with `ENABLE_UBSAN=ON ENABLE_INTEGER_SANITIZER=ON` (which adds `-fno-sanitize-recover=integer`), so pre-fix the conversion **aborts** the parse. The script inspects the build's `CMakeCache.txt` and **skips cleanly** on a non-sanitizer build rather than report a misleading pass. The pass/fail signal is the absence of the `runtime error: implicit conversion` line — not the tool exit code (the trigger profiles are intentionally invalid, so `iccFromXml` exits non-zero either way).

## Verification

- **FAILS pre-fix** (both sites fire, exit 2) on the integer-sanitizer build
- **PASSES post-fix** (`ctest -R 1342-1343` → 1/1 passed)
- **SKIPS** on a plain ASan-only build (CMakeCache gate)

## Merge order

This test is red until #1344 (the fix) lands — same convention as prior fix/test splits. **Merge #1344 first, then this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)