### PR TITLE
fix(#1729): use spectral data info tag signature (sdin)

### DIFF
--- a/.github/scripts/iccdev-issue-1729-spectral-data-info-sig.sh
+++ b/.github/scripts/iccdev-issue-1729-spectral-data-info-sig.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+###############################################################################
+# iccFromXml/iccDumpProfile issue-1729 spectral data info tag signature
+###############################################################################
+#
+# The MCS display fixtures Testing/Display/LCDDisplay.xml and
+# Testing/Display/LaserProjector.xml carried their spectralDataInfoType tag under
+# the signature 'smwi' (0x736D7769), which is not a registered ICC signature. On
+# a fromXml -> dump round-trip iccDumpProfile reported it as
+# "Unknown 'smwi' = 736D7769" and the Version 5 summary listed
+# "Spectral Data Info (sdin)  ---" (absent), because the tag never landed in the
+# registered 'sdin' (icSigSpectralDataInfoTag, 0x7364696E) slot.
+#
+# #1729 corrects the two fixtures to use 'sdin'. There is no committed .icc for
+# these profiles (only the XML is tracked), so this guards the fix by rebuilding
+# each profile with iccFromXml and asserting iccDumpProfile now recognizes the tag
+# as spectralDataInfoTag ('sdin') and no longer emits the "Unknown 'smwi'" line.
+# The header declares no spectralPCS, so the sdin<->spectralPCS conformance check
+# stays gated off and validation is otherwise unchanged by the relabel.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TESTING_DIR -- path to the Testing/ tree
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit codes: 0 pass or clean skip; 2 regression.
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1729-spectral-data-info-sig}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+DUMP="$(find "$TOOLS_DIR" -maxdepth 2 -name iccDumpProfile -type f 2>/dev/null | head -1)"
+LOGFILE="$OUTDIR/issue-1729-spectral-data-info-sig.log"
+
+regress() {
+  echo "  [FAIL] issue-1729-spectral-data-info-sig -- $1"
+  exit 2
+}
+
+echo "=== iccFromXml/iccDumpProfile issue-1729 spectral data info tag signature regression ==="
+
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ] || [ -z "$DUMP" ] || [ ! -x "$DUMP" ]; then
+  echo "  [SKIP] iccFromXml or iccDumpProfile not built under $TOOLS_DIR"
+  exit 0
+fi
+
+# The two MCS display fixtures whose spectralDataInfoType tag was mislabeled.
+FIXTURES=(
+  "Display/LCDDisplay.xml"
+  "Display/LaserProjector.xml"
+)
+
+checked=0
+for rel in "${FIXTURES[@]}"; do
+  xml="$TESTING_DIR/$rel"
+  [ -f "$xml" ] || xml="$REPO_ROOT/Testing/$rel"
+  if [ ! -f "$xml" ]; then
+    echo "  [info] fixture missing, skipping: $rel"
+    continue
+  fi
+
+  icc="$OUTDIR/$(basename "${rel%.xml}").icc"
+  if ! "$FROMXML" "$xml" "$icc" > "$LOGFILE" 2>&1; then
+    sed -n '1,8p' "$LOGFILE"
+    regress "iccFromXml failed to build $rel"
+  fi
+
+  "$DUMP" "$icc" ALL > "$LOGFILE" 2>&1
+
+  # Regression 1: the mislabeled signature must be gone -- no "Unknown 'smwi'"
+  # line and no raw 0x736D7769 signature in the dump.
+  if grep -qi "smwi\|736D7769" "$LOGFILE"; then
+    grep -ni "smwi\|736D7769" "$LOGFILE" | sed -n '1,4p'
+    regress "$rel still emits the unregistered 'smwi' signature (0x736D7769)"
+  fi
+
+  # Regression 2: the tag must now be recognized as spectralDataInfoTag ('sdin').
+  if ! grep -qi "spectralDataInfoTag\|Spectral Data Info (sdin) *PRESENT" "$LOGFILE"; then
+    sed -n '1,12p' "$LOGFILE"
+    regress "$rel does not report a recognized spectralDataInfoTag ('sdin')"
+  fi
+
+  checked=$((checked + 1))
+done
+
+if [ "$checked" -eq 0 ]; then
+  echo "  [SKIP] no display fixtures available to exercise the spectral data info signature"
+  exit 0
+fi
+
+echo "  [PASS] issue-1729-spectral-data-info-sig -- $checked fixture(s) report spectralDataInfoTag ('sdin'), no 'smwi'"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2498,6 +2498,20 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1395-profileclass-signame.sh"
 )
 
