### PR TITLE
Fix: bound m_nSubElem ToJson walk by MAX_CALC_ELEMENTS (CodeQL unbounded-loop)

### DIFF
--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1994,7 +1994,11 @@ bool CIccMpeJsonCalculator::ToJson(IccJson &j)
   // Emit sub-elements (anonymous, in order)
   if (m_SubElem && m_nSubElem) {
     IccJson elems = IccJson::array();
-    for (icUInt32Number i = 0; i < m_nSubElem; i++) {
+    // CWE-400/CWE-834: m_nSubElem is the CIccMpeCalculator field that Read() caps at
+    // MAX_CALC_ELEMENTS (IccMpeCalc.h) while sizing m_SubElem[], so this serialization
+    // walk never exceeds the allocation. Mirror the cap inline so the bound is explicit
+    // at the point of iteration; a valid count is strictly less than the cap.
+    for (icUInt32Number i = 0; i < m_nSubElem && i < MAX_CALC_ELEMENTS; i++) {
       if (!m_SubElem[i]) return false;
       IIccExtensionMpe *pExt = m_SubElem[i]->GetExtension();
       if (!pExt || strcmp(pExt->GetExtClassName(), "CIccMpeJson") != 0)


### PR DESCRIPTION
## Summary
`CIccMpeJsonCalculator` derives from `CIccMpeCalculator`, whose `Read()` caps `m_nSubElem` at `MAX_CALC_ELEMENTS` (IccMpeCalc.h, included via IccMpeJson.h) while sizing `m_SubElem[]`. The `ToJson` serialization walk is therefore bounded in practice, but the `iccdev/unbounded-profile-loop` query (CWE-400/834) wants the cap mirrored in the loop condition (`i < m_nSubElem && i < MAX_CALC_ELEMENTS`).

Value-preserving: a valid count is strictly less than the cap. Identical inline-bound form validated by #1527, where the 13 IccMpeCalc sibling alerts flipped to `fixed` on the post-merge CodeQL re-scan.

## Alerts
Clears CodeQL `iccdev/unbounded-profile-loop` at IccMpeJson.cpp:1997 — alert #754.

## Test
None — value-preserving and unreachable at runtime (`Read()` rejects oversized counts before any serialization). Verification is the CodeQL re-scan, as with #1527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)