### PR TITLE
Fix: iccSpecSepToTiff returns failure status on too-few-args usage error (#1514)

### DIFF
--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -147,8 +147,14 @@ int main(int argc, char* argv[]) {
   const int minargs = 8; // argc = 8 without profile, 9 with profile
   
   if (argc < minargs) {
+    // Too few arguments is a usage *error*, not a successful help request: this
+    // tool has no explicit -h/--help flag, so Usage() only ever fires here, on a
+    // malformed invocation.  Returning 0 reported success to the caller even
+    // though nothing was produced (#1514), so wrapper scripts/CI could not tell
+    // a no-op apart from a real conversion.  Fail like every other error exit in
+    // main(), all of which return -1 (process status 255).
     Usage(argv[0]);
-    return 0;
+    return -1;
   }
 
   bool bCompress = atoi(argv[2]) != 0;


### PR DESCRIPTION
## Summary
Fixes #1514. `iccSpecSepToTiff` printed `Usage()` and **returned 0** when invoked with fewer than the required arguments — reporting *success* for a malformed invocation, so wrapper scripts and CI could not distinguish a no-op from a real conversion.

The tool has no explicit `-h`/`--help` flag, so the `argc < minargs` path is **always** an error, never a help request. This returns `-1` to fail like every other error exit in `main()` (process status 255).

## Note on the original QA repro
The repro in #1514 — `iccSpecSepToTiff foo.bar 0 0 tiff_with_subifd_chain.tif 730 380 -5` — exercises **correct, documented behavior**: `argv[4]` is an input filename **prefix** (channel numbers are appended, e.g. `spec_` → `spec_730`), per the Usage text. Passing a complete TIFF filename there yields `tiff_with_subifd_chain.tif730`, which does not exist, and the tool already exits **255** with `Cannot open input …`. That path was never broken. The actionable defect is the adjacent **usage path returning 0**, which this PR fixes.

## Scope
- One file, `Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp`: `return 0;` → `return -1;` on the too-few-args path, with an explanatory comment. Value-preserving for every valid invocation.

## Testing
Regression added in the companion in-repo PR (`iccdev.specsep-usage-exit-code-regression`). Red-green verified locally: pre-fix the no-args/too-few-args cases exit 0 (fail), post-fix they exit 255 (pass); the missing-input guard stays 255 throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
