### PR TITLE
fix: align iccSpecSepToTiff profile embedding

### DIFF
--- a/.github/scripts/iccdev-specsep-cli-args-regression-tests.sh
+++ b/.github/scripts/iccdev-specsep-cli-args-regression-tests.sh
@@ -36,6 +36,12 @@ SPECSEP="$TOOLS_DIR/IccSpecSepToTiff/iccSpecSepToTiff"
 SPECTRAL_PREFIX="$REPO_ROOT/.github/ci/test-data/spectral/spec_"
 HARVEST_PREFIX="$REPO_ROOT/.github/ci/test-data/specsep-harvest/gray300/spec_"
 PROFILE="$REPO_ROOT/Testing/sRGB_v4_ICC_preference.icc"
+TEXT_PROFILE="$REPO_ROOT/Tools/CmdLine/IccSpecSepToTiff/Readme.md"
+EMPTY_PROFILE="$OUTDIR/empty-profile.icc"
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+SPECTRAL_XML="$REPO_ROOT/Testing/hybrid/MultSpectralRGB.xml"
+SPECTRAL_PROFILE="$OUTDIR/MultSpectralRGB.icc"
+SPECTRAL36_DIR="$OUTDIR/spectral36"
 
 PASS=0
 FAIL=0
@@ -155,6 +161,69 @@ check_tiffinfo_contains() {
   return 0
 }
 
+generate_spectral36_inputs() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+
+  python3 - "$SPECTRAL36_DIR" <<'PY'
+import pathlib
+import struct
+import sys
+
+root = pathlib.Path(sys.argv[1])
+root.mkdir(parents=True, exist_ok=True)
+
+
+def ifd_entry(tag, tag_type, count, value):
+    entry = struct.pack("<HHI", tag, tag_type, count)
+    if tag_type == 3 and count == 1:
+        return entry + struct.pack("<H", value) + b"\0\0"
+    return entry + struct.pack("<I", value)
+
+
+def write_tiff(path, fill):
+    width = height = 2
+    pixels = bytes([fill & 0xff]) * (width * height)
+    ifd_offset = 8 + len(pixels)
+    entries = [
+        (256, 4, 1, width),
+        (257, 4, 1, height),
+        (258, 3, 1, 8),
+        (259, 3, 1, 1),
+        (262, 3, 1, 1),
+        (273, 4, 1, 8),
+        (277, 3, 1, 1),
+        (278, 4, 1, height),
+        (279, 4, 1, len(pixels)),
+        (284, 3, 1, 1),
+        (296, 3, 1, 2),
+        (339, 3, 1, 1),
+    ]
+    data = bytearray(b"II" + struct.pack("<H", 42) + struct.pack("<I", ifd_offset))
+    data.extend(pixels)
+    data.extend(struct.pack("<H", len(entries)))
+    for entry in sorted(entries):
+        data.extend(ifd_entry(*entry))
+    data.extend(struct.pack("<I", 0))
+    path.write_bytes(data)
+
+
+for i in range(1, 37):
+    write_tiff(root / f"spec_{i}", i * 7)
+PY
+}
+
+prepare_spectral_profile() {
+  if [ ! -x "$FROMXML" ] || [ ! -f "$SPECTRAL_XML" ]; then
+    return 1
+  fi
+
+  "$FROMXML" "$SPECTRAL_XML" "$SPECTRAL_PROFILE" > "$OUTDIR/fromxml-MultSpectralRGB.log" 2>&1 &&
+    [ -s "$SPECTRAL_PROFILE" ] &&
+    generate_spectral36_inputs
+}
+
 echo "=== iccSpecSepToTiff CLI argument regression ==="
 
 if [ ! -x "$SPECSEP" ]; then
@@ -163,18 +232,39 @@ if [ ! -x "$SPECSEP" ]; then
 fi
 
 run_expect_success \
