### PR TITLE
Add CodeQL + CTest for the #1356/#1359 patterns; fix the latent siblings they surface (#1361)

### DIFF
--- a/.github/codeql-queries/signature-serialized-without-zero-guard.ql
+++ b/.github/codeql-queries/signature-serialized-without-zero-guard.ql
@@ -1,0 +1,99 @@
+/**
+ * @name ICC signature serialized without a zero round-trip guard
+ * @description An ICC four-byte signature serialized through the icGetSig*
+ *              text helpers does not survive a round-trip when it is zero:
+ *              icGetSigStr(0) / icGetColorSigStr(0) emit the literal text
+ *              "NULL", and the inverse icGetSigVal("NULL") returns 0x4E554C4C
+ *              (the ASCII bytes 'N','U','L','L'), not 0. The JSON serializer
+ *              guards every such header field with `field ? helper(...) : ""`;
+ *              a header field that the JSON serializer guards but another
+ *              serializer (e.g. XML) emits unconditionally will silently
+ *              corrupt a zero/NoData signature on round-trip. This is the
+ *              class of bug fixed in #1356 (data colour space / PCS).
+ * @kind problem
+ * @problem.severity warning
+ * @precision high
+ * @id iccdev/signature-serialized-without-zero-guard
+ * @tags correctness
+ *       reliability
+ *       round-trip
+ *       external/cwe/cwe-704
+ */
+
+import cpp
+
+/**
+ * The icGetSig*-family text helpers that render a zero signature as the literal
+ * string "NULL" (see IccUtil.cpp). icGetSigVal() cannot invert that "NULL" back
+ * to 0, so a zero signature passed to one of these for serialization is lossy
+ * unless the zero case is guarded out.
+ */
+predicate isSigToTextHelper(Function f) {
+  f.getName() = ["icGetSigStr", "icGetColorSigStr", "icGetColorSig", "icGetSig"]
+}
+
+/**
+ * Holds if `fc` renders header field `f` to text via a sig-to-text helper. The
+ * signature value is the third positional argument (buf, bufSize, sig, ...);
+ * accept a direct field access or one wrapped in an explicit cast.
+ */
+predicate sigHelperOnField(FunctionCall fc, Field f) {
+  isSigToTextHelper(fc.getTarget()) and
+  exists(FieldAccess fa |
+    (fa = fc.getArgument(2) or fa = fc.getArgument(2).(Cast).getExpr()) and
+    fa.getTarget() = f
+  )
+}
+
+/**
+ * Holds if the call `fc` is control-dependent on a condition that tests field
+ * `f` -- covering both the ternary idiom `f ? helper(...) : ""` and an
+ * enclosing `if (f != 0) { ... helper(...) }` block. Such a call never renders
+ * a zero `f`, so it cannot corrupt the round-trip.
+ */
+predicate zeroGuardedOnField(FunctionCall fc, Field f) {
+  // Ternary idiom: `f ? helper(...) : ""` -- the call lives in the then branch
+  // of a ConditionalExpr whose condition references field f.
+  exists(ConditionalExpr ce, FieldAccess fa |
+    fc = ce.getThen().getAChild*() and
+    fa = ce.getCondition().getAChild*() and
+    fa.getTarget() = f
+  )
+  or
+  // Enclosing `if (f != 0) { ... helper(...) }` block guarding the same field.
+  exists(IfStmt ifs, FieldAccess fa |
+    fc.getEnclosingStmt().getParentStmt*() = ifs.getThen() and
+    fa = ifs.getCondition().getAChild*() and
+    fa.getTarget() = f
+  )
+}
+
+/** Holds if `fc` serializes a signature inside a `*ToXml*` function. */
+predicate inXmlSerializer(FunctionCall fc) {
+  fc.getEnclosingFunction().getName().matches("%ToXml%")
+}
+
+/**
+ * Holds if header field `f` is serialized in a `*ToJson*` function with the
+ * zero case guarded -- proof that the field can legitimately be zero and that
+ * the project's own convention is to guard it.
+ */
+predicate jsonGuardsField(Field f) {
+  exists(FunctionCall jc |
+    sigHelperOnField(jc, f) and
+    jc.getEnclosingFunction().getName().matches("%ToJson%") and
+    zeroGuardedOnField(jc, f)
+  )
+}
+
+from FunctionCall xmlCall, Field f
+where
+  sigHelperOnField(xmlCall, f) and
+  inXmlSerializer(xmlCall) and
+  not zeroGuardedOnField(xmlCall, f) and
+  jsonGuardsField(f)
+select xmlCall,
+  "Header signature field '" + f.getName() + "' is serialized unconditionally here, but the " +
+    "JSON serializer guards its zero case. A zero/NoData signature will not round-trip: " +
+    "icGetSig*(0) emits \"NULL\" and icGetSigVal(\"NULL\") returns 0x4E554C4C. Guard with " +
+    "`" + f.getName() + " ? helper(...) : \"\"` to match the JSON serializer (see #1356)."

