### PR TITLE
Fix: bound CIccTagArray copy/validate walks (unbounded-profile-loop) + NULL-deref in Validate

### DIFF
--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1092,17 +1092,25 @@ CIccTagArray::CIccTagArray(const CIccTagArray &tagAry)
 {
   m_TagVals = NULL;
   m_nSize = 0;
-  if (tagAry.m_nSize) {
-    m_TagVals = new IccTagPtr[tagAry.m_nSize];
+  // CWE-400/CWE-834: a well-formed source satisfies m_nSize == allocated
+  // (m_TagVals), with m_nSize bounded by Read()'s 2^20 entry cap and matched
+  // by SetSize(). Clamp the copy to the same explicit upper limit Describe()
+  // and Cleanup() use, and walk the clamped local rather than the field, so a
+  // corrupted source count can't drive an unbounded allocation/copy here. Real
+  // arrays (<= 2^20 from Read) are always below this bound and never clamped.
+  const icUInt32Number nMaxArrayEntries = 0xffffff;
+  icUInt32Number nCopy = (tagAry.m_nSize > nMaxArrayEntries) ? nMaxArrayEntries : tagAry.m_nSize;
+  if (nCopy) {
+    m_TagVals = new IccTagPtr[nCopy];
 
     icUInt32Number i;
-    for (i=0; i<tagAry.m_nSize; i++) {
+    for (i=0; i<nCopy; i++) {
       if (tagAry.m_TagVals[i].ptr)
         m_TagVals[i].ptr = tagAry.m_TagVals[i].ptr->NewCopy();
       else
         m_TagVals[i].ptr = NULL;
     }
-    m_nSize = tagAry.m_nSize;
+    m_nSize = nCopy;
   }
   m_sigArrayType = tagAry.m_sigArrayType;
 
@@ -1131,17 +1139,24 @@ CIccTagArray &CIccTagArray::operator=(const CIccTagArray &tagAry)
 
   m_TagVals = NULL;
   m_nSize = 0;
-  if (tagAry.m_nSize) {
-    m_TagVals = new IccTagPtr[tagAry.m_nSize];
+  // CWE-400/CWE-834: mirror the copy-constructor guard above - clamp the copy
+  // to the same explicit upper limit Describe()/Cleanup() use and walk the
+  // clamped local rather than the field, so a corrupted source count can't
+  // drive an unbounded allocation/copy. Real arrays (<= 2^20 from Read) never
+  // reach this bound.
+  const icUInt32Number nMaxArrayEntries = 0xffffff;
+  icUInt32Number nCopy = (tagAry.m_nSize > nMaxArrayEntries) ? nMaxArrayEntries : tagAry.m_nSize;
+  if (nCopy) {
+    m_TagVals = new IccTagPtr[nCopy];
 
     icUInt32Number i;
-    for (i=0; i<tagAry.m_nSize; i++) {
+    for (i=0; i<nCopy; i++) {
       if (tagAry.m_TagVals[i].ptr)
         m_TagVals[i].ptr = tagAry.m_TagVals[i].ptr->NewCopy();
       else
         m_TagVals[i].ptr = NULL;
     }
-    m_nSize = tagAry.m_nSize;
+    m_nSize = nCopy;
   }
 
   m_sigArrayType = tagAry.m_sigArrayType;
@@ -1562,7 +1577,20 @@ icValidateStatus CIccTagArray::Validate(std::string sigPath, std::string &sRepor
   CIccInfo Info;
   std::string sigAryPath = sigPath + icGetSigPath(m_sigArrayType);
 
-  if (m_pArray) {  //Should call GetArrayHandler before validate to get 
+  // CWE-400/CWE-834: m_nSize is bounded by Read()'s 2^20 entry cap and matched
+  // by SetSize(), but assert the same explicit upper limit Describe()/Cleanup()
+  // use before the element-validation walks below, so a corrupted count can't
+  // drive them unbounded. A count this large only arises from corruption (Read
+  // caps well below it), so report it as a critical error rather than walking.
+  const icUInt32Number nMaxArrayEntries = 0xffffff;
+  if (m_nSize > nMaxArrayEntries) {
+    sReport += icMsgValidateCriticalError;
+    sReport += Info.GetSigPathName(sigPath);
+    sReport += " - Tag array entry count exceeds sane maximum.\n";
+    return icMaxStatus(rv, icValidateCriticalError);
+  }
+
+  if (m_pArray) {  //Should call GetArrayHandler before validate to get
     rv = icMaxStatus(rv, m_pArray->Validate(sigPath, sReport, pProfile));
   }
   else if (m_sigArrayType==icSigUtf8TextTypeArray) { //UTF8 text arrays are known
@@ -1579,16 +1607,24 @@ icValidateStatus CIccTagArray::Validate(std::string sigPath, std::string &sRepor
     }
     icUInt32Number i;
     for (i=0; i<m_nSize; i++) {
-      rv = icMaxStatus(rv, m_TagVals[i].ptr->Validate(sigAryPath, sReport, pProfile));
+      // m_TagVals[i].ptr is NULL for sparse array slots - Read() stores NULL
+      // for entries with zero offset/size (a spec-legal empty slot) - so guard
+      // the deref as Describe()/Write()/Cleanup() already do; without it,
+      // validating a sparse or malformed array crashes on a NULL deref.
+      if (m_TagVals[i].ptr)
+        rv = icMaxStatus(rv, m_TagVals[i].ptr->Validate(sigAryPath, sReport, pProfile));
     }
   }
-  else { 
+  else {
     icUInt32Number i;
     sReport += "Unknown tag array type - Validating array sub-tags\n";
     rv = icMaxStatus(rv, icValidateWarning);
 
     for (i=0; i<m_nSize; i++) {
-      rv = icMaxStatus(rv, m_TagVals[i].ptr->Validate(sigAryPath, sReport, pProfile));
+      // Same sparse-slot guard as the UTF8 branch above: a NULL element is a
+      // legal empty slot from Read(), not a deref target.
+      if (m_TagVals[i].ptr)
+        rv = icMaxStatus(rv, m_TagVals[i].ptr->Validate(sigAryPath, sReport, pProfile));
     }
   }
 


### PR DESCRIPTION
## Summary
Resolves four `iccdev/unbounded-profile-loop` alerts in `CIccTagArray` and fixes an adjacent **NULL-pointer dereference** found while tracing the same loops.

## The loops are in fact bounded
`m_nSize` is the array entry count. The only untrusted entry point, `CIccTagArray::Read()`, is already hardened (IccTagComposite.cpp:1334-1350):
```cpp
static const icUInt32Number kMaxArrayEntries = 0x100000;            // 2^20 hard cap
if (count > kMaxArrayEntries) return false;
icUInt64Number tableBytes = (icUInt64Number)count * sizeof(icPositionNumber);
if ((icUInt64Number)headerSize + tableBytes > size) return false;  // bound by tag bytes
... SetSize(count) ...                                             // allocate m_TagVals to match
```
So `m_nSize <= 2^20` **and** `m_nSize == allocated(m_TagVals)` on every path (Read, `SetSize`, copy). The query misses this because Read bounds the **local** `count`, not the field, so its setup-guard exemption (`conditionMentionsFieldAndBound`) never matches.

**This file already chose the remediation:** `Describe()` (:1248) and `Cleanup()` (:1610) were previously resolved with an explicit in-function `0xffffff` guard — which is why they're no longer flagged. This PR extends that same pattern to the remaining walk sites (real arrays are `<= 2^20` and never reach the bound, so nothing legitimate is clamped):

| Alert | Site | Fix |
|---|---|---|
| #970 | copy ctor `:1099` | clamp copied count to `0xffffff`, walk the clamped local (mirrors `Cleanup()`) |
| #969 | `operator=` `:1138` | same |
| #962 / #963 | `Validate()` `:1581/:1590` | assert `m_nSize <= 0xffffff` before the element walks (critical error on the corruption-only overflow) |

## ⚠️ Bonus fix — NULL-deref in `Validate()`
Both element-validation loops called `m_TagVals[i].ptr->Validate(...)` with **no NULL check**, but `Read()` legitimately stores `NULL` for **sparse slots** (zero offset/size entries — `:1362`), and `Describe()`/`Write()`/`Cleanup()` all guard the deref. A profile with a sparse tag array therefore **crashed `iccDumpProfile -v`** on validation. Now guarded as the siblings do.

## Scope / verification
- Source-only (IccProfLib); no Build/CMake/CI changes.
- `iccDumpProfile -v` on the MCS tag-array sample profiles (`Testing/mcs/*-MVIS.icc`) validates clean — no regression on the normal path.
- A crafted sparse-array fixture for the NULL-deref will follow as a paired in-repo regression test (fork-gate split).

## Not in this PR
`Write()` (#965) is left to its current assignee — a single guard on its `if (m_nSize)` block (:1441) resolves all three Write loops (**#964 / #965 / #966**) together, so it's cleaner for that owner to land it than to split it here.

Fixes alerts #962, #963, #969, #970.

🤖 Generated with [Claude Code](https://claude.com/claude-code)