### PR TITLE
Fix: invalid-enum load in config encoding selector (#1422); regression tests for #1421 + #1422

### DIFF
--- a/.github/scripts/iccdev-issue-1421-cfg-transform-enum-load.sh
+++ b/.github/scripts/iccdev-issue-1421-cfg-transform-enum-load.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1421 - invalid-enum load in CIccCfgProfile::toJson()
+###############################################################################
+#
+# iccApplyProfiles' "-exportcfg" path parses the per-profile rendering-intent
+# code from the command line in CIccCfgProfileSequence::fromArgs().  The intent
+# code is a packed decimal whose tens field selects the xform LUT type:
+#
+#     nType  = abs(nIntent) / 10;     // e.g. 65535 decodes to nType == 53
+#     pProf->m_transform = (icXformLutType)nType;
+#
+# icXformLutType only defines 0x0..0xD.  CIccCfgProfile::toJson() then reads
+# m_transform back out via icGetTransformName(m_transform, ...).  At the bisected
+# commit (b90ac39, May 2024) the decoded nType was stored unclamped, so a value
+# like 53 was loaded as an icXformLutType in toJson() -- undefined behaviour that
+# UBSan's -fsanitize=enum (part of -fsanitize=undefined) traps:
+#
+#   IccCmmConfig.cpp: runtime error: load of value 53,
+#       which is not a valid value for type 'icXformLutType'
+#     in CIccCfgProfile::toJson(...)
+#     #1 CIccCfgProfileSequence::toJson(...)
+#
+# Commit b087101 (#1400, "range check intents and xform lut types from command
+# line") pins the decoded nType to [icXformLutMinimum, icXformLutMaximum] before
+# it is stored, so toJson() can never load an out-of-range icXformLutType.  This
+# test locks that fix in: it replays the exact #1421 repro (intent 65535) through
+# -exportcfg and fails if the invalid-enum load reappears.
+#
+# -exportcfg writes the config (and so runs the toJson load) immediately after
+# argument parsing, before any image or profile is opened, so this test is
+# self-contained and drives the vulnerable path with placeholder file names.
+#
+# The enum check only exists when the tool was built with the UBSan "enum" check,
+# i.e. -fsanitize=undefined (ENABLE_UBSAN / ENABLE_SANITIZERS, or an explicit
+# -fsanitize=undefined/enum flag).  On a build without it the test SKIPS rather
+# than report a misleading pass.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (no invalid-enum load) or skipped cleanly
+#   2 - UBSan invalid-enum-load finding (regression)
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1421-cfg-transform-enum-load}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/build-dbg/Tools"; do
+    if [ -d "$candidate" ]; then TOOLS_DIR="$candidate"; break; fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect:$BUILD_ROOT/IccConnect/IccLibConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+APPLY="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplyProfiles -type f 2>/dev/null | head -1)"
+LOGFILE="$OUTDIR/issue-1421-cfg-transform-enum-load.log"
+
+echo "=== iccApplyProfiles issue-1421 CIccCfgProfile::toJson invalid-enum-load regression ==="
+
+if [ -z "$APPLY" ] || [ ! -x "$APPLY" ]; then
+  echo "  [SKIP] iccApplyProfiles not built under $TOOLS_DIR"
+  exit 0
+fi
+
+# Only meaningful when the tool was built with the UBSan enum check, which lives
+# in -fsanitize=undefined.  Walk up from the tool to its CMakeCache.txt and
+# require ENABLE_UBSAN/ENABLE_SANITIZERS or an explicit -fsanitize=undefined/enum
+# flag.  Plain ASan (without UBSan) does not have the enum check.
+CACHE=""
+probe="$(dirname "$APPLY")"
+for _ in 1 2 3 4 5; do
+  if [ -f "$probe/CMakeCache.txt" ]; then CACHE="$probe/CMakeCache.txt"; break; fi
+  probe="$(dirname "$probe")"
+done
+ubsan=0
+if [ -n "$CACHE" ]; then
+  if grep -qiE "ENABLE_UBSAN:BOOL=ON|ENABLE_SANITIZERS:BOOL=ON" "$CACHE"; then
+    ubsan=1
+  elif grep -iE "CMAKE_(CXX|C)_FLAGS" "$CACHE" | grep -qiE "fsanitize=.*(undefined|enum)"; then
+    ubsan=1
+  fi
+fi
+if [ "$ubsan" -ne 1 ]; then
+  echo "  [SKIP] tool not built with UBSan enum check (CMakeCache: ${CACHE:-none})"
+  exit 0
+fi
+
+# Export the config for a profile whose rendering-intent code 65535 decodes to an
+# out-of-range xform LUT type (nType == 53).  -exportcfg serialises the parsed
+# config (running CIccCfgProfile::toJson, which loads m_transform) before any
+# image or profile file is opened, so placeholder file names are sufficient; the
+# tool exits non-zero regardless.  Keep UBSan from halting so the diagnostic is
+# captured in the log; the enum-load message is the signal we test for.
+rm -f "$LOGFILE"
+ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0" \
+UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+  "$APPLY" -exportcfg "$OUTDIR/issue-1421-cfg.json" \
+    "$OUTDIR/issue-1421-nosrc.tif" "$OUTDIR/issue-1421-nodst.tif" 2 1 0 1 1 \
+    -embedded 3 "$OUTDIR/issue-1421-noprof.icc" 65535 > "$LOGFILE" 2>&1
+
+if grep -qE "not a valid value for type 'icXformLutType'" "$LOGFILE"; then
+  echo "  [FAIL] issue-1421 -- CIccCfgProfile::toJson invalid-enum load reappeared"
+  grep -E "not a valid value for type 'icXformLutType'|toJson|IccCmmConfig.cpp" "$LOGFILE" | head
+  exit 2
+fi
+
+echo "  [PASS] issue-1421-cfg-transform-enum-load -- out-of-range xform type pinned before toJson load"
+exit 0

