### PR TITLE
Fix: guard the two remaining float-to-int casts (CodeQL #2281, #1902)

### DIFF
--- a/IccProfLib/IccColorimetry.cpp
+++ b/IccProfLib/IccColorimetry.cpp
@@ -217,6 +217,7 @@ static void resampleCore(const Grid &src, const std::vector<double> &v,
     // valid t this is a no-op: floor(t) is already in [0, n-2]. Mirrors the
     // adjacent-guard form used in #1478.
     double tf = std::floor(t);                      // source segment index (base sample v[i])
+    if (!std::isfinite(tf)) tf = 0.0;               // explicit NaN/Inf guard local to the cast (CWE-681)
     if (!(tf >= 0.0)) tf = 0.0;                     // also catches NaN
     else if (tf > n - 2) tf = n - 2;               // keep the i+1 neighbour in range at the top
     int i = (int)tf;

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -77,6 +77,7 @@
 #include <map>
 #include <sstream>  // Make sure to include this header
 #include <iomanip>  // Include this header for setw and setfill
+#include <cmath>    // std::isfinite for NaN/Inf-safe float->int casts
 
 typedef  std::map<icUInt32Number, icTagSignature> IccOffsetTagSigMap;
 
@@ -912,7 +913,15 @@ bool CIccTagXmlNamedColor2::ToXml(std::string &xml, std::string blanks/* = ""*/)
         for (j=0; j<(int)m_nDeviceCoords; j++) {
           if (j)
             xml+=" ";
-          snprintf(buf, bufSize, "%d", (int)(pEntry->deviceCoords[j] * 65535.0 + 0.5));
+          // CWE-681 (CodeQL #1902): deviceCoords come from a parsed profile and may be
+          // NaN/Inf for malformed input; a non-finite float->int cast is undefined
+          // behaviour. Guard finiteness and clamp to the valid 16-bit device range
+          // [0,65535] before the cast (a no-op for any conformant coord in [0,1]).
+          double dc = pEntry->deviceCoords[j] * 65535.0 + 0.5;
+          if (!std::isfinite(dc)) dc = 0.0;
+          else if (dc < 0.0) dc = 0.0;
+          else if (dc > 65535.0) dc = 65535.0;
+          snprintf(buf, bufSize, "%d", (int)dc);
           xml += buf;
         }
         xml += "\n";


### PR DESCRIPTION
## Summary

Closes the two remaining `iccdev/float-to-int-cast` (CWE-681) alerts under the **#1541 CodeQL Cleanup** rollup. A float→int cast of a non-finite (NaN/Inf) operand is undefined behaviour, and a malformed profile can drive non-finite floats into both conversions.

### `IccColorimetry.cpp` resampleCore — alert **#2281**
The cast operand `tf` is *already* bounded (the `isfinite(t)` guard ~25 lines above + the `!(tf >= 0.0)` clamp that also catches NaN). But the guard is outside the query's local 5-line window and the comparison form isn't recognised as a NaN check, so the query re-flags the cast. This alert is **new today** (created 09:19, after #1525 merged) — fingerprint drift onto the shifted cast line. Fix: add an explicit `std::isfinite(tf)` guard immediately above the cast. Redundant for valid data, but makes the NaN guard local to the conversion and easier to read.

### `IccTagXml.cpp` `CIccTagXmlNamedColor2::ToXml` — alert **#1902**
**Genuine gap.** The XML writer cast `(int)(deviceCoords[j] * 65535.0 + 0.5)` had **no guard at all**, and `deviceCoords` come straight from a parsed profile. Guard finiteness and clamp to the valid 16-bit device range `[0,65535]` before the cast — a no-op for any conformant coord in `[0,1]`. Adds `<cmath>` for `std::isfinite`.

## Verification
- Both files `clang++-18 -std=c++17 -fsyntax-only` clean (EXIT=0).
- Value-preserving for conformant profiles; the CodeQL rescan is the verification (no behavioural test).

Refs #1541, #1902, #2281.

🤖 Generated with [Claude Code](https://claude.com/claude-code)