### PR TITLE
Test: non-finite spectral range endpoint guard (#2230)

### DIFF
--- a/.github/ci/regression/colorimetry-methods.cpp
+++ b/.github/ci/regression/colorimetry-methods.cpp
@@ -608,6 +608,26 @@ void testInputGuards()
     check(set && !calc.PrepareEmissive(g),
           "PrepareEmissive(NaN in xbar) -> false (operator finiteness catch)", 0.0);
   }
+
+  // H8: a range with a non-finite endpoint is ill-formed -> rejected (#2230).
+  // icFloat16 endpoints can encode +/-Inf; an infinite endpoint passes the
+  // strictly-increasing check (end > -Inf is true) yet drives Grid::step to Inf
+  // and the per-sample position t to NaN, which would otherwise reach the
+  // (int)floor(t) cast in resampleCore() as undefined behaviour (CWE-681). The
+  // boundary guard must reject it -- fails red if that finiteness check is removed.
+  {
+    icSpectralRange infStart = makeRange(-INFINITY, 700, 31);  // start = float16 -Inf
+    icSpectralRange good = makeRange(400, 700, 31);
+    std::vector<icFloatNumber> in(31, (icFloatNumber)0.5), out(31);
+    check(!icSpectralResample(infStart, &in[0], good, &out[0]),
+          "resample(non-finite src endpoint) -> false", 0.0);
+    check(!icSpectralResample(good, &in[0], infStart, &out[0]),
+          "resample(non-finite dst endpoint) -> false", 0.0);
+
+    CIccColorimetricCalculator calc;
+    std::vector<icFloatNumber> obs = makeObserver(400, 700, 31);
+    check(!calc.SetObserver(infStart, &obs[0]), "SetObserver(non-finite endpoint) -> false", 0.0);
+  }
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

In-repo regression for CodeQL **#2230** (`iccdev/float-to-int-cast`, CWE-681),
paired with the source fix in #1525.

An `icSpectralRange` with a non-finite (`icFloat16` ±Inf) endpoint passed the
strictly-increasing check but drove `Grid::step` to Inf and the per-sample
position `t` to NaN, which reached the `(int)std::floor(t)` cast in
`resampleCore()` as undefined behaviour:

```
IccColorimetry.cpp:204:18: runtime error: -nan is outside the range of
representable values of type 'int'
```

## What this adds

**Part H8** of the `iccdev.colorimetry-methods` contract test: feeds an
Inf-endpoint range through `icSpectralResample` (src and dst) and
`CIccColorimetricCalculator::SetObserver`, asserting each is rejected. Red if the
`rangeWellFormed()` finiteness guard is removed. No new CMake registration — the
test is already wired as `iccdev.colorimetry-methods`.

## Verification (clang-18, `-fsanitize=address,undefined`)

| binary | result |
|--------|--------|
| **unfixed** (#1525 not applied) | UBSan abort `-nan is outside the range … of type 'int'` at `:204` |
| **fixed** (#1525 applied) | all invariants pass, exit 0 |

## Merge order

Merge **#1525 first**; H8 is red until the boundary guard lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)