### PR TITLE
Fix: round-trip through XYZ-PCS profiles — CMM Lab→XYZ scaling + native-PCS round-trip eval (#1355)

### DIFF
--- a/.github/scripts/iccdev-issue-1355-roundtrip-mattrc-invertibility-regression.sh
+++ b/.github/scripts/iccdev-issue-1355-roundtrip-mattrc-invertibility-regression.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1355 - matrix/TRC (PCSXYZ) profiles must round-trip near-exactly
+###############################################################################
+#
+# A matrix/TRC display profile is an analytic, exactly-invertible transform, so a
+# device->PCS->device round trip should return ~0 dE. iccRoundTrip reported ~20 dE
+# mean for every such profile, which traced to two independent defects (both fixed
+# in the PR that adds this test):
+#
+#   1. CIccPcsXform::ConnectFirst (IccCmm.cpp) omitted the actual->internal XYZ
+#      rescale (pushXyzToXyzIn) after a Lab->XYZ step, so Lab->device through an
+#      XYZ-PCS profile was ~2x off (factor 65535/32768). Central CMM bug.
+#   2. CIccEvalCompare::EvaluateProfile (IccEval.cpp) forced the round-trip
+#      connection space to Lab even for XYZ-PCS profiles, injecting a numerically
+#      lossy XYZ<->Lab (L* cube-root) conversion pair into every leg; it now
+#      connects through the profile's native PCS.
+#
+# This test runs iccRoundTrip on committed matrix/TRC PCSXYZ fixtures and FAILS if
+# RT1 mean dE exceeds THRESHOLD (was ~20 before the fix, ~0 after).
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#
+# Exit codes:
+#   0 - pass, or skipped cleanly (tool / fixtures unavailable)
+#   2 - regression: a matrix/TRC PCSXYZ profile failed to round-trip
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+THRESHOLD=1.0
+
+find_tool() {
+  find "$TOOLS_DIR" -maxdepth 2 -name "$1" -type f 2>/dev/null | head -1
+}
+
+RT="$(find_tool iccRoundTrip)"
+if [ -z "$RT" ] || [ ! -x "$RT" ]; then
+  echo "[SKIP] iccRoundTrip not built under $TOOLS_DIR"
+  exit 0
+fi
+
+# Committed matrix/TRC RGB profiles whose PCS is XYZ -- exactly invertible, so RT1
+# mean dE must be ~0. All three exhibited ~20 dE before the fix.
+FIXTURES=(
+  ".github/ci/regression/gamma-2.20703125.icc"
+  ".github/ci/regression/para-gamma-2.4.icc"
+  ".github/ci/test-data/v5dspobs-lcddisplay.icc"
+)
+
+rc=0
+ran=0
+for f in "${FIXTURES[@]}"; do
+  p="$REPO_ROOT/$f"
+  if [ ! -f "$p" ]; then
+    echo "[SKIP] missing fixture: $f"
+    continue
+  fi
+  ran=$((ran + 1))
+  mean="$("$RT" "$p" 1 | awk '/Round Trip 1/{x=1} x&&/Mean DeltaE/{print $3; exit}')"
+  if [ -z "$mean" ]; then
+    echo "[FAIL] $f: could not parse RT1 mean dE"
+    rc=2
+    continue
+  fi
+  if awk "BEGIN{exit !($mean > $THRESHOLD)}"; then
+    echo "[FAIL] $f: RT1 mean dE=$mean > $THRESHOLD (Lab<->XYZ round-trip regression)"
+    rc=2
+  else
+    echo "[PASS] $f: RT1 mean dE=$mean"
+  fi
+done
+
+if [ "$ran" -eq 0 ]; then
+  echo "[SKIP] no fixtures available"
+  exit 0
+fi
+
+exit $rc

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1190,6 +1190,18 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1361-header-sig-roundtrip-regression.sh"
 )
 