--- a/.github/scripts/iccdev-issue-1422-cfg-encoding-enum-load.sh
+++ b/.github/scripts/iccdev-issue-1422-cfg-encoding-enum-load.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1422 - invalid-enum load in CIccCfgDataApply::fromArgs()
+###############################################################################
+#
+# iccApplyNamedCmm's "-exportcfganddata" path parses the destination encoding
+# selector straight from the command line.  CIccCfgDataApply::fromArgs() did:
+#
+#     int nDstEncoding;
+#     icParseIntArg(args[1], nDstEncoding);
+#     icFloatColorEncoding dstEncoding = (icFloatColorEncoding)nDstEncoding;
+#     if (!icIsJsonColorEncoding(dstEncoding))   // <-- loads the enum
+#       return 0;
+#
+# icFloatColorEncoding only defines 0..icEncodeUnknown.  When the caller passes
+# an out-of-range value (the fuzz repro passes 9), narrowing it to the enum and
+# then *reading* it is undefined behaviour -- UBSan's -fsanitize=enum (part of
+# -fsanitize=undefined) traps the load:
+#
+#   IccCmmConfig.cpp:345: runtime error: load of value 9,
+#       which is not a valid value for type 'icFloatColorEncoding'
+#     in CIccCfgDataApply::fromArgs(char const**, int, bool)
+#
+# The fix range-checks the raw int (icIsJsonColorEncoding now takes an int) and
+# only narrows to the enum once the value is known valid, so the out-of-range
+# value is never loaded as an enum.
+#
+# The selector is parsed before any data file or profile is opened, so this test
+# is self-contained: it drives the exact "9" encoding argument with placeholder
+# file names and fails if the invalid-enum load reappears.
+#
+# The enum check only exists when the tool was built with the UBSan "enum" check,
+# i.e. -fsanitize=undefined (ENABLE_UBSAN / ENABLE_SANITIZERS, or an explicit
+# -fsanitize=undefined/enum flag).  On a build without it the test SKIPS rather
+# than report a misleading pass.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (no invalid-enum load) or skipped cleanly
+#   2 - UBSan invalid-enum-load finding (regression)
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1422-cfg-encoding-enum-load}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/build-dbg/Tools"; do
+    if [ -d "$candidate" ]; then TOOLS_DIR="$candidate"; break; fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect:$BUILD_ROOT/IccConnect/IccLibConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+
+APPLY="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplyNamedCmm -type f 2>/dev/null | head -1)"
+LOGFILE="$OUTDIR/issue-1422-cfg-encoding-enum-load.log"
+
+echo "=== iccApplyNamedCmm issue-1422 CIccCfgDataApply::fromArgs invalid-enum-load regression ==="
+
+if [ -z "$APPLY" ] || [ ! -x "$APPLY" ]; then
+  echo "  [SKIP] iccApplyNamedCmm not built under $TOOLS_DIR"
+  exit 0
+fi
+
+# Only meaningful when the tool was built with the UBSan enum check, which lives
+# in -fsanitize=undefined.  Walk up from the tool to its CMakeCache.txt and
+# require ENABLE_UBSAN/ENABLE_SANITIZERS or an explicit -fsanitize=undefined/enum
+# flag.  Plain ASan (without UBSan) does not have the enum check.
+CACHE=""
+probe="$(dirname "$APPLY")"
+for _ in 1 2 3 4 5; do
+  if [ -f "$probe/CMakeCache.txt" ]; then CACHE="$probe/CMakeCache.txt"; break; fi
+  probe="$(dirname "$probe")"
+done
+ubsan=0
+if [ -n "$CACHE" ]; then
+  if grep -qiE "ENABLE_UBSAN:BOOL=ON|ENABLE_SANITIZERS:BOOL=ON" "$CACHE"; then
+    ubsan=1
+  elif grep -iE "CMAKE_(CXX|C)_FLAGS" "$CACHE" | grep -qiE "fsanitize=.*(undefined|enum)"; then
+    ubsan=1
+  fi
+fi
+if [ "$ubsan" -ne 1 ]; then
+  echo "  [SKIP] tool not built with UBSan enum check (CMakeCache: ${CACHE:-none})"
+  exit 0
+fi
+
+# A minimal placeholder data file; the encoding selector "9" is parsed (and the
+# invalid-enum load is hit) before this file or the profiles are ever opened, so
+# the tool exits non-zero on the unparsable configuration regardless.  Keep UBSan
+# from halting so the diagnostic is captured in the log; the enum-load message is
+# the signal we test for.
+DATAFILE="$OUTDIR/issue-1422-placeholder-data.txt"
+printf '0.0 0.0 0.0 0.0\n' > "$DATAFILE"
+rm -f "$LOGFILE"
+ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0" \
+UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+  "$APPLY" -exportcfganddata "$OUTDIR/issue-1422-cfg.json" "$DATAFILE" 9 1 \
+    "$OUTDIR/issue-1422-nope1.icc" 10003 "$OUTDIR/issue-1422-nope2.icc" 3 > "$LOGFILE" 2>&1
+
+if grep -qE "not a valid value for type 'icFloatColorEncoding'" "$LOGFILE"; then
+  echo "  [FAIL] issue-1422 -- CIccCfgDataApply::fromArgs invalid-enum load reappeared"
+  grep -E "not a valid value for type 'icFloatColorEncoding'|icIsJsonColorEncoding|IccCmmConfig.cpp" "$LOGFILE" | head
+  exit 2
+fi
+
+echo "  [PASS] issue-1422-cfg-encoding-enum-load -- out-of-range encoding rejected without invalid-enum load"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1324,6 +1324,42 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1410-encoding-yxy-xyz-dbz.sh"
  )
 
