### PR TITLE
Fix: bound CIccEvalCompare::EvaluateProfile sample count — unbounded nGran^ndim round-trip DoS (#1405)

### DIFF
--- a/.github/scripts/iccdev-issue-1405-roundtrip-sample-cap.sh
+++ b/.github/scripts/iccdev-issue-1405-roundtrip-sample-cap.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+###############################################################################
+# iccRoundTrip issue-1405 unbounded device-space round-trip sampling (DoS)
+###############################################################################
+#
+# CIccEvalCompare::EvaluateProfile() walks an nGran^ndim grid of device samples,
+# running two CMM Apply() calls at every node.  The count explodes geometrically
+# with the channel count: a 6-channel profile at the default granularity of 33
+# is 33^6 ~= 1.3 billion samples, and the evaluation ran for over an hour before
+# returning -- a CWE-400 uncontrolled-resource-consumption hazard reachable from
+# the iccRoundTrip tool with any high-channel (or fuzzer-crafted) profile.  The
+# evaluator now rejects an over-budget sample count up front and returns
+# icCmmStatTooManySamples ("Too many samples used"), which iccRoundTrip surfaces.
+#
+# This test regenerates the 6-channel SixChanCameraRef profile from its tracked
+# XML (the .icc artifacts are .gitignored) and runs iccRoundTrip under a short
+# timeout: pre-fix the tool never terminates (the timeout fires); post-fix it
+# returns immediately reporting "Too many samples used".  A normal 3-channel
+# profile (33^3 = 35937 samples, far under the cap) must still round-trip, so the
+# cap is proven not over-aggressive.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit codes: 0 pass or clean skip; 2 regression.
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1405-roundtrip-sample-cap}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/build-dbg/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+
+ROUNDTRIP="$(find "$TOOLS_DIR" -maxdepth 2 -name iccRoundTrip -type f 2>/dev/null | head -1)"
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+SIXCHAN_XML="$REPO_ROOT/Testing/SpecRef/SixChanCameraRef.xml"
+RGB_ICC="$REPO_ROOT/Testing/sRGB_v4_ICC_preference.icc"
+LOGFILE="$OUTDIR/issue-1405-roundtrip-sample-cap.log"
+
+# Post-fix the over-budget profile is rejected in well under a second; pre-fix it
+# runs for over an hour.  Any modest ceiling cleanly separates the two.
+DOS_TIMEOUT=45
+
+regress() {
+  echo "  [FAIL] issue-1405-roundtrip-sample-cap -- $1"
+  exit 2
+}
+
+check_sanitizers() {
+  if grep -qE "ERROR: AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|LeakSanitizer|DEADLYSIGNAL" "$1" 2>/dev/null; then
+    sed -n '1,80p' "$1"
+    return 1
+  fi
+  return 0
+}
+
+echo "=== iccRoundTrip issue-1405 unbounded round-trip sampling regression ==="
+
+if [ -z "$ROUNDTRIP" ] || [ ! -x "$ROUNDTRIP" ]; then
+  echo "  [SKIP] iccRoundTrip not built under $TOOLS_DIR"
+  exit 0
+fi
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "  [SKIP] iccFromXml not built under $TOOLS_DIR (needed to build the 6-channel fixture)"
+  exit 0
+fi
+if [ ! -f "$SIXCHAN_XML" ]; then
+  echo "  [SKIP] $SIXCHAN_XML missing"
+  exit 0
+fi
+
+# 1) Build the 6-channel (6CLR) fixture from its tracked XML, then round-trip it.
+#    Pre-fix: 33^6 samples never terminate -> timeout fires (rc 124).
+#    Post-fix: rejected up front with "Too many samples used".
+SIXCHAN_ICC="$OUTDIR/SixChanCameraRef.icc"
+rm -f "$SIXCHAN_ICC" "$LOGFILE"
+if ! "$FROMXML" "$SIXCHAN_XML" "$SIXCHAN_ICC" > "$LOGFILE" 2>&1 || [ ! -s "$SIXCHAN_ICC" ]; then
+  sed -n '1,20p' "$LOGFILE"
+  echo "  [SKIP] could not generate 6-channel fixture from XML"
+  exit 0
+fi
+
+timeout "$DOS_TIMEOUT" "$ROUNDTRIP" "$SIXCHAN_ICC" > "$LOGFILE" 2>&1
+rc=$?
+check_sanitizers "$LOGFILE" || regress "sanitizer error round-tripping the 6-channel profile"
+
+if [ "$rc" -eq 124 ]; then
+  regress "6-channel round trip did not terminate within ${DOS_TIMEOUT}s -- sample count (33^6) uncapped"
+fi
+if ! grep -q "Too many samples used" "$LOGFILE"; then
+  sed -n '1,20p' "$LOGFILE"
+  regress "6-channel round trip was not rejected with 'Too many samples used' (rc=$rc)"
+fi
+
+# 2) Positive control: a normal 3-channel profile (33^3 << cap) must still
+#    round-trip cleanly, proving the cap rejects nothing legitimate.
+if [ -f "$RGB_ICC" ]; then
+  timeout 120 "$ROUNDTRIP" "$RGB_ICC" > "$LOGFILE" 2>&1
+  rc=$?
+  check_sanitizers "$LOGFILE" || regress "sanitizer error round-tripping the 3-channel control profile"
+  if [ "$rc" -ne 0 ] || ! grep -q "Round Trip 1" "$LOGFILE"; then
+    sed -n '1,20p' "$LOGFILE"
+    regress "3-channel control profile failed to round-trip (rc=$rc) -- cap too aggressive"
+  fi
+else
+  echo "  [INFO] $RGB_ICC missing -- skipping positive control"
+fi
+
+echo "  [PASS] issue-1405-roundtrip-sample-cap -- 6-channel over-budget refused, 3-channel still round-trips"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1293,6 +1293,21 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1394-xml-num-array-dos.sh"
 )
 
