### PR TITLE
Fix: iccPngDump fails to inject ICC into paletted PNGs (#1383)

### DIFF
--- a/.github/scripts/iccdev-issue-1383-pngdump-palette-injection.sh
+++ b/.github/scripts/iccdev-issue-1383-pngdump-palette-injection.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+###############################################################################
+# iccPngDump issue-1383 paletted-PNG ICC injection regression
+###############################################################################
+#
+# Injecting an ICC profile into an indexed-colour (PNG_COLOR_TYPE_PALETTE) PNG
+# failed with "libpng error: Valid palette required for paletted images" because
+# the tool copied IHDR but not the PLTE/tRNS chunks to the output before
+# png_write_info().  This test generates a paletted PNG, injects an ICC profile,
+# and verifies the profile round-trips back out byte-for-byte.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit codes: 0 pass or clean skip; 1 regression.
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1383-pngdump-palette-injection}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-/dev/null}"
+
+PNGDUMP="$TOOLS_DIR/IccPngDump/iccPngDump"
+INPUT_PNG="$OUTDIR/palette-2x2.png"
+INPUT_ICC="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+OUTPUT_PNG="$OUTDIR/palette-2x2-icc.png"
+EXTRACTED_ICC="$OUTDIR/extracted.icc"
+LOGFILE="$OUTDIR/issue-1383-pngdump-palette-injection.log"
+
+fail() {
+  echo "  [FAIL] issue-1383-pngdump-palette-injection -- $1"
+  exit 1
+}
+
+check_sanitizers() {
+  if grep -qE "ERROR: AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|LeakSanitizer|DEADLYSIGNAL" "$1" 2>/dev/null; then
+    sed -n '1,80p' "$1"
+    return 1
+  fi
+  return 0
+}
+
+generate_palette_png() {
+  command -v python3 >/dev/null 2>&1 || return 1
+  python3 - "$INPUT_PNG" <<'PY'
+import sys, zlib, struct, binascii, pathlib
+
+def chunk(typ, data):
+    return (struct.pack(">I", len(data)) + typ + data +
+            struct.pack(">I", binascii.crc32(typ + data) & 0xffffffff))
+
+w = h = 2
+ihdr = struct.pack(">IIBBBBB", w, h, 8, 3, 0, 0, 0)        # bitdepth 8, colour type 3 (palette)
+plte = bytes([0, 0, 0, 255, 0, 0, 0, 255, 0, 0, 0, 255])  # 4-entry palette
+raw = b"".join(b"\x00" + bytes(w) for _ in range(h))       # filter 0 + index bytes
+png = (b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) +
+       chunk(b"PLTE", plte) + chunk(b"IDAT", zlib.compress(raw, 9)) + chunk(b"IEND", b""))
+pathlib.Path(sys.argv[1]).write_bytes(png)
+PY
+}
+
+echo "=== iccPngDump issue-1383 paletted-PNG ICC injection regression ==="
+
+if [ ! -x "$PNGDUMP" ]; then
+  echo "  [SKIP] missing executable: $PNGDUMP"
+  exit 0
+fi
+if [ ! -f "$INPUT_ICC" ]; then
+  echo "  [SKIP] missing input ICC: $INPUT_ICC"
+  exit 0
+fi
+if ! generate_palette_png; then
+  echo "  [SKIP] python3 unavailable; cannot synthesize palette PNG"
+  exit 0
+fi
+
+# Inject the ICC profile into the paletted PNG.
+rm -f "$LOGFILE" "$OUTPUT_PNG" "$EXTRACTED_ICC"
+exit_code=0
+timeout 30 "$PNGDUMP" "$INPUT_PNG" --write-icc "$INPUT_ICC" --output "$OUTPUT_PNG" > "$LOGFILE" 2>&1 || exit_code=$?
+
+check_sanitizers "$LOGFILE" || fail "sanitizer finding during injection"
+
+if grep -Fq "Valid palette required for paletted images" "$LOGFILE" 2>/dev/null; then
+  sed -n '1,40p' "$LOGFILE"
+  fail "paletted-PNG injection still rejected by libpng (#1383)"
+fi
+if [ "$exit_code" -ne 0 ]; then
+  sed -n '1,40p' "$LOGFILE"
+  fail "injection exited non-zero ($exit_code)"
+fi
+if [ ! -s "$OUTPUT_PNG" ]; then
+  fail "no output PNG written"
+fi
+
+# Re-extract the profile and confirm it round-trips byte-for-byte.
+exit_code=0
+timeout 30 "$PNGDUMP" "$OUTPUT_PNG" "$EXTRACTED_ICC" >> "$LOGFILE" 2>&1 || exit_code=$?
+check_sanitizers "$LOGFILE" || fail "sanitizer finding during extraction"
+if [ "$exit_code" -ne 0 ] || [ ! -s "$EXTRACTED_ICC" ]; then
+  sed -n '1,40p' "$LOGFILE"
+  fail "could not re-extract injected ICC profile"
+fi
+if ! cmp -s "$INPUT_ICC" "$EXTRACTED_ICC"; then
+  fail "extracted ICC does not match the injected profile"
+fi
+
+echo "  [PASS] issue-1383-pngdump-palette-injection -- paletted PNG ICC round-trip"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -988,6 +988,14 @@ iccdev_add_script_test(
 )
 
 iccdev_add_script_test(
+  iccdev.issue-1383-pngdump-palette-injection
+  60
+  "iccdev;tools;pngdump;palette;issue-1383;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1383-pngdump-palette-injection.sh"
+)
+
+iccdev_add_script_test(
   iccdev.issue-1167-jpegdump-byte-regression
   120
   "iccdev;tools;jpegdump;asan;regression"

--- a/Tools/CmdLine/IccPngDump/iccPngDump.cpp
+++ b/Tools/CmdLine/IccPngDump/iccPngDump.cpp
@@ -463,6 +463,31 @@ bool InjectIccProfile(const std::string& inputPng,
                  png_get_compression_type(png_ptr, info_ptr),
                  png_get_filter_type(png_ptr, info_ptr));
 
+    // libpng requires the palette (PLTE) -- and any transparency (tRNS) -- to be
+    // set on the output before png_write_info() for indexed-colour images.
+    // Copying only IHDR left paletted PNGs failing with "Valid palette required
+    // for paletted images" when injecting an ICC profile (#1383), so propagate
+    // the palette (and tRNS) from the input here.
+    if (png_get_color_type(png_ptr, info_ptr) == PNG_COLOR_TYPE_PALETTE) {
+        png_colorp palette = NULL;
+        int num_palette = 0;
+        if (!png_get_PLTE(png_ptr, info_ptr, &palette, &num_palette) || !palette || num_palette <= 0) {
+            png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
+            png_destroy_write_struct(&write_ptr, &write_info_ptr);
+            fclose(fpIn); fclose(fpOut);
+            LOG_ERROR("Palette PNG is missing a valid PLTE chunk.");
+            return false;
+        }
+        png_set_PLTE(write_ptr, write_info_ptr, palette, num_palette);
+
+        png_bytep trans_alpha = NULL;
+        int num_trans = 0;
+        png_color_16p trans_color = NULL;
+        if (png_get_tRNS(png_ptr, info_ptr, &trans_alpha, &num_trans, &trans_color)) {
+            png_set_tRNS(write_ptr, write_info_ptr, trans_alpha, num_trans, trans_color);
+        }
+    }
+
     // only now is it safe to attach ICC
     png_set_iCCP(write_ptr, write_info_ptr, "icc", 0, iccData.data(), static_cast<png_uint_32>(iccData.size()));
 


### PR DESCRIPTION
## Summary

Injecting an ICC profile into an indexed-colour (`PNG_COLOR_TYPE_PALETTE`) PNG failed with `libpng error: Valid palette required for paletted images`. `InjectIccProfile()` copied the input IHDR to the output but never propagated the `PLTE` (and `tRNS`) chunks before `png_write_info()`, which libpng requires for paletted images.

## Changes

- **`iccPngDump.cpp`**: for `PNG_COLOR_TYPE_PALETTE` inputs, copy the input `PLTE` — and `tRNS` when present — to the output `write_info_ptr` before `png_write_info()`. Fail cleanly (with cleanup) if a palette PNG is missing its `PLTE`.
- **Test**: new `iccdev.issue-1383-pngdump-palette-injection` CTest. It synthesizes a paletted PNG in pure Python (zlib + CRC, no PIL), injects an ICC profile, and verifies the profile round-trips back out **byte-for-byte**.

## Verification (before → after)

| | master | this PR |
|---|---|---|
| inject ICC into paletted PNG | `libpng error: Valid palette required…` / `Failed to inject` | succeeds |
| re-extract injected ICC | — | byte-identical to the input profile |

The new test **fails against master and passes with the fix**.

Refs #1383.
