### PR TITLE
Fix: bound IccXML ToXml/ParseXml serialization loops driven by profile fields

### DIFF
--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2466,6 +2466,15 @@ bool CIccMpeXmlCalculator::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
   int i;
 
+  // CWE-400/CWE-834: the walk below iterates m_nSubElem over m_SubElem[].
+  // CIccMpeCalculator::Read() caps m_nSubElem at MAX_CALC_ELEMENTS and allocates
+  // m_SubElem to match (IccMpeCalc.cpp), so on a valid element the walk never
+  // exceeds the allocation; assert that same bound so a corrupted count can't
+  // drive an unbounded serialization walk.
+  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  if (m_nSubElem > MAX_CALC_ELEMENTS)
+    return false;
+
   if (m_SubElem && m_nSubElem) {
     xml += blanks2 + "<SubElements>\n";
     for (i=0; i<(int)m_nSubElem; i++) {

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -840,6 +840,17 @@ bool CIccTagXmlNamedColor2::ToXml(std::string &xml, std::string blanks/* = ""*/)
   int i, j;
   std::string str;
 
+  // CWE-400/CWE-834: the entry walk below iterates m_nSize and, per entry, the
+  // device-coord walk iterates m_nDeviceCoords. Read() caps these at
+  // kMaxNamedColorEntries / kMaxNamedColorDeviceCoords and sizes the entry list
+  // and each entry's deviceCoords[] to match (IccTagBasic.cpp), so on a valid
+  // tag the loops never exceed the allocations; assert those same bounds here so
+  // a corrupted count can't drive an unbounded serialization walk.
+  const icUInt32Number kMaxNamedColorEntries = 65536;
+  const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+  if (m_nSize > kMaxNamedColorEntries || m_nDeviceCoords > kMaxNamedColorDeviceCoords)
+    return false;
+
   snprintf(line, bufSize, "<NamedColors VendorFlag=\"%08x\" CountOfDeviceCoords=\"%d\" DeviceEncoding=\"int16\"", (unsigned int) m_nVendorFlags, (unsigned int) m_nDeviceCoords);
   xml += blanks + line;
 
@@ -1015,8 +1026,14 @@ bool CIccTagXmlNamedColor2::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
                 coords.ParseArray(pNode->children);
                 icUInt8Number *pBuf = coords.GetBuf();
 
+                // CWE-400/CWE-834: clamp the field to the same load-time bound as
+                // the float branch below (deviceCoords[] is sized to it) so a
+                // corrupted count can't drive an out-of-range copy.
+                const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+                icUInt32Number nDevCoords = (m_nDeviceCoords > kMaxNamedColorDeviceCoords)
+                                              ? kMaxNamedColorDeviceCoords : m_nDeviceCoords;
                 icUInt32Number j;
-                for (j = 0; j < m_nDeviceCoords && j < coords.GetSize(); j++) {
+                for (j = 0; j < nDevCoords && j < coords.GetSize(); j++) {
                   pNamedColor->deviceCoords[j] = (icFloatNumber)pBuf[j] / 255.0f;
                 }
               }
@@ -1026,8 +1043,14 @@ bool CIccTagXmlNamedColor2::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
                 coords.ParseArray(pNode->children);
                 icUInt16Number *pBuf = coords.GetBuf();
 
+                // CWE-400/CWE-834: clamp the field to the same load-time bound as
+                // the float branch below (deviceCoords[] is sized to it) so a
+                // corrupted count can't drive an out-of-range copy.
+                const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+                icUInt32Number nDevCoords = (m_nDeviceCoords > kMaxNamedColorDeviceCoords)
+                                              ? kMaxNamedColorDeviceCoords : m_nDeviceCoords;
                 icUInt32Number j;
-                for (j = 0; j < m_nDeviceCoords && j < coords.GetSize(); j++) {
+                for (j = 0; j < nDevCoords && j < coords.GetSize(); j++) {
                   pNamedColor->deviceCoords[j] = (icFloatNumber)pBuf[j] / 65535.0f;
                 }
               }
@@ -1632,6 +1655,13 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ToXml(std::string &xml, std::string blanks/
 {
   const size_t bufSize = 512;
   char buf[bufSize];
+
+  // CWE-400/CWE-834: m_nSize is bounded by the tag byte size in Read() and m_Num is
+  // allocated to match; assert the same explicit upper limit used by the FixedNum/Num
+  // siblings so a corrupted count can't drive an unbounded serialization walk.
+  const icUInt32Number nMaxNumValues = 0xffffff;
+  if (this->m_nSize > nMaxNumValues)
+    return false;
 
   if (this->m_nSize==1) {
 #ifdef _WIN32
@@ -2791,6 +2821,15 @@ bool CIccTagXmlCurve::ToXml(std::string &xml, icConvertType nType, std::string b
   const size_t bufSize = 40;
   char buf[bufSize];
   int i;
+
+  // CWE-400/CWE-834: each encoding branch below walks m_Curve over m_nSize.
+  // CIccTagCurve::Read() bounds m_nSize by the tag byte size and allocates
+  // m_Curve to match (IccTagLut.cpp), so on a valid tag the walk never exceeds
+  // the allocation; assert an explicit upper limit so a corrupted count can't
+  // drive an unbounded serialization walk.
+  const icUInt32Number nMaxCurveEntries = 0xffffff;
+  if (m_nSize > nMaxCurveEntries)
+    return false;
 
   if (!m_nSize) {
     xml += blanks + "<Curve/>\n";


### PR DESCRIPTION
## Summary

Clears the **IccXML cluster of the `iccdev/unbounded-profile-loop` CodeQL alerts** (8 alerts: #1029, #1035, #1042, #1043, #1045, #1047, #2219, #2220). Each is a serialization/parse loop whose iteration count comes straight from a profile field with no in-function upper-bound guard the query can see.

| File | Function | Field | Alerts |
|------|----------|-------|--------|
| `IccTagXml.cpp` | `CIccTagXmlNamedColor2::ToXml` | `m_nSize` entries + `m_nDeviceCoords` coords | #1045 |
| `IccTagXml.cpp` | `CIccTagXmlNamedColor2::ParseXml` | `m_nDeviceCoords` (int8 + int16) | #1042, #1043 |
| `IccTagXml.cpp` | `CIccTagXmlFloatNum<>::ToXml` | `m_nSize` | #1047 |
| `IccTagXml.cpp` | `CIccTagXmlCurve::ToXml` | `m_nSize` (8/16/float branches) | #2219, #2220, #1035 |
| `IccMpeXml.cpp` | `CIccMpeXmlCalculator::ToXml` | `m_nSubElem` | #1029 |

## Why these are bounded (and why we still guard)

In every case the field is already capped at load time and the backing array is allocated to match, so a **valid** profile never exceeds the allocation:

- `kMaxNamedColorEntries` (65536) / `kMaxNamedColorDeviceCoords` (256) — `IccTagBasic.cpp`
- `CIccTagCurve::Read` bounds `m_nSize` by the tag byte size — `IccTagLut.cpp`
- `MAX_CALC_ELEMENTS` (65536) — `IccMpeCalc.cpp`

These guards are **defense-in-depth**: they assert the same bound in the serializer so a corrupted count on an in-memory object can't drive an unbounded walk. The query is satisfied by an in-function `if (field > MAX)` guard / a clamped loop local.

## House-style consistency

- ToXml sites use the existing **`if (field > MAX) return false;`** idiom already present on the `FixedNum`/`Num` siblings in this file.
- The ParseXml int8/int16 branches reuse the **clamp-to-local** pattern already present in the sibling `float` branch (which was previously fixed).

## Verification

- `IccXML2-static` builds clean; `iccToXml` / `iccFromXml` build clean.
- Value-preserving on profiles that exercise every guarded path:
  - `Testing/Named/NamedColorV4.icc` — 4 device coords, 20 entries (NamedColor2 ToXml + int16 ParseXml)
  - `Testing/sRGB_v4_ICC_preference.icc` — 6 `<Curve>` elements
  - `Testing/Calc/srgbCalc++Test.icc` — 8 calc `<SubElements>`
- `XML → ICC → XML` round-trip on NamedColorV4 is **byte-identical**.

Source-only (IccXML); no behavior change on valid input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)