### PR TITLE
Fix: CI leak regressions silently disabled by detect_leaks=0 (false green)

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -216,9 +216,19 @@ function(iccdev_add_cmmsearch_namedcolor_ownership_test)
   target_link_libraries(iccCmmSearchNamedColorOwnershipTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
   add_dependencies(check iccCmmSearchNamedColorOwnershipTest)
 
+  # This regression's pass/fail signal IS the LeakSanitizer at-exit scan, but the
+  # CI tool-test job and ICCDEV_TEST_ENV both export ASAN_OPTIONS=...detect_leaks=0
+  # to silence unrelated leaks in the smoke-tested tools.  Inheriting that would
+  # disable LSan here and let a profile leak pass undetected.  Launch through
+  # `cmake -E env ASAN_OPTIONS=detect_leaks=1` to force leak detection on for
+  # this test's own process.  Set ONLY detect_leaks=1: appending halt_on_error=0
+  # makes the runtime print the leak but exit 0, and a ':' option separator is
+  # mis-parsed and silently disables the check.
   add_test(
     NAME iccdev.cmmsearch-namedcolor-ownership
-    COMMAND "$<TARGET_FILE:iccCmmSearchNamedColorOwnershipTest>"
+    COMMAND "${CMAKE_COMMAND}" -E env
+      "ASAN_OPTIONS=detect_leaks=1"
+      "$<TARGET_FILE:iccCmmSearchNamedColorOwnershipTest>"
       "${ICCDEV_REPO_ROOT}/.github/ci/test-data/fuzz-nmcl-9c09d1e6.icc"
   )
   set_tests_properties(iccdev.cmmsearch-namedcolor-ownership PROPERTIES


### PR DESCRIPTION
## The bug

The CI tool-test job (`ci-iccdev-tool-tests.yml`, "Run CTest tool suites" step) and `ICCDEV_TEST_ENV` both export `ASAN_OPTIONS=...,detect_leaks=0` to silence unrelated leaks in the smoke-tested tools. The **C++ LeakSanitizer-based leak regressions** inherit that and run their `add_test` binary directly with no override — so **LeakSanitizer is disabled for exactly the tests whose pass/fail signal is the at-exit leak scan.** They pass even when the leak they exist to catch is present (a false green).

The script-based leak regressions (`#1336`/`#1337`) are unaffected because they re-set `detect_leaks=1` internally before invoking the tool.

### Proof
For `iccdev.xform-create-tag-ownership` (#1308) on pre-fix master, clean build:
- `detect_leaks=0` (CI's env) → **EXIT 0, false PASS** — 608-byte leak masked
- `detect_leaks=1` → 608-byte leak reported, EXIT 1

## The fix

Launch each LSan leak regression through `cmake -E env ASAN_OPTIONS=detect_leaks=1` (the same override the script tests use), forcing leak detection back on for that test's own process. This PR fixes the **`cmmsearch-namedcolor-ownership` (#1332)** test, which is already on master; the sibling `xform-create-tag-ownership` (#1308) gets the identical fix in its own PR **#1348**.

Two subtleties (both verified, both encoded in the comment):
- Use **only** `detect_leaks=1`. Appending `halt_on_error=0` makes the runtime *print* the leak but exit 0 — ctest would still pass.
- Use a **comma** separator, not `:` — `detect_leaks=1:...` is mis-parsed and silently leaves leak detection off.

## Verification (clean build, CI env `detect_leaks=0` exported)

`iccdev.cmmsearch-namedcolor-ownership`:
- with the #1333 fix present → **PASS**
- with the NamedColor-reject `delete` reverted → **FAIL**, `568 byte(s) leaked in 10 allocations`

So the test now genuinely guards against a future regression instead of passing unconditionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)