### PR TITLE
Test: regression for signed atoi() -> unsigned wrap in IccTagXml ParseXml (#1346)

### DIFF
--- a/.github/ci/test-data/ub-cicp-colorprimaries-1346.xml
+++ b/.github/ci/test-data/ub-cicp-colorprimaries-1346.xml
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType></PreferredCMMType>
+    <ProfileVersion>5.10</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false" ExtendedRangePCS="true"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.9504222269" Y="1.0000000000" Z="1.0884541014"/>
+    </PCSIlluminant>
+    <ProfileCreator></ProfileCreator>
+    <ProfileID>1</ProfileID>
+  </Header>
+  <Tags>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[BT.2100 PQ Full Range RGB to/from Scene Light]]></LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+	
+	<AToB1Tag> <multiProcessElementType>
+	  <MultiProcessElements InputChannels="3" OutputChannels="3">
+		  <!-- Apply PQ EOTF -->
+		  <CurveSetElement InputChannels="3" OutputChannels="3">
+			  <SegmentedCurve>
+				  <FormulaSegment Start="-infinity" End="0.0" FunctionType="0">1 0 0 0</FormulaSegment>
+				  <FormulaSegment Start="0" End="+infinity" FunctionType="6">0.1593017578125 0.01268331351565597 0.8359375 18.8515625 18.6875 10000 1.0</FormulaSegment>
+				</SegmentedCurve>
+			  <DuplicateCurve Index="0"/>
+			  <DuplicateCurve Index="0"/>
+			</CurveSetElement>
+			
+		  <!-- Apply Inverse PQ OOTF Part 1 -->
+		  <CurveSetElement InputChannels="3" OutputChannels="3">
+			  <SegmentedCurve>
+				  <FormulaSegment Start="-infinity" End="0.0" FunctionType="0">1 0 0 0</FormulaSegment>
+				  <FormulaSegment Start="0" End="+infinity" FunctionType="0">0.416666666666667 0.01 0 0 </FormulaSegment>
+				</SegmentedCurve>
+			  <DuplicateCurve Index="0"/>
+			  <DuplicateCurve Index="0"/>
+			</CurveSetElement>
+			
+		  <!-- Apply Inverse PQ OOTF Part 2 -->
+		  <CurveSetElement InputChannels="3" OutputChannels="3">
+			  <SegmentedCurve>
+				  <FormulaSegment Start="-infinity" End="0.0" FunctionType="0">1 0 0 0</FormulaSegment>
+				  <FormulaSegment Start="0" End="0.408996170511594" FunctionType="0">1 0.03733572281959379 0 0 </FormulaSegment>
+				  <FormulaSegment Start="0.408996170511594" End="+infinity" FunctionType="3">2.222222222222222 0.01680084945094824 0.909918107370337 0.09008189262966333 0 </FormulaSegment>
+				</SegmentedCurve>
+			  <DuplicateCurve Index="0"/>
+			  <DuplicateCurve Index="0"/>
+			</CurveSetElement>
+			
+      <!-- Scale so that 203cd/m^2 becomes Media White Point -->
+			<MatrixElement InputChannels="3" OutputChannels="3">
+			  <MatrixData InvertMatrix="true">
+				  203 0 0
+          0 203 0
+          0 0 203
+				</MatrixData>
+			</MatrixElement>
+		
+			<!-- Convert RGB to XYZ -->
+			<MatrixElement InputChannels="3" OutputChannels="3">
+			  <MatrixData>
+				  0.63695805 0.14461690 0.16888098
+          0.26270021 0.67799807 0.05930172
+          0.00000000 0.02807269 1.06098506
+				</MatrixData>
+			</MatrixElement>
+
+	  </MultiProcessElements>
+	</multiProcessElementType> </AToB1Tag>
+	
+	<BToA1Tag> <multiProcessElementType>
+    <MultiProcessElements InputChannels="3" OutputChannels="3">
+			<!-- Convert XYZ to RGB -->
+			<MatrixElement InputChannels="3" OutputChannels="3">
+			  <MatrixData InvertMatrix="true">
+				  0.63695805 0.14461690 0.16888098
+          0.26270021 0.67799807 0.05930172
+          0.00000000 0.02807269 1.06098506
+				</MatrixData>
+			</MatrixElement>
+
+      <!-- Invert scaling of media white point to 203cd/m^2-->
+			<MatrixElement InputChannels="3" OutputChannels="3">
+			  <MatrixData >
+				  203 0 0
+          0 203 0
+          0 0 203
+				</MatrixData>
+			</MatrixElement>
+		
+		  <!-- Apply PQ OOTF / 10000 -->
+		  <CurveSetElement InputChannels="3" OutputChannels="3">
+			  <SegmentedCurve>
+				  <FormulaSegment Start="-infinity" End="0.0" FunctionType="0">1 0 0 0</FormulaSegment>
+				  <FormulaSegment Start="0" End="0.0003024" FunctionType="0">1 0.026784 0 0</FormulaSegment>
+				  <FormulaSegment Start="0.0003024" End="+infinity" FunctionType="3">0.45 0.0001099 59.5208 0 -0.0000099 </FormulaSegment>
+				</SegmentedCurve>
+			  <DuplicateCurve Index="0"/>
+			  <DuplicateCurve Index="0"/>
+			</CurveSetElement>
+
+		  <!-- Apply Inverse PQ EOTF -->
+		  <CurveSetElement InputChannels="3" OutputChannels="3">
+			  <SegmentedCurve>
+				  <FormulaSegment Start="-infinity" End="0.0" FunctionType="0">1 0 0 0</FormulaSegment>
+				  <FormulaSegment Start="0.08333333333333333" End="+infinity" FunctionType="7">78.84375 0.1593017578125 0.8359375 18.8515625 18.6875 1.0</FormulaSegment>
+				</SegmentedCurve>
+			  <DuplicateCurve Index="0"/>
+			  <DuplicateCurve Index="0"/>
+			</CurveSetElement>
+			
+      </MultiProcessElements>
+    </multiProcessElementType> </BToA1Tag>
+	
+	<HToS1Tag> <multiProcessElementType>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+			<!-- Convert XYZ to RGB -->
+			<MatrixElement InputChannels="3" OutputChannels="3">
+			  <MatrixData InvertMatrix="true">
+				  0.63695805 0.14461690 0.16888098
+          0.26270021 0.67799807 0.05930172
+          0.00000000 0.02807269 1.06098506
+				</MatrixData>
+			</MatrixElement>
+
+      <!-- Invert scaling of 75% media white point -->
+			<MatrixElement InputChannels="3" OutputChannels="3">
+			  <MatrixData InvertMatrix="true">
+				  4.804804804804805 0 0
+          0 4.804804804804805 0
+          0 0 4.804804804804805
+				</MatrixData>
+			</MatrixElement>
+
+		  <!-- Apply SDR OOTF -->
+			<MatrixElement InputChannels="3" OutputChannels="4">
+			  <MatrixData>
+				  1 0 0
+					0 1 0
+					0 0 1
+					0.2627 0.6780 0.0593
+				</MatrixData>
+			</MatrixElement>
+			
+			<ToneMapElement InputChannels="4" OutputChannels="3">
+			  <!-- Based on note 2 of page 8 in Rec. ITU-R BT.2100-2 document gamma for SDR should be 0.9419.
+					Subtracting 1 from this in curve below results in -0.058070-->
+			  <LuminanceCurve>
+				  <SegmentedCurve>
+				  <FormulaSegment Start="-infinity" End="0.0" FunctionType="0">1 0 0 0</FormulaSegment>
+				  <FormulaSegment Start="0" End="1" FunctionType="0">-0.058070 1 0 0</FormulaSegment>
+					<FormulaSegment Start="1" End="+infinity" FunctionType="0">1 0 0 1</FormulaSegment>
+					</SegmentedCurve>
+				</LuminanceCurve>
+				<ToneMapFunctions>
+				  <ToneMapFunction FunctionType="0">1 0.0 0</ToneMapFunction>
+				  <DuplicateFunction Index="0"/>
+				  <DuplicateFunction Index="0"/>
+				</ToneMapFunctions>
+			</ToneMapElement>
+
+			<!-- Convert RGB to XYZ -->
+			<MatrixElement InputChannels="3" OutputChannels="3">
+			  <MatrixData>
+				  0.63695805 0.14461690 0.16888098
+          0.26270021 0.67799807 0.05930172
+          0.00000000 0.02807269 1.06098506
+				</MatrixData>
+			</MatrixElement>
+
+      </MultiProcessElements>
+    </multiProcessElementType> </HToS1Tag>
+
+	  <!-- D65 to D50 MAT -->
+    <customToStandardPccTag> <multiProcessElementType>
+	  <MultiProcessElements InputChannels="3" OutputChannels="3">
+	    <MatrixElement InputChannels="3" OutputChannels="3">
+		  <MatrixData>
+		    1.15213478 -0.06226214 -0.06292737
+		    0.09892068 0.93407047 -0.02579682
+		   -0.02836701 0.03469112 0.75031996
+		  </MatrixData>
+	    </MatrixElement>
+	  </MultiProcessElements>
+    </multiProcessElementType> </customToStandardPccTag>
+
+    <!-- D50 to D65 MAT -->
+    <standardToCustomPccTag> <multiProcessElementType>
+	  <MultiProcessElements InputChannels="3" OutputChannels="3">
+	    <MatrixElement InputChannels="3" OutputChannels="3">
+		  <MatrixData InvertMatrix="true">
+		    1.15213478 -0.06226214 -0.06292737
+		    0.09892068 0.93407047 -0.02579682
+		   -0.02836701 0.03469112 0.75031996
+		  </MatrixData>
+	    </MatrixElement>
+	  </MultiProcessElements>
+    </multiProcessElementType> </standardToCustomPccTag>
+	
+	<!-- Abreviated D65 spectral viewing conditions -->
+	<spectralViewingConditionsTag> <spectralViewingConditionsType>
+	  <StdObserver>CIE 1931 (two degree) standard observer</StdObserver>
+	  <IlluminantXYZ X="192.9372214083083" Y="203.00000000" Z="221.0265153142868"/>
+	  <StdIlluminant>Illuminant D65</StdIlluminant>
+	  <ColorTemperature>6500.00000000</ColorTemperature>
+	  <SurroundXYZ X="4.752148310549465" Y="5.00000000" Z="5.444002840253368"/>
+	</spectralViewingConditionsType> </spectralViewingConditionsTag>
+
+  <!-- D65 White point indicating extended PCS range -->
+	<mediaWhitePointTag> <XYZArrayType>
+	  <XYZNumber X="0.197822914481250" Y="0.208125" Z="0.226668119568750"/>
+	</XYZArrayType> </mediaWhitePointTag>
+
+    <cicpTag> <cicpType>
+      <cicpFields ColorPrimaries="-1" TransferCharacteristics="18" MatrixCoefficients="0" VideoFullRangeFlag="1"/>
+    </cicpType> </cicpTag>
+
+	<copyrightTag> <multiLocalizedUnicodeType>
+	  <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2022 International Color Consortium]]></LocalizedText>
+	</multiLocalizedUnicodeType> </copyrightTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/scripts/iccdev-issue-1346-imageparse-atoi-unsigned-regression.sh
+++ b/.github/scripts/iccdev-issue-1346-imageparse-atoi-unsigned-regression.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1346 - signed atoi() -> unsigned wrap in IccTagXml ParseXml
+###############################################################################
+#
+# #1346 tracks the pervasive pattern (reported as #1342/#1343) where ParseXml
+# handlers in IccXML/IccLibXML/IccTagXml.cpp read an XML attribute with atoi()
+# (a signed int) and store it into an unsigned icUIntNN target.  A negative
+# attribute wrapped to a large unsigned value; where the conversion is implicit
+# UBSan's implicit-integer-sign-change check (part of the "integer" group)
+# flags it as a runtime error, e.g.:
+#
+#   IccTagXml.cpp:1172:27: runtime error: implicit conversion from type 'int'
+#   of value -1 (32-bit, signed) to type 'icUInt8Number' (aka 'unsigned char')
+#   changed the value to 255 (8-bit, unsigned)
+#
+# The fix routes the affected sites through icXmlAttrToUInt(), which floors
+# negatives to 0 so no signed->unsigned wrap occurs.  This test replays a PoC
+# profile whose cicpFields ColorPrimaries attribute is negative through
+# iccFromXml and fails if the implicit-conversion runtime error reappears.
+#
+# The PoC is a VALID profile (a copy of Testing/HDR/BT2100PQFullScene.xml with
+# ColorPrimaries set to -1), so iccFromXml parses and saves it successfully:
+# the pass/fail signal is purely the presence of the UBSan diagnostic, not the
+# tool exit code.
+#
+# Note: only the implicit "Class A" sites can be exercised this way.  The
+# "Class B" sites carry an explicit (icUIntNN) cast that suppresses the UBSan
+# check, so they are invisible to any sanitizer-based test and are guarded by
+# code review / the shared helper instead.
+#
+# This check is only meaningful when iccFromXml was built with the UBSan
+# integer / implicit-conversion sanitizer (the ci-iccdev-tool-tests workflow
+# builds with ENABLE_UBSAN=ON ENABLE_INTEGER_SANITIZER=ON).  On a plain build
+# the conversion check is absent, so the test SKIPS rather than report a
+# misleading pass.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (no sign-change error) or skipped cleanly
+#   2 - UBSan implicit-conversion finding (regression)
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1346}"
+DATA_DIR="$REPO_ROOT/.github/ci/test-data"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+
+# Only meaningful under a build instrumented with the integer / implicit
+# conversion sanitizer.  Inspect the build's CMakeCache.txt (walk up from the
+# tool location) for either the ENABLE_* options or an explicit -fsanitize flag
+# covering integer/undefined/implicit conversions.
+CACHE=""
+probe="$(dirname "$FROMXML")"
+for _ in 1 2 3 4 5; do
+  if [ -f "$probe/CMakeCache.txt" ]; then CACHE="$probe/CMakeCache.txt"; break; fi
+  probe="$(dirname "$probe")"
+done
+sanitized=0
+if [ -n "$CACHE" ]; then
+  if grep -qiE "ENABLE_INTEGER_SANITIZER:BOOL=ON|ENABLE_UBSAN:BOOL=ON" "$CACHE"; then
+    sanitized=1
+  elif grep -iE "CMAKE_(CXX|C)_FLAGS" "$CACHE" | grep -qiE "fsanitize=[^ ]*(integer|undefined|implicit)"; then
+    sanitized=1
+  fi
+fi
+if [ "$sanitized" -ne 1 ]; then
+  echo "[SKIP] iccFromXml not built with the integer/implicit-conversion sanitizer (CMakeCache: ${CACHE:-none})"
+  exit 0
+fi
+
+CICP_XML="$DATA_DIR/ub-cicp-colorprimaries-1346.xml"
+
+status=0
+run_case() {
+  local issue="$1" xml="$2"
+  if [ ! -f "$xml" ]; then
+    echo "[SKIP] PoC XML missing: $xml"
+    return
+  fi
+  # Declare then assign separately so the $(basename ...) exit status is not
+  # masked by `local` (shellcheck SC2155).
+  local log
+  log="$OUTDIR/$(basename "$xml").log"
+  # Keep ASan quiet about any unrelated leaks so UBSan's conversion diagnostic
+  # is the only thing we key on; the tool itself exits 0 on this valid profile.
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$FROMXML" "$xml" "$OUTDIR/$(basename "$xml").out" > "$log" 2>&1
+
+  if grep -qE "runtime error: implicit conversion" "$log"; then
+    echo "[FAIL] #$issue: signed->unsigned conversion of an XML attribute reappeared"
+    grep -E "runtime error: implicit conversion|cicpFields|ParseXml|IccTagXml" "$log" | head
+    status=2
+  else
+    echo "[PASS] #$issue: negative XML attribute parsed without signed->unsigned conversion"
+  fi
+}
+
+run_case 1346 "$CICP_XML"
+
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1029,6 +1029,20 @@ set_tests_properties(iccdev.profile-visualize-regressions PROPERTIES
   FIXTURES_REQUIRED iccdev_profiles
 )
 
