### PR TITLE
Fix: bound m_nSubElem-driven serialization/apply loops in CIccMpeCalculator (unbounded-profile-loop)

### DIFF
--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -5187,6 +5187,15 @@ bool CIccMpeCalculator::Begin(icElemInterp nInterp, CIccTagMultiProcessElement *
   if (!m_calcFunc->Begin(this, pMPE))
     return false;
 
+  // CWE-400/CWE-834: the walk below calls Begin() on each of the m_nSubElem
+  // sub-elements held in m_SubElem[]. CIccMpeCalculator::Read() rejects any
+  // m_nSubElem >= MAX_CALC_ELEMENTS and sizes m_SubElem[] to the accepted count,
+  // so on a valid element the walk never exceeds the allocation; reject that same
+  // bound here so a corrupted count can't drive an unbounded begin walk.
+  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  if (m_nSubElem >= MAX_CALC_ELEMENTS)
+    return false;
+
   icUInt32Number n;
   for (n=0; n<m_nSubElem; n++) {
     if (m_SubElem[n] && !m_SubElem[n]->Begin(nInterp, pMPE))
@@ -5209,6 +5218,15 @@ bool CIccMpeCalculator::Begin(icElemInterp nInterp, CIccTagMultiProcessElement *
 CIccApplyMpe *CIccMpeCalculator::GetNewApply(CIccApplyTagMpe *pApplyTag)
 {
   //CIccApplyTagMpe *pApplyTagEx = (CIccApplyTagMpe*)pApplyTag;
+
+  // CWE-400/CWE-834: this builds the parallel apply object whose loop below clones
+  // each of the m_nSubElem sub-elements into pApply->m_SubElem[]. Read() bounds
+  // m_nSubElem by MAX_CALC_ELEMENTS and sizes m_SubElem[] to match; reject the
+  // same bound up front (before any allocation, so no leak) so a corrupted count
+  // can't drive an unbounded clone walk.
+  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  if (m_nSubElem >= MAX_CALC_ELEMENTS)
+    return NULL;
 
   CIccApplyMpeCalculator *pApply = new (std::nothrow) CIccApplyMpeCalculator(this);
 
@@ -5298,8 +5316,15 @@ icValidateStatus CIccMpeCalculator::Validate(std::string sigPath, std::string &s
 
   icUInt32Number i;
 
+  // CWE-400/CWE-834: the walk below validates each of the m_nSubElem sub-elements
+  // in m_SubElem[]. Read() bounds m_nSubElem by MAX_CALC_ELEMENTS and sizes
+  // m_SubElem[] to the accepted count; clamp the loop to that same bound (as Read()
+  // itself does) so a corrupted count can't drive an unbounded validation walk.
+  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  icUInt32Number nSub = (m_nSubElem > MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
+
   if (m_SubElem) {
-    for (i=0; i<m_nSubElem; i++) {
+    for (i=0; i<nSub; i++) {
       if (m_SubElem[i])
         rv = icMaxStatus(rv, m_SubElem[i]->Validate(mpeSigPath, sReport, pMPE, pProfile));
     }
@@ -5340,6 +5365,14 @@ bool CIccMpeCalculator::IsLateBinding() const
 {
   icUInt32Number i;
 
+  // CWE-400/CWE-834: the walk below queries each of the m_nSubElem sub-elements in
+  // m_SubElem[]. Read() bounds m_nSubElem by MAX_CALC_ELEMENTS and sizes m_SubElem[]
+  // to match; reject that same bound so a corrupted count can't drive an unbounded
+  // walk (a missing late-binding answer is the safe default).
+  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  if (m_nSubElem >= MAX_CALC_ELEMENTS)
+    return false;
+
   if (m_SubElem) {
     for (i=0; i<m_nSubElem; i++) {
       if (m_SubElem[i] && m_SubElem[i]->IsLateBinding())
@@ -5362,6 +5395,14 @@ bool CIccMpeCalculator::IsLateBinding() const
  ******************************************************************************/
 bool CIccMpeCalculator::IsLateBindingReflectance() const
 {
+  // CWE-400/CWE-834: the walk below queries each of the m_nSubElem sub-elements in
+  // m_SubElem[]. Read() bounds m_nSubElem by MAX_CALC_ELEMENTS and sizes m_SubElem[]
+  // to match; reject that same bound so a corrupted count can't drive an unbounded
+  // walk (a missing late-binding answer is the safe default).
+  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  if (m_nSubElem >= MAX_CALC_ELEMENTS)
+    return false;
+
   icUInt32Number i;
 
   if (m_SubElem) {


### PR DESCRIPTION
## Summary

Bounds the four CodeQL `iccdev/unbounded-profile-loop` alerts in `IccProfLib/IccMpeCalc.cpp`, all in `CIccMpeCalculator`, all driven by the profile-controlled field **`m_nSubElem`** walking `m_SubElem[]` with no in-function upper-bound check (CWE-400 / CWE-834). Part of #1394.

| Alert | Function | Line | Form applied |
|---|---|---|---|
| #888 | `Begin()` | 5191 | guard `if (m_nSubElem >= MAX_CALC_ELEMENTS) return false;` |
| #887 | `GetNewApply()` | 5233 | guard before any allocation → `return NULL` (no leak) |
| #886 | `Validate()` | 5302 | clamp-to-local `nSub` (keeps validating every in-bounds elem) |
| #884 | `IsLateBindingReflectance()` | 5368 | guard `if (m_nSubElem >= MAX_CALC_ELEMENTS) return false;` |

The unflagged twin `IsLateBinding()` gets the same guard for consistency (identical pattern, would otherwise be a latent alert).

## Why this is safe / why bounded

`CIccMpeCalculator::Read()` already **rejects** any `m_nSubElem >= MAX_CALC_ELEMENTS` (65536) and allocates `m_SubElem[]` to the accepted count, and `Write()` enforces the same bound before serializing (`IccMpeCalc.cpp:5057`). So on any validly-loaded element these walks never exceed the allocation — the guards are **defense-in-depth** against a corrupted in-memory count and reuse the cap the class already enforces. No behavior change on valid input.

## House style

Each site reuses an idiom already present in this exact file: the guard-form mirrors `Write()` (`:5057`); the `Validate()` clamp-to-local `nSub` mirrors `Read()`. `GetNewApply()`'s guard is placed before `new CIccApplyMpeCalculator` so the early return cannot leak. Every edit carries a why-comment describing both the change and the surrounding walk.

## Verification

- `IccProfLib2-static` builds clean.
- Validation reports (`iccDumpProfile … 1`) **byte-identical** (modulo embedded build hash) across all six `Testing/Calc` profiles — `srgbCalc++Test`, `srgbCalcTest`, `argbCalc`, `CameraModel`, `ElevenChanKubelkaMunk`, `RGBWProjector` — exercising the `Validate` / `IsLateBinding` / `IsLateBindingReflectance` paths.
- `iccRoundTrip` on calc profiles runs unchanged (exercises `Begin` / `GetNewApply` / `Apply`).

Source-only (`IccProfLib`) → fork-safe. No paired CTest (a crafted corrupt-count profile would be fork-gate-split; deferred — defense-in-depth, not a live bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)