+# #1421 - CIccCfgProfileSequence::fromArgs decodes a packed rendering-intent code
+# whose tens field selects the xform LUT type (intent 65535 -> nType 53), and
+# CIccCfgProfile::toJson reads it back via icGetTransformName. icXformLutType only
+# defines 0x0..0xD, so at the bisected commit (b90ac39) toJson loaded value 53 as
+# an icXformLutType -- UBSan -fsanitize=enum undefined behaviour. #1400 (b087101)
+# pins the decoded type to valid range before storing it; this test replays the
+# 65535 repro through iccApplyProfiles -exportcfg and fails if the invalid-enum
+# load reappears. -exportcfg runs the toJson load before any file is opened, so
+# placeholder names suffice. Only meaningful under a -fsanitize=undefined build
+# (ENABLE_UBSAN/ENABLE_SANITIZERS); SKIPS otherwise.
+iccdev_add_script_test(
+  iccdev.issue-1421-cfg-transform-enum-load
+  120
+  "iccdev;cmm;config;security;ub;issue-1421;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1421-cfg-transform-enum-load.sh"
+ )
+
+# #1422 - CIccCfgDataApply::fromArgs (iccApplyNamedCmm -exportcfganddata) narrowed
+# the destination encoding selector straight from the command line to an
+# icFloatColorEncoding and then read it in icIsJsonColorEncoding. The enum only
+# defines 0..icEncodeUnknown, so an out-of-range selector (the fuzz repro passes 9)
+# was loaded as an invalid enum -- UBSan -fsanitize=enum undefined behaviour at
+# IccCmmConfig.cpp:345. The fix range-checks the raw int before narrowing. The
+# selector is parsed before any data/profile file is opened, so this test drives
+# the exact "9" argument with placeholder names and fails if the invalid-enum load
+# reappears. Only meaningful under a -fsanitize=undefined build
+# (ENABLE_UBSAN/ENABLE_SANITIZERS); SKIPS otherwise.
+iccdev_add_script_test(
+  iccdev.issue-1422-cfg-encoding-enum-load
+  120
+  "iccdev;cmm;config;security;ub;issue-1422;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1422-cfg-encoding-enum-load.sh"
+ )
+
 # #1405 - CIccEvalCompare::EvaluateProfile walked an nGran^ndim device-sample
 # grid with no bound, so a 6-channel profile at the default granularity 33 ran
 # 33^6 (~1.3 billion) samples for over an hour (CWE-400). Regenerates the 6CLR

