### PR TITLE
Fix: signed-shift UB in CIccTagXmlMultiLocalizedUnicode::ToXml language-code pack (#1483)

### DIFF
--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -1917,8 +1917,15 @@ bool CIccTagXmlMultiLocalizedUnicode::ToXml(std::string &xml, std::string blanks
 
   for (i=m_Strings->begin(); i!=m_Strings->end(); i++) {
     icUtf16ToUtf8(bufstr, i->GetBuf(), i->GetLength());
+    // Pack the 16-bit language/country codes into the 32-bit signature expected by
+    // icGetSigStr(). m_nLanguageCode is a 16-bit unsigned that promotes to (signed)
+    // int before the shift, so a high-bit language code (>= 0x8000) makes
+    // m_nLanguageCode<<16 overflow into negative territory -- signed overflow UB,
+    // and the resulting negative int silently wraps when passed to icGetSigStr's
+    // icUInt32Number parameter. Cast to icUInt32Number first so the whole pack is
+    // computed in well-defined unsigned arithmetic.
     icXmlDumpLocalizedText(xml, blanks, "LocalizedText",
-                           icGetSigStr(data, 256, (i->m_nLanguageCode<<16) + i->m_nCountryCode),
+                           icGetSigStr(data, 256, ((icUInt32Number)i->m_nLanguageCode<<16) + i->m_nCountryCode),
                            bufstr);
   }
   return true;
@@ -4578,8 +4585,11 @@ bool CIccTagXmlProfileSequenceId::ToXml(std::string &xml, std::string blanks/* =
 
       for (i=pid->m_desc.m_Strings->begin(); i!=pid->m_desc.m_Strings->end(); i++) {
         icUtf16ToUtf8(bufstr, i->GetBuf(), i->GetLength());
+        // Cast to icUInt32Number before the shift: see CIccTagXmlMultiLocalizedUnicode::ToXml
+        // -- m_nLanguageCode<<16 otherwise promotes to signed int and overflows for
+        // language codes >= 0x8000, then wraps when handed to icGetSigStr.
         icXmlDumpLocalizedText(xml, blanks + " ", "LocalizedText",
-                               icGetSigStr(data, bufSize, (i->m_nLanguageCode<<16) + i->m_nCountryCode),
+                               icGetSigStr(data, bufSize, ((icUInt32Number)i->m_nLanguageCode<<16) + i->m_nCountryCode),
                                bufstr);
       }
     }
@@ -4669,8 +4679,10 @@ bool CIccTagXmlDict::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
         for (i=nv->GetNameLocalized()->m_Strings->begin(); i!=nv->GetNameLocalized()->m_Strings->end(); i++) {
           icUtf16ToUtf8(bufstr, i->GetBuf(), i->GetLength());
+          // Cast to icUInt32Number before the shift: see CIccTagXmlMultiLocalizedUnicode::ToXml
+          // -- avoids signed-int overflow / value-changing wrap for language codes >= 0x8000.
           icXmlDumpLocalizedText(xml, blanks + "  ", "LocalizedName",
-                                 icGetSigStr(data, bufSize, (i->m_nLanguageCode<<16) + i->m_nCountryCode),
+                                 icGetSigStr(data, bufSize, ((icUInt32Number)i->m_nLanguageCode<<16) + i->m_nCountryCode),
                                  bufstr);
         }
       }
@@ -4679,8 +4691,10 @@ bool CIccTagXmlDict::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
         for (i=nv->GetValueLocalized()->m_Strings->begin(); i!=nv->GetValueLocalized()->m_Strings->end(); i++) {
           icUtf16ToUtf8(bufstr, i->GetBuf(), i->GetLength());
+          // Cast to icUInt32Number before the shift: see CIccTagXmlMultiLocalizedUnicode::ToXml
+          // -- avoids signed-int overflow / value-changing wrap for language codes >= 0x8000.
           icXmlDumpLocalizedText(xml, blanks + "  ", "LocalizedValue",
-                                 icGetSigStr(data, bufSize, (i->m_nLanguageCode<<16) + i->m_nCountryCode),
+                                 icGetSigStr(data, bufSize, ((icUInt32Number)i->m_nLanguageCode<<16) + i->m_nCountryCode),
                                  bufstr);
         }
       }


### PR DESCRIPTION
Fixes #1483.

## Problem
`CIccTagXmlMultiLocalizedUnicode::ToXml()` packs the per-string 16-bit language/country codes into the 32-bit signature `icGetSigStr()` wants:

```cpp
icGetSigStr(data, 256, (i->m_nLanguageCode<<16) + i->m_nCountryCode)
```

`m_nLanguageCode` is `icUInt16Number`, which integer-promotes to **signed** `int` before `<<16`. Any language code with the high bit set (`>= 0x8000`) makes `m_nLanguageCode<<16` overflow into a negative `int` (signed-overflow UB), and that negative value silently wraps when handed to `icGetSigStr`'s `icUInt32Number` parameter:

```
IccTagXml.cpp:1921:51: runtime error: implicit conversion from type 'int' of value
-1737599661 (32-bit, signed) to type 'icUInt32Number' (aka 'unsigned int') changed
the value to 2557367635 (32-bit, unsigned)
```

## Fix
Cast `m_nLanguageCode` to `icUInt32Number` before the shift so the whole pack is computed in well-defined unsigned arithmetic. The result is **value-preserving** on two's-complement targets — only the UB is removed — so emitted XML is byte-identical.

The same idiom appears at **4 identical call sites**; all are fixed:
- `CIccTagXmlMultiLocalizedUnicode::ToXml` (the reported line 1921)
- `CIccTagXmlProfileSequenceId::ToXml` (`LocalizedText`)
- `CIccTagXmlDict::ToXml` (`LocalizedName`)
- `CIccTagXmlDict::ToXml` (`LocalizedValue`)

## Verification
- `IccXML2-static` + `iccToXml` build clean.
- The reporter's exact UBSan flags (`-fsanitize=...,integer,...`) on a minimal repro of the expression: the original `(lang<<16)+ctry` triggers the *implicit conversion … changed the value* diagnostic; the casted form is clean — and **both compute the identical value** (`0x987F1593`), confirming the fix changes no behavior.
- `iccToXml` on the crafted repro profile from the issue: output **byte-identical** before vs after the fix (the crafted high-bit code `LanguageCountry="986E5553h"` still round-trips exactly), `rc=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)