### PR TITLE
fix(#1061,#2260): NaN-safe SparseMatrix set() + fix UInt16 truncation

### DIFF
--- a/.github/ci/regression/iccsparsematrix-set-roundtrip.cpp
+++ b/.github/ci/regression/iccsparsematrix-set-roundtrip.cpp
@@ -1,0 +1,71 @@
+// Regression for CIccSparseMatrixUInt8::set / CIccSparseMatrixUInt16::set in
+// IccProfLib/IccSparseMatrix.h.
+//
+// Two defects were fixed together (alerts #1061 and #2260):
+//   1. NaN-blind clamp (both entry types). The old guard `value < 0.0 ? 0 : ...`
+//      lets a NaN fall through to `(icUInt8/16Number)(NaN * scale + 0.5)`, an
+//      undefined float->int cast (CWE-681). The fix uses `!(value > 0.0) ? 0`,
+//      which is false for NaN and for value<=0, so both route to 0 before the cast.
+//   2. Truncation in the UInt16 entry. `set()` cast the scaled value to
+//      (icUInt8Number) while storing into a 16-bit slot, so any value in (0,1)
+//      whose scaled result exceeds 255 was truncated to 8 bits before widening --
+//      e.g. 0.5 -> (icUInt8Number)32768 == 0. get() then read it back as 0.0,
+//      breaking the set()/get() round-trip against get()'s /65535.0f.
+//
+// The set()/get() methods are inline, so this exercises the exact shipped code.
+// Assertions are mutation-verified: reverting either fix makes a case below fail
+// (NaN -> nonzero garbage; UInt16 0.5 -> raw 0 -> get() 0.0).
+
+#include "IccSparseMatrix.h"
+
+#include <cmath>
+#include <cstdio>
+
+static int g_fails = 0;
+
+static void check(bool ok, const char *what) {
+  if (!ok) { fprintf(stderr, "FAIL: %s\n", what); ++g_fails; }
+}
+
+int main(void) {
+  // ---- CIccSparseMatrixUInt8 ----
+  {
+    icUInt8Number buf[4] = {0};
+    CIccSparseMatrixUInt8 e;
+    e.init(buf);
+
+    e.set(0, 0.5f);
+    check(std::fabs(e.get(0) - 0.5f) < 0.01f, "UInt8 set(0.5) round-trip");
+
+    e.set(1, std::nanf(""));                 // must NOT hit the UB cast
+    check(buf[1] == 0, "UInt8 set(NaN) -> 0 (no UB cast)");
+
+    e.set(2, -3.0f);
+    check(buf[2] == 0, "UInt8 set(negative) -> 0");
+
+    e.set(3, 5.0f);
+    check(buf[3] == 255, "UInt8 set(>1) -> 255");
+  }
+
+  // ---- CIccSparseMatrixUInt16 (also guards the truncation fix) ----
+  {
+    icUInt16Number buf[4] = {0};
+    CIccSparseMatrixUInt16 e;
+    e.init(buf);
+
+    e.set(0, 0.5f);
+    // Pre-fix this stored (icUInt8Number)32768 == 0; the fix stores ~32768.
+    check(buf[0] > 32000, "UInt16 set(0.5) stores full 16-bit value (truncation fix)");
+    check(std::fabs(e.get(0) - 0.5f) < 0.01f, "UInt16 set(0.5) round-trip");
+
+    e.set(1, std::nanf(""));
+    check(buf[1] == 0, "UInt16 set(NaN) -> 0 (no UB cast)");
+
+    e.set(2, 1.0f);
+    check(buf[2] == 65535, "UInt16 set(1.0) -> 65535");
+  }
+
+  if (g_fails == 0)
+    printf("PASS: IccSparseMatrix set() NaN-safety + UInt16 round-trip\n");
+  return g_fails ? 1 : 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -500,6 +500,48 @@ function(iccdev_add_mpecalc_matrix_overflow_test)
   endif()
 endfunction()
 
+# Guards CIccSparseMatrixUInt8::set / CIccSparseMatrixUInt16::set in IccSparseMatrix.h
+# (alerts #1061, #2260): (1) the clamp is NaN-safe -- `!(value > 0.0) ? 0` routes NaN
+# and value<=0 to 0 before the float->int cast, where the old `value < 0.0` test let a
+# NaN reach the undefined cast; (2) the UInt16 entry casts to (icUInt16Number), not the
+# truncating (icUInt8Number) that stored e.g. 0.5 as 0 into the 16-bit slot. The set()/
+# get() methods are inline, so the test exercises the shipped code; reverting either fix
+# fails an assertion.
+function(iccdev_add_sparsematrix_set_roundtrip_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccSparseMatrixSetRoundtripTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/iccsparsematrix-set-roundtrip.cpp"
+  )
+  target_link_libraries(iccSparseMatrixSetRoundtripTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccSparseMatrixSetRoundtripTest)
+
+  add_test(
+    NAME iccdev.iccsparsematrix-set-roundtrip
+    COMMAND "$<TARGET_FILE:iccSparseMatrixSetRoundtripTest>"
+  )
+  set_tests_properties(iccdev.iccsparsematrix-set-roundtrip PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 25
+    LABELS "iccdev;sparsematrix;nan;roundtrip;regression"
+  )
+  if(WIN32)
+    set(_sparsematrix_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccSparseMatrixSetRoundtripTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _sparsematrix_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.iccsparsematrix-set-roundtrip PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_sparsematrix_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # Guards CIccCmmSearch::AddXform profile ownership (#1332): the search CMM
 # rejects a NamedColor profile (no search LUT) and, like the base AddXform
 # contract (#1327), must free it.  The helper feeds a NamedColor profile through
@@ -1735,6 +1777,7 @@ if(WIN32)
   iccdev_add_pawg_q4_xyz_pcs_decode_test()
   iccdev_add_pawg_q1q3_relative_intent_test()
   iccdev_add_mpecalc_matrix_overflow_test()
+  iccdev_add_sparsematrix_set_roundtrip_test()
   iccdev_add_cmmsearch_namedcolor_ownership_test()
   iccdev_add_xform_create_tag_ownership_test()
   iccdev_add_xform_abstorel_adjust_test()
@@ -1940,6 +1983,7 @@ iccdev_add_pawg_q4_characterization_test()
 iccdev_add_pawg_q4_xyz_pcs_decode_test()
 iccdev_add_pawg_q1q3_relative_intent_test()
 iccdev_add_mpecalc_matrix_overflow_test()
+iccdev_add_sparsematrix_set_roundtrip_test()
 iccdev_add_cmmsearch_namedcolor_ownership_test()
 iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_xform_abstorel_adjust_test()

--- a/IccProfLib/IccSparseMatrix.h
+++ b/IccProfLib/IccSparseMatrix.h
@@ -105,7 +105,10 @@ public:
   CIccSparseMatrixUInt8() {}
 
   virtual icFloatNumber get(int index) const {return (icFloatNumber)m_pData[index]/255.0f;}
-  virtual void set(int index, icFloatNumber value) {m_pData[index] = value<0.0 ? 0 : (value > 1.0 ? 255 : (icUInt8Number)(value*255.0f+0.5f));}
+  // !(value > 0.0) rejects NaN and value<=0 (both -> 0) BEFORE the cast. A plain
+  // value<0.0 test lets a NaN fall through to (icUInt8Number)(NaN*255+0.5), which is
+  // undefined behavior on the float->int cast (CWE-681, alert #1061).
+  virtual void set(int index, icFloatNumber value) {m_pData[index] = !(value > 0.0) ? 0 : (value > 1.0 ? 255 : (icUInt8Number)(value*255.0f+0.5f));}
 
 };
 
@@ -115,7 +118,11 @@ public:
   CIccSparseMatrixUInt16() {}
 
   virtual icFloatNumber get(int index) const {return (icFloatNumber)m_pData[index]/65535.0f;}
-  virtual void set(int index, icFloatNumber value) {m_pData[index] = value<0.0 ? 0 : (value > 1.0 ? 65535 : (icUInt8Number)(value*65535.0f+0.5f));}
+  // Same NaN guard as the UInt8 entry (alert #2260). Also fixes a data-loss bug: the
+  // cast is (icUInt16Number), not (icUInt8Number) -- the 8-bit cast truncated the
+  // scaled value into the 16-bit slot (e.g. 0.5 -> 32768 & 0xff == 0), breaking the
+  // set()/get() round-trip against get()'s /65535.0f above.
+  virtual void set(int index, icFloatNumber value) {m_pData[index] = !(value > 0.0) ? 0 : (value > 1.0 ? 65535 : (icUInt16Number)(value*65535.0f+0.5f));}
 
 };
 


### PR DESCRIPTION
## Summary

Fixes two defects in `CIccSparseMatrixUInt8::set` / `CIccSparseMatrixUInt16::set`
(`IccProfLib/IccSparseMatrix.h`), flagged by the `iccdev/float-to-int-cast` alerts
#1061 and #2260:

1. **NaN-blind clamp (both entry types).** The old guard
   `value < 0.0 ? 0 : (value > 1.0 ? MAX : cast)` lets a `NaN` fall through *both*
   tests to `(icUInt8/16Number)(NaN * scale + 0.5)` — an undefined float→int cast
   (CWE-681). Replaced the lower test with `!(value > 0.0) ? 0`, which is `false`
   for `NaN` and for `value <= 0`, so both route to `0` before the cast. This is the
   same idiom the visualization code already uses to reject a non-finite `vs`.

2. **Truncation in the UInt16 entry (data loss).** `set()` cast the scaled value to
   `(icUInt8Number)` while storing into a 16-bit slot, so any value in `(0,1)` whose
   scaled result exceeds 255 was truncated to 8 bits before widening — e.g. `0.5`
   stored as `(icUInt8Number)32768 == 0`, which `get()` read back as `0.0`, breaking
   the `set()`/`get()` round-trip against `get()`'s `/65535.0f`. Cast is now
   `(icUInt16Number)`.

## Verification

New regression `.github/ci/regression/iccsparsematrix-set-roundtrip.cpp` exercises the
inline `set()`/`get()` directly (CTest `iccdev.iccsparsematrix-set-roundtrip`).

Local, red-green:

- With the fix: `ctest -R iccsparsematrix-set-roundtrip` passes.
- Reverting the fix: the UInt16 truncation assertions fail in any build; the `NaN`
  cast additionally traps under the ASAN+UBSAN job.
- Before/after (`value = 0.5`, UInt16): pre-fix stored raw `0` → `get() = 0.0000`;
  post-fix stores raw `32768` → `get() = 0.5000`.

## Note on the alerts

The fix makes the casts provably NaN-safe, but the guard form (`!(value > 0.0)`) is a
relational test, not an `isnan/isfinite` call, so the `float-to-int-cast` query will
not auto-clear #1061/#2260 on merge. They convert from real bugs into query-blind
false positives; I'll dismiss them with that rationale once this lands.

Refs #1061 #2260
