### PR TITLE
Localize IccTagEmbedIcc anonymous namespace under iccDEV (#1425)

### DIFF
--- a/IccProfLib/IccTagEmbedIcc.cpp
+++ b/IccProfLib/IccTagEmbedIcc.cpp
@@ -84,6 +84,17 @@ Copyright:  ? see ICC Software License
 #include "IccIO.h"
 #include "IccDefs.h"
 
+// Wrap this translation unit in the iccDEV namespace under the library-wide
+// USEICCDEVNAMESPACE convention (see IccArrayFactory.cpp / IccTagFactory.cpp).
+// This localizes the file-local anonymous namespace below so it documents as
+// iccDEV::anonymous_namespace{IccTagEmbedIcc.cpp} instead of a top-level
+// anonymous_namespace{} (issue #1425). The macro is off in the default build,
+// so this is compiled away there and only the Doxygen pass / namespace-enabled
+// builds see the wrapper; behaviour is unchanged either way.
+#ifdef USEICCDEVNAMESPACE
+namespace iccDEV {
+#endif
+
 /**
 ****************************************************************************
 * Name: CIccTagEmbedProfile::CIccTagEmbedProfile
@@ -546,3 +557,7 @@ icValidateStatus CIccTagEmbeddedProfile::Validate(std::string sigPath, std::stri
   
   return rv;
 }
+
+#ifdef USEICCDEVNAMESPACE
+} //namespace iccDEV
+#endif


### PR DESCRIPTION
## Summary

Fixes #1425. The embedded-profile depth-guard helper added in #858 lives in a file-local **anonymous namespace**, so Doxygen documents it as a top-level `anonymous_namespace{IccTagEmbedIcc.cpp}` — inconsistent with the sibling guard in `IccTagJson.cpp` (#861), which shows as `iccDEV::anonymous_namespace{IccTagJson.cpp}`.

This wraps the translation unit in the library-wide `USEICCDEVNAMESPACE`-gated `iccDEV` namespace — exactly the convention `IccArrayFactory.cpp`, `IccTagFactory.cpp`, and `IccTagJson.cpp` already use — so the anonymous namespace nests under `iccDEV` and documents as `iccDEV::anonymous_namespace{IccTagEmbedIcc.cpp}`.

```cpp
#ifdef USEICCDEVNAMESPACE
namespace iccDEV {
#endif
...                       // existing file body, incl. the anonymous-namespace depth guard
#ifdef USEICCDEVNAMESPACE
} //namespace iccDEV
#endif
```

## Why this is safe

`ENABLE_USEICCDEVNAMESPACE` defaults **OFF**, so `USEICCDEVNAMESPACE` is undefined in every default/CI build — the wrapper is preprocessed away and the file compiles byte-for-byte as before. The macro is predefined only by the Doxygen pass (`.github/ci/doxygen/Doxyfile`), which parses rather than compiles. The depth-guard behaviour is unchanged in all cases.

## Verification

- **Default (macro-off) build:** `IccTagEmbedIcc.cpp` recompiles and `IccProfLib2` links cleanly; `-fsyntax-only` is clean.
- **Macro-on (Doxygen) semantics:** preprocessor-confirmed that the `EmbedDepthGuard` anonymous namespace lexically nests inside `namespace iccDEV`, matching the `IccTagJson.cpp` precedent that already renders `iccDEV::anonymous_namespace{...}`.

No regression test — this is a documentation-namespacing change with no behavioural effect in any compiled build.

> Note: the `ENABLE_USEICCDEVNAMESPACE=ON` build is independently non-compiling on current master (e.g. `IccCAM.cpp`, and headers like `IccTagEmbedIcc.h`/`IccTagJson.h` don't wrap their classes) — that pre-existing state is out of scope here; this change only makes the embed file consistent with the JSON sibling for the default build + Doxygen.

Refs #1425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)