--- a/.github/codeql-queries/version-blind-space-validation.ql
+++ b/.github/codeql-queries/version-blind-space-validation.ql
@@ -1,0 +1,56 @@
+/**
+ * @name Header colour space validated in a condition without a version test
+ * @description Some data colour space signatures are version-specific: the zero
+ *              "no data" space (0x00000000) and the iccMAX N-channel spaces
+ *              (ncXXXX) are only valid for v5/iccMAX profiles (ICC.1 7.2.8 /
+ *              Table 15); a v2/v4 data colour space must come from Table 19.
+ *              CIccInfo::IsValidSpace() is version-blind and accepts the ncXXXX
+ *              family for any version, so using it directly as the test of an
+ *              `if` that gates a header colour-space (m_Header.colorSpace /
+ *              m_Header.pcs) error -- without that same condition consulting
+ *              m_Header.version -- lets an iccMAX-only space pass on a v2/v4
+ *              profile. This is the class of bug fixed in #1359 (which moved the
+ *              data-colour-space check behind a version gate; the DeviceLink PCS
+ *              check has the same shape).
+ * @kind problem
+ * @problem.severity warning
+ * @precision medium
+ * @id iccdev/version-blind-space-validation
+ * @tags correctness
+ *       spec-conformance
+ *       external/cwe/cwe-393
+ */
+
+import cpp
+
+/** A version-blind colour-space validity predicate from CIccInfo. */
+predicate isVersionBlindSpaceCheck(Function f) {
+  f.getName() = ["IsValidSpace", "IsValidSpectralSpace"]
+}
+
+/** Holds if `e` (or a descendant) reads a header field named `name`. */
+predicate refsHeaderField(Expr e, string name) {
+  exists(FieldAccess fa | fa = e.getAChild*() and fa.getTarget().getName() = name)
+}
+
+from FunctionCall vc, IfStmt ifs
+where
+  isVersionBlindSpaceCheck(vc.getTarget()) and
+  // Validates a profile *header* colour space (the version-dependent fields).
+  exists(FieldAccess fa |
+    (fa = vc.getArgument(0) or fa = vc.getArgument(0).(Cast).getExpr()) and
+    fa.getTarget().getName() = ["colorSpace", "pcs"]
+  ) and
+  // The check is used directly as (part of) an `if` condition that gates the
+  // error -- i.e. its result is the validity decision, not pre-combined with a
+  // version-aware flag (as #1359 restructured the data-colour-space check).
+  vc = ifs.getCondition().getAChild*() and
+  // ... and that same condition never consults the profile version.
+  not refsHeaderField(ifs.getCondition(), "version") and
+  // Restrict to the profile-library validation surface.
+  vc.getFile().getRelativePath().matches("%IccProfLib/%")
+select vc,
+  "Header colour space is validated by " + vc.getTarget().getName() +
+    "() directly in an `if` condition that never consults m_Header.version. " +
+    "IsValidSpace() is version-blind, so iccMAX-only spaces (ncXXXX) can pass on a v2/v4 " +
+    "profile. Gate the check by major version, as #1359 did for the data colour space."

