### PR TITLE
Fix: adjacent NaN/range guard on resampleCore float->int cast (CodeQL #2230)

### DIFF
--- a/IccProfLib/IccColorimetry.cpp
+++ b/IccProfLib/IccColorimetry.cpp
@@ -209,8 +209,17 @@ static void resampleCore(const Grid &src, const std::vector<double> &v,
       continue;
     }
 
-    int i = (int)std::floor(t);                     // source segment index (base sample v[i])
-    if (i > n - 2) i = n - 2;                        // keep the i+1 neighbour in range at the top
+    // CWE-681 (#2230): the isfinite(t) guard above already prevents a non-finite
+    // t from reaching this float->int conversion, and t is in (0, n-1) here, but
+    // clamp the cast operand to the valid segment range [0, n-2] right at the
+    // conversion so the NaN/range check is local to the cast (a float->int cast
+    // of a non-finite or out-of-range value is undefined behaviour). For any
+    // valid t this is a no-op: floor(t) is already in [0, n-2]. Mirrors the
+    // adjacent-guard form used in #1478.
+    double tf = std::floor(t);                      // source segment index (base sample v[i])
+    if (!(tf >= 0.0)) tf = 0.0;                     // also catches NaN
+    else if (tf > n - 2) tf = n - 2;               // keep the i+1 neighbour in range at the top
+    int i = (int)tf;
     double X = t - i;                               // fractional position within segment i
     if (interp == icSpectralInterpSprague && haveExt)
       out[j] = spragueEval(ext, i, X);


### PR DESCRIPTION
## Summary
#1525 added an `isfinite(t)` early-`continue` in `resampleCore` that dominates the `int i = (int)std::floor(t)` conversion, eliminating the CWE-681 UB at runtime (a non-finite `t` can no longer reach the cast). That fix is correct and merged.

However, the `iccdev/float-to-int-cast` query is **syntactic** — it cannot see a finiteness guard separated from the cast by the intervening `t<=0` / `t>=n-1` end-range branches — so alert **#2230** stayed open even though the bug is fixed. (Same query blind-spot as #1093.)

This applies the **adjacent-guard form accepted in #1478**: extract the cast operand into a local `tf`, clamp it to the valid segment range `[0, n-2]` (the `!(tf >= 0.0)` test also catches NaN) immediately before the conversion, then cast the local.

## Value-preserving
For any valid `t`, `floor(t)` is already in `[0, n-2]` (line 212 is only reachable with `0 < t < n-1`, which forces `n >= 2`), so the clamp is a no-op. It also subsumes the pre-existing post-cast clamp `if (i > n-2) i = n-2`.

## Alerts
Clears CodeQL `iccdev/float-to-int-cast` at IccColorimetry.cpp:212 — alert #2230.

## Test
None added — the runtime finiteness path is already covered by the merged regression #1526 (Part H8, non-finite spectral range). This change is value-preserving; CodeQL re-scan is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)