### PR TITLE
Fix: signed integer overflow in calc Transpose/Solve matrix-size product (#1447, #1448)

### DIFF
--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -581,15 +581,22 @@ public:
     size_t ss = os.pStack->size();
     int r=op->data.select.v1+1;
     int c=op->data.select.v2+1;
-    int nSize = r*c;
+    // v1/v2 are icUInt16Number, so r and c can each reach 65536 and r*c can reach
+    // ~2^32 -- well past INT_MAX.  Computing the product in int overflowed (UBSan:
+    // "65536 * 32768 cannot be represented in type 'int'", #1448) and wrapped to a
+    // negative value that slipped past the "nSize>ss" guard, leading to a bad
+    // resize / out-of-bounds stack index.  Compute the product in size_t (as the
+    // sibling op at OsExtendArgs already does) so the guard rejects oversized
+    // requests; once it passes, nSize<=ss<=icMaxDataStackSize so it fits an int.
+    size_t nSize = (size_t)r*(size_t)c;
 
-    if (nSize>(int)ss)
+    if (nSize>ss)
       return false;
 
     if (r>1 && c>1) {
       int j, k;
 
-      if (os.pScratch->size()<(size_t)nSize)
+      if (os.pScratch->size()<nSize)
         os.pScratch->resize(nSize);
 
       icFloatNumber *ptrStack = &(*os.pStack)[ss-nSize];
@@ -619,17 +626,22 @@ public:
     size_t ss = os.pStack->size();
     int r=op->data.select.v1+1;
     int c=op->data.select.v2+1;
-    int nMSize = r*c;
-    int nSize = nMSize + c;
+    // r and c (icUInt16Number+1) can each reach 65536, so r*c can reach ~2^32 --
+    // past INT_MAX.  The int product overflowed (UBSan: "65536 * 32768 cannot be
+    // represented in type 'int'", #1447) and wrapped negative, slipping past the
+    // "nSize>ss" guard into a bad stack index.  Compute the matrix size in size_t;
+    // after the guard nSize<=ss<=icMaxDataStackSize so the narrow uses below fit.
+    size_t nMSize = (size_t)r*(size_t)c;
+    size_t nSize = nMSize + (size_t)c;
 
-    if (nSize>(int)ss)
+    if (nSize>ss)
       return false;
 
     if (r>1 && c>1) {
 
       if (os.pScratch->size()<(size_t)c)
         os.pScratch->resize(c);
-      
+
       icFloatNumber *ptrStack = &(*os.pStack)[ss-nSize];
       icFloatNumber *x = &(*os.pScratch)[0];
       icFloatNumber *mtx = ptrStack;


### PR DESCRIPTION
Fixes #1447. Fixes #1448.

### Problem
`CIccOpDefTranspose::Exec` and `CIccOpDefSolve::Exec` (`IccProfLib/IccMpeCalc.cpp`) compute the matrix element count as `int nSize = r*c` (Solve also `nMSize = r*c`), where `r` and `c` are `(icUInt16Number select field) + 1` and can each reach **65536**. `r*c` then reaches ~2³², overflowing `int`. On the verified PoCs (UBSan):

```
IccMpeCalc.cpp:584:18 runtime error: signed integer overflow: 65536 * 32768 cannot be represented in type 'int'   (Transpose, #1448)
IccMpeCalc.cpp:622:19 runtime error: signed integer overflow: 65536 * 32768 cannot be represented in type 'int'   (Solve, #1447)
```

The wrapped (negative) product slips past the `nSize>(int)ss` guard, then drives a bad `pScratch->resize()` and an out-of-bounds `&(*pStack)[ss-nSize]`. Validation caps `ArgsUsed` at `icMaxDataStackSize`, so a crafted profile passes `Begin()` and still reaches `Exec` with an overflowing `r*c` — exactly how the reports trigger it.

### Fix
Compute the size products in `size_t` — the **same idiom the sibling matrix-copy op already uses** a few ops above (`size_t ntSize = (size_t)n*(size_t)t`) — so the `>ss` guard rejects oversized requests instead of wrapping. Once the guard passes, the value is `≤ ss ≤ icMaxDataStackSize` (65535) and fits the `int` uses that follow.

### Verification
Built `IccProfLib` under `-fsanitize=signed-integer-overflow` and ran both PoCs through a CMM (the `iccRoundTrip` path):
- **pre-fix:** traps at `:584` / `:622` (the exact bisect breadcrumbs).
- **fixed:** both complete cleanly, no trap.

### Notes
- Verified external reports by **@h0rk1p**, bisected to `1f0a9dd` (2015).
- Source-only (one file) so it clears the fork-PR maintainer-automation gate. The mutation-verified UBSan regression (embeds both PoCs) is the in-repo branch `test-1447-1448-mpecalc-matrix-size-overflow-regression`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)