--- a/.github/scripts/iccdev-issue-1361-header-sig-roundtrip-regression.sh
+++ b/.github/scripts/iccdev-issue-1361-header-sig-roundtrip-regression.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1361 - header signature fields must survive an XML round-trip
+#                      when zero (generalises #1356 / #1358)
+###############################################################################
+#
+# #1356 fixed the XML serializer corrupting a zero *data colour space* / PCS
+# signature: icGetSig*(0) emits the literal "NULL", and icGetSigVal("NULL")
+# reparses it to 0x4E554C4C, so a zero signature did not round-trip. The same
+# unguarded pattern existed for the other header signature fields that the JSON
+# serializer already guards -- PreferredCMMType (cmmId), ProfileDeviceClass
+# (deviceClass) and ProfileCreator (creator). The companion CodeQL query
+# .github/codeql-queries/signature-serialized-without-zero-guard.ql detects the
+# pattern statically; this test exercises it dynamically.
+#
+# It zeroes those three header fields in a real profile, serialises it to XML
+# and parses it back, and FAILS if any field is corrupted to 0x4E554C4C
+# ("NULL" packed as ASCII) instead of round-tripping as zero.
+#
+# Header byte offsets (ICC.1 Table 13):
+#   cmmId       @ 4   (PreferredCMMType)
+#   deviceClass @ 12  (ProfileDeviceClass)
+#   creator     @ 80  (ProfileCreator)
+#
+# Plain functional round-trip test -- no sanitizer build required.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass, or skipped cleanly (tools / fixture unavailable)
+#   2 - regression: a zeroed header signature was corrupted on XML round-trip
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1361}"
+FIXTURE="$REPO_ROOT/.github/ci/test-data/nodata-colourspace-1356.icc"
+mkdir -p "$OUTDIR"
+
+find_tool() {
+  find "$TOOLS_DIR" -maxdepth 2 -name "$1" -type f 2>/dev/null | head -1
+}
+
+TOXML="$(find_tool iccToXml)"
+FROMXML="$(find_tool iccFromXml)"
+
+for t in "$TOXML" "$FROMXML"; do
+  if [ -z "$t" ] || [ ! -x "$t" ]; then
+    echo "[SKIP] required tool missing under $TOOLS_DIR (need iccToXml, iccFromXml)"
+    exit 0
+  fi
+done
+
+if [ ! -f "$FIXTURE" ]; then
+  echo "[SKIP] fixture missing: $FIXTURE"
+  exit 0
+fi
+
+BASE="$OUTDIR/zerosig.icc"
+XML="$OUTDIR/zerosig.xml"
+RT="$OUTDIR/zerosig.roundtrip.icc"
+
+cp "$FIXTURE" "$BASE"
+
+# Zero cmmId / deviceClass / creator in the (mutable) copy. dd with notrunc
+# overwrites in place without changing file length.
+zero4() { # offset
+  printf '\x00\x00\x00\x00' | dd of="$BASE" bs=1 seek="$1" count=4 conv=notrunc status=none
+}
+zero4 4    # cmmId
+zero4 12   # deviceClass
+zero4 80   # creator
+
+# Read 4 big-endian header bytes at an offset as lowercase hex.
+read4() { # file offset
+  dd if="$1" bs=1 skip="$2" count=4 status=none 2>/dev/null | od -An -tx1 | tr -d ' \n'
+}
+
+"$TOXML" "$BASE" "$XML" > "$OUTDIR/toxml.log" 2>&1
+
+status=0
+
+# The three elements must serialize empty, never the literal "NULL".
+for tag in PreferredCMMType ProfileDeviceClass ProfileCreator; do
+  if grep -qiE "<$tag>[[:space:]]*NULL[[:space:]]*</$tag>" "$XML"; then
+    echo "[FAIL] #1361: iccToXml emitted <$tag>NULL</$tag> for a zero signature"
+    status=2
+  fi
+done
+
+"$FROMXML" "$XML" "$RT" > "$OUTDIR/fromxml.log" 2>&1
+
+if [ ! -f "$RT" ]; then
+  echo "[SKIP] iccFromXml produced no output (invalid intermediate profile); cannot verify bytes"
+  exit 0
+fi
+
+# Each field must round-trip as zero, never 0x4E554C4C ('NULL' packed as ASCII).
+check_field() { # name offset
+  local name="$1" off="$2" val
+  val="$(read4 "$RT" "$off")"
+  if [ "$val" = "4e554c4c" ]; then
+    echo "[FAIL] #1361: $name corrupted to 0x4E554C4C on XML round-trip"
+    status=2
+  elif [ "$val" = "00000000" ]; then
+    echo "[PASS] #1361: $name survived the XML round-trip as zero"
+  else
+    echo "[FAIL] #1361: $name unexpected value 0x$val after round-trip (expected 00000000)"
+    status=2
+  fi
+}
+check_field cmmId       4
+check_field deviceClass 12
+check_field creator     80
+
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1162,6 +1162,21 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1356-xml-colorspace-null-roundtrip-regression.sh"
 )
 
