### PR TITLE
fix: harden iccTiffDump export args

### DIFF
--- a/.github/scripts/iccdev-tiffdump-output-hardening-tests.sh
+++ b/.github/scripts/iccdev-tiffdump-output-hardening-tests.sh
@@ -21,6 +21,11 @@ if [ ! -f "$SAMPLE_TIFF" ]; then
   echo "[FAIL] missing sample TIFF: $SAMPLE_TIFF"
   exit 1
 fi
+NO_PROFILE_TIFF="$REPO_ROOT/.github/ci/test-data/spectral/spec_1"
+if [ ! -f "$NO_PROFILE_TIFF" ]; then
+  echo "[FAIL] missing no-profile sample TIFF: $NO_PROFILE_TIFF"
+  exit 1
+fi
 
 pass=0
 fail=0
@@ -71,6 +76,33 @@ newline.icc"
 
   [ -s "$dst" ] || return 1
   grep -Fq 'Profile extracted to: '"$OUTDIR"'/export_with_\nnewline.icc' "$log"
+}
+
+test_extra_arg_rejected() {
+  local dst="$OUTDIR/extra-arg.icc"
+  local log="$OUTDIR/tiffdump-extra-arg.log"
+
+  rm -f "$dst"
+  if "$TIFFDUMP" "$SAMPLE_TIFF" "$dst" extra-token > "$log" 2>&1; then
+    return 1
+  fi
+
+  grep -Fq "Usage: iccTiffDump tiff_file {exported_icc_file}" "$log" || return 1
+  [ ! -e "$dst" ]
+}
+
+test_missing_embedded_profile_export_rejected() {
+  local dst="$OUTDIR/no-profile-export.icc"
+  local log="$OUTDIR/tiffdump-no-profile-export.log"
+
+  rm -f "$dst"
+  if "$TIFFDUMP" "$NO_PROFILE_TIFF" "$dst" > "$log" 2>&1; then
+    return 1
+  fi
+
+  grep -Fq "Profile:           None" "$log" || return 1
+  grep -Fq "No embedded ICC profile to extract" "$log" || return 1
+  [ ! -e "$dst" ]
 }
 
 # ---------------------------------------------------------------------------
@@ -172,6 +204,8 @@ echo "=== iccTiffDump output hardening regression ==="
 run_ok "tiffdump-profile-description-escape" test_profile_description_escaping
 run_ok "tiffdump-input-path-escape" test_input_path_escaping
 run_ok "tiffdump-export-path-escape" test_export_path_escaping
+run_ok "tiffdump-extra-arg-reject" test_extra_arg_rejected
+run_ok "tiffdump-no-profile-export-reject" test_missing_embedded_profile_export_rejected
 run_ok "tiffdump-palette-photometric-report" test_palette_photometric_report
 run_ok "tiffdump-noncompliant-embedded-icc-reject" test_noncompliant_embedded_icc_rejected
 

--- a/.github/scripts/iccdev-tiffdump-output-hardening-tests.sh
+++ b/.github/scripts/iccdev-tiffdump-output-hardening-tests.sh
@@ -139,6 +139,34 @@ path.write_bytes(d)
 PY
 }
 
