### PR TITLE
Reconcile icCmmSignature enum + GetCmmSigName with the CMM registry (#1459 follow-up)

### DIFF
--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -2082,6 +2082,24 @@ const icChar *CIccInfo::GetCmmSigName(icCmmSignature sig)
   case icSigZoran:
     return "Zoran";
 
+  // These CMM signatures are defined in the icCmmSignature enum but previously
+  // had no name here, so GetCmmSigName() returned "Unknown..." for them and any
+  // consumer that gates on the name (e.g. iccPawgReport's S3 check) treated a
+  // legitimately registered CMM as unregistered.
+  case icSigWindowsCMS:
+    return "Windows Color System (WCS)";
+
+  case icSigOnyxGraphics:
+    return "Onyx Graphics";
+
+  // Added from registry.color.org/cmm-signatures (entries missing from the
+  // earlier "as of Mar 6, 2018" enum snapshot).
+  case icSigReprointelligence:
+    return "Reprointelligence";
+
+  case icSigICC:
+    return "International Color Consortium";
+
   default:
     return GetUnknownName(sig);
   }

--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -1034,7 +1034,7 @@ typedef enum {
     icSigWindowsCMS                     = 0x57435320,  /* 'WCS ' */
     icSigMutoh                          = 0x5349474E,  /* 'SIGN' */
     icSigOnyxGraphics                   = 0x4f4e5958,  /* 'ONYX' */
-    icSigRefIccMAX                      = 0x52494343,  /* 'RIMX' */
+    icSigRefIccMAX                      = 0x52494D58,  /* 'RIMX' */
     icSigDemoIccMAX                     = 0x44494d58,  /* 'DIMX' */
     icSigIccDEV                         = 0x49434344,  /* 'ICCD' */
     icSigRolfGierling                   = 0x52474d53,  /* 'RGMS' */
@@ -1044,6 +1044,8 @@ typedef enum {
     icSigVivo                           = 0x7669766F,  /* 'VIVO' */
     icSigWareToGo                       = 0x57544720,  /* 'WTG ' */
     icSigZoran                          = 0x7a633030,  /* 'zc00' */
+    icSigReprointelligence              = 0x72657072,  /* 'repr' */
+    icSigICC                            = 0x69636364,  /* 'iccd' */
     icSigUnknownCmm                     = 0x00000000,
     
 /* Convenience Enum Definition - Not defined in ICC specification */


### PR DESCRIPTION
## Context
Non-governance follow-up to #1459. While diffing registry.color.org for the S3 manufacturer/creator fix (#1470), the CMM signature table was found to diverge from the public **CMM registry** (registry.color.org/cmm-signatures) in three ways. Each made `GetCmmSigName()` return `"Unknown…"` for a *registered* CMM, which makes consumers that gate on the name — e.g. iccPawgReport's S3 check — treat it as unregistered.

## Changes (`IccProfLib`)
1. **`WCS `/`ONYX` had no name.** `icSigWindowsCMS` and `icSigOnyxGraphics` exist in the `icCmmSignature` enum but had no `case` in `GetCmmSigName()` → added.
2. **`icSigRefIccMAX` value/comment mismatch.** It held `0x52494343` (`'RICC'`) while its own comment *and* the registry say the RefIccMAX CMM signature is `'RIMX'` (`0x52494D58`). Corrected the value to match. No other code references the old value (verified repo-wide; the only grep hits are `paramet`**`RICC`**`urve` false-positives).
3. **Two registry entries missing** from the "as of Mar 6, 2018" enum snapshot: `icSigReprointelligence` (`'repr'`) and `icSigICC` (`'iccd'`, the consortium), with matching `GetCmmSigName()` cases.

## Notes
- Additive except the single RefIccMAX value correction. Builds clean (no duplicate-case).
- Naming of the two new constants (`icSigReprointelligence`, `icSigICC`) is open to maintainer preference — trivial to rename in review.
- Documented under §B of `registry/PERMISSIVENESS_DELTAS.md` in #1470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
