### PR TITLE
Test: regression for CIccXform::Create tag-overload profile ownership (#1308)

### DIFF
--- a/.github/ci/regression/xform-create-tag-ownership.cpp
+++ b/.github/ci/regression/xform-create-tag-ownership.cpp
@@ -1,0 +1,84 @@
+/*
+    File:       xform-create-tag-ownership.cpp
+
+    Contains:   CTest helper for CIccXform::Create(CIccProfile*, CIccTag*, ...)
+                profile ownership (issue #1308).
+
+    Post-#1327 every CIccCmm::AddXform overload owns the profile it is given: it
+    stores the profile on success or frees it on failure.  AddXform(CIccProfile*,
+    CIccTag*) forwards the profile to the tag-based CIccXform::Create overload and
+    relies on Create to free it when no xform can be built (the "CIccXform::Create
+    has already deleted the profile" comment at the AddXform call site).  Before
+    #1308 that tag-based Create returned NULL on its failure paths WITHOUT freeing
+    the profile, so the owned profile leaked.
+
+    This helper hands a valid profile plus a NULL transform tag to that overload.
+    A NULL tag makes Create take its "unsupported element" failure path and return
+    NULL, which must now free the profile.  The profile is opened and passed inside
+    a helper function, so once AddXform takes ownership nothing in main() holds a
+    pointer to it; a profile Create failed to free is therefore unreachable and is
+    reported by the at-exit LeakSanitizer scan (the iccDEV ASan CI job).  The
+    status check guards that the intended Create-failure path was exercised.
+
+    Usage:
+      xform-create-tag-ownership <profile.icc>
+
+    Exit codes:
+      0 - Create failed as expected and (under ASan at exit) the profile was freed
+      1 - unexpected status
+      2 - usage / profile-open error
+      (non-zero is also forced by LeakSanitizer at exit if the profile leaks)
+*/
+
+#include "IccCmm.h"
+#include "IccProfile.h"
+
+#include <cstdio>
+
+// Kept in its own function so AddXform is the only thing that ever owns the
+// opened profile; nothing in main() can act as a LeakSanitizer root for it.
+static icStatusCMM add_profile_with_null_tag(const char* profilePath, bool& opened)
+{
+  CIccProfile* pProfile = OpenIccProfile(profilePath);
+  opened = (pProfile != NULL);
+  if (!pProfile)
+    return icCmmStatBad;
+
+  // Hand the owned profile to the tag-based AddXform overload with a NULL tag.
+  // Create cannot build an xform for a NULL tag, so it returns NULL and -- post
+  // #1308 -- frees the profile we just gave it.  The pointer is not retained
+  // here, so a leaked profile becomes unreachable for LeakSanitizer.
+  CIccCmm cmm;
+  return cmm.AddXform(pProfile, (CIccTag*)NULL);
+}
+
+int main(int argc, char** argv)
+{
+  if (argc != 2) {
+    std::fprintf(stderr, "usage: %s <profile.icc>\n",
+                 argv[0] ? argv[0] : "xform-create-tag-ownership");
+    return 2;
+  }
+
+  bool opened = false;
+  icStatusCMM rv = add_profile_with_null_tag(argv[1], opened);
+
+  if (!opened) {
+    std::fprintf(stderr, "xform-create-tag-ownership: could not open '%s'\n", argv[1]);
+    return 2;
+  }
+
+  // A NULL tag yields no xform, so AddXform must report BadXform.
+  if (rv != icCmmStatBadXform) {
+    std::fprintf(stderr,
+      "xform-create-tag-ownership: expected BadXform (%d), got %d (%s)\n",
+      (int)icCmmStatBadXform, (int)rv, CIccCmm::GetStatusText(rv));
+    return 1;
+  }
+
+  std::fprintf(stdout, "xform-create-tag-ownership: status=%d (%s)\n",
+               (int)rv, CIccCmm::GetStatusText(rv));
+  // Returns to the runtime; under ASan the at-exit LeakSanitizer check fails the
+  // process if the tag-based Create left the owned profile unfreed (#1308).
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -257,9 +257,22 @@ function(iccdev_add_xform_create_tag_ownership_test)
   target_link_libraries(iccXformCreateTagOwnershipTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
   add_dependencies(check iccXformCreateTagOwnershipTest)
 
+  # This regression's pass/fail signal IS the LeakSanitizer at-exit scan, but the
+  # CI tool-test job and ICCDEV_TEST_ENV both export ASAN_OPTIONS=detect_leaks=0
+  # to silence unrelated leaks in the smoke-tested tools.  Inheriting that would
+  # disable LSan here and make the test a false pass even when the profile leaks.
+  # Force leak detection back on for this test's own process by launching it
+  # through `cmake -E env` (the same override mechanism the script tests use; a
+  # CTest ENVIRONMENT property is NOT reliable for ASAN_OPTIONS here).  Set ONLY
+  # detect_leaks=1: do not append halt_on_error=0 -- with halt_on_error=0 the
+  # runtime still prints the leak but exits 0, so ctest would pass on a real
+  # leak.  Plain detect_leaks=1 makes a detected leak exit non-zero (the failure
+  # signal ctest needs).
   add_test(
     NAME iccdev.xform-create-tag-ownership
-    COMMAND "$<TARGET_FILE:iccXformCreateTagOwnershipTest>"
+    COMMAND "${CMAKE_COMMAND}" -E env
+      "ASAN_OPTIONS=detect_leaks=1"
+      "$<TARGET_FILE:iccXformCreateTagOwnershipTest>"
       "${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc"
   )
   set_tests_properties(iccdev.xform-create-tag-ownership PROPERTIES

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -241,6 +241,47 @@ function(iccdev_add_cmmsearch_namedcolor_ownership_test)
   endif()
 endfunction()
 
+# Guards CIccXform::Create(CIccProfile*, CIccTag*) profile ownership (#1308):
+# AddXform hands its owned profile to the tag-based Create overload, which must
+# free it when no xform can be built.  The helper feeds a valid profile plus a
+# NULL tag, so Create takes its failure path; a profile it fails to free is
+# unreachable and reported by the ASan/LSan CI job.
+function(iccdev_add_xform_create_tag_ownership_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccXformCreateTagOwnershipTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/xform-create-tag-ownership.cpp"
+  )
+  target_link_libraries(iccXformCreateTagOwnershipTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccXformCreateTagOwnershipTest)
+
+  add_test(
+    NAME iccdev.xform-create-tag-ownership
+    COMMAND "$<TARGET_FILE:iccXformCreateTagOwnershipTest>"
+      "${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc"
+  )
+  set_tests_properties(iccdev.xform-create-tag-ownership PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;cmm;xform;leak;issue-1308;regression"
+  )
+  if(WIN32)
+    set(_xform_create_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccXformCreateTagOwnershipTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _xform_create_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.xform-create-tag-ownership PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_xform_create_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_fileio_getlength_position_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -556,6 +597,7 @@ if(WIN32)
   iccdev_add_parser_restore_calls_test()
   iccdev_add_tag_layout_shared_data_test()
   iccdev_add_cmmsearch_namedcolor_ownership_test()
+  iccdev_add_xform_create_tag_ownership_test()
 
   return()
 endif()
@@ -613,6 +655,7 @@ iccdev_add_fileio_seek_tell_test()
 iccdev_add_parser_restore_calls_test()
 iccdev_add_tag_layout_shared_data_test()
 iccdev_add_cmmsearch_namedcolor_ownership_test()
+iccdev_add_xform_create_tag_ownership_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")


### PR DESCRIPTION
## Summary

Deterministic CTest regression for **#1308** — the tag-based `CIccXform::Create` overload leaking the profile it was given on failure. Pairs with fix PR #1347.

`iccdev.xform-create-tag-ownership` hands a valid profile plus a **NULL transform tag** to `CIccCmm::AddXform(CIccProfile*, CIccTag*)`. The NULL tag forces the tag-based `Create` onto its failure path, which must free the owned profile. The profile is opened and passed inside a helper, so a profile `Create` fails to free is **unreachable** and reported by the at-exit LeakSanitizer scan (the iccDEV ASan CI job). A status check confirms the intended `Create`-failure path (`BadXform`) was exercised.

## What's added

- `.github/ci/regression/xform-create-tag-ownership.cpp` (C++ helper linking `IccProfLib`)
- CMake registration `iccdev.xform-create-tag-ownership` (label `issue-1308`), using the tracked `Testing/sRGB_v4_ICC_preference.icc`

## Verification

- **FAILS pre-fix** — 608 B leaked (the profile + its 11 tag allocations)
- **PASSES post-fix** (`ctest -R xform-create-tag` → 1/1)

## Merge order

Red until #1347 (the fix) lands — same convention as prior fix/test splits. **Merge #1347 first, then this.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)