+generate_defaulted_packbits_gray_tiff() {
+  # 32x32 8-bit grayscale PackBits TIFF.  It intentionally omits
+  # SamplesPerPixel, SampleFormat, and Orientation so CTiffImg must accept the
+  # baseline/defaulted tag values reported by libtiff.
+  "$PYTHON" - "$1" <<'PY'
+import struct, sys, pathlib
+path = pathlib.Path(sys.argv[1])
+w = h = 32; bps = 8
+packbits = bytes([129, 0]) * ((w * h) // 128)
+doff = 8; ifd = doff + len(packbits)
+if ifd % 2:
+    packbits += b"\0"; ifd += 1
+entries = [(256, 4, 1, w), (257, 4, 1, h), (258, 3, 1, bps),
+           (259, 3, 1, 32773), (262, 3, 1, 1), (273, 4, 1, doff),
+           (278, 4, 1, h), (279, 4, 1, len(packbits)), (284, 3, 1, 1),
+           (296, 3, 1, 2)]
+entries.sort()
+d = bytearray(b"II" + struct.pack("<H", 42) + struct.pack("<I", ifd))
+d += packbits
+d += struct.pack("<H", len(entries))
+for t, ty, c, v in entries:
+    d += struct.pack("<HHI", t, ty, c)
+    d += (struct.pack("<H", v) + b"\0\0") if (ty == 3 and c == 1) else struct.pack("<I", v)
+d += struct.pack("<I", 0)
+path.write_bytes(d)
+PY
+}
+
 generate_tiff_with_icc() {
   # 2x2 RGB TIFF embedding the ICC bytes from file $2 (tag 34675, out-of-line).
   "$PYTHON" - "$1" "$2" <<'PY'
@@ -178,6 +206,16 @@ test_palette_photometric_report() {
   grep -Eq 'Photometric:[[:space:]]+Palette' "$log"
 }
 
+test_defaulted_packbits_gray_loads() {
+  [ -n "$PYTHON" ] || { echo "    [SKIP] python3 unavailable"; return 0; }
+  local tif="$OUTDIR/defaulted-packbits-gray.tif"
+  local log="$OUTDIR/tiffdump-defaulted-packbits-gray.log"
+  generate_defaulted_packbits_gray_tiff "$tif" || return 1
+  "$TIFFDUMP" "$tif" > "$log" 2>&1
+  grep -Eq 'SamplesPerPixel:[[:space:]]+1' "$log" || return 1
+  grep -Eq 'Compression:[[:space:]]+PackBits' "$log"
+}
+
 test_noncompliant_embedded_icc_rejected() {
   [ -n "$PYTHON" ] || { echo "    [SKIP] python3 unavailable"; return 0; }
   local srgb="$ICCDEV_TESTING/sRGB_v4_ICC_preference.icc"
@@ -207,6 +245,7 @@ run_ok "tiffdump-export-path-escape" test_export_path_escaping
 run_ok "tiffdump-extra-arg-reject" test_extra_arg_rejected
 run_ok "tiffdump-no-profile-export-reject" test_missing_embedded_profile_export_rejected
 run_ok "tiffdump-palette-photometric-report" test_palette_photometric_report
+run_ok "tiffdump-defaulted-packbits-gray-load" test_defaulted_packbits_gray_loads
 run_ok "tiffdump-noncompliant-embedded-icc-reject" test_noncompliant_embedded_icc_rejected
 
 echo "iccTiffDump output hardening regression: $pass passed, $fail failed, $((pass + fail)) total"

--- a/.github/scripts/iccdev-tool-coverage-baseline.sh
+++ b/.github/scripts/iccdev-tool-coverage-baseline.sh
@@ -945,7 +945,7 @@ fi
 echo ""
 
 # =============================================================================
-# 10. iccTiffDump (9 tests)
+# 10. iccTiffDump (10 tests)
 # =============================================================================
 echo "--- 10. iccTiffDump ---"
 TIFFDUMP="$TOOLS/IccTiffDump/iccTiffDump"
@@ -953,12 +953,22 @@ TIFFDUMP="$TOOLS/IccTiffDump/iccTiffDump"
 if [ -f "$TIFF_8BIT" ]; then
   run_test "tdump-01" "Dump TIFF 8-bit metadata" \
     "$TIFFDUMP" "$TIFF_8BIT"
-
-  run_test "tdump-06" "Extract ICC from TIFF to file" \
-    "$TIFFDUMP" "$TIFF_8BIT" "$OUTDIR/tiff_extracted.icc"
 else
   skip_test "tdump-01" "Dump TIFF 8-bit metadata" "8-bit TIFF fixture unavailable"
-  skip_test "tdump-06" "Extract ICC from TIFF to file" "8-bit TIFF fixture unavailable"
+fi
+
+if [ -f "$ICCDEV_TESTING/hybrid/Data/TShirtDesignKW.tif" ]; then
+  run_test "tdump-06" "Extract ICC from TIFF to file" \
+    "$TIFFDUMP" "$ICCDEV_TESTING/hybrid/Data/TShirtDesignKW.tif" "$OUTDIR/tiff_extracted.icc"
+else
+  skip_test "tdump-06" "Extract ICC from TIFF to file" "embedded-ICC TIFF fixture unavailable"
+fi
+
+if [ -f "$REPO_ROOT/.github/ci/test-data/spectral/spec_1" ]; then
+  run_expect_exit "tdump-06b" "Reject ICC export when TIFF has no profile" 255 \
+    "$TIFFDUMP" "$REPO_ROOT/.github/ci/test-data/spectral/spec_1" "$OUTDIR/tiff_no_profile.icc"
+else
+  skip_test "tdump-06b" "Reject ICC export when TIFF has no profile" "no-profile TIFF fixture unavailable"
 fi
 
 if [ -f "$TIFF_16BIT" ]; then

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -403,19 +403,23 @@ bool CTiffImg::Open(const char *szFname)
   }
   icUInt16Number *nSampleInfo=NULL;
 
-  TIFFGetField(m_hTif, TIFFTAG_IMAGEWIDTH, &m_nWidth);
-  TIFFGetField(m_hTif, TIFFTAG_IMAGELENGTH, &m_nHeight);
-  TIFFGetField(m_hTif, TIFFTAG_PHOTOMETRIC, &m_nPhoto);
-  TIFFGetField(m_hTif, TIFFTAG_PLANARCONFIG, &m_nPlanar);
-  TIFFGetField(m_hTif, TIFFTAG_SAMPLESPERPIXEL, &m_nSamples);
+  if (!TIFFGetField(m_hTif, TIFFTAG_IMAGEWIDTH, &m_nWidth) ||
+      !TIFFGetField(m_hTif, TIFFTAG_IMAGELENGTH, &m_nHeight) ||
+      !TIFFGetField(m_hTif, TIFFTAG_PHOTOMETRIC, &m_nPhoto) ||
+      !TIFFGetField(m_hTif, TIFFTAG_BITSPERSAMPLE, &m_nBitsPerSample)) {
+    Close();
+    return false;
+  }
+
+  TIFFGetFieldDefaulted(m_hTif, TIFFTAG_PLANARCONFIG, &m_nPlanar);
+  TIFFGetFieldDefaulted(m_hTif, TIFFTAG_SAMPLESPERPIXEL, &m_nSamples);
   TIFFGetField(m_hTif, TIFFTAG_EXTRASAMPLES, &m_nExtraSamples, &nSampleInfo);
-  TIFFGetField(m_hTif, TIFFTAG_BITSPERSAMPLE, &m_nBitsPerSample);
-  TIFFGetField(m_hTif, TIFFTAG_SAMPLEFORMAT, &m_nSampleFormat);
-  TIFFGetField(m_hTif, TIFFTAG_ROWSPERSTRIP, &m_nRowsPerStrip);
-  TIFFGetField(m_hTif, TIFFTAG_ORIENTATION, &m_nOrientation);
+  TIFFGetFieldDefaulted(m_hTif, TIFFTAG_SAMPLEFORMAT, &m_nSampleFormat);
+  TIFFGetFieldDefaulted(m_hTif, TIFFTAG_ROWSPERSTRIP, &m_nRowsPerStrip);
+  TIFFGetFieldDefaulted(m_hTif, TIFFTAG_ORIENTATION, &m_nOrientation);
   TIFFGetField(m_hTif, TIFFTAG_XRESOLUTION, &m_fXRes);
   TIFFGetField(m_hTif, TIFFTAG_YRESOLUTION, &m_fYRes);
-  TIFFGetField(m_hTif, TIFFTAG_COMPRESSION, &m_nCompress);
+  TIFFGetFieldDefaulted(m_hTif, TIFFTAG_COMPRESSION, &m_nCompress);
   
   if (m_nWidth == 0 || m_nHeight == 0 || m_nRowsPerStrip == 0 ||
       m_nSamples == 0 || m_nSamples > kMaxTiffSamples ||

--- a/Tools/CmdLine/IccTiffDump/Readme.md
+++ b/Tools/CmdLine/IccTiffDump/Readme.md
@@ -10,6 +10,22 @@ Run without arguments to print the current command syntax and supported options:
 iccTiffDump
 ```
 
+Dump TIFF metadata and embedded ICC profile metadata:
+
+```sh
+iccTiffDump image.tif
+```
+
+Extract an embedded ICC profile:
+
+```sh
+iccTiffDump image.tif embedded.icc
+```
+
+The no-argument form is a help/syntax path and exits successfully. Other
+malformed invocations fail: extra trailing arguments are rejected, missing input
+files fail, and export requests fail when the TIFF has no embedded ICC profile.
+
 ## See Also
 
 - [CLI tool reference](../../../docs/tools-cli-reference.md)

--- a/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
+++ b/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
@@ -271,6 +271,10 @@ int main(int argc, icChar* argv[])
     Usage();
     return 0;
   }
+  else if (argc > 3) {
+    Usage();
+    return -1;
+  }
 
   std::string srcName = icSanitizeConsoleText(argv[1]);
 
@@ -351,6 +355,11 @@ int main(int argc, icChar* argv[])
     }
   } else {
     printf("Profile:           None\n");
+    if (argc > 2) {
+      printf("\nNo embedded ICC profile to extract\n");
+      SrcImg.Close();
+      return -1;
+    }
   }
 
   SrcImg.Close();

--- a/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
+++ b/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
@@ -111,6 +111,7 @@ IdList compression_types[] = {
   {COMPRESSION_NONE,         "None"},
   {COMPRESSION_LZW,          "LZW"},
   {COMPRESSION_JPEG,         "JPEG"},
+  {COMPRESSION_PACKBITS,     "PackBits"},
   {COMPRESSION_DEFLATE,      "Deflate"},
   {COMPRESSION_ADOBE_DEFLATE,"Deflate"},
   {UNKNOWNID,                "Unknown"},


### PR DESCRIPTION
## PR Summary

#1605

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
