### PR TITLE
fix(#1735): fail the spectral-data-info-sig gate on any nonzero dump exit

### DIFF
--- a/.github/scripts/iccdev-issue-1729-spectral-data-info-sig.sh
+++ b/.github/scripts/iccdev-issue-1729-spectral-data-info-sig.sh
@@ -111,16 +111,17 @@ for rel in "${FIXTURES[@]}"; do
   scan_sanitizer "$fromxml_log" "iccFromXml built $rel"
 
   # Dump the profile with no -v, so iccDumpProfile does not run validation and a
-  # successful dump returns 0. (With -v it returns 0 for OK/warning/noncompliant
-  # and -1 only for a critical error, but validation is off here.) Fatal errors
-  # return negative codes -- -1 for bad args, -3 for a failed tag dump or stdout
-  # write (-> shell 255/253) -- and a crash raises a signal (>=128). So only
-  # rc>=126 (fatal returns + signals) fails the gate; a 0 success passes.
+  # successful dump returns 0. Its only other returns are fatal: -1 for bad args
+  # and -3 for a failed tag dump or stdout write (-> shell 255/253), plus a
+  # signal (>=128) on a crash -- it never returns a value in 1..125. 0 is
+  # therefore the sole success, so fail the gate on any nonzero status. (This is
+  # stricter than a >=126 test and future-proofs the gate should iccDumpProfile
+  # ever grow a small nonzero return; refs #1735.)
   "$DUMP" "$icc" ALL > "$dump_log" 2>&1
   dump_rc=$?
-  if [ "$dump_rc" -ge 126 ]; then
+  if [ "$dump_rc" -ne 0 ]; then
     sed -n '1,12p' "$dump_log"
-    regress "iccDumpProfile crashed or failed fatally on $rel (rc=$dump_rc)"
+    regress "iccDumpProfile failed on $rel (rc=$dump_rc)"
   fi
   scan_sanitizer "$dump_log" "iccDumpProfile dumped $rel"
 


### PR DESCRIPTION
Fixes #1735. Follow-up to #1734, which auto-merged at its pre-amend head before this change could be folded onto that branch — so it lands here instead.

## What #1735 asked
A low-confidence Copilot comment on #1734 argued the gate's `rc>=126` test "accepts statuses 1–125, which the repository classifies as graceful failures," and suggested failing on every nonzero status.

## Assessment
The **premise does not hold** for this tool. `iccDumpProfile`'s complete return contract (`Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp` lines 340/370/377/392/415/733/776/785):

| exit | meaning | shell |
|---|---|---|
| `0` | success | 0 |
| `-1` | bad args | 255 |
| `-3` | failed tag dump / stdout write | 253 |
| `-1`/`-2` | critical / unknown validation (**only** with `-v`) | 255 / 254 |

It never returns a value in 1..125 in any mode, and this gate invokes it **without `-v`**, so every nonzero exit is already ≥253 and the old `rc>=126` test caught all of them. There was no actual gap.

## Why adopt it anyway
The suggested change is still strictly better:
- `0` is the sole success, so `rc!=0` is the direct, self-evident gate.
- It does not rely on the reader knowing iccDumpProfile's exact exit codes.
- It future-proofs the gate should iccDumpProfile ever grow a small nonzero return.

Changed `[ "$dump_rc" -ge 126 ]` → `[ "$dump_rc" -ne 0 ]` and rewrote the comment to state the real contract.

## Verification
Gate re-run green on both tracked fixtures (`LCDDisplay`, `LaserProjector`) — each dumps at rc=0 and reports `spectralDataInfoTag` (`sdin`) with no residual `smwi`.
