### PR TITLE
Apply devicePccTag alternate PCC in abstract-profile CMM processing (#1559)

### DIFF
--- a/.github/ci/regression/dpcc-pcc-replacement.cpp
+++ b/.github/ci/regression/dpcc-pcc-replacement.cpp
@@ -1,0 +1,122 @@
+// Regression for #1559 (follow-up to #626): a devicePccTag ('dpcc') on an
+// abstract iccMAX profile must replace the profile-level connection conditions
+// with the matching members of its profileConnectionConditionsStructure ('pcc ')
+// when the CMM reads the profile through the IIccProfileConnectionConditions
+// interface (spec 9.2.x+1 / 12.2.y).
+//
+// The CMM always reaches a profile's PCC via getPccViewingConditions /
+// getCustomToStandardPcc / getStandardToCustomPcc / getMediaWhiteXYZ (and the
+// illuminant/observer getters, which all derive from getPccViewingConditions).
+// This test pins that, for an abstract profile carrying a dpcc tag, those
+// getters return the structure members rather than the profile's own tags --
+// and that the replacement is gated to abstract iccMAX profiles, so a non-abstract
+// profile still falls back to its profile-level tags. Each "dpcc wins" assertion
+// is red-green: it fails if getDevicePccElem is bypassed.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccProfile.h"
+#include "IccTagBasic.h"
+#include "IccTagComposite.h"
+#include "IccTagMPE.h"
+#include "IccUtil.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <cmath>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[dpcc-pcc-replacement] FAIL: %s\n", what);
+  }
+}
+
+CIccTagXYZ *makeXYZ(icFloatNumber X, icFloatNumber Y, icFloatNumber Z)
+{
+  CIccTagXYZ *p = new CIccTagXYZ();
+  p->SetSize(1);
+  icXYZNumber *pv = p->GetXYZ(0);
+  pv->X = icDtoF(X);
+  pv->Y = icDtoF(Y);
+  pv->Z = icDtoF(Z);
+  return p;
+}
+
+bool approx(icFloatNumber a, icFloatNumber b) { return std::fabs(a - b) < 1.0e-4f; }
+
+} // namespace
+
+int main()
+{
+  // Profile-level media white point (the value that must be SHADOWED by dpcc).
+  const icFloatNumber profWhite[3] = { 0.9000f, 1.0000f, 0.8000f };
+  // dpcc mwpt member (the replacement value that must WIN for an abstract profile).
+  const icFloatNumber pccWhite[3]  = { 0.5000f, 0.6000f, 0.7000f };
+
+  CIccProfile profile;
+  profile.m_Header.version     = icVersionNumberV5;
+  profile.m_Header.deviceClass = icSigAbstractClass;
+
+  profile.AttachTag(icSigMediaWhitePointTag, makeXYZ(profWhite[0], profWhite[1], profWhite[2]));
+
+  // Build the devicePccTag: a 'pcc ' struct with mwpt/svcn/c2sp/s2cp members.
+  CIccTagStruct *pDpcc = new CIccTagStruct();
+  pDpcc->SetTagStructType(icSigProfileConnectionConditionsStruct);
+
+  CIccTagXYZ *pPccWhite = makeXYZ(pccWhite[0], pccWhite[1], pccWhite[2]);
+  CIccTagSpectralViewingConditions *pSvcn = new CIccTagSpectralViewingConditions();
+  CIccTagMultiProcessElement *pC2s = new CIccTagMultiProcessElement();
+  CIccTagMultiProcessElement *pS2c = new CIccTagMultiProcessElement();
+
+  pDpcc->AttachElem(icSigPccMediaWhitePointMbr, pPccWhite);
+  pDpcc->AttachElem(icSigPccSpectralViewingConditionsMbr, pSvcn);
+  pDpcc->AttachElem(icSigPccCustomToStandardPccMbr, pC2s);
+  pDpcc->AttachElem(icSigPccStandardToCustomPccMbr, pS2c);
+
+  profile.AttachTag(icSigDevicePccTag, pDpcc);
+
+  // --- Abstract profile: every getter resolves to the dpcc member. ---
+  icFloatNumber w[3] = { 0 };
+  profile.getMediaWhiteXYZ(w);
+  check(approx(w[0], pccWhite[0]) && approx(w[1], pccWhite[1]) && approx(w[2], pccWhite[2]),
+        "abstract: getMediaWhiteXYZ returns dpcc mwpt member, not profile tag");
+
+  check(profile.getPccViewingConditions() == pSvcn,
+        "abstract: getPccViewingConditions returns dpcc svcn member");
+  check(profile.getCustomToStandardPcc() == pC2s,
+        "abstract: getCustomToStandardPcc returns dpcc c2sp member");
+  check(profile.getStandardToCustomPcc() == pS2c,
+        "abstract: getStandardToCustomPcc returns dpcc s2cp member");
+
+  // --- Gate: a non-abstract profile ignores dpcc and falls back to its tags. ---
+  // No profile-level svcn/c2sp/s2cp tags were attached, so the fallback path
+  // returns NULL there and the profile mediaWhitePointTag for the white point.
+  profile.m_Header.deviceClass = icSigOutputClass;
+
+  profile.getMediaWhiteXYZ(w);
+  check(approx(w[0], profWhite[0]) && approx(w[1], profWhite[1]) && approx(w[2], profWhite[2]),
+        "non-abstract: getMediaWhiteXYZ falls back to profile mediaWhitePointTag");
+  check(profile.getPccViewingConditions() == NULL,
+        "non-abstract: getPccViewingConditions ignores dpcc svcn member");
+  check(profile.getCustomToStandardPcc() == NULL,
+        "non-abstract: getCustomToStandardPcc ignores dpcc c2sp member");
+
+  // --- Gate: a v2/v4 abstract profile also ignores dpcc (amendment is v5-only). ---
+  profile.m_Header.deviceClass = icSigAbstractClass;
+  profile.m_Header.version     = icVersionNumberV4_3;
+  check(profile.getCustomToStandardPcc() == NULL,
+        "v4 abstract: getCustomToStandardPcc ignores dpcc (v5-only amendment)");
+
+  if (g_fail)
+    std::fprintf(stderr, "[dpcc-pcc-replacement] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stderr, "[dpcc-pcc-replacement] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -660,6 +660,41 @@ function(iccdev_add_extended_device_colorspace_test)
   endif()
 endfunction()
 
+function(iccdev_add_dpcc_pcc_replacement_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccDpccPccReplacementTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/dpcc-pcc-replacement.cpp"
+  )
+  target_link_libraries(iccDpccPccReplacementTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccDpccPccReplacementTest)
+
+  add_test(
+    NAME iccdev.dpcc-pcc-replacement
+    COMMAND "$<TARGET_FILE:iccDpccPccReplacementTest>"
+  )
+  set_tests_properties(iccdev.dpcc-pcc-replacement PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;spec;cmm;issue-1559;regression"
+  )
+  if(WIN32)
+    set(_dpcc_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccDpccPccReplacementTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _dpcc_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.dpcc-pcc-replacement PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_dpcc_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_fileio_getlength_position_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -1073,6 +1108,7 @@ if(WIN32)
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
   iccdev_add_extended_device_colorspace_test()
+  iccdev_add_dpcc_pcc_replacement_test()
   iccdev_add_windows_iccdevcmm_smoke_test()
 
   return()
@@ -1141,6 +1177,7 @@ iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
 iccdev_add_extended_device_colorspace_test()
+iccdev_add_dpcc_pcc_replacement_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -3412,6 +3412,98 @@ icUInt16Number CIccProfile::GetParentSpaceSamples() const
 
 /**
  ****************************************************************************
+ * Name: CIccProfile::getDevicePccElem
+ *
+ * Purpose: Look up a member sub-tag of this profile's devicePccTag ('dpcc')
+ *  profileConnectionConditionsStructure. The extended device colour space
+ *  amendment (9.2.x+1 / 12.2.y) lets an abstract profile carry alternate
+ *  replacement profile connection conditions in this structure; the PCC
+ *  interface getters consult it before the profile's own PCC tags.
+ *
+ * Args:
+ *  sigMember = the 'pcc ' member signature to retrieve,
+ *  sigType   = the required tag type of that member
+ *
+ * Return: the member tag, or NULL when no replacement applies.
+ *****************************************************************************
+ */
+CIccTag* CIccProfile::getDevicePccElem(icSignature sigMember, icTagTypeSignature sigType)
+{
+  // The devicePccTag is only defined for abstract iccMAX (v5) profiles.
+  if (m_Header.version < icVersionNumberV5 || m_Header.deviceClass != icSigAbstractClass)
+    return NULL;
+
+  CIccTag *pTag = FindTag(icSigDevicePccTag);
+  if (!pTag || pTag->GetTagStructType() != icSigProfileConnectionConditionsStruct)
+    return NULL;
+
+  return ((CIccTagStruct*)pTag)->FindElemOfType(sigMember, sigType);
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccProfile::getPccViewingConditions
+ *
+ * Purpose: Get the spectral viewing conditions for profile connection,
+ *  preferring a devicePccTag svcn member when present (#626 / #1559).
+ *  getPccIlluminant/CCT/Observer and getNormIlluminantXYZ/getLumIlluminantXYZ
+ *  all derive from this getter, so overriding it here also applies the dpcc
+ *  illuminant/observer (and the iXYZ PCS illuminant, 12.2.y.2.1) to them.
+ *****************************************************************************
+ */
+const CIccTagSpectralViewingConditions *CIccProfile::getPccViewingConditions()
+{
+  // Replacement svcn from the devicePccTag structure, else the profile's own svcn.
+  CIccTag *pElem = getDevicePccElem(icSigPccSpectralViewingConditionsMbr, icSigSpectralViewingConditionsType);
+  if (pElem)
+    return (const CIccTagSpectralViewingConditions*)pElem;
+
+  return (const CIccTagSpectralViewingConditions*)FindTagOfType(icSigSpectralViewingConditionsTag,
+                                                                icSigSpectralViewingConditionsType);
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccProfile::getCustomToStandardPcc
+ *
+ * Purpose: Get the custom-to-standard PCC transform, preferring a devicePccTag
+ *  c2sp member when present (#626 / #1559).
+ *****************************************************************************
+ */
+CIccTagMultiProcessElement *CIccProfile::getCustomToStandardPcc()
+{
+  // Replacement c2sp from the devicePccTag structure, else the profile's own c2sp tag.
+  CIccTag *pElem = getDevicePccElem(icSigPccCustomToStandardPccMbr, icSigMultiProcessElementType);
+  if (pElem)
+    return (CIccTagMultiProcessElement*)pElem;
+
+  return (CIccTagMultiProcessElement*)FindTagOfType(icSigCustomToStandardPccTag, icSigMultiProcessElementType);
+}
+
+
+/**
+ ****************************************************************************
+ * Name: CIccProfile::getStandardToCustomPcc
+ *
+ * Purpose: Get the standard-to-custom PCC transform, preferring a devicePccTag
+ *  s2cp member when present (#626 / #1559).
+ *****************************************************************************
+ */
+CIccTagMultiProcessElement *CIccProfile::getStandardToCustomPcc()
+{
+  // Replacement s2cp from the devicePccTag structure, else the profile's own s2cp tag.
+  CIccTag *pElem = getDevicePccElem(icSigPccStandardToCustomPccMbr, icSigMultiProcessElementType);
+  if (pElem)
+    return (CIccTagMultiProcessElement*)pElem;
+
+  return (CIccTagMultiProcessElement*)FindTagOfType(icSigStandardToCustomPccTag, icSigMultiProcessElementType);
+}
+
+
+/**
+ ****************************************************************************
  * Name: CIccProfile::getPccIlluminant
  * 
  * Purpose: Get the Illuminant associated with profile connection.
@@ -3580,7 +3672,11 @@ void CIccProfile::getLumIlluminantXYZ(icFloatNumber *pXYZ)
  */
 bool CIccProfile::getMediaWhiteXYZ(icFloatNumber *pXYZ)
 {
-  CIccTag *pTag = FindTag(icSigMediaWhitePointTag);
+  // Prefer a devicePccTag mwpt member when present; it replaces the profile's
+  // mediaWhitePointTag for an abstract profile (#626 / #1559, spec 12.2.y.2.2).
+  CIccTag *pTag = getDevicePccElem(icSigPccMediaWhitePointMbr, icSigXYZType);
+  if (!pTag)
+    pTag = FindTag(icSigMediaWhitePointTag);
   if (pTag && pTag->GetType()==icSigXYZType) {
     CIccTagXYZ *pXYZTag = (CIccTagXYZ*)pTag;
     icXYZNumber *pMediaXYZ = pXYZTag->GetXYZ(0);

--- a/IccProfLib/IccProfile.h
+++ b/IccProfLib/IccProfile.h
@@ -193,17 +193,17 @@ public:
 	bool IsTagPresent(icSignature sig) const { return (GetTag(sig)!=NULL); }
 
 
-  //Implement the IIccProfileConnectionConditions interface
-  virtual const CIccTagSpectralViewingConditions *getPccViewingConditions() { return (const CIccTagSpectralViewingConditions*)
-                                                                                FindTagOfType(icSigSpectralViewingConditionsTag, 
-                                                                                              icSigSpectralViewingConditionsType); }
-  virtual CIccTagMultiProcessElement *getCustomToStandardPcc() { return (CIccTagMultiProcessElement*)
-                                                                   FindTagOfType(icSigCustomToStandardPccTag, 
-                                                                                 icSigMultiProcessElementType); }
-
-  virtual CIccTagMultiProcessElement *getStandardToCustomPcc() { return (CIccTagMultiProcessElement*)
-                                                                   FindTagOfType(icSigStandardToCustomPccTag, 
-                                                                                 icSigMultiProcessElementType); }
+  //Implement the IIccProfileConnectionConditions interface.
+  //
+  // For an abstract profile that carries a devicePccTag ('dpcc'), the iccMAX
+  // extended device colour space amendment (9.2.x+1 / 12.2.y) replaces these
+  // profile-level connection conditions with the matching members of the tag's
+  // profileConnectionConditionsStructure. Each getter prefers the structure
+  // member (via getDevicePccElem) and falls back to the profile's own tag, so
+  // every consumer of the PCC interface picks up the replacement automatically.
+  virtual const CIccTagSpectralViewingConditions *getPccViewingConditions();
+  virtual CIccTagMultiProcessElement *getCustomToStandardPcc();
+  virtual CIccTagMultiProcessElement *getStandardToCustomPcc();
   virtual icIlluminant getPccIlluminant();
   virtual icFloatNumber getPccCCT();
   virtual icStandardObserver getPccObserver();
@@ -216,6 +216,13 @@ public:
   bool calcMediaWhiteXYZ(icFloatNumber *pXYZ, IIccProfileConnectionConditions *pObservingPCC);
 
 protected:
+
+  // Return the member sub-tag of the given signature/type from this profile's
+  // devicePccTag ('dpcc') profileConnectionConditionsStructure, or NULL when the
+  // profile is not an abstract iccMAX profile, has no devicePccTag, or the member
+  // is absent. Used by the PCC interface getters to apply the extended device
+  // colour space amendment's connection-condition replacements (#626 / #1559).
+  CIccTag* getDevicePccElem(icSignature sigMember, icTagTypeSignature sigType);
 
   void Cleanup();
   IccTagEntry* GetTag(icSignature sig) const;


### PR DESCRIPTION
## Summary

Implements the **behavioural** half of the iccMAX Extended Device Colour Space amendment: actually *applying* a `devicePccTag` (`dpcc`) during CMM processing of an abstract profile. Fixes #1559.

PR #1558 added parsing/validation/XML for `dpcc`/`pcc `/`srng`/`dsrn` but left `dpcc` inert — it parsed and validated but had no effect on a transform. Per spec **9.2.x+1 / 12.2.y**, when an abstract profile carries a `dpcc` tag, the members of its `profileConnectionConditionsStructure` (`pcc `) **logically replace** the profile-level PCC tags for all PCS-side PCC processing.

> ⚠️ **Stacked on #1558** (the `dpcc`/`pcc `/`srng` types land there). Base PR is set to the #1558 branch so this diff shows only the #1559 delta — merge #1558 first, then retarget this to `master`.

## Approach — no CMM or ownership changes

The CMM always reaches a profile's connection conditions through the `IIccProfileConnectionConditions` interface that `CIccProfile` implements, and a transform's `m_pConnectionConditions` is set to the profile itself (`IccCmm.cpp:1234`/`1369`). So the replacement lives entirely inside `CIccProfile`'s getters — nothing in the CMM, and no lifetime plumbing (members are borrowed pointers owned by the `dpcc` struct, exactly like the existing `FindTagOfType` getters).

- New protected **`getDevicePccElem(memberSig, type)`** — returns the matching member of the `dpcc` tag's `pcc ` structure, gated to abstract iccMAX (v5) profiles; `NULL` otherwise.
- `getPccViewingConditions` / `getCustomToStandardPcc` / `getStandardToCustomPcc` moved out-of-line and now prefer the `svcn` / `c2sp` / `s2cp` members, falling back to the profile's own tags.
- `getMediaWhiteXYZ` prefers the `dpcc` `mwpt` member (12.2.y.2.2).

`getPccIlluminant`/`CCT`/`Observer` and `getNormIlluminantXYZ`/`getLumIlluminantXYZ` all derive from `getPccViewingConditions`, so the `svcn` replacement (and thus the `iXYZ` PCS-illuminant semantics, 12.2.y.2.1) **cascades to them automatically** — overriding one getter covers six.

| `pcc ` member | replaces |
|---|---|
| `svcn` | spectralViewingConditionsTag (→ illuminant/observer getters) |
| `c2sp` | customToStandardPccTag |
| `s2cp` | standardToCustomPccTag |
| `mwpt` | mediaWhitePointTag |

## Testing

New CTest **`iccdev.dpcc-pcc-replacement`** (IccProfLib-only): an abstract v5 profile carrying a `dpcc` tag resolves all four getters to the structure members over its profile-level tags; a non-abstract profile and a v2/v4 profile both fall back to the profile tags (the amendment is abstract-/v5-only).

**Red-green verified** — neutralising `getDevicePccElem` makes the four "dpcc wins" assertions fail while the gate assertions still pass.

Local tools-ON build: library compiles clean; the validation, PCC (`pcc-zero-illuminant`), named-colour CMM (`namedcolor-apply`, `v5-namedcmm`), CAM, and tag/xform suites pass unchanged. (The 8 failing tests are all `[FAIL] missing executable` for image tools built only when `ENABLE_IMAGE_TOOLS=ON`, unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
