### PR TITLE
Fix: iccJpegDump can't read/write multi-segment APP2 ICC profiles (#1382)

### DIFF
--- a/.github/scripts/iccdev-issue-1382-jpegdump-app2-reassembly.sh
+++ b/.github/scripts/iccdev-issue-1382-jpegdump-app2-reassembly.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+###############################################################################
+# iccJpegDump issue-1382 APP2 ICC chunk reassembly regression
+###############################################################################
+#
+# iccJpegDump located the embedded ICC profile by raw-scanning the JPEG bytes for
+# the 'acsp' signature and stopped at the first APP2 segment, so it could not
+# handle ICC profiles split across multiple APP2 segments (the standard way
+# profiles larger than ~64 KB are embedded).  The tool now parses APP2
+# "ICC_PROFILE" segments, reassembles their chunks in order, and chunks the
+# profile on injection.  This test round-trips a single-segment profile and a
+# multi-segment (>64 KB) payload, asserting byte-for-byte fidelity.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit codes: 0 pass or clean skip; 1 regression.
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1382-jpegdump-app2-reassembly}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+
+JPEGDUMP="$(find "$TOOLS_DIR" -maxdepth 2 -name iccJpegDump -type f 2>/dev/null | head -1)"
+INPUT_ICC="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+BASE_JPEG="$OUTDIR/base.jpg"
+LOGFILE="$OUTDIR/issue-1382-jpegdump-app2-reassembly.log"
+
+fail() {
+  echo "  [FAIL] issue-1382-jpegdump-app2-reassembly -- $1"
+  exit 1
+}
+
+check_sanitizers() {
+  if grep -qE "ERROR: AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|LeakSanitizer|DEADLYSIGNAL" "$1" 2>/dev/null; then
+    sed -n '1,80p' "$1"
+    return 1
+  fi
+  return 0
+}
+
+# inject $1(icc) into the base JPEG -> $2(out.jpg), extract -> $3(out.icc),
+# and require the extracted bytes to equal the injected bytes.
+roundtrip() {
+  local icc="$1" jpg="$2" icc_out="$3"
+  rm -f "$jpg" "$icc_out" "$LOGFILE"
+  "$JPEGDUMP" "$BASE_JPEG" --write-icc "$icc" --output "$jpg" > "$LOGFILE" 2>&1 || return 1
+  "$JPEGDUMP" "$jpg" "$icc_out" >> "$LOGFILE" 2>&1 || return 1
+  check_sanitizers "$LOGFILE" || return 1
+  cmp -s "$icc" "$icc_out"
+}
+
+echo "=== iccJpegDump issue-1382 APP2 ICC chunk reassembly regression ==="
+
+if [ -z "$JPEGDUMP" ] || [ ! -x "$JPEGDUMP" ]; then
+  echo "  [SKIP] iccJpegDump not built under $TOOLS_DIR"
+  exit 0
+fi
+if [ ! -f "$INPUT_ICC" ]; then
+  echo "  [SKIP] missing input ICC: $INPUT_ICC"
+  exit 0
+fi
+
+# Minimal valid JPEG container: SOI + EOI.  iccJpegDump prepends the ICC APP2
+# segment(s) after SOI and copies the rest, so this is sufficient to round-trip.
+printf '\xff\xd8\xff\xd9' > "$BASE_JPEG"
+
+# 1) Single-segment profile (sRGB, ~60 KB) must round-trip byte-for-byte.
+if ! roundtrip "$INPUT_ICC" "$OUTDIR/single.jpg" "$OUTDIR/single_out.icc"; then
+  sed -n '1,40p' "$LOGFILE"
+  fail "single-segment ICC profile did not round-trip"
+fi
+
+# 2) Multi-segment payload (>64 KB) must be split across APP2 segments on inject
+#    and reassembled on extract.  Use a deterministic 140 KB blob (3 chunks).
+BIG="$OUTDIR/big.bin"
+head -c 140000 /dev/zero | tr '\0' 'A' > "$BIG"
+if ! roundtrip "$BIG" "$OUTDIR/multi.jpg" "$OUTDIR/multi_out.icc"; then
+  sed -n '1,40p' "$LOGFILE"
+  fail "multi-segment payload did not round-trip (APP2 reassembly)"
+fi
+
+# The injected JPEG must actually contain more than one ICC_PROFILE APP2 segment.
+chunks="$(grep -a -o "ICC_PROFILE" "$OUTDIR/multi.jpg" 2>/dev/null | wc -l | tr -d ' ')"
+if [ "${chunks:-0}" -lt 2 ]; then
+  fail "expected multiple ICC_PROFILE APP2 segments, found ${chunks:-0}"
+fi
+
+echo "  [PASS] issue-1382-jpegdump-app2-reassembly -- single + multi-segment ICC round-trip (${chunks} chunks)"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -996,6 +996,14 @@ iccdev_add_script_test(
 )
 
 iccdev_add_script_test(
+  iccdev.issue-1382-jpegdump-app2-reassembly
+  60
+  "iccdev;tools;jpegdump;app2;issue-1382;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1382-jpegdump-app2-reassembly.sh"
+)
+
+iccdev_add_script_test(
   iccdev.issue-1168-pawg-calculator-hbo
   120
   "iccdev;tools;pawg;calculator;asan;regression"

--- a/Tools/CmdLine/IccJpegDump/iccJpegDump.cpp
+++ b/Tools/CmdLine/IccJpegDump/iccJpegDump.cpp
@@ -188,90 +188,88 @@ static bool ReadBinaryStream(std::istream& input, std::vector<unsigned char>& da
 //   true if a valid ICC profile was found and written to disk, false otherwise.
 // ============================================================================
 bool ExtractIccFromJpeg(const char* jpegPath, const char* iccOutPath) {
-    FILE* fp = fopen(jpegPath, "rb");
-    if (!fp) safe_exit("Cannot open input JPEG file.");
+    std::ifstream file(jpegPath, std::ios::binary);
+    if (!file) safe_exit("Cannot open input JPEG file.");
+
+    std::vector<unsigned char> data;
+    if (!ReadBinaryStream(file, data)) safe_exit("Failed to read input JPEG file.");
+
+    const size_t n = data.size();
+    if (n < 2 || data[0] != 0xFF || data[1] != 0xD8) {
+        LOG_ERROR("Not a valid JPEG file (missing SOI).");
+        return false;
+    }
+
+    // ICC profiles are carried in one or more APP2 segments, each beginning with
+    // the 12-byte "ICC_PROFILE\0" signature followed by a 1-based chunk number and
+    // a chunk count; the profile is those chunks concatenated in order (ITU-T T.871
+    // / ICC Annex B).  Walk the JPEG marker structure and reassemble them.  The old
+    // code stopped at the first APP2 and otherwise scanned raw bytes for 'acsp',
+    // which truncated multi-segment profiles and matched arbitrary data (#1382).
+    static const unsigned char kSig[12] = {
+        'I','C','C','_','P','R','O','F','I','L','E','\0' };
+
+    std::vector<std::vector<unsigned char> > chunks;
+    std::vector<bool> seen;
+    unsigned int totalChunks = 0;
+    size_t pos = 2;  // past SOI
+
+    while (pos < n) {
+        if (data[pos] != 0xFF) { pos++; continue; }        // resync to next marker
+        while (pos < n && data[pos] == 0xFF) pos++;         // skip marker 0xFF + fill
+        if (pos >= n) break;
+        unsigned char m = data[pos++];
+
+        if (m == 0xD9 || m == 0xDA) break;                  // EOI, or SOS (entropy data follows)
+        if (m == 0x01 || (m >= 0xD0 && m <= 0xD7)) continue; // standalone markers (no length)
+
+        if (pos + 2 > n) break;
+        unsigned int segLen = (unsigned int)((data[pos] << 8) | data[pos + 1]);
+        pos += 2;
+        if (segLen < 2 || pos + (segLen - 2) > n) break;
+        size_t payloadLen = segLen - 2;
+        const unsigned char* seg = &data[pos];
+
+        if (m == 0xE2 && payloadLen >= 14 && memcmp(seg, kSig, 12) == 0) {
+            unsigned int seq = seg[12];
+            unsigned int total = seg[13];
+            if (seq == 0 || total == 0 || seq > total) {
+                LOG_ERROR("Invalid ICC_PROFILE APP2 chunk sequence.");
+                return false;
+            }
+            if (totalChunks == 0) {
+                totalChunks = total;
+                chunks.resize(total);
+                seen.assign(total, false);
+            }
+            else if (total != totalChunks) {
+                LOG_ERROR("Inconsistent ICC_PROFILE APP2 chunk count.");
+                return false;
+            }
+            if (seen[seq - 1]) {
+                LOG_ERROR("Duplicate ICC_PROFILE APP2 chunk.");
+                return false;
+            }
+            seen[seq - 1] = true;
+            chunks[seq - 1].assign(seg + 14, seg + payloadLen);
+            printf("[INFO] ICC_PROFILE APP2 chunk %u/%u (%zu bytes).\n",
+                   seq, total, payloadLen - 14);
+        }
+        pos += payloadLen;
+    }
+
+    if (totalChunks == 0) {
+        LOG_ERROR("No ICC_PROFILE APP2 marker found.");
+        return false;
+    }
 
     std::vector<unsigned char> iccData;
-    unsigned char marker[2];
-    bool found = false;
-
-    // ------------------------------------------------------------
-    // Iterate JPEG markers and scan for APPx segments
-    // ------------------------------------------------------------
-    while (fread(marker, 1, 2, fp) == 2) {
-        if (marker[0] != 0xFF) break;
-        if (marker[1] == 0xD9) break;  // EOI
-
-        unsigned short len = 0;
-        if (fread(&len, 2, 1, fp) != 1) break;
-        len = ntohs(len);
-
-        if (len < 2) break;
-        std::vector<unsigned char> segment(len - 2);
-        if (fread(segment.data(), 1, segment.size(), fp) != segment.size())
-            break;
-
-        printf("[INFO] Scanning segment 0x%02X, length: %u bytes\n", marker[1], len);
-
-        // --------------------------------------------------------
-        // Check for APP2 ICC_PROFILE header (spec-compliant)
-        // --------------------------------------------------------
-        if (marker[1] == 0xE2 && len > 16) {
-            if (memcmp(segment.data(), "ICC_PROFILE\0", 12) == 0) {
-                unsigned char* dataStart = segment.data() + 14;
-                size_t dataLen = segment.size() - 14;
-                iccData.insert(iccData.end(), dataStart, dataStart + dataLen);
-                printf("[INFO] Found ICC_PROFILE in APP2 segment.\n");
-                found = true;
-                break;
-            }
-        }
-
-        // --------------------------------------------------------
-        // Fallback: Search all APPx for "acsp" ICC signature
-        // --------------------------------------------------------
-        if (marker[1] >= 0xE0 && marker[1] <= 0xEF) {
-            for (size_t i = 0; i + 4 < segment.size(); ++i) {
-                if (memcmp(&segment[i], "acsp", 4) == 0) {
-                    iccData.insert(iccData.end(), segment.begin() + i, segment.end());
-                    printf("[INFO] Found 'acsp' ICC magic in APP segment 0x%02X at offset %zu.\n", marker[1], i);
-                    goto done;
-                }
-            }
-        }
-    }
-
-    // ------------------------------------------------------------
-    // Raw Fallback: Scan entire file for "acsp"
-    // ------------------------------------------------------------
-    if (!found) {
-        std::ifstream file(jpegPath, std::ios::binary);
-        if (!file) {
-            LOG_ERROR("Fallback open failed.");
+    for (unsigned int i = 0; i < totalChunks; ++i) {
+        if (!seen[i]) {
+            LOG_ERROR("Incomplete ICC_PROFILE APP2 sequence (missing chunk).");
             return false;
         }
-
-        std::vector<unsigned char> raw;
-        if (!ReadBinaryStream(file, raw)) {
-            LOG_ERROR("Fallback read failed.");
-            return false;
-        }
-
-        for (size_t i = 0; i + 4 < raw.size(); ++i) {
-            if (memcmp(&raw[i], "acsp", 4) == 0) {
-                iccData.insert(iccData.end(), raw.begin() + i, raw.end());
-                printf("[INFO] Fallback: Found 'acsp' in raw file at offset %zu.\n", i);
-                break;
-            }
-        }
-    }
-
-done:
-    fclose(fp);
-
-    if (iccData.empty()) {
-        LOG_ERROR("No ICC profile found.");
-        return false;
+        iccData.insert(iccData.end(), chunks[i].begin(), chunks[i].end());
     }
 
     FILE* out = icOpenWriteBinaryFile(iccOutPath);
@@ -280,7 +278,8 @@ done:
     if (failed) safe_exit("Failed to write output ICC file.");
     if (!icFlushAndClose(out)) safe_exit("Failed to close output ICC file.");
 
-    printf("[INFO] ICC profile extracted to: %s\n", iccOutPath);
+    printf("[INFO] ICC profile extracted to: %s (%zu bytes, %u chunk(s))\n",
+           iccOutPath, iccData.size(), totalChunks);
     return true;
 }
 
@@ -351,17 +350,35 @@ bool InjectIccIntoJpeg(const char* inputPath, const char* iccPath, const char* o
     //   - Total Segs  : 1
     //   - ICC Data    : full profile binary
     // ------------------------------------------------------------------------
-    std::string sig = "ICC_PROFILE";
-    unsigned short markerLen = 2 + sig.size() + 1 + 2 + iccData.size(); // length includes itself
-    unsigned short markerBE = htons(markerLen);
+    // Split the profile across as many APP2 segments as needed.  Each segment's
+    // length is a 2-byte field, so a profile larger than ~64 KB MUST be chunked --
+    // the previous single-segment write overflowed that field for large profiles.
+    // Each segment carries "ICC_PROFILE\0" + a 1-based chunk number + the total
+    // chunk count, matching the reassembly in ExtractIccFromJpeg (#1382).
+    static const unsigned char kSig[12] = {
+        'I','C','C','_','P','R','O','F','I','L','E','\0' };
+    const size_t kMaxChunk = 65535 - 2 - 12 - 2;   // length field - len - sig - seq/count
+    size_t totalChunks = (iccData.size() + kMaxChunk - 1) / kMaxChunk;
+    if (totalChunks == 0)
+        totalChunks = 1;
+    if (totalChunks > 255)
+        safe_exit("ICC profile too large to embed in a JPEG (>255 APP2 chunks).");
 
-    if (fputc(0xFF, out) == EOF || fputc(0xE2, out) == EOF ||
-        fwrite(&markerBE, 2, 1, out) != 1 ||
-        fwrite(sig.c_str(), 1, sig.size(), out) != sig.size() ||
-        fputc(0x00, out) == EOF ||
-        fputc(1, out) == EOF || fputc(1, out) == EOF ||
-        fwrite(iccData.data(), 1, iccData.size(), out) != iccData.size()) {
-        safe_exit("Failed to write ICC APP2 segment.");
+    for (size_t i = 0; i < totalChunks; ++i) {
+        size_t off = i * kMaxChunk;
+        size_t remaining = iccData.size() - off;
+        size_t chunkLen = remaining < kMaxChunk ? remaining : kMaxChunk;
+        unsigned short segLen = (unsigned short)(2 + 12 + 2 + chunkLen);
+        unsigned short segLenBE = htons(segLen);
+
+        if (fputc(0xFF, out) == EOF || fputc(0xE2, out) == EOF ||
+            fwrite(&segLenBE, 2, 1, out) != 1 ||
+            fwrite(kSig, 1, 12, out) != 12 ||
+            fputc((int)(i + 1), out) == EOF ||       // chunk number (1-based)
+            fputc((int)totalChunks, out) == EOF ||   // chunk count
+            fwrite(iccData.data() + off, 1, chunkLen, out) != chunkLen) {
+            safe_exit("Failed to write ICC APP2 segment.");
+        }
     }
 
     // ------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`iccJpegDump` located the embedded ICC profile by **raw-scanning the JPEG bytes for the `'acsp'` signature** and stopped at the first APP2 segment. That mis-extracted (it grabbed from the `'acsp'` offset to EOF) and could not handle ICC profiles **split across multiple APP2 segments** — the standard embedding for profiles larger than ~64 KB.

## Changes (`Tools/CmdLine/IccJpegDump/iccJpegDump.cpp`)

- **`ExtractIccFromJpeg`** — walk the JPEG marker structure, collect every APP2 `"ICC_PROFILE\0"` segment, validate the 1-based chunk number / count (rejecting bad sequences, duplicates and gaps), and **reassemble the chunks in order** (ITU-T T.871 / ICC Annex B). The raw `'acsp'` byte-scan fallback is removed.
- **`InjectIccIntoJpeg`** — split the profile across as many APP2 segments as needed; the previous single-segment write overflowed the 2-byte segment length for large profiles. Capped at 255 chunks.

## Verification

| | master | this PR |
|---|---|---|
| single-segment profile (sRGB, ~60 KB) round-trip | mis-extracted (`Fallback: Found 'acsp' at offset …`) | **byte-identical** |
| multi-segment payload (140 KB → 3 APP2 chunks) | not produced / not reassembled | **byte-identical** |

New CTest `iccdev.issue-1382-jpegdump-app2-reassembly` round-trips both a single-segment profile and a multi-segment (>64 KB) payload and asserts the injected JPEG carries multiple `ICC_PROFILE` APP2 segments. It is dependency-free (a `printf` SOI/EOI base JPEG, no PIL) and **fails against master, passes with the fix**.

Refs #1382.
