### PR TITLE
fix(#1743): CIccTagZipUtf8Text::SetText failure contract + UTF-16 over-read + zlib leaks

### DIFF
--- a/.github/ci/regression/ziputf8-settext-contract.cpp
+++ b/.github/ci/regression/ziputf8-settext-contract.cpp
@@ -1,0 +1,155 @@
+// Regression: CIccTagZipUtf8Text::SetText() success/failure contract (#1743).
+//
+// SetText() reported success unconditionally. On an AllocBuffer() failure it
+// returned true while leaving the tag empty (m_pZipBuf NULL, m_nBufSize 0), so a
+// caller checking the return value could not distinguish "text stored" from
+// "nothing stored" - the same silent data loss class as #1521. The fix propagates
+// the allocation result, and replaces the (int)m_nBufSize-bounded copy loop with a
+// bulk copy so the length can no longer be narrowed to int.
+//
+// SCOPE, stated plainly: this test does NOT reproduce the allocation failure.
+// AllocBuffer() is public but non-virtual, so there is no override hook, and
+// forcing malloc to fail would need platform-specific interposition that will not
+// run portably in CI (this suite is also built for Windows). What it does instead
+// is pin the invariant the bug violated - "SetText() returning true implies the
+// tag actually holds a deflated buffer" - and guard the bulk-copy change against a
+// wrong length, which IS the part a mistake here would silently corrupt. Both are
+// green before and after the fix on a machine where allocation succeeds; they are
+// contract and regression guards, not a red-green reproduction of the OOM path.
+//
+// Built and registered only when ICC_USE_ZLIB is enabled (the option added in
+// #1530); without zlib SetText() always returns false and none of this applies.
+#include "IccTag.h"
+#include "IccProfile.h"
+
+#include <cstdio>
+#include <string>
+
+static int g_fail = 0;
+#define CHECK(c) do { if(!(c)){ std::printf("FAIL line %d: %s\n", __LINE__, #c); g_fail=1; } } while(0)
+
+// Round-trip helper. NOTE on an existing quirk this test had to be written around:
+// SetText() deflates strlen(szText) + 1 bytes, i.e. it includes the NUL terminator
+// in the compressed stream, and GetText() appends every inflated byte to the output
+// string. A round trip therefore yields the original text plus a trailing '\0', so
+// GetText(out) gives out.size() == strlen(text) + 1 and out != text. That is
+// long-standing behaviour on both sides (the strlen + 1 is unrelated to #1743 and
+// unchanged by it), so assert what the library actually does rather than what the
+// name suggests; comparing with == would fail against unmodified master too.
+static void checkRoundTrip(CIccTagZipUtf8Text &tag, const std::string &expect,
+                           const char *what)
+{
+  std::string out;
+  if (!tag.GetText(out)) {
+    std::printf("FAIL: %s - GetText failed\n", what);
+    g_fail = 1;
+    return;
+  }
+  if (out.size() != expect.size() + 1 ||
+      out.compare(0, expect.size(), expect) != 0 ||
+      out[expect.size()] != '\0') {
+    std::printf("FAIL: %s - round trip mismatch (got %zu bytes, expected %zu + NUL)\n",
+                what, out.size(), expect.size());
+    g_fail = 1;
+  }
+}
+
+// The invariant #1743 is about: a true return must mean the deflated bytes are
+// actually stored. Before the fix this held only because the allocation happened to
+// succeed; it was not enforced.
+static void checkStoredOnSuccess(const CIccTagZipUtf8Text &tag, bool bSetOk, const char *what)
+{
+  CHECK(bSetOk);
+  if (!bSetOk)
+    return;
+  if (tag.GetBuffer() == NULL || tag.BufferSize() == 0) {
+    std::printf("FAIL: %s - SetText returned true but tag holds no data "
+                "(buf=%p size=%u)\n",
+                what, (const void *)tag.GetBuffer(), (unsigned)tag.BufferSize());
+    g_fail = 1;
+  }
+}
+
+int main()
+{
+  // Redundant plaintext so deflate measurably shrinks it, and long enough that a
+  // wrong bulk-copy length truncates visibly rather than by a byte or two.
+  std::string plain;
+  for (int i = 0; i < 5000; i++)
+    plain += (char)('A' + (i % 26));
+
+  {
+    CIccTagZipUtf8Text tag;
+    const bool ok = tag.SetText((const icChar *)plain.c_str());
+    checkStoredOnSuccess(tag, ok, "5000-byte plaintext");
+
+    // The stored stream must be the deflated form, not the plaintext.
+    CHECK(tag.BufferSize() < plain.size());
+
+    // Round trip. This is what a wrong length in the bulk copy would break: a short
+    // copy leaves a truncated deflate stream that fails to inflate or inflates to
+    // the wrong text.
+    checkRoundTrip(tag, plain, "5000-byte plaintext");
+  }
+
+  // Empty and NULL input: SetText treats NULL as "", and deflate still emits a
+  // header, so the success contract applies here too - BufferSize() must be > 0.
+  {
+    CIccTagZipUtf8Text tag;
+    const bool ok = tag.SetText((const icChar *)"");
+    checkStoredOnSuccess(tag, ok, "empty string");
+    checkRoundTrip(tag, "", "empty string");
+  }
+
+  {
+    CIccTagZipUtf8Text tag;
+    const bool ok = tag.SetText((const icUChar *)NULL);
+    checkStoredOnSuccess(tag, ok, "NULL pointer");
+    checkRoundTrip(tag, "", "NULL pointer");
+  }
+
+  // Overwriting an existing buffer goes through AllocBuffer()'s realloc path with a
+  // different size, which is where a stale m_nBufSize would show up as a copy of the
+  // wrong length.
+  {
+    CIccTagZipUtf8Text tag;
+    CHECK(tag.SetText((const icChar *)plain.c_str()));
+    const icUInt32Number nFirst = tag.BufferSize();
+
+    std::string shorter = plain.substr(0, 100);
+    const bool ok = tag.SetText((const icChar *)shorter.c_str());
+    checkStoredOnSuccess(tag, ok, "overwrite with shorter text");
+    CHECK(tag.BufferSize() != nFirst);
+    checkRoundTrip(tag, shorter, "overwrite with shorter text");
+  }
+
+  // The icUChar16 overload converts UTF-16 to UTF-8 and tail-calls the icUChar one.
+  // #1743: the converter does not NUL-terminate its output, and the icUChar overload
+  // reads its argument with strlen(), so before the fix this ran strlen() off the end
+  // of the conversion buffer - a heap over-read ASAN flags (READ of size N, 0 bytes
+  // after the region). Exercising the overload here reproduces that path; the fix
+  // pushes an explicit terminator before the tail call.
+  {
+    CIccTagZipUtf8Text tag;
+    icUChar16 wide[6] = { 'h', 'e', 'l', 'l', 'o', 0 };
+    const bool ok = tag.SetText(wide);
+    checkStoredOnSuccess(tag, ok, "icUChar16 overload");
+    checkRoundTrip(tag, "hello", "icUChar16 overload");
+  }
+
+  // #1743: the empty UTF-16 string is the second half of the same bug. len==0 leaves
+  // the conversion vector empty, so &text[0] is undefined before strlen() even runs.
+  // NULL is special-cased in the overload, but L"" is not - it reaches the conversion
+  // path. The pushed terminator makes &text[0] valid here too.
+  {
+    CIccTagZipUtf8Text tag;
+    icUChar16 empty[1] = { 0 };
+    const bool ok = tag.SetText(empty);
+    checkStoredOnSuccess(tag, ok, "icUChar16 empty string");
+    checkRoundTrip(tag, "", "icUChar16 empty string");
+  }
+
+  std::printf(g_fail ? "ziputf8-settext-contract: FAILED\n"
+                     : "ziputf8-settext-contract: PASSED\n");
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1413,6 +1413,57 @@ function(iccdev_add_tagdata_zlib_roundtrip_test)
   endif()
 endfunction()
 
+# CIccTagZipUtf8Text::SetText() success/failure contract (#1743). SetText() used to
+# return true even when AllocBuffer() failed, so a caller could not tell "text
+# stored" from "nothing stored"; the copy was also bounded by (int)m_nBufSize,
+# narrowing an icUInt32Number to int. Pins the invariant a true return implies a
+# populated buffer, and guards the bulk copy that replaced the loop against a wrong
+# length. Same zlib gating as the #1521 test above: without ICC_USE_ZLIB, SetText()
+# always returns false and none of these invariants hold.
+function(iccdev_add_ziputf8_settext_contract_test)
+  if(NOT ICC_USE_ZLIB)
+    return()
+  endif()
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccZipUtf8SetTextContractTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/ziputf8-settext-contract.cpp"
+  )
+  target_compile_features(iccZipUtf8SetTextContractTest PRIVATE cxx_std_17)
+  # IccProfLib links ZLIB::ZLIB and defines ICC_USE_ZLIB=1 PUBLIC, so both
+  # propagate to this executable; link zlib explicitly as belt-and-braces.
+  target_link_libraries(iccZipUtf8SetTextContractTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  if(TARGET ZLIB::ZLIB)
+    target_link_libraries(iccZipUtf8SetTextContractTest PRIVATE ZLIB::ZLIB)
+  endif()
+  add_dependencies(check iccZipUtf8SetTextContractTest)
+
+  add_test(
+    NAME iccdev.ziputf8-settext-contract
+    COMMAND "$<TARGET_FILE:iccZipUtf8SetTextContractTest>"
+  )
+  set_tests_properties(iccdev.ziputf8-settext-contract PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;tag;zlib;compression;issue-1743;regression"
+  )
+  if(WIN32)
+    set(_ziputf8_settext_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccZipUtf8SetTextContractTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _ziputf8_settext_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.ziputf8-settext-contract PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_ziputf8_settext_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_parser_restore_calls_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -1676,6 +1727,7 @@ if(WIN32)
   iccdev_add_profile_write_failure_test()
   iccdev_add_fileio_seek_tell_test()
   iccdev_add_tagdata_zlib_roundtrip_test()
+  iccdev_add_ziputf8_settext_contract_test()
   iccdev_add_parser_restore_calls_test()
   iccdev_add_tag_layout_shared_data_test()
   iccdev_add_pawg_q2_tonecurves_test()
@@ -1880,6 +1932,7 @@ iccdev_add_fileio_getlength_position_test()
 iccdev_add_profile_write_failure_test()
 iccdev_add_fileio_seek_tell_test()
 iccdev_add_tagdata_zlib_roundtrip_test()
+iccdev_add_ziputf8_settext_contract_test()
 iccdev_add_parser_restore_calls_test()
 iccdev_add_tag_layout_shared_data_test()
 iccdev_add_pawg_q2_tonecurves_test()

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -1180,6 +1180,14 @@ void CIccTagUtf8Text::SetText(const icUChar16 *szText)
 
   icConvertUTF16toUTF8(szText, &szText[len], text, lenientConversion);
 
+  // #1743: icConvertUTF16toUTF8() only appends the converted bytes - it does not
+  // NUL-terminate - but the icUChar overload of SetText() below reads its argument
+  // with strlen(). Passing &text[0] as-is runs strlen() off the end of the vector
+  // (ASAN: heap-buffer-overflow READ), and for empty input (len==0) the vector is
+  // also empty, so &text[0] is itself undefined. Push an explicit terminator to make
+  // the buffer both non-empty and a valid C string before handing it over.
+  text.push_back(0);
+
   SetText((const icUChar*)&text[0]);
 }
 
@@ -1505,6 +1513,11 @@ bool CIccTagZipUtf8Text::GetText(std::string &str) const
   zstat = inflateReset(&zstr);
 
   if (zstat != Z_OK) {
+    // Mirror of the deflateReset() path in SetText(): inflateInit() has already
+    // allocated the stream's internal state, so returning without inflateEnd()
+    // leaks it. The decode loop below does call inflateEnd() before its own error
+    // returns; only this early exit was missing it.
+    inflateEnd(&zstr);
     return false;
   }
 
@@ -1584,6 +1597,11 @@ bool CIccTagZipUtf8Text::SetText(const icUChar *szText)
   zstr.avail_in = nSize;
 
   if (zstat != Z_OK) {
+    // deflateInit() succeeded above, so it has already allocated the stream's
+    // internal state; bailing out here without deflateEnd() leaks it. Every other
+    // post-init failure path in this function calls deflateEnd() first - this one
+    // did not.
+    deflateEnd(&zstr);
     return false;
   }
 
@@ -1616,7 +1634,17 @@ bool CIccTagZipUtf8Text::SetText(const icUChar *szText)
   icUInt32Number nCompressedSize = (icUInt32Number)compress.size();
   icUChar *pBuf = AllocBuffer(nCompressedSize);
 
-  if (pBuf && nCompressedSize) {
+  // #1743: AllocBuffer() returns NULL when its allocation fails, leaving the tag
+  // empty (m_pZipBuf NULL, m_nBufSize 0). The copy below is guarded on pBuf, but the
+  // function used to return true regardless - reporting success while storing
+  // nothing, the same silent data loss as #1521. Every other failure path in this
+  // function returns false, so propagate the allocation result too. (The >4 GB
+  // reject above and the bulk memcpy that replaced the old (int)m_nBufSize-bounded
+  // copy loop both came from #1745; this adds only the missing failure return.)
+  if (!pBuf)
+    return false;
+
+  if (nCompressedSize) {
     memcpy(pBuf, &compress[0], nCompressedSize);
   }
 
@@ -1645,6 +1673,12 @@ bool CIccTagZipUtf8Text::SetText(const icUChar16 *szText)
   for (len=0; szText[len]; len++);
 
   icConvertUTF16toUTF8(szText, &szText[len], text, lenientConversion);
+
+  // #1743: see the matching note in CIccTagUtf8Text::SetText above. The converter
+  // leaves the bytes un-terminated and the icUChar overload strlen()s them, so an
+  // explicit terminator is required to avoid a heap over-read (and to keep &text[0]
+  // defined when len==0 leaves the vector empty).
+  text.push_back(0);
 
   return SetText((const icUChar*)&text[0]);
 }


### PR DESCRIPTION
Closes #1743.

## Summary

`CIccTagZipUtf8Text::SetText()` reported success even when its buffer allocation
failed - returning `true` while leaving the tag empty (`m_pZipBuf` NULL, `m_nBufSize`
0), so a caller checking the return value could not tell "text stored" from "nothing
stored." Same silent-data-loss class as #1521.

While addressing that, three further defects in the same tag surfaced and are fixed
here. The larger one is a heap over-read that xsscx asked be handled in the same PR.

## Fixes

### 1. The reported bug — false success on allocation failure
`#1745` (merged after the issue was filed) refactored the copy in this function to a
bulk `memcpy` and added a >4 GB reject, but kept the unconditional `return true`, so
the defect survived. This adds the missing failure return:

```cpp
  icUChar *pBuf = AllocBuffer(nCompressedSize);
  if (!pBuf)
    return false;               // was: fall through to return true
  if (nCompressedSize)
    memcpy(pBuf, &compress[0], nCompressedSize);
```

xsscx's requested `(int)m_nBufSize` narrowing nit was already resolved by #1745's
`memcpy`, so it is not repeated here.

### 2. UTF-16 heap-buffer-overflow READ (CWE-125) — both overloads
`icConvertUTF16toUTF8()` appends only the converted bytes and does **not**
NUL-terminate, but `SetText(const icUChar*)` reads its argument with `strlen()`.
Passing `&text[0]` ran `strlen()` off the end of the conversion vector. ASAN on a
`"hello"` input:

```
ERROR: AddressSanitizer: heap-buffer-overflow ... READ of size 9
  #1 CIccTagZipUtf8Text::SetText(unsigned char const*)  IccTagBasic.cpp:1562
  #2 CIccTagZipUtf8Text::SetText(unsigned short const*) IccTagBasic.cpp:1664
```

Present in **both** `CIccTagUtf8Text::SetText(const icUChar16*)` and
`CIccTagZipUtf8Text::SetText(const icUChar16*)` (identical code). The same path also
dereferences `&text[0]` on an empty vector when the input is `L""` (`len==0`) — UB
before `strlen()` even runs; only a NULL pointer was special-cased. Both are fixed by
pushing an explicit terminator before the tail call.

### 3 & 4. zlib stream-state leaks on the reset-failure paths
- `deflateReset()` failure in `SetText()` returned without `deflateEnd()`, leaking the
  state `deflateInit()` had already allocated. Every other post-init failure path in
  the function calls `deflateEnd()` first.
- `inflateReset()` failure in `GetText()` had the mirror leak; fixed the same way.

## Test

New `.github/ci/regression/ziputf8-settext-contract.cpp`, registered for both Windows
and non-Windows and `ICC_USE_ZLIB`-gated like the #1521 sibling. It pins the
success/failure contract — a `true` return must leave a populated buffer — plus round
trips over plaintext, empty, NULL, realloc-overwrite, and both UTF-16 overloads
including the empty-string case, so the over-read path is exercised.

## Verification

- Builds clean under strict warnings.
- Contract test passes; **fails on the UTF-16 case if the terminator fix is reverted**
  (red-green for defect 2).
- Runs clean under ASAN with `detect_leaks=1` — no over-read, no zlib leak.
- Tag/zlib CTest gates (including #1521 and #1726) stay green on the merged tree.

## Honest limitation

The allocation-failure return (fix 1) has **no red-green test**: `AllocBuffer()` is
non-virtual, so forcing `malloc` to fail is not portable in CI (this suite also builds
for Windows). That is stated in the test header. Fixes 2–4 are exercised directly.

## Scope

One source file (`IccProfLib/IccTagBasic.cpp`) plus the test and its CMake
registration. No CI/workflow changes.
