### PR TITLE
fix: refresh mcp runtime openssl packages

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,71 @@
+###############################################################
+#
+# Copyright (c) 2026 International Color Consortium.
+#                 All rights reserved.
+#                 https://color.org
+#
+# Intent: Prepare GitHub Copilot coding agent dependencies.
+#
+###############################################################
+
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - ".github/workflows/copilot-setup-steps.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    defaults:
+      run:
+        shell: bash --noprofile --norc {0}
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          persist-credentials: false
+
+      # preflight: allow-package-install reason=copilot-agent-bootstrap
+      - name: Install build and test prerequisites
+        env:
+          BASH_ENV: /dev/null
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          source .github/scripts/sanitize-sed.sh
+
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            clang \
+            clang-tools \
+            cmake \
+            curl \
+            g++ \
+            gcc \
+            git-lfs \
+            jq \
+            libjpeg-dev \
+            libpng-dev \
+            libtiff-dev \
+            libxml2-dev \
+            make \
+            ninja-build \
+            nlohmann-json3-dev \
+            pkg-config \
+            python3-dev \
+            python3-pip \
+            python3-venv \
+            shellcheck \
+            zlib1g-dev
+
+          git lfs install --local

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,12 +1,10 @@
-###############################################################
+# Copilot Setup Steps
 #
 # Copyright (c) 2026 International Color Consortium.
 #                 All rights reserved.
 #                 https://color.org
 #
 # Intent: Prepare GitHub Copilot coding agent dependencies.
-#
-###############################################################
 
 name: Copilot Setup Steps
 

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -25,9 +25,6 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
-    defaults:
-      run:
-        shell: bash --noprofile --norc {0}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
         with:
@@ -35,6 +32,7 @@ jobs:
 
       # preflight: allow-package-install reason=copilot-agent-bootstrap
       - name: Install build and test prerequisites
+        shell: bash --noprofile --norc {0}
         env:
           BASH_ENV: /dev/null
         run: |

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -31,6 +31,16 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Checkout trusted workflow scripts
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
+        with:
+          persist-credentials: false
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: .trusted-workflow-scripts
+          sparse-checkout: .github/scripts/sanitize-sed.sh
+          sparse-checkout-cone-mode: false
+
       # preflight: allow-package-install reason=copilot-agent-bootstrap
       - name: Install build and test prerequisites
         shell: bash --noprofile --norc {0}
@@ -40,6 +50,9 @@ jobs:
           set -euo pipefail
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
+          SANITIZER="$GITHUB_WORKSPACE/.trusted-workflow-scripts/.github/scripts/sanitize-sed.sh"
+          # shellcheck source=/dev/null
+          source "$SANITIZER"
 
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -13,6 +13,9 @@ on:
   push:
     paths:
       - ".github/workflows/copilot-setup-steps.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/copilot-setup-steps.yml"
 
 permissions:
   contents: read
@@ -37,7 +40,6 @@ jobs:
           set -euo pipefail
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
-          source .github/scripts/sanitize-sed.sh
 
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -76,12 +76,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg8 \
     libpng16-16t64 \
     libstdc++6 \
-    libssl3t64=3.5.5-1ubuntu3.2 \
+    libssl3t64 \
     libtiff6 \
     libxml2-16 \
-    openssl-provider-legacy=3.5.5-1ubuntu3.2 \
+    openssl-provider-legacy \
     python3 \
     zlib1g \
+ && for pkg in libssl3t64 openssl-provider-legacy; do \
+      version="$(dpkg-query -W -f='${Version}' "$pkg")"; \
+      dpkg --compare-versions "$version" ge 3.5.5-1ubuntu3.2 || { \
+        echo "Package $pkg version $version is below required 3.5.5-1ubuntu3.2" >&2; \
+        exit 1; \
+      }; \
+    done \
  && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /opt/iccdev /opt/iccdev

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -82,10 +82,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     openssl-provider-legacy \
     python3 \
     zlib1g \
+ && min_openssl_version="3.5.5-1ubuntu3.2" \
  && for pkg in libssl3t64 openssl-provider-legacy; do \
       version="$(dpkg-query -W -f='${Version}' "$pkg")"; \
-      dpkg --compare-versions "$version" ge 3.5.5-1ubuntu3.2 || { \
-        echo "Package $pkg version $version is below required 3.5.5-1ubuntu3.2" >&2; \
+      dpkg --compare-versions "$version" ge "$min_openssl_version" || { \
+        echo "Package $pkg version $version is below required $min_openssl_version" >&2; \
         exit 1; \
       }; \
     done \

--- a/Dockerfile.mcp
+++ b/Dockerfile.mcp
@@ -76,8 +76,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg8 \
     libpng16-16t64 \
     libstdc++6 \
+    libssl3t64=3.5.5-1ubuntu3.2 \
     libtiff6 \
     libxml2-16 \
+    openssl-provider-legacy=3.5.5-1ubuntu3.2 \
     python3 \
     zlib1g \
  && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## PR Summary

#1702

- Refreshes the MCP runtime OpenSSL packages with a fail-closed minimum-version guard.
- Adds `.github/workflows/copilot-setup-steps.yml` so Copilot coding agent sessions preinstall iccDEV build, Python, MCP, and shell-validation prerequisites.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Updated documentation for user-visible behavior changes
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [x] For Python package changes, followed `docs/python-packaging-release.md` for PR and merge requirements
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).

