### PR TITLE
Fix: match copy ctors with copy assignment (Rule of Two) (#1495)

### DIFF
--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -897,6 +897,12 @@ public:
   CIccPcsStepMatrix(icUInt16Number nRows, icUInt16Number nCols, bool bInitIdentity=false) : CIccMatrixMath(nRows, nCols, bInitIdentity) {}
   CIccPcsStepMatrix(const CIccPcsStepMatrix &mat) : CIccMatrixMath(mat) {}
   CIccPcsStepMatrix(const CIccMatrixMath &mat) : CIccMatrixMath(mat) {}
+  // PCS steps are polymorphic and always handled through pointers (Mult/concat/
+  // reduce return newly allocated objects); they are never value-assigned. The
+  // base CIccMatrixMath owns a raw buffer with no copy assignment operator, so
+  // an implicit one would shallow-copy and double free. Match the copy
+  // constructor (Rule of Two) by deleting assignment to keep this clone-only.
+  CIccPcsStepMatrix &operator=(const CIccPcsStepMatrix &) = delete;
   virtual icPcsStepType GetType() { return icPcsStepMatrix; }
 
   virtual ~CIccPcsStepMatrix() {}

--- a/IccProfLib/IccMpeSpectral.h
+++ b/IccProfLib/IccMpeSpectral.h
@@ -92,6 +92,10 @@ class ICCPROFLIB_API CIccMpeSpectralMatrix : public CIccMultiProcessElement
 public:
   CIccMpeSpectralMatrix();
   CIccMpeSpectralMatrix(const CIccMpeSpectralMatrix &ITPC);
+  // Match the copy constructor with a copy assignment operator (Rule of Two);
+  // copyData performs the same deep copy (with free of the prior buffers) that
+  // the concrete subclasses already rely on.
+  CIccMpeSpectralMatrix &operator=(const CIccMpeSpectralMatrix &ITPC) { copyData(ITPC); return *this; }
   virtual ~CIccMpeSpectralMatrix();
 
   virtual void Describe(std::string &sDescription, int nVerboseness);
@@ -201,6 +205,10 @@ class ICCPROFLIB_API CIccMpeSpectralCLUT : public CIccMultiProcessElement
 public:
   CIccMpeSpectralCLUT();
   CIccMpeSpectralCLUT(const CIccMpeSpectralCLUT &ITPC);
+  // Match the copy constructor with a copy assignment operator (Rule of Two);
+  // copyData performs the same deep copy (with free of the prior buffers) that
+  // the concrete subclasses already rely on.
+  CIccMpeSpectralCLUT &operator=(const CIccMpeSpectralCLUT &ITPC) { copyData(ITPC); return *this; }
   virtual ~CIccMpeSpectralCLUT();
 
   virtual void Describe(std::string &sDescription, int nVerboseness);
@@ -329,6 +337,10 @@ class ICCPROFLIB_API CIccMpeSpectralObserver : public CIccMultiProcessElement
 public:
   CIccMpeSpectralObserver();
   CIccMpeSpectralObserver(const CIccMpeSpectralObserver &ITPC);
+  // Match the copy constructor with a copy assignment operator (Rule of Two);
+  // copyData performs the same deep copy (with free of the prior buffers) that
+  // the concrete subclasses already rely on.
+  CIccMpeSpectralObserver &operator=(const CIccMpeSpectralObserver &ITPC) { copyData(ITPC); return *this; }
   virtual ~CIccMpeSpectralObserver();
 
   virtual void Describe(std::string &sDescription, int nVerboseness);


### PR DESCRIPTION
Fixes #1495.

## Problem
CodeQL `cpp/rule-of-two` flagged four classes that declare a copy constructor but no matching copy assignment operator. Each owns (directly or via a base) a raw buffer with a deep-copying copy constructor and a freeing destructor, so the compiler-generated copy assignment would shallow-copy the pointer and **double free** — a latent Rule of Three gap.

| Alert | Class | Owned resource |
|---|---|---|
| [#177](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/177) | `CIccMpeSpectralMatrix` | `m_pMatrix`, `m_pOffset`, `m_pWhite` (malloc) |
| [#176](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/176) | `CIccMpeSpectralCLUT` | spectral CLUT buffers |
| [#175](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/175) | `CIccMpeSpectralObserver` | observer buffers |
| [#173](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/173) | `CIccPcsStepMatrix` | `m_vals` (via `CIccMatrixMath` base) |

## Fix
Two complementary resolutions, each matching the class's actual usage:

**`CIccMpeSpectral{Matrix,CLUT,Observer}`** — these intermediate base classes already provide a `copyData()` helper that deep-copies with a free of the prior buffers; the concrete leaf subclasses (`CIccMpeEmissionMatrix`, `CIccMpeReflectanceCLUT`, …) all define `operator=(...) { copyData(...); return *this; }`, but the bases never did. **Complete the established idiom** by giving each base the same `copyData`-based assignment operator, so base-level assignment is now as safe as the subclasses already are.

**`CIccPcsStepMatrix`** — PCS steps are polymorphic and handled solely through pointers (`Mult`/`concat`/`reduce` return newly allocated objects); they are never value-assigned. The base `CIccMatrixMath` owns a raw buffer and defines no copy assignment, so an implicit one would double free. **Delete** the copy assignment operator to satisfy the Rule of Two and keep the type clone-only — turning a latent shallow-copy double free into a compile error (Core Guidelines C.67).

## Safety
Value-preserving for every existing call site — no code assigns any of these types by value (verified). Alert #174 (`CIccCamConverter`) was already dismissed and is unchanged.

## Verification
`g++ -std=c++17 -fsyntax-only` compiles `IccMpeSpectral.cpp` and `IccCmm.cpp` cleanly. Source-only (two headers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)