+# #1405 - CIccEvalCompare::EvaluateProfile walked an nGran^ndim device-sample
+# grid with no bound, so a 6-channel profile at the default granularity 33 ran
+# 33^6 (~1.3 billion) samples for over an hour (CWE-400). Regenerates the 6CLR
+# SixChanCameraRef fixture from its tracked XML and round-trips it under a short
+# timeout: pre-fix the tool never terminates, post-fix it reports "Too many
+# samples used"; a 3-channel control still round-trips. iccFromXml-gated. The
+# CTest ceiling sits above the script's internal 45s DoS timeout.
+iccdev_add_script_test(
+  iccdev.issue-1405-roundtrip-sample-cap
+  180
+  "iccdev;roundtrip;security;dos;issue-1405;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1405-roundtrip-sample-cap.sh"
+)
+
 # Describe sink + options API smoke test. Verifies byte-equivalence
 # between the legacy std::string Describe() and the new
 # Describe(IDescribeSink&, const DescribeOptions&) virtual, plus

--- a/IccProfLib/IccEval.cpp
+++ b/IccProfLib/IccEval.cpp
@@ -79,6 +79,39 @@ namespace iccDEV {
 //static const icFloatNumber SMALLNUM = (icFloatNumber)0.0001; // currently unused
 //static const icFloatNumber LESSTHANONE = (icFloatNumber)(1.0 - SMALLNUM); // currently unused
 
+// A profile round trip walks an nGran^ndim grid of device samples, running two
+// CMM Apply() calls at every node.  That count explodes geometrically with the
+// channel count: a 6-channel profile at the default granularity of 33 is 33^6
+// ~= 1.3 billion samples and the evaluation runs for over an hour before it
+// returns -- a CWE-400 uncontrolled-resource-consumption hazard reachable from
+// the iccRoundTrip tool with any high-channel (or fuzzer-crafted) profile.
+// In practice no real workflow round-trips a grid this dense: such profiles do
+// not exist in the wild beyond ~4 channels (the embedded A2B grid alone would
+// be prohibitively large), so capping the total sample budget rejects nothing
+// legitimate.  A 4-channel CMYK round trip at gran 33 is 33^4 ~= 1.19M, safely
+// under the cap; 5+ channels at the default granularity exceed it.
+static const icUInt32Number icMaxRoundTripSamples = 2000000;
+
+// Return true when nGran^ndim would exceed icMaxRoundTripSamples, evaluated
+// without overflowing icUInt32Number: the running product is compared against
+// the cap divided by nGran before each multiply, so the product itself never
+// wraps.  nGran < 2 is also rejected -- it is a degenerate granularity that
+// would make the stepsize 1/(nGran-1) below divide by zero, and never reflects
+// a real sampling request.
+static bool icRoundTripSamplesExceedCap(icUInt8Number nGran, int nDim)
+{
+  if (nGran < 2 || nDim < 1)
+    return true;
+
+  icUInt32Number nSamples = 1;
+  for (int i = 0; i < nDim; i++) {
+    if (nSamples > icMaxRoundTripSamples / nGran)
+      return true;
+    nSamples *= nGran;
+  }
+  return false;
+}
+
 icStatusCMM CIccEvalCompare::EvaluateProfile(CIccProfile *pProfile, icUInt8Number nGran/* =0 */,
                                              icRenderingIntent nIntent/* =icUnknownIntent */, icXformInterp nInterp/* =icInterpLinear */,
                                              bool buseMpeTags/* =true */)
@@ -163,6 +196,13 @@ icStatusCMM CIccEvalCompare::EvaluateProfile(CIccProfile *pProfile, icUInt8Numbe
         nGran = 33;
     }
   }
