### PR TITLE
Ci fix windows packaging failure

### DIFF
--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -714,8 +714,8 @@ jobs:
           $count = $allFiles.Count
           Write-Host "`n===== Staged Bundle Contents ($count files) =====" -ForegroundColor Cyan
           foreach ($ext in @('*.exe','*.dll','*.lib','*.icc','*.md')) {
-            $matched = $allFiles | Where-Object { $_.Name -like $ext }
-            if ($matched) {
+            $matched = @($allFiles | Where-Object { $_.Name -like $ext })
+            if ($matched.Count -gt 0) {
               Write-Host "`n--- $ext ($($matched.Count)) ---"
               $matched | ForEach-Object {
                 $rel = $_.FullName.Replace((Resolve-Path $stage).Path + '\', '')
@@ -1544,7 +1544,7 @@ jobs:
   release:
     name: "Publish Latest Release"
     needs: [linux, macos, windows, wasm, cpack-linux, doxygen]
-    if: ${{ github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/ci-fix-windows-packaging-failure' }}
     runs-on: ubuntu-latest
     environment: release
     timeout-minutes: 15


### PR DESCRIPTION
## PR Summary
### #1623  Success
2026-07-01 00:48:43 UTC
```
Run actions/attest-build-provenance@f14352a605c57b0a66e0d49bba5825967f1dbedf
  with:
    subject-checksums: release-assets/SHA256SUMS
    push-to-registry: false
    create-storage-record: true
    show-summary: true
    github-token: ***
Run actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26
  with:
    subject-checksums: release-assets/SHA256SUMS
    push-to-registry: false
    create-storage-record: true
    show-summary: true
    github-token: ***
  env:
    NODE_OPTIONS: --max-http-header-size=32768
Attestation type: Build Provenance
Attestation created for 9 subjects
Attestation signed using certificate from Public Good Sigstore instance
Attestation signature uploaded to Rekor transparency log
[https://search.sigstore.dev?logIndex=2028834073](https://search.sigstore.dev/?logIndex=2028834073)
Attestation uploaded to repository
https://github.com/InternationalColorConsortium/iccDEV/attestations/33369881
```

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