+# #1729 - Testing/Display/LCDDisplay.xml and LaserProjector.xml stored their
+# spectralDataInfoType tag under the unregistered signature 'smwi' (0x736D7769),
+# so a fromXml -> dump round-trip reported "Unknown 'smwi'" and never populated
+# the registered 'sdin' (spectralDataInfoTag) slot. The fixtures were corrected to
+# 'sdin'; this rebuilds each with iccFromXml and asserts iccDumpProfile recognizes
+# the tag as spectralDataInfoTag and no longer emits the "Unknown 'smwi'" line.
+iccdev_add_script_test(
+  iccdev.issue-1729-spectral-data-info-sig
+  120
+  "iccdev;tools;dump;fromxml;signame;issue-1729;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1729-spectral-data-info-sig.sh"
+)
+
 # #1394 - CIccTagXmlNum::ToXml walked m_nSize without a bound, so a malformed
 # ui08/ui16/ui32/ui64 array drove an unbounded serialization loop (CWE-400/834):
 # a ~16 MB ui08 tag ballooned to ~80 MB of XML. Asserts the 0xffffff cap refuses

--- a/Testing/Display/LCDDisplay.xml
+++ b/Testing/Display/LCDDisplay.xml
@@ -518,7 +518,8 @@
       <XYZNumber X="0.93313599" Y="1.00000000" Z="0.93353271"/>
     </XYZType>
     <spectralDataInfoType>
-      <TagSignature>smwi</TagSignature>
+      <!-- #1729: 'sdin' is the registered spectralDataInfoTag signature; 'smwi' (0x736D7769) is unregistered and dumps as "Unknown" -->
+      <TagSignature>sdin</TagSignature>
       <SpectralSpace>656D0191h</SpectralSpace>
       <SpectralRange>
         <Wavelengths start="400.000000" end="700.000000" steps="31"/>

--- a/Testing/Display/LaserProjector.xml
+++ b/Testing/Display/LaserProjector.xml
@@ -763,7 +763,8 @@
       <XYZNumber X="0.84127808" Y="1.00000000" Z="0.96372986"/>
     </XYZType>
     <spectralDataInfoType>
-      <TagSignature>smwi</TagSignature>
+      <!-- #1729: 'sdin' is the registered spectralDataInfoTag signature; 'smwi' (0x736D7769) is unregistered and dumps as "Unknown" -->
+      <TagSignature>sdin</TagSignature>
       <SpectralSpace>es0191</SpectralSpace>
       <SpectralRange>
         <Wavelengths start="400.000000" end="700.000000" steps="31"/>


### PR DESCRIPTION
## Summary

Fixes #1729 — the MCS display fixtures `Testing/Display/LCDDisplay.xml` and `Testing/Display/LaserProjector.xml` stored their `spectralDataInfoType` tag under the signature **`smwi`** (`0x736D7769`), which is not a registered ICC signature. On a `iccFromXml` → `iccDumpProfile` round-trip this surfaced as:

```
Unknown 'smwi' = 736D7769  'smwi'   29472   24   0
...
Spectral Data Info (sdin)              ---
```

The registered signature for a spectralDataInfo tag is **`sdin`** (`icSigSpectralDataInfoTag` = `0x7364696E`). Adopts @xsscx's fix from the `ci-qa-pr-sdin-swpt` handoff (`4f82ec93`).

## Fix (@xsscx's diff)

```diff
     <spectralDataInfoType>
-      <TagSignature>smwi</TagSignature>
+      <TagSignature>sdin</TagSignature>
```

in both fixtures. The neighboring `swpt` (`icSigSpectralWhitePointTag`) was already correct.

## Why this is safe

- There is **no pre-existing `sdin` tag** in either profile — the summary shows `Spectral Data Info (sdin)  ---` precisely because the tag was mislabeled `smwi`. So the relabel fills the vacant slot; it does **not** create a duplicate-signature collision.
- Correcting the signature activates the `sdin` ⇄ `spectralPCS` conformance check in `CIccTagSpectralDataInfo::Validate` (`IccTagBasic.cpp:11806`), but that check is gated on `m_Header.spectralPCS != 0`. Both fixtures declare **no** `spectralPCS` in the header, so the check stays off and the validation report is **byte-identical** before and after — the only change is the tag-table label (`Unknown 'smwi'` → `spectralDataInfoTag 'sdin'`, summary flips to `PRESENT`).

## Added in this PR

- **Regression test `iccdev.issue-1729-spectral-data-info-sig`** (`.github/scripts/iccdev-issue-1729-spectral-data-info-sig.sh`): rebuilds both fixtures with `iccFromXml`, dumps them, and asserts each reports a recognized `spectralDataInfoTag ('sdin')` and **no** `Unknown 'smwi'` / `736D7769`. Mirrors the `#1395` profile-class-signame script test. Skips cleanly when the tools aren't built.

  Red-green verified: reverting either fixture to `smwi` fails the test (exit 2); the corrected fixtures pass (exit 0).

## Verification

- `iccFromXml` + `iccDumpProfile -v 25` on both profiles: `Unknown 'smwi'` gone; tag now dumps as `spectralDataInfoTag 'sdin'`; Version 5 summary shows `Spectral Data Info (sdin)  PRESENT`.
- Full `Validation Report` diff before → after is empty (relabel-only; no new warnings/errors).
- No C++/library source changed, so no new CodeQL surface.
