### PR TITLE
Add extended device colour space support (#626)

### DIFF
--- a/.github/ci/regression/dpcc-pcc-replacement.cpp
+++ b/.github/ci/regression/dpcc-pcc-replacement.cpp
@@ -1,0 +1,122 @@
+// Regression for #1559 (follow-up to #626): a devicePccTag ('dpcc') on an
+// abstract iccMAX profile must replace the profile-level connection conditions
+// with the matching members of its profileConnectionConditionsStructure ('pcc ')
+// when the CMM reads the profile through the IIccProfileConnectionConditions
+// interface (spec 9.2.x+1 / 12.2.y).
+//
+// The CMM always reaches a profile's PCC via getPccViewingConditions /
+// getCustomToStandardPcc / getStandardToCustomPcc / getMediaWhiteXYZ (and the
+// illuminant/observer getters, which all derive from getPccViewingConditions).
+// This test pins that, for an abstract profile carrying a dpcc tag, those
+// getters return the structure members rather than the profile's own tags --
+// and that the replacement is gated to abstract iccMAX profiles, so a non-abstract
+// profile still falls back to its profile-level tags. Each "dpcc wins" assertion
+// is red-green: it fails if getDevicePccElem is bypassed.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccProfile.h"
+#include "IccTagBasic.h"
+#include "IccTagComposite.h"
+#include "IccTagMPE.h"
+#include "IccUtil.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <cmath>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[dpcc-pcc-replacement] FAIL: %s\n", what);
+  }
+}
+
+CIccTagXYZ *makeXYZ(icFloatNumber X, icFloatNumber Y, icFloatNumber Z)
+{
+  CIccTagXYZ *p = new CIccTagXYZ();
+  p->SetSize(1);
+  icXYZNumber *pv = p->GetXYZ(0);
+  pv->X = icDtoF(X);
+  pv->Y = icDtoF(Y);
+  pv->Z = icDtoF(Z);
+  return p;
+}
+
+bool approx(icFloatNumber a, icFloatNumber b) { return std::fabs(a - b) < 1.0e-4f; }
+
+} // namespace
+
+int main()
+{
+  // Profile-level media white point (the value that must be SHADOWED by dpcc).
+  const icFloatNumber profWhite[3] = { 0.9000f, 1.0000f, 0.8000f };
+  // dpcc mwpt member (the replacement value that must WIN for an abstract profile).
+  const icFloatNumber pccWhite[3]  = { 0.5000f, 0.6000f, 0.7000f };
+
+  CIccProfile profile;
+  profile.m_Header.version     = icVersionNumberV5;
+  profile.m_Header.deviceClass = icSigAbstractClass;
+
+  profile.AttachTag(icSigMediaWhitePointTag, makeXYZ(profWhite[0], profWhite[1], profWhite[2]));
+
+  // Build the devicePccTag: a 'pcc ' struct with mwpt/svcn/c2sp/s2cp members.
+  CIccTagStruct *pDpcc = new CIccTagStruct();
+  pDpcc->SetTagStructType(icSigProfileConnectionConditionsStruct);
+
+  CIccTagXYZ *pPccWhite = makeXYZ(pccWhite[0], pccWhite[1], pccWhite[2]);
+  CIccTagSpectralViewingConditions *pSvcn = new CIccTagSpectralViewingConditions();
+  CIccTagMultiProcessElement *pC2s = new CIccTagMultiProcessElement();
+  CIccTagMultiProcessElement *pS2c = new CIccTagMultiProcessElement();
+
+  pDpcc->AttachElem(icSigPccMediaWhitePointMbr, pPccWhite);
+  pDpcc->AttachElem(icSigPccSpectralViewingConditionsMbr, pSvcn);
+  pDpcc->AttachElem(icSigPccCustomToStandardPccMbr, pC2s);
+  pDpcc->AttachElem(icSigPccStandardToCustomPccMbr, pS2c);
+
+  profile.AttachTag(icSigDevicePccTag, pDpcc);
+
+  // --- Abstract profile: every getter resolves to the dpcc member. ---
+  icFloatNumber w[3] = { 0 };
+  profile.getMediaWhiteXYZ(w);
+  check(approx(w[0], pccWhite[0]) && approx(w[1], pccWhite[1]) && approx(w[2], pccWhite[2]),
+        "abstract: getMediaWhiteXYZ returns dpcc mwpt member, not profile tag");
+
+  check(profile.getPccViewingConditions() == pSvcn,
+        "abstract: getPccViewingConditions returns dpcc svcn member");
+  check(profile.getCustomToStandardPcc() == pC2s,
+        "abstract: getCustomToStandardPcc returns dpcc c2sp member");
+  check(profile.getStandardToCustomPcc() == pS2c,
+        "abstract: getStandardToCustomPcc returns dpcc s2cp member");
+
+  // --- Gate: a non-abstract profile ignores dpcc and falls back to its tags. ---
+  // No profile-level svcn/c2sp/s2cp tags were attached, so the fallback path
+  // returns NULL there and the profile mediaWhitePointTag for the white point.
+  profile.m_Header.deviceClass = icSigOutputClass;
+
+  profile.getMediaWhiteXYZ(w);
+  check(approx(w[0], profWhite[0]) && approx(w[1], profWhite[1]) && approx(w[2], profWhite[2]),
+        "non-abstract: getMediaWhiteXYZ falls back to profile mediaWhitePointTag");
+  check(profile.getPccViewingConditions() == NULL,
+        "non-abstract: getPccViewingConditions ignores dpcc svcn member");
+  check(profile.getCustomToStandardPcc() == NULL,
+        "non-abstract: getCustomToStandardPcc ignores dpcc c2sp member");
+
+  // --- Gate: a v2/v4 abstract profile also ignores dpcc (amendment is v5-only). ---
+  profile.m_Header.deviceClass = icSigAbstractClass;
+  profile.m_Header.version     = icVersionNumberV4_3;
+  check(profile.getCustomToStandardPcc() == NULL,
+        "v4 abstract: getCustomToStandardPcc ignores dpcc (v5-only amendment)");
+
+  if (g_fail)
+    std::fprintf(stderr, "[dpcc-pcc-replacement] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stderr, "[dpcc-pcc-replacement] all assertions passed\n");
+
+  return g_fail;
+}

--- a/.github/ci/regression/extended-device-colorspace.cpp
+++ b/.github/ci/regression/extended-device-colorspace.cpp
@@ -1,0 +1,164 @@
+// Regression for #626: iccMAX "Extended Device Colour Space" amendment support.
+//
+// The amendment (ICC.2:2023 minor revision, 30 Oct 2025) adds:
+//   * spectralRangeType   ('srng', 10.2.w)  -- a 20-byte tag type carrying a
+//                                              spectral + bi-spectral range.
+//   * deviceSpectralRangeTag ('dsrn', 9.2.x) -- holds an srng.
+//   * devicePccTag        ('dpcc', 9.2.x+1) -- a tagStructType of ...
+//   * profileConnectionConditionsStructure ('pcc ', 12.2.y) -- 6 member sub-tags.
+//
+// This test pins the library-level contract that those signatures/types are
+// registered, round-trip losslessly, and validate their required members. It
+// links IccProfLib only (mirroring the other regression executables) and uses
+// CIccMemIO for the binary round-trip; the XML round-trip is exercised by the
+// iccToXml/iccFromXml tools build.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccTagBasic.h"
+#include "IccTagComposite.h"
+#include "IccTagFactory.h"
+#include "IccStructFactory.h"
+#include "IccStructBasic.h"
+#include "IccIO.h"
+#include "IccUtil.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[extended-device-colorspace] FAIL: %s\n", what);
+  }
+}
+
+// --- 1. spectralRangeType ('srng') is registered and round-trips losslessly. ---
+void testSpectralRangeType()
+{
+  // The factory must build a CIccTagSpectralRange for the new type signature.
+  CIccTag *pTag = CIccTagCreator::CreateTag(icSigSpectralRangeType);
+  check(pTag != NULL, "srng: factory creates a tag");
+  if (!pTag)
+    return;
+  check(pTag->GetType() == icSigSpectralRangeType, "srng: GetType() == icSigSpectralRangeType");
+
+  CIccTagSpectralRange *pSrc = dynamic_cast<CIccTagSpectralRange*>(pTag);
+  check(pSrc != NULL, "srng: factory tag is a CIccTagSpectralRange");
+  if (!pSrc) {
+    delete pTag;
+    return;
+  }
+
+  // Populate a 380..730nm @ 10nm visible range plus a bi-spectral range so both
+  // halves of the 20-byte structure are exercised.
+  pSrc->m_nReserved = 0;
+  pSrc->m_spectralRange.start = icFtoF16(380.0f);
+  pSrc->m_spectralRange.end   = icFtoF16(730.0f);
+  pSrc->m_spectralRange.steps = 36;
+  pSrc->m_biSpectralRange.start = icFtoF16(400.0f);
+  pSrc->m_biSpectralRange.end   = icFtoF16(700.0f);
+  pSrc->m_biSpectralRange.steps = 31;
+
+  CIccMemIO io;
+  check(io.Alloc(64, true), "srng: allocate write buffer");
+  check(pSrc->Write(&io), "srng: Write() succeeds");
+
+  // srng is a fixed 20-byte structure (Table W).
+  check(io.GetLength() == 20, "srng: serialized length is 20 bytes");
+
+  io.Seek(0, icSeekSet);
+  CIccTagSpectralRange dst;
+  check(dst.Read(io.GetLength(), &io), "srng: Read() succeeds");
+
+  check(dst.m_spectralRange.start == pSrc->m_spectralRange.start &&
+        dst.m_spectralRange.end   == pSrc->m_spectralRange.end   &&
+        dst.m_spectralRange.steps == pSrc->m_spectralRange.steps,
+        "srng: spectral range round-trips");
+  check(dst.m_biSpectralRange.start == pSrc->m_biSpectralRange.start &&
+        dst.m_biSpectralRange.end   == pSrc->m_biSpectralRange.end   &&
+        dst.m_biSpectralRange.steps == pSrc->m_biSpectralRange.steps,
+        "srng: bi-spectral range round-trips");
+
+  // A buffer shorter than the fixed structure must be rejected, not over-read.
+  io.Seek(0, icSeekSet);
+  CIccTagSpectralRange tooShort;
+  check(!tooShort.Read(8, &io), "srng: short read rejected");
+
+  delete pTag;
+}
+
+// --- 2. profileConnectionConditionsStructure ('pcc ') handler + required members. ---
+void testProfileConnectionConditionsStruct()
+{
+  // The struct factory must build the dedicated handler for the new struct sig.
+  std::string sName;
+  check(CIccStructCreator::GetStructSigName(sName, icSigProfileConnectionConditionsStruct),
+        "pcc: struct signature has a registered name");
+  check(sName == "profileConnectionConditionsStructure",
+        "pcc: struct name is profileConnectionConditionsStructure");
+
+  CIccTagStruct ts;
+  check(ts.SetTagStructType(icSigProfileConnectionConditionsStruct),
+        "pcc: SetTagStructType succeeds");
+  IIccStruct *pHandler = ts.GetStructHandler();
+  check(pHandler != NULL, "pcc: struct handler created");
+  if (pHandler)
+    check(std::string(pHandler->GetDisplayName()) == "profileConnectionConditionsStructure",
+          "pcc: handler display name");
+
+  // Attach the four unconditionally-required members (iXYZ/svcn/c2sp/s2cp) plus
+  // mwpt. Validate() checks member *presence* by signature, so lightweight XYZ
+  // tags stand in for the members here. The struct takes ownership.
+  ts.AttachElem(icSigPccPcsIlluminantXYZMbr, new CIccTagXYZ());
+  ts.AttachElem(icSigPccSpectralViewingConditionsMbr, new CIccTagXYZ());
+  ts.AttachElem(icSigPccCustomToStandardPccMbr, new CIccTagXYZ());
+  ts.AttachElem(icSigPccStandardToCustomPccMbr, new CIccTagXYZ());
+  ts.AttachElem(icSigPccMediaWhitePointMbr, new CIccTagXYZ());
+
+  std::string sReport;
+  ts.Validate("", sReport, NULL);
+  check(sReport.find("Missing required profileConnectionConditions member") == std::string::npos,
+        "pcc: complete structure reports no missing-member error");
+
+  // Drop a required member (s2cp) and confirm the missing-member error fires.
+  check(ts.DeleteElem(icSigPccStandardToCustomPccMbr), "pcc: delete s2cp member");
+  std::string sReport2;
+  ts.Validate("", sReport2, NULL);
+  check(sReport2.find("Missing required profileConnectionConditions member") != std::string::npos,
+        "pcc: missing required member is flagged");
+}
+
+// --- 3. The new tag and type signatures resolve to their amendment names. ---
+void testSignatureNames()
+{
+  check(std::string(CIccTagCreator::GetTagSigName(icSigDeviceSpectralRangeTag)) == "deviceSpectralRangeTag",
+        "dsrn: tag signature name");
+  check(std::string(CIccTagCreator::GetTagSigName(icSigDevicePccTag)) == "devicePccTag",
+        "dpcc: tag signature name");
+  check(std::string(CIccTagCreator::GetTagTypeSigName(icSigSpectralRangeType)) == "spectralRangeType",
+        "srng: tag type name");
+}
+
+} // namespace
+
+int main()
+{
+  testSpectralRangeType();
+  testProfileConnectionConditionsStruct();
+  testSignatureNames();
+
+  if (g_fail)
+    std::fprintf(stderr, "[extended-device-colorspace] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stderr, "[extended-device-colorspace] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -625,6 +625,41 @@ function(iccdev_add_getvalues_nstart_test)
   endif()
 endfunction()
 
+function(iccdev_add_extended_device_colorspace_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccExtendedDeviceColorSpaceTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/extended-device-colorspace.cpp"
+  )
+  target_link_libraries(iccExtendedDeviceColorSpaceTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccExtendedDeviceColorSpaceTest)
+
+  add_test(
+    NAME iccdev.extended-device-colorspace
+    COMMAND "$<TARGET_FILE:iccExtendedDeviceColorSpaceTest>"
+  )
+  set_tests_properties(iccdev.extended-device-colorspace PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;spec;tag;issue-626;regression"
+  )
+  if(WIN32)
+    set(_extdevcs_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccExtendedDeviceColorSpaceTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _extdevcs_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.extended-device-colorspace PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_extdevcs_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_fileio_getlength_position_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -1037,6 +1072,7 @@ if(WIN32)
   iccdev_add_xform_create_tag_ownership_test()
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
+  iccdev_add_extended_device_colorspace_test()
   iccdev_add_windows_iccdevcmm_smoke_test()
 
   return()
@@ -1104,6 +1140,7 @@ iccdev_add_cmmsearch_namedcolor_ownership_test()
 iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
+iccdev_add_extended_device_colorspace_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -660,6 +660,41 @@ function(iccdev_add_extended_device_colorspace_test)
   endif()
 endfunction()
 
+function(iccdev_add_dpcc_pcc_replacement_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccDpccPccReplacementTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/dpcc-pcc-replacement.cpp"
+  )
+  target_link_libraries(iccDpccPccReplacementTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccDpccPccReplacementTest)
+
+  add_test(
+    NAME iccdev.dpcc-pcc-replacement
+    COMMAND "$<TARGET_FILE:iccDpccPccReplacementTest>"
+  )
+  set_tests_properties(iccdev.dpcc-pcc-replacement PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;spec;cmm;issue-1559;regression"
+  )
+  if(WIN32)
+    set(_dpcc_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccDpccPccReplacementTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _dpcc_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.dpcc-pcc-replacement PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_dpcc_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_fileio_getlength_position_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -1073,6 +1108,7 @@ if(WIN32)
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
   iccdev_add_extended_device_colorspace_test()
+  iccdev_add_dpcc_pcc_replacement_test()
   iccdev_add_windows_iccdevcmm_smoke_test()
 
   return()
@@ -1141,6 +1177,7 @@ iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
 iccdev_add_extended_device_colorspace_test()
+iccdev_add_dpcc_pcc_replacement_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1640,7 +1640,18 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
       bValidSpace = false;
 
     if (!bValidSpace) {
-      if (!(m_Header.version>=icVersionNumberV5 && m_Header.deviceClass==icSigAbstractClass && Info.IsValidSpectralSpace(m_Header.colorSpace) && IsTagPresent(icSigDToB0Tag))) {
+      // A spectral colour space signature (Table 21) is permitted as the data
+      // colour space of a v5 profile.  The pre-amendment form was an abstract
+      // profile carrying a DToB0 tag.  The iccMAX extended device colour space
+      // amendment (7.2.8) additionally allows spectral device colour spaces for
+      // other classes, in which case the spectral range shall be defined by a
+      // deviceSpectralRangeTag ('dsrn') or by the header spectral/bi-spectral
+      // range fields (7.2.22/7.2.23); a spectral space with neither is rejected.
+      bool bV5Spectral = (m_Header.version>=icVersionNumberV5 && Info.IsValidSpectralSpace(m_Header.colorSpace));
+      bool bAbstractSpectral = bV5Spectral && m_Header.deviceClass==icSigAbstractClass && IsTagPresent(icSigDToB0Tag);
+      bool bDeviceSpectral = bV5Spectral && (IsTagPresent(icSigDeviceSpectralRangeTag) ||
+                                             m_Header.spectralRange.steps);
+      if (!(bAbstractSpectral || bDeviceSpectral)) {
         sReport += icMsgValidateCriticalError;
         // For an iccMAX-only space on a v2/v4 profile report the raw value
         // rather than the friendly descriptor: GetColorSpaceSigName() renders
@@ -2677,6 +2688,27 @@ bool CIccProfile::IsTypeValid(icTagSignature tagSig, icTagTypeSignature typeSig,
       return false;
     else return true;
   }
+
+  case icSigDeviceSpectralRangeTag:
+    {
+      // Extended device colour space amendment (9.2.x): the deviceSpectralRangeTag
+      // carries a spectralRangeType and is only defined for iccMAX (v5) profiles.
+      if (m_Header.version >= icVersionNumberV5 && typeSig==icSigSpectralRangeType)
+        return true;
+      else
+        return false;
+    }
+
+  case icSigDevicePccTag:
+    {
+      // Extended device colour space amendment (9.2.x+1): the devicePccTag carries
+      // a tagStructType of profileConnectionConditionsStructure ('pcc ').
+      if (m_Header.version >= icVersionNumberV5 &&
+          typeSig==icSigTagStructType && structSig==icSigProfileConnectionConditionsStruct)
+        return true;
+      else
+        return false;
+    }
 
   //The Private Tag case
   default:

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -3412,6 +3412,98 @@ icUInt16Number CIccProfile::GetParentSpaceSamples() const
 
 /**
  ****************************************************************************
+ * Name: CIccProfile::getDevicePccElem
+ *
+ * Purpose: Look up a member sub-tag of this profile's devicePccTag ('dpcc')
+ *  profileConnectionConditionsStructure. The extended device colour space
+ *  amendment (9.2.x+1 / 12.2.y) lets an abstract profile carry alternate
+ *  replacement profile connection conditions in this structure; the PCC
+ *  interface getters consult it before the profile's own PCC tags.
+ *
+ * Args:
+ *  sigMember = the 'pcc ' member signature to retrieve,
+ *  sigType   = the required tag type of that member
+ *
+ * Return: the member tag, or NULL when no replacement applies.
+ *****************************************************************************
+ */
+CIccTag* CIccProfile::getDevicePccElem(icSignature sigMember, icTagTypeSignature sigType)
+{
+  // The devicePccTag is only defined for abstract iccMAX (v5) profiles.
+  if (m_Header.version < icVersionNumberV5 || m_Header.deviceClass != icSigAbstractClass)
+    return NULL;
+
+  CIccTag *pTag = FindTag(icSigDevicePccTag);
+  if (!pTag || pTag->GetTagStructType() != icSigProfileConnectionConditionsStruct)
+    return NULL;
+
+  return ((CIccTagStruct*)pTag)->FindElemOfType(sigMember, sigType);
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccProfile::getPccViewingConditions
+ *
+ * Purpose: Get the spectral viewing conditions for profile connection,
+ *  preferring a devicePccTag svcn member when present (#626 / #1559).
+ *  getPccIlluminant/CCT/Observer and getNormIlluminantXYZ/getLumIlluminantXYZ
+ *  all derive from this getter, so overriding it here also applies the dpcc
+ *  illuminant/observer (and the iXYZ PCS illuminant, 12.2.y.2.1) to them.
+ *****************************************************************************
+ */
+const CIccTagSpectralViewingConditions *CIccProfile::getPccViewingConditions()
+{
+  // Replacement svcn from the devicePccTag structure, else the profile's own svcn.
+  CIccTag *pElem = getDevicePccElem(icSigPccSpectralViewingConditionsMbr, icSigSpectralViewingConditionsType);
+  if (pElem)
+    return (const CIccTagSpectralViewingConditions*)pElem;
+
+  return (const CIccTagSpectralViewingConditions*)FindTagOfType(icSigSpectralViewingConditionsTag,
+                                                                icSigSpectralViewingConditionsType);
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccProfile::getCustomToStandardPcc
+ *
+ * Purpose: Get the custom-to-standard PCC transform, preferring a devicePccTag
+ *  c2sp member when present (#626 / #1559).
+ *****************************************************************************
+ */
+CIccTagMultiProcessElement *CIccProfile::getCustomToStandardPcc()
+{
+  // Replacement c2sp from the devicePccTag structure, else the profile's own c2sp tag.
+  CIccTag *pElem = getDevicePccElem(icSigPccCustomToStandardPccMbr, icSigMultiProcessElementType);
+  if (pElem)
+    return (CIccTagMultiProcessElement*)pElem;
+
+  return (CIccTagMultiProcessElement*)FindTagOfType(icSigCustomToStandardPccTag, icSigMultiProcessElementType);
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccProfile::getStandardToCustomPcc
+ *
+ * Purpose: Get the standard-to-custom PCC transform, preferring a devicePccTag
+ *  s2cp member when present (#626 / #1559).
+ *****************************************************************************
+ */
+CIccTagMultiProcessElement *CIccProfile::getStandardToCustomPcc()
+{
+  // Replacement s2cp from the devicePccTag structure, else the profile's own s2cp tag.
+  CIccTag *pElem = getDevicePccElem(icSigPccStandardToCustomPccMbr, icSigMultiProcessElementType);
+  if (pElem)
+    return (CIccTagMultiProcessElement*)pElem;
+
+  return (CIccTagMultiProcessElement*)FindTagOfType(icSigStandardToCustomPccTag, icSigMultiProcessElementType);
+}
+
+
+/**
+ ****************************************************************************
  * Name: CIccProfile::getPccIlluminant
  * 
  * Purpose: Get the Illuminant associated with profile connection.
@@ -3580,7 +3672,11 @@ void CIccProfile::getLumIlluminantXYZ(icFloatNumber *pXYZ)
  */
 bool CIccProfile::getMediaWhiteXYZ(icFloatNumber *pXYZ)
 {
-  CIccTag *pTag = FindTag(icSigMediaWhitePointTag);
+  // Prefer a devicePccTag mwpt member when present; it replaces the profile's
+  // mediaWhitePointTag for an abstract profile (#626 / #1559, spec 12.2.y.2.2).
+  CIccTag *pTag = getDevicePccElem(icSigPccMediaWhitePointMbr, icSigXYZType);
+  if (!pTag)
+    pTag = FindTag(icSigMediaWhitePointTag);
   if (pTag && pTag->GetType()==icSigXYZType) {
     CIccTagXYZ *pXYZTag = (CIccTagXYZ*)pTag;
     icXYZNumber *pMediaXYZ = pXYZTag->GetXYZ(0);

--- a/IccProfLib/IccProfile.h
+++ b/IccProfLib/IccProfile.h
@@ -193,17 +193,17 @@ public:
 	bool IsTagPresent(icSignature sig) const { return (GetTag(sig)!=NULL); }
 
 
-  //Implement the IIccProfileConnectionConditions interface
-  virtual const CIccTagSpectralViewingConditions *getPccViewingConditions() { return (const CIccTagSpectralViewingConditions*)
-                                                                                FindTagOfType(icSigSpectralViewingConditionsTag, 
-                                                                                              icSigSpectralViewingConditionsType); }
-  virtual CIccTagMultiProcessElement *getCustomToStandardPcc() { return (CIccTagMultiProcessElement*)
-                                                                   FindTagOfType(icSigCustomToStandardPccTag, 
-                                                                                 icSigMultiProcessElementType); }
-
-  virtual CIccTagMultiProcessElement *getStandardToCustomPcc() { return (CIccTagMultiProcessElement*)
-                                                                   FindTagOfType(icSigStandardToCustomPccTag, 
-                                                                                 icSigMultiProcessElementType); }
+  //Implement the IIccProfileConnectionConditions interface.
+  //
+  // For an abstract profile that carries a devicePccTag ('dpcc'), the iccMAX
+  // extended device colour space amendment (9.2.x+1 / 12.2.y) replaces these
+  // profile-level connection conditions with the matching members of the tag's
+  // profileConnectionConditionsStructure. Each getter prefers the structure
+  // member (via getDevicePccElem) and falls back to the profile's own tag, so
+  // every consumer of the PCC interface picks up the replacement automatically.
+  virtual const CIccTagSpectralViewingConditions *getPccViewingConditions();
+  virtual CIccTagMultiProcessElement *getCustomToStandardPcc();
+  virtual CIccTagMultiProcessElement *getStandardToCustomPcc();
   virtual icIlluminant getPccIlluminant();
   virtual icFloatNumber getPccCCT();
   virtual icStandardObserver getPccObserver();
@@ -216,6 +216,13 @@ public:
   bool calcMediaWhiteXYZ(icFloatNumber *pXYZ, IIccProfileConnectionConditions *pObservingPCC);
 
 protected:
+
+  // Return the member sub-tag of the given signature/type from this profile's
+  // devicePccTag ('dpcc') profileConnectionConditionsStructure, or NULL when the
+  // profile is not an abstract iccMAX profile, has no devicePccTag, or the member
+  // is absent. Used by the PCC interface getters to apply the extended device
+  // colour space amendment's connection-condition replacements (#626 / #1559).
+  CIccTag* getDevicePccElem(icSignature sigMember, icTagTypeSignature sigType);
 
   void Cleanup();
   IccTagEntry* GetTag(icSignature sig) const;

--- a/IccProfLib/IccStructBasic.cpp
+++ b/IccProfLib/IccStructBasic.cpp
@@ -610,6 +610,72 @@ IIccStruct* CIccStructProfileInfo::NewCopy(CIccTagStruct *pTagStruct) const
 
 
 
+static SIccElemNameSig g_IccStructProfileConnectionConditionsMbrTable[] = {
+  { icSigPccPcsIlluminantXYZMbr,          "pccPcsIlluminantXYZMbr" },
+  { icSigPccMediaWhitePointMbr,           "pccMediaWhitePointMbr" },
+  { icSigPccSpectralWhitePointMbr,        "pccSpectralWhitePointMbr" },
+  { icSigPccSpectralViewingConditionsMbr, "pccSpectralViewingConditionsMbr" },
+  { icSigPccCustomToStandardPccMbr,       "pccCustomToStandardPccMbr" },
+  { icSigPccStandardToCustomPccMbr,       "pccStandardToCustomPccMbr" },
+  { 0, NULL },
+};
+
+CIccStructProfileConnectionConditions::CIccStructProfileConnectionConditions(CIccTagStruct *pTagStruct)
+{
+  m_pTagStruct = pTagStruct;
+  m_pElemNameSigTable = g_IccStructProfileConnectionConditionsMbrTable;
+}
+
+
+CIccStructProfileConnectionConditions::~CIccStructProfileConnectionConditions()
+{
+
+}
+
+
+IIccStruct* CIccStructProfileConnectionConditions::NewCopy(CIccTagStruct *pTagStruct) const
+{
+  CIccStructProfileConnectionConditions *rv = new CIccStructProfileConnectionConditions(pTagStruct);
+
+  return rv;
+}
+
+
+icValidateStatus CIccStructProfileConnectionConditions::Validate(std::string sigPath, std::string &sReport, const CIccProfile* pProfile/* = NULL*/) const
+{
+  icValidateStatus rv = icValidateOK;
+
+  if (m_pTagStruct) {
+    CIccInfo Info;
+    std::string sSigPathName = Info.GetSigPathName(sigPath);
+
+    // iXYZ, svcn, c2sp and s2cp are unconditionally required (spec 12.2.y, Table Y).
+    if (!m_pTagStruct->FindElem(icSigPccPcsIlluminantXYZMbr) ||
+        !m_pTagStruct->FindElem(icSigPccSpectralViewingConditionsMbr) ||
+        !m_pTagStruct->FindElem(icSigPccCustomToStandardPccMbr) ||
+        !m_pTagStruct->FindElem(icSigPccStandardToCustomPccMbr)) {
+      rv = icMaxStatus(rv, icValidateCriticalError);
+      sReport += icMsgValidateCriticalError;
+      sReport += sSigPathName;
+      sReport += " - Missing required profileConnectionConditions member(s).\n";
+    }
+
+    // mwpt is required for a colorimetric connection, swpt for a spectral one;
+    // a usable structure must provide at least one media white point member.
+    if (!m_pTagStruct->FindElem(icSigPccMediaWhitePointMbr) &&
+        !m_pTagStruct->FindElem(icSigPccSpectralWhitePointMbr)) {
+      rv = icMaxStatus(rv, icValidateWarning);
+      sReport += icMsgValidateWarning;
+      sReport += sSigPathName;
+      sReport += " - Missing media (mwpt) or spectral (swpt) white point member.\n";
+    }
+  }
+
+  return icMaxStatus(rv, CIccStructUnknown::Validate(sigPath, sReport, pProfile));
+}
+
+
+
 static SIccElemNameSig g_IccStructTintZeroMbrTable[] = {
   { icSigTnt0DeviceDataMbr, "tnt0DeviceDataMbr" },
   { icSigTnt0PcsDataMbr, "tnt0PcsDataMbr" },

--- a/IccProfLib/IccStructBasic.h
+++ b/IccProfLib/IccStructBasic.h
@@ -266,6 +266,35 @@ protected:
 
 /**
 ****************************************************************************
+* Class: CIccStructProfileConnectionConditions
+*
+* Purpose: Struct handler for the profileConnectionConditionsStructure ('pcc ')
+*   added by the iccMAX extended device colour space amendment (spec 12.2.y).
+*   It carries member tags that parallel the profile-level PCC tags they
+*   logically replace when a devicePccTag is used for PCS/PCC processing of an
+*   abstract profile. svcn / c2sp / s2cp / iXYZ are always required; mwpt is
+*   required for a colorimetric connection and swpt for a spectral connection.
+*****************************************************************************
+*/
+class ICCPROFLIB_API CIccStructProfileConnectionConditions : public CIccStructUnknown
+{
+public:
+  CIccStructProfileConnectionConditions(CIccTagStruct *pTagStruct = NULL);
+  virtual ~CIccStructProfileConnectionConditions();
+  virtual IIccStruct* NewCopy(CIccTagStruct *pNewTagStruct) const;
+
+  virtual const icChar *GetClassName() const { return "CIccStructProfileConnectionConditions"; }
+  virtual const icChar *GetDisplayName() const { return "profileConnectionConditionsStructure"; }
+
+  virtual icValidateStatus Validate(std::string sigPath, std::string &sReport, const CIccProfile* pProfile = NULL) const;
+
+protected:
+
+};
+
+
+/**
+****************************************************************************
 * Class: CIccStructTintZero
 *
 * Purpose: The Named Color struct handler

--- a/IccProfLib/IccStructFactory.cpp
+++ b/IccProfLib/IccStructFactory.cpp
@@ -98,6 +98,9 @@ IIccStruct* CIccBasicStructFactory::CreateStruct(icStructSignature structTypeSig
     case icSigNamedColorStruct:
       return new (std::nothrow) CIccStructNamedColor(pTagStruct);
 
+    case icSigProfileConnectionConditionsStruct:
+      return new (std::nothrow) CIccStructProfileConnectionConditions(pTagStruct);
+
     case icSigProfileInfoStruct:
       return new (std::nothrow) CIccStructProfileInfo(pTagStruct);
 
@@ -120,6 +123,7 @@ static struct {
   {icSigColorEncodingParamsSruct, "colorEncodingParamsStructure"},
   {icSigMeasurementInfoStruct, "measurementInfoStructure"},
   {icSigNamedColorStruct, "namedColorStructure"},
+  {icSigProfileConnectionConditionsStruct, "profileConnectionConditionsStructure"},
   {icSigProfileInfoStruct, "profileInfoStructure"},
   {icSigTintZeroStruct, "tintZeroStructure"},
   {(icStructSignature)0, ""},

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -11823,10 +11823,239 @@ icValidateStatus CIccTagSpectralDataInfo::Validate(std::string sigPath, std::str
 
 /**
  ****************************************************************************
- * Name: CIccTagSpectralViewingConditions::CIccTagSpectralViewingConditions
- * 
+ * Name: CIccTagSpectralRange::CIccTagSpectralRange
+ *
  * Purpose: Constructor
- * 
+ *
+ *****************************************************************************
+ */
+CIccTagSpectralRange::CIccTagSpectralRange()
+{
+  m_nReserved = 0;
+  memset(&m_spectralRange, 0, sizeof(m_spectralRange));
+  memset(&m_biSpectralRange, 0, sizeof(m_biSpectralRange));
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccTagSpectralRange::CIccTagSpectralRange
+ *
+ * Purpose: Copy Constructor
+ *
+ * Args:
+ *  ITSR = The CIccTagSpectralRange object to be copied
+ *****************************************************************************
+ */
+CIccTagSpectralRange::CIccTagSpectralRange(const CIccTagSpectralRange &ITSR)
+{
+  m_nReserved = ITSR.m_nReserved;
+  m_spectralRange = ITSR.m_spectralRange;
+  m_biSpectralRange = ITSR.m_biSpectralRange;
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccTagSpectralRange::operator=
+ *
+ * Purpose: Copy Operator
+ *
+ * Args:
+ *  SpectralRangeTag = The CIccTagSpectralRange object to be copied
+ *****************************************************************************
+ */
+CIccTagSpectralRange &CIccTagSpectralRange::operator=(const CIccTagSpectralRange &SpectralRangeTag)
+{
+  if (&SpectralRangeTag == this)
+    return *this;
+
+  m_nReserved = SpectralRangeTag.m_nReserved;
+  m_spectralRange = SpectralRangeTag.m_spectralRange;
+  m_biSpectralRange = SpectralRangeTag.m_biSpectralRange;
+
+  return *this;
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccTagSpectralRange::~CIccTagSpectralRange
+ *
+ * Purpose: Destructor
+ *
+ *****************************************************************************
+ */
+CIccTagSpectralRange::~CIccTagSpectralRange()
+{
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccTagSpectralRange::Read
+ *
+ * Purpose: Read in the tag contents into a data block
+ *
+ * Args:
+ *  size - # of bytes in tag,
+ *  pIO - IO object to read tag from
+ *
+ * Return:
+ *  true = successful, false = failure
+ *****************************************************************************
+ */
+bool CIccTagSpectralRange::Read(icUInt32Number size, CIccIO *pIO)
+{
+  icTagTypeSignature sig;
+
+  // spectralRangeType is a fixed 20-byte structure (Table W): type signature,
+  // 4 reserved bytes, then two icSpectralRange (6 bytes each).
+  if (sizeof(icTagTypeSignature) + sizeof(icUInt32Number) + 6*sizeof(icUInt16Number) > size)
+    return false;
+
+  if (!pIO) {
+    m_nReserved = 0;
+    memset(&m_spectralRange, 0, sizeof(m_spectralRange));
+    memset(&m_biSpectralRange, 0, sizeof(m_biSpectralRange));
+    return false;
+  }
+
+  if (!pIO->Read32(&sig))
+    return false;
+
+  if (!pIO->Read32(&m_nReserved))
+    return false;
+
+  if (!pIO->Read16(&m_spectralRange.start))
+    return false;
+
+  if (!pIO->Read16(&m_spectralRange.end))
+    return false;
+
+  if (!pIO->Read16(&m_spectralRange.steps))
+    return false;
+
+  if (!pIO->Read16(&m_biSpectralRange.start))
+    return false;
+
+  if (!pIO->Read16(&m_biSpectralRange.end))
+    return false;
+
+  if (!pIO->Read16(&m_biSpectralRange.steps))
+    return false;
+
+  return true;
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccTagSpectralRange::Write
+ *
+ * Purpose: Write the tag to a file
+ *
+ * Args:
+ *  pIO - The IO object to write tag to.
+ *
+ * Return:
+ *  true = succesful, false = failure
+ *****************************************************************************
+ */
+bool CIccTagSpectralRange::Write(CIccIO *pIO)
+{
+  icTagTypeSignature sig = GetType();
+
+  if (!pIO)
+    return false;
+
+  if (!pIO->Write32(&sig))
+    return false;
+
+  if (!pIO->Write32(&m_nReserved))
+    return false;
+
+  if (!pIO->Write16(&m_spectralRange.start))
+    return false;
+
+  if (!pIO->Write16(&m_spectralRange.end))
+    return false;
+
+  if (!pIO->Write16(&m_spectralRange.steps))
+    return false;
+
+  if (!pIO->Write16(&m_biSpectralRange.start))
+    return false;
+
+  if (!pIO->Write16(&m_biSpectralRange.end))
+    return false;
+
+  if (!pIO->Write16(&m_biSpectralRange.steps))
+    return false;
+
+  return true;
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccTagSpectralRange::Describe
+ *
+ * Purpose: Dump data associated with the tag to a string
+ *
+ * Args:
+ *  sDescription - string to concatenate tag dump to
+ *****************************************************************************
+ */
+void CIccTagSpectralRange::Describe(std::string &sDescription, int /* nVerboseness */)
+{
+  const size_t bufSize = 256;
+  icChar buf[bufSize];
+
+  snprintf(buf, bufSize, "SpectralRange: start %fnm end %fnm with %d steps\n", icF16toF(m_spectralRange.start), icF16toF(m_spectralRange.end), m_spectralRange.steps);
+  sDescription += buf;
+  if (m_biSpectralRange.steps) {
+    snprintf(buf, bufSize, "BiSpectralRange: start %fnm end %fnm with %d steps\n", icF16toF(m_biSpectralRange.start), icF16toF(m_biSpectralRange.end), m_biSpectralRange.steps);
+    sDescription += buf;
+  }
+}
+
+
+/**
+******************************************************************************
+* Name: CIccTagSpectralRange::Validate
+*
+* Purpose: Check tag data validity.
+*
+* Args:
+*  sig = signature of tag being validated,
+*  sReport = String to add report information to
+*
+* Return:
+*  icValidateStatusOK if valid, or other error status.
+******************************************************************************
+*/
+icValidateStatus CIccTagSpectralRange::Validate(std::string sigPath, std::string &sReport, const CIccProfile* pProfile/*=NULL*/) const
+{
+  icValidateStatus rv = CIccTag::Validate(sigPath, sReport, pProfile);
+
+  CIccInfo Info;
+  std::string sSigPathName = Info.GetSigPathName(sigPath);
+
+  rv = icMaxStatus(rv, Info.CheckData(sReport, m_spectralRange, "Spectral Range"));
+  if (m_biSpectralRange.steps)
+    rv = icMaxStatus(rv, Info.CheckData(sReport, m_biSpectralRange, "Bispectral Range"));
+
+  return rv;
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccTagSpectralViewingConditions::CIccTagSpectralViewingConditions
+ *
+ * Purpose: Constructor
+ *
  *****************************************************************************
  */
 CIccTagSpectralViewingConditions::CIccTagSpectralViewingConditions()

--- a/IccProfLib/IccTagBasic.h
+++ b/IccProfLib/IccTagBasic.h
@@ -1801,6 +1801,44 @@ public:
 };
 
 
+/**
+****************************************************************************
+* Class: CIccTagSpectralRange
+*
+* Purpose: The spectralRangeType ('srng') tag type, added by the iccMAX
+*   extended device colour space amendment (spec 10.2.w). It carries the
+*   spectral wavelength range (and, for bi-spectral spaces, the bi-spectral
+*   wavelength range) for a device colour space that uses a spectral colour
+*   space signature in the header. Used by the deviceSpectralRangeTag ('dsrn').
+*   Wire layout (Table W, 20 bytes): type signature, 4 reserved bytes, then
+*   the spectralRange and bi-spectralRange (icSpectralRange, 6 bytes each).
+*   The bi-spectral range is zero when the colour space is not bi-spectral.
+*****************************************************************************
+*/
+class ICCPROFLIB_API CIccTagSpectralRange : public CIccTag
+{
+public:
+  CIccTagSpectralRange();
+  CIccTagSpectralRange(const CIccTagSpectralRange &ITSR);
+  CIccTagSpectralRange &operator=(const CIccTagSpectralRange &SpectralRangeTag);
+  virtual CIccTag* NewCopy() const {return new CIccTagSpectralRange(*this);}
+  virtual ~CIccTagSpectralRange();
+
+  virtual icTagTypeSignature GetType() const { return icSigSpectralRangeType; }
+  virtual const icChar *GetClassName() const { return "CIccTagSpectralRange"; }
+
+  virtual bool Read(icUInt32Number size, CIccIO *pIO);
+  virtual bool Write(CIccIO *pIO);
+  virtual void Describe(std::string &sDescription, int nVerboseness);
+
+  virtual icValidateStatus Validate(std::string sigPath, std::string &sReport, const CIccProfile* pProfile=NULL) const;
+
+  icUInt32Number m_nReserved;
+  icSpectralRange m_spectralRange;
+  icSpectralRange m_biSpectralRange;
+};
+
+
 class CIccMatrixMath;
 
 /**

--- a/IccProfLib/IccTagFactory.cpp
+++ b/IccProfLib/IccTagFactory.cpp
@@ -142,6 +142,8 @@ icSigNamePair g_icTagNameTable[] = {
   {icSigDateTimeTag, "dateTimeTag"},
   {icSigDeviceMfgDescTag, "deviceMfgDescTag"},
   {icSigDeviceModelDescTag, "deviceModelDescTag"},
+  {icSigDevicePccTag, "devicePccTag"},
+  {icSigDeviceSpectralRangeTag, "deviceSpectralRangeTag"},
   {icSigMetaDataTag, "metaDataTag"},
   {icSigDToB0Tag, "DToB0Tag"},
   {icSigDToB1Tag, "DToB1Tag"},
@@ -266,6 +268,7 @@ struct {
   {icSigScreeningType, "screeningType"},
   {icSigSignatureType, "signatureType"},
   {icSigSpectralDataInfoType, "spectralDataInfoType"},
+  {icSigSpectralRangeType, "spectralRangeType"},
   {icSigSpectralViewingConditionsType, "spectralViewingConditionsType"},
   {icSigTextType, "textType"},
   {icSigTextDescriptionType, "textDescriptionType"},
@@ -423,6 +426,9 @@ CIccTag* CIccSpecTagFactory::CreateTag(icTagTypeSignature tagSig)
 
     case icSigSpectralDataInfoType:
       return new(std::nothrow) CIccTagSpectralDataInfo;
+
+    case icSigSpectralRangeType:
+      return new(std::nothrow) CIccTagSpectralRange;
 
     case icSigSpectralViewingConditionsType:
       return new(std::nothrow) CIccTagSpectralViewingConditions;

--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -405,7 +405,9 @@ typedef enum {
 #endif
     icSigDeviceMfgDescTag                  = 0x646D6E64,  /* 'dmnd' */
     icSigDeviceModelDescTag                = 0x646D6464,  /* 'dmdd' */
+    icSigDevicePccTag                      = 0x64706363,  /* 'dpcc' iccMAX extended device colour space amendment */
     icSigDeviceSettingsTag                 = 0x64657673,  /* 'devs' Removed in V4 */
+    icSigDeviceSpectralRangeTag            = 0x6473726E,  /* 'dsrn' iccMAX extended device colour space amendment */
     icSigDToB0Tag                          = 0x44324230,  /* 'D2B0' */
     icSigDToB1Tag                          = 0x44324231,  /* 'D2B1' */
     icSigDToB2Tag                          = 0x44324232,  /* 'D2B2' */
@@ -563,6 +565,7 @@ typedef enum {
     icSigSegmentedCurveType             = 0x63757266,  /* 'curf' */
     icSigSignatureType                  = 0x73696720,  /* 'sig ' */
     icSigSparseMatrixArrayType          = 0x736D6174,  /* 'smat' */
+    icSigSpectralRangeType              = 0x73726E67,  /* 'srng' iccMAX extended device colour space amendment */
     icSigSpectralViewingConditionsType  = 0x7376636e,  /* 'svcn' */
     icSigSpectralDataInfoType           = 0x7364696e,  /* 'sdin' */
     icSigTagArrayType                   = 0x74617279,  /* 'tary' */
@@ -605,6 +608,7 @@ typedef enum {
     icSigColorEncodingParamsSruct       = 0x63657074,  /* 'cept' */
     icSigMeasurementInfoStruct          = 0x6d656173,  /* 'meas' */
     icSigNamedColorStruct               = 0x6e6d636c,  /* 'nmcl' */
+    icSigProfileConnectionConditionsStruct = 0x70636320,  /* 'pcc ' iccMAX extended device colour space amendment */
     icSigProfileInfoStruct              = 0x70696e66,  /* 'pinf' */
     icSigTintZeroStruct                 = 0x746e7430,  /* 'tnt0' */
     icSigUndefinedStruct                = 0x00000000,
@@ -852,6 +856,26 @@ typedef enum {
   icSigTnt0UnknownMbr           = 0x3f3f3f3f,  /* '????' */
   icMaxTnt0Mbr                  = 0xFFFFFFFF,
 } icTintZeroMemberSignature;
+
+
+/**
+* ProfileConnectionConditionsStructure (icSigProfileConnectionConditionsStruct)
+* Member Tag signatures (iccMAX extended device colour space amendment, 12.2.y).
+* The members parallel the profile-level PCC tags they logically replace when the
+* containing structure (a devicePccTag) is used for PCS/PCC processing.
+*/
+typedef enum {
+  icSigPccPcsIlluminantXYZMbr        = 0x6958595a,  /* 'iXYZ' PCS illuminant XYZ */
+  icSigPccMediaWhitePointMbr         = 0x6d777074,  /* 'mwpt' Media white point */
+  icSigPccSpectralWhitePointMbr      = 0x73777074,  /* 'swpt' Spectral white point */
+  icSigPccSpectralViewingConditionsMbr = 0x7376636e, /* 'svcn' Spectral viewing conditions */
+  icSigPccCustomToStandardPccMbr     = 0x63327370,  /* 'c2sp' Custom to standard PCC transform */
+  icSigPccStandardToCustomPccMbr     = 0x73326370,  /* 's2cp' Standard to custom PCC transform */
+
+/* Convenience Enum Definitions - Not defined in proposal*/
+  icSigPccUnknownMbr            = 0x3f3f3f3f,  /* '????' */
+  icMaxPccMbr                   = 0xFFFFFFFF,
+} icProfileConnectionConditionsMemberSignature;
 
 
 /** 

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -849,6 +849,59 @@ bool CIccTagXmlSpectralDataInfo::ParseXml(xmlNode *pNode, std::string &parseStr)
 }
 
 
+bool CIccTagXmlSpectralRange::ToXml(std::string &xml, std::string blanks/* = ""*/)
+{
+  const size_t lineSize = 256;
+  char line[lineSize];
+
+  xml += blanks + "<SpectralRange>\n";
+  snprintf(line, lineSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_spectralRange.start), icF16toF(m_spectralRange.end), m_spectralRange.steps);
+  xml += blanks + line;
+  xml += blanks + "</SpectralRange>\n";
+
+  if (m_biSpectralRange.steps) {
+    xml += blanks + "<BiSpectralRange>\n";
+    snprintf(line, lineSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_biSpectralRange.start), icF16toF(m_biSpectralRange.end), m_biSpectralRange.steps);
+    xml += blanks + line;
+    xml += blanks + "</BiSpectralRange>\n";
+  }
+
+  return true;
+}
+
+
+bool CIccTagXmlSpectralRange::ParseXml(xmlNode *pNode, std::string &parseStr)
+{
+  xmlNode *pChild;
+
+  if (!(pChild = icXmlFindNode(pNode, "SpectralRange"))) {
+    parseStr += "No SpectralRange section found\n";
+    return false;
+  }
+
+  if (!(pChild = icXmlFindNode(pChild->children, "Wavelengths"))) {
+    parseStr += "SpectralRange missing Wavelengths\n";
+    return false;
+  }
+
+  m_spectralRange.start = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "start")));
+  m_spectralRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "end")));
+  m_spectralRange.steps = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pChild, "steps"));
+
+  pChild = icXmlFindNode(pNode, "BiSpectralRange");
+
+  if (pChild) {
+    if ((pChild = icXmlFindNode(pChild->children, "Wavelengths"))) {
+      m_biSpectralRange.start = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "start")));
+      m_biSpectralRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "end")));
+      m_biSpectralRange.steps = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pChild, "steps"));
+    }
+  }
+
+  return true;
+}
+
+
 bool CIccTagXmlNamedColor2::ToXml(std::string &xml, std::string blanks/* = ""*/)
 {
   const size_t bufSize = 256;

--- a/IccXML/IccLibXML/IccTagXml.h
+++ b/IccXML/IccLibXML/IccTagXml.h
@@ -441,6 +441,19 @@ public:
   virtual bool ParseXml(xmlNode *pNode, std::string &parseStr);
 };
 
+class ICCPROFLIB_API CIccTagXmlSpectralRange : public CIccTagSpectralRange, public CIccTagXml
+{
+public:
+  virtual ~CIccTagXmlSpectralRange() {}
+
+  virtual const char *GetClassName() const {return "CIccTagXmlSpectralRange"; }
+
+  virtual IIccExtensionTag *GetExtension() {return this; }
+
+  virtual bool ToXml(std::string &xml, std::string blanks="");
+  virtual bool ParseXml(xmlNode *pNode, std::string &parseStr);
+};
+
 class ICCPROFLIB_API CIccTagXmlSpectralViewingConditions : public CIccTagSpectralViewingConditions, public CIccTagXml
 {
 public:

--- a/IccXML/IccLibXML/IccTagXmlFactory.cpp
+++ b/IccXML/IccLibXML/IccTagXmlFactory.cpp
@@ -179,6 +179,9 @@ CIccTag* CIccTagXmlFactory::CreateTag(icTagTypeSignature tagSig)
   case icSigSpectralDataInfoType:
     return new(std::nothrow) CIccTagXmlSpectralDataInfo;
 
+  case icSigSpectralRangeType:
+    return new(std::nothrow) CIccTagXmlSpectralRange;
+
   case icSigProfileSequenceDescType:
     return new(std::nothrow) CIccTagXmlProfileSeqDesc;
 


### PR DESCRIPTION
## Summary

Implements the iccMAX **Extended Device Colour Space** amendment (ICC.2:2023 minor revision, passed by the ICC Steering Committee 30 Oct 2025). Spectral colour space signatures may now be used as a profile's data colour space with their range carried by a new tag, and an abstract profile may supply replacement profile connection conditions for its source space. Fixes #626.

This PR lands the **representation, validation, XML round-trip and tool visibility** for the new tags/types — the bulk of "support is needed for the additional tag types and tags." See the scope note below.

## New signatures (`icProfileHeader.h`)

| Element | Signature | Spec |
|---|---|---|
| deviceSpectralRangeTag | `dsrn` (0x6473726e) | 9.2.x |
| devicePccTag | `dpcc` (0x64706363) | 9.2.x+1 |
| spectralRangeType (tag type) | `srng` (0x73726e67) | 10.2.w |
| profileConnectionConditionsStructure (struct) | `pcc ` (0x70636320) | 12.2.y |

Plus `icProfileConnectionConditionsMemberSignature` for the six `pcc ` members (iXYZ/mwpt/swpt/svcn/c2sp/s2cp).

## What's implemented

**`spectralRangeType` (`srng`)** — `CIccTagSpectralRange` (`IccTagBasic.{h,cpp}`): the fixed 20-byte structure of Table W (type sig, 4 reserved bytes, spectral range, bi-spectral range). `Read`/`Write`/`Describe`/`Validate` mirror the existing `CIccTagSpectralDataInfo`. Registered in `CIccSpecTagFactory` (CreateTag + type-name) and the XML factory (`CIccTagXmlSpectralRange`) for `iccToXml`/`iccFromXml`.

**`profileConnectionConditionsStructure` (`pcc `)** — `CIccStructProfileConnectionConditions` (`IccStructBasic.{h,cpp}`): member-name table and a `Validate()` that requires `iXYZ`/`svcn`/`c2sp`/`s2cp` unconditionally and warns when neither media (`mwpt`) nor spectral (`swpt`) white point is present. All six members reuse existing tag types, so no new sub-tag types are added. Registered in `CIccBasicStructFactory`.

**Header / type validation (`IccProfile.cpp`)**
- `CheckHeader`: a v5 profile may use a spectral data colour space generally (§7.2.8), not only the pre-amendment abstract+`DToB0` form. When it does, the range must come from a `dsrn` tag or the header spectral/bi-spectral range fields, else it's rejected. **The existing abstract+`DToB0` path is preserved byte-for-byte.**
- `IsTypeValid`: `dsrn` must contain an `srng`; `dpcc` must contain a `tagStructType` of `pcc `.

Signature-name tables (tag, tag-type, struct) updated so dumps and XML render friendly names.

## Testing

New CTest **`iccdev.extended-device-colorspace`** (IccProfLib-only, mirrors the other regression executables): `srng` binary round-trip + short-read rejection, `pcc ` handler creation and display name, required-member validation (complete structure vs. one missing `s2cp`), and resolution of the new signature names. Passes.

Built tools-ON locally (`ENABLE_TOOLS=ON`, image tools off): full library + all command-line tools compile and link clean; the validation / xml / v5 / tag / spec / xyztype suites pass unchanged. (The 8 failing tests in my local run are all `[FAIL] missing executable` for image tools built only when `ENABLE_IMAGE_TOOLS=ON`, unrelated to this change.)

## Scope note

This PR covers parsing, representation, validation, XML round-trip and tool visibility. The **CMM behavioural application of `devicePccTag`** — actually swapping in the alternate profile connection conditions during abstract-profile PCS/PCC processing (spec 9.2.x+1 / 12.2.y) — is a deeper change to the transform pipeline and is left as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
