### PR TITLE
Fix: iccV5DspObsToV4Dsp emits rXYZ/gXYZ/bXYZ as XYZType, not s15Fixed16ArrayType (#1362)

### DIFF
--- a/Tools/CmdLine/IccV5DspObsToV4Dsp/IccV5DspObsToV4Dsp.cpp
+++ b/Tools/CmdLine/IccV5DspObsToV4Dsp/IccV5DspObsToV4Dsp.cpp
@@ -228,22 +228,28 @@ int main(int argc, char* argv[])
   matrixMpe->Apply(mtxApply, in, rRGB);
   pTagC2S->Apply(pAppyC2S.get(), out, in);
  
-  CIccTagS15Fixed16* primaryXYZ = new CIccTagS15Fixed16(3);
-  (*primaryXYZ)[0] = icDtoF(out[0]); (*primaryXYZ)[1] = icDtoF(out[1]); (*primaryXYZ)[2] = icDtoF(out[2]);
+  // The red/green/blue matrix-column tags (rXYZ/gXYZ/bXYZ, a.k.a.
+  // red/green/blueColorantTag) must be XYZType per ICC.1 9.2.46 / 9.2.31 /
+  // 9.2.4 (each an array of one XYZNumber, 10.31). Emitting them as
+  // s15Fixed16ArrayType ('sf32') produced a non-compliant profile that
+  // consumers keying on the spec type (e.g. dynamic_cast<CIccTagXYZ*>) cannot
+  // read. Use CIccTagXYZ so the tag carries the correct 'XYZ ' type signature.
+  CIccTagXYZ* primaryXYZ = new CIccTagXYZ;
+  (*primaryXYZ)[0].X = icDtoF(out[0]); (*primaryXYZ)[0].Y = icDtoF(out[1]); (*primaryXYZ)[0].Z = icDtoF(out[2]);
   pIcc->AttachTag(icSigRedColorantTag, primaryXYZ); // pointer ownership is passed to the profile
 
   matrixMpe->Apply(mtxApply, in, gRGB);
   pTagC2S->Apply(pAppyC2S.get(), out, in);
 
-  primaryXYZ = new CIccTagS15Fixed16(3);
-  (*primaryXYZ)[0] = icDtoF(out[0]); (*primaryXYZ)[1] = icDtoF(out[1]); (*primaryXYZ)[2] = icDtoF(out[2]);
+  primaryXYZ = new CIccTagXYZ;
+  (*primaryXYZ)[0].X = icDtoF(out[0]); (*primaryXYZ)[0].Y = icDtoF(out[1]); (*primaryXYZ)[0].Z = icDtoF(out[2]);
   pIcc->AttachTag(icSigGreenColorantTag, primaryXYZ); // pointer ownership is passed to the profile
 
   matrixMpe->Apply(mtxApply, in, bRGB);
   pTagC2S->Apply(pAppyC2S.get(), out, in);
 
-  primaryXYZ = new CIccTagS15Fixed16(3);
-  (*primaryXYZ)[0] = icDtoF(out[0]); (*primaryXYZ)[1] = icDtoF(out[1]); (*primaryXYZ)[2] = icDtoF(out[2]);
+  primaryXYZ = new CIccTagXYZ;
+  (*primaryXYZ)[0].X = icDtoF(out[0]); (*primaryXYZ)[0].Y = icDtoF(out[1]); (*primaryXYZ)[0].Z = icDtoF(out[2]);
   pIcc->AttachTag(icSigBlueColorantTag, primaryXYZ); // pointer ownership is passed to the profile
 
   if (!SaveIccProfile(argv[3], pIcc)) {


### PR DESCRIPTION
Closes #1362.

## Problem

`iccV5DspObsToV4Dsp` created the red/green/blue matrix-column tags (`rXYZ`/`gXYZ`/`bXYZ`, a.k.a. `red/green/blueColorantTag`) as `CIccTagS15Fixed16`, which serializes with the type signature `'sf32'` (s15Fixed16ArrayType). ICC.1 §9.2.46 / §9.2.31 / §9.2.4 require these tags to be **XYZType** (`'XYZ '`, §10.31) — an array of one `XYZNumber`.

The numeric data was correct (XYZType and a 3-element s15Fixed16ArrayType share the same 20-byte layout), but the wrong type signature made the profile **NonCompliant** and unreadable by consumers keying on the spec type — e.g. `dynamic_cast<CIccTagXYZ*>(FindTag(icSigRedMatrixColumnTag))` returned `nullptr` in the PAWG quality metrics (`IccQualityMetrics.h`).

## Fix

```cpp
CIccTagXYZ* primaryXYZ = new CIccTagXYZ;            // 'XYZ ', one XYZNumber
(*primaryXYZ)[0].X = icDtoF(out[0]);
(*primaryXYZ)[0].Y = icDtoF(out[1]);
(*primaryXYZ)[0].Z = icDtoF(out[2]);
pIcc->AttachTag(icSigRedColorantTag, primaryXYZ);
```
(same for green/blue).

## Verification

Regenerated `LCDDisplayCat8Obs.icc` from the committed inputs:

| | Before | After |
|---|---|---|
| rXYZ/gXYZ/bXYZ on-disk type | `sf32` (`73663332`) | `XYZ ` (`58595A20`) |
| `iccDumpProfile` type | s15Fixed16ArrayType | XYZArrayType |
| colorant NonCompliant warning | `Invalid tag type` ×3 | gone |
| red primary | — | X=0.5150 Y=0.2760 Z=-0.0035 (preserved) |

A paired regression test (assert the three matrix-column tags serialize as `'XYZ '`) will follow per the fix/test split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)