### PR TITLE
Fix: Bisect: 1f0a9dd | Windows Silent Failures

### DIFF
--- a/.github/workflows/ci-code-coverage.yml
+++ b/.github/workflows/ci-code-coverage.yml
@@ -18,17 +18,6 @@ permissions:
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - master
-    paths:
-      - '.github/workflows/ci-code-coverage.yml'
-      - 'Build/Cmake/**'
-      - 'IccJSON/**'
-      - 'IccProfLib/**'
-      - 'IccXML/**'
-      - 'Testing/**'
-      - 'Tools/**'
 
 concurrency:
   group: "coverage-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}"

--- a/.github/workflows/ci-pr-win.yml
+++ b/.github/workflows/ci-pr-win.yml
@@ -257,6 +257,212 @@ jobs:
           Write-Host "========= Building iccDEV ... ================`n"
           cmake --build build -- /m /maxcpucount
 
+      - name: Run batch profile creation routines
+        shell: pwsh -NoProfile -NoLogo -NonInteractive -Command {0}
+        env:
+          POWERSHELL_TELEMETRY_OPTOUT: "1"
+          POWERSHELL_UPDATECHECK: Off
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+          $ProgressPreference = 'SilentlyContinue'
+          git config --global credential.helper ""
+          if (Test-Path Env:GITHUB_TOKEN) {
+            Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
+          }
+          . .github/scripts/sanitize.ps1
+
+          function Resolve-ExistingPath([string] $Path) {
+            if (-not (Test-Path -LiteralPath $Path)) {
+              throw "Required path missing: $(Sanitize-Line $Path)"
+            }
+            return (Resolve-Path -LiteralPath $Path).Path
+          }
+
+          function Invoke-Native {
+            param(
+              [Parameter(Mandatory = $true)][string] $FilePath,
+              [Parameter(Mandatory = $true)][string[]] $Arguments,
+              [Parameter(Mandatory = $true)][string] $WorkingDirectory
+            )
+            Push-Location -LiteralPath $WorkingDirectory
+            try {
+              & $FilePath @Arguments
+              if ($LASTEXITCODE -ne 0) {
+                $safePath = Sanitize-Line $FilePath
+                throw "$safePath failed with exit code $LASTEXITCODE"
+              }
+            } finally {
+              Pop-Location
+            }
+          }
+
+          $buildDir = Resolve-ExistingPath 'Build\Cmake\build'
+          $sourceTestingDir = Resolve-ExistingPath 'Testing'
+          $workRoot = Join-Path $env:RUNNER_TEMP 'iccdev-batch-profile-routines'
+          $workTestingDir = Join-Path $workRoot 'Testing'
+          if (Test-Path -LiteralPath $workRoot) {
+            Remove-Item -Recurse -Force -LiteralPath $workRoot
+          }
+          New-Item -ItemType Directory -Force -Path $workRoot | Out-Null
+          Copy-Item -Recurse -Force `
+            -LiteralPath $sourceTestingDir `
+            -Destination $workTestingDir
+
+          $iccFromXmlExe = Get-ChildItem -LiteralPath $buildDir `
+            -Recurse -File -Filter 'iccFromXml.exe' |
+            Sort-Object FullName |
+            Select-Object -First 1
+          if (-not $iccFromXmlExe) {
+            throw 'iccFromXml.exe was not found in the Windows build tree'
+          }
+
+          $runtimeDirs = New-Object 'System.Collections.Generic.List[string]'
+          Get-ChildItem -LiteralPath $buildDir `
+            -Recurse -File -Include *.exe,*.dll | ForEach-Object {
+              $runtimeDirs.Add($_.DirectoryName)
+            }
+          Get-ChildItem -LiteralPath 'scripts\buildsystems' `
+            -Recurse -Directory `
+            -ErrorAction SilentlyContinue | ForEach-Object {
+              $runtimeDirs.Add($_.FullName)
+            }
+          $env:TOOLDIR = Split-Path -Parent $iccFromXmlExe.FullName
+          if (-not $env:TOOLDIR.EndsWith('\')) {
+            $env:TOOLDIR += '\'
+          }
+          $runtimeDirs.Add($env:TOOLDIR.TrimEnd('\'))
+          $runtimePath = ($runtimeDirs | Sort-Object -Unique) -join ';'
+          if (-not $runtimePath) {
+            throw 'No build runtime directories found for batch profile routines'
+          }
+          $systemPath = @(
+            "$env:SystemRoot\system32",
+            "$env:SystemRoot",
+            "$env:SystemRoot\System32\Wbem"
+          ) -join ';'
+          $env:PATH = "$env:TOOLDIR;$runtimePath;$systemPath"
+
+          $batchFiles = Get-ChildItem -LiteralPath $sourceTestingDir -Recurse -File -Filter '*.bat' |
+            Sort-Object FullName
+          if ($batchFiles.Count -eq 0) {
+            throw 'No Testing batch files found'
+          }
+
+          $profileCommandCount = 0
+          foreach ($batchFile in $batchFiles) {
+            $relativePath = [System.IO.Path]::GetRelativePath(
+              $sourceTestingDir,
+              $batchFile.FullName
+            )
+            $workBatch = Join-Path $workTestingDir $relativePath
+            $workDir = Split-Path -Parent $workBatch
+            $currentWorkDir = $workDir
+            $dirStack = New-Object 'System.Collections.Generic.List[string]'
+            $lines = Get-Content -LiteralPath $batchFile.FullName
+            $lineNumber = 0
+            foreach ($line in $lines) {
+              $lineNumber++
+              $cmd = $line.Trim()
+              if (-not $cmd) { continue }
+              if ($cmd.StartsWith(
+                'rem ',
+                [System.StringComparison]::OrdinalIgnoreCase
+              )) { continue }
+              if ($cmd.StartsWith('::')) { continue }
+              if ($cmd.StartsWith(':')) { continue }
+              if ($cmd.StartsWith('@')) {
+                $cmd = $cmd.Substring(1).Trim()
+              }
+              if ($cmd -match '(?i)^echo\s+') { continue }
+
+              if ($cmd -match '(?i)^if\s+not\s+exist\s+(.+?)\s+(md|mkdir)\s+(.+)$') {
+                $checkPath = $Matches[1].Trim().Trim('"')
+                $createPath = $Matches[3].Trim().Trim('"')
+                if ([System.IO.Path]::IsPathRooted($checkPath)) {
+                  $candidateCheck = $checkPath
+                } else {
+                  $candidateCheck = Join-Path $currentWorkDir $checkPath
+                }
+                if (-not (Test-Path -LiteralPath $candidateCheck)) {
+                  if ([System.IO.Path]::IsPathRooted($createPath)) {
+                    $candidateCreate = $createPath
+                  } else {
+                    $candidateCreate = Join-Path $currentWorkDir $createPath
+                  }
+                  New-Item -ItemType Directory -Force -Path $candidateCreate | Out-Null
+                }
+                continue
+              }
+
+              if ($cmd -match '(?i)^(md|mkdir)\s+(.+)$') {
+                $targetDir = $Matches[2].Trim().Trim('"')
+                if ([System.IO.Path]::IsPathRooted($targetDir)) {
+                  $candidateDir = $targetDir
+                } else {
+                  $candidateDir = Join-Path $currentWorkDir $targetDir
+                }
+                New-Item -ItemType Directory -Force -Path $candidateDir | Out-Null
+                continue
+              }
+
+              if ($cmd -match '(?i)^(cd|chdir)\s+(.+)$') {
+                $targetDir = $Matches[2].Trim()
+                if ($targetDir -match '(?i)^/d\s+(.+)$') {
+                  $targetDir = $Matches[1].Trim()
+                }
+                $targetDir = $targetDir.Trim('"')
+                if ([System.IO.Path]::IsPathRooted($targetDir)) {
+                  $candidateDir = $targetDir
+                } else {
+                  $candidateDir = Join-Path $currentWorkDir $targetDir
+                }
+                $currentWorkDir = Resolve-ExistingPath $candidateDir
+                continue
+              }
+
+              if ($cmd -match '(?i)^pushd\s+(.+)$') {
+                $dirStack.Add($currentWorkDir)
+                $targetDir = $Matches[1].Trim().Trim('"')
+                if ([System.IO.Path]::IsPathRooted($targetDir)) {
+                  $candidateDir = $targetDir
+                } else {
+                  $candidateDir = Join-Path $currentWorkDir $targetDir
+                }
+                $currentWorkDir = Resolve-ExistingPath $candidateDir
+                continue
+              }
+
+              if ($cmd -match '(?i)^popd\b') {
+                if ($dirStack.Count -eq 0) {
+                  throw "Unmatched popd in $relativePath line $lineNumber"
+                }
+                $lastIndex = $dirStack.Count - 1
+                $currentWorkDir = $dirStack[$lastIndex]
+                $dirStack.RemoveAt($lastIndex)
+                continue
+              }
+
+              $profilePattern = '(?i)^(%TOOLDIR%)?iccFromXml(\.exe)?\b'
+              if ($cmd -notmatch $profilePattern) { continue }
+
+              $profileCommandCount++
+              Write-Host (
+                "[PROFILE] {0}:{1}: {2}" -f $relativePath, $lineNumber, $cmd
+              )
+              Invoke-Native cmd.exe @('/d', '/v:off', '/c', $cmd) $currentWorkDir
+            }
+          }
+
+          if ($profileCommandCount -eq 0) {
+            throw 'No iccFromXml profile creation routines found in batch files'
+          }
+          Write-Host (
+            "[OK] Executed $profileCommandCount profile creation routines " +
+            "from $($batchFiles.Count) Testing batch files"
+          )
+
       - name: Run Windows CTest check
         shell: pwsh -NoProfile -NoLogo -NonInteractive -Command {0}
         env:

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -649,8 +649,11 @@ int main(int argc, const char** argv)
   };
 
   //Read each line
+  bool bApplySuccess = true;
   for (i=0; i<(int)SrcImg.GetHeight(); i++) {
     if (!SrcImg.ReadLine(pSBuf)) {
+      printf("Error reading line %d from Tiff file - '%s'\n", i, cfgApply.m_srcImgFile.c_str());
+      bApplySuccess = false;
       break;
     }
     if (bUseRowApply) {
@@ -701,6 +704,8 @@ int main(int argc, const char** argv)
 
     //Output the converted pixels to the destination image
     if (!DstImg.WriteLine(pDBuf)) {
+      printf("Error writing line %d to Tiff file - '%s'\n", i, cfgApply.m_dstImgFile.c_str());
+      bApplySuccess = false;
       break;
     }
 
@@ -724,5 +729,5 @@ int main(int argc, const char** argv)
 
   DstImg.Close();
 
-  return 0;
+  return bApplySuccess ? 0 : -1;
 }


### PR DESCRIPTION
## PR Summary

2026-06-30 00:28:47 UTC

### Resolved #1610 
```
PS C:\tmp\fix\iccDEV>  cd C:\tmp\fix\iccDEV\Testing\hybrid; mkdir ICC,Results,config -Force; iccFromXml MultSpectralRGB.xml ICC\MultSpectralRGB.icc; iccApplyProfiles -exportcfg config\makeMS_smCows.json Data\smCows380_5_780.tif Results\MS_smCows.tif 2 1 0 1 1 -embedded 3 ICC\MultSpectralRGB.icc 10003; iccTiffDump Results\MS_smCows.tif


    Directory: C:\tmp\fix\iccDEV\Testing\hybrid


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
d-----         6/29/2026   5:08 PM                ICC
d-----         6/29/2026   5:08 PM                Results
d-----         6/29/2026   5:06 PM                config
Profile parsed and saved correctly

TIFFReadDirectory: Warning, Sum of Photometric type-related color channels and ExtraSamples doesn't match SamplesPerPixel. Defining non-color channels as ExtraSamples..
100%
-------------------->Tiff Image Dump<---------------------------
Filename:          Results\MS_smCows.tif
Size:              (600 x 420) pixels, (8.33" x 5.83")
Planar:            Interleaved samples
BitsPerSample:     16 (unsigned integer)
SamplesPerPixel:   8
ExtraSamples:      5
Photometric:       RGB
BytesPerLine:      9600
Resolution:        (72.000000 x 72.000000) pixels per/inch
Compression:       LZW
Profile:           Embedded
 Version:          4.40
 Class:            ColorSpace
 Color Space:      RgbData
 Colorimetric PCS: XYZData
 Description:      RGB view of MultiSpectral 8 Channel Data
 Sub-Profile:      Embedded
  Version:          5.10
  Class:            ColorSpace
  SubClass:         'mspc' = 6D737063
  Color Space:      MCH8Data/8ColorData
  Spectral PCS:     0x0024ChannelReflectanceData
  Spectral Range:   start=380.0nm, end=730.0nm, steps=36
  Description:      Eight Channel Abridged Reflectance Encoder/Decoder


PS C:\tmp\fix\iccDEV\Testing\hybrid>
PS C:\tmp\fix\iccDEV\Testing\hybrid> dir .\Results\


    Directory: C:\tmp\fix\iccDEV\Testing\hybrid\Results


Mode                 LastWriteTime         Length Name
----                 -------------         ------ ----
-a----         6/29/2026   5:08 PM              0 cmykGraysEst.txt
-a----         6/29/2026   5:08 PM              0 cmykGraysRef.txt
-a----         6/29/2026   5:08 PM          12880 LCDDisplayCat8Obs.icc
-a----         6/29/2026   5:16 PM        2174340 MS_smCows.tif

```

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
