### PR TITLE
Spelling: anglicise operator-facing validation/report strings to "colour" (#1360)

### DIFF
--- a/IccProfLib/IccArrayBasic.cpp
+++ b/IccProfLib/IccArrayBasic.cpp
@@ -503,7 +503,7 @@ icValidateStatus CIccArrayNamedColor::Validate(std::string sigPath, std::string 
     int nBad = 0;
 
     if (n<1) {
-      sReport += "Named Color array must have at least 1 entry\n";
+      sReport += "NamedColor array must have at least 1 entry\n";
       rv = icMaxStatus(rv, icValidateCriticalError);
     }
 
@@ -608,7 +608,7 @@ icValidateStatus CIccArrayNamedColor::Validate(std::string sigPath, std::string 
       }
     }
     if (nBad) {
-      sReport += "Named Color array has invalid tag struct entries!\n";
+      sReport += "NamedColor array has invalid tag struct entries!\n";
       rv = icMaxStatus(rv, icValidateCriticalError);
     }
   }

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -8448,11 +8448,11 @@ const icChar* CIccCmm::GetStatusText(icStatusCMM stat)
   case icCmmStatProfileMissingTag:
     return "Missing tag in profile";
   case icCmmStatColorNotFound:
-    return "Color not found";
+    return "Colour not found";
   case icCmmStatIncorrectApply:
     return "Incorrect Apply object";
   case icCmmStatBadColorEncoding:
-    return "Invalid color encoding used";
+    return "Invalid colour encoding used";
   case icCmmStatAllocErr:
     return "Memory allocation error";
   case icCmmStatBadLutType:

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1650,7 +1650,7 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
         if (m_Header.version<icVersionNumberV5 && bIccMaxOnlySpace)
           snprintf(buf, bufSize, " - Invalid data colour space (0x%08X) for a v2/v4 profile; only iccMAX (v5) permits this!\n", (unsigned int)m_Header.colorSpace);
         else
-          snprintf(buf, bufSize, " - %s: Unknown color space!\n", Info.GetColorSpaceSigName(m_Header.colorSpace));
+          snprintf(buf, bufSize, " - %s: Unknown colour space!\n", Info.GetColorSpaceSigName(m_Header.colorSpace));
         sReport += buf;
         rv = icMaxStatus(rv, icValidateCriticalError);
       }
@@ -1708,7 +1708,7 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
         if (m_Header.version<icVersionNumberV5 && bIccMaxOnlyPcs)
           snprintf(buf, bufSize, " - Invalid pcs colour space (0x%08X) for a v2/v4 profile; only iccMAX (v5) permits this!\n", (unsigned int)m_Header.pcs);
         else
-          snprintf(buf, bufSize, " - %s: Unknown pcs color space!\n", Info.GetColorSpaceSigName(m_Header.pcs));
+          snprintf(buf, bufSize, " - %s: Unknown pcs colour space!\n", Info.GetColorSpaceSigName(m_Header.pcs));
         sReport += buf;
         rv = icMaxStatus(rv, icValidateCriticalError);
       }
@@ -1722,7 +1722,7 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
 
         default:
           sReport += icMsgValidateCriticalError;
-          snprintf(buf, bufSize, " - %s: Invalid pcs color space!\n", Info.GetColorSpaceSigName(m_Header.pcs));
+          snprintf(buf, bufSize, " - %s: Invalid pcs colour space!\n", Info.GetColorSpaceSigName(m_Header.pcs));
           sReport += buf;
           rv = icMaxStatus(rv, icValidateCriticalError);
           break;
@@ -1821,7 +1821,7 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
 
         default:
           sReport += icMsgValidateCriticalError;
