### PR TITLE
Fix: iccTiffDump/iccSpecSepToTiff mishandle TIFF palette photometric (#1380, #1381)

### DIFF
--- a/.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh
+++ b/.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh
@@ -38,6 +38,7 @@ MALFORMED_FILE="$MALFORMED_DIR/spec_3"
 PACKED_DIR="$OUTDIR/specsep-packed"
 PACKED_FILE="$PACKED_DIR/spec_1"
 VALID_DIR="$OUTDIR/specsep-valid"
+PALETTE_DIR="$OUTDIR/specsep-palette"
 LOGFILE="$OUTDIR/specsep-tiff-geometry.log"
 OUTPUT_TIFF="$OUTDIR/specsep-geometry-output.tif"
 
@@ -320,10 +321,92 @@ run_specsep_descending_range_accept() {
   pass_case "$name" "descending range accepted without sanitizer findings"
 }
 
+generate_palette_tiff() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+  local path="$1"
+  mkdir -p "$(dirname "$path")"
+  # Minimal 2x2 8-bit PHOTOMETRIC_PALETTE (=3) TIFF, including the required
+  # ColorMap (tag 320); libtiff treats a palette photometric without a colormap
+  # as min-is-black, so the colormap is what makes this a genuine palette file.
+  python3 - "$path" <<'PY'
+import struct, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+w = h = 2; bps = 8; ncol = 1 << bps
+pix = bytes(w * h); doff = 8; ifd = doff + len(pix)
+if ifd % 2:
+    pix += b"\0"; ifd += 1
+cmap = b"".join(struct.pack("<H", (i * 65535) // (ncol - 1))
+                for _ in range(3) for i in range(ncol))
+entries = [(256, 4, 1, w), (257, 4, 1, h), (258, 3, 1, bps), (259, 3, 1, 1),
+           (262, 3, 1, 3), (273, 4, 1, doff), (277, 3, 1, 1), (278, 4, 1, h),
+           (279, 4, 1, len(pix)), (284, 3, 1, 1), (296, 3, 1, 2),
+           (320, 3, 3 * ncol, 0)]
+entries.sort()
+cmap_off = ifd + 2 + len(entries) * 12 + 4
+entries = [(t, ty, c, (cmap_off if t == 320 else v)) for (t, ty, c, v) in entries]
+d = bytearray(b"II" + struct.pack("<H", 42) + struct.pack("<I", ifd)); d += pix
+d += struct.pack("<H", len(entries))
+for t, ty, c, v in entries:
+    d += struct.pack("<HHI", t, ty, c)
+    d += (struct.pack("<H", v) + b"\0\0") if (ty == 3 and c == 1) else struct.pack("<I", v)
+d += struct.pack("<I", 0); d += cmap
+path.write_bytes(d)
+PY
+}
+
+run_specsep_palette_reject() {
+  local name="specsep-palette-reject"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$LOGFILE" "$OUTPUT_TIFF"
+
+  if [ ! -x "$SPECSEP" ]; then
+    fail_case "$name" "missing executable: $SPECSEP"
+    return
+  fi
+
+  if ! generate_palette_tiff "$PALETTE_DIR/spec_0"; then
+    fail_case "$name" "python3 unavailable or palette TIFF generation failed"
+    return
+  fi
+
+  # iccSpecSepToTiff must refuse palette input: GetPhoto() returns the internal
+  # PHOTO_PALETTE enum, which the tool now compares correctly (#1381).
+  timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$PALETTE_DIR/spec_" 0 0 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 255 ]; then
+    fail_case "$name" "expected graceful reject exit=255, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq "is a palette based file" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "missing palette rejection text (#1381)"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ -e "$OUTPUT_TIFF" ]; then
+    fail_case "$name" "output TIFF created despite palette rejection"
+    return
+  fi
+
+  pass_case "$name" "palette input rejected (#1381) without sanitizer findings"
+}
+
 echo "=== iccSpecSepToTiff malformed TIFF geometry regression ==="
 run_specsep_geometry_reject
 run_specsep_packed_bps_reject
 run_specsep_descending_range_accept
+run_specsep_palette_reject
 echo "iccSpecSepToTiff malformed TIFF geometry regression: $PASS passed, $FAIL failed, $TOTAL total"
 
 if [ "$FAIL" -ne 0 ]; then

--- a/.github/scripts/iccdev-tiffdump-output-hardening-tests.sh
+++ b/.github/scripts/iccdev-tiffdump-output-hardening-tests.sh
@@ -73,10 +73,107 @@ newline.icc"
   grep -Fq 'Profile extracted to: '"$OUTDIR"'/export_with_\nnewline.icc' "$log"
 }
 
+# ---------------------------------------------------------------------------
+# #1380: palette photometric must be reported (not silently "Min Is White"), and
+# a parsed embedded ICC that fails conformance must be rejected, not rewritten.
+# ---------------------------------------------------------------------------
+PYTHON="$(command -v python3 || true)"
+
+generate_palette_tiff() {
+  # Minimal 2x2 8-bit PHOTOMETRIC_PALETTE (=3) TIFF with the required ColorMap.
+  "$PYTHON" - "$1" <<'PY'
+import struct, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+w = h = 2; bps = 8; ncol = 1 << bps
+pix = bytes(w * h); doff = 8; ifd = doff + len(pix)
+if ifd % 2:
+    pix += b"\0"; ifd += 1
+cmap = b"".join(struct.pack("<H", (i * 65535) // (ncol - 1))
+                for _ in range(3) for i in range(ncol))
+entries = [(256, 4, 1, w), (257, 4, 1, h), (258, 3, 1, bps), (259, 3, 1, 1),
+           (262, 3, 1, 3), (273, 4, 1, doff), (277, 3, 1, 1), (278, 4, 1, h),
+           (279, 4, 1, len(pix)), (284, 3, 1, 1), (296, 3, 1, 2),
+           (320, 3, 3 * ncol, 0)]
+entries.sort()
+cmap_off = ifd + 2 + len(entries) * 12 + 4
+entries = [(t, ty, c, (cmap_off if t == 320 else v)) for (t, ty, c, v) in entries]
+d = bytearray(b"II" + struct.pack("<H", 42) + struct.pack("<I", ifd)); d += pix
+d += struct.pack("<H", len(entries))
+for t, ty, c, v in entries:
+    d += struct.pack("<HHI", t, ty, c)
+    d += (struct.pack("<H", v) + b"\0\0") if (ty == 3 and c == 1) else struct.pack("<I", v)
+d += struct.pack("<I", 0); d += cmap
+path.write_bytes(d)
+PY
+}
+
+generate_tiff_with_icc() {
+  # 2x2 RGB TIFF embedding the ICC bytes from file $2 (tag 34675, out-of-line).
+  "$PYTHON" - "$1" "$2" <<'PY'
+import struct, sys, pathlib
+path = pathlib.Path(sys.argv[1]); icc = pathlib.Path(sys.argv[2]).read_bytes()
+w = h = 2; bps = 8; spp = 3
+pix = bytes(w * h * spp); doff = 8; ifd = doff + len(pix)
+if ifd % 2:
+    pix += b"\0"; ifd += 1
+entries = [(256, 4, 1, w), (257, 4, 1, h), (258, 3, spp, 0), (259, 3, 1, 1),
+           (262, 3, 1, 2), (273, 4, 1, doff), (277, 3, 1, spp), (278, 4, 1, h),
+           (279, 4, 1, len(pix)), (284, 3, 1, 1), (296, 3, 1, 2),
+           (34675, 7, len(icc), 0)]
+entries.sort()
+base = ifd + 2 + len(entries) * 12 + 4
+bps_off = base; icc_off = bps_off + spp * 2
+entries = [(t, ty, c, (bps_off if t == 258 else icc_off if t == 34675 else v))
+           for (t, ty, c, v) in entries]
+d = bytearray(b"II" + struct.pack("<H", 42) + struct.pack("<I", ifd)); d += pix
+d += struct.pack("<H", len(entries))
+for t, ty, c, v in entries:
+    d += struct.pack("<HHI", t, ty, c)
+    d += (struct.pack("<H", v) + b"\0\0") if (ty == 3 and c == 1) else struct.pack("<I", v)
+d += struct.pack("<I", 0)
+d += b"".join(struct.pack("<H", bps) for _ in range(spp))  # BitsPerSample (out-of-line)
+d += icc                                                   # embedded ICC profile
+path.write_bytes(d)
+PY
+}
+
+test_palette_photometric_report() {
+  [ -n "$PYTHON" ] || { echo "    [SKIP] python3 unavailable"; return 0; }
+  local pal="$OUTDIR/palette.tif"
+  local log="$OUTDIR/tiffdump-palette.log"
+  generate_palette_tiff "$pal" || return 1
+  "$TIFFDUMP" "$pal" > "$log" 2>&1 || true
+  grep -Eq 'Photometric:[[:space:]]+Palette' "$log"
+}
+
+test_noncompliant_embedded_icc_rejected() {
+  [ -n "$PYTHON" ] || { echo "    [SKIP] python3 unavailable"; return 0; }
+  local srgb="$ICCDEV_TESTING/sRGB_v4_ICC_preference.icc"
+  [ -f "$srgb" ] || { echo "    [SKIP] missing $srgb"; return 0; }
+  local bad="$OUTDIR/noncompliant.icc"
+  local tif="$OUTDIR/rgb-noncompliant-icc.tif"
+  local out="$OUTDIR/extracted-noncompliant.icc"
+  local log="$OUTDIR/tiffdump-noncompliant-icc.log"
+  # Make a non-conformant profile by zeroing the data colour space @offset 16.
+  "$PYTHON" - "$srgb" "$bad" <<'PY'
+import sys, pathlib
+b = bytearray(pathlib.Path(sys.argv[1]).read_bytes())
+b[16:20] = b"\0\0\0\0"
+pathlib.Path(sys.argv[2]).write_bytes(b)
+PY
+  generate_tiff_with_icc "$tif" "$bad" || return 1
+  rm -f "$out"
+  "$TIFFDUMP" "$tif" "$out" > "$log" 2>&1 || true
+  grep -Fq "violates the ICC specification" "$log" || return 1
+  [ ! -e "$out" ]   # must NOT have written the non-conformant profile (#1380)
+}
+
 echo "=== iccTiffDump output hardening regression ==="
 run_ok "tiffdump-profile-description-escape" test_profile_description_escaping
 run_ok "tiffdump-input-path-escape" test_input_path_escaping
 run_ok "tiffdump-export-path-escape" test_export_path_escaping
+run_ok "tiffdump-palette-photometric-report" test_palette_photometric_report
+run_ok "tiffdump-noncompliant-embedded-icc-reject" test_noncompliant_embedded_icc_rejected
 
 echo "iccTiffDump output hardening regression: $pass passed, $fail failed, $((pass + fail)) total"
 

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -562,8 +562,14 @@ unsigned int CTiffImg::GetPhoto()
     return PHOTO_CIELAB;
   else if (m_nPhoto==PHOTOMETRIC_ICCLAB)
     return PHOTO_ICCLAB;
+  else if (m_nPhoto==PHOTOMETRIC_PALETTE)
+    // Palette TIFFs previously fell through to PHOTO_MINISWHITE and were silently
+    // accepted; give them their own value so callers can reject them (#1381).
+    return PHOTO_PALETTE;
   else
-    return PHOTO_MINISWHITE;
+    // Report unrecognised photometrics as UNKNOWN rather than masking them as
+    // PHOTO_MINISWHITE, so callers fail closed on unsupported input (#1380).
+    return PHOTO_UNKNOWN;
 }
 
 

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.h
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.h
@@ -76,6 +76,13 @@
 #define PHOTO_CIELAB      2
 #define PHOTO_ICCLAB      3
 #define PHOTO_RGB         4
+// PHOTO_PALETTE / PHOTO_UNKNOWN are CTiffImg's INTERNAL photometric values
+// (returned by GetPhoto()), and are deliberately NOT libtiff's PHOTOMETRIC_*
+// constants.  GetPhoto() must map PHOTOMETRIC_PALETTE to PHOTO_PALETTE so callers
+// can detect/reject palette input (#1381), and report anything it does not
+// recognise as PHOTO_UNKNOWN instead of silently as PHOTO_MINISWHITE (#1380).
+#define PHOTO_PALETTE     5
+#define PHOTO_UNKNOWN     0xffffffff
 
 class CTiffImg  
 {

--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -208,7 +208,11 @@ int main(int argc, char* argv[]) {
       return -1;
     }
 
-    if (infile[i].GetPhoto() == PHOTOMETRIC_PALETTE) {
+    // GetPhoto() returns CTiffImg's internal PHOTO_* enum, not a libtiff
+    // PHOTOMETRIC_* constant, so the palette check must compare against
+    // PHOTO_PALETTE.  Comparing against PHOTOMETRIC_PALETTE never matched, so
+    // palette input was wrongly accepted and converted (#1381).
+    if (infile[i].GetPhoto() == PHOTO_PALETTE) {
       printf("input %s is a palette based file\n", filename);
       return -1;
     }

--- a/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
+++ b/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
@@ -103,6 +103,7 @@ IdList photo_types[] = {
   {PHOTO_CIELAB,     "CIELab"},
   {PHOTO_ICCLAB,     "IccLab"},
   {PHOTO_RGB,        "RGB"},
+  {PHOTO_PALETTE,    "Palette"},
   {UNKNOWNID,        "Unknown"},
 };
 
@@ -259,7 +260,24 @@ int main(int argc, icChar* argv[])
       DumpProfileInfo(pProfile, " ");
       if (argc > 2) {
         std::string dstName = icSanitizeConsoleText(argv[2]);
-        if (pProfile->ReadTags(pProfile) && SaveIccProfile(argv[2], pProfile)) {
+        std::string validateReport;
+        if (!pProfile->ReadTags(pProfile)) {
+          printf("\nUnable to extract profile\n");
+          delete pProfile;
+          SrcImg.Close();
+          return -1;
+        }
+        // Don't rewrite a non-conformant embedded profile to disk: a parsed
+        // profile that fails required-tag validation must be reported and
+        // refused, not silently exported (#1380).
+        else if (pProfile->Validate(validateReport) > icValidateWarning) {
+          printf("\nEmbedded ICC profile violates the ICC specification; not extracting:\n%s",
+                 validateReport.c_str());
+          delete pProfile;
+          SrcImg.Close();
+          return -1;
+        }
+        else if (SaveIccProfile(argv[2], pProfile)) {
           printf("\nProfile extracted to: %s\n", dstName.c_str());
         }
         else {


### PR DESCRIPTION
## Summary

`CTiffImg::GetPhoto()` maps libtiff `PHOTOMETRIC_*` values to an internal `PHOTO_*` enum but had **no case for `PHOTOMETRIC_PALETTE`**, so palette TIFFs fell through to `PHOTO_MINISWHITE` and were silently accepted; unrecognised photometrics were likewise masked as `PHOTO_MINISWHITE`. This is the shared root cause of #1380 and #1381.

Scope: `Tools/CmdLine/IccApplyProfiles/TiffImg.{h,cpp}`, `IccTiffDump`, `IccSpecSepToTiff`, and the two existing TIFF regression scripts.

## Changes

- **TiffImg**: add internal `PHOTO_PALETTE` / `PHOTO_UNKNOWN`; `GetPhoto()` maps `PHOTOMETRIC_PALETTE → PHOTO_PALETTE` and reports unrecognised photometrics as `PHOTO_UNKNOWN` rather than `MINISWHITE`.
- **iccSpecSepToTiff** (#1381): compare `GetPhoto()` against the internal `PHOTO_PALETTE`, not the libtiff `PHOTOMETRIC_PALETTE` constant — palette input is now actually rejected instead of silently converted to a BlackIsZero output.
- **iccTiffDump** (#1380): report palette as `"Palette"`; and **validate a parsed embedded ICC before export** — a non-conformant profile is reported and refused, not silently rewritten to disk.
- **Tests**: extend `iccdev-specsep-tiff-geometry-regression-tests.sh` and `iccdev-tiffdump-output-hardening-tests.sh` (already CTest-registered) with a self-contained pure-python palette-TIFF and embedded-ICC-TIFF generator, plus palette-reject, palette-report and non-conformant-embedded-ICC-reject cases.

## Verification (before → after, same inputs)

| behaviour | master | this PR |
|---|---|---|
| iccTiffDump palette report | `Min Is White` | `Palette` |
| iccSpecSepToTiff palette input | accepted (output produced) | rejected |
| iccTiffDump non-conformant embedded ICC | exported to disk | refused, no file |
| normal MinIsBlack input (regression) | accepted | accepted |

The three new test cases **fail against master tools and pass with the fix**; existing cases are unaffected. `iccApplyProfiles` does not call `GetPhoto()`, so the default change does not affect it.

Refs #1380, #1381.
