### PR TITLE
Fix: clamp float->int casts on Lab L* 8-bit encode and CLUT XML dump (iccdev/float-to-int-cast)

### DIFF
--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -9791,7 +9791,19 @@ icStatusCMM CIccCmm::FromInternalEncoding(icColorSpaceSignature nSpace, icFloatC
           {
             icLabFromPcs(pInput);
 
-            pInput[0] = (icUInt8Number)(pInput[0]/100.0 * 255.0 + 0.5);
+            // icABtoU8() clamps the a*/b* channels (NaN/<0/>255) before their
+            // cast; the L* channel is scaled by hand here, so apply the same
+            // guard. Without it an out-of-range or NaN L* (e.g. produced by a
+            // malformed transform) yields an out-of-range float->uint8
+            // conversion, which is undefined behavior.
+            icFloatNumber l8 = pInput[0] / 100.0f * 255.0f + 0.5f;
+            if (std::isnan(pInput[0]))
+              l8 = 0.0f;
+            else if (l8 < 0.0f)
+              l8 = 0.0f;
+            else if (l8 > 255.0f)
+              l8 = 255.0f;
+            pInput[0] = (icUInt8Number)l8;
             pInput[1] = icABtoU8(pInput[1]);
             pInput[2] = icABtoU8(pInput[2]);
             break;

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -246,13 +246,23 @@ public:
     switch(m_nType) {
       case icConvert8Bit:
         for (i=0; i<m_nSamples; i++) {
-          snprintf(buf, bufSize, " %3d", (icUInt8Number)(pData[i]*255.0 + 0.5));
+          // Clamp to [0,1] (the !(v>=0) test also catches NaN) before scaling:
+          // CLUT sample data from a malformed profile may fall outside the
+          // normalized range, and an out-of-range float->uint cast is UB. The
+          // sibling scalar serializer (icXmlDumpArrayValue) clamps the same way.
+          icFloatNumber v = pData[i];
+          if (!(v >= 0.0)) v = 0.0;
+          else if (v > 1.0) v = 1.0;
+          snprintf(buf, bufSize, " %3d", (icUInt8Number)(v*255.0 + 0.5));
           *m_xml += buf;
         }
         break;
       case icConvert16Bit:
         for (i=0; i<m_nSamples; i++) {
-          snprintf(buf, bufSize, " %5d", (icUInt16Number)(pData[i]*65535.0 + 0.5));
+          icFloatNumber v = pData[i];
+          if (!(v >= 0.0)) v = 0.0;
+          else if (v > 1.0) v = 1.0;
+          snprintf(buf, bufSize, " %5d", (icUInt16Number)(v*65535.0 + 0.5));
           *m_xml += buf;
         }
         break;


### PR DESCRIPTION
## Summary
Two `iccdev/float-to-int-cast` code-scanning alerts flag float→int casts where an out-of-range float would be converted (UB in C++). Both sites lack the range guard their immediate siblings already apply.

## Sites fixed
**1. `IccCmm.cpp` — Lab 8-bit encode (alert #1064, `:9794`)**
In the `icEncode8Bit` Lab branch, `a*`/`b*` go through `icABtoU8()` (which clamps NaN/`<0`/`>255` before the cast — `IccUtil.cpp:798`), but `L*` was scaled and cast by hand with **no** guard:
```cpp
pInput[0] = (icUInt8Number)(pInput[0]/100.0 * 255.0 + 0.5);   // no clamp
pInput[1] = icABtoU8(pInput[1]);                               // clamped
```
A malformed transform yielding an out-of-range or NaN `L*` then hit an out-of-range `float→uint8` conversion. Fix applies the same `isnan` + `[0,255]` clamp to `L*` (NaN → 0 = black). The 16-bit Lab path uses `icFtoU16` (already clamps), so it was never flagged and is untouched.

**2. `IccUtilXml.cpp` — CLUT XML dump (alerts #1130 `:249`, #1131 `:255`)**
`CIccDumpXmlCLUT::PixelOp` scaled and cast CLUT samples with no clamp, while the scalar serializer `icXmlDumpArrayValue` in the same file already clamps to `[0,1]` first (`:721-722`, `:727-728`). A malformed profile with out-of-range CLUT samples hit an out-of-range `float→uint` cast on XML dump. Fix clamps to `[0,1]` first (`!(v>=0)` also rejects NaN).

## Scope / safety
- Pure robustness against malformed profile data (encode + XML-dump paths); valid profiles are unaffected since their values are already in range.
- Source-only (IccProfLib + IccXML); no Build/CMake/CI changes.
- Both libs rebuild clean (`IccProfLib2-static`, `IccXML2-static`).

## Not in this PR
The remaining `float-to-int-cast` alerts were triaged separately:
- **Dismissed false-positive (15):** `IccTagLut.cpp` CLUT-interpolation casts (guarded by `std::isfinite` + grid clamp) and the `icXmlDumpArrayValue` casts (already range-clamped).
- **Left open (lower-priority / assigned):** `IccCmm.cpp:9990/10049` (post-`FromInternalEncoding` `+0.5` casts), `IccUtilXml.cpp:955` (XML read-path template cast), `IccTagXml.cpp:887` (xsscx), `iccProfileVisualize.cpp:2161` (ChrisCoxArt).

Fixes alerts #1064, #1130, #1131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)