### PR TITLE
Fix: CIccMatrixMath copy-assignment operator (Rule of Two, #172)

### DIFF
--- a/IccProfLib/IccMatrixMath.cpp
+++ b/IccProfLib/IccMatrixMath.cpp
@@ -131,6 +131,37 @@ CIccMatrixMath::CIccMatrixMath(const CIccMatrixMath &matrix)
 
 /**
 **************************************************************************
+* Name: CIccMatrixMath::operator=
+*
+* Purpose:
+*  Copy assignment (Rule of Two).  The copy constructor above deep-copies the
+*  owned m_vals buffer and the destructor frees it; without this matching
+*  operator the compiler-generated assignment would shallow-copy m_vals, so the
+*  source and target would share one buffer and double-free it on destruction.
+**************************************************************************
+*/
+CIccMatrixMath &CIccMatrixMath::operator=(const CIccMatrixMath &matrix)
+{
+  if (this == &matrix)
+    return *this;
+
+  int nTotal = matrix.m_nRows * matrix.m_nCols;
+  // Allocate the replacement before releasing the old buffer so a failed
+  // allocation leaves this object unchanged (strong exception guarantee).
+  icFloatNumber *vals = new icFloatNumber[nTotal];
+  memcpy(vals, matrix.m_vals, nTotal*sizeof(icFloatNumber));
+
+  delete[] m_vals;
+  m_vals = vals;
+  m_nRows = matrix.m_nRows;
+  m_nCols = matrix.m_nCols;
+
+  return *this;
+}
+
+
+/**
+**************************************************************************
 * Name: CIccMatrixMath::~CIccMatrixMath
 * 
 * Purpose: 

--- a/IccProfLib/IccMatrixMath.h
+++ b/IccProfLib/IccMatrixMath.h
@@ -91,6 +91,10 @@ class ICCPROFLIB_API CIccMatrixMath
 public:
   CIccMatrixMath(icUInt16Number nRows, icUInt16Number nCols, bool bInitIdentity=false);
   CIccMatrixMath(const CIccMatrixMath &mat);
+  // Rule of Two: the copy constructor deep-copies the owned m_vals buffer and the
+  // destructor deletes it, so a matching deep-copy assignment operator is required
+  // -- the implicit one would shallow-copy m_vals and double-free on destruction.
+  CIccMatrixMath &operator=(const CIccMatrixMath &mat);
   virtual ~CIccMatrixMath();
 
   virtual void VectorMult(icFloatNumber *pDst, const icFloatNumber *pSrc) const;


### PR DESCRIPTION
## Summary

Fixes CodeQL alert **#172** (`cpp/rule-of-two`) on `CIccMatrixMath`
(`IccProfLib/IccMatrixMath.{h,cpp}`).

The class declares a copy constructor that **deep-copies** its owned `m_vals`
buffer and a destructor that `delete[]`s it — but **no copy-assignment operator**.
The compiler-generated assignment shallow-copies `m_vals`, so the source and
target share one buffer and **double-free** it on destruction.

## Fix

Add a matching deep-copy `operator=` with self-assignment handling, allocating
the replacement buffer before releasing the old one (strong exception guarantee).
Same defect class as #1495/#1500.

## Verification (clang-18, `-fsanitize=address`)

```cpp
CIccMatrixMath a(3,3,true), b(2,2,true);
b = a;   // both destruct at scope exit
```

| | result |
|---|---|
| **before** | `AddressSanitizer: attempting double-free ... in operator delete[]`, exit 1 |
| **after** | clean, exit 0 |

## Scope

Source-only, value-preserving. Per the sibling rule-of-two fix #1500, no separate
CTest is added — the CodeQL re-scan closing the alert is the check, and the
double-free is reproduced/closed under ASan above. Builds clean under clang-18
strict (`-Wall -Wextra`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)