### PR TITLE
Fix: cap recursion depth in composite tag Read paths (#1437)

### DIFF
--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -85,6 +85,31 @@
 #include "IccStructFactory.h"
 #include "IccArrayFactory.h"
 
+// Guard against attacker-crafted profiles that nest composite tags
+// (tagArrayType / tagStructType) arbitrarily deep. CIccTagArray::Read and
+// CIccTagStruct::Read each create their element tags (CIccTagCreator::CreateTag
+// / CIccTag::Create) and call pTag->Read() on them; an element may itself be a
+// composite tag, so the two functions mutually recurse (an array of structs of
+// arrays of ...) with one native C++ stack frame per nesting level and only
+// ~24 attacker bytes needed per level. With no depth cap this exhausts the call
+// stack and crashes the process (SIGSEGV) before any validation/describe runs.
+// The existing per-level caps (kMaxArrayEntries, the struct dir-size check)
+// bound the WIDTH of a single level, NOT the nesting DEPTH. A single shared
+// thread_local counter caps both entry points because they recurse into each
+// other. This mirrors the embedded-profile depth guard in IccTagEmbedIcc.cpp
+// (kMaxEmbeddedProfileDepth=8); 30 levels is far beyond any legitimate profile
+// while staying well clear of the smallest (~1 MB Emscripten/wasm) stack.
+namespace {
+  static thread_local int s_compositeTagDepth = 0;
+  static const int kMaxCompositeTagDepth = 30;
+
+  struct CompositeDepthGuard {
+    CompositeDepthGuard()  { ++s_compositeTagDepth; }
+    ~CompositeDepthGuard() { --s_compositeTagDepth; }
+    bool TooDeep() const { return s_compositeTagDepth > kMaxCompositeTagDepth; }
+  };
+}
+
 void IIccStruct::Describe(std::string &sDescription, int nVerboseness) const
 {
   if (m_pTagStruct) {
@@ -368,6 +393,13 @@ void CIccTagStruct::Describe(std::string &sDescription, int nVerboseness)
  ******************************************************************************/
 bool CIccTagStruct::Read(icUInt32Number size, CIccIO *pIO)
 {
+  // Bound recursion depth across the array<->struct composite Read paths
+  // (see CompositeDepthGuard above): a struct element may be another struct
+  // or array, so LoadElem -> pTag->Read can re-enter here unboundedly.
+  CompositeDepthGuard depthGuard;
+  if (depthGuard.TooDeep())
+    return false;
+
   icTagTypeSignature sig;
 
   m_tagSize = size;
@@ -1252,9 +1284,17 @@ void CIccTagArray::Describe(std::string &sDescription, int nVerboseness)
 ******************************************************************************/
 bool CIccTagArray::Read(icUInt32Number size, CIccIO *pIO)
 {
+  // Bound recursion depth across the array<->struct composite Read paths
+  // (see CompositeDepthGuard above): an array element may be another array
+  // or struct, so the CreateTag + pTag->Read loop below can re-enter here
+  // unboundedly on a deeply-nested tagArrayType chain.
+  CompositeDepthGuard depthGuard;
+  if (depthGuard.TooDeep())
+    return false;
+
   icTagTypeSignature sig;
 
-  icUInt32Number headerSize = sizeof(icTagTypeSignature) + 
+  icUInt32Number headerSize = sizeof(icTagTypeSignature) +
     sizeof(icUInt32Number) +
     sizeof(icTagTypeSignature) +
     sizeof(icStructSignature) +


### PR DESCRIPTION
## Summary
Fixes #1437 — uncontrolled recursion / stack-exhaustion DoS (CWE-674) in the composite tag read path.

`CIccTagArray::Read` (`IccTagComposite.cpp:1350`) and `CIccTagStruct::Read` (via `LoadElem` → `pTag->Read`, `:917`) each create their element tags and call `Read()` on them. An element may itself be a composite tag, so the two functions **mutually recurse** (an array of structs of arrays of …) — one native C++ stack frame per nesting level, ~24 attacker bytes/level. With no depth cap, a deeply-nested `tagArrayType`/`tagStructType` chain in an attacker `.icc` exhausts the stack and crashes the process (SIGSEGV) before any validation runs.

The pre-existing caps bound only the **width** of a level (`kMaxArrayEntries`, the struct dir-size check), not the nesting **depth**. The library's only recursion caps cover embedded profiles, the MPE calculator and CLUT iterate — none protect the composite path (`git log` confirms a depth cap was never added to `IccTagComposite.cpp`).

## Fix
A single shared `thread_local CompositeDepthGuard` (cap **30**) entered at the top of both `Read` functions. Because the two paths recurse into each other, one shared counter bounds both. Mirrors the embedded-profile depth guard in `IccTagEmbedIcc.cpp` (`kMaxEmbeddedProfileDepth=8`). 30 levels is far beyond any legitimate profile while staying clear of the smallest (~1 MB Emscripten/wasm) stack.

## Verification (ASan)
A nested `tagArrayType` blob fed straight to `CIccTagArray::Read` via `CIccMemIO`:

| depth | before fix | after fix |
|-------|-----------|-----------|
| 5 (legit) | `Read()` → true | `Read()` → true |
| 200000 (attack) | **ASan stack-overflow** at `IccTagComposite.cpp:1350` | `Read()` → false, no crash |

Pre-fix ASan trace (truncated):
```
==ERROR: AddressSanitizer: stack-overflow
  #6 CIccTagArray::Read  IccTagComposite.cpp:1348
  #7 CIccTagArray::Read  IccTagComposite.cpp:1350
  #8 CIccTagArray::Read  IccTagComposite.cpp:1350
  ... (recursing)
```

A standalone CTest regression follows in a paired test PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)