### PR TITLE
Fix: iccPawgReport Q1/Q3 — round-trip & smoothness use relative colorimetric, not header intent (#1455)

### DIFF
--- a/Tools/CmdLine/IccPawgReport/IccQualityMetrics.h
+++ b/Tools/CmdLine/IccPawgReport/IccQualityMetrics.h
@@ -527,10 +527,24 @@ inline bool status_ok(icStatusCMM status, const std::string &phase, std::string 
   return false;
 }
 
+// Build a CMM step for the round-trip / smoothness metrics.  The intent defaults
+// to RELATIVE COLORIMETRIC and callers should leave it that way unless they have a
+// specific reason: these metrics measure how invertible / smooth the transform is,
+// which must be assessed colorimetrically.  Passing icUnknownIntent (the AddXform
+// default) instead resolves to the profile *header* rendering intent -- Perceptual
+// for most output profiles -- and round-tripping the perceptual A2B/B2A pair, which
+// deliberately compresses gamut, is not a clean inverse and reports spuriously
+// large dE (e.g. CRPC6 round trip max 21 dE under Perceptual vs ~3 under Relative).
+//
+// Absolute colorimetric would give the same round-trip numbers as relative: the
+// media-white adaptation it adds is a per-channel XYZ (von Kries) scale that the
+// forward leg multiplies in and the reverse leg divides back out, so it cancels
+// over a round trip.  Relative is therefore the simpler correct default here.
 inline bool begin_profile_cmm(CIccProfile *pIcc,
                               CIccCmm &cmm,
                               const char *direction,
-                              std::string &reason) {
+                              std::string &reason,
+                              icRenderingIntent intent = icRelativeColorimetric) {
   if (!pIcc) {
     reason = "Profile handle is null";
     return false;
@@ -542,7 +556,7 @@ inline bool begin_profile_cmm(CIccProfile *pIcc,
     return false;
   }
 
-  icStatusCMM status = cmm.AddXform(*pIcc);
+  icStatusCMM status = cmm.AddXform(*pIcc, intent);
   if (!status_ok(status, std::string(direction) + " AddXform", reason)) {
     return false;
   }


### PR DESCRIPTION
Fixes #1455.

### Problem
`iccPawgReport`'s round-trip (**Q1**) and smoothness (**Q3**) metrics build their CMM steps via `iccquality::begin_profile_cmm()`, which called `cmm.AddXform(*pIcc)` with the default `nIntent = icUnknownIntent`. That resolves to the profile's **header rendering intent** — Perceptual for most output profiles — so Q1 round-trips through the perceptual `A2B0`/`B2A0` pair. Perceptual rendering deliberately compresses gamut, so `A2B ∘ B2A` is **not** a clean inverse and the round-trip ΔE is spuriously large.

### Fix
Default `begin_profile_cmm()` to **relative colorimetric** (the intent `iccRoundTrip` / `CIccEvalCompare` already use), and thread an explicit `intent` parameter for callers that need otherwise. A round-trip / smoothness metric measures how invertible / smooth the transform is, which must be assessed colorimetrically; relative is the conventional choice. (Absolute would give identical round-trip numbers — the media-white von Kries scale cancels over a round trip — so relative is the simpler correct default. Q4 characterization, a *one-way* comparison where the media white does **not** cancel, correctly uses absolute and builds its own CMM, per #1452/#1454.)

### Verification (real profiles, before → after)
| Profile | header intent | Q1 first ΔE max — before | after | verdict |
|---|---|---|---|---|
| `Testing/CMYK-3DLUTs/CMYK-3DLUTs.icc` | Perceptual | **22.63** | **3.04** | **FAIL → OK** |
| `Testing/hybrid/ICC/CMYK_Hybrid_Profile.icc` | — | 7.21 | 3.40 | OK → OK |

The before values match the issue's CRPC6 repro (max ~21 under Perceptual vs ~2 under Relative) and the established `iccRoundTrip` tool. The bug was producing a **false FAIL** verdict on CMYK-3DLUTs.

### Notes for reviewers
- **Source-only by design** (one file, `IccQualityMetrics.h`) so it clears the fork-PR maintainer-automation gate. The mutation-verified CTest is the separate in-repo branch `test-1455-pawg-q1q3-relative-colorimetric-regression`.
- **Independent of #1452/#1454** — `begin_profile_cmm` is untouched by those, so this is based directly on master (single commit) and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)