### PR TITLE
Fix: bound remaining profile-field-driven loops in IccTagBasic (unbounded-profile-loop)

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -3391,6 +3391,14 @@ void CIccTagNamedColor2::Describe(std::string &sDescription, int /* nVerboseness
   if (m_nSize > kMaxNamedColorEntries)
     return;
 
+  // CWE-400/CWE-834: each entry's device-coordinate count is the second profile-
+  // controlled dimension. Read() caps it at kMaxNamedColorDeviceCoords and sizes
+  // every entry to match; assert that bound here so the inner per-entry coordinate
+  // walk below can't run unbounded on a corrupted m_nDeviceCoords.
+  const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+  if (m_nDeviceCoords > kMaxNamedColorDeviceCoords)
+    return;
+
   for (i=0; i<m_nSize; i++) {
     snprintf(buf, bufSize, "Color[%u]: %s :", (unsigned int)i, pNamedColor->rootName);
     sDescription += buf;
@@ -4147,6 +4155,14 @@ icValidateStatus CIccTagXYZ::Validate(std::string sigPath, std::string &sReport,
     rv = icMaxStatus(rv, icValidateWarning);
     return rv;
   }
+
+  // CWE-400/CWE-834: m_nSize is derived from the tag byte size in Read() and the
+  // m_XYZ array is allocated to match; assert the same explicit ceiling Describe()
+  // uses (see CIccTagXYZ::Describe) so a corrupted count can't drive an unbounded
+  // validation walk over m_XYZ.
+  const icUInt32Number nMaxXYZValues = 65536;
+  if (m_nSize > nMaxXYZValues)
+    return icMaxStatus(rv, icValidateCriticalError);
 
   for (int i=0; i<(int)m_nSize; i++) {
     rv = icMaxStatus(rv, Info.CheckData(sReport, m_XYZ[i], sSigPathName + ":XYZ"));
@@ -4976,6 +4992,13 @@ bool CIccTagSparseMatrixArray::Read(icUInt32Number size, CIccIO *pIO)
   if (!Reset(nNumMatrices, nChannels))
     return false;
 
+  // CWE-400/CWE-834: Reset() set m_nSize from the already-capped nNumMatrices, so
+  // this is normally an invariant assertion; state it in terms of the field so the
+  // read loop below - and the Write()/Describe() walks that also iterate m_nSize -
+  // carry an explicit upper bound against a corrupted count.
+  if (m_nSize > kMaxSparseMatrixArrayCount)
+    return false;
+
   icUInt8Number *matrix_end = m_RawData + (size_t)m_nSize * nBytesPerMatrix;  // overflow detection
 
   if (m_nSize) {
@@ -5187,6 +5210,13 @@ bool CIccTagSparseMatrixArray::Write(CIccIO *pIO)
   if (nNeededSize >= (0x100000000ULL - pIO->Tell()))
     return false;
 
+  // CWE-400/CWE-834: Read() caps the matrix count at kMaxSparseMatrixArrayCount;
+  // assert the same ceiling on m_nSize here so an object whose count was corrupted
+  // through another path can't drive an unbounded write walk over m_RawData.
+  const icUInt32Number kMaxSparseMatrixArrayCount = 65536;
+  if (m_nSize > kMaxSparseMatrixArrayCount)
+    return false;
+
   for (i=0; i<(int)m_nSize; i++) {
     icUInt8Number *pMatrix = m_RawData + (size_t)i * nBytesPerMatrix;
     if (!mtx.Reset(pMatrix, nBytesPerMatrix, icSparseMatrixFloatNum, true))
@@ -5261,6 +5291,12 @@ void CIccTagSparseMatrixArray::Describe(std::string &sDescription, int /* nVerbo
 
   int i, r, c;
   icUInt32Number nBytesPerMatrix = m_nChannelsPerMatrix * sizeof(icFloatNumber);
+  // CWE-400/CWE-834: Read() caps the matrix count at kMaxSparseMatrixArrayCount;
+  // assert the same ceiling so a corrupted m_nSize can't drive an unbounded
+  // describe walk over the matrix array.
+  const icUInt32Number kMaxSparseMatrixArrayCount = 65536;
+  if (m_nSize > kMaxSparseMatrixArrayCount)
+    return;
   for (i=0; i<(int)m_nSize; i++) {
     CIccSparseMatrix mtx(&m_RawData[i*nBytesPerMatrix], nBytesPerMatrix, icSparseMatrixFloatNum, true);
 
@@ -5870,10 +5906,16 @@ void CIccTagFixedNum<T, Tsig>::Describe(std::string &sDescription, int /* nVerbo
 
       sDescription += "\nArrayForm:\n";
     }
+    // CWE-400/CWE-834: m_nSize is derived from the tag byte size in Read() and the
+    // m_Num array is allocated to match; assert an explicit ceiling so a corrupted
+    // count can't drive an unbounded describe walk over the value array.
+    const icUInt32Number nMaxNumArrayEntries = 0xffffff;
+    if (m_nSize > nMaxNumArrayEntries)
+      return;
     sDescription.reserve(sDescription.size() + m_nSize*79);
 
     for (i=0; i<m_nSize; i++) {
-      if (Tsig==icSigS15Fixed16ArrayType) 
+      if (Tsig==icSigS15Fixed16ArrayType)
         snprintf(buf, bufSize, "Value[%u] = %8.4lf\n", (unsigned int)i, icFtoD(m_Num[i]));
       else
         snprintf(buf, bufSize, "Value[%u] = %8.4lf\n", (unsigned int)i, icUFtoD(m_Num[i]));
@@ -6091,6 +6133,13 @@ bool CIccTagFixedNum<T, Tsig>::ValuePos(icFloatNumber &DstPos, icFloatNumber val
     DstPos = val/lv - 1.0f;
     return true;
   }
+
+  // CWE-400/CWE-834: m_nSize is bounded by the tag byte size in Read() and m_Num is
+  // allocated to match; assert an explicit ceiling so a corrupted count can't drive
+  // an unbounded search of the value array below.
+  const icUInt32Number nMaxNumArrayEntries = 0xffffff;
+  if (m_nSize > nMaxNumArrayEntries)
+    return false;
 
   icUInt32Number i;
   for (i=1; i<m_nSize; i++, lv=nv) {
@@ -6381,6 +6430,12 @@ void CIccTagNum<T, Tsig>::Describe(std::string &sDescription, int /* nVerbosenes
   }
   else {
     icUInt32Number i;
+    // CWE-400/CWE-834: m_nSize is derived from the tag byte size in Read() and the
+    // m_Num array is allocated to match; assert an explicit ceiling so a corrupted
+    // count can't drive an unbounded describe walk over the value array.
+    const icUInt32Number nMaxNumArrayEntries = 0xffffff;
+    if (m_nSize > nMaxNumArrayEntries)
+      return;
     sDescription.reserve(sDescription.size() + m_nSize*79);
 
     for (i=0; i<m_nSize; i++) {
@@ -6441,6 +6496,12 @@ void CIccTagNum<icUInt64Number, icSigUInt64ArrayType>::Describe(std::string &sDe
   }
   else {
     icUInt32Number i;
+    // CWE-400/CWE-834: m_nSize is derived from the tag byte size in Read() and the
+    // m_Num array is allocated to match; assert an explicit ceiling so a corrupted
+    // count can't drive an unbounded describe walk (icUInt64Array specialization).
+    const icUInt32Number nMaxNumArrayEntries = 0xffffff;
+    if (m_nSize > nMaxNumArrayEntries)
+      return;
     sDescription.reserve(sDescription.size() + m_nSize*79);
 
     for (i=0; i<m_nSize; i++) {
@@ -6683,6 +6744,13 @@ bool CIccTagNum<T, Tsig>::ValuePos(icFloatNumber &DstPos, icFloatNumber val, boo
     DstPos = val/lv - 1.0f;
     return true;
   }
+
+  // CWE-400/CWE-834: m_nSize is bounded by the tag byte size in Read() and m_Num is
+  // allocated to match; assert an explicit ceiling so a corrupted count can't drive
+  // an unbounded search of the value array below.
+  const icUInt32Number nMaxNumArrayEntries = 0xffffff;
+  if (m_nSize > nMaxNumArrayEntries)
+    return false;
 
   icUInt32Number i;
   for (i=1; i<m_nSize; i++, lv=nv) {
@@ -7012,7 +7080,14 @@ void CIccTagFloatNum<T, Tsig>::Describe(std::string &sDescription, int /* nVerbo
       n=8;
     else
       n=4;
-    
+
+    // CWE-400/CWE-834: m_nSize is derived from the tag byte size in Read() and the
+    // m_Num array is allocated to match; assert an explicit ceiling so a corrupted
+    // count can't drive an unbounded describe walk over the value array.
+    const icUInt32Number nMaxNumArrayEntries = 0xffffff;
+    if (m_nSize > nMaxNumArrayEntries)
+      return;
+
     for (i=0; i<m_nSize; i++) {
       if (i&& !(i%n))
         sDescription += "\n";
@@ -7242,6 +7317,13 @@ bool CIccTagFloatNum<T, Tsig>::ValuePos(icFloatNumber &DstPos, icFloatNumber val
     DstPos = val/lv - 1.0f;
     return true;
   }
+
+  // CWE-400/CWE-834: m_nSize is bounded by the tag byte size in Read() and m_Num is
+  // allocated to match; assert an explicit ceiling so a corrupted count can't drive
+  // an unbounded search of the value array below.
+  const icUInt32Number nMaxNumArrayEntries = 0xffffff;
+  if (m_nSize > nMaxNumArrayEntries)
+    return false;
 
   icUInt32Number i;
   for (i=1; i<m_nSize; i++, lv=nv) {
@@ -8716,6 +8798,14 @@ void CIccTagData::Describe(std::string &sDescription, int /* nVerboseness */)
   const size_t bufSize = 128;
   icChar buf[bufSize];
 
+  // CWE-400/CWE-834: m_nSize is the data byte count derived from the tag byte size
+  // in Read() and m_pData is allocated to match; assert an explicit ceiling so a
+  // corrupted size can't drive either of the per-byte describe walks below
+  // (Ascii and UTF-8 branches) past a sane limit.
+  const icUInt32Number nMaxTagDataBytes = 0x10000000;
+  if (m_nSize > nMaxTagDataBytes)
+    return;
+
   sDescription = "\n";
   if (IsTypeCompressed())
     sDescription += "Compressed ";  // If data is compressed, prepend appropriate text
@@ -8806,6 +8896,17 @@ icValidateStatus CIccTagData::Validate(std::string sigPath, std::string &sReport
 
   CIccInfo Info;
   std::string sSigPathName = Info.GetSigPathName(sigPath);
+
+  // CWE-400/CWE-834: m_nSize is the data byte count derived from the tag byte size
+  // in Read() and m_pData is allocated to match; assert an explicit ceiling so a
+  // corrupted size can't drive the per-byte Ascii scan below past a sane limit.
+  const icUInt32Number nMaxTagDataBytes = 0x10000000;
+  if (m_nSize > nMaxTagDataBytes) {
+    sReport += icMsgValidateCriticalError;
+    sReport += sSigPathName;
+    sReport += " - Data size exceeds sane maximum.\n";
+    return icMaxStatus(rv, icValidateCriticalError);
+  }
 
   // Mask bits to match processing in Describe() so warnings are appropriate
   switch(m_nDataFlag&(icCompressedData|icDataTypeMask)) {
@@ -9506,6 +9607,12 @@ bool CIccTagColorantTable::Write(CIccIO *pIO)
 
   size_t nNum8 = sizeof(m_pData->name);
   size_t nNum16 = sizeof(m_pData->data)/sizeof(icUInt16Number);
+
+  // CWE-400/CWE-834: Read() rejects nCount > 0xffff and sizes m_pData to match;
+  // assert the same ceiling on m_nCount here so an object whose count was corrupted
+  // through another path can't drive an unbounded write walk over m_pData.
+  if (m_nCount > 0xffff)
+    return false;
 
   for (icUInt32Number i=0; i<m_nCount; i++) {
     if (pIO->Write8(&m_pData[i].name[0],nNum8) != nNum8)
@@ -12690,6 +12797,13 @@ void CIccTagEmbeddedHeightImage::Describe(std::string &sDescription, int /* nVer
 
   sDescription += "\nImage Data:\n";
 
+  // CWE-400/CWE-834: m_nSize is the image byte count derived from the tag byte size
+  // in Read() and m_pData is allocated to match; assert an explicit ceiling so a
+  // corrupted size can't drive an unbounded per-byte hex dump of the image data.
+  const icUInt32Number nMaxImageDataBytes = 0x10000000;
+  if (m_nSize > nMaxImageDataBytes)
+    return;
+
   for (int i = 0; i<(int)m_nSize; i++) {
     if (!(i & 0x1f))
       sDescription += "\n";
@@ -12994,6 +13108,13 @@ void CIccTagEmbeddedNormalImage::Describe(std::string &sDescription, int /* nVer
   sDescription += buf;
 
   sDescription += "\nImage Data:\n";
+
+  // CWE-400/CWE-834: m_nSize is the image byte count derived from the tag byte size
+  // in Read() and m_pData is allocated to match; assert an explicit ceiling so a
+  // corrupted size can't drive an unbounded per-byte hex dump of the image data.
+  const icUInt32Number nMaxImageDataBytes = 0x10000000;
+  if (m_nSize > nMaxImageDataBytes)
+    return;
 
   for (int i = 0; i < (int)m_nSize; i++) {
     if (!(i & 0x1f))


### PR DESCRIPTION
## Summary

Completes the CodeQL **`iccdev/unbounded-profile-loop`** remediation for `IccProfLib/IccTagBasic.cpp` started in #989 (Read-time count caps) and #1251 (in-loop guards). The CodeQL scan **after** #1251 (category `iccdev-custom-security`, run on `b1141410`) still flags **18 loops** — these are not stale; they are exactly the loops #1251's pass left behind.

**Fixes 18 alerts:** #916 #917 #918 #922 #923 #924 #925 #926 #927 #928 #929 #930 #931 #933 #934 #935 #937 #943.

## Why #1251 missed them (systematic gaps)

- Guarded each tag's `Describe()` but not its sibling `Validate()` / `Write()` / `ValuePos()` walks (e.g. `CIccTagXYZ::Describe` is guarded, `::Validate` #937 was not).
- Re-guarded the **primary** count `m_nSize` but not **secondary** fields — `m_nDeviceCoords` (#943), `m_nCount` (#918).
- Never covered the numeric **`ValuePos()`** interpolation helpers (#930/#928/#925).

The query only credits an in-function `if (<field> > <bound>)` that references the **field itself**, so the pre-existing guards on locals (`nNum`/`nCount`/`nNumMatrices`/`nSize` param) are invisible to it.

## Severity framing

Every count here is derived in `Read()` as `(tagSize − header)/elemSize`, with the backing array allocated to match and `SetSize()` failing the `realloc` on extreme sizes. Work is **linear in input** — no small-input→huge-work amplification (the amplifiable count×struct cases, SparseMatrix/NamedColor, were capped in #989). These are **defense-in-depth ceilings + clean CodeQL**, matching the established house pattern in `CIccTagXYZ::Describe` / `CIccTagNamedColor2::Describe`.

## Loops bounded

| Tag method | Field | Cap |
|---|---|---|
| `CIccTagXYZ::Validate` | `m_nSize` | 65536 (reuses SetSize/Describe cap) |
| `CIccTagSparseMatrixArray::Read` / `Write` / `Describe` | `m_nSize` | 65536 (reuses Read cap) |
| `CIccTagNamedColor2::Describe` inner per-entry walk | `m_nDeviceCoords` | 256 (reuses Read cap) |
| `CIccTagFixedNum` / `Num` / `FloatNum` `Describe` + `ValuePos` | `m_nSize` | `0xffffff` |
| `CIccTagNum<icUInt64Number>::Describe` (specialization) | `m_nSize` | `0xffffff` |
| `CIccTagData::Describe` (Ascii + UTF-8) + `Validate` | `m_nSize` | `0x10000000` |
| `CIccTagColorantTable::Write` | `m_nCount` | `0xffff` (reuses Read cap) |
| `CIccTagEmbeddedHeightImage` / `EmbeddedNormalImage` `::Describe` | `m_nSize` | `0x10000000` |

Caps reuse each tag's existing Read()-time limit where one exists; numeric arrays use `0xffffff` (matches IccTagComposite, #1480); byte/image arrays use `0x10000000` (= existing `MAX_UNKNOWN_TAG_SIZE`) so legitimate embedded PNG/TIFF image data is **never** rejected.

## Left intentionally unchanged

The three NUL-terminated **string-scan** loops — `CIccTagText::Validate`, `CIccTagZipUtf8Text::Validate`, `CIccTagTextDescription::Describe` (#1991 #950 #949). They iterate `i < m_nBufSize && szText[i]` over an allocated, NUL-terminated, size-capped buffer (the textbook-safe `strlen`-style idiom); a count guard there adds no safety.

## Verification

- `IccProfLib2-static` builds clean (no tautology warnings — all fields are `icUInt32Number`).
- `iccDumpProfile -v 100 <p> ALL` validates **rc=0 / no regression** on profiles exercising the guarded paths: FloatNum + XYZ `Describe` (`18ChanWithSpots-MVIS`), NamedColor2 `Describe` incl. device coords (`Named/NamedColorV4`), SparseMatrix `Describe` (`Named/SparseMatrixNamedColor`).

## Adjacent (out of scope, noted for follow-up)

`CIccTagText::Read` does not check `GetBuffer()`'s return before `Read8`-ing into it — a possible NULL-deref on a failed large allocation. Unrelated to this cluster; flagged for a separate look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)