### PR TITLE
Fix: reject gamutBoundaryDescType tag with 0 PCS channels (CWE-400, #1581)

### DIFF
--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -6171,7 +6171,20 @@ bool CIccTagGamutBoundaryDesc::Read(icUInt32Number size, CIccIO *pIO)
     !pIO->Read16(&m_nDeviceChannels))
     return false;
 
-  if (m_nPCSChannels > 3)
+  // m_nPCSChannels is the per-vertex PCS coordinate count and is mandatory: a
+  // gamut boundary is a solid in PCS space, so every vertex must carry at least
+  // one PCS coordinate (in practice the PCS dimensionality, 1..3). Beyond being
+  // geometrically required, a zero value is a security hole: the maximum-count
+  // check below bounds m_NumberOfVertices via nVertices*nPCSChannels (and
+  // *nDeviceChannels). If m_nPCSChannels is 0 (and m_nDeviceChannels is 0, which
+  // is legitimately allowed because device coords are optional) that product
+  // collapses to 0, so the tag-size bound no longer constrains m_NumberOfVertices
+  // at all. A crafted tag can then declare ~2^31 vertices in a tiny tag, pass
+  // Read(), and make Describe()/Validate() spin for billions of iterations
+  // (CWE-400 uncontrolled resource consumption, issue #1581). Rejecting a zero
+  // PCS-channel count here restores the size bound and parses the malformed tag
+  // as unreadable, which is the correct outcome for non-conformant data.
+  if (m_nPCSChannels < 1 || m_nPCSChannels > 3)
     return false;
 
   if (m_nDeviceChannels > 15)


### PR DESCRIPTION
## Summary

Fixes a CWE-400 (uncontrolled resource consumption) hang in `iccDumpProfile` reported in #1581: `iccDumpProfile -v 100 <profile> ALL` runs for **11m45s** on a 358-byte malformed profile carrying a `gamutBoundaryDescType` tag.

## Root cause

`CIccTagGamutBoundaryDesc::Read` (`IccProfLib/IccTagLut.cpp`) bounds `m_NumberOfVertices` only through the products `nVertices * m_nPCSChannels` and `nVertices * m_nDeviceChannels` in its tag-size check. `m_nPCSChannels` was validated for an upper bound (`> 3`) but **never a lower bound**, so a tag declaring `m_nPCSChannels == 0` and `m_nDeviceChannels == 0` (device coords are legitimately optional) zeroes both products. The size bound then no longer constrains the vertex count:

| field | value in repro |
|---|---|
| `m_nPCSChannels` | **0** |
| `m_nDeviceChannels` | 0 |
| `m_NumberOfVertices` | **1,953,497,600** |
| `m_NumberOfTriangles` | 5 |

The size guard computes `20 + 5·12 + nVerts·0·4 + nVerts·0·4 = 80 ≤ 168` → tag accepted. `Describe()` (with `-v > 75`) then runs its per-vertex loop ~1.95 billion times, building a multi-GB `std::string`.

## Fix

A gamut boundary is a solid in PCS space, so every vertex must carry at least one PCS coordinate; `m_nPCSChannels == 0` is non-conformant. Tightening the existing check to `(m_nPCSChannels < 1 || m_nPCSChannels > 3)` restores the size bound, so a near-2^31 vertex count would require ≥7.8 GB and fail the size check. The malformed tag parses as unreadable, which `iccDumpProfile` surfaces as `Tag has invalid structure!` in **0.006s**.

## Verification

- **Repro:** 11m45s hang → 0.006s rejection (confirmed on current `master`).
- **No regression:** a valid `gbd` tag (3 PCS channels, 468 vertices, 900 triangles) still parses and dumps fully.

## Test

Regression coverage is in-repo PR (test branch `test-1581-gbd-zero-pcs-channels`) because the CTest touches `Build/Cmake`, which is fork-gated. **Merge this fix first.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