+# #1346: signed atoi() -> unsigned wrap in IccTagXml ParseXml handlers.
+# Replays a PoC profile with a negative cicpFields ColorPrimaries attribute
+# through iccFromXml; under the integer/implicit-conversion sanitizer the test
+# FAILS if UBSan's implicit-integer-sign-change diagnostic reappears, and SKIPS
+# cleanly on a plain (non-sanitizer) build.  Uses a committed PoC, so it needs
+# no generated-profile fixture.
+iccdev_add_script_test(
+  iccdev.issue-1346-imageparse-atoi-unsigned-regression
+  60
+  "iccdev;xml;imageparse;issue-1346;regression;ubsan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1346-imageparse-atoi-unsigned-regression.sh"
+)
+
 # Describe sink + options API smoke test. Verifies byte-equivalence
 # between the legacy std::string Describe() and the new
 # Describe(IDescribeSink&, const DescribeOptions&) virtual, plus


### PR DESCRIPTION
## Summary

Deterministic regression for the **#1346** sweep (fix: #1349). Replays a PoC profile with a negative `cicpFields ColorPrimaries` attribute through `iccFromXml`; under the integer / implicit-conversion sanitizer it fails if UBSan's `implicit-integer-sign-change` diagnostic reappears, and skips cleanly on a plain build.

