### PR TITLE
Fix: bound two JSON ToJson serialization walks by field guard (CodeQL unbounded-loop)

### DIFF
--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1996,8 +1996,10 @@ bool CIccMpeJsonCalculator::ToJson(IccJson &j)
     IccJson elems = IccJson::array();
     // CWE-400/CWE-834: m_nSubElem is the CIccMpeCalculator field that Read() caps at
     // MAX_CALC_ELEMENTS (IccMpeCalc.h) while sizing m_SubElem[], so this serialization
-    // walk never exceeds the allocation. Mirror the cap inline so the bound is explicit
-    // at the point of iteration; a valid count is strictly less than the cap.
+    // walk never exceeds the allocation. Assert that bound on the field before the
+    // walk (a valid count is strictly less than the cap) and keep it mirrored inline.
+    if (m_nSubElem >= MAX_CALC_ELEMENTS)
+      return false;
     for (icUInt32Number i = 0; i < m_nSubElem && i < MAX_CALC_ELEMENTS; i++) {
       if (!m_SubElem[i]) return false;
       IIccExtensionMpe *pExt = m_SubElem[i]->GetExtension();

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -1322,10 +1322,12 @@ bool CIccTagJsonFloatNum<T, A, Tsig>::ToJson(IccJson &j)
 {
   IccJson arr = IccJson::array();
   // CWE-400/CWE-834: m_nSize is bounded by the tag byte size in Read() and m_Num is
-  // allocated to match; mirror the same explicit cap the integer sibling
-  // (CIccTagJsonNum::ToJson) uses, inline in the loop condition, so a corrupted count
-  // can't drive an unbounded serialization walk. A valid count is strictly less.
+  // allocated to match; cap this serialization walk so a corrupted count can't drive
+  // an unbounded loop. Assert the bound on the field before the walk (a valid count
+  // is strictly less) and keep it mirrored inline in the loop condition.
   const icUInt32Number nMaxNumValues = 0xffffff;
+  if (this->m_nSize > nMaxNumValues)
+    return false;
   for (icUInt32Number i = 0; i < this->m_nSize && i < nMaxNumValues; i++)
     arr.push_back((double)this->m_Num[i]);
   j["values"] = arr;


### PR DESCRIPTION
## Summary

Clears the last two `iccdev/unbounded-profile-loop` false positives in the JSON serialization path (alerts #2275, #2276), completing the family after #1540 fixed the query's bound-regex.

| alert | loop | field | cap |
|---|---|---|---|
| #2275 | `CIccMpeJsonCalculator::ToJson` | `m_nSubElem` | `MAX_CALC_ELEMENTS` |
| #2276 | `CIccTagJsonFloatNum::ToJson` | `m_nSize` | `0xffffff` |

Both walks were already bounded **inline** in the `for` condition (from #1534/#1535), but the query credits only a **field-referencing `if`-guard before the loop** (`hasPriorBoundGuardInFunction`), not a bound mirrored in the loop condition. This adds those guards (return false on a count at/above the cap) and keeps the inline bounds as defence-in-depth.

Both counts are already enforced at `Read()` (m_nSubElem sized into `m_SubElem[]`; m_nSize bounded by the tag byte size), so the guards are **value-preserving** — a valid count is always below the cap and the guard never trips for conformant data.

## Verification

Both files compile clean (`-fsyntax-only` with the JSON include set). The authoritative check is the post-merge `iccdev-custom-security` rescan — #2275/#2276 should flip to `fixed`.

Source-only; no build/CI files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)