### PR TITLE
Fix: bound m_nSubElem ToXml walk by MAX_CALC_ELEMENTS (CodeQL unbounded-loop)

### DIFF
--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2477,7 +2477,9 @@ bool CIccMpeXmlCalculator::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
   if (m_SubElem && m_nSubElem) {
     xml += blanks2 + "<SubElements>\n";
-    for (i=0; i<(int)m_nSubElem; i++) {
+    // Mirror the MAX_CALC_ELEMENTS bound (rejected above) inline so the walk has an
+    // explicit cap at the point of iteration; a valid count is strictly less.
+    for (i=0; i<(int)m_nSubElem && i<(int)MAX_CALC_ELEMENTS; i++) {
       if (m_SubElem[i]) {
         IIccExtensionMpe *pExt = m_SubElem[i]->GetExtension();
         if (pExt && !strcmp(pExt->GetExtClassName(), "CIccMpeXml")) {


### PR DESCRIPTION
## Summary
`CIccMpeXmlCalculator::ToXml` already rejects `m_nSubElem >= MAX_CALC_ELEMENTS` a few lines above the serialization walk, but the `iccdev/unbounded-profile-loop` query (CWE-400/834) is not satisfied by an early-return guard across that distance. This mirrors the same cap inline in the loop condition (`i < (int)m_nSubElem && i < (int)MAX_CALC_ELEMENTS`).

Value-preserving: a valid count is strictly less than the cap. Identical inline-bound form validated by #1527, where the 13 IccMpeCalc sibling alerts flipped to `fixed` on the post-merge CodeQL re-scan.

## Alerts
Clears CodeQL `iccdev/unbounded-profile-loop` at IccMpeXml.cpp:2480 — alert #1029.

## Test
None — value-preserving and unreachable at runtime (the early-return guard already rejects oversized counts). Verification is the CodeQL re-scan, as with #1527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)