### PR TITLE
Fix: iccPawgReport huge allocation on directory input (#1519)

### DIFF
--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -179,8 +179,18 @@ bool LoadRawProfile(const char *szFilename, RawProfile &raw)
 
   in.seekg(0, std::ios::end);
   std::streamoff end = in.tellg();
-  if (end < 0) {
-    raw.readError = "unable to determine file size";
+  // A directory (or other non-regular path) can be opened by std::ifstream
+  // successfully, yet tellg() then reports a nonsensical length: libstdc++
+  // returns LLONG_MAX (0x7fffffffffffffff) for a directory such as "/tmp".
+  // That value flowed straight into raw.data.resize() below, requesting a ~9 EB
+  // allocation that aborts under AddressSanitizer ("requested allocation size
+  // 0x7fffffffffffffff", #1519).  An ICC profile carries its size in a uint32
+  // header field, so any length that cannot fit a conformant profile is not one
+  // we could ever load; reject it here exactly like an unreadable file so the
+  // caller degrades to the same graceful "parse failed" report it already emits
+  // for a missing path, instead of crashing.
+  if (end < 0 || (uint64_t)end > 0xFFFFFFFFull) {
+    raw.readError = "input is not a readable regular file";
     return false;
   }
   in.seekg(0, std::ios::beg);


### PR DESCRIPTION
## Summary

Fixes #1519. `iccPawgReport /tmp` (a directory) aborted under AddressSanitizer:

```
==ERROR: AddressSanitizer: requested allocation size 0x7fffffffffffffff
(0x8000000000001000 after adjustments ...) exceeds maximum supported size
of 0x10000000000 ... in operator new(unsigned long)
```

In a non-sanitizer build the same input throws `std::bad_alloc`.

## Root cause

The crash is in the **tool-local** raw loader `LoadRawProfile()`
(`Tools/CmdLine/IccPawgReport/PawgReport.cpp`), *before* `ValidateIccProfile()`
— which already rejects a directory cleanly (this is exactly why `iccDumpProfile`
prints a graceful "Unable to parse '…' as ICC profile!" for the same path).

`LoadRawProfile()` opens the path with `std::ifstream` and sizes its buffer from
`tellg()`. A directory **opens successfully**, but libstdc++ then returns
`LLONG_MAX` from `tellg()`, which flowed straight into `raw.data.resize()` as a
~9 EB allocation request.

## Fix

An ICC profile carries its size in a `uint32` header field, so any length that
cannot fit a conformant profile is not one we could ever load. Reject such
lengths the same way an unreadable file is already rejected, so a directory
degrades to the identical graceful "parse failed" report the tool already emits
for a missing path:

```cpp
if (end < 0 || (uint64_t)end > 0xFFFFFFFFull) {
  raw.readError = "input is not a readable regular file";
  return false;
}
```

## Verification (clang-18, `-fsanitize=address`)

| build | input | before | after |
|-------|-------|--------|-------|
| ASan  | `/tmp` | `allocation-size-too-big` abort | exit 1, graceful report, **no** ASan finding |
| ASan  | valid profile | report, exit 0 | report, exit 0 (unchanged) |

## Scope

Source-only, value-preserving for all valid profiles. The paired CTest
regression (extends `iccdev.pawg-report-regressions` with a directory-input
crash guard) is filed as a separate in-repo PR, since it touches
`.github/scripts/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)