### PR TITLE
Fix: -Wstringop-truncation in CIccTagNamedColor2 SetPrefix/SetSufix (#1494)

### DIFF
--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -3188,7 +3188,12 @@ bool CIccTagNamedColor2::SetSize(icUInt32Number nSize, icInt32Number nDeviceCoor
 */
 void CIccTagNamedColor2::SetPrefix(const icChar *szPrefix)
 {
-  strncpy(m_szPrefix, szPrefix, sizeof(m_szPrefix));
+  // Copy at most sizeof-1 bytes so the explicit terminator below always has
+  // room. Passing the full destination size as the bound makes GCC's
+  // -Wstringop-truncation flag the call (it cannot see the following NUL
+  // store); capping at sizeof-1 is value-preserving because that last byte was
+  // already being overwritten with '\0'.
+  strncpy(m_szPrefix, szPrefix, sizeof(m_szPrefix)-1);
   m_szPrefix[sizeof(m_szPrefix)-1]='\0';
 }
 
@@ -3205,7 +3210,9 @@ void CIccTagNamedColor2::SetPrefix(const icChar *szPrefix)
 */
 void CIccTagNamedColor2::SetSufix(const icChar *szSufix)
 {
-  strncpy(m_szSufix, szSufix, sizeof(m_szSufix));
+  // See SetPrefix: cap the strncpy bound at sizeof-1 so the explicit NUL store
+  // has room and -Wstringop-truncation is satisfied; value-preserving.
+  strncpy(m_szSufix, szSufix, sizeof(m_szSufix)-1);
   m_szSufix[sizeof(m_szSufix)-1]='\0';
 }
 


### PR DESCRIPTION
Fixes #1494.

## Problem
Under the new strict CI configuration (`-Wall -Wextra -Wpedantic -Werror`), GCC's `-Wstringop-truncation` promotes a latent warning in `CIccTagNamedColor2::SetPrefix()` and `SetSufix()` to a hard build error:

```
IccTagBasic.cpp:3191:10: error: 'char* __builtin_strncpy(char*, const char*, long unsigned int)'
  specified bound 32 equals destination size [-Werror=stringop-truncation]
   strncpy(m_szPrefix, szPrefix, sizeof(m_szPrefix));
```

Both setters passed a `strncpy` bound equal to the destination size (`sizeof(m_szPrefix) == sizeof(m_szSufix) == 32`) and then NUL-terminated the final byte on the following line. The code was already safe, but with the bound equal to the buffer size GCC cannot account for the trailing NUL store and flags the call.

## Not a regression
This is original code from `1f0a9dd2` ("Initial REFIccMAX Repository Creation"); neither setter has been modified since. It was promoted from a long-standing latent warning to a hard error purely by the stricter build flags (hence the `Bisect` label landing on the CMake-flags change, not a source change).

## Fix
Cap the `strncpy` bound at `sizeof-1` in both setters. This is **value-preserving** — byte 31 was already overwritten with `'\0'` by the existing terminator line — and lets GCC prove the terminator has room, clearing the diagnostic. Why-comments added per the iccDEV convention. These are the only two equal-bound `strncpy` calls in `IccProfLib`, so the fix is complete in scope.

## Verification
`g++ -std=c++17 -Wall -Wextra -Wpedantic -Werror -fno-omit-frame-pointer -g -IIccProfLib -c IccProfLib/IccTagBasic.cpp` compiles the translation unit cleanly (object produced, no `stringop-truncation` diagnostics). Source-only change; the strict CI build is the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)