## Files

- `.github/ci/test-data/ub-cicp-colorprimaries-1346.xml` — PoC: a valid copy of `Testing/HDR/BT2100PQFullScene.xml` with `ColorPrimaries="-1"`. Because it is otherwise valid, `iccFromXml` parses and saves it; the pass/fail signal is purely the sanitizer diagnostic, not the tool exit code.
- `.github/scripts/iccdev-issue-1346-imageparse-atoi-unsigned-regression.sh` — gates on the build's `CMakeCache.txt` (`ENABLE_INTEGER_SANITIZER`/`ENABLE_UBSAN`, or an explicit `-fsanitize=*integer/undefined/implicit`); `[SKIP]`s otherwise; signal = presence of `runtime error: implicit conversion`. Exit 0 pass/skip, 2 on finding.
- `Build/Cmake/Testing/CMakeLists.txt` — registers `iccdev.issue-1346-imageparse-atoi-unsigned-regression` (labels include `ubsan`).

## Scope note

This exercises the implicit **Class A** arm of the sweep. The explicit-cast **Class B** sites carry an `(icUIntNN)` cast that suppresses the UBSan check, so they are invisible to any sanitizer-based test by construction — they are guarded by the shared `icXmlAttrToUInt()` helper and review in #1349, not here.

## Verification (clang-18, `-DENABLE_ASAN=ON -DENABLE_UBSAN=ON -DENABLE_INTEGER_SANITIZER=ON`)

- **pre-fix master:** `[FAIL]` exit 2 — `IccTagXml.cpp:1172: runtime error: implicit conversion from type 'int' of value -1 ... changed the value to 255`, stack in `CIccTagXmlCicp::ParseXml`.
- **with #1349:** `[PASS]` exit 0.
- **plain build:** `[SKIP]`.

> ⚠️ Expected to stay **red on master until the fix #1349 is merged** — the regression is doing its job by detecting the unfixed UB. Merge #1349 first, then this goes green (fork-gate split: fix on fork, test upstream).

🤖 Generated with [Claude Code](https://claude.com/claude-code)