### PR TITLE
fix: harden iccSpecSepToTiff argument parsing

### DIFF
--- a/.github/scripts/iccdev-specsep-cli-args-regression-tests.sh
+++ b/.github/scripts/iccdev-specsep-cli-args-regression-tests.sh
@@ -315,6 +315,54 @@ run_expect_reject \
   "$OUTDIR/non-divisible-range.tif" \
   0 0 "$SPECTRAL_PREFIX" 1 10 4
 
+run_expect_reject \
+  "specsep-nan-start" \
+  "Invalid channel range" \
+  "$OUTDIR/nan-start.tif" \
+  0 0 "$SPECTRAL_PREFIX" nan 3 1
+
+run_expect_reject \
+  "specsep-float-start" \
+  "Invalid channel range" \
+  "$OUTDIR/float-start.tif" \
+  0 0 "$SPECTRAL_PREFIX" 1.0 3 1
+
+run_expect_reject \
+  "specsep-hex-start" \
+  "Invalid channel range" \
+  "$OUTDIR/hex-start.tif" \
+  0 0 "$SPECTRAL_PREFIX" 0x1 3 1
+
+run_expect_reject \
+  "specsep-plus-start" \
+  "Invalid channel range" \
+  "$OUTDIR/plus-start.tif" \
+  0 0 "$SPECTRAL_PREFIX" +1 3 1
+
+run_expect_reject \
+  "specsep-leading-space-start" \
+  "Invalid channel range" \
+  "$OUTDIR/leading-space-start.tif" \
+  0 0 "$SPECTRAL_PREFIX" " 1" 3 1
+
+run_expect_reject \
+  "specsep-int-overflow-start" \
+  "Invalid channel range" \
+  "$OUTDIR/int-overflow-start.tif" \
+  0 0 "$SPECTRAL_PREFIX" 2147483648 3 1
+
+run_expect_reject \
+  "specsep-int-underflow-start" \
+  "Invalid channel range" \
+  "$OUTDIR/int-underflow-start.tif" \
+  0 0 "$SPECTRAL_PREFIX" -2147483649 3 1
+
+run_expect_reject \
+  "specsep-printf-pattern-prefix" \
+  "Cannot open input" \
+  "$OUTDIR/printf-pattern-prefix.tif" \
+  0 0 "$SPECTRAL_PREFIX%03d.tif" 1 3 1
+
 echo "iccSpecSepToTiff CLI argument regression: $PASS passed, $FAIL failed, $TOTAL total"
 
 if [ "$FAIL" -ne 0 ]; then

--- a/Tools/CmdLine/IccSpecSepToTiff/Readme.md
+++ b/Tools/CmdLine/IccSpecSepToTiff/Readme.md
@@ -11,8 +11,11 @@ The fourth argument is a literal filename prefix. `iccSpecSepToTiff` appends the
 channel number to that prefix, so `spec_` with `start=1` opens `spec_1`, then
 `spec_2`, and so on. It is not a `printf` format string.
 
-`compress` and `sep` must be literal boolean values (`0` or `1`). The channel
-range must be exact: repeatedly adding `incr` to `start` must land on `end`.
+`compress` and `sep` must be literal boolean values (`0` or `1`). `start`,
+`end`, and `incr` must be plain decimal integers with an optional leading minus
+sign only; whitespace, `+`, `NaN`, floats, hex, and out-of-range values are
+rejected. The channel range must be exact: repeatedly adding `incr` to `start`
+must land on `end`.
 When the optional profile argument is provided, the profile file must be
 readable, non-empty, parse as ICC, pass ICC validation without non-compliance,
 and match the output sample count:

--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -118,6 +118,7 @@ void Usage(const char *name)
   printf("Notes:\n");
   printf("\t-h/--help are not option flags; run without arguments to print this usage.\n");
   printf("\tinfile_prefix is not a printf format string; \"spec_00\" with start=1 opens \"spec_001\".\n");
+  printf("\tstart/end/increment must be plain decimal integers; whitespace, '+', NaN, and floats are rejected.\n");
   printf("\tEmbedded profiles must parse and validate as ICC profiles. If a spectral PCS is present,\n");
   printf("\tits channel count/range steps must match the generated TIFF SamplesPerPixel.\n");
   printf("\tWithout a spectral PCS, profile data color-space samples must match TIFF SamplesPerPixel.\n");
@@ -130,11 +131,26 @@ void Usage(const char *name)
 
 static bool parseIntArg(const char *text, int &value)
 {
+  if (!text || !text[0])
+    return false;
+
+  const char *digits = text;
+  if (*digits == '-') {
+    ++digits;
+    if (!*digits)
+      return false;
+  }
+
+  for (const char *p = digits; *p; ++p) {
+    if (*p < '0' || *p > '9')
+      return false;
+  }
+
   char *end = NULL;
   errno = 0;
   long parsed = strtol(text, &end, 10);
 
-  if (errno || !text[0] || *end || parsed < INT_MIN || parsed > INT_MAX)
+  if (errno || *end || parsed < INT_MIN || parsed > INT_MAX)
     return false;
 
   value = (int)parsed;
@@ -388,18 +404,15 @@ int main(int argc, char* argv[]) {
   std::vector<CTiffImg> infile(nSamples);
 
   for (size_t i=0; i<nSamples; i++) {
-    const int max_path_length = 510;
-    char filename[ max_path_length ];
-    
     long long channelNum = (long long)start + (long long)i * (long long)step;
-    snprintf(filename, max_path_length, "%s%lld", argv[4], channelNum);
-    if (!infile[i].Open(filename)) {
-      printf("Cannot open input %s\n", filename);
+    std::string filename = std::string(argv[4]) + std::to_string(channelNum);
+    if (!infile[i].Open(filename.c_str())) {
+      printf("Cannot open input %s\n", filename.c_str());
       return -1;
     }
 
     if (infile[i].GetSamples() != 1) {
-      printf("input %s does not have 1 sample per pixel\n", filename);
+      printf("input %s does not have 1 sample per pixel\n", filename.c_str());
       return -1;
     }
 
@@ -408,7 +421,7 @@ int main(int argc, char* argv[]) {
     // PHOTO_PALETTE.  Comparing against PHOTOMETRIC_PALETTE never matched, so
     // palette input was wrongly accepted and converted (#1381).
     if (infile[i].GetPhoto() == PHOTO_PALETTE) {
-      printf("input %s is a palette based file\n", filename);
+      printf("input %s is a palette based file\n", filename.c_str());
       return -1;
     }
 
@@ -418,7 +431,7 @@ int main(int argc, char* argv[]) {
       infile[i].GetPhoto() != infile[0].GetPhoto() ||
       infile[i].GetXRes() != infile[0].GetXRes() ||
       infile[i].GetYRes() != infile[0].GetYRes())) {
-        printf("input %s does not have same format as other files\n", filename);
+        printf("input %s does not have same format as other files\n", filename.c_str());
         return -1;
     }
   }


### PR DESCRIPTION
Fixes #1672

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