-  "specsep-harvest-gray300-profile" \
-  "$OUTDIR/harvest-gray300-profile.tif" \
-  0 0 "$HARVEST_PREFIX" 1 8 1 "$PROFILE"
-check_tiffinfo_contains "specsep-harvest-gray300-profile" "$OUTDIR/harvest-gray300-profile.tif" "Samples/Pixel: 8" &&
-  check_tiffinfo_contains "specsep-harvest-gray300-profile" "$OUTDIR/harvest-gray300-profile.tif" "ICC Profile: <present>" &&
-  check_tiffinfo_contains "specsep-harvest-gray300-profile" "$OUTDIR/harvest-gray300-profile.tif" "Image Width: 300 Image Length: 300"
+  "specsep-harvest-gray300-no-profile" \
+  "$OUTDIR/harvest-gray300-no-profile.tif" \
+  0 0 "$HARVEST_PREFIX" 1 8 1
+check_tiffinfo_contains "specsep-harvest-gray300-no-profile" "$OUTDIR/harvest-gray300-no-profile.tif" "Samples/Pixel: 8" &&
+  check_tiffinfo_contains "specsep-harvest-gray300-no-profile" "$OUTDIR/harvest-gray300-no-profile.tif" "Image Width: 300 Image Length: 300"
+
+run_expect_success \
+  "specsep-srgb-profile-matching-3ch" \
+  "$OUTDIR/srgb-profile-matching-3ch.tif" \
+  0 0 "$SPECTRAL_PREFIX" 1 3 1 "$PROFILE"
+check_tiffinfo_contains "specsep-srgb-profile-matching-3ch" "$OUTDIR/srgb-profile-matching-3ch.tif" "Samples/Pixel: 3" &&
+  check_tiffinfo_contains "specsep-srgb-profile-matching-3ch" "$OUTDIR/srgb-profile-matching-3ch.tif" "ICC Profile: <present>"
 
 run_expect_success \
   "specsep-fast-separate-planes" \
   "$OUTDIR/fast-separate.tif" \
   0 1 "$SPECTRAL_PREFIX" 1 10 1
 check_tiffinfo_contains "specsep-fast-separate-planes" "$OUTDIR/fast-separate.tif" "Planar Configuration: separate image planes"
+
+if prepare_spectral_profile; then
+  run_expect_success \
+    "specsep-spectral-profile-matching-36ch" \
+    "$OUTDIR/spectral-profile-matching-36ch.tif" \
+    0 0 "$SPECTRAL36_DIR/spec_" 1 36 1 "$SPECTRAL_PROFILE"
+
+  run_expect_reject \
+    "specsep-spectral-profile-sample-mismatch" \
+    "do not match TIFF SamplesPerPixel" \
+    "$OUTDIR/spectral-profile-sample-mismatch.tif" \
+    0 0 "$SPECTRAL36_DIR/spec_" 1 4 1 "$SPECTRAL_PROFILE"
+else
+  echo "  [SKIP] specsep-spectral-profile-alignment -- missing iccFromXml or MultSpectralRGB.xml"
+fi
 
 run_expect_reject \
   "specsep-invalid-compress-bool" \
@@ -199,6 +289,25 @@ run_expect_reject \
   "Cannot open profile" \
   "$OUTDIR/missing-profile.tif" \
   0 0 "$SPECTRAL_PREFIX" 1 3 1 "$OUTDIR/no-such-profile.icc"
+
+run_expect_reject \
+  "specsep-non-icc-profile" \
+  "Cannot parse profile" \
+  "$OUTDIR/non-icc-profile.tif" \
+  0 0 "$SPECTRAL_PREFIX" 1 3 1 "$TEXT_PROFILE"
+
+: > "$EMPTY_PROFILE"
+run_expect_reject \
+  "specsep-empty-profile" \
+  "refusing to embed zero-length ICC data" \
+  "$OUTDIR/empty-profile.tif" \
+  0 0 "$SPECTRAL_PREFIX" 1 3 1 "$EMPTY_PROFILE"
+
+run_expect_reject \
+  "specsep-profile-sample-mismatch" \
+  "do not match TIFF SamplesPerPixel" \
+  "$OUTDIR/profile-sample-mismatch.tif" \
+  0 0 "$HARVEST_PREFIX" 1 8 1 "$PROFILE"
 
 run_expect_reject \
   "specsep-non-divisible-range" \

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -650,9 +650,7 @@ bool CTiffImg::GetIccProfile(unsigned char *&pProfile, unsigned int &nLen)
 
 bool CTiffImg::SetIccProfile(unsigned char *pProfile, unsigned int nLen)
 {
-  TIFFSetField(m_hTif, TIFFTAG_ICCPROFILE, nLen, pProfile);
-  
-  return true;
+  return TIFFSetField(m_hTif, TIFFTAG_ICCPROFILE, nLen, pProfile) == 1;
 }
 
 #ifdef USEICCDEVNAMESPACE

--- a/Tools/CmdLine/IccSpecSepToTiff/Readme.md
+++ b/Tools/CmdLine/IccSpecSepToTiff/Readme.md
@@ -1,19 +1,30 @@
 # IccSpecSepToTiff
 
 `iccSpecSepToTiff` combines separate TIFF images for spectral wavelengths into a
