### PR TITLE
Fix: XML serializer corrupts zero header colour-space signature on round-trip (#1355)

### DIFF
--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -107,9 +107,20 @@ bool CIccProfileXml::ToXmlWithBlanks(std::string &xml, std::string blanks)
     xml += blanks + line;
   }
 
-  snprintf(line, bufSize, "    <DataColourSpace>%s</DataColourSpace>\n", icFixXml(fix, icGetColorSigStr(buf, bufSize, m_Header.colorSpace)));
+  // Header colour-space signatures are serialized as four-character text. A zero
+  // signature (0x00000000) must round-trip back to zero, but icGetColorSigStr(0)
+  // returns the literal "NULL"; the inverse icGetSigVal("NULL") then packs the
+  // ASCII bytes 'N','U','L','L' into 0x4E554C4C, corrupting the value on reparse
+  // (see iccFromXml turning a NoData header into "Unknown 'NULL' = 4E554C4C").
+  // Emit an empty element for a zero signature instead -- icXmlGetChildSigVal()
+  // returns 0 for an empty element, restoring the original value. This mirrors the
+  // JSON serializer (IccProfileJson.cpp), which already guards these fields the
+  // same way. Note: per ICC.1 (v4.4.0.0) 7.2.6 / Table 19 a zero data colour
+  // space is itself invalid for a v2/v4 profile; faithfully preserving the bytes
+  // is a serialization concern, leaving the validator to flag the malformance.
+  snprintf(line, bufSize, "    <DataColourSpace>%s</DataColourSpace>\n", m_Header.colorSpace ? icFixXml(fix, icGetColorSigStr(buf, bufSize, m_Header.colorSpace)) : "");
   xml += blanks + line;
-  snprintf(line, bufSize, "    <PCS>%s</PCS>\n",  icFixXml(fix, icGetColorSigStr(buf, bufSize, m_Header.pcs)));
+  snprintf(line, bufSize, "    <PCS>%s</PCS>\n",  m_Header.pcs ? icFixXml(fix, icGetColorSigStr(buf, bufSize, m_Header.pcs)) : "");
   xml += blanks + line;
 
   snprintf(line, bufSize, "    <CreationDateTime>%d-%02d-%02dT%02d:%02d:%02d</CreationDateTime>\n",


### PR DESCRIPTION
## Summary

Closes the FromXml/FromJson divergence reported in #1355. `CIccProfileXml::ToXml()` serialized the **data colour space** and **PCS** header signatures with `icGetColorSigStr()` **unconditionally**. For a zero signature (`0x00000000`) that helper returns the literal text `NULL`, and the inverse `icGetSigVal("NULL")` on reparse packs the ASCII bytes `N`,`U`,`L`,`L` into `0x4E554C4C`. A `NoData` header therefore became `Unknown 'NULL' = 4E554C4C` after a `ToXml -> FromXml` round-trip.

The JSON serializer already guards both fields (`IccProfileJson.cpp:136-137`), emitting `""` for a zero signature, which round-trips back to `0` -> `NoData`. **That guard is the entire reason `iccFromXml` and `iccFromJson` reported different data colour spaces for the same profile.**

## Fix

Mirror the JSON behaviour in `IccProfileXml.cpp`: emit an empty element for a zero `DataColourSpace` / `PCS` signature. `icXmlGetChildSigVal()` already returns `0` for an empty element, so the value round-trips faithfully.

```diff
- ... icFixXml(fix, icGetColorSigStr(buf, bufSize, m_Header.colorSpace)) ...
+ ... m_Header.colorSpace ? icFixXml(fix, icGetColorSigStr(buf, bufSize, m_Header.colorSpace)) : "" ...
```
(same guard applied to `<PCS>`)

## Verification

Repro profile: `Testing/hybrid/Results/LCDDisplayCat8Obs.icc` (emitted by `iccV5DspObsToV4Dsp`, header data colour space = `NoData`/`0x00000000`).

| Path | Before | After |
|---|---|---|
| `iccToXml` element | `<DataColourSpace>NULL</DataColourSpace>` | `<DataColourSpace></DataColourSpace>` |
| `iccFromXml` re-dump | `Unknown 'NULL' = 4E554C4C` | `NoData` |
| `iccFromJson` re-dump (unchanged) | `NoData` | `NoData` |

- FromXml and FromJson now agree.
- A normal RGB/XYZ display profile still serializes `RGB `/`XYZ ` and round-trips intact (no regression).

## Scope / spec note

A zero data colour space is **itself invalid** for a v2/v4 profile per ICC.1 (v4.4.0.0) §7.2.6 / Table 19 — this PR does **not** try to "correct" the malformed profile, only to stop the serializer from corrupting the bytes. Faithful preservation is a serializer concern; flagging the malformance is the validator's job. See the analysis on #1355 for the full spec discussion (including the `"NoData"` descriptor and the colorant-tag classification, both tracked separately).

A paired regression test PR will follow per the established fix/test split (cf. #1344/#1345).

🤖 Generated with [Claude Code](https://claude.com/claude-code)