### PR TITLE
Test: regression for iccSpecSepToTiff usage-path exit code (#1514)

### DIFF
--- a/.github/scripts/iccdev-issue-1514-specsep-usage-exit-code-regression-tests.sh
+++ b/.github/scripts/iccdev-issue-1514-specsep-usage-exit-code-regression-tests.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+###############################################################################
+# iccSpecSepToTiff usage-path exit-code regression (#1514)
+###############################################################################
+#
+# #1514: invoking iccSpecSepToTiff with too few arguments printed Usage() and
+# returned 0 -- a success status for what is actually a malformed invocation,
+# so wrapper scripts / CI could not distinguish a no-op from a real conversion.
+# The fix makes the argc<minargs path return -1 (process status 255), matching
+# every other error exit in main().
+#
+# This test asserts:
+#   1. no-args            -> non-zero exit (the #1514 fix) + Usage printed
+#   2. too-few-args       -> non-zero exit (the #1514 fix) + Usage printed
+#   3. valid argc, missing input prefix -> exit 255 + "Cannot open input"
+#      (regression guard: the real-error path must keep failing non-zero)
+#
+# Before the fix, cases 1 and 2 exit 0 and this script FAILs (red); after the
+# fix they exit 255 and it PASSes (green).
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-specsep-usage-exit-code-regression}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+SPECSEP="$TOOLS_DIR/IccSpecSepToTiff/iccSpecSepToTiff"
+LOGFILE="$OUTDIR/specsep-usage-exit-code.log"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+fail_case() {
+  echo "  [FAIL] $1 -- $2"
+  FAIL=$((FAIL + 1))
+}
+
+pass_case() {
+  echo "  [PASS] $1 -- $2"
+  PASS=$((PASS + 1))
+}
+
+check_sanitizers() {
+  local name="$1"
+  local log="$2"
+  if grep -Eq "ERROR: AddressSanitizer|LeakSanitizer: detected memory leaks|runtime error:" "$log" 2>/dev/null; then
+    fail_case "$name" "sanitizer finding in tool output"
+    return 1
+  fi
+  return 0
+}
+
+# Cases 1 & 2: malformed (too few args) must fail non-zero AND still print Usage.
+run_usage_nonzero() {
+  local name="$1"; shift
+  TOTAL=$((TOTAL + 1))
+  local exit_code=0
+  timeout 60 "$SPECSEP" "$@" > "$LOGFILE" 2>&1 || exit_code=$?
+
+  check_sanitizers "$name" "$LOGFILE" || { sed -n '1,20p' "$LOGFILE"; return; }
+
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "expected non-zero exit for malformed invocation, got exit=0 (#1514)"
+    sed -n '1,20p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq "Usage:" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "missing Usage text on malformed invocation"
+    sed -n '1,20p' "$LOGFILE"
+    return
+  fi
+
+  pass_case "$name" "malformed invocation rejected with exit=$exit_code and Usage printed"
+}
+
+# Case 3: well-formed argc but the input prefix resolves to no files -- the
+# pre-existing error path that already returned -1; guard it stays non-zero.
+run_missing_input_reject() {
+  local name="iccSpecSepToTiff missing-input-prefix still exits non-zero"
+  TOTAL=$((TOTAL + 1))
+  local exit_code=0
+  local out="$OUTDIR/should-not-exist.tif"
+  rm -f "$out"
+  # 8 args (no profile): output compress sep prefix start end incr
+  timeout 60 "$SPECSEP" "$out" 0 0 "$OUTDIR/no-such-prefix_" 0 0 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  check_sanitizers "$name" "$LOGFILE" || { sed -n '1,20p' "$LOGFILE"; return; }
+
+  if [ "$exit_code" -ne 255 ]; then
+    fail_case "$name" "expected exit=255 for missing input, got exit=$exit_code"
+    sed -n '1,20p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq "Cannot open input" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "missing 'Cannot open input' diagnostic"
+    sed -n '1,20p' "$LOGFILE"
+    return
+  fi
+
+  if [ -e "$out" ]; then
+    fail_case "$name" "output TIFF created despite missing input"
+    return
+  fi
+
+  pass_case "$name" "missing input rejected with exit=255"
+}
+
+if [ ! -x "$SPECSEP" ]; then
+  echo "iccSpecSepToTiff not found at $SPECSEP -- skipping (build Tools first)"
+  exit 0
+fi
+
+echo "=== iccSpecSepToTiff usage-path exit-code regression (#1514) ==="
+run_usage_nonzero "iccSpecSepToTiff no-args exits non-zero"
+run_usage_nonzero "iccSpecSepToTiff too-few-args exits non-zero" foo.bar 0 0
+run_missing_input_reject
+echo "iccSpecSepToTiff usage-path exit-code regression: $PASS passed, $FAIL failed, $TOTAL total"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1092,6 +1092,14 @@ iccdev_add_script_test(
 )
 
 iccdev_add_script_test(
+  iccdev.specsep-usage-exit-code-regression
+  120
+  "iccdev;specsep;tiff;usage;exitcode;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1514-specsep-usage-exit-code-regression-tests.sh"
+)
+
+iccdev_add_script_test(
   iccdev.dump-profile-header-regression
   120
   "iccdev;dump;profile;header;regression;asan"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN apt-get update \
     g++=4:15.2.0-5ubuntu1 \
     lsb-release=12.1-2build1 \
     make=4.4.1-3 \
-    libxml2-dev=2.15.2+dfsg-0.1 \
+    zlib1g=1:1.3.dfsg+really1.3.1-1ubuntu3 \
+    libxml2-16=2.15.2+dfsg-0.1ubuntu0.1 \
+    libxml2-dev=2.15.2+dfsg-0.1ubuntu0.1 \
     nlohmann-json3-dev=3.12.0.really.3.12.0.really.3.11.3-3build1 \
     libtiff-dev=4.7.0-3ubuntu4 \
     libjpeg-dev=8c-2ubuntu12 \
@@ -77,7 +79,7 @@ LABEL org.opencontainers.image.title="iccDEV Build Container" \
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libc6=2.43-2ubuntu2 \
-    libxml2-16=2.15.2+dfsg-0.1 \
+    libxml2-16=2.15.2+dfsg-0.1ubuntu0.1 \
     libtiff6=4.7.0-3ubuntu4 \
     libjpeg8=8c-2ubuntu12 \
     libpng16-16t64=1.6.57-1 \

--- a/Dockerfile.ci-regression
+++ b/Dockerfile.ci-regression
@@ -50,7 +50,9 @@ RUN apt-get update \
     libssl-dev=3.5.5-1ubuntu3.2 \
     libtiff-dev=4.7.0-3ubuntu4 \
     libwxgtk3.2-dev=3.2.9+dfsg-1 \
-    libxml2-dev=2.15.2+dfsg-0.1 \
+    zlib1g=1:1.3.dfsg+really1.3.1-1ubuntu3 \
+    libxml2-16=2.15.2+dfsg-0.1ubuntu0.1 \
+    libxml2-dev=2.15.2+dfsg-0.1ubuntu0.1 \
     lcov=2.4-3 \
     lsb-release=12.1-2build1 \
     llvm=1:21.1.6-71 \


### PR DESCRIPTION
## Summary
In-repo regression for #1514 (companion to the fork fix PR). Registers `iccdev.specsep-usage-exit-code-regression`, which asserts `iccSpecSepToTiff`:
1. exits **non-zero** with no args (and still prints `Usage:`),
2. exits **non-zero** with too few args (and still prints `Usage:`),
3. **guard:** keeps exiting **255** with `Cannot open input` when a well-formed invocation has a missing input prefix (the pre-existing error path must not regress).

## Why this is split / stays red until the fix lands
Per the fork-gate, test/automation under `.github/` + `Build/Cmake/Testing/` must be in-repo, while the source fix goes from the fork. This test **exercises the #1514 fix**, so it is **red until that fix merges**: before the fix the two usage cases exit 0 and FAIL; after it they exit 255 and PASS.

**Merge the fix PR first**, then this one (rebased on master).

## Verification
Red-green proven locally on `build-dbg`: unfixed binary → `1 passed, 2 failed`; fixed binary → `3 passed, 0 failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
