### PR TITLE
fix(#1751): scope CodeQL guard-suppression clauses to the enclosing function

### DIFF
--- a/.github/codeql-queries/float-to-int-cast.ql
+++ b/.github/codeql-queries/float-to-int-cast.ql
@@ -24,7 +24,7 @@ where
   not exists(FunctionCall guard |
     guard.getTarget().getName().regexpMatch("(?i)(isnan|isinf|isfinite|fpclassify|__builtin_isnan)") and
     // Scope the guard to the SAME function as the cast. Without this the clause
-    // constrains only cast.getFile() (lines 32/34) and compares raw line numbers,
+    // constrains only the cast's file path below and compares raw line numbers,
     // never tying the guard to the cast's file or function - so an isfinite() on
     // line N of one file suppresses an unguarded cast on line N of a *different*
     // file (a soundness hole: real findings silently dropped). Equal enclosing

--- a/.github/codeql-queries/float-to-int-cast.ql
+++ b/.github/codeql-queries/float-to-int-cast.ql
@@ -23,6 +23,14 @@ where
   // Not in a context that is already guarded by isnan/isinf/isfinite
   not exists(FunctionCall guard |
     guard.getTarget().getName().regexpMatch("(?i)(isnan|isinf|isfinite|fpclassify|__builtin_isnan)") and
+    // Scope the guard to the SAME function as the cast. Without this the clause
+    // constrains only cast.getFile() (lines 32/34) and compares raw line numbers,
+    // never tying the guard to the cast's file or function - so an isfinite() on
+    // line N of one file suppresses an unguarded cast on line N of a *different*
+    // file (a soundness hole: real findings silently dropped). Equal enclosing
+    // functions pin guard and cast to one function body, hence one file; the line
+    // window below then narrows to a guard textually preceding the cast within it.
+    guard.getEnclosingFunction() = cast.getEnclosingFunction() and
     guard.getLocation().getStartLine() >= cast.getLocation().getStartLine() - 5 and
     guard.getLocation().getStartLine() <= cast.getLocation().getStartLine()
   ) and

--- a/.github/codeql-queries/unbounded-profile-loop.ql
+++ b/.github/codeql-queries/unbounded-profile-loop.ql
@@ -76,6 +76,13 @@ where
   not hasSetupBoundGuardInSameType(fa.getTarget()) and
   not exists(FunctionCall minCall |
     minCall.getTarget().getName().matches("%min%") and
+    // Scope the min() exemption to the loop's own function. Without this it matched
+    // any *min*-named call within three lines of ANY loop in ANY file, suppressing
+    // unrelated loops (the same soundness hole fixed in float-to-int-cast.ql). The
+    // sibling guards above - hasPriorBoundGuardInFunction and
+    // hasSetupBoundGuardInSameType - are already function-scoped; only this
+    // exemption was left comparing bare line numbers. Mirror them.
+    minCall.getEnclosingFunction() = loop.getEnclosingFunction() and
     minCall.getLocation().getStartLine() >= loop.getLocation().getStartLine() - 3 and
     minCall.getLocation().getStartLine() <= loop.getLocation().getStartLine()
   ) and


### PR DESCRIPTION
## Summary

Fixes the soundness bug reported in #1751: `float-to-int-cast.ql` and
`unbounded-profile-loop.ql` each contained a guard-suppression `exists()` clause that
compared **raw line numbers only**, with nothing tying the guard to the cast/loop's file or
function. A guard call (`isfinite` / `min`) on line N of *one* file therefore suppressed an
unrelated cast/loop on line N of a *different* file — a false **negative** that silently
drops real findings, independent of any alert state.

This PR lands **only the soundness fix** (Piece 1 in #1751). The false-*positive* reduction
work (guard-form matching, provenance/bound-shape) is deferred to a separate, measured PR as
the issue requests.

## The fix

Add an enclosing-function equality to each exemption, so the guard must live in the same
function as the cast/loop it exempts:

- `float-to-int-cast.ql`: `guard.getEnclosingFunction() = cast.getEnclosingFunction()`
- `unbounded-profile-loop.ql`: `minCall.getEnclosingFunction() = loop.getEnclosingFunction()`

This mirrors the already-correct sibling predicates in the loop query
(`hasPriorBoundGuardInFunction`, `hasSetupBoundGuardInSameType`), which were the only guards
already function-scoped — the `minCall` exemption was the one left comparing bare line numbers.
The existing line-window is kept as a secondary narrowing (a guard textually preceding the cast
within the same function); reworking the window into a fallback is part of the deferred FP work.

## Validation (measured, both directions)

Local CodeQL DB over a Debug build with `ENABLE_TOOLS=ON`, counting unique `path:line` sites:

| Query | Before (master) | After | Recovered | Dropped |
|---|---|---|---|---|
| `float-to-int-cast` | 63 | 70 | **+7** | **0** |
| `unbounded-profile-loop` | 1 | 2 | **+1** | **0** |

**AFTER is a superset of BEFORE for both queries — no previously-reported site is lost** (the
no-new-false-negative check). The count *rising* is the correct direction for a soundness fix:
these sites were being silently suppressed by cross-file line-number collisions.

Recovered sites (genuine unguarded casts/loops that were being masked):

- `IccProfLib/IccPrmg.cpp:153`, `:165`
- `IccProfLib/IccSparseMatrix.h:108`, `:118`
- `IccProfLib/IccUtil.cpp:618`
- `Tools/CmdLine/IccProfilePlot/IccVizModel.cpp:1215`
- `Tools/CmdLine/IccProfilePlot/MiniTIFF.cpp:325`
- `IccJSON/IccLibJSON/IccTagJson.cpp:1232` (`m_nSize` loop)

Both queries also `codeql query compile` cleanly.

## CI note

The CodeQL security workflow (`ci-codeql-security.yml`) is gated on the `codeql-ready` label,
so it will not build a DB and re-run these queries against this PR automatically. The
before/after numbers above are the local evidence; a maintainer applying `codeql-ready` will
reproduce them in CI.

Refs #1751
