### PR TITLE
Fix: recognise 65536/0xffffff bounds in unbounded-profile-loop query (false positives)

### DIFF
--- a/.github/codeql-queries/unbounded-profile-loop.ql
+++ b/.github/codeql-queries/unbounded-profile-loop.ql
@@ -27,8 +27,15 @@ predicate isNarrowCountType(Type t) {
 
 predicate conditionMentionsFieldAndBound(Expr condition, Field field) {
   condition.getAChild*().(FieldAccess).getTarget() = field and
+  // Match a guard that names a recognised upper bound. NOTE: object-like macros
+  // (e.g. #define MAX_CALC_ELEMENTS 65536) are expanded before CodeQL builds the
+  // AST, so a guard written `field >= MAX_CALC_ELEMENTS` presents here as the
+  // literal `65536`, never the macro spelling. The bare value must therefore be
+  // listed alongside the macro name. Includes the concrete caps used across the
+  // library: 65536 (MAX_CALC_ELEMENTS) and 16777215/0xffffff (the 24-bit array
+  // serialization cap) in addition to the previously-listed 4096/65535.
   condition.getAChild*().toString().regexpMatch(
-    "(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|MAX_CALC_ELEMENTS|kMax).*"
+    "(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|65536|16777215|0xffffff|MAX_CALC_ELEMENTS|kMax).*"
   )
 }
 


### PR DESCRIPTION
## Summary

The `iccdev/unbounded-profile-loop` query (added in #1226) is reporting **false positives** on loops that are provably bounded — including every loop guarded by the shared `MAX_CALC_ELEMENTS` cap. This fixes the query's bound-recognition regex.

## Root cause

`conditionMentionsFieldAndBound` credits a loop as guarded only if it finds an `if (field >= LIMIT)` whose `LIMIT` text matches:

```ql
"(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|MAX_CALC_ELEMENTS|kMax).*"
```

Two gaps make this blind to the caps the library actually uses:

1. **Object-like macros are expanded before CodeQL builds the AST.** A guard written `field >= MAX_CALC_ELEMENTS` (where `#define MAX_CALC_ELEMENTS 65536`) presents in the AST as the literal **`65536`** — the spelling `MAX_CALC_ELEMENTS` never appears, so that alternative can never match a macro.
2. The numeric list contained `65535` but **not `65536`** (the actual cap value), and not `16777215`/`0xffffff` (the 24-bit array-serialization cap used in the JSON/XML number paths).

So guards built on `MAX_CALC_ELEMENTS` were entirely invisible to the bound check.

## Evidence

On master tip (commit `1576257`, which contains the merged guards from #1487/#1488/#1527/#1532–#1535), alert **#2274** fires on `IccProfLib/IccMpeCalc.cpp:3614`:

```cpp
3595:  if (m_nOps >= MAX_CALC_ELEMENTS)   // field-referencing guard, same function
3598:  ...
3614:  for (i=0; i<m_nOps && i<MAX_CALC_ELEMENTS; i++)   // <-- still flagged
```

The `hasPriorBoundGuardInFunction` exemption is designed for exactly this shape (guard above loop, same function, references the field). It fails only because `MAX_CALC_ELEMENTS` → `65536` is not in the regex. 18 further alerts (#2262–#2280) are the same pattern across `IccMpeCalc`, `IccTagMPE`, `IccMpeXml`, `IccMpeJson`, `IccTagJson`.

## Fix

Add the concrete cap values to the alternation (`65536`, `16777215`, `0xffffff`) with a comment explaining the macro-expansion gotcha. No library code changes — the existing field-referencing `if`-guards in the calc `Read`/`Write`/`Validate` methods are now correctly credited, so the false positives clear on the next scan.

```diff
-    "(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|MAX_CALC_ELEMENTS|kMax).*"
+    "(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|65536|16777215|0xffffff|MAX_CALC_ELEMENTS|kMax).*"
```

## Verification

CodeQL CLI not available in my local env; regex validated for both well-formedness and intended match/no-match behaviour against the real guard strings. The authoritative check is the post-merge `iccdev-custom-security` rescan — alerts #2262–#2280 should flip to `fixed`.

@xsscx — this touches your query from #1226; flagging for your review since it changes detection logic (a false-positive reduction, not a coverage change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)