-single multi-sample TIFF image. It can optionally embed an iccMAX profile.
+single multi-sample TIFF image. It can optionally validate and embed an ICC
+profile whose channel model matches the generated TIFF.
 
 ## Usage
 
 Run without arguments to print the current command syntax and supported options.
-The fourth argument is a filename prefix. `iccSpecSepToTiff` appends the channel
-number to that prefix, so `spec_` with `start=1` opens `spec_1`, then `spec_2`,
-and so on.
+The fourth argument is a literal filename prefix. `iccSpecSepToTiff` appends the
+channel number to that prefix, so `spec_` with `start=1` opens `spec_1`, then
+`spec_2`, and so on. It is not a `printf` format string.
 
 `compress` and `sep` must be literal boolean values (`0` or `1`). The channel
 range must be exact: repeatedly adding `incr` to `start` must land on `end`.
 When the optional profile argument is provided, the profile file must be
-readable or the command fails without writing an output TIFF.
+readable, non-empty, parse as ICC, pass ICC validation without non-compliance,
+and match the output sample count:
+
+- If the profile has an ICC.2 spectral PCS, the spectral PCS channel count and
+  spectral range steps must equal the generated TIFF `SamplesPerPixel`.
+- Otherwise, the profile data color-space sample count must equal the generated
+  TIFF `SamplesPerPixel`.
+
+The command fails before creating output when these checks fail. This prevents
+TIFF files from carrying mislabeled `ICC Profile` tag data or profiles that
+cannot describe the image samples.
 
 ```sh
 iccSpecSepToTiff
@@ -24,6 +35,25 @@ Example:
 ```sh
 iccSpecSepToTiff out.tif 0 0 .github/ci/test-data/spectral/spec_ 1 10 1
 ```
+
+The checked-in CI spectral fixtures are intentionally tiny and may appear very
+small in image viewers. For manual display review, use the larger
+`.github/ci/test-data/specsep-harvest/gray300/spec_` sequence or create larger
+single-channel TIFF inputs.
+
+## Input and Output Notes
+
+- Input TIFFs must have identical dimensions, resolution, sample format,
+  photometric interpretation, and `BitsPerSample`.
+- Each input TIFF must have exactly one sample per pixel.
+- Photometric interpretation must be `MINISBLACK` or `MINISWHITE`; palette,
+  RGB, CMYK, and unknown photometrics are rejected.
+- `BitsPerSample` must be byte-aligned. Uncompressed output supports any
+  byte-aligned sample size accepted by the TIFF helper. LZW compression is
+  limited to 8-, 16-, or 32-bit samples.
+- Output uses explicit `ExtraSamples` metadata for every sample beyond the
+  first. Very high channel-count spectral TIFFs can be valid but may exceed
+  limits in display tools such as ImageMagick.
 
 ## See Also
 

--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -81,6 +81,7 @@
 #include <vector>
 #include <memory>
 #include <limits>
+#include <string>
 #include "IccCmm.h"
 #include "IccUtil.h"
 #include "IccDefs.h"
@@ -107,12 +108,20 @@ void Usage(const char *name)
   
   printf("\toutput: path/name of the TIFF file to be created\n");                               // argv[1]
   printf("\tcompress: boolean (0 | 1), should the output be compressed\n");                     // argv[2]
-  printf("\tsep: boolean (0 | 1), plane data be seperated in the output TIFF\n");               // argv[3]
-  printf("\tinfile_prefix: input filename prefix; channel numbers are appended, example: \"spec_\"\n"); // argv[4]
+  printf("\tsep: boolean (0 | 1), plane data are separated in the output TIFF\n");              // argv[3]
+  printf("\tinfile_prefix: literal input filename prefix; channel numbers are appended, example: \"spec_\"\n"); // argv[4]
   printf("\tstart: integer, first channel number to process\n");                                // argv[5]
   printf("\tend: integer, last channel number to process\n");                                   // argv[6]
   printf("\tincrement: integer, increment between channels\n");                                 // argv[7]
-  printf("\tprofile: optional ICC profile to embed in the output TIFF\n");                      // argv[8]
+  printf("\tprofile: optional ICC profile to validate and embed in the output TIFF\n");         // argv[8]
+  printf("\n");
+  printf("Notes:\n");
+  printf("\t-h/--help are not option flags; run without arguments to print this usage.\n");
+  printf("\tinfile_prefix is not a printf format string; \"spec_00\" with start=1 opens \"spec_001\".\n");
+  printf("\tEmbedded profiles must parse and validate as ICC profiles. If a spectral PCS is present,\n");
+  printf("\tits channel count/range steps must match the generated TIFF SamplesPerPixel.\n");
+  printf("\tWithout a spectral PCS, profile data color-space samples must match TIFF SamplesPerPixel.\n");
+  printf("\tCI fixture images are intentionally tiny; use larger source TIFFs for visual display review.\n");
   printf("Built with IccProfLib version " ICCPROFLIBVER "\n");
   printf("\n");
 }
@@ -153,6 +162,160 @@ static bool checkedSizeProduct(size_t a, size_t b, size_t &result)
     return false;
 
   result = a * b;
+  return true;
+}
+
+static const char *validateStatusName(icValidateStatus status)
+{
+  switch (status) {
+  case icValidateOK:
+    return "OK";
+  case icValidateWarning:
+    return "Warning";
+  case icValidateNonCompliant:
+    return "NonCompliant";
+  case icValidateCriticalError:
+    return "CriticalError";
+  default:
+    return "Unknown";
+  }
+}
+
+static void printFirstValidationLine(const std::string &report)
+{
+  if (report.empty())
+    return;
+
+  size_t end = report.find('\n');
+  std::string line = report.substr(0, end == std::string::npos ? report.size() : end);
+  if (!line.empty())
+    printf("Profile validation detail: %s\n", line.c_str());
+}
+
+static void sigToText(icUInt32Number sig, char *buf, size_t bufSize)
+{
+  if (!buf || !bufSize)
+    return;
+
+  buf[0] = '\0';
+  icGetColorSigStr(buf, bufSize, sig);
+}
+
+static bool validateProfileSampleCompatibility(const CIccProfile *profile,
+                                               size_t nSamples,
+                                               const char *profilePath)
+{
+  if (!profile)
+    return false;
+
+  const icHeader &header = profile->m_Header;
+  char colorSpace[64];
+  char pcs[64];
+  char spectralPcs[64];
+
+  sigToText(header.colorSpace, colorSpace, sizeof(colorSpace));
+  sigToText(header.pcs, pcs, sizeof(pcs));
+  sigToText(header.spectralPCS, spectralPcs, sizeof(spectralPcs));
+
+  if (header.spectralPCS != icSigNoSpectralData) {
+    icUInt32Number spectralSamples = icGetSpaceSamples((icColorSpaceSignature)header.spectralPCS);
+
+    if (!spectralSamples || spectralSamples != nSamples) {
+      printf("Profile %s spectral PCS samples (%u, %s) do not match TIFF SamplesPerPixel (%zu).\n",
+             profilePath, (unsigned int)spectralSamples, spectralPcs, nSamples);
+      return false;
+    }
+
+    if (!header.spectralRange.steps || header.spectralRange.steps != nSamples) {
+      printf("Profile %s spectral PCS range steps (%u) do not match TIFF SamplesPerPixel (%zu).\n",
+             profilePath, (unsigned int)header.spectralRange.steps, nSamples);
+      return false;
+    }
+
+    printf("ICC profile accepted: %s, status=conformant, data=%s, PCS=%s, spectralPCS=%s, spectralRangeSteps=%u, TIFFSamples=%zu\n",
+           profilePath, colorSpace, pcs, spectralPcs, (unsigned int)header.spectralRange.steps, nSamples);
+    return true;
+  }
+
+  icUInt32Number dataSamples = profile->GetSpaceSamples();
+  if (!dataSamples || dataSamples != nSamples) {
+    printf("Profile %s data color-space samples (%u, %s) do not match TIFF SamplesPerPixel (%zu).\n",
+           profilePath, (unsigned int)dataSamples, colorSpace, nSamples);
+    return false;
+  }
+
+  printf("ICC profile accepted: %s, status=conformant, data=%s, PCS=%s, TIFFSamples=%zu\n",
+         profilePath, colorSpace, pcs, nSamples);
+  return true;
+}
+
+static bool readValidateProfile(const char *profilePath,
+                                size_t nSamples,
+                                std::unique_ptr<unsigned char[]> &destProfile,
+                                size_t &destProfileLength)
+{
+  destProfile.reset();
+  destProfileLength = 0;
+
+  CIccFileIO io;
+  if (!io.Open(profilePath, "rb")) {
+    printf("Cannot open profile %s\n", profilePath);
+    return false;
+  }
+
+  destProfileLength = io.GetLength();
+  if (!destProfileLength) {
+    io.Close();
+    printf("Profile %s is empty; refusing to embed zero-length ICC data.\n", profilePath);
+    return false;
+  }
+
+  if (destProfileLength > (size_t)std::numeric_limits<icUInt32Number>::max()) {
+    io.Close();
+    printf("Profile %s is too large to embed in TIFF ICCProfile tag: %zu bytes\n",
+           profilePath, destProfileLength);
+    return false;
+  }
+
+  destProfile.reset(new unsigned char[destProfileLength]);
+  if (io.Read8(destProfile.get(), destProfileLength) != destProfileLength) {
+    io.Close();
+    printf("Cannot read complete profile %s\n", profilePath);
+    return false;
+  }
+  io.Close();
+
+  std::string validateReport;
+  icValidateStatus validateStatus = icValidateOK;
+  std::unique_ptr<CIccProfile> profile(ValidateIccProfile(destProfile.get(),
+                                                         (icUInt32Number)destProfileLength,
+                                                         validateReport,
+                                                         validateStatus));
+  if (!profile) {
+    printf("Cannot parse profile %s as an ICC profile.\n", profilePath);
+    printFirstValidationLine(validateReport);
+    return false;
+  }
+
+  if (validateStatus >= icValidateNonCompliant) {
+    printf("Profile %s failed ICC validation: %s.\n",
+           profilePath, validateStatusName(validateStatus));
+    printFirstValidationLine(validateReport);
+    return false;
+  }
+
+  std::unique_ptr<CIccProfile> compatibilityProfile(OpenIccProfile(destProfile.get(),
+                                                                  (icUInt32Number)destProfileLength,
+                                                                  true));
+  const CIccProfile *profileForSamples = profile.get();
+  if (compatibilityProfile &&
+      compatibilityProfile->m_Header.spectralPCS != icSigNoSpectralData) {
+    profileForSamples = compatibilityProfile.get();
+  }
+
+  if (!validateProfileSampleCompatibility(profileForSamples, nSamples, profilePath))
+    return false;
+
   return true;
 }
 
@@ -311,17 +474,8 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<unsigned char[]> destProfile;
   size_t destProfileLength = 0;
   if (argc>8) {
-    CIccFileIO io;
-    if (io.Open(argv[8], "rb")) {
-      destProfileLength = io.GetLength();
-      destProfile.reset( new unsigned char[destProfileLength] );
-      io.Read8( destProfile.get(), destProfileLength );
-      io.Close();
-    }
-    else {
-      printf("Cannot open profile %s\n", argv[8]);
+    if (!readValidateProfile(argv[8], nSamples, destProfile, destProfileLength))
       return -1;
-    }
   }
 
   CTiffImg outfile;
@@ -333,7 +487,10 @@ int main(int argc, char* argv[]) {
   }
 
   if (destProfile) {
-    outfile.SetIccProfile( destProfile.get(), (unsigned int)destProfileLength );
+    if (!outfile.SetIccProfile( destProfile.get(), (unsigned int)destProfileLength )) {
+      printf("Unable to embed ICC profile in %s\n", argv[1]);
+      return -1;
+    }
   }
 
   for (unsigned int i=0; i<f->GetHeight(); i++) {

--- a/docs/tools-cli-reference.md
+++ b/docs/tools-cli-reference.md
@@ -43,7 +43,15 @@ source transform from the first profile; `0` uses its destination transform.
 
 `iccSpecSepToTiff` treats the input argument as a filename prefix and appends
 each channel number from `start` through `end`. For a single input named
-`spec_3`, pass prefix `spec_` with `start=3` and `end=3`.
+`spec_3`, pass prefix `spec_` with `start=3` and `end=3`. The prefix is literal,
+not a `printf` pattern: `spec_%03d.tif` opens `spec_%03d.tif1`, not `spec_001.tif`.
+
+When `{profile}` is provided, the file is parsed and validated as an ICC profile
+before any output is written. ICC.2 spectral PCS profiles must have spectral PCS
+channels and spectral range steps equal to the generated TIFF `SamplesPerPixel`;
+non-spectral profiles must have a data color-space sample count equal to
+`SamplesPerPixel`. Non-ICC bytes, empty files, non-compliant profiles, and
+sample-count mismatches are rejected.
 
 ## Text Data Encoding Values
 


### PR DESCRIPTION
## PR Summary

#1618 

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
