### PR TITLE
fix(#1754): give processLuts external linkage + fuzz-harnessable entry

### DIFF
--- a/Tools/CmdLine/IccProfilePlot/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfilePlot/iccProfileVisualize.cpp
@@ -82,6 +82,9 @@
 #include "MiniPDF.hpp"
 #include "spectralLocus.hpp"
 #include "IccVizModel.hpp"   // data-first visualization engine (graphs + raster)
+#include "iccProfileVisualize.hpp"   // our own processLuts() decl - keeps the
+                                     // definition below in sync with the entry
+                                     // point exposed to out-of-line callers
 
 // #define MEMORY_LEAK_CHECK to enable C RTL memory leak checking (slow!)
 #define MEMORY_LEAK_CHECK
@@ -1340,7 +1343,11 @@ int renderNeutralAxisGraph( const iccviz::Graph &graph, PDFWriter &pdffile )
 /******************************************************************************/
 
 // output graphic representation of 1D and nD LUTs
-static
+// Non-static: external linkage so an out-of-line driver (a fuzz/regression
+// harness) can link against this entry point; declared in
+// iccProfileVisualize.hpp, which the includes above pull in to keep the two
+// in sync. It was `static` (internal linkage) as the tool's private driver,
+// which is why a caller in another translation unit could not reach it.
 int processLuts(CIccProfile *pIcc, const char *profilePath )
 {
   int outputItems = 0;
@@ -1496,6 +1503,13 @@ void printUsage(void)
 
 /******************************************************************************/
 
+// The CLI entry point is just an argv loop around processLuts(). A harness that
+// links this object for processLuts() supplies its own entry point (libFuzzer
+// provides main; a regression driver defines its own), so build that harness
+// with -DICC_PROFILEVISUALIZE_NO_MAIN to drop ours and avoid a duplicate-main
+// link error. The normal tool build leaves the macro undefined and compiles
+// main() unchanged.
+#ifndef ICC_PROFILEVISUALIZE_NO_MAIN
 int main(int argc, char* argv[])
 {
 #if defined(MEMORY_LEAK_CHECK) && defined(_DEBUG)
@@ -1562,5 +1576,6 @@ int main(int argc, char* argv[])
 
   return status;
 }
+#endif // ICC_PROFILEVISUALIZE_NO_MAIN
 
 /******************************************************************************/

--- a/Tools/CmdLine/IccProfilePlot/iccProfileVisualize.hpp
+++ b/Tools/CmdLine/IccProfilePlot/iccProfileVisualize.hpp
@@ -92,9 +92,10 @@
 class CIccProfile;
 
 // Render every visualization pIcc supports to PDF/TIFF written alongside
-// profilePath (used to derive the output basename). Returns the count of
-// output items produced; 0 means the profile yielded nothing to draw, which
-// the CLI treats as a per-file failure.
+// profilePath (used to derive the output basename). Returns the count accumulated
+// for rendered PDF pages and successfully rendered raster descriptors; output
+// I/O failures are logged but are not reflected in this value. 0 means the
+// profile yielded nothing to draw, which the CLI treats as a per-file failure.
 int processLuts(CIccProfile *pIcc, const char *profilePath);
 
 #endif // ICC_PROFILEVISUALIZE_HPP

--- a/Tools/CmdLine/IccProfilePlot/iccProfileVisualize.hpp
+++ b/Tools/CmdLine/IccProfilePlot/iccProfileVisualize.hpp
@@ -1,0 +1,100 @@
+/*
+  File:     iccProfileVisualize.hpp
+
+  Contains: Public entry point of the iccProfileVisualizePlot tool - declares
+            processLuts() so an out-of-line caller (a fuzz/regression harness,
+            an alternate driver) can invoke it without redeclaring it or pulling
+            in the whole translation unit and its main().
+
+  Version:  V1
+
+  Copyright:  (c) see below
+*/
+
+/*
+ * The ICC Software License, Version 0.2
+ *
+ *
+ * Copyright (c) 2003-2026 The International Color Consortium. All rights
+ * reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *  notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *  notice, this list of conditions and the following disclaimer in
+ *  the documentation and/or other materials provided with the
+ *  distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and "The
+ *  International Color Consortium" must not be used to imply that the
+ *  ICC organization endorses or promotes products derived from this
+ *  software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR
+ * ITS CONTRIBUTING MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the The International Color Consortium.
+ *
+ *
+ * Membership in the ICC is encouraged when this software is used for
+ * commercial purposes.
+ *
+ *
+ * For more information on The International Color Consortium, please
+ * see <http://www.color.org/>.
+ *
+ *
+ */
+
+/**
+ * iccProfileVisualize - public entry point.
+ *
+ * processLuts() is the whole-profile driver behind the iccProfileVisualizePlot
+ * CLI: given an opened profile it enumerates the visualizations the profile
+ * supports (iccviz::Enumerate), renders each one's DATA, and writes the PDF
+ * plots + nD-CLUT TIFFs next to the input file. main() is just an argv loop
+ * around it.
+ *
+ * It lives in iccProfileVisualize.cpp with no declaration of its own, so it was
+ * reachable only from that translation unit's main(). This header hoists the
+ * declaration out so another driver - a libFuzzer/regression harness that feeds
+ * profiles straight to processLuts() - can call it after including this file and
+ * linking the object, instead of copy-declaring the prototype (which silently
+ * rots if the signature changes). Pair it with -DICC_PROFILEVISUALIZE_NO_MAIN
+ * on that harness build to drop this file's main() and avoid a duplicate-main
+ * clash with the harness's own entry point.
+ */
+
+#ifndef ICC_PROFILEVISUALIZE_HPP
+#define ICC_PROFILEVISUALIZE_HPP
+
+// Only a CIccProfile* is named in the interface, so forward-declare it rather
+// than pull in IccProfile.h - matches IccVizModel.hpp and keeps this header
+// cheap for a harness that already has its own ICC includes.
+class CIccProfile;
+
+// Render every visualization pIcc supports to PDF/TIFF written alongside
+// profilePath (used to derive the output basename). Returns the count of
+// output items produced; 0 means the profile yielded nothing to draw, which
+// the CLI treats as a per-file failure.
+int processLuts(CIccProfile *pIcc, const char *profilePath);
+
+#endif // ICC_PROFILEVISUALIZE_HPP


### PR DESCRIPTION
Fixes #1754.

## Problem
`processLuts()` in `Tools/CmdLine/IccProfilePlot/iccProfileVisualize.cpp` was `static` (internal linkage) with no declaration of its own, reachable only from that translation unit's `main()`. An out-of-line driver — xsscx's `icc_profilevisualize_fuzzer.cpp` — calling `processLuts(profile, profilePath)` fails at compile with `use of undeclared identifier 'processLuts'`, and would not have linked even with a local prototype because internal linkage keeps the symbol private to the TU.

Bisected to `2d5cc8d` (#1517), which introduced `processLuts` as the tool's private driver.

## Fix
Three coordinated changes, all in our-owned `IccProfilePlot/`:

1. **New `iccProfileVisualize.hpp`** declaring `int processLuts(CIccProfile*, const char*)`. The `.cpp` includes it so definition and declaration stay in sync (a signature drift now fails the build instead of rotting a copy-pasted prototype). Forward-declares `CIccProfile` per the sibling `IccVizModel.hpp` convention.
2. **Dropped `static`** from the definition → external linkage, so the symbol is linkable from another translation unit. This is the actual enabler; a header alone would fix only the compile error, not the link.
3. **Guarded `main()`** behind `#ifndef ICC_PROFILEVISUALIZE_NO_MAIN`. A harness that links this object for `processLuts()` supplies its own entry point (libFuzzer provides `main`); the guard lets it build with `-DICC_PROFILEVISUALIZE_NO_MAIN` to drop ours and avoid a duplicate-`main` link clash. The normal tool build leaves the macro undefined and compiles `main()` unchanged.

No CMake change: the new header sits alongside existing sources already on the target's include path.

## Verification
- Normal `iccProfileVisualizePlot` build compiles + links clean.
- `nm` on the normal object: `T processLuts` (was `t`/static) and `T main`.
- `nm` on the harness-mode object (`-DICC_PROFILEVISUALIZE_NO_MAIN`): `T processLuts`, **no `main`**.
- CLI smoke test unchanged: no-args prints usage (exit 0); a real profile drives PDF/TIFF output (exit 0).