### PR TITLE
CodeQL: add unbounded-clut-index query (CWE-125, #1548 pattern)

### DIFF
--- a/.github/codeql-queries/README.md
+++ b/.github/codeql-queries/README.md
@@ -16,6 +16,7 @@ They complement GitHub's standard `cpp-security-and-quality` suite.
 | `snprintf-size-mismatch` | CWE-120 | Buffer smaller than formatted output |
 | `unchecked-allocation` | CWE-252, CWE-476 | Allocation result used without null check |
 | `unbounded-profile-loop` | CWE-400, CWE-834 | Loop bound from profile field without cap |
+| `unbounded-clut-index` | CWE-125 | CLUT `GetData()` buffer indexed without a length bound (#1548) |
 | `float-to-int-cast` | CWE-681 | Float-to-integer cast without range check |
 | `division-by-zero-profile` | CWE-369 | Division by profile-derived value |
 | `world-writable-output` | CWE-732 | File created with world-writable mode |

--- a/.github/codeql-queries/unbounded-clut-index.ql
+++ b/.github/codeql-queries/unbounded-clut-index.ql
@@ -1,0 +1,103 @@
+/**
+ * @name Unbounded index into CLUT/LUT sample data
+ * @description A CmdLine tool reads a buffer returned by CIccCLUT/CIccMBB::GetData()
+ *              with a computed index but never bounds that index against the CLUT's
+ *              actual sample count (NumPoints() x channels). A malformed or
+ *              non-square CLUT can drive the index past the end of the sample array,
+ *              giving an out-of-bounds read (CWE-125). This is the pattern behind the
+ *              iccProfilePlot buildClutRaster() heap-buffer-overflow (issue #1548):
+ *              the tile-packing geometry was derived from the grid arrangement, not
+ *              from the real array length.
+ * @kind problem
+ * @problem.severity warning
+ * @security-severity 6.5
+ * @precision medium
+ * @id iccdev/unbounded-clut-index
+ * @tags security
+ *       correctness
+ *       external/cwe/cwe-125
+ */
+
+import cpp
+
+// Scope to the CmdLine tools.  The IccProfLib core interpolation paths
+// (CIccCLUT::Interp*, MPE elements) also index GetData() results, but they are
+// bounded by their own input-clamping invariants and are intentionally out of
+// scope here -- this query targets the tool-side report/render code where the
+// index is reconstructed from profile geometry (the #1548 class).
+private predicate isToolSource(File f) {
+  f.getRelativePath().regexpMatch("Tools/.*") and
+  not f.getRelativePath().regexpMatch("(?i).*(^|/)(test|tests|Testing)(/|$).*")
+}
+
+// A `…GetData(…)` call whose receiver is a CLUT / multi-dimensional-LUT object,
+// i.e. the flat icFloatNumber sample array a CLUT raster walk indexes into.
+private predicate isClutGetDataCall(FunctionCall call) {
+  call.getTarget().getName() = "GetData" and
+  exists(string t | t = call.getTarget().getDeclaringType().getName() |
+    t.regexpMatch("(?i)CIcc.*(CLUT|MBB)")
+  )
+}
+
+// A LOCAL pointer initialised from such a call -- e.g. `clutData = clut->GetData(0)`.
+// Requiring a local (not a member) keeps this to the in-function "fetch then index"
+// shape of #1548 and excludes the member-pointer caches used elsewhere.
+private predicate isClutDataLocal(LocalVariable v) {
+  exists(FunctionCall call |
+    isClutGetDataCall(call) and
+    call = v.getInitializer().getExpr().getAChild*()
+  )
+}
+
+// Names that denote the CLUT's own sample/node length -- a comparison or
+// min()/clamp against one of these is what actually bounds a CLUT index. Kept
+// deliberately CLUT-specific (NumPoints/NumOffset/SampleCount/node counts) rather
+// than the broad *Size/*Count families: an unrelated `nSize`/`vector.size()`
+// comparison elsewhere in a large function must NOT be credited as a bound on the
+// CLUT array (that loose form let the original iccProfileVisualize index slip
+// through). The #1548 fix's `clutSampleCount` (= NumPoints() x channels) matches.
+bindingset[name]
+private predicate isLengthName(string name) {
+  name.regexpMatch(
+    "(?i)^(.*NumPoints.*|.*NumOffset.*|.*SampleCount.*|.*ClutSize.*|" +
+    ".*ClutSampleCount.*|.*nNodes.*|.*MaxNodes.*|.*NodeCount.*)$"
+  )
+}
+
+// True when an earlier statement in the same function bounds something against a
+// length-named symbol: either a comparison (`idx > clutSampleCount`,
+// `i < NumPoints()*nout`) or a std::min/clamp, referencing a count/size name.
+// This is what the #1548 fix added (`in + outputChannels > clutSampleCount`), and
+// what already-correct loop-bounded indexing (`for (...; i < NumPoints()*n; ...)`)
+// satisfies -- so both clear the alert.
+private predicate hasLengthBoundBefore(ArrayExpr access) {
+  exists(Expr guard |
+    guard.getEnclosingFunction() = access.getEnclosingFunction() and
+    guard.getLocation().getStartLine() < access.getLocation().getStartLine() and
+    (
+      guard instanceof ComparisonOperation
+      or
+      guard.(FunctionCall).getTarget().getName().regexpMatch("(?i)^(min|clamp|clip)$")
+    ) and
+    exists(Expr ref |
+      ref = guard.getAChild*() and
+      (
+        isLengthName(ref.(VariableAccess).getTarget().getName())
+        or
+        isLengthName(ref.(FunctionCall).getTarget().getName())
+      )
+    )
+  )
+}
+
+from ArrayExpr ae, LocalVariable v
+where
+  ae.getArrayBase().(VariableAccess).getTarget() = v and
+  isClutDataLocal(v) and
+  not hasLengthBoundBefore(ae) and
+  isToolSource(ae.getFile())
+select ae,
+  "Index into CLUT sample buffer '" + v.getName() +
+  "' (from GetData()) without a prior bound check against the CLUT element count " +
+  "(e.g. NumPoints() x channels). A malformed/non-square CLUT can read past the " +
+  "array end; add an explicit length guard before this access (CWE-125, see #1548)."


### PR DESCRIPTION
## Summary

Adds a custom CodeQL query `iccdev/unbounded-clut-index` that flags the bug class behind #1548: a CmdLine tool indexes a buffer returned by `CIccCLUT`/`CIccMBB::GetData()` with a *computed* index but never bounds it against the CLUT's real sample count (`NumPoints()` × channels), so a malformed / non-square CLUT can read past the array end (CWE-125).

This is a tripwire for the pattern, split out from the #1548 fix (PR #1517) so that PR stays focused on the fixes + regressions.

## Scoping (deliberately precise / low-noise)

- **Sink:** a *local* pointer initialised from a CLUT/MBB `GetData()` call and indexed in the same function — the "fetch then index" shape of #1548. Member-pointer caches and cross-function indexing are excluded.
- **Files:** `Tools/` only. The IccProfLib core interpolation paths (`CIccCLUT::Interp*`, MPE elements) also index `GetData()` results but are bounded by their own input-clamping invariants and are intentionally out of scope.
- **Cleared when:** a prior comparison or `std::min` in the same function references a CLUT-length name (`NumPoints`/`NumOffset`/`SampleCount`/node counts) — i.e. the exact guard the #1548 fix adds. Broad `*Size`/`*Count` names are intentionally *not* credited (an unrelated `nSize`/`vector.size()` comparison must not count as a CLUT bound).

## Verification (against a real CodeQL DB of the tool tree)

- ✅ **Clears** the fixed `IccVizModel.cpp` (its `clutSampleCount = NumPoints()×channels` guard).
- ✅ **Excludes** the IccProfLib core `GetData()`-index sites (`IccMpeBasic`/`IccMpeSpectral`).
- ⚠️ **Flags** the still-unbounded reference `Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp:1620/1623/1626` — a genuine latent gap in the standalone tool (its strides are correct, so its exposure is malformed-metadata only, but the read is unbounded). Surfaced for maintainer triage.

`security-severity 6.5` (medium) — annotates, does not block the required check. Query compiles clean (`gh codeql query compile`).

Refs #1548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)