### PR TITLE
IccColorimetry: add Loaded Weight Table reduction method (#1475)

### DIFF
--- a/.github/ci/regression/colorimetry-methods.cpp
+++ b/.github/ci/regression/colorimetry-methods.cpp
@@ -630,6 +630,174 @@ void testInputGuards()
   }
 }
 
+// ---- Part I: loaded weighting table (icXYZCalcLoadedTable) ----------------------
+// The calculator carries a complete weighting-table operator that it ALWAYS keeps
+// populated: seeded with a registry LWL table at construction, re-seeded to track the
+// selected standard observer+illuminant, or replaced via LoadWeightingTable(). This
+// part pins that contract -- every assertion is red-green against the feature:
+//   I1 default seed == registry D50/1931        (breaks if the ctor seed is removed)
+//   I2 auto-track to the selected registry combo (breaks if SetStandard* re-seed goes)
+//   I3 non-registry illuminant keeps a valid seed
+//   I4 LoadWeightingTable validation rejects garbage, leaving the prior table intact
+//   I5 a valid load (incl. negative weights) pins the table against later SetStandard*
+//   I6 Prepare(icXYZCalcLoadedTable) needs a matching grid and reduces correctly
+//   I7 ResetWeightingTableToRegistry reaches LED-B1 (no wire-enum); unknown -> false
+//   I8 the static GetRegistryWeightingTable accessor == the free function
+void testLoadedWeightingTable()
+{
+  // Exact-grid + value comparison of two 3*steps tables; large sentinel if grids differ.
+  auto tableDiff = [](const icSpectralRange &ra, const icFloatNumber *a,
+                      const icSpectralRange &rb, const icFloatNumber *b) -> double {
+    if (!a || !b || ra.start != rb.start || ra.end != rb.end || ra.steps != rb.steps)
+      return 1e9;
+    double m = 0.0;
+    for (int i = 0; i < 3 * (int)ra.steps; i++)
+      m = std::max(m, std::fabs((double)a[i] - (double)b[i]));
+    return m;
+  };
+
+  icSpectralRange regR;
+  const icFloatNumber *regD50_1931 = icGetColorimetryWeightingTable(icStdObs1931TwoDegrees, icWtIllumD50, regR);
+
+  // I1: a fresh calculator already has the registry D50/1931 table loaded (the seed),
+  // so icXYZCalcLoadedTable is usable with no caller setup.
+  {
+    CIccColorimetricCalculator calc;
+    icSpectralRange lr; const icFloatNumber *lw = NULL;
+    bool got = calc.GetLoadedWeightingTable(lr, lw);
+    check(got && lw, "loaded I1: default table present after construction", 0.0);
+    double d = tableDiff(lr, lw, regR, regD50_1931);
+    check(d < TOL_EXACT, "loaded I1: default seed == registry D50/1931", d);
+  }
+
+  // I2: setting a standard observer + illuminant that the registry publishes re-seeds
+  // the loaded table to that exact combination.
+  {
+    CIccColorimetricCalculator calc;
+    check(calc.SetStandardObserver(icStdObs1964TenDegrees), "loaded I2: set 1964 observer", 0.0);
+    check(calc.SetStandardIlluminant(icIlluminantD65),      "loaded I2: set D65 illuminant", 0.0);
+    icSpectralRange lr; const icFloatNumber *lw = NULL;
+    calc.GetLoadedWeightingTable(lr, lw);
+    icSpectralRange rr; const icFloatNumber *rw = icGetColorimetryWeightingTable(icStdObs1964TenDegrees, icWtIllumD65, rr);
+    double d = tableDiff(lr, lw, rr, rw);
+    check(d < TOL_EXACT, "loaded I2: auto-tracks to registry D65/1964", d);
+  }
+
+  // I3: an illuminant with no registry table (D93) leaves the previous valid seed in
+  // place rather than clearing it -- the method never ends up table-less.
+  {
+    CIccColorimetricCalculator calc;
+    calc.SetStandardObserver(icStdObs1931TwoDegrees);
+    calc.SetStandardIlluminant(icIlluminantD50);   // -> registry D50/1931
+    calc.SetStandardIlluminant(icIlluminantD93);   // no registry table; keep D50/1931
+    icSpectralRange lr; const icFloatNumber *lw = NULL;
+    bool got = calc.GetLoadedWeightingTable(lr, lw);
+    double d = tableDiff(lr, lw, regR, regD50_1931);
+    check(got && d < TOL_EXACT, "loaded I3: non-registry illuminant retains prior seed", d);
+  }
+
+  // I4: LoadWeightingTable validation. Build a valid baseline from the registry table,
+  // then mutate it to trip each gate; a rejected load must leave the prior table intact.
+  {
+    CIccColorimetricCalculator calc;                      // starts at registry D50/1931
+    const int n = (int)regR.steps;                        // 41
+    icSpectralRange g = makeRange(380, 780, n);
+    std::vector<icFloatNumber> base(regD50_1931, regD50_1931 + 3 * n);
+
+    check(!calc.LoadWeightingTable(g, NULL), "loaded I4: null weights -> false", 0.0);
+
+    icSpectralRange g1 = makeRange(500, 500, 1);
+    std::vector<icFloatNumber> one(3, (icFloatNumber)0.1);
+    check(!calc.LoadWeightingTable(g1, &one[0]), "loaded I4: < 2 samples -> false", 0.0);
+
+    std::vector<icFloatNumber> nan = base; nan[5] = (icFloatNumber)NAN;
+    check(!calc.LoadWeightingTable(g, &nan[0]), "loaded I4: non-finite value -> false", 0.0);
+
+    std::vector<icFloatNumber> huge = base; huge[5] = (icFloatNumber)1e30;
+    check(!calc.LoadWeightingTable(g, &huge[0]), "loaded I4: absurd magnitude -> false", 0.0);
+
+    // None of the rejected loads disturbed the seeded table.
+    icSpectralRange lr; const icFloatNumber *lw = NULL;
+    calc.GetLoadedWeightingTable(lr, lw);
+    double d = tableDiff(lr, lw, regR, regD50_1931);
+    check(d < TOL_EXACT, "loaded I4: rejected loads leave prior table intact", d);
+  }
+
+  // I5: a valid load -- including a legitimately NEGATIVE weight (LWL tables have them;
+  // values are not clamped) -- takes effect and PINS the table: a later SetStandard*
+  // no longer re-seeds it.
+  {
+    CIccColorimetricCalculator calc;
+    const int n = (int)regR.steps;
+    icSpectralRange g = makeRange(380, 780, n);
+    std::vector<icFloatNumber> custom(regD50_1931, regD50_1931 + 3 * n);
+    custom[0] = (icFloatNumber)(-0.5);                    // negative weight is accepted
+    check(calc.LoadWeightingTable(g, &custom[0]), "loaded I5: valid load (w/ negative) -> true", 0.0);
+
+    icSpectralRange lr; const icFloatNumber *lw = NULL;
+    calc.GetLoadedWeightingTable(lr, lw);
+    double d = tableDiff(lr, lw, g, &custom[0]);
+    check(d < TOL_EXACT, "loaded I5: loaded values retrievable verbatim", d);
+
+    calc.SetStandardObserver(icStdObs1964TenDegrees);     // would re-seed if not pinned
+    calc.SetStandardIlluminant(icIlluminantA);
+    calc.GetLoadedWeightingTable(lr, lw);
+    double d2 = tableDiff(lr, lw, g, &custom[0]);
+    check(d2 < TOL_EXACT, "loaded I5: load pins table against later SetStandard*", d2);
+  }
+
+  // I6: Prepare(icXYZCalcLoadedTable) requires the measurement grid to equal the loaded
+  // table's grid (a weighting table cannot be re-gridded); on a match it reduces a
+  // perfect diffuser to the illuminant XYZ (registry Y=100 scale), identical to applying
+  // the table directly with icApplyWeightingTable.
+  {
+    CIccColorimetricCalculator calc;                      // registry D50/1931, Y=100
+    icSpectralRange lr; const icFloatNumber *lw = NULL;
+    calc.GetLoadedWeightingTable(lr, lw);
+
+    icSpectralRange mismatch = makeRange(400, 700, 31);
+    check(!calc.Prepare(mismatch, icXYZCalcLoadedTable), "loaded I6: mismatched grid -> false", 0.0);
+
+    bool ready = calc.Prepare(lr, icXYZCalcLoadedTable);
+    check(ready, "loaded I6: matching grid -> Prepare ok", 0.0);
+    if (ready) {
+      std::vector<icFloatNumber> diffuser(lr.steps, (icFloatNumber)1.0);
+      icFloatNumber viaCalc[3] = { 0, 0, 0 }, viaApply[3] = { 0, 0, 0 };
+      calc.ReflectanceToXYZ(&diffuser[0], viaCalc);
+      icApplyWeightingTable(lr, lw, &diffuser[0], viaApply);
+      check(std::fabs((double)viaCalc[1] - 100.0) < 1e-2, "loaded I6: diffuser Y==100 (registry scale)",
+            std::fabs((double)viaCalc[1] - 100.0));
+      double e = 0.0;
+      for (int k = 0; k < 3; k++) e = std::max(e, std::fabs((double)viaCalc[k] - (double)viaApply[k]));
+      check(e < TOL_EXACT, "loaded I6: calculator path == icApplyWeightingTable", e);
+    }
+  }
+
+  // I7: ResetWeightingTableToRegistry reaches the registry illuminants with no
+  // icIlluminant wire-enum (LED-B1, F11); an unpublished combination is rejected.
+  {
+    CIccColorimetricCalculator calc;
+    bool ok = calc.ResetWeightingTableToRegistry(icStdObs1931TwoDegrees, icWtIllumLED_B1);
+    check(ok, "loaded I7: reset to LED-B1/1931 -> true", 0.0);
+    icSpectralRange lr; const icFloatNumber *lw = NULL;
+    calc.GetLoadedWeightingTable(lr, lw);
+    icSpectralRange rr; const icFloatNumber *rw = icGetColorimetryWeightingTable(icStdObs1931TwoDegrees, icWtIllumLED_B1, rr);
+    double d = tableDiff(lr, lw, rr, rw);
+    check(d < TOL_EXACT, "loaded I7: reset installs the LED-B1 table", d);
+    check(!calc.ResetWeightingTableToRegistry(icStdObsUnknown, icWtIllumD50),
+          "loaded I7: reset(unpublished combo) -> false", 0.0);
+  }
+
+  // I8: the static registry accessor on the class forwards to the free function.
+  {
+    icSpectralRange ra, rb;
+    const icFloatNumber *a = CIccColorimetricCalculator::GetRegistryWeightingTable(icStdObs1931TwoDegrees, icWtIllumA, ra);
+    const icFloatNumber *b = icGetColorimetryWeightingTable(icStdObs1931TwoDegrees, icWtIllumA, rb);
+    check(a != NULL && a == b && ra.steps == rb.steps,
+          "loaded I8: static GetRegistryWeightingTable == free function", 0.0);
+  }
+}
+
 } // namespace
 
 int main()
