### PR TITLE
IccTagBasic: bound GetValues source start offset (#1553)

### DIFF
--- a/.github/ci/regression/getvalues-nstart-bound.cpp
+++ b/.github/ci/regression/getvalues-nstart-bound.cpp
@@ -1,0 +1,83 @@
+// Regression for #1553: CIccTag*NumArray::GetValues must bound the SOURCE start
+// offset (nStart), not only the destination length, or m_Num[i+nStart] reads past
+// the end of the array (CWE-125, out-of-bounds read).
+//
+// xsscx's fuzz repro reached CIccTagFloatNum<float,...>::GetValues at
+// IccTagBasic.cpp:7172 through iccApplyNamedCmm -- the named-colour reverse lookup
+// (CIccArrayNamedColor::FindPcsColor) passes a fixed nVectorSize=3 while nStart steps
+// by the device-sample count, so it over-reads on device data with < 3 channels. The
+// FloatNum variant guarded only nVectorSize; the two integer siblings guarded
+// nVectorSize+nStart, a sum that wraps for a huge nStart and slips past the check; the
+// sparse-matrix variant used '>' where '>=' is required (one matrix past the end).
+//
+// This test pins the corrected contract on the num-array family. Each assertion is
+// red-green: the "-> false" cases return true (and read out of bounds) if the matching
+// guard is reverted. The sparse-matrix '>'->'>=' off-by-one is a one-token bound fix
+// covered by inspection (constructing a populated sparse-matrix tag in isolation is
+// out of proportion to the change).
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccTagBasic.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[getvalues-nstart] FAIL: %s\n", what);
+  }
+}
+
+// Exercise one CIccTagNumArray subclass: a valid in-range window must succeed, while a
+// window whose start pushes the read past the end -- including the icUInt32Number
+// overflow case -- must be rejected (not over-read).
+template <typename TagT>
+void exerciseNumArray(const char *name)
+{
+  const icUInt32Number N = 8;
+  TagT t;
+  t.SetSize(N);                       // m_Num now holds N entries; valid indices [0,N)
+  icFloatNumber dst[8] = { 0 };
+
+  char msg[96];
+
+  // Valid: nStart=N-3, nVectorSize=3 reads exactly the last three entries [N-3,N).
+  std::snprintf(msg, sizeof(msg), "%s: valid in-range window -> true", name);
+  check(t.GetValues(dst, N - 3, 3), msg);
+
+  // Over-read: nStart=N-2, nVectorSize=3 would read m_Num[N-2..N], and index N is OOB.
+  std::snprintf(msg, sizeof(msg), "%s: nStart over-read -> false (#1553)", name);
+  check(!t.GetValues(dst, N - 2, 3), msg);
+
+  // Exact-end start: nStart=N, nVectorSize=1 -> m_Num[N] is one past the end.
+  std::snprintf(msg, sizeof(msg), "%s: nStart == m_nSize -> false", name);
+  check(!t.GetValues(dst, N, 1), msg);
+
+  // Overflow: a huge nStart makes nStart+nVectorSize wrap to a small value; the
+  // overflow-safe bound must still reject it rather than wrap past the guard.
+  std::snprintf(msg, sizeof(msg), "%s: overflow nStart -> false", name);
+  check(!t.GetValues(dst, 0xFFFFFFFFu, 2), msg);
+}
+
+} // namespace
+
+int main()
+{
+  exerciseNumArray<CIccTagFloat32>("FloatNum");      // the defect with the public repro
+  exerciseNumArray<CIccTagS15Fixed16>("FixedNum");   // overflow-safe normalization
+  exerciseNumArray<CIccTagUInt8>("Num");             // overflow-safe normalization
+
+  if (g_fail) {
+    std::fprintf(stderr, "[getvalues-nstart] %d assertion(s) failed\n", g_fail);
+    return g_fail;
+  }
+  std::printf("[getvalues-nstart] all assertions passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -586,6 +586,45 @@ function(iccdev_add_colorimetry_methods_test)
   endif()
 endfunction()
 
+# #1553: CIccTag*NumArray::GetValues must bound the source start offset (nStart), not
+# only the destination length, or m_Num[i+nStart] over-reads (CWE-125). Pins the
+# corrected bound on the FloatNum (the repro'd defect), FixedNum and Num variants; each
+# assertion is red-green against the matching guard. Header + IccProfLib only.
+function(iccdev_add_getvalues_nstart_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccGetValuesNStartTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/getvalues-nstart-bound.cpp"
+  )
+  target_link_libraries(iccGetValuesNStartTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccGetValuesNStartTest)
+
+  add_test(
+    NAME iccdev.getvalues-nstart-bound
+    COMMAND "$<TARGET_FILE:iccGetValuesNStartTest>"
+  )
+  set_tests_properties(iccdev.getvalues-nstart-bound PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;security;tag;issue-1553;regression"
+  )
+  if(WIN32)
+    set(_getvalues_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccGetValuesNStartTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _getvalues_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.getvalues-nstart-bound PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_getvalues_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_fileio_getlength_position_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -997,6 +1036,7 @@ if(WIN32)
   iccdev_add_cmmsearch_namedcolor_ownership_test()
   iccdev_add_xform_create_tag_ownership_test()
   iccdev_add_colorimetry_methods_test()
+  iccdev_add_getvalues_nstart_test()
   iccdev_add_windows_iccdevcmm_smoke_test()
 
   return()
@@ -1063,6 +1103,7 @@ iccdev_add_mpecalc_matrix_overflow_test()
 iccdev_add_cmmsearch_namedcolor_ownership_test()
 iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_colorimetry_methods_test()
+iccdev_add_getvalues_nstart_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -5607,7 +5607,9 @@ bool CIccTagSparseMatrixArray::GetValues(icFloatNumber *DstVector, icUInt32Numbe
   if (nStart % nBytesPerMatrix != 0)
     return false;
 
-  if (nStart / nBytesPerMatrix > m_nSize)
+  // CWE-125: ">" let the matrix index equal m_nSize -- one past the last valid index
+  // (0..m_nSize-1) -- so the memcpy below read a whole matrix beyond m_RawData. ">=".
+  if (nStart / nBytesPerMatrix >= m_nSize)
     return false;
 
   memcpy(DstVector, m_RawData+nStart, nVectorSize);
@@ -5984,7 +5986,9 @@ bool CIccTagFixedNum<T, Tsig>::SetSize(icUInt32Number nSize, bool bZeroNew/*=tru
 template <class T, icTagTypeSignature Tsig>
 bool CIccTagFixedNum<T, Tsig>::GetValues(icFloatNumber *DstVector, icUInt32Number nStart, icUInt32Number nVectorSize) const
 {
-  if (nVectorSize+nStart >m_nSize)
+  // CWE-125: overflow-safe form of "nVectorSize+nStart > m_nSize" -- that sum of two
+  // icUInt32Number can wrap for a huge nStart and slip past the guard; this cannot.
+  if (nVectorSize > m_nSize || nStart > m_nSize - nVectorSize)
     return false;
 
   icUInt32Number i;
@@ -6574,10 +6578,10 @@ bool CIccTagNum<T, Tsig>::SetSize(icUInt32Number nSize, bool bZeroNew/*=true*/)
 template <class T, icTagTypeSignature Tsig>
 bool CIccTagNum<T, Tsig>::GetValues(icFloatNumber *DstVector, icUInt32Number nStart, icUInt32Number nVectorSize) const
 {
-  if (nVectorSize+nStart >m_nSize)
-    return false;
-    
-  if (nVectorSize > m_nSize)
+  // CWE-125: overflow-safe bound on both the start offset and the length. The original
+  // "nVectorSize+nStart > m_nSize" can wrap for a huge nStart; this form cannot, and it
+  // subsumes the separate nVectorSize > m_nSize check that followed.
+  if (nVectorSize > m_nSize || nStart > m_nSize - nVectorSize)
     return false;
 
   icUInt32Number i;
@@ -7171,7 +7175,15 @@ bool  CIccTagFloatNum<T, Tsig>::SetSize(icUInt32Number nSize, bool bZeroNew/*=tr
 template <class T, icTagTypeSignature Tsig>
 bool CIccTagFloatNum<T, Tsig>::GetValues(icFloatNumber *DstVector, icUInt32Number nStart, icUInt32Number nVectorSize) const
 {
-  if (nVectorSize > m_nSize)
+  // CWE-125: bound the SOURCE read as well as the destination length. The original
+  // check guarded only nVectorSize (the output write below), so a non-zero nStart let
+  // m_Num[i+nStart] read past the end of the array when nStart+nVectorSize > m_nSize
+  // (e.g. CIccArrayNamedColor::FindPcsColor passes a fixed nVectorSize=3 while nStart
+  // steps by the device-sample count, over-reading on <3-channel device data).
+  // Written nStart > m_nSize - nVectorSize rather than nStart+nVectorSize > m_nSize so
+  // the sum cannot wrap (both operands are icUInt32Number); nVectorSize > m_nSize is
+  // tested first so the subtraction never underflows.
+  if (nVectorSize > m_nSize || nStart > m_nSize - nVectorSize)
     return false;
 
   icUInt32Number i;


### PR DESCRIPTION
## Summary

`CIccTag*NumArray::GetValues` bounded only the destination length, not the source
start offset, so `m_Num[i+nStart]` read past the end of the array when
`nStart + nVectorSize > m_nSize` (CWE-125, out-of-bounds read). Fixes #1553.

xsscx's fuzz repro reached `CIccTagFloatNum::GetValues` (`IccTagBasic.cpp:7172`) via
`iccApplyNamedCmm` — `CIccArrayNamedColor::FindPcsColor` passes a fixed
`nVectorSize=3` while `nStart` steps by the device-sample count, over-reading on
device data with fewer than 3 channels (ASan: 4-byte-read-heap-buffer-overflow).

## The fix (whole GetValues family)

| Variant | Was | Now |
|---|---|---|
| `CIccTagFloatNum` (the repro'd defect) | guards `nVectorSize` only | bounds `nStart` too |
| `CIccTagFixedNum` / `CIccTagNum` | `nVectorSize+nStart > m_nSize` (wraps for huge `nStart`) | overflow-safe form |
| `CIccTagSparseMatrixArray` | `>` (matrix index may equal `m_nSize`, one past the end) | `>=` |

All four use the overflow-safe guard
`if (nVectorSize > m_nSize || nStart > m_nSize - nVectorSize) return false;`
(`nVectorSize > m_nSize` is tested first so the subtraction can never underflow).
**Value-preserving for every in-range call** — `FindDeviceColor`/`FindSpectralColor`
pass `nStart+nVectorSize == sampleCount*D <= m_nSize` and still succeed; only the
genuinely over-reading `FindPcsColor` on <3-channel device data now returns false
instead of reading past the buffer.

## Testing

New CTest **`iccdev.getvalues-nstart-bound`** (FloatNum / FixedNum / Num): a valid
in-range window succeeds; over-read, exact-end, and `icUInt32Number`-overflow starts
are rejected. Each assertion is red-green — reverting the guard makes the over-read
cases return `true` and the overflow case wild-reads `m_Num[~4e9]` and crashes (the
vulnerability itself).

Validated locally with a tools-ON build: the named-colour CMM apply path that reaches
the defect — `iccdev.namedcolor-apply-regressions` (via `iccApplyNamedCmm`) — passes,
along with the v5 named-CMM, std-observer, named-colour overprint, CMM-search and
tag-layout regressions. No regressions; the new test and the existing tag/CMM/named-
colour suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