+
+  // nGran is now resolved (passed in, or derived from the A2B grid / default 33).
+  // Refuse the evaluation when the resulting nGran^ndim sample count would blow
+  // past the budget -- otherwise the sampling loop below runs effectively
+  // forever for wide device spaces.  See issue #1405 (CWE-400).
+  if (icRoundTripSamplesExceedCap(nGran, ndim))
+    return icCmmStatTooManySamples;
 
   // ccox - what the heck are we trying to do with steps? We don't really use the values.
   const icFloatNumber stepsize = (icFloatNumber)(1.0/(icFloatNumber)(nGran-1));

--- a/Tools/CmdLine/IccRoundTrip/iccRoundTrip.cpp
+++ b/Tools/CmdLine/IccRoundTrip/iccRoundTrip.cpp
@@ -176,7 +176,10 @@ int main(int argc, char* argv[])
   icStatusCMM stat = eval.EvaluateProfile(argv[1], 0, nIntent, icInterpLinear, nUseMPE);
 
   if (stat!=icCmmStatOk) {
-    printf("Unable to perform round trip on '%s'\n", argv[1]);
+    // Decode the status so callers can tell an outright failure (e.g. an
+    // unreadable profile) from a deliberate refusal such as "Too many samples
+    // used", which guards the round trip against wide device spaces (#1405).
+    printf("Unable to perform round trip on '%s': %s\n", argv[1], CIccCmm::GetStatusText(stat));
     return -1;
   }
 
@@ -185,7 +188,7 @@ int main(int argc, char* argv[])
   stat = prmg.EvaluateProfile(argv[1], nIntent, icInterpLinear, nUseMPE);
 
   if (stat!=icCmmStatOk) {
-    printf("Unable to perform PRMG analysis on '%s'\n", argv[1]);
+    printf("Unable to perform PRMG analysis on '%s': %s\n", argv[1], CIccCmm::GetStatusText(stat));
     return -1;
   }
 


### PR DESCRIPTION
Fixes #1405.

## The defect (CWE-400)

`CIccEvalCompare::EvaluateProfile` walks an `nGran^ndim` grid of device samples, running two CMM `Apply()` calls at every node. That count explodes geometrically with the device-channel count: a 6-channel profile at the default granularity of 33 is **33⁶ ≈ 1.3 billion** samples. @xsscx's libFuzzer artifact ran for **1h23m / 5032 CPU-seconds** before it was killed — an uncontrolled-resource-consumption hazard reachable straight from the `iccRoundTrip` CLI.

Reproduces today with a profile already in the tree:
```
$ iccRoundTrip Testing/SpecRef/SixChanCameraRef.icc      # 6CLR, hits default nGran=33
  ... runs for > 1 hour ...
```

## The fix

`IccProfLib/IccEval.cpp` — compute `nGran^ndim` with an **overflow-safe** running product (compared against the cap ÷ nGran before each multiply, so it never wraps) and refuse the run up front when it would exceed a **2,000,000-sample** budget, returning the existing `icCmmStatTooManySamples`.

The cap rejects nothing legitimate. As discussed on the issue, no real workflow round-trips a grid this dense beyond ~4 channels — the embedded A2B grid alone would be prohibitively large, and A2B/B2A CLUTs are deliberately asymmetric (B2A input is the 3-D PCS, not N-D device). A 4-channel CMYK round trip at gran 33 is 33⁴ ≈ 1.19M, safely under the cap; 5+ channels at the default granularity exceed it.

Scope notes:
- The sibling **`CIccPRMG::EvaluateProfile` is already bounded** — it samples the 3-D PCS at a fixed 0.01 step (~1M points) regardless of device-channel count, so only the device-space evaluator needed the guard.
- `nGran < 2` is also rejected — a degenerate granularity that would otherwise divide by zero at `1/(nGran-1)`.

`Tools/CmdLine/IccRoundTrip/iccRoundTrip.cpp` — decode the CMM status on the failure paths via the existing `CIccCmm::GetStatusText`, so the deliberate refusal (`Too many samples used`) is distinguishable from an outright failure:
```
Unable to perform round trip on 'SixChanCameraRef.icc': Too many samples used
```

## Regression test

`iccdev.issue-1405-roundtrip-sample-cap` regenerates the 6CLR `SixChanCameraRef` fixture from its tracked XML (the `.icc` artifacts are `.gitignored`) and round-trips it under a 45s timeout:

| build | result |
|-------|--------|
| master (pre-fix) | **FAIL** — never terminates, timeout fires |
| this PR | **PASS** — rejected immediately with "Too many samples used" |

A 3-channel control (`sRGB_v4_ICC_preference.icc`, 33³ ≈ 36k samples) must still round-trip cleanly, proving the cap is not over-aggressive. `iccFromXml`-gated; sanitizer-aware.

Verified locally: FAIL on master, PASS on the fix, and the sibling `#1355` round-trip test still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