+# #1355 - matrix/TRC (PCSXYZ) profiles must round-trip near-exactly. Guards the
+# two CMM/eval fixes (ConnectFirst actual->internal XYZ rescale; native-PCS
+# round-trip connection): iccRoundTrip RT1 mean dE was ~20 before, ~0 after.
+# Skips cleanly if iccRoundTrip is not built.
+iccdev_add_script_test(
+  iccdev.issue-1355-roundtrip-mattrc-invertibility-regression
+  120
+  "iccdev;cmm;roundtrip;issue-1355;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1355-roundtrip-mattrc-invertibility-regression.sh"
+)
+
 # Describe sink + options API smoke test. Verifies byte-equivalence
 # between the legacy std::string Describe() and the new
 # Describe(IDescribeSink&, const DescribeOptions&) virtual, plus

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -2568,11 +2568,19 @@ icStatusCMM CIccPcsXform::ConnectFirst(CIccXform* pToXform, icColorSpaceSignatur
   else if (srcSpace == icSigLabData) {
 
     if (pToXform->GetSrcSpace() == icSigXYZData) {
+      // Incoming PCS is Lab feeding a transform whose source space is XYZ.
+      // CIccPcsStepLabToXyz emits *actual* (unscaled) XYZ, but an XYZ-source
+      // transform consumes *internal* XYZ (scaled by icXyzToXyzIn = 32768/65535).
+      // Mirror ConnectLast() and the icSigXYZData source branch above by rescaling
+      // actual->internal XYZ here; without it the XYZ handed to the transform is
+      // ~2x too large (65535/32768) and the Lab->device direction (e.g. round-trip
+      // evaluation through a matrix/TRC display profile) is grossly wrong.
       pushLabToXyz(pToXform->m_pConnectionConditions);
       if (pToXform->NeedAdjustSrcPCS()) {
         pushScale3(pToXform->m_PCSScale[0], pToXform->m_PCSScale[1], pToXform->m_PCSScale[2]);
         pushOffset3(pToXform->m_PCSOffset[0], pToXform->m_PCSOffset[1], pToXform->m_PCSOffset[2]);
       }
+      pushXyzToXyzIn();
     }
     else if (pToXform->NeedAdjustSrcPCS()) {
       pushLabToXyz(pToXform->m_pConnectionConditions);

--- a/IccProfLib/IccEval.cpp
+++ b/IccProfLib/IccEval.cpp
@@ -96,8 +96,16 @@ icStatusCMM CIccEvalCompare::EvaluateProfile(CIccProfile *pProfile, icUInt8Numbe
     return icCmmStatInvalidProfile;
   }
 
-  CIccCmm dev2Lab(icSigUnknownData, icSigLabData);
-  CIccCmm Lab2Dev2Lab(icSigLabData, icSigLabData, false);
+  // Connect the round-trip CMMs through the profile's native PCS.  Forcing the
+  // connection space to Lab for an XYZ-PCS profile inserts a gratuitous XYZ<->Lab
+  // conversion pair (the L* cube root and its inverse) into every transform leg --
+  // wasted math, and numerically lossy at high chroma where the round trip should
+  // be exactly invertible.  Use XYZ directly when the profile PCS is XYZ; otherwise
+  // Lab.  Either way the comparison below is still performed in L*a*b*.
+  const bool bXyzConnect = (pProfile->m_Header.pcs == icSigXYZData);
+  const icColorSpaceSignature connSpace = bXyzConnect ? icSigXYZData : icSigLabData;
+  CIccCmm dev2Lab(icSigUnknownData, connSpace);
+  CIccCmm Lab2Dev2Lab(connSpace, connSpace, false);
   icXformLutType nLutType = buseMpeTags ? icXformLutColor : icXformLutColorimetric;
 
   icStatusCMM result;
@@ -184,9 +192,19 @@ icStatusCMM CIccEvalCompare::EvaluateProfile(CIccProfile *pProfile, icUInt8Numbe
     Lab2Dev2Lab.Apply(roundPcs1, devPcs);  //First round trip gets color into output gamut
     Lab2Dev2Lab.Apply(roundPcs2, roundPcs1);  //Second round trip find reproducibility error
 
-    icLabFromPcs(devPcs);
-    icLabFromPcs(roundPcs1);
-    icLabFromPcs(roundPcs2);
+    // Decode the PCS samples to actual L*a*b* for the dE comparison.  When the
+    // connection space is XYZ the samples are internal XYZ, so undo the internal
+    // scaling (icXyzFromPcs) and convert XYZ->Lab; otherwise they are internal Lab.
+    if (bXyzConnect) {
+      icXyzFromPcs(devPcs);    icXYZtoLab(devPcs);
+      icXyzFromPcs(roundPcs1); icXYZtoLab(roundPcs1);
+      icXyzFromPcs(roundPcs2); icXYZtoLab(roundPcs2);
+    }
+    else {
+      icLabFromPcs(devPcs);
+      icLabFromPcs(roundPcs1);
+      icLabFromPcs(roundPcs2);
+    }
 
     Compare(sPixel, devPcs, roundPcs1, roundPcs2);
   }


### PR DESCRIPTION
Round-trip evaluation of matrix/TRC display profiles (raised in #1355) reported ~20 ΔE mean where an analytic, exactly-invertible transform should give ~0. The cause is **two independent defects**; this PR fixes both together to keep one review.

### Fix 1 — `CIccPcsXform::ConnectFirst` (IccCmm.cpp): central CMM bug
The `Lab → XYZ-source transform` branch ran `pushLabToXyz` (which emits *actual* XYZ) but omitted the `pushXyzToXyzIn()` rescale to *internal* XYZ that `ConnectLast()` and the XYZ-source branch both apply. Any `Lab→device` transform through an XYZ-PCS profile was therefore ~2× off (factor 65535/32768). This affects **every consumer of that code path**, not just the evaluator.

### Fix 2 — `CIccEvalCompare::EvaluateProfile` (IccEval.cpp): round-trip eval
It forced the connection space to Lab even for XYZ-PCS profiles, injecting a gratuitous, numerically lossy XYZ↔Lab (L\* cube-root) conversion pair into every leg. It now connects through the profile's **native PCS** (XYZ when `pcs==XYZ`, else Lab); the ΔE comparison is still performed in L\*a\*b\*.

### On scope
**For the round-trip issue alone, Fix 2 is sufficient** — connecting through XYZ never enters Fix 1's code path. But Fix 1 is a genuine, central CMM correctness bug discovered along the way and must be corrected regardless, so both are included here as one PR for the moderator.

### Validation — `iccRoundTrip` RT1 mean / max ΔE

| Profile (matrix/TRC, PCSXYZ) | baseline | Fix 1 only | Fix 2 (= both) |
|---|---|---|---|
| gamma-2.20703125 | 20.54 / 47.72 | ~0 | **0.00 / 0.04** |
| para-gamma-2.4 | 19.72 / 45.68 | ~0 | **0.01 / 0.37** |
| v5dspobs-lcddisplay | 20.78 / 46.53 | ~0 | **0.01 / 0.22** |
| sRGB_D65_colorimetric | 25.72 / 41.18 | 0.00 / 0.00 | **0.00 / 0.00** |
| AdobeRGB (a98) | 21.75 / 54.36 | 0.00 / 0.02 | **0.00 / 0.02** |
| Display P3 | 21.60 / 51.24 | 0.00 / 1.99 | **0.00 / 0.01** |
| LCDDisplayCat8Obs | 20.32 / 44.16 | 0.03 / 6.57 | **0.01 / 0.21** |
| CGATS21_CRPC6 (CMYK / Lab PCS) | 0.33 / 3.04 | 0.33 / 3.04 | **0.33 / 3.04** (unchanged) |

The **Fix 2 (= both)** column is reached by Fix 2 alone — with Fix 2 in place the Fix-1 path isn't exercised, which is why its residual max (Lab-encoding amplification at high chroma, e.g. Cat8Obs 6.57) disappears. Lab-PCS profiles (CMYK CLUT) are unchanged by both fixes.

### Test
Adds CTest regression `iccdev.issue-1355-roundtrip-mattrc-invertibility-regression` over committed PCSXYZ fixtures; FAILS if RT1 mean ΔE > 1.0 (verified: passes with the fix, fails on the baseline tool with exit 2).

Refs #1355.
