### PR TITLE
Test: CIccTagData zlib compression round-trip (#1521)

### DIFF
--- a/.github/ci/regression/tagdata-zlib-roundtrip.cpp
+++ b/.github/ci/regression/tagdata-zlib-roundtrip.cpp
@@ -1,0 +1,86 @@
+// Regression: CIccTagData zlib compression round-trip (#1521).
+//
+// Exercises the compressed-dataType read/write path completed in #1521. The
+// stub this replaces left CIccTagData::Read() with the on-disk zlib bytes
+// uninterpreted and CIccTagData::Write() writing zero payload bytes (silent
+// data loss). This test loads plaintext into a compressed-flagged data tag,
+// writes it (must deflate to fewer bytes than the plaintext), reads it back
+// (must inflate to the exact original), and verifies a second round-trip is
+// stable. An uncompressed control confirms the non-compressed path is verbatim.
+//
+// Built and registered only when ICC_USE_ZLIB is enabled (the option added in
+// #1530); without zlib the library cannot deflate and these invariants do not
+// hold.
+#include "IccTag.h"
+#include "IccIO.h"
+#include "IccProfile.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+static int g_fail = 0;
+#define CHECK(c) do { if(!(c)){ std::printf("FAIL line %d: %s\n", __LINE__, #c); g_fail=1; } } while(0)
+
+int main()
+{
+  // Plaintext with redundancy so deflate measurably shrinks it.
+  std::string plain;
+  for (int i = 0; i < 5000; i++)
+    plain += (char)('A' + (i % 26));
+  const icUInt32Number nPlain = (icUInt32Number)plain.size();
+
+  // Compressed-binary data tag loaded with the plaintext.
+  CIccTagData src;
+  src.SetDataType(icCompressedBinaryData);   // icCompressedData | icBinaryData
+  CHECK(src.IsTypeCompressed());
+  CHECK(src.SetSize(nPlain, false));
+  std::memcpy(src.GetData(0), plain.data(), nPlain);
+
+  // Write -> on-disk form is a deflate stream, smaller than the plaintext.
+  CIccMemIO io;
+  CHECK(io.Alloc(64 + nPlain, true));
+  CHECK(src.Write(&io));
+  const icUInt32Number nWritten = (icUInt32Number)io.Tell();
+  std::printf("plaintext=%u bytes, written(tag incl 12-byte header)=%u bytes\n",
+              nPlain, nWritten);
+  CHECK(nWritten < nPlain);   // compression must have shrunk the payload
+  CHECK(nWritten > 12);       // 3x uint32 header + a non-empty deflate stream
+
+  // Read back -> Read() inflates to the exact original plaintext.
+  io.Seek(0, icSeekSet);
+  CIccTagData dst;
+  CHECK(dst.Read(nWritten, &io));
+  CHECK(dst.IsTypeCompressed());
+  CHECK(dst.GetSize() == nPlain);
+  CHECK(std::memcmp(dst.GetData(0), plain.data(), nPlain) == 0);
+
+  // Second round-trip from the read-back tag must remain byte-exact.
+  CIccMemIO io2;
+  CHECK(io2.Alloc(64 + nPlain, true));
+  CHECK(dst.Write(&io2));
+  const icUInt32Number nWritten2 = (icUInt32Number)io2.Tell();
+  io2.Seek(0, icSeekSet);
+  CIccTagData dst2;
+  CHECK(dst2.Read(nWritten2, &io2));
+  CHECK(dst2.GetSize() == nPlain);
+  CHECK(std::memcmp(dst2.GetData(0), plain.data(), nPlain) == 0);
+
+  // Uncompressed control: a plain ascii tag round-trips verbatim, no compression.
+  CIccTagData u;
+  u.SetDataType(icAsciiData);
+  CHECK(!u.IsTypeCompressed());
+  CHECK(u.SetSize(nPlain, false));
+  std::memcpy(u.GetData(0), plain.data(), nPlain);
+  CIccMemIO io3;
+  CHECK(io3.Alloc(64 + nPlain, true));
+  CHECK(u.Write(&io3));
+  CHECK((icUInt32Number)io3.Tell() == 12 + nPlain);   // header + verbatim payload
+
+  if (g_fail) {
+    std::printf("RESULT: FAIL\n");
+    return 1;
+  }
+  std::printf("RESULT: PASS (CIccTagData zlib round-trip invariants held)\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -699,6 +699,53 @@ function(iccdev_add_profile_write_failure_test)
   endif()
 endfunction()
 
+function(iccdev_add_tagdata_zlib_roundtrip_test)
+  # Compressed dataType read/write only works when the library is built with
+  # zlib (#1530 ICC_USE_ZLIB option); skip otherwise so the deflate/inflate
+  # invariants this test asserts are never checked against a no-zlib build.
+  if(NOT ICC_USE_ZLIB)
+    return()
+  endif()
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccTagDataZlibRoundtripTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/tagdata-zlib-roundtrip.cpp"
+  )
+  target_compile_features(iccTagDataZlibRoundtripTest PRIVATE cxx_std_17)
+  # IccProfLib links ZLIB::ZLIB and defines ICC_USE_ZLIB=1 PUBLIC, so both
+  # propagate to this executable; link zlib explicitly as belt-and-braces.
+  target_link_libraries(iccTagDataZlibRoundtripTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  if(TARGET ZLIB::ZLIB)
+    target_link_libraries(iccTagDataZlibRoundtripTest PRIVATE ZLIB::ZLIB)
+  endif()
+  add_dependencies(check iccTagDataZlibRoundtripTest)
+
+  add_test(
+    NAME iccdev.tagdata-zlib-roundtrip
+    COMMAND "$<TARGET_FILE:iccTagDataZlibRoundtripTest>"
+  )
+  set_tests_properties(iccdev.tagdata-zlib-roundtrip PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;tag;zlib;compression;issue-1521;regression"
+  )
+  if(WIN32)
+    set(_tagdata_zlib_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccTagDataZlibRoundtripTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _tagdata_zlib_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.tagdata-zlib-roundtrip PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_tagdata_zlib_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_parser_restore_calls_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -939,6 +986,7 @@ if(WIN32)
   iccdev_add_fileio_getlength_position_test()
   iccdev_add_profile_write_failure_test()
   iccdev_add_fileio_seek_tell_test()
+  iccdev_add_tagdata_zlib_roundtrip_test()
   iccdev_add_parser_restore_calls_test()
   iccdev_add_tag_layout_shared_data_test()
   iccdev_add_pawg_q2_tonecurves_test()
@@ -1004,6 +1052,7 @@ iccdev_add_embedio_read8_bounds_test()
 iccdev_add_fileio_getlength_position_test()
 iccdev_add_profile_write_failure_test()
 iccdev_add_fileio_seek_tell_test()
+iccdev_add_tagdata_zlib_roundtrip_test()
 iccdev_add_parser_restore_calls_test()
 iccdev_add_tag_layout_shared_data_test()
 iccdev_add_pawg_q2_tonecurves_test()


### PR DESCRIPTION
## Summary

In-repo CTest for the **#1521 code-half** (compressed `dataType` read/write), now landable since #1530 merged the `ICC_USE_ZLIB` CMake option. Pairs with **#1539** (the fix).

`iccdev.tagdata-zlib-roundtrip`:
1. Loads a 5000-byte redundant plaintext into a compressed-flagged `CIccTagData`.
2. `Write()` → asserts the on-disk form **deflated smaller** than the plaintext (the old stub wrote 0 payload bytes).
3. `Read()` → asserts inflate yields the **exact** original.
4. Second round-trip → asserts byte-stability.
5. Uncompressed control tag → asserts verbatim write (no compression on the non-compressed path).

## Gating

Registered only when `ICC_USE_ZLIB` is ON — the test function early-returns otherwise, so the deflate/inflate invariants are never asserted against a build that cannot compress. `ICC_USE_ZLIB=1` and `ZLIB::ZLIB` propagate `PUBLIC` from IccProfLib; zlib is also linked explicitly.

## Verification (local, clang-18)

| config | result |
|---|---|
| `-DICC_USE_ZLIB=ON` | builds, `ctest -N` lists it, **passes** — `plaintext=5000 → tag=73 bytes → exact round-trip` |
| `-DICC_USE_ZLIB=OFF` | correctly **not registered** (gate holds) |

Against the pre-#1539 stub the same harness fails (Write emits only the 12-byte header — payload lost), so it is a true red/green guard.

> ⚠️ Merge ordering: this is green only once **#1539** (the fix) is in. If CI here runs with `ICC_USE_ZLIB=OFF` (the default), the test is skipped and CI stays green regardless; it actively guards the fix only in a zlib-enabled build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)