### PR TITLE
Fix: comment intentional empty conditional branches (#1498)

### DIFF
--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -7389,7 +7389,9 @@ icStatusCMM CIccXformNamedColor::Apply(CIccApplyXform*  /* pApply */, icFloatNum
 icStatusCMM CIccXformNamedColor::SetSrcSpace(icColorSpaceSignature nSrcSpace)
 {
   if (m_pArray) {
-
+    // Array-backed named-color xform: the source space is accepted as-is. The
+    // PCS/device/named-data validation below applies only to the single-tag
+    // (m_pTag) case.
   }
   else if (m_pTag) {
     CIccTagNamedColor2 *pTag = m_pTag;
@@ -7422,7 +7424,9 @@ icStatusCMM CIccXformNamedColor::SetDestSpace(icColorSpaceSignature nDestSpace)
     return icCmmStatBadSpaceLink;
 
   if (m_pArray) {
-
+    // Array-backed named-color xform: the destination space is accepted as-is.
+    // The PCS/device/named-data validation below applies only to the single-tag
+    // (m_pTag) case.
   }
   else if (m_pTag) {
     CIccTagNamedColor2 *pTag = (CIccTagNamedColor2*)m_pTag;

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -432,7 +432,9 @@ public:
           }
         }
         else if (m_pFirstProfile->m_Header.version >= icVersionNumberV5) {
-
+          // V5+ source profiles carry colorant naming through the V5 machinery
+          // rather than the legacy colorantTable tag, so there is nothing to
+          // copy across for the CLR input space here.
         }
       }
 
@@ -445,7 +447,8 @@ public:
             }
           }
           else if (m_pLastProfile->m_Header.version >= icVersionNumberV5) {
-
+            // V5+ destination DeviceLink: no legacy colorantTableOut tag to copy;
+            // V5 colorant naming is handled through the V5 machinery elsewhere.
           }
         }
         else if (m_pLastProfile->m_Header.version < icVersionNumberV5) {
@@ -455,7 +458,8 @@ public:
           }
         }
         else if (m_pLastProfile->m_Header.version >= icVersionNumberV5) {
-
+          // V5+ destination profile: no legacy colorantTable tag to copy; V5
+          // colorant naming is handled through the V5 machinery elsewhere.
         }
       }
 


### PR DESCRIPTION
Fixes #1498.

## Problem
CodeQL `cpp/empty-block` ([alerts #277–#281](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/277)) flagged five empty conditional branches "without comment". All five are **intentional no-ops**; this documents them so the analyzer (and readers) can see they are deliberate.

| Alert | Location | Empty branch |
|---|---|---|
| #278 | `IccCmm.cpp:7391` | `if (m_pArray) {}` in `SetSrcSpace` |
| #277 | `IccCmm.cpp:7424` | `if (m_pArray) {}` in `SetDestSpace` |
| #279 | `iccApplyToLink.cpp:434` | `else if (version >= V5) {}` (source CLR) |
| #280 | `iccApplyToLink.cpp:447` | `else if (version >= V5) {}` (dest DeviceLink) |
| #281 | `iccApplyToLink.cpp:457` | `else if (version >= V5) {}` (dest) |

## Why they're intentional
- **`CIccXformNamedColor::SetSrcSpace`/`SetDestSpace`** — the empty `if (m_pArray)` branch means the array-backed named-color transform accepts the requested space as-is; the PCS/device/named-data space validation in the `else if (m_pTag)` branch applies only to the single-tag case.
- **`iccApplyToLink`** — when copying colorant naming into the generated DeviceLink, the legacy `colorantTable`/`colorantTableOut` tags are copied only for **pre-V5** source/destination profiles. V5+ profiles carry colorant naming through the V5 machinery, so there is intentionally nothing to copy.

## Change
Comment-only; no behaviour change. Verified `IccCmm.cpp` compiles cleanly with `g++ -std=c++17 -fsyntax-only`. Source-only (`Tools/` is not maintainer-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)