-          snprintf(buf, bufSize, "%s: Invalid spectral PCS color space!\n", Info.GetColorSpaceSigName((icColorSpaceSignature)m_Header.spectralPCS));
+          snprintf(buf, bufSize, "%s: Invalid spectral PCS colour space!\n", Info.GetColorSpaceSigName((icColorSpaceSignature)m_Header.spectralPCS));
           sReport += buf;
           rv = icMaxStatus(rv, icValidateCriticalError);
           break;

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -12169,7 +12169,7 @@ void CIccTagSpectralViewingConditions::Describe(std::string &sDescription, int n
   sDescription += info.GetIlluminantName(m_stdIlluminant);
   sDescription += "\n";
 
-  snprintf(buf, bufSize, "Color Temperature: %.1fK\n\n", m_colorTemperature);
+  snprintf(buf, bufSize, "Colour Temperature: %.1fK\n\n", m_colorTemperature);
   sDescription += buf;
 
   if (m_illuminant) {

--- a/IccProfLib/IccTagEmbedIcc.cpp
+++ b/IccProfLib/IccTagEmbedIcc.cpp
@@ -402,11 +402,11 @@ void CIccTagEmbeddedProfile::Describe(std::string& sDescription, int /* nVerbose
     sDescription += buf;
     snprintf(buf, bufSize, "Creator:            %s\n", icGetSig(buf2, bufSize, pHdr->creator));
     sDescription += buf;
-    snprintf(buf, bufSize, "Data Color Space:   %s\n", Fmt.GetColorSpaceSigName(pHdr->colorSpace));
+    snprintf(buf, bufSize, "Data Colour Space:  %s\n", Fmt.GetColorSpaceSigName(pHdr->colorSpace));
     sDescription += buf;
     snprintf(buf, bufSize, "Flags               %s\n", Fmt.GetProfileFlagsName(pHdr->flags));
     sDescription += buf;
-    snprintf(buf, bufSize, "PCS Color Space:    %s\n", Fmt.GetColorSpaceSigName(pHdr->pcs));
+    snprintf(buf, bufSize, "PCS Colour Space:   %s\n", Fmt.GetColorSpaceSigName(pHdr->pcs));
     sDescription += buf;
     snprintf(buf, bufSize, "Platform:           %s\n", Fmt.GetPlatformSigName(pHdr->platform));
     sDescription += buf;
@@ -455,11 +455,11 @@ void CIccTagEmbeddedProfile::Describe(std::string& sDescription, int /* nVerbose
       sDescription += "BiSpectral Range:   Not Defined\n";
     }
     if (pHdr->mcs) {
-      snprintf(buf, bufSize, "MCS Color Space:    %s\n", Fmt.GetColorSpaceSigName((icColorSpaceSignature)pHdr->mcs));
+      snprintf(buf, bufSize, "MCS Colour Space:   %s\n", Fmt.GetColorSpaceSigName((icColorSpaceSignature)pHdr->mcs));
       sDescription += buf;
     }
     else {
-      sDescription += "MCS Color Space:    Not Defined\n";
+      sDescription += "MCS Colour Space:   Not Defined\n";
     }
 
     sDescription += "\nProfile Tags\n";


### PR DESCRIPTION
Implements the scope agreed on #1360. Aligns operator-facing validation and `Describe()` output with ICC editorial usage — ISO **"colour"** in human-readable text, while spec-defined identifiers, tag names, signature/type tokens and the canonical term **"colorimetric"** (ICC.1 / ICC.2) retain **"color"**.

### (A) Report prose → "colour" — 11 strings
| File | Strings |
|---|---|
| `IccProfile.cpp` | ×4 — `Unknown`/`Invalid [pcs/spectral PCS]` **colour** space |
| `IccTagEmbedIcc.cpp` | ×4 — `Data`/`PCS`/`MCS` **Colour** Space: describe labels |
| `IccCmm.cpp` | ×2 — `Colour not found`, `Invalid colour encoding used` |
| `IccTagBasic.cpp` | ×1 — `Colour Temperature:` (matches ICC.2) |

In `IccTagEmbedIcc.cpp` the padding is trimmed one space so the `%s` value column stays aligned with the surrounding `Creator:`/`Platform:`/`Profile Class:` block (column 20).

### (B) Spec-label normalisation (retains "Color") — 2 strings
`IccArrayBasic.cpp:506/611` — `"Named Color array"` → `"NamedColor array"`. These were the only two-word stragglers; the spec label and the other ten `NamedColor` occurrences in the same file are already one word.

### Deliberately NOT changed
`colorimetric`/`colorimetry`; `colorant`/`colorantTableTag`; the `Get*SigName` display labels (`ColorSpaceClass`, `…ColorData` — they mirror spec signatures/identifiers and are parsed nowhere, but track the identifier spelling); CMM registry names (`ColorGear`, `LinoColor`, `Windows Color System`); CICP `ColorPrimaries`; and all C identifiers.

### Risk
String-literal changes only — no identifier, signature, API or file-format change; 13 insertions / 13 deletions. No regression script matches on "color space". The validator already emits "colour" in the #1359 and CICP lines, so this removes an existing internal inconsistency rather than introducing one.

Prepared for @maxderhak / @dwtza to accept or decline per the #1360 editorial decision.

Refs #1360, #1355.

🤖 Generated with [Claude Code](https://claude.com/claude-code)