### PR TITLE
Refactor: consolidate MPE calc element-count cap into one shared MAX_CALC_ELEMENTS (re-land of #1488, rebased onto #1487)

### DIFF
--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1725,7 +1725,12 @@ bool CIccMpeJsonCalculator::UpdateLocals(std::string &func, std::string sFunc,
       }
       int voffset = vo + nLocalsOffset;
       int vsize   = vs + 1;
-      if (voffset + vsize > 65535) {
+      // The temporary-variable memory holds up to 65536 slots (indices 0..65535,
+      // i.e. icMaxDataStackSize + 1); a [voffset, voffset+vsize) range fits iff
+      // voffset + vsize <= 65536. Use > 65536 to match the named-variable bounds
+      // checks above: the prior > 65535 was off-by-one and wrongly rejected a
+      // local that legitimately occupies the final slot.
+      if (voffset + vsize > 65536) {
         parseStr += "Local variable out of bounds - too many variables.\n";
         return false;
       }

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -3587,8 +3587,11 @@ bool CIccCalculatorFunc::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read32(&m_nOps))
     return false;
 
-  // Prevent excessive allocation and overflows - limit to 65536 elements (reasonable max)
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  // CWE-400/CWE-834: m_nOps is a 32-bit count with no ICC.2-imposed maximum.
+  // Reject counts at or above the shared MAX_CALC_ELEMENTS cap (IccMpeCalc.h)
+  // before allocating m_Op[] or driving the op loop below, so a corrupt or
+  // hostile count cannot force an unbounded allocation. ">= reject": a valid
+  // count is strictly less than the cap.
   if (m_nOps >= MAX_CALC_ELEMENTS)
     return false;
 
@@ -4632,11 +4635,12 @@ CIccMpeCalculator::CIccMpeCalculator(const CIccMpeCalculator &channelGen)
   if (channelGen.m_nSubElem) {
     icUInt32Number i;
 
-    // CWE-400/CWE-834: m_nSubElem is bounded by MAX_CALC_ELEMENTS on load and the
-    // m_SubElem array is allocated to match; clamp the copy loop to that bound so
-    // a corrupted count can't drive an unbounded walk.
-    const icUInt32Number MAX_CALC_ELEMENTS = 65536;
-    icUInt32Number nSub = (m_nSubElem > MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
+    // CWE-400/CWE-834: m_nSubElem is a 32-bit count bounded by the shared
+    // MAX_CALC_ELEMENTS cap (IccMpeCalc.h) on load, with m_SubElem[] sized to
+    // match. A constructor/assignment cannot reject, so clamp the copy loop to
+    // that same cap (using the >= boundary shared with the reject paths) so a
+    // corrupted count can't drive an unbounded walk.
+    icUInt32Number nSub = (m_nSubElem >= MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
 
     m_SubElem = (CIccMultiProcessElement**)calloc(m_nSubElem, sizeof(CIccMultiProcessElement*));
     if (m_SubElem) {
@@ -4689,11 +4693,12 @@ CIccMpeCalculator &CIccMpeCalculator::operator=(const CIccMpeCalculator &channel
   if (channelGen.m_nSubElem) {
     icUInt32Number i;
 
-    // CWE-400/CWE-834: m_nSubElem is bounded by MAX_CALC_ELEMENTS on load and the
-    // m_SubElem array is allocated to match; clamp the copy loop to that bound so
-    // a corrupted count can't drive an unbounded walk.
-    const icUInt32Number MAX_CALC_ELEMENTS = 65536;
-    icUInt32Number nSub = (m_nSubElem > MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
+    // CWE-400/CWE-834: m_nSubElem is a 32-bit count bounded by the shared
+    // MAX_CALC_ELEMENTS cap (IccMpeCalc.h) on load, with m_SubElem[] sized to
+    // match. A constructor/assignment cannot reject, so clamp the copy loop to
+    // that same cap (using the >= boundary shared with the reject paths) so a
+    // corrupted count can't drive an unbounded walk.
+    icUInt32Number nSub = (m_nSubElem >= MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
 
     m_SubElem = (CIccMultiProcessElement**)calloc(m_nSubElem, sizeof(CIccMultiProcessElement*));
     if (m_SubElem) {
@@ -4750,10 +4755,11 @@ void CIccMpeCalculator::SetSize(icUInt16Number nInputChannels, icUInt16Number nO
   icUInt32Number i;
 
   if (m_SubElem) {
-    // CWE-400/CWE-834: m_nSubElem is bounded by MAX_CALC_ELEMENTS on load and the
-    // m_SubElem array is allocated to match; clamp the delete loop to that bound.
-    const icUInt32Number MAX_CALC_ELEMENTS = 65536;
-    icUInt32Number nSub = (m_nSubElem > MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
+    // CWE-400/CWE-834: m_nSubElem is a 32-bit count bounded by the shared
+    // MAX_CALC_ELEMENTS cap (IccMpeCalc.h) on load, with m_SubElem[] sized to
+    // match. SetSize() cannot reject, so clamp the delete loop to that same cap
+    // (>= boundary) so a corrupted count can't drive an unbounded walk.
+    icUInt32Number nSub = (m_nSubElem >= MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
     for (i=0; i<nSub; i++) {
       if (m_SubElem[i]) {
         m_SubElem[i]->SetParentObject(nullptr);
@@ -4840,10 +4846,11 @@ void CIccMpeCalculator::Describe(std::string &sDescription, int nVerboseness)
 
     if (m_nSubElem && m_SubElem) {
       icUInt32Number i;
-      // CWE-400/CWE-834: m_nSubElem is bounded by MAX_CALC_ELEMENTS on load and the
-      // m_SubElem array is allocated to match; clamp the describe walk to that bound.
-      const icUInt32Number MAX_CALC_ELEMENTS = 65536;
-      icUInt32Number nSub = (m_nSubElem > MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
+      // CWE-400/CWE-834: m_nSubElem is a 32-bit count bounded by the shared
+      // MAX_CALC_ELEMENTS cap (IccMpeCalc.h) on load, with m_SubElem[] sized to
+      // match. Describe() cannot reject, so clamp the describe walk to that same
+      // cap (>= boundary) so a corrupted count can't drive an unbounded walk.
+      icUInt32Number nSub = (m_nSubElem >= MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
       for (i=0; i<nSub; i++) {
         snprintf(buf, bufSize, "BEGIN_SUBCALCELEM %u\n", (unsigned int) i);
         sDescription += buf;
@@ -4933,8 +4940,12 @@ bool CIccMpeCalculator::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read32(&nSubElem))
     return false;
 
-  // Prevent excessive allocation and overflows - limit to 65536 elements (reasonable max)
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  // CWE-400/CWE-834: nSubElem is a 32-bit count read straight from the profile
+  // with no ICC.2-imposed maximum. Reject counts at or above the shared
+  // MAX_CALC_ELEMENTS cap (IccMpeCalc.h) before sizing m_SubElem[], so a corrupt
+  // or hostile count cannot force an unbounded allocation. This is the
+  // authoritative load-time gate the copy/describe/validate clamps rely on.
+  // ">= reject": a valid count is strictly less than the cap.
   if (nSubElem >= MAX_CALC_ELEMENTS)
     return false;
 
@@ -5050,10 +5061,11 @@ bool CIccMpeCalculator::Write(CIccIO *pIO)
   if (!pIO->Write16(&m_nOutputChannels))
     return false;
 
-  // CWE-400/CWE-834: m_nSubElem is bounded by MAX_CALC_ELEMENTS on load; reject
-  // anything larger before serializing the count so a corrupted value can't be
-  // written or drive the unbounded sub-element write loop below.
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  // CWE-400/CWE-834: m_nSubElem is bounded by the shared MAX_CALC_ELEMENTS cap
+  // (IccMpeCalc.h) on load; reject anything at or above it before serialising the
+  // count so a corrupted value can't be written or drive the unbounded
+  // sub-element write loop below. ">= reject" matches the load-time gate (a valid
+  // count is strictly less than the cap).
   if (m_nSubElem >= MAX_CALC_ELEMENTS)
     return false;
 
@@ -5192,7 +5204,6 @@ bool CIccMpeCalculator::Begin(icElemInterp nInterp, CIccTagMultiProcessElement *
   // m_nSubElem >= MAX_CALC_ELEMENTS and sizes m_SubElem[] to the accepted count,
   // so on a valid element the walk never exceeds the allocation; reject that same
   // bound here so a corrupted count can't drive an unbounded begin walk.
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
   if (m_nSubElem >= MAX_CALC_ELEMENTS)
     return false;
 
@@ -5224,7 +5235,6 @@ CIccApplyMpe *CIccMpeCalculator::GetNewApply(CIccApplyTagMpe *pApplyTag)
   // m_nSubElem by MAX_CALC_ELEMENTS and sizes m_SubElem[] to match; reject the
   // same bound up front (before any allocation, so no leak) so a corrupted count
   // can't drive an unbounded clone walk.
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
   if (m_nSubElem >= MAX_CALC_ELEMENTS)
     return NULL;
 
@@ -5320,7 +5330,6 @@ icValidateStatus CIccMpeCalculator::Validate(std::string sigPath, std::string &s
   // in m_SubElem[]. Read() bounds m_nSubElem by MAX_CALC_ELEMENTS and sizes
   // m_SubElem[] to the accepted count; clamp the loop to that same bound (as Read()
   // itself does) so a corrupted count can't drive an unbounded validation walk.
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
   icUInt32Number nSub = (m_nSubElem > MAX_CALC_ELEMENTS) ? MAX_CALC_ELEMENTS : m_nSubElem;
 
   if (m_SubElem) {
@@ -5369,7 +5378,6 @@ bool CIccMpeCalculator::IsLateBinding() const
   // m_SubElem[]. Read() bounds m_nSubElem by MAX_CALC_ELEMENTS and sizes m_SubElem[]
   // to match; reject that same bound so a corrupted count can't drive an unbounded
   // walk (a missing late-binding answer is the safe default).
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
   if (m_nSubElem >= MAX_CALC_ELEMENTS)
     return false;
 
@@ -5399,7 +5407,6 @@ bool CIccMpeCalculator::IsLateBindingReflectance() const
   // m_SubElem[]. Read() bounds m_nSubElem by MAX_CALC_ELEMENTS and sizes m_SubElem[]
   // to match; reject that same bound so a corrupted count can't drive an unbounded
   // walk (a missing late-binding answer is the safe default).
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
   if (m_nSubElem >= MAX_CALC_ELEMENTS)
     return false;
 
@@ -5463,8 +5470,10 @@ bool CIccMpeCalculator::SetElem(icUInt32Number idx, CIccMultiProcessElement *pEl
 {
   bool rv = true;
 
-  // Prevent excessive allocation - limit to 65536 elements (reasonable max)
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  // CWE-400/CWE-834: idx indexes (and, via idx+1, sizes) the sub-element array.
+  // Reject any index at or above the shared MAX_CALC_ELEMENTS cap (IccMpeCalc.h)
+  // before the realloc/calloc below, so a hostile index can't force an unbounded
+  // allocation.
   if (idx >= MAX_CALC_ELEMENTS)
     return false;
 
@@ -5549,13 +5558,13 @@ CIccApplyMpeCalculator::~CIccApplyMpeCalculator()
   icUInt32Number i;
 
   if (m_SubElem) {
-    // CWE-400/CWE-834: m_nSubElem is bounded by MAX_CALC_ELEMENTS in
-    // CIccMpeCalculator::Read and the m_SubElem array is allocated to match
-    // (see GetNewApply). Clamp defensively so a corrupted count can never drive
-    // an unbounded free loop over the array.
-    const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+    // CWE-400/CWE-834: m_nSubElem is bounded by the shared MAX_CALC_ELEMENTS cap
+    // (IccMpeCalc.h) in CIccMpeCalculator::Read and m_SubElem[] is allocated to
+    // match (see GetNewApply). A destructor cannot reject, so clamp the free loop
+    // defensively to that same cap (>= boundary) so a corrupted count can never
+    // drive an unbounded walk over the array.
     icUInt32Number nSubElem = m_nSubElem;
-    if (nSubElem > MAX_CALC_ELEMENTS)
+    if (nSubElem >= MAX_CALC_ELEMENTS)
       nSubElem = MAX_CALC_ELEMENTS;
     for (i=0; i<nSubElem; i++) {
       delete m_SubElem[i];

--- a/IccProfLib/IccMpeCalc.h
+++ b/IccProfLib/IccMpeCalc.h
@@ -90,6 +90,22 @@ class IIccOpDef;
 
 #define icMaxDataStackSize 65535
 
+// Defensive upper bound on the number of elements parsed from a calc-based
+// multiProcessElement. ICC.2 stores every one of these as a 32-bit count with
+// NO maximum imposed by the specification: the calculator sub-element count
+// (m_nSubElem) and operation count (m_nOps) inside a calcElement, plus the
+// processing-element count (m_nProcElements) of a multiProcessElementType tag.
+// This cap exists solely to bound memory and loop iteration against corrupt or
+// hostile counts; it is an arbitrary round 2^16 ceiling (orders of magnitude
+// larger than any real-world profile) and is deliberately NOT derived from any
+// field width. It is applied uniformly as a ">= reject": a valid count is
+// strictly less than MAX_CALC_ELEMENTS (i.e. at most 65535). Centralised here
+// so every load, copy, serialise, describe and validate path shares one value
+// and one boundary. NB: this is the element-COUNT cap and is distinct from the
+// temporary-variable memory size (icMaxDataStackSize + 1 = 65536 slots) used by
+// the calc variable-addressing checks, which happens to share the same number.
+#define MAX_CALC_ELEMENTS 65536
+
 
 
 /************************************************************************

--- a/IccProfLib/IccTagMPE.cpp
+++ b/IccProfLib/IccTagMPE.cpp
@@ -78,6 +78,7 @@
 #include <cstdlib>
 #include "IccTagMPE.h"
 #include "IccIO.h"
+#include "IccMpeCalc.h"  // shared MAX_CALC_ELEMENTS element-count cap
 #include "IccMpeFactory.h"
 #include <map>
 #include <new>
@@ -1028,8 +1029,12 @@ bool CIccTagMultiProcessElement::Read(icUInt32Number size, CIccIO *pIO)
   if (!pIO->Read32(&m_nProcElements))
     return false;
 
-  // Prevent excessive allocation and overflows - limit to 65536 elements (reasonable max)
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
+  // CWE-400/CWE-834: m_nProcElements is a 32-bit count read straight from the
+  // profile with no ICC.2-imposed maximum. Reject counts at or above the shared
+  // MAX_CALC_ELEMENTS cap (IccMpeCalc.h) before sizing m_position[] so a corrupt
+  // or hostile count cannot force an unbounded allocation; the byte-size check
+  // immediately below is the tighter, authoritative bound. ">= reject": a valid
+  // count is strictly less than the cap.
   if (m_nProcElements >= MAX_CALC_ELEMENTS)
     return false;
 

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2467,12 +2467,12 @@ bool CIccMpeXmlCalculator::ToXml(std::string &xml, std::string blanks/* = ""*/)
   int i;
 
   // CWE-400/CWE-834: the walk below iterates m_nSubElem over m_SubElem[].
-  // CIccMpeCalculator::Read() caps m_nSubElem at MAX_CALC_ELEMENTS and allocates
-  // m_SubElem to match (IccMpeCalc.cpp), so on a valid element the walk never
-  // exceeds the allocation; assert that same bound so a corrupted count can't
+  // CIccMpeCalculator::Read() caps m_nSubElem at the shared MAX_CALC_ELEMENTS cap
+  // (IccMpeCalc.h, reached here via IccMpeXml.h) and sizes m_SubElem[] to match,
+  // so on a valid element the walk never exceeds the allocation. Reject the same
+  // bound with the same ">=" boundary used on load, so a corrupted count can't
   // drive an unbounded serialization walk.
-  const icUInt32Number MAX_CALC_ELEMENTS = 65536;
-  if (m_nSubElem > MAX_CALC_ELEMENTS)
+  if (m_nSubElem >= MAX_CALC_ELEMENTS)
     return false;
 
   if (m_SubElem && m_nSubElem) {
@@ -3245,7 +3245,12 @@ bool CIccMpeXmlCalculator::UpdateLocals(std::string &func, std::string sFunc, st
       voffset = _voffset + nLocalsOffset;
       vsize = _vsize + 1;
 
-      if (voffset + vsize > 65535) {
+      // The temporary-variable memory holds up to 65536 slots (indices 0..65535,
+      // i.e. icMaxDataStackSize + 1); a [voffset, voffset+vsize) range fits iff
+      // voffset + vsize <= 65536. Use > 65536 to match the named-variable bounds
+      // checks above: the prior > 65535 was off-by-one and wrongly rejected a
+      // local that legitimately occupies the final slot.
+      if (voffset + vsize > 65536) {
         parseStr += "Local variable out of bounds - too many variables.\n";
         return false;
       }


### PR DESCRIPTION
## Re-land of #1488, rebased onto current master (#1487)

Re-submits the `MAX_CALC_ELEMENTS` consolidation from #1488 (reverted in #1490), now built on current master so CI validates the **integrated** tree. Closes #1491.

### What went wrong the first time (owning it)

#1488 and #1487 were both mine and edited the same `MAX_CALC_ELEMENTS` declarations. #1488 was CI-tested against a base predating #1487, so its header `#define` never compiled against #1487's five local `const … = 65536;` guards. Once both landed, the macro expanded over those locals → `const icUInt32Number 65536 = 65536;` → compile error (#1489). `docs/linear-stack-workflow.md` (rebase on `origin/master` + local build before push) would have caught it; I didn't run it on the up-to-date base. This re-land fixes the process miss, not just the symptom.

### What's different here

- Branched off current master (post-#1487); removes **all** local declarations including #1487's five (`Begin`/`GetNewApply`/`Validate`/`IsLateBinding`/`IsLateBindingReflectance`) — the ones the original #1488 couldn't see.
- Bounds unchanged: same value (65536), same operators; comparisons resolve the shared header macro.
- Otherwise identical to #1488: single `#define` in `IccMpeCalc.h`, uniform `>=` reject, the two calc temp-var off-by-one fixes, `#include "IccMpeCalc.h"` in `IccTagMPE.cpp`.

### Verification

Integrated TU passes `g++ -fsyntax-only`; 0 surviving local redeclarations, 1 header `#define`. Full PR CI here runs the rebased tree — the check the original never got.

Closes #1491. Refs #1488, #1489, #1490, #1487.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHH4RtTPysVWG8g698TKFP
