### PR TITLE
Fix: bound FloatNum ToJson m_nSize walk by nMaxNumValues (CodeQL unbounded-loop)

### DIFF
--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -1321,7 +1321,12 @@ template <class T, class A, icTagTypeSignature Tsig>
 bool CIccTagJsonFloatNum<T, A, Tsig>::ToJson(IccJson &j)
 {
   IccJson arr = IccJson::array();
-  for (icUInt32Number i = 0; i < this->m_nSize; i++)
+  // CWE-400/CWE-834: m_nSize is bounded by the tag byte size in Read() and m_Num is
+  // allocated to match; mirror the same explicit cap the integer sibling
+  // (CIccTagJsonNum::ToJson) uses, inline in the loop condition, so a corrupted count
+  // can't drive an unbounded serialization walk. A valid count is strictly less.
+  const icUInt32Number nMaxNumValues = 0xffffff;
+  for (icUInt32Number i = 0; i < this->m_nSize && i < nMaxNumValues; i++)
     arr.push_back((double)this->m_Num[i]);
   j["values"] = arr;
   return true;


### PR DESCRIPTION
## Summary
`CIccTagJsonFloatNum::ToJson` walked `m_nSize` over `m_Num[]` with no explicit cap, while the integer sibling `CIccTagJsonNum::ToJson` already bounds the identical walk at `nMaxNumValues` (`0xffffff`). `m_nSize` is bounded by the tag byte size in `Read()` and `m_Num` is allocated to match, so the walk is bounded in practice; this mirrors the sibling's cap **inline** in the loop condition (`i < m_nSize && i < nMaxNumValues`).

Value-preserving: a valid count is strictly less than the cap. Identical inline-bound form validated by #1527.

## Alerts
Clears CodeQL `iccdev/unbounded-profile-loop` at IccTagJson.cpp:1324 — alert #769.

## Test
None — value-preserving and unreachable at runtime (`Read()` bounds the count by the tag byte size). Verification is the CodeQL re-scan, as with #1527.

🤖 Generated with [Claude Code](https://claude.com/claude-code)