### PR TITLE
Fix: remove always-false matrix-size overflow guards in IccMpeJson (#1497)

### DIFF
--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1008,12 +1008,12 @@ bool CIccMpeJsonMatrix::ParseJson(const IccJson &j, std::string &parseStr)
 
   icUInt16Number nIn  = (icUInt16Number)nInInt;
   icUInt16Number nOut = (icUInt16Number)nOutInt;
-  icUInt64Number nEntries64 = (icUInt64Number)nIn * nOut;
-  if (nEntries64 > 0xFFFFFFFFUL) {
-    parseStr += "MatrixElement size is too large\n";
-    return false;
-  }
-  icUInt32Number nEntries = (icUInt32Number)nEntries64;
+  // icJsonValidMatrixChannels has already bounded nIn and nOut to
+  // [1, kIccJsonMaxMatrixChannels] (255), so the entry count is at most
+  // 255*255 = 65025 and always fits icUInt32Number. The former 64-bit
+  // "> 0xFFFFFFFF" overflow guard was therefore unreachable (flagged by
+  // CodeQL cpp/constant-comparison as always false); compute directly.
+  icUInt32Number nEntries = (icUInt32Number)nIn * nOut;
 
   if (j.contains("matrix") && !j["matrix"].is_array()) {
     parseStr += "matrix must be an array in MatrixElement\n";
@@ -1027,7 +1027,7 @@ bool CIccMpeJsonMatrix::ParseJson(const IccJson &j, std::string &parseStr)
   bool bHasMatrix = j.contains("matrix") && j["matrix"].is_array();
   bool bHasConstants = j.contains("constants") && j["constants"].is_array();
 
-  if (bHasMatrix && j["matrix"].size() != nEntries64) {
+  if (bHasMatrix && j["matrix"].size() != nEntries) {
     parseStr += "matrix count does not match MatrixElement size\n";
     return false;
   }
@@ -2230,12 +2230,12 @@ static bool icSpectralMatrixFromJson(const IccJson &j, CIccMpeSpectralMatrix *pM
     return false;
 
   const int nSteps = (int)range.steps;
-  icUInt64Number nMatrixValues64 = (icUInt64Number)nVectors * range.steps;
-  if (nMatrixValues64 > 0x7fffffffUL) {
-    parseStr += "spectral matrix element size is too large\n";
-    return false;
-  }
-  int nMatrixValues = (int)nMatrixValues64;
+  // nVectors is bounded to [1, kIccJsonMaxMatrixChannels] (255) above and
+  // range.steps is a 16-bit sample count (<= 65535), so the value count is at
+  // most 255*65535 = 16711425 and always fits a signed int. The former 64-bit
+  // "> 0x7fffffff" overflow guard was therefore unreachable (flagged by CodeQL
+  // cpp/constant-comparison as always false); compute directly.
+  int nMatrixValues = nVectors * (int)range.steps;
 
   if (!pMtx->SetSize((icUInt16Number)nIn, (icUInt16Number)nOut, range)) {
     parseStr += "Unable to SetSize in spectral matrix element\n";


### PR DESCRIPTION
Fixes #1497.

## Problem
CodeQL `cpp/constant-comparison` (alerts [#1617](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/1617), [#1618](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/1618)) flagged two matrix-size overflow guards in `IccMpeJson.cpp` whose comparison can never be true:

| Location | Guard | CodeQL note |
|---|---|---|
| `CIccMpeJsonMatrix::ParseJson` (1012) | `if (nEntries64 > 0xFFFFFFFFUL)` | always false because `nEntries64 <= 4294836225` |
| `icSpectralMatrixFromJson` (2234) | `if (nMatrixValues64 > 0x7fffffffUL)` | always false because `nMatrixValues64 <= 16711425` |

Both guards (added in #944 as CWE-400 hardening) are defensive narrowing checks, but the operands are already bounded **tighter than the threshold** upstream:

- `icJsonValidMatrixChannels()` restricts `inputChannels`/`outputChannels` to `[1, kIccJsonMaxMatrixChannels]` (255), so `nIn*nOut <= 65025` — never `> 0xFFFFFFFF`.
- In the spectral path `nVectors` is likewise `<= 255` and `range.steps` is a 16-bit count (`<= 65535`), so the product `<= 16711425` — never `> 0x7fffffff`.

The guarded branches are therefore unreachable dead code.

## Fix
Remove the 64-bit intermediates and the dead guards; compute the counts directly in their destination types (`icUInt32Number` / `int`), which the validated operand ranges guarantee cannot overflow. The downstream "matrix count does not match" check now compares against the `icUInt32Number nEntries`.

**Behaviour-preserving:** every input that could reach the removed branch was already rejected by `icJsonValidMatrixChannels`. No test referenced the removed `"... size is too large"` diagnostics.

## Not a regression
The dead guards date to #944, not recent work.

## Verification
`g++ -std=c++17 -fsyntax-only` compiles `IccMpeJson.cpp` cleanly (including the updated downstream `nEntries` comparison). Source-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)