### PR TITLE
Fix: reject non-finite spectral range endpoints (NaN-cast, #2230)

### DIFF
--- a/IccProfLib/IccColorimetry.cpp
+++ b/IccProfLib/IccColorimetry.cpp
@@ -188,6 +188,14 @@ static void resampleCore(const Grid &src, const std::vector<double> &v,
     double w = dst.nm(j);                           // destination wavelength (nm)
     double t = (src.step != 0.0) ? (w - src.start) / src.step : 0.0;  // position in source samples
 
+    // Defence in depth for the (int)floor(t) cast below: callers validate ranges
+    // via rangeWellFormed() (which now rejects non-finite endpoints), so t should
+    // always be finite here, but a non-finite t would slip past both end-range
+    // tests (every comparison with NaN is false) and reach the cast as undefined
+    // behaviour (CWE-681, #2230).  Treat a degenerate position as the first
+    // sample rather than casting it.
+    if (!std::isfinite(t)) { out[j] = v[0]; continue; }
+
     if (t <= 0.0) {                                 // at/below first sample
       if (t > -1e-9) { out[j] = v[0]; continue; }   // within rounding of the first sample
       out[j] = (extend == icSpectralExtendLinear && n > 1)
@@ -235,6 +243,16 @@ static void toDouble(const icFloatNumber *p, int n, std::vector<double> &v) {
 // loops from silently working off a negative or zero wavelength step.
 static bool rangeWellFormed(const icSpectralRange &r) {
   if (!r.steps)
+    return false;
+  // Endpoints are icFloat16 and so can encode +/-Inf or NaN from a malformed
+  // profile.  Reject any non-finite endpoint: a multi-sample range with an
+  // infinite endpoint slips past the strictly-increasing check below (e.g.
+  // start = -Inf with a finite end still satisfies end > start) yet yields
+  // Grid::step = Inf and a per-sample position t = (w - start)/step = NaN, which
+  // then reaches the (int)floor(t) cast in resampleCore() -- undefined behaviour
+  // on the cast (CWE-681, #2230).  Reject it here, the module's Tier-1 boundary.
+  if (!std::isfinite((double)icF16toF(r.start)) ||
+      !std::isfinite((double)icF16toF(r.end)))
     return false;
   if (r.steps > 1 && !(icF16toF(r.end) > icF16toF(r.start)))
     return false;


### PR DESCRIPTION
## Summary

Fixes CodeQL alert **#2230** (`iccdev/float-to-int-cast`, CWE-681) at
`IccProfLib/IccColorimetry.cpp:204` — `(int)std::floor(t)` casts a NaN/Inf
position `t` to `int` (undefined behaviour).

## Reachable from a malformed profile

`icSpectralRange` endpoints are `icFloat16` and can encode ±Inf. `rangeWellFormed()`
only checked the endpoints are strictly increasing — which an infinite endpoint
satisfies (`start = -Inf`, finite `end` ⇒ `end > start`). Such a range builds
`Grid::step = Inf`, so `t = (w - start)/step = NaN`, which slips past both
end-range tests (every comparison with NaN is false) and reaches the cast.

UBSan confirms:
```
IccColorimetry.cpp:204:18: runtime error: -nan is outside the range of
representable values of type 'int'
```

## Fix (two layers, matching the module's Tier-1/Tier-2 boundary design)

- **`rangeWellFormed()`** now rejects any non-finite endpoint → a poisoned range
  never reaches the resample loop (the proper boundary fix).
- **`resampleCore()`** additionally skips a non-finite `t` (holds the first
  sample) as defence in depth for the cast itself, should a future caller bypass
  the boundary check.

Value-preserving for all well-formed ranges.

## Verification (clang-18, `-fsanitize=address,undefined`)

The paired regression adds **Part H8** to the `iccdev.colorimetry-methods`
contract test (feeds an Inf-endpoint range through `icSpectralResample` /
`SetObserver`). Red-green:

| | result |
|---|---|
| **without fix** | UBSan: `-nan is outside the range of representable values of type 'int'` at `:204`, exit 1 |
| **with fix** | all invariants pass, exit 0 |

## Scope

Source-only. The regression test (`.github/ci/regression/colorimetry-methods.cpp`,
already registered as `iccdev.colorimetry-methods`) is filed as a separate in-repo
PR since it touches `.github/`. This closes a gap in the IccColorimetry module
landed by #1503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)