+# #1361: generalises #1356 to the remaining header signature fields that the
+# JSON serializer guards but the XML serializer did not -- PreferredCMMType
+# (cmmId), ProfileDeviceClass (deviceClass) and ProfileCreator (creator).
+# Zeroes those three fields in a real profile and fails if any is corrupted to
+# 0x4E554C4C ("NULL") on an iccToXml -> iccFromXml round-trip.  Companion to the
+# static CodeQL query signature-serialized-without-zero-guard.ql.  Plain
+# functional test -- skips cleanly if the tools/fixture are absent.
+iccdev_add_script_test(
+  iccdev.issue-1361-header-sig-roundtrip-regression
+  60
+  "iccdev;xml;signature;roundtrip;issue-1361;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1361-header-sig-roundtrip-regression.sh"
+)
+
 # Describe sink + options API smoke test. Verifies byte-equivalence
 # between the legacy std::string Describe() and the new
 # Describe(IDescribeSink&, const DescribeOptions&) virtual, plus

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1693,9 +1693,22 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
   }
   else {
     if (m_Header.deviceClass==icSigLinkClass) {
-      if (!Info.IsValidSpace(m_Header.pcs)) {
+      // A DeviceLink PCS holds the B-side connection (output) colour space. As
+      // with the data colour space (#1359), the iccMAX N-channel spaces (ncXXXX)
+      // are only valid for v5/iccMAX; IsValidSpace() is version-blind, so gate
+      // them by major version for v2/v4 DeviceLink profiles and report the raw
+      // value rather than the friendly descriptor when an iccMAX-only space
+      // appears on a v2/v4 profile.
+      bool bValidPcs = Info.IsValidSpace(m_Header.pcs);
+      bool bIccMaxOnlyPcs = icGetColorSpaceType(m_Header.pcs)==icSigNChannelData;
+      if (m_Header.version<icVersionNumberV5 && bIccMaxOnlyPcs)
+        bValidPcs = false;
+      if (!bValidPcs) {
         sReport += icMsgValidateCriticalError;
-        snprintf(buf, bufSize, " - %s: Unknown pcs color space!\n", Info.GetColorSpaceSigName(m_Header.pcs));
+        if (m_Header.version<icVersionNumberV5 && bIccMaxOnlyPcs)
+          snprintf(buf, bufSize, " - Invalid pcs colour space (0x%08X) for a v2/v4 profile; only iccMAX (v5) permits this!\n", (unsigned int)m_Header.pcs);
+        else
+          snprintf(buf, bufSize, " - %s: Unknown pcs color space!\n", Info.GetColorSpaceSigName(m_Header.pcs));
         sReport += buf;
         rv = icMaxStatus(rv, icValidateCriticalError);
       }

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -91,7 +91,11 @@ bool CIccProfileXml::ToXmlWithBlanks(std::string &xml, std::string blanks)
 
   xml += blanks + "<IccProfile>\n";
   xml += blanks + "  <Header>\n";
-  snprintf(line, bufSize, "    <PreferredCMMType>%s</PreferredCMMType>\n", icFixXml(fix, icGetColorSigStr(buf, bufSize, m_Header.cmmId)));
+  // Guard every zero header signature the same way as the data colour space /
+  // PCS below (and the JSON serializer): icGetSig*(0) emits the literal "NULL",
+  // which icGetSigVal("NULL") reparses to 0x4E554C4C, corrupting a legitimately
+  // zero PreferredCMMType on round-trip. Emit an empty element for zero instead.
+  snprintf(line, bufSize, "    <PreferredCMMType>%s</PreferredCMMType>\n", m_Header.cmmId ? icFixXml(fix, icGetColorSigStr(buf, bufSize, m_Header.cmmId)) : "");
   xml += blanks + line;
   snprintf(line, bufSize, "    <ProfileVersion>%s</ProfileVersion>\n", info.GetVersionName(m_Header.version));
   xml += blanks + line;
@@ -99,7 +103,9 @@ bool CIccProfileXml::ToXmlWithBlanks(std::string &xml, std::string blanks)
     snprintf(line, bufSize,"    <ProfileSubClassVersion>%s</ProfileSubClassVersion>\n", info.GetSubClassVersionName(m_Header.version));
     xml += blanks + line;
   }
-  snprintf(line, bufSize, "    <ProfileDeviceClass>%s</ProfileDeviceClass>\n", icFixXml(fix, icGetSigStr(buf, bufSize, m_Header.deviceClass)));
+  // Guard the zero case as above so a zero device class round-trips as 0 rather
+  // than being corrupted to 0x4E554C4C via the "NULL" text encoding.
+  snprintf(line, bufSize, "    <ProfileDeviceClass>%s</ProfileDeviceClass>\n", m_Header.deviceClass ? icFixXml(fix, icGetSigStr(buf, bufSize, m_Header.deviceClass)) : "");
   xml += blanks + line;
 
   if (m_Header.deviceSubClass) {
@@ -168,7 +174,9 @@ bool CIccProfileXml::ToXmlWithBlanks(std::string &xml, std::string blanks)
 
   xml += blanks + line;
   
-  snprintf(line, bufSize, "    <ProfileCreator>%s</ProfileCreator>\n", icFixXml(fix, icGetSigStr(buf, bufSize, m_Header.creator)));
+  // Guard the zero case as above so a zero creator round-trips as 0 rather than
+  // being corrupted to 0x4E554C4C via the "NULL" text encoding.
+  snprintf(line, bufSize, "    <ProfileCreator>%s</ProfileCreator>\n", m_Header.creator ? icFixXml(fix, icGetSigStr(buf, bufSize, m_Header.creator)) : "");
   xml += blanks + line;
 
   if (m_Header.profileID.ID32[0] || m_Header.profileID.ID32[1] || 


### PR DESCRIPTION
Closes #1361. Adds the CodeQL/CTest coverage requested to "identify same/similar issues" from #1356, #1358 and #1359 — and fixes the real latent instances the new queries surface, so both queries run clean.

## CodeQL queries (detection)

**`signature-serialized-without-zero-guard.ql`** — the #1356 round-trip class. An ICC four-byte signature serialized through the `icGetSig*` text helpers does not round-trip when zero: `icGetSig*(0)` emits the literal `"NULL"`, and `icGetSigVal("NULL")` returns `0x4E554C4C`. The query flags a header field that the JSON serializer guards with `field ? helper(...) : ""` but a `*ToXml*` serializer emits unconditionally. Understands both the ternary and `if (field != 0) { ... }` guard idioms.

**`version-blind-space-validation.ql`** — the #1359 class. A header colour space validated by the version-blind `CIccInfo::IsValidSpace()` *directly in an `if` condition* that never consults `m_Header.version`, so iccMAX-only spaces (`ncXXXX`) pass on a v2/v4 profile.

Both validated against a locally-built CodeQL DB (CodeQL CLI 2.25.6):

| Query | on `master` | on this branch |
|---|---|---|
| signature-serialized-without-zero-guard | **3 findings** (`cmmId`, `deviceClass`, `creator`) | 0 |
| version-blind-space-validation | **1 finding** (DeviceLink PCS check) | 0 |

## Fixes the queries surface

- **`IccProfileXml.cpp`** — guard the zero case for the three remaining header signature fields the JSON serializer already guards: `PreferredCMMType` (cmmId), `ProfileDeviceClass` (deviceClass), `ProfileCreator` (creator). Same corruption as #1356 (`"NULL"` → `0x4E554C4C`); now emit an empty element for zero.
- **`IccProfile.cpp`** — version-gate the DeviceLink **PCS** colour-space check exactly as #1359 gated the data colour space. A v2/v4 DeviceLink with an `ncXXXX` PCS was accepted unflagged; it is now a critical error reporting the raw value.

## CTest (dynamic)

**`iccdev-issue-1361-header-sig-roundtrip-regression.sh`** — generalises the #1358 round-trip test to cmmId/deviceClass/creator: zeroes them in a real profile, serialises to XML and back, and fails if any is corrupted to `0x4E554C4C`. Verified **FAIL on master / PASS on this branch**. Registered as `iccdev.issue-1361-header-sig-roundtrip-regression`.

## Verification summary
- Zero cmmId/deviceClass/creator now round-trip as `0` (not `0x4E554C4C`); the #1356 data-colour-space test still passes.
- v4 DeviceLink with `ncXXXX` PCS → `Invalid pcs colour space (0x6E630004) for a v2/v4 profile…`; v5 and normal v2/v4 profiles unaffected; the #1359 data-colour-space diagnostic is intact.

## Note on scope
This PR bundles detection (the queries/test #1361 asked for) with the small fixes those detectors surface, so the committed queries are green against the repo. The two source fixes (serializer guards in `IccProfileXml.cpp`; PCS version-gate in `IccProfile.cpp`) are each a direct analog of an already-merged fix (#1356 / #1359) and are isolated in their own commit — happy to split them into separate fix PRs if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)