--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -179,11 +179,20 @@ static const char* clrEncNames[] = { "value", "float", "unitFloat", "percent",
 static icFloatColorEncoding clrEncValues[] = { icEncodeValue, icEncodeFloat, icEncodeUnitFloat, icEncodePercent,
                                                icEncode8Bit, icEncode16Bit, icEncode16BitV2, icEncodeUnknown };
 
-static bool icIsJsonColorEncoding(icFloatColorEncoding v)
+// Validate a caller-supplied encoding selector against the set of encodings the
+// JSON config understands.  The argument is taken as a plain int, NOT an
+// icFloatColorEncoding: the value arrives straight from a command-line integer
+// (icParseIntArg) and may be outside the enum's defined range (0..icEncodeUnknown).
+// Materializing such a value in an icFloatColorEncoding variable and then reading
+// it is undefined behavior -- UBSan's -fsanitize=enum traps the load (issue #1422,
+// "load of value 9, which is not a valid value for type 'icFloatColorEncoding'").
+// Comparing the raw int against each (promoted) table entry keeps every load in
+// range, so callers can range-check the int before they ever narrow it to the enum.
+static bool icIsJsonColorEncoding(int v)
 {
   int i;
   for (i = 0; clrEncNames[i]; i++) {
-    if (v == clrEncValues[i])
+    if (v == (int)clrEncValues[i])
       return true;
   }
 
@@ -341,10 +350,13 @@ int CIccCfgDataApply::fromArgs(const char** args, int nArg, bool bReset)
   if (!icParseIntArg(args[1], nDstEncoding))
     return 0;
 
-  icFloatColorEncoding dstEncoding = (icFloatColorEncoding)nDstEncoding;
-  if (!icIsJsonColorEncoding(dstEncoding))
+  // Range-check the parsed integer while it is still an int.  Casting an
+  // out-of-range value (the fuzz PoC for #1422 passes 9; the enum only defines
+  // 0..icEncodeUnknown) to icFloatColorEncoding and then loading it is UB, so
+  // reject first and only narrow to the enum once the value is known valid.
+  if (!icIsJsonColorEncoding(nDstEncoding))
     return 0;
-  m_dstEncoding = dstEncoding;
+  m_dstEncoding = (icFloatColorEncoding)nDstEncoding;
 
   const char *colon = strchr(args[1], ':');
   if (colon) {


### PR DESCRIPTION
## Summary

Two UBSan invalid-enum-load findings in the JSON-config path (`IccConnect/IccLibConnect/IccCmmConfig.cpp`), both reachable from the command line via the config exporters. Fixes #1422 and locks in the existing fix for #1421.

### #1422 — `CIccCfgDataApply::fromArgs()` (genuinely unfixed)

`iccApplyNamedCmm -exportcfganddata` parses the destination encoding selector straight from the command line, narrowed it to `icFloatColorEncoding`, then **read** it in `icIsJsonColorEncoding()`:

```cpp
icFloatColorEncoding dstEncoding = (icFloatColorEncoding)nDstEncoding;
if (!icIsJsonColorEncoding(dstEncoding))   // <-- loads the enum
```

`icFloatColorEncoding` only defines `0..icEncodeUnknown`. An out-of-range selector (the fuzz repro passes `9`) is loaded as an invalid enum — UBSan `-fsanitize=enum` (part of `-fsanitize=undefined`) traps:

```
IccCmmConfig.cpp:345: runtime error: load of value 9, which is not a valid value for type 'icFloatColorEncoding'
  in CIccCfgDataApply::fromArgs(char const**, int, bool)
```

**Fix:** `icIsJsonColorEncoding()` now takes a plain `int` and range-checks the raw value; `fromArgs` only narrows to the enum once the value is known valid, so the out-of-range value is never loaded as an enum.

### #1421 — `CIccCfgProfile::toJson()` (already fixed on master by #1400)

`iccApplyProfiles -exportcfg` decodes a packed rendering-intent code whose tens field selects the xform LUT type (intent `65535` → `nType == 53`); `toJson()` reads it back via `icGetTransformName(m_transform, …)`. `icXformLutType` only defines `0x0..0xD`, so at the bisected commit `b90ac39` (May 2024) `toJson()` loaded value `53` as an `icXformLutType`.

Commit `b087101` (#1400, "range check intents and xform lut types from command line") already pins the decoded type to valid range before storing it. **Verified the `65535` repro no longer traps on current master; with #1400's pin reverted it reproduces exactly** (`load of value 53 … icXformLutType` in `toJson` ← `CIccCfgProfileSequence::toJson`). This PR adds a regression test to lock that in — no code change needed for #1421.

## Tests

Two sanitizer-gated CTest regressions replay the exact fuzz repros through the config exporters. Both exporters serialise the parsed config **before any image/profile file is opened**, so the tests are self-contained (placeholder file names — no generated fixtures needed). They gate on a `-fsanitize=undefined` build (`ENABLE_UBSAN` / `ENABLE_SANITIZERS`) and SKIP otherwise, matching the existing `#1406`/`#1410` UB regressions.

- `iccdev.issue-1422-cfg-encoding-enum-load`
- `iccdev.issue-1421-cfg-transform-enum-load`

**Verified bidirectionally** (clang `-fsanitize=address,undefined,integer`): both tests **FAIL (exit 2)** on the vulnerable build (#1422 native to master; #1421 with #1400's pin reverted) and **PASS** on the fixed build.

Refs #1421, #1422.

🤖 Generated with [Claude Code](https://claude.com/claude-code)