### PR TITLE
fix(#1726): recognize UTF-8 tag arrays (mcta)

### DIFF
--- a/.github/ci/regression/utf8-textarray-handler.cpp
+++ b/.github/ci/regression/utf8-textarray-handler.cpp
@@ -1,0 +1,144 @@
+// Regression for #1726: multiplexTypeArrayTag ('mcta') is a tagArrayType whose
+// array signature is icSigUtf8TextTypeArray ('utf8'); it carries the per-channel
+// UTF-8 names of a Multiplex Color Space (MCS) profile.
+//
+// Before the fix, CIccBasicArrayFactory::CreateArray had no case for 'utf8', so
+// every mcta fell to the CIccArrayUnknown fallback and validating it emitted a
+// spurious "Unknown tag array type!" line even though the tag is conformant.
+// Worse, the "UTF8 text arrays are known" branch in CIccTagArray::Validate (which
+// holds the MCS channel-count check) had become unreachable once
+// Read()/SetTagArrayType() started eagerly populating m_pArray.
+//
+// The fix (per maintainer approach on #1726) makes CreateArray return NULL for
+// 'utf8', so m_pArray stays NULL and the dedicated utf8 branch in
+// CIccTagArray::Validate handles the array directly - reviving the channel-count
+// check. This test also covers the per-element utf8Type conformance
+// check added in that branch.
+//
+// This test builds mcta-shaped tagArrays in memory and validates them against a
+// profile whose header declares a 5-channel MCS. It is red-green: reverting the
+// factory 'utf8' case makes GetArrayHandler() return a non-NULL CIccArrayUnknown
+// and validation emit the "Unknown tag array type" line, failing cases 1-2;
+// dropping the element-type check fails case 3.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccTagComposite.h"
+#include "IccTagBasic.h"
+#include "IccProfile.h"
+#include "IccUtil.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[utf8-textarray] FAIL: %s\n", what);
+  }
+}
+
+// Build an mcta-shaped tagArray: array signature 'utf8', nText elements each a
+// CIccTagUtf8Text channel name. When badIdx >= 0, index badIdx instead gets a
+// CIccTagText (icSigTextType) -- a text tag of the wrong type -- to exercise the
+// element-type conformance check. The array takes ownership of every attached
+// element (freed by delete arr).
+CIccTagArray *buildMcta(icUInt32Number nText, int badIdx = -1)
+{
+  CIccTagArray *arr = new CIccTagArray(icSigUtf8TextTypeArray);
+  arr->SetSize(nText);
+  for (icUInt32Number i = 0; i < nText; i++) {
+    if ((int)i == badIdx) {
+      CIccTagText *bad = new CIccTagText();
+      bad->SetText("wrong-type");
+      check(arr->AttachTag(i, bad), "AttachTag wrong-type element");
+    }
+    else {
+      CIccTagUtf8Text *t = new CIccTagUtf8Text();
+      t->SetText("channel");
+      check(arr->AttachTag(i, t), "AttachTag utf8 element");
+    }
+  }
+  return arr;
+}
+
+} // namespace
+
+int main()
+{
+  // 'mc' namespace with 5 channels; icGetMultiplexColorSpaceSamples maps this to 5.
+  // Assert the encoding up front so the test fails loudly if that mapping changes.
+  const icMultiplexColorSignature mcs5 = (icMultiplexColorSignature)0x6d630005;
+  check(icGetMultiplexColorSpaceSamples(mcs5) == 5,
+        "0x6d630005 resolves to a 5-channel MCS");
+
+  // sigPath whose first signature is the multiplexTypeArrayTag, so the utf8
+  // branch's MCS channel-count check (gated on that path) is exercised.
+  const std::string mctaPath = icGetSigPath(icSigMultiplexTypeArrayTag);
+
+  CIccProfile profile;
+  profile.m_Header.mcs = mcs5;
+
+  // Case 1 (the #1726 defect): a conformant 5-channel mcta must route to a NULL
+  // handler (the factory 'utf8' case) so the dedicated utf8 branch validates it
+  // with no "Unknown tag array type" line and no channel-count complaint.
+  {
+    CIccTagArray *arr = buildMcta(5);
+
+    check(arr->GetArrayHandler() == NULL,
+          "utf8 array routes to a NULL handler, not the Unknown fallback (#1726)");
+
+    std::string report;
+    arr->Validate(mctaPath, report, &profile);
+    check(report.find("Unknown tag array type") == std::string::npos,
+          "conformant mcta produces no 'Unknown tag array type' line (#1726)");
+    check(report.find("does not match MCS") == std::string::npos,
+          "5 channel names match the 5-channel MCS header (no mismatch reported)");
+
+    delete arr;
+  }
+
+  // Case 2: the revived channel-count check -- 3 names against a 5-channel MCS
+  // header must be flagged critical. This path was dead before the fix.
+  {
+    CIccTagArray *arr = buildMcta(3);
+
+    std::string report;
+    arr->Validate(mctaPath, report, &profile);
+    check(report.find("does not match MCS in header") != std::string::npos,
+          "channel-count mismatch (3 names vs 5-channel MCS) is flagged (#1726)");
+
+    delete arr;
+  }
+
+  // Case 3: element-type conformance -- a non-utf8Type element must be rejected.
+  // The check is strict to utf8Type (not zut8Type) to match the MCS runtime, which
+  // requires AreAllOfType(icSigUtf8TextType); see CIccPcsXform::Connect.
+  {
+    CIccTagArray *arr = buildMcta(5, /*badIdx*/ 2);
+
+    std::string report;
+    arr->Validate(mctaPath, report, &profile);
+    check(report.find("not a utf8Type text tag") != std::string::npos,
+          "a non-utf8Type element inside a utf8 text array is flagged (#1726)");
+
+    delete arr;
+  }
+
+  if (g_fail) {
+    std::fprintf(stderr, "[utf8-textarray] %d assertion(s) failed\n", g_fail);
+    return g_fail;
+  }
+  std::printf("[utf8-textarray] all assertions passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -766,6 +766,41 @@ function(iccdev_add_gbd_zero_pcs_test)
   endif()
 endfunction()
 
+function(iccdev_add_utf8_textarray_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccUtf8TextArrayTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/utf8-textarray-handler.cpp"
+  )
+  target_link_libraries(iccUtf8TextArrayTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccUtf8TextArrayTest)
+
+  add_test(
+    NAME iccdev.utf8-textarray-handler
+    COMMAND "$<TARGET_FILE:iccUtf8TextArrayTest>"
+  )
+  set_tests_properties(iccdev.utf8-textarray-handler PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;tag;array;issue-1726;regression"
+  )
+  if(WIN32)
+    set(_utf8_array_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccUtf8TextArrayTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _utf8_array_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.utf8-textarray-handler PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_utf8_array_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_extended_device_colorspace_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -1616,6 +1651,7 @@ if(WIN32)
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
   iccdev_add_gbd_zero_pcs_test()
+  iccdev_add_utf8_textarray_test()
   iccdev_add_extended_device_colorspace_test()
   iccdev_add_dpcc_pcc_replacement_test()
   iccdev_add_iccviz_metrics_test()
@@ -1816,6 +1852,7 @@ iccdev_add_xform_abstorel_adjust_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
 iccdev_add_gbd_zero_pcs_test()
+iccdev_add_utf8_textarray_test()
 iccdev_add_extended_device_colorspace_test()
 iccdev_add_dpcc_pcc_replacement_test()
 iccdev_add_iccviz_metrics_test()

--- a/IccProfLib/IccArrayBasic.cpp
+++ b/IccProfLib/IccArrayBasic.cpp
@@ -108,7 +108,7 @@ CIccArrayUnknown::~CIccArrayUnknown()
 
 IIccArray* CIccArrayUnknown::NewCopy(CIccTagArray *pTagArray) const
 {
-  CIccArrayUnknown *rv = new (std::nothrow) CIccArrayUnknown(pTagArray);
+  CIccArrayUnknown *rv = new (std::nothrow) CIccArrayUnknown(pTagArray, m_sig);
 
   return rv;
 }
@@ -126,8 +126,18 @@ icValidateStatus CIccArrayUnknown::Validate(std::string sigPath, std::string &sR
 
   if (m_pTag) {
     icUInt32Number i;
-    
-    sReport += "Unknown tag array type!\n";
+    char sig[20];
+    CIccInfo info;
+    char msg[128];
+
+    snprintf(msg, sizeof(msg),
+             " - Unknown tag array type %s with %u entries; validating array sub-tags.\n",
+             icGetSig(sig, sizeof(sig), m_sig), (unsigned int)m_pTag->GetSize());
+    sReport += icMsgValidateWarning;
+    sReport += info.GetSigPathName(sigPath);
+    sReport += msg;
+    rv = icMaxStatus(rv, icValidateWarning);
+
     for (i=0; i<m_pTag->GetSize(); i++) {
       CIccTag *pTag = m_pTag->GetIndex(i);
       if (!pTag) {

--- a/IccProfLib/IccArrayFactory.cpp
+++ b/IccProfLib/IccArrayFactory.cpp
@@ -89,6 +89,10 @@ IIccArray* CIccBasicArrayFactory::CreateArray(icArraySignature arrayTypeSig, CIc
     case icSigColorantInfoArray:
       return new (std::nothrow) CIccArrayColorantInfo(pTagArray);
 
+    case icSigUtf8TextTypeArray:
+      // UTF-8 arrays are validated directly by CIccTagArray::Validate().
+      return NULL;
+
     default:
       return new (std::nothrow) CIccArrayUnknown(pTagArray, arrayTypeSig);
   }

--- a/IccProfLib/IccTagComposite.cpp
+++ b/IccProfLib/IccTagComposite.cpp
@@ -1611,8 +1611,27 @@ icValidateStatus CIccTagArray::Validate(std::string sigPath, std::string &sRepor
       // for entries with zero offset/size (a spec-legal empty slot) - so guard
       // the deref as Describe()/Write()/Cleanup() already do; without it,
       // validating a sparse or malformed array crashes on a NULL deref.
-      if (m_TagVals[i].ptr)
+      if (m_TagVals[i].ptr) {
+        // #1726: every element of a utf8TextTypeArray must itself be a utf8Type
+        // text tag. This is kept strict (utf8Type only, not the zip-compressed
+        // zut8Type) to agree with the MCS runtime: CIccPcsXform::Connect requires
+        // AreAllOfType(icSigUtf8TextType) and casts each entry to CIccTagUtf8Text
+        // (IccCmm.cpp), so an array we declared conformant while carrying a zut8Type
+        // element could never actually form an MCS link. Flag a wrong element type,
+        // reporting the offending index, before recursing into its own Validate.
+        icTagTypeSignature elemType = m_TagVals[i].ptr->GetType();
+        if (elemType != icSigUtf8TextType) {
+          char buf[128];
+          snprintf(buf, sizeof(buf),
+                   " - UTF-8 text array element at index %u is not a utf8Type text tag.\n",
+                   (unsigned int)i);
+          sReport += icMsgValidateCriticalError;
+          sReport += Info.GetSigPathName(sigPath);
+          sReport += buf;
+          rv = icMaxStatus(rv, icValidateCriticalError);
+        }
         rv = icMaxStatus(rv, m_TagVals[i].ptr->Validate(sigAryPath, sReport, pProfile));
+      }
     }
   }
   else {

--- a/Testing/expected-invalid-fromxml.tsv
+++ b/Testing/expected-invalid-fromxml.tsv
@@ -21,7 +21,6 @@ SparseMatrixNamedColor	invalid-saved	Unknown color space	named-color sparse matr
 *SelectMID	invalid-saved	Invalid PCS designator for MultiplexIdentificationClass	MCS multiplex identification fixtures are tracked negative conformance vectors
 *Select-MID	invalid-saved	Invalid PCS designator for MultiplexIdentificationClass	MCS multiplex identification fixtures are tracked negative conformance vectors
 *-Mid_Overprint	invalid-saved	Invalid PCS designator for MultiplexIdentificationClass	overprint multiplex identification fixtures are tracked negative conformance vectors
-*MVIS*	invalid-saved	Unknown tag array type	MCS visualization fixtures expose known tag-array reconstruction diagnostics
 ISO22028-Encoded*	invalid-saved	Encoding Class has non-zero Header	encoding-class fixtures preserve non-zero reserved header diagnostics
 sRgbEncoding*	invalid-saved	Encoding Class has non-zero Header	encoding-class fixtures preserve non-zero reserved header diagnostics
 LCDDisplayCat8Obs	invalid-saved	Negative Z value	display category-eight observer fixture has tracked red colorant diagnostics


### PR DESCRIPTION
## Summary

Fixes #1726 — `iccDumpProfile -v 100 <mcs-profile> ALL` emits a spurious `Unknown tag array type!` line on **fully conformant** profiles that carry a `multiplexTypeArrayTag` (`mcta`) — a `tagArrayType` whose array signature is `icSigUtf8TextTypeArray` (`utf8`), holding the per-channel names of a Multiplex Color Space (MCS) profile.

Built on @xsscx's approach from the `ci-qa-pr-fp-tary` handoff branch (commit `4eb2bb72`).

## Root cause

`CIccBasicArrayFactory::CreateArray` had no `icSigUtf8TextTypeArray` case, so every `mcta` fell through to the `CIccArrayUnknown` fallback and printed the false-positive line — even though `g_icArrayNames` already advertised `utf8` as a known array type. Because `Read()`→`SetTagArrayType()` eagerly populates `m_pArray` with that `Unknown` handler, the dedicated `else if (m_sigArrayType==icSigUtf8TextTypeArray)` branch in `CIccTagArray::Validate` — which holds the MCS channel-count check — had become unreachable, so that check silently stopped running for loaded profiles.

The `SetTagArrayType` return (`… || m_sigArrayType == icSigUtf8TextTypeArray`) and that Validate branch are both vestiges of the original design intent: `utf8` was meant to have a **NULL** handler and be validated inline.

## Fix (@xsscx's approach)

- `CIccBasicArrayFactory::CreateArray` returns `NULL` for `icSigUtf8TextTypeArray`, restoring the intended design: `m_pArray` stays NULL and the dedicated `utf8` branch in `CIccTagArray::Validate` handles the array — reviving the MCS channel-count check.
- `CIccArrayUnknown::Validate` now emits a proper `icMsgValidateWarning` with the array signature and entry count (for *genuinely* unknown array types) instead of the bare `Unknown tag array type!`.
- `CIccArrayUnknown::NewCopy` now forwards `m_sig` (previously dropped, so copies lost their array signature).
- `Testing/expected-invalid-fromxml.tsv`: removes the obsolete `*MVIS*` "Unknown tag array type" expected-invalid line — those MCS fixtures are now recognized.

## Added in this PR

- **Per-element conformance check** in the `utf8` branch of `CIccTagArray::Validate`: each element must be a `utf8Type` or `zut8Type` text tag; a wrong element type is flagged critical, reporting the offending index. (`zut8Type` is accepted as the lenient superset v5 allows for text tags; the spec names `utf8Type` and no producer emits `zut8` here — drop this hunk if you'd prefer the strictly-minimal fix.)
- **CTest `iccdev.utf8-textarray-handler`** (`.github/ci/regression/utf8-textarray-handler.cpp`): builds `mcta`-shaped tag arrays in memory and validates them against a 5-channel MCS header —
  1. conformant 5-channel `mcta` → routes to a NULL handler, no `Unknown tag array type` line, no channel-count complaint;
  2. 3 names vs 5-channel MCS → the revived channel-count check flags it critical;
  3. a non-`utf8`/`zut8` element → the element-type check flags it.

  Red-green verified: reverting the factory `utf8` case fails cases 1–2; dropping the element-type check fails case 3.

## Verification

- Library + `iccDumpProfile` build clean; `Unknown tag array type!` gone on `Testing/hybrid/ICC/CMYK-STop_Overprint_Profile.icc` and sibling MCS profiles.
- Full `Testing/` corpus swept: all existing `UTF8TextArray` elements are `utf8Type`, so the new element-type check does not invalidate any conformant fixture.
- Local CodeQL (custom iccDEV security suite + standard `cpp-security-and-quality`): the fix code (`IccArrayFactory.cpp`, the `utf8` branch in `IccTagComposite.cpp`, and the `IccArrayBasic.cpp` edits) introduces no new alerts. (Pre-existing `CIccArrayNamedColor` alerts elsewhere in `IccArrayBasic.cpp` are untouched by this change.)