@@ -640,6 +808,7 @@ int main()
   testWeightingFreeFunctions();
   testStandardAccessors();
   testRegistryWeightingTables();
+  testLoadedWeightingTable();
   testEmissive();
   testInputGuards();
 

--- a/IccProfLib/IccColorimetry.cpp
+++ b/IccProfLib/IccColorimetry.cpp
@@ -610,6 +610,51 @@ static const icUInt16Number kColorimetryWtSteps      = 41;
 // <<<END GENERATED WEIGHTING TABLES
 
 //==========================================================================
+// Loaded-weighting-table helpers (validation + registry tracking)
+//
+// These live outside the top anonymous namespace because registryWeightCeiling()
+// reads the generated kColorimetryWtTables above; they are file-static all the same.
+//==========================================================================
+
+// Upper bound on the sample count a caller may load. The registry tables use 41
+// (380-780 @ 10 nm); 1 nm over a wide span is a few hundred, so this is generous
+// headroom while bounding m_loadedWt (3*steps floats) against a runaway allocation.
+static const int kMaxLoadedWtSteps = 4096;
+
+// Map an ICC wire illuminant to the registry weighting-table illuminant, when one
+// exists. Only D50/D65/A have both a wire-enum and a published registry table; D93
+// (and the rest) have no registry LWL table, and the registry's LED-B1/F11 have no
+// wire-enum (reach them via ResetWeightingTableToRegistry instead).
+static bool mapIlluminantToRegistry(icIlluminant illum, icColorimetryWeightingIlluminant &reg) {
+  switch (illum) {
+    case icIlluminantD50: reg = icWtIllumD50; return true;
+    case icIlluminantD65: reg = icWtIllumD65; return true;
+    case icIlluminantA:   reg = icWtIllumA;   return true;
+    default:              return false;
+  }
+}
+
+// Magnitude sanity ceiling for LoadWeightingTable, derived (per request) from the
+// values in the in-tree registry LWL tables: take the largest |weight| present across
+// all baked registry tables and allow a generous multiple. This lets the registry's
+// own Y=100 data, a Y=1-normalised variant, and the legitimately negative LWL weights
+// all pass, while rejecting gross garbage (NaN/Inf are caught separately; this catches
+// absurd magnitudes). It is a defensive gate, NOT a correctness requirement -- callers
+// with an unusual radiometric scale that legitimately exceeds it can pre-scale.
+static double registryWeightCeiling() {
+  static const double HEADROOM = 16.0;
+  double mx = 0.0;
+  for (int t = 0; t < kColorimetryWtTableCount; t++) {
+    const icFloatNumber *p = kColorimetryWtTables[t].pWeights;
+    for (int i = 0; i < 3 * (int)kColorimetryWtSteps; i++) {
+      double a = std::fabs((double)p[i]);
+      if (a > mx) mx = a;
+    }
+  }
+  return mx * HEADROOM;
+}
+
+//==========================================================================
 // Public free functions
 //==========================================================================
 
