### PR TITLE
Fix: bound m_nNumInput + NULL-safe curve walks in CIccXformNDLut::Begin (unbounded-profile-loop)

### DIFF
--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -6683,14 +6683,33 @@ icStatusCMM CIccXformNDLut::Begin()
 
   m_nNumInput = m_pTag->m_nInput;
 
+  // CWE-400/CWE-834: m_nNumInput is a copy of the tag's icUInt8Number input channel
+  // count (m_pTag->m_nInput), so it is bounded to 0..255, and the m_Curves* arrays
+  // walked below are allocated to match it (CIccMBB::NewCurvesA/B/M size by
+  // m_nInput/m_nOutput). Assert that bound explicitly and reject an out-of-range
+  // count as an invalid LUT so the per-channel curve walks can never be driven past
+  // those arrays even if the count reached this object corrupted.
+  const int kMaxLutInputChannels = 256;
+  if (m_nNumInput < 0 || m_nNumInput >= kMaxLutInputChannels)
+    return icCmmStatInvalidLut;
+
   m_ApplyCurvePtrA = m_ApplyCurvePtrB = m_ApplyCurvePtrM = NULL;
 
   if (m_pTag->m_bInputMatrix) {
     if (m_pTag->m_CurvesB) {
       Curve = m_pTag->m_CurvesB;
 
-      for (i=0; i<m_nNumInput; i++)
+      // CWE-476: a Read()-accepted tag can still carry NULL curve slots when the
+      // profile declared more channels than it supplied curves - CIccMBB::Validate
+      // reports exactly this as "Incorrect number of B-curves". The apply path skips
+      // Validate, so reject a missing curve here as an invalid LUT instead of
+      // dereferencing NULL. After this loop every Curve[i] (i<count) is non-NULL, so
+      // the IsIdentity walk below needs no further guard.
+      for (i=0; i<m_nNumInput; i++) {
+        if (!Curve[i])
+          return icCmmStatInvalidLut;
         Curve[i]->Begin();
+      }
 
       for (i=0; i<m_nNumInput; i++) {
         if (!Curve[i]->IsIdentity()) {
@@ -6707,7 +6726,11 @@ icStatusCMM CIccXformNDLut::Begin()
     if (m_pTag->m_CurvesA) {
       Curve = m_pTag->m_CurvesA;
 
+      // CWE-476: reject NULL curve slots (see the m_CurvesB note above) so this
+      // output-side walk can't dereference a missing A-curve on a malformed tag.
       for (i=0; i<m_pTag->m_nOutput; i++) {
+        if (!Curve[i])
+          return icCmmStatInvalidLut;
         Curve[i]->Begin();
       }
 
@@ -6724,8 +6747,13 @@ icStatusCMM CIccXformNDLut::Begin()
     if (m_pTag->m_CurvesA) {
       Curve = m_pTag->m_CurvesA;
 
-      for (i=0; i<m_nNumInput; i++)
+      // CWE-476: reject NULL curve slots (see the m_CurvesB note above) so this
+      // input-side walk can't dereference a missing A-curve on a malformed tag.
+      for (i=0; i<m_nNumInput; i++) {
+        if (!Curve[i])
+          return icCmmStatInvalidLut;
         Curve[i]->Begin();
+      }
 
       for (i=0; i<m_nNumInput; i++) {
         if (!Curve[i]->IsIdentity()) {
@@ -6742,7 +6770,11 @@ icStatusCMM CIccXformNDLut::Begin()
     if (m_pTag->m_CurvesM) {
       Curve = m_pTag->m_CurvesM;
 
+      // CWE-476: reject NULL curve slots (see the m_CurvesB note above) so this
+      // output-side walk can't dereference a missing M-curve on a malformed tag.
       for (i=0; i<m_pTag->m_nOutput; i++) {
+        if (!Curve[i])
+          return icCmmStatInvalidLut;
         Curve[i]->Begin();
       }
 
@@ -6757,7 +6789,11 @@ icStatusCMM CIccXformNDLut::Begin()
     if (m_pTag->m_CurvesB) {
       Curve = m_pTag->m_CurvesB;
 
+      // CWE-476: reject NULL curve slots (see the m_CurvesB note above) so this
+      // output-side walk can't dereference a missing B-curve on a malformed tag.
       for (i=0; i<m_pTag->m_nOutput; i++) {
+        if (!Curve[i])
+          return icCmmStatInvalidLut;
         Curve[i]->Begin();
       }
 


### PR DESCRIPTION
## Summary

Resolves the IccCmm portion of the CodeQL **`iccdev/unbounded-profile-loop`** backlog — alerts **#815 #816 #819 #820**, all in `CIccXformNDLut::Begin()` — and fixes a reachable NULL-deref on the apply path found while confirming those loops.

## The 4 alerts (bounded; cleared by a field guard)

The four flagged loops iterate `m_nNumInput` over the tag's per-channel curve arrays. `m_nNumInput` is declared **`int`** (so CodeQL treats it as an unbounded count), but it is only ever assigned `m_pTag->m_nInput` — an **`icUInt8Number`** — so its value is bounded to `0..255`. A guard right after that assignment states the invariant in terms of the field and rejects an out-of-range count as an invalid LUT, which the query credits for all four loops:

```cpp
const int kMaxLutInputChannels = 256;
if (m_nNumInput < 0 || m_nNumInput >= kMaxLutInputChannels)
  return icCmmStatInvalidLut;
```

## Adjacent bug fixed: NULL-deref on the apply path (CWE-476)

`m_Curves{A,B,M}` slots are `memset` to NULL on allocation (`CIccMBB::NewCurvesA/B/M`), and a profile that declares more channels than it supplies curves leaves NULL slots in a **Read()-accepted** tag — `CIccMBB::Validate` explicitly handles this and reports *"Incorrect number of B-curves"*. But `Begin()` is on the **apply path**, which does not require a prior `Validate()`, and it called `Curve[i]->Begin()` / `Curve[i]->IsIdentity()` with **no NULL check** → crash on such a malformed profile.

Each of the five curve blocks now rejects a NULL slot (`return icCmmStatInvalidLut`) in its first walk. Because that leaves every `Curve[i]` non-NULL, the following `IsIdentity` walk needs no further guard, and `Apply()` never runs on a half-built transform.

No out-of-bounds component: loop bounds match the array sizes exactly — `IsInputB() == IsInputMatrix() == m_bInputMatrix` gates the `m_nInput` vs `m_nOutput` sizing in `NewCurves*`, and the input loops use `m_nNumInput == m_nInput`.

## Left for follow-up (noted, not touched)

`CIccXform3DLut::Begin()` and `CIccXform4DLut::Begin()` dereference the same curve slots without a NULL check (fixed `Curve[0..2]`/`Curve[0..3]` **and** `m_nOutput` loops) — the identical latent crash. Left for a focused follow-up rather than expanding this cluster's change across the apply hot path.

## Verification

- `IccProfLib2-static` builds clean.
- `iccRoundTrip` on a 3-channel profile (`sRGB_v4_ICC_preference`) is unchanged — valid-profile apply path intact. (The MCS/multiplex MVIS samples report "Invalid profile" on master too — pre-existing, unrelated to this change.)
- Guards fire only on `m_nNumInput >= 256` or a NULL curve slot, neither of which occurs for a well-formed profile, so valid profiles are unaffected by construction.
- A crafted-malformed-profile regression test (NULL curve slot → clean reject instead of crash) is a sensible fork-gate-split follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)