### PR TITLE
Fix: version-aware data colour space validation; reject iccMAX-only spaces on v2/v4 (#1355)

### DIFF
--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1625,10 +1625,32 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
         (m_Header.deviceClass!=icSigNamedColorClass &&
          m_Header.deviceClass!=icSigMultiplexIdentificationClass &&
          m_Header.deviceClass!=icSigMultiplexVisualizationClass)) {
-    if (!Info.IsValidSpace(m_Header.colorSpace)) {
+    // A v2/v4 profile's data colour space must be one of the signatures
+    // positively enumerated in ICC.1 (v4.4.0.0) 7.2.6 / Table 19.  Two families
+    // of signature are *only* legal for iccMAX (v5) and must be rejected on a
+    // v2/v4 profile: the zero "no data" space (0x00000000) and the N-channel
+    // spaces ncXXXX (introduced by iccMAX 7.2.8 / Table 15 for MultiplexLink,
+    // MultiplexVisualization and abstract profiles).  IsValidSpace() is
+    // version-blind and accepts the ncXXXX family for any version, so gate them
+    // here by major version.
+    bool bValidSpace = Info.IsValidSpace(m_Header.colorSpace);
+    bool bIccMaxOnlySpace = (m_Header.colorSpace==icSigNoColorData) ||
+                            (icGetColorSpaceType(m_Header.colorSpace)==icSigNChannelData);
+    if (m_Header.version<icVersionNumberV5 && bIccMaxOnlySpace)
+      bValidSpace = false;
+
+    if (!bValidSpace) {
       if (!(m_Header.version>=icVersionNumberV5 && m_Header.deviceClass==icSigAbstractClass && Info.IsValidSpectralSpace(m_Header.colorSpace) && IsTagPresent(icSigDToB0Tag))) {
         sReport += icMsgValidateCriticalError;
-        snprintf(buf, bufSize, " - %s: Unknown color space!\n", Info.GetColorSpaceSigName(m_Header.colorSpace));
+        // For an iccMAX-only space on a v2/v4 profile report the raw value
+        // rather than the friendly descriptor: GetColorSpaceSigName() renders
+        // 0x00000000 as "NoData", which would imply a legitimate (v5-only)
+        // space on a profile where it is simply invalid.  Other unrecognised
+        // signatures keep the existing "Unknown ..." wording.
+        if (m_Header.version<icVersionNumberV5 && bIccMaxOnlySpace)
+          snprintf(buf, bufSize, " - Invalid data colour space (0x%08X) for a v2/v4 profile; only iccMAX (v5) permits this!\n", (unsigned int)m_Header.colorSpace);
+        else
+          snprintf(buf, bufSize, " - %s: Unknown color space!\n", Info.GetColorSpaceSigName(m_Header.colorSpace));
         sReport += buf;
         rv = icMaxStatus(rv, icValidateCriticalError);
       }


### PR DESCRIPTION
## Summary

Follow-up to the #1355 investigation (see [analysis](https://github.com/InternationalColorConsortium/iccDEV/issues/1355)). `CIccProfile::CheckHeader()` validated the header data colour space with the **version-blind** `CIccInfo::IsValidSpace()` and described failures via `GetColorSpaceSigName()`. Two spec-conformance problems for **v2/v4** profiles:

1. **N-channel spaces (`ncXXXX`) were accepted on any version.** They are an iccMAX (v5) construct — ICC.1 §7.2.8 / Table 15, for MultiplexLink / MultiplexVisualization / abstract. A v2/v4 data colour space must come from ICC.1 (v4.4.0.0) **§7.2.6 / Table 19**, which does not list them. A v4 profile carrying e.g. `0x6E630003` passed validation unflagged.
2. **A zero data colour space (`0x00000000`) was reported as `NoData: Unknown color space!`.** `NoData` is a legitimate *v5-only* descriptor (Table 15); printing it on a v2/v4 profile lends an invalid value undue legitimacy.

## Fix

Gate both iccMAX-only families (zero and `ncXXXX`) by major version. On a v2/v4 profile they are now a **critical error** and the diagnostic reports the **raw value** instead of the friendly descriptor:

```
 - Invalid data colour space (0x00000000) for a v2/v4 profile; only iccMAX (v5) permits this!
```

v5 behaviour is unchanged: `NoData` stays valid for NamedColor / Multiplex classes and `ncXXXX` spaces stay valid.

## Verification

| Profile | Before | After |
|---|---|---|
| v4, `0x00000000` (the #1355 profile) | `NoData: Unknown color space!` | `Invalid data colour space (0x00000000) for a v2/v4 profile…` |
| v4, `0x6E630003` (nc, 3-ch) | **accepted (unflagged)** | `Invalid data colour space (0x6E630003) for a v2/v4 profile…` |
| v5, `0x6E630003` (nc, 3-ch) | accepted | accepted (unchanged) |
| v4, normal RGB display | clean | clean (no false positive) |

## Notes / scope
- This is the validation-logic half of the #1355 follow-ups. The serializer round-trip fix is **#1356**; this PR is independent of it.
- The `iccDumpProfile` *header dump* line still prints `Data Color Space: NoData` (that is the raw header field renderer, `GetColorSpaceSigName`, not the validator). Making that renderer version-aware everywhere is a broader change; this PR scopes to the **validation** path, which is what flags conformance. Happy to extend if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)