@@ -787,11 +832,27 @@ const icFloatNumber *icGetColorimetryWeightingTable(icStandardObserver obs,
 //==========================================================================
 
 CIccColorimetricCalculator::CIccColorimetricCalculator()
-  : m_bHaveWhite(false), m_bReady(false) {
+  : m_bHaveWhite(false),
+    m_bWtUserLoaded(false), m_bStdObs(false), m_stdObs(icStdObs1931TwoDegrees),
+    m_bRegIllum(false), m_regIllum(icWtIllumD50),
+    m_bReady(false) {
   memset(&m_obsRange, 0, sizeof(m_obsRange));
   memset(&m_illumRange, 0, sizeof(m_illumRange));
   memset(&m_whiteRange, 0, sizeof(m_whiteRange));
+  memset(&m_loadedWtRange, 0, sizeof(m_loadedWtRange));
   memset(&m_measRange, 0, sizeof(m_measRange));
+
+  // Seed the loaded weighting table so icXYZCalcLoadedTable works immediately, with no
+  // "table loaded yet?" check required of the caller (see the strong note in the
+  // header). Default to the registry LWL table for the ICC PCS conditions (CIE 1931
+  // 2-degree observer, D50); SetStandardObserver/SetStandardIlluminant re-seed it to
+  // match the selected published combination until a caller loads a custom table.
+  icSpectralRange r;
+  const icFloatNumber *p = icGetColorimetryWeightingTable(icStdObs1931TwoDegrees, icWtIllumD50, r);
+  if (p) {
+    m_loadedWtRange = r;
+    m_loadedWt.assign(p, p + 3 * (int)r.steps);
+  }
 }
 
 CIccColorimetricCalculator::~CIccColorimetricCalculator() {}
@@ -803,6 +864,11 @@ bool CIccColorimetricCalculator::SetObserver(const icSpectralRange &range, const
   m_obsRange = range;
   m_obs.assign(pObserver, pObserver + 3*(int)range.steps);
   m_bReady = false;
+  // A custom observer has no registry mapping; drop the standard-id tracking so the
+  // loaded-table seed is not (mis)attributed to it. SetStandardObserver re-establishes
+  // it below. Any existing registry seed is left in place (still a valid table).
+  m_bStdObs = false;
+  seedLoadedWeightingTable();
   return true;
 }
 
@@ -812,6 +878,8 @@ bool CIccColorimetricCalculator::SetIlluminant(const icSpectralRange &range, con
   m_illumRange = range;
   m_illum.assign(pIlluminant, pIlluminant + (int)range.steps);
   m_bReady = false;
+  m_bRegIllum = false;             // custom illuminant: no registry mapping (see SetObserver)
+  seedLoadedWeightingTable();
   return true;
 }
 
@@ -819,14 +887,52 @@ bool CIccColorimetricCalculator::SetStandardObserver(icStandardObserver obs)
 {
   icSpectralRange range;
   const icFloatNumber *p = icGetStandardObserver(obs, range);
-  return p ? SetObserver(range, p) : false;   // SetObserver copies, so p need not persist
+  if (!p || !SetObserver(range, p))   // SetObserver copies, so p need not persist
+    return false;
+  // Record the standard observer id and re-seed the loaded table to the registry LWL
+  // table for the now-known (observer, illuminant) pair when one is published.
+  m_bStdObs = true;
+  m_stdObs = obs;
+  seedLoadedWeightingTable();
+  return true;
 }
 
 bool CIccColorimetricCalculator::SetStandardIlluminant(icIlluminant illum)
 {
   icSpectralRange range;
   const icFloatNumber *p = icGetStandardIlluminant(illum, range);
-  return p ? SetIlluminant(range, p) : false;
+  if (!p || !SetIlluminant(range, p))
+    return false;
+  icColorimetryWeightingIlluminant reg;
+  if (mapIlluminantToRegistry(illum, reg)) {
+    m_bRegIllum = true;
+    m_regIllum = reg;
+  }
+  else {
+    m_bRegIllum = false;          // e.g. D93 -- no registry LWL table; keep prior seed
+  }
+  seedLoadedWeightingTable();
+  return true;
+}
+
+void CIccColorimetricCalculator::seedLoadedWeightingTable()
+{
+  // Keep the icXYZCalcLoadedTable operator pointed at the registry LWL table for the
+  // currently-selected viewing conditions -- UNLESS the caller has loaded/pinned a
+  // custom table, which must never be clobbered. Requires a standard observer AND an
+  // illuminant that maps to a published registry table; otherwise the previous seed is
+  // retained (so a valid table is always present). See the strong note in the header.
+  if (m_bWtUserLoaded)
+    return;
+  if (!m_bStdObs || !m_bRegIllum)
+    return;
+  icSpectralRange r;
+  const icFloatNumber *p = icGetColorimetryWeightingTable(m_stdObs, m_regIllum, r);
+  if (p) {
+    m_loadedWtRange = r;
+    m_loadedWt.assign(p, p + 3 * (int)r.steps);
+    m_bReady = false;            // any operator built from a stale seed is invalidated
+  }
 }
 
 bool CIccColorimetricCalculator::SetEmissiveWhite(const icSpectralRange &range, const icFloatNumber *pWhite) {
@@ -839,11 +945,91 @@ bool CIccColorimetricCalculator::SetEmissiveWhite(const icSpectralRange &range, 
   return true;
 }
 
+bool CIccColorimetricCalculator::LoadWeightingTable(const icSpectralRange &range,
+                                                   const icFloatNumber *pWeights) {
+  // Validate against the in-tree registry LWL tables' characteristics (see header).
+  // Tier 1: range geometry and sample-count bounds (2..kMaxLoadedWtSteps; registry = 41).
+  if (!rangeWellFormed(range) || !pWeights)
+    return false;
+  int n = (int)range.steps;
+  if (n < 2 || n > kMaxLoadedWtSteps)
+    return false;
+  // Tier 2: every Wx,Wy,Wz weight must be finite...
+  if (!allFinite(pWeights, 3*n))
+    return false;
+  // ...and within a generous registry-derived magnitude ceiling. Negative weights are
+  // accepted (legitimate in LWL tables) and values are NOT clamped -- this only rejects
+  // gross garbage, mirroring icApplyWeightingTable's no-clamp policy.
+  double ceiling = registryWeightCeiling();
+  for (int i = 0; i < 3*n; i++) {
+    if (std::fabs((double)pWeights[i]) > ceiling)
+      return false;
+  }
+  // Commit only after full validation, so a rejected load leaves the prior table intact.
+  m_loadedWtRange = range;
+  m_loadedWt.assign(pWeights, pWeights + 3*n);
+  m_bWtUserLoaded = true;   // pin it: SetStandard* re-seeding no longer applies
+  m_bReady = false;
+  return true;
+}
+
+bool CIccColorimetricCalculator::ResetWeightingTableToRegistry(
+    icStandardObserver obs, icColorimetryWeightingIlluminant illum) {
+  icSpectralRange r;
+  const icFloatNumber *p = icGetColorimetryWeightingTable(obs, illum, r);
+  if (!p)
+    return false;            // (obs,illum) not one of the registry's published tables
+  m_loadedWtRange = r;
+  m_loadedWt.assign(p, p + 3 * (int)r.steps);
+  m_bWtUserLoaded = true;    // an explicit registry choice; pin it like a load
+  m_bReady = false;
+  return true;
+}
+
+bool CIccColorimetricCalculator::GetLoadedWeightingTable(icSpectralRange &range,
+                                                        const icFloatNumber *&pWeights) const {
+  if (m_loadedWt.empty()) {  // only in a degenerate state (the ctor seeds a table)
+    memset(&range, 0, sizeof(range));
+    pWeights = NULL;
+    return false;
+  }
+  range = m_loadedWtRange;
+  pWeights = &m_loadedWt[0];
+  return true;
+}
+
+const icFloatNumber *CIccColorimetricCalculator::GetRegistryWeightingTable(
+    icStandardObserver obs, icColorimetryWeightingIlluminant illum, icSpectralRange &range) {
+  return icGetColorimetryWeightingTable(obs, illum, range);   // forwards to the baked-in data
+}
+
 bool CIccColorimetricCalculator::Prepare(const icSpectralRange &measRange, icXYZCalcMethod method,
                                          icSpectralInterpMethod interp, icSpectralExtendMethod extend) {
-  if (!rangeWellFormed(measRange) || !m_obs.size() || !m_illum.size())
+  if (!rangeWellFormed(measRange))
     return false;
   int nm = (int)measRange.steps;
+
+  if (method == icXYZCalcLoadedTable) {
+    // The loaded table is itself the complete 3 x N (Wx,Wy,Wz) operator at its own grid;
+    // it folds observer+illuminant in already (so no SetObserver/SetIlluminant is needed)
+    // and cannot be re-gridded without recomputation (WP56). The measurement must
+    // therefore be sampled on exactly the loaded table's grid -- require an exact match.
+    if (m_loadedWt.empty() ||
+        m_loadedWtRange.start != measRange.start ||
+        m_loadedWtRange.end   != measRange.end   ||
+        m_loadedWtRange.steps != measRange.steps)
+      return false;
+    m_measRange = measRange;
+    m_M = m_loadedWt;
+    if (!allFinite(&m_M[0], 3*nm))   // belt-and-braces (validated at load time)
+      return false;
+    m_bReady = true;
+    return true;
+  }
+
+  // DirectSum / Weighting / Sprague all integrate an observer against an illuminant.
+  if (!m_obs.size() || !m_illum.size())
+    return false;
   m_measRange = measRange;
   m_M.assign(3*nm, 0.0f);
 

--- a/IccProfLib/IccColorimetry.h
+++ b/IccProfLib/IccColorimetry.h
@@ -90,16 +90,30 @@ namespace iccDEV {
  *  - icXYZCalcWeighting: the weighting-function method X = R.w (eqn 2 of WP56),
  *    using self-computed triangular/ASTM-style weights (icComputeWeightingTable).
  *    Recommended for intervals that are not 1 or 5 nm (e.g. 10 nm instrument data).
- *    The registry's own published LWL tables are available separately as baked-in
- *    static data via icGetColorimetryWeightingTable() + icApplyWeightingTable().
+ *    The registry's own published LWL tables are available as baked-in static data
+ *    via icGetColorimetryWeightingTable() + icApplyWeightingTable(), or through the
+ *    calculator via icXYZCalcLoadedTable (below).
  *  - icXYZCalcSpragueTo1nm: reconstruct the measurement onto a fine grid with
  *    CIE 167:2005 Sprague interpolation before summation. Recommended fallback
  *    when no suitable weighting function is available.
+ *  - icXYZCalcLoadedTable: apply a complete weighting-table operator that the
+ *    calculator holds (Wx,Wy,Wz blocks -- exactly the form of a registry LWL table).
+ *    The table is either one the caller supplies at run time with
+ *    CIccColorimetricCalculator::LoadWeightingTable(), or -- until then -- the
+ *    registry LWL table the calculator seeds itself with. This makes the registry-LWL
+ *    reduction available *through* the calculator (cf. the standalone
+ *    icGetColorimetryWeightingTable() + icApplyWeightingTable()), with the table
+ *    selectable and overridable after construction.
+ *    IMPORTANT: the calculator is NEVER without a table -- it is seeded with a
+ *    registry LWL table at construction (see CIccColorimetricCalculator) -- so this
+ *    method is usable immediately and the caller NEVER has to load a table first nor
+ *    handle a "no table loaded" error.
  */
 enum icXYZCalcMethod {
   icXYZCalcDirectSum     = 0,
   icXYZCalcWeighting     = 1,
   icXYZCalcSpragueTo1nm  = 2,
+  icXYZCalcLoadedTable   = 3,
 };
 
 /** Interpolation used when resampling equally-spaced spectral data between ranges. */
@@ -217,6 +231,26 @@ ICCPROFLIB_API const icFloatNumber *icGetColorimetryWeightingTable(
  *  normalised so the adopted white radiance maps to Y = 1, mirroring
  *  CIccPcc::getEmissiveObserver(); RadianceToXYZ() then applies it.  A calculator
  *  holds one prepared operator at a time -- whichever Prepare* was called last.
+ *
+ *  LOADED WEIGHTING TABLE (icXYZCalcLoadedTable) -- READ THIS:
+ *  The calculator also carries a complete weighting-table operator (3 x N Wx,Wy,Wz,
+ *  the same form as a registry LWL table) that Prepare(.., icXYZCalcLoadedTable)
+ *  applies directly. This operator is ALWAYS POPULATED, so the icXYZCalcLoadedTable
+ *  method NEVER needs a "table loaded yet?" check by the caller and NEVER returns a
+ *  "no table" error:
+ *    - At construction it is seeded with the registry LWL table for the ICC PCS
+ *      conditions (CIE 1931 2-degree observer, D50).
+ *    - SetStandardObserver()/SetStandardIlluminant() RE-SEED it with the registry
+ *      LWL table for the selected combination whenever that pair is one the registry
+ *      publishes (1931/1964 x D50/D65/A); for any other selection the previous
+ *      registry seed is retained (it stays a valid registry table).
+ *    - LoadWeightingTable() REPLACES it with a caller-supplied table and pins it
+ *      (later SetStandard* calls then leave it untouched). ResetWeightingTableToRegistry()
+ *      restores a chosen registry table.
+ *  This "default to the registry LWL table in all cases" design is deliberate: it
+ *  spares the caller any extra error/branch logic around the loaded-table method.
+ *  Retrieve whichever table is in effect with GetLoadedWeightingTable(); retrieve a
+ *  raw registry table with GetRegistryWeightingTable().
  **************************************************************************
  */
 class ICCPROFLIB_API CIccColorimetricCalculator
@@ -268,6 +302,56 @@ public:
   /// the operator from PrepareEmissive. Returns false if no operator is prepared.
   bool RadianceToXYZ(const icFloatNumber *pRadiance, icFloatNumber *pXYZ) const;
 
+  // -- Loaded weighting table (the icXYZCalcLoadedTable method) ----------------------
+  //
+  // The calculator ALWAYS holds a valid weighting-table operator for
+  // icXYZCalcLoadedTable (seeded at construction, re-seeded by SetStandard*; see the
+  // class header above). The methods below load/replace, reset, and retrieve it.
+
+  /// Load a custom weighting-table operator to be used by icXYZCalcLoadedTable.
+  /// Layout is identical to a registry LWL table: 3*range.steps samples as consecutive
+  /// Wx,Wy,Wz blocks over the equally-spaced grid 'range' (each (wavelength,weight)
+  /// pair is one grid point x one channel). The table IS the complete operator that
+  /// reduces a reflectance vector sampled on 'range' to XYZ -- so a subsequent
+  /// Prepare(measRange, icXYZCalcLoadedTable) requires measRange to equal 'range'
+  /// (a weighting table cannot be re-gridded without recomputation; see WP56).
+  ///
+  /// The table is validated against the characteristics of the in-tree registry LWL
+  /// tables: the range must be well formed with 2..N samples, every value must be
+  /// finite, and magnitudes must not exceed a generous multiple of the largest weight
+  /// present in the baked-in registry tables. Negative weights are accepted -- they are
+  /// legitimate in LWL tables by construction -- and values are never clamped.
+  ///
+  /// On success the loaded table is PINNED: subsequent SetStandardObserver/
+  /// SetStandardIlluminant calls no longer re-seed it (call ResetWeightingTableToRegistry
+  /// to go back to a registry table). Returns false (leaving the previous table intact)
+  /// if validation fails. Resets any prepared operator.
+  bool LoadWeightingTable(const icSpectralRange &range, const icFloatNumber *pWeights); // 3*range.steps
+
+  /// Replace the loaded weighting table with the baked-in registry LWL table for
+  /// (obs,illum) and pin it (as LoadWeightingTable does). This also reaches the two
+  /// registry illuminants -- LED-B1 and F11 -- that have no icIlluminant wire-enum and
+  /// so cannot be selected through SetStandardIlluminant. Returns false (table
+  /// unchanged) if (obs,illum) is not one of the registry's published combinations.
+  bool ResetWeightingTableToRegistry(icStandardObserver obs,
+                                     icColorimetryWeightingIlluminant illum);
+
+  /// Retrieve the weighting table currently in effect for icXYZCalcLoadedTable (the
+  /// registry seed, or a caller-loaded table). Fills 'range' and points pWeights at the
+  /// internal 3*range.steps Wx,Wy,Wz operator (valid until the next Load/Reset/SetStandard*
+  /// or destruction; do not free). Always succeeds for a live calculator (a table is
+  /// always present); returns false only in the degenerate empty state.
+  bool GetLoadedWeightingTable(icSpectralRange &range, const icFloatNumber *&pWeights) const;
+
+  /// Retrieve a baked-in registry LWL weighting table directly (forwards to the free
+  /// function icGetColorimetryWeightingTable). Fills 'range' and returns the static
+  /// 3*range.steps Wx,Wy,Wz operator, or nullptr if (obs,illum) is not published. This
+  /// is the registry counterpart of GetLoadedWeightingTable(); it does not touch the
+  /// calculator's state (hence static).
+  static const icFloatNumber *GetRegistryWeightingTable(icStandardObserver obs,
+                                                        icColorimetryWeightingIlluminant illum,
+                                                        icSpectralRange &range);
+
   /// True once Prepare() has built a usable operator.
   bool IsReady() const { return m_bReady; }
 
@@ -280,6 +364,18 @@ private:
   bool m_bHaveWhite;                    // emissive adopted white supplied?
   icSpectralRange m_whiteRange;
   std::vector<icFloatNumber> m_white;   // m_whiteRange.steps (emissive adopted white)
+
+  // Loaded weighting-table operator for icXYZCalcLoadedTable. ALWAYS POPULATED (see
+  // the class header): seeded with a registry LWL table at construction, re-seeded to
+  // track the selected standard observer+illuminant, or replaced by LoadWeightingTable.
+  std::vector<icFloatNumber> m_loadedWt;             // 3*m_loadedWtRange.steps (Wx,Wy,Wz)
+  icSpectralRange m_loadedWtRange;
+  bool m_bWtUserLoaded;                              // caller supplied/pinned a table?
+  bool m_bStdObs;                                    // current observer is a known standard id?
+  icStandardObserver m_stdObs;                       //   ...which one
+  bool m_bRegIllum;                                  // current illuminant maps to a registry table?
+  icColorimetryWeightingIlluminant m_regIllum;       //   ...which one
+  void seedLoadedWeightingTable();                   // re-seed from registry when appropriate
 
   icSpectralRange m_measRange;
   std::vector<icFloatNumber> m_M;       // prepared 3*m_measRange.steps operator


### PR DESCRIPTION
## Summary

Adds a fourth spectral→XYZ reduction method to `CIccColorimetricCalculator`:
**`icXYZCalcLoadedTable`** ("Loaded Weight Table"). It applies a weighting-table
operator supplied at run time, in the same 3×N `Wx,Wy,Wz` layout as the registry
LWL tables — i.e. the registry-LWL reduction made available *through* the
calculator, with the table selectable and overridable after construction.

Builds on #1503; refs #1475. Source + test in one in-repo PR (the regression test
lives under `.github/ci` and is wired via `Build/Cmake`).

## Always-populated guarantee (the key design point)

The loaded operator is **never absent**, so the method never needs a "table loaded
yet?" check and never returns a "no table" error — by deliberate design, to spare
callers any extra error/branch logic:

- **Seeded** with the registry **D50 / CIE 1931 2°** LWL table at construction.
- **Auto-re-seeded** to the registry table for the selected standard observer +
  illuminant whenever that pair is a published registry combination (D50/D65/A);
  a non-registry illuminant (e.g. D93) retains the prior valid seed.
- **Pinned** once `LoadWeightingTable()` supplies a custom table — later
  `SetStandard*` calls no longer re-seed it.

This guarantee is documented strongly in the header (enum doc + class "READ THIS"
block + per-method docs).

## API added

- `LoadWeightingTable(range, pWeights)` — load a custom `3×steps` operator at run time.
- `ResetWeightingTableToRegistry(obs, illum)` — install any baked registry table;
  reaches the registry's **LED-B1** and **F11** illuminants, which have no
  `icIlluminant` wire-enum and so can't be selected via `SetStandardIlluminant`.
- `GetLoadedWeightingTable(range, pWeights)` — retrieve the table currently in effect.
- `static GetRegistryWeightingTable(obs, illum, range)` — retrieve a raw registry
  table (forwards to `icGetColorimetryWeightingTable`).

## Validation

`LoadWeightingTable` validates against the in-tree registry tables' characteristics:
well-formed range, 2..4096 samples, all finite, and magnitude within a generous
multiple of the largest weight present in the baked-in registry tables. **Negative
weights are accepted** (legitimate in LWL tables by construction) and values are
**never clamped**, matching `icApplyWeightingTable`'s policy. A rejected load leaves
the prior table intact. `Prepare(icXYZCalcLoadedTable)` requires the measurement grid
to equal the loaded table's grid — a weighting table cannot be re-gridded without
recomputation (WP56).

## Relationship to #1503

This **intentionally reverses** the #1503 "no runtime weighting-table ingestion"
decision, at maintainer request. It is **mechanism only** — no registry numbers and
no reduction math change — so it is independent of the verify-first table audit.

## Testing

Extends the `iccdev.colorimetry-methods` CTest with **Part I (I1–I8)**: default seed,
auto-tracking, no-clobber, every validation gate, pinning, grid-match, registry-path
equivalence, and the static accessor. Red-green verified (a ctor-seed D50→D65 mutation
trips I1/I4); strict-clean under `-Wall -Wextra -Wpedantic`; full module builds and
`ctest #15` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
