### PR TITLE
Fix: IccV5DspObsToV4Dsp emits a non-conformant v4 header — set colorSpace/PCS, add mediaWhitePointTag, enforce input contract (#1371)

### DIFF
--- a/Tools/CmdLine/IccV5DspObsToV4Dsp/IccV5DspObsToV4Dsp.cpp
+++ b/Tools/CmdLine/IccV5DspObsToV4Dsp/IccV5DspObsToV4Dsp.cpp
@@ -98,6 +98,34 @@ void Usage() {
 }
 
 
+/**
+ ******************************************************************************
+ * iccV5DspObsToV4Dsp -- STRICT INPUT CONTRACT
+ *
+ * This tool performs exactly ONE conversion (see Usage() above):
+ *
+ *     iccV5DspObsToV4Dsp  inputV5.icc  inputObserverV5.icc  outputV4.icc
+ *
+ *   inputV5.icc         : an ICC v5 *display* profile carrying SPECTRAL data --
+ *                         an AToB1 multiProcessElement of exactly
+ *                         [CurveSetElement, EmissionMatrixElement], 3->3 (the
+ *                         spectral emission of the R/G/B primaries + white).
+ *   inputObserverV5.icc : an ICC v5 *observer* / Profile Connection Conditions
+ *                         profile (ColorSpace class) -- a spectralViewingConditions
+ *                         tag (observer colour-matching functions + illuminant)
+ *                         and a customToStandardPcc multiProcessElement, 3->3.
+ *
+ * It emits a plain v4.3 RGB matrix/TRC *display* profile (PCSXYZ): the display's
+ * spectral emission is integrated against the observer to yield the rXYZ/gXYZ/bXYZ
+ * colorants and the media white point (M*(1,1,1)) in the standard D50 PCS, and the
+ * display tone response becomes rTRC/gTRC/bTRC.
+ *
+ * Because only this one output shape is ever produced, the implementation is
+ * deliberately narrow: any input not satisfying the contract above is REJECTED
+ * (return -2), never coerced.  Do not broaden the accepted inputs without
+ * revisiting the construction in main().
+ ******************************************************************************
+ */
 int main(int argc, char* argv[])
 {
   if (argc < 4) {   // name + 3 arguments
@@ -115,6 +143,14 @@ int main(int argc, char* argv[])
   if (dspIcc->m_Header.version < icVersionNumberV5 ||
     dspIcc->m_Header.deviceClass != icSigDisplayClass) {
     printf("%s is not a V5 display profile\n", argv[1]);
+    return -2;
+  }
+
+  // Per the input contract the display must be RGB: the output is an RGB
+  // matrix/TRC profile built from three (1,0,0)/(0,1,0)/(0,0,1) primaries below,
+  // so a non-RGB data colour space cannot be honoured.
+  if (dspIcc->m_Header.colorSpace != icSigRgbData) {
+    printf("%s is not an RGB display profile (data colour space must be 'RGB ')\n", argv[1]);
     return -2;
   }
 
@@ -145,19 +181,30 @@ int main(int argc, char* argv[])
     return -2;
   }
 
-  if (pccIcc->m_Header.version < icVersionNumberV5) {
-    printf("%s is not a V5 profile\n", argv[2]);
+  // The observer input is a v5 Profile Connection Conditions profile, which the
+  // ICC spec carries as a ColorSpace-class ('spac') profile (subclass 'pcc ').
+  if (pccIcc->m_Header.version < icVersionNumberV5 ||
+    pccIcc->m_Header.deviceClass != icSigColorSpaceClass) {
+    printf("%s is not a V5 observer (ColorSpace-class PCC) profile\n", argv[2]);
     return -2;
   }
 
   CIccTagSpectralViewingConditions* pTagSvcn = (CIccTagSpectralViewingConditions*)pccIcc->FindTagOfType(icSigSpectralViewingConditionsTag, icSigSpectralViewingConditionsType);
   CIccTagMultiProcessElement* pTagC2S = (CIccTagMultiProcessElement*)pccIcc->FindTagOfType(icSigCustomToStandardPccTag, icSigMultiProcessElementType);
 
+  // Require both PCC pieces the conversion actually uses: a customToStandardPcc
+  // 3->3 transform, and a spectralViewingConditions tag that carries a usable
+  // observer (its colour-matching functions are integrated against the display
+  // emission below).  Checking getObserver() here turns a would-be cryptic
+  // failure in EmissionMatrix::Begin into a clear up-front rejection.
+  icSpectralRange obsRange;
   if (!pTagSvcn ||
     !pTagC2S ||
     pTagC2S->NumInputChannels() != 3 ||
-    pTagC2S->NumOutputChannels() != 3) {
-    printf("%s doesn't have Profile Connection Conditions\n", argv[2]);
+    pTagC2S->NumOutputChannels() != 3 ||
+    !pTagSvcn->getObserver(obsRange) ||
+    !obsRange.steps) {
+    printf("%s doesn't have Profile Connection Conditions (observer + customToStandardPcc)\n", argv[2]);
     return -2;
   }
 
@@ -186,6 +233,14 @@ int main(int argc, char* argv[])
   pIcc->InitHeader();
   pIcc->m_Header.deviceClass = icSigDisplayClass;
   pIcc->m_Header.version = icVersionNumberV4_3;
+  // The output is an RGB device profile whose connection space is XYZ: a
+  // matrix/TRC display profile is PCSXYZ-only (ICC.1 8.3.2).  InitHeader() leaves
+  // colorSpace = 0 (NoData) and pcs = the icSigLabData default, so without these
+  // two assignments the tool emits a header its own validator rejects (#1359
+  // flags colorSpace = 0 as a critical error) and which cannot be round-tripped
+  // (#1371).  Set them to match the rTRC/gTRC/bTRC + rXYZ/gXYZ/bXYZ tags below.
+  pIcc->m_Header.colorSpace = icSigRgbData;
+  pIcc->m_Header.pcs        = icSigXYZData;
 
   CIccTag* pDesc = dspIcc->FindTag(icSigProfileDescriptionTag);
 
@@ -251,6 +306,22 @@ int main(int argc, char* argv[])
   primaryXYZ = new CIccTagXYZ;
   (*primaryXYZ)[0].X = icDtoF(out[0]); (*primaryXYZ)[0].Y = icDtoF(out[1]); (*primaryXYZ)[0].Z = icDtoF(out[2]);
   pIcc->AttachTag(icSigBlueColorantTag, primaryXYZ); // pointer ownership is passed to the profile
+
+  // mediaWhitePointTag is mandatory for a v4 display profile (ICC.1 8.3.4 / Table
+  // 32).  The white point is a DERIVED quantity, not a copy of either input's
+  // stored white: push full white RGB(1,1,1) through the same observer-integrated
+  // emission matrix and custom->standard PCC used for the colorants above -- i.e.
+  // M*(1,1,1).  This is exactly the white a CMM reproduces from the output matrix
+  // (the sum of the colorant columns), already in the standard D50 PCS.  Neither
+  // source white is usable here: argv[1]'s is pre-observer-integration and
+  // argv[2]'s is pre-D65->D50 adaptation.  Its absence left the profile
+  // non-conformant (#1371).
+  const icFloatNumber wRGB[3] = { 1.0f, 1.0f, 1.0f };
+  matrixMpe->Apply(mtxApply, in, wRGB);
+  pTagC2S->Apply(pAppyC2S.get(), out, in);
+  CIccTagXYZ* whiteXYZ = new CIccTagXYZ;
+  (*whiteXYZ)[0].X = icDtoF(out[0]); (*whiteXYZ)[0].Y = icDtoF(out[1]); (*whiteXYZ)[0].Z = icDtoF(out[2]);
+  pIcc->AttachTag(icSigMediaWhitePointTag, whiteXYZ); // pointer ownership is passed to the profile
 
   if (!SaveIccProfile(argv[3], pIcc)) {
     printf("Unable to create %s\n", argv[3]);


### PR DESCRIPTION
## Summary

`iccV5DspObsToV4Dsp` builds its v4.3 output header/tags from scratch but set only `deviceClass` and `version`, so it emitted a profile that its own validator rejects (#1359 flags `colorSpace=0` as critical) and that cannot be round-tripped (#1371). Three of the four non-conformances from #1371 are fixed here; the fourth (colorant tag type) was already fixed by #1362.

Scope: `Tools/CmdLine/IccV5DspObsToV4Dsp/IccV5DspObsToV4Dsp.cpp` only.

## Changes

1. **Header** — set `m_Header.colorSpace = icSigRgbData` and `m_Header.pcs = icSigXYZData` (matrix/TRC is PCSXYZ-only, ICC.1 §8.3.2).
2. **`mediaWhitePointTag`** (ICC.1 §8.3.4) — added as the **derived** white `M·(1,1,1)`: full white pushed through the same observer-integrated emission matrix + `customToStandardPcc` as the colorants, i.e. the white a CMM reproduces from the output matrix, in the standard D50 PCS. Neither input's stored white is usable here (argv[1]'s is pre-observer-integration; argv[2]'s is pre-D65→D50).
3. **Contract banner + input validation** — a banner documents the tool's single supported conversion, and validation now rejects anything outside it: an RGB display, a ColorSpace-class observer (PCC) profile, and a `spectralViewingConditions` tag carrying a usable observer (the latter turns a cryptic late failure into a clear up-front rejection).

## Verification (byte-level, same inputs, before → after)

| check | master | this PR |
|---|---|---|
| data colour space @16 | `0x00000000` (NoData) | `'RGB '` |
| PCS @20 | `'Lab '` | `'XYZ '` |
| rXYZ/gXYZ/bXYZ on-disk type | `'XYZ '` (via #1362) | `'XYZ '` |
| `mediaWhitePointTag` | absent (8 tags) | present (9 tags) |
| `iccRoundTrip` RT1 mean ΔE | *Unable to perform round trip* | 0.01 |

Rejection paths verified: observer passed as display, display passed as observer, and a v4 RGB profile passed as display are each refused with a clear message (non-zero exit). The `#1362` regression still passes, and its committed fixtures satisfy the tightened contract.

Refs #1371; companion to #1356 / #1359 / #1362. A header/`wtpt` conformance regression test (`iccdev.issue-1371-v5dspobs-header-regression`) will follow as a sibling PR.
