### PR TITLE
Fix: bound m_nApply-driven search walks in CIccApplyCmmSearch (unbounded-profile-loop)

### DIFF
--- a/IccProfLib/IccCmmSearch.cpp
+++ b/IccProfLib/IccCmmSearch.cpp
@@ -87,7 +87,13 @@ CIccApplyCmmSearch::CIccApplyCmmSearch(CIccCmm* pBaseCmm) : CIccApplyCmm(pBaseCm
   icUInt16Number nSrcSamples = pCmm->m_dst_to_mid[0]->GetSourceSamples();
 
   m_mid_data.resize(m_nApply);
-  for (size_t i = 0; i < m_nApply; i++) {
+  // CWE-400/CWE-834: m_nApply is derived from the host-attached PCC container
+  // sizes (m_pcc/m_dst_to_mid), not a profile field, and is already bounded to
+  // m_dst_to_mid.size() above; clamp the per-entry allocation walk to the actual
+  // m_mid_data allocation as well so a corrupted count can never run out of
+  // range -- mirrors the defensive clamps on the Apply() walks below.
+  size_t nApply = (m_nApply < m_mid_data.size()) ? m_nApply : m_mid_data.size();
+  for (size_t i = 0; i < nApply; i++) {
     m_mid_data[i].resize(m_nSamples);
   }
   m_pixel.resize(m_nSamples);
@@ -113,7 +119,18 @@ icFloatNumber CIccApplyCmmSearch::costFunc(CIccSearchVec& point)
   CIccCmmSearch* pCmm = (CIccCmmSearch*)m_pCmm;
   icFloatNumber sum = 0.0;
   icFloatNumber div = 0.0;
-  for (size_t i = 0; i < m_nApply; i++) {
+  // CWE-400/CWE-834: the cost walk indexes three parallel containers
+  // (m_dst_to_mid, m_mid_data, m_weight) by i; by construction all are
+  // >= m_nApply, but clamp to the smallest so a corrupted m_nApply can never
+  // index any of them out of range -- same guard form as Apply() above.
+  size_t nApply = m_nApply;
+  if (nApply > pCmm->m_dst_to_mid.size())
+    nApply = pCmm->m_dst_to_mid.size();
+  if (nApply > m_mid_data.size())
+    nApply = m_mid_data.size();
+  if (nApply > pCmm->m_weight.size())
+    nApply = pCmm->m_weight.size();
+  for (size_t i = 0; i < nApply; i++) {
     pCmm->m_dst_to_mid[i]->Apply(&m_pixel[0], &point.vec()[0]);
 
     if (m_bNeedPcsToLab) {
@@ -170,7 +187,7 @@ icStatusCMM CIccApplyCmmSearch::Apply(icFloatNumber* DstPixel, const icFloatNumb
 {
   CIccCmmSearch* pCmm = (CIccCmmSearch*)m_pCmm;
 
-    if (!pCmm->m_src_to_mid.size()) { //src == mid so copy pixel data into mid search pixels
+  if (!pCmm->m_src_to_mid.size()) { //src == mid so copy pixel data into mid search pixels
     // CWE-400/CWE-834: m_nApply is set from container sizes at Begin() and bounds
     // the m_mid_data walk; clamp to the actual allocation so a corrupted count
     // can't drive an unbounded or out-of-range walk.
@@ -194,7 +211,10 @@ icStatusCMM CIccApplyCmmSearch::Apply(icFloatNumber* DstPixel, const icFloatNumb
 
   //Cost function needs delteEab so convert from PCS encoding to Lab for comparisons
   if (m_bNeedPcsToLab) {
-    for (size_t i = 0; i < m_nApply; i++) {
+    // CWE-400/CWE-834: same clamp as the m_mid_data walks above -- bound the
+    // Lab conversion to the actual allocation rather than the raw m_nApply.
+    size_t nApply = (m_nApply < m_mid_data.size()) ? m_nApply : m_mid_data.size();
+    for (size_t i = 0; i < nApply; i++) {
       icLabFromPcs(&m_mid_data[i][0]);
     }
   }


### PR DESCRIPTION
## Summary

CodeQL `iccdev/unbounded-profile-loop` flags two loops in `CIccApplyCmmSearch` whose iteration count is `m_nApply`:

- `IccCmmSearch.cpp:90` — the constructor `m_mid_data` allocation walk
- `IccCmmSearch.cpp:116` — the `costFunc` walk

### Triage: not a malformed-profile DoS

`m_nApply` is **not** a profile field. It is set in the `CIccApplyCmmSearch` constructor from the host-attached profile-connection-condition containers:

```cpp
m_nApply = pCmm->m_pcc.size();          // count of PCCs the host attached via AttachPCC()
if (!m_nApply) m_nApply = 1;
if (m_nApply > pCmm->m_dst_to_mid.size())
  m_nApply = pCmm->m_dst_to_mid.size(); // already bounded
```

`m_pcc` grows only through the `AttachPCC()` API (`m_pcc.push_back`), which also validates each entry (non-null PCC, finite weight > 0). Nothing in a profile byte-stream drives it, and it is already capped to `m_dst_to_mid.size()`. Every container the two loops index (`m_mid_data`, `m_dst_to_mid`, `m_weight`) is `>= m_nApply` by construction. So the findings are **not reachable as a DoS** — they are false positives for the rule's stated threat.

### Why change anything, then?

The sibling `Apply()` walks were already given explicit defensive clamps (lines 177 / 185, with the same CWE-400/CWE-834 comments) during the #1332-era hardening, while the constructor and `costFunc` walks were left in the raw `i < m_nApply` form — which is exactly why CodeQL still flags them and not the others.

This PR makes the safety **uniform and explicit** by mirroring that established guard form: each walk is clamped to the actual size of the container(s) it indexes.

- Constructor walk → clamp to `m_mid_data.size()`
- `costFunc` walk (indexes three parallel containers) → clamp to the smallest of `m_dst_to_mid` / `m_mid_data` / `m_weight`
- `Apply()` PcsToLab walk → clamped to `m_mid_data` the same way, for consistency

The clamps are **value-preserving no-ops** on every well-formed search.

### Drive-by

Fixes a stray 4-space indentation on the `if` at the top of `Apply()` so it lines up with its `else` — a clang-tidy `readability-misleading-indentation` note left over from the earlier hardening edit, in the same function touched here.

## Verification

- IccProfLib builds clean (gcc, no new warnings).
- Existing `iccdev.cmmsearch-namedcolor-ownership` regression still passes.
- No behavioral change; source-only `IccProfLib` change (no new test — the guarded path is unreachable by construction, so there is nothing to red-green).

Addresses CodeQL alerts #841 and #843.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHH4RtTPysVWG8g698TKFP
