### PR TITLE
range check intents and xform lut types from command line

### DIFF
--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -1005,7 +1005,6 @@ int CIccCfgProfileSequence::fromArgs(const char** args, int nArg, bool bReset)
         }
         bFirst = false;
       }
-      int nType;
       int nIntent = atoi(args[1]);
 
       pProf->m_useD2BxB2Dx = true;
@@ -1030,7 +1029,7 @@ int CIccCfgProfileSequence::fromArgs(const char** args, int nArg, bool bReset)
       nIntent = nIntent % 10000;
       pProf->m_adjustPcsLuminance = nIntent / 1000 != 0;
       nIntent = nIntent % 1000;
-      nType = abs(nIntent) / 10;
+      int nType = abs(nIntent) / 10;
       nIntent = nIntent % 10;
 
       switch (nType) {
@@ -1048,6 +1047,13 @@ int CIccCfgProfileSequence::fromArgs(const char** args, int nArg, bool bReset)
       default:
         break;
       }
+      
+      // pin decoded values to valid range
+      if (nIntent < (int)icPerceptual || nIntent > (int)icAbsoluteColorimetric)
+        nIntent = icPerceptual;
+      
+      if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
+       nType = icXformLutColor;
 
       pProf->m_intent = (icRenderingIntent)nIntent;
       pProf->m_transform = (icXformLutType)nType;
@@ -1257,6 +1263,13 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
         pProf->m_useBPC = true;
         nType = icXformLutColor;
       }
+      
+      // pin decoded values to valid range
+      if (nIntent < (int)icPerceptual || nIntent > (int)icAbsoluteColorimetric)
+        nIntent = icPerceptual;
+      
+      if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
+       nType = icXformLutColor;
 
       pProf->m_intent = (icRenderingIntent)nIntent;
       pProf->m_transform = (icXformLutType)nType;
@@ -1298,6 +1311,13 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
     else if (nType == 4) {
       nType = icXformLutColor;
     }
+      
+    // pin decoded values to valid range
+    if (nIntent < (int)icPerceptual || nIntent > (int)icAbsoluteColorimetric)
+      nIntent = icPerceptual;
+      
+    if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
+      nType = icXformLutColor;
 
     m_intentInitial = (icRenderingIntent)nIntent;
     m_transformInitial = (icXformLutType)nType;

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -134,6 +134,9 @@ typedef enum {
   icXformLutNamedColorimetric  = 0xB,
   icXformLutNamedSpectral      = 0xC,
   icXformLutNamedDevice        = 0xD,
+  
+  icXformLutMinimum = 0x0,              // used for error checking
+  icXformLutMaximum = 0xD,              // used for error checking
  } icXformLutType;
 
   // Note: Named-color variants that pin which member of a v5 NamedColor

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -783,7 +783,16 @@ int main(int argc, icChar* argv[])
         nType = 0;
         Hint.AddHint(new CIccApplyBPCHint());
         break;
+      default:
+        break;
       }
+      
+      // pin decoded values to valid range
+      if (nIntent < (int)icPerceptual || nIntent > (int)icAbsoluteColorimetric)
+        nIntent = icPerceptual;
+      
+      if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
+       nType = icXformLutColor;
 
       if (nLuminance) {
         Hint.AddHint(new CIccLuminanceMatchingHint());


### PR DESCRIPTION
Fixes #1375

## Summary

Validate range of intents and Xform lut types read from the command line, before casting them to enums.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
