### PR TITLE
fix(#1724): accept registered CMM signatures + allow-list regression

### DIFF
--- a/.github/ci/regression/cmm-registry-allowlist.cpp
+++ b/.github/ci/regression/cmm-registry-allowlist.cpp
@@ -1,0 +1,88 @@
+// Regression test for the CMM-signature validation allow-list catch-up landed
+// for #1724 in IccProfLib/IccProfile.cpp (CIccProfile::CheckHeader).
+//
+// Background: PR #1473 reconciled the icCmmSignature enum and GetCmmSigName()
+// name table with registry.color.org/cmm-signatures -- it gave names to the
+// live-registry CMMs 'repr' (Reprointelligence) and 'iccd' (ICC).  But #1473 did
+// NOT add those two to the CMM allow-list switch in CheckHeader(), so
+// CIccProfile::Validate() still emitted
+//   "<name>: Unregistered CMM signature."
+// for a header whose preferred-CMM field was one of the two now-named sigs.  The
+// #1724 change adds `case icSigReprointelligence:` and `case icSigICC:` to that
+// switch (the enum value of icSigICC is 0x69636364 = ASCII 'iccd'), so the two
+// registered CMMs validate cleanly, matching the names #1473 already gave them.
+//
+// This test drives CheckHeader() directly through a minimal subclass (it reads
+// only m_Header, so no tags or profile body are needed) and asserts, per the
+// live CMM registry as re-verified on 2026-07-21:
+//   * 'repr' and 'iccd' -- registered -> must NOT warn (the #1724 fix)
+//   * 'WCS ' and 'RIMX' -- registered and already allow-listed before #1724
+//                          -> must NOT warn (guards against a regression that
+//                          drops an existing allow-list entry)
+//   * 'MSFT' -- NOT a registered CMM (it is the Microsoft *platform* signature;
+//               Microsoft's registered CMM is 'WCS ') -> must STILL warn, so the
+//               fix stayed narrow and did not blanket-accept a named-but-
+//               unregistered signature
+//   * 'ZZZZ' -- unregistered junk -> must STILL warn (negative control)
+//
+// Reverting the two-line IccProfile.cpp change flips the 'repr'/'iccd' cases from
+// no-warn to warn and fails this test.
+//
+// Exit code 0 = pass, 1 = a case regressed.
+
+#include "IccProfile.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <string>
+
+static int g_failures = 0;
+static bool check(bool cond, const char *msg) {
+  if (cond) { std::printf("ok:   %s\n", msg); }
+  else      { std::printf("FAIL: %s\n", msg); ++g_failures; }
+  return cond;
+}
+
+// CheckHeader() is protected; expose it for the test.  A default-constructed
+// CIccProfile zero-fills m_Header (cmmId 0 == icSigUnknownCmm, itself allow-
+// listed), so setting cmmId is the only field the CMM branch of CheckHeader
+// reads.  Other header fields left zero may raise unrelated warnings, but this
+// test greps only for the CMM-specific message.
+class HeaderProbe : public CIccProfile {
+public:
+  icValidateStatus RunCheckHeader(std::string &report) const {
+    return CheckHeader(report);
+  }
+};
+
+// True iff CheckHeader emits the "Unregistered CMM signature" warning for the
+// given preferred-CMM signature value.
+static bool cmmWarns(icUInt32Number cmm) {
+  HeaderProbe p;
+  p.m_Header.cmmId = cmm;
+  std::string report;
+  p.RunCheckHeader(report);
+  return report.find("Unregistered CMM signature") != std::string::npos;
+}
+
+int main() {
+  // The #1724 fix: two registered CMMs that #1473 named but left warning.
+  check(!cmmWarns(icSigReprointelligence), "'repr' (registered) validates without CMM warning");
+  check(!cmmWarns(icSigICC),               "'iccd' (registered) validates without CMM warning");
+
+  // Already allow-listed before #1724 -- present here to catch a regression that
+  // drops an existing accepted signature.
+  check(!cmmWarns(icSigWindowsCMS),        "'WCS ' (registered) still validates without CMM warning");
+  check(!cmmWarns(icSigRefIccMAX),         "'RIMX' (registered) still validates without CMM warning");
+
+  // Must still warn: 'MSFT' is the Microsoft platform signature, not a
+  // registered CMM, so the fix deliberately does not accept it.
+  check(cmmWarns(icSigMicrosoftCMM),       "'MSFT' (platform sig, not a registered CMM) still warns");
+
+  // Negative control: unregistered junk must still warn.
+  check(cmmWarns(0x5A5A5A5A /* 'ZZZZ' */), "'ZZZZ' (unregistered) still warns");
+
+  if (g_failures) { std::printf("\n%d check(s) FAILED\n", g_failures); return 1; }
+  std::printf("\nall checks passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -314,6 +314,49 @@ function(iccdev_add_pawg_q4_xyz_pcs_decode_test)
   endif()
 endfunction()
 
+# Guards the CMM-signature validation allow-list catch-up landed for #1724 in
+# CIccProfile::CheckHeader (IccProfLib/IccProfile.cpp).  PR #1473 named the live-
+# registry CMMs 'repr' and 'iccd' but left them out of CheckHeader's accept-list,
+# so Validate() still warned "Unregistered CMM signature" for them.  This test
+# drives CheckHeader directly and pins: 'repr'/'iccd' (and the already-listed
+# 'WCS '/'RIMX') validate without a CMM warning, while 'MSFT' (a platform sig,
+# not a registered CMM) and unregistered junk still warn.  Core IccProfLib only,
+# so no extra include dirs are needed.
+function(iccdev_add_cmm_registry_allowlist_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCmmRegistryAllowlistTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/cmm-registry-allowlist.cpp"
+  )
+  target_link_libraries(iccCmmRegistryAllowlistTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccCmmRegistryAllowlistTest)
+
+  add_test(
+    NAME iccdev.cmm-registry-allowlist
+    COMMAND "$<TARGET_FILE:iccCmmRegistryAllowlistTest>"
+  )
+  set_tests_properties(iccdev.cmm-registry-allowlist PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;pawg;cmm;registry;regression"
+  )
+  if(WIN32)
+    set(_cmm_allowlist_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCmmRegistryAllowlistTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _cmm_allowlist_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.cmm-registry-allowlist PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_cmm_allowlist_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # Guards iccPawgReport's Q2 curve-invertibility scope (#1458): the round-trip
 # inverse-error metric must apply to tone-reproduction curves (rTRC/gTRC/bTRC/
 # kTRC) only, not to LUT A/B/M shaper curves.  A B2A output shaper curve
@@ -1734,6 +1777,7 @@ if(WIN32)
   iccdev_add_pawg_q4_characterization_test()
   iccdev_add_pawg_q4_xyz_pcs_decode_test()
   iccdev_add_pawg_q1q3_relative_intent_test()
+  iccdev_add_cmm_registry_allowlist_test()
   iccdev_add_mpecalc_matrix_overflow_test()
   iccdev_add_cmmsearch_namedcolor_ownership_test()
   iccdev_add_xform_create_tag_ownership_test()
@@ -1939,6 +1983,7 @@ iccdev_add_pawg_q2_tonecurves_test()
 iccdev_add_pawg_q4_characterization_test()
 iccdev_add_pawg_q4_xyz_pcs_decode_test()
 iccdev_add_pawg_q1q3_relative_intent_test()
+iccdev_add_cmm_registry_allowlist_test()
 iccdev_add_mpecalc_matrix_overflow_test()
 iccdev_add_cmmsearch_namedcolor_ownership_test()
 iccdev_add_xform_create_tag_ownership_test()

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -1986,6 +1986,8 @@ icValidateStatus CIccProfile::CheckHeader(std::string &sReport, const CIccProfil
     case icSigWareToGo:
     case icSigZoran:
     case icSigOnyxGraphics:
+    case icSigReprointelligence:
+    case icSigICC:
       break;
 
     default:
@@ -3197,7 +3199,7 @@ bool CIccProfile::CheckFileSize(CIccIO *pIO) const
  ****************************************************************************
  * Name: CIccProfile::CheckTagLayout
  *
- * Purpose: Validate the structural layout of the tag table — areas the header
+ * Purpose: Validate the structural layout of the tag table - areas the header
  *  and per-tag checks do not cover: padding between tags (which must be no more
  *  than three zero bytes), overlapping tag data, and unused data after the last
  *  tag. These are non-critical: the profile is usable, but its layout deviates

--- a/Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md
+++ b/Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md
@@ -39,43 +39,46 @@ reject, while still warning on signatures absent from the registry (see section 
 
 ---
 
-## B. CMM signature field - RESOLVED by the issue-1724 IccProfLib update
+## B. CMM signature field
 
 S3's CMM check uses `CIccInfo::GetCmmSigName()` (IccProfLib/IccUtil.cpp) and
-warns when it returns an "Unknown..." name. Issue #1724 carries the follow-up
-IccProfLib update requested by the #1459 review: the core CMM enum, name table,
-and profile validation allow-list now match the live CMM registry rows described
-below. No PawgReport-local CMM table was added; S3 continues to consume the core
-IccProfLib lookup.
+warns when it returns an "Unknown..." name. Two rounds of IccProfLib work bring
+the core CMM enum, name table, and profile-validation allow-list into agreement
+with the live CMM registry. No PawgReport-local CMM table was added; S3 continues
+to consume the core IccProfLib lookup.
 
-### B1. Enum entries with no `GetCmmSigName()` case - fixed
-The `icCmmSignature` enum (icProfileHeader.h, "as of Mar 6, 2018") defines these,
-but `GetCmmSigName()` had no `case` for them, so S3 reported them Unknown. The
-issue-1724 update adds both name-table cases and keeps the existing enum values:
+### B1/B2/B3 - RESOLVED by PR #1473 (enum + name table)
 
-| Enum | Value | ASCII |
-|------|-------|-------|
-| `icSigWindowsCMS`   | `0x57435320` | `WCS ` |
-| `icSigOnyxGraphics` | `0x4F4E5958` | `ONYX` |
+PR #1473 ("Reconcile icCmmSignature enum + GetCmmSigName with the CMM registry")
+already reconciled the enum values and `GetCmmSigName()` name-table cases with
+registry.color.org/cmm-signatures. Recorded here for completeness; **no code for
+these rows ships in the issue-1724 change** - they were verified present in
+`master` before this report:
 
-### B2. Live CMM registry entries absent from the IccProfLib enum - fixed
-These registry.color.org/cmm-signatures entries were present in the live CMM
-registry but absent from the enum snapshot. The issue-1724 update adds enum and
-`GetCmmSigName()` coverage for all three, and `CIccProfile::Validate()` now
-accepts `repr` and `iccd` as registered CMM signatures:
+- **B1 - name-table cases added.** `icSigWindowsCMS` (`0x57435320` `WCS `) and
+  `icSigOnyxGraphics` (`0x4F4E5958` `ONYX`) had enum entries but no
+  `GetCmmSigName()` `case`; #1473 added the names.
+- **B2 - registry entries added to the enum + names.** `RIMX` (`0x52494D58`,
+  ICC/RefIccMAX), `iccd` (`0x69636364`, ICC) and `repr` (`0x72657072`,
+  Reprointelligence) were absent from the enum snapshot; #1473 added enum values
+  and `GetCmmSigName()` coverage for all three.
+- **B3 - latent value/comment mismatch corrected.** `icSigRefIccMAX` had value
+  `0x52494343` (ASCII `RICC`) while its comment and the registry said
+  `RIMX = 0x52494D58`; #1473 changed the value to `0x52494D58` to match.
 
-| Value | ASCII | Vendor |
-|-------|-------|--------|
-| `0x52494D58` | `RIMX` | ICC (RefIccMAX) |
-| `0x69636364` | `iccd` | ICC |
-| `0x72657072` | `repr` | Reprointelligence |
+### B4. Validation allow-list catch-up - the issue-1724 change
 
-### B3. Latent value/comment mismatch - fixed
-`icSigRefIccMAX = 0x52494343` (= ASCII `RICC`) but its comment says `/* 'RIMX' */`,
-and the registry lists RefIccMAX's CMM signature as `RIMX = 0x52494D58`. The enum
-*value* and the registry disagreed. The issue-1724 update changes
-`icSigRefIccMAX` to `0x52494D58` (RIMX), matching the registry and the existing
-comment.
+#1473 named `repr`/`iccd` but did **not** add them to the CMM allow-list in
+`CIccProfile::CheckHeader()`, so `CIccProfile::Validate()` still emitted
+"Unregistered CMM signature" for the two (now-named) sigs. The issue-1724 change
+is exactly this two-line catch-up: it adds `case icSigReprointelligence:` and
+`case icSigICC:` to that switch so `repr` and `iccd` validate cleanly, matching
+the names #1473 gave them. (`WCS `/`ONYX`/`RIMX`/`ICCD` were already allow-listed.)
+All four registry memberships were re-verified against
+registry.color.org/cmm-signatures on 2026-07-21: `repr`, `iccd`, `RIMX`, `WCS `
+and `ONYX` are registered; `MSFT` is **not** a registered CMM (it is a platform
+signature), so `icSigMicrosoftCMM` is deliberately left out of the allow-list and
+still warns.
 
 **Permissiveness direction:** this is a targeted correction for registered CMM
 signatures. Unknown or unregistered CMM signatures still warn.

--- a/Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md
+++ b/Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md
@@ -13,19 +13,19 @@ three-component (RGB) color encoding registry, colorimetry data, profile library
 
 ---
 
-## A. Manufacturer / creator header fields — RESOLVED by the #1459 S3 fix
+## A. Manufacturer / creator header fields - RESOLVED by the #1459 S3 fix
 
 **Defect:** S3 validated the header `manufacturer` and `creator` fields against
-the registered *private tag-signature ranges* (`FindRegisteredPrivateTag`) — the
-wrong registry. ICC.1:2022-05 §7.2.17 requires these fields to match a signature
+the registered *private tag-signature ranges* (`FindRegisteredPrivateTag`) - the
+wrong registry. ICC.1:2022-05 section 7.2.17 requires these fields to match a signature
 in the **device manufacturer** section of the ICC signature registry (the
 Manufacturer Signatures registry), or be zero.
 
 **Magnitude:** of the **279** signatures in the Manufacturer Signatures registry,
-**271** fall in *no* private tag-signature range — i.e. the old code would have
+**271** fall in *no* private tag-signature range - i.e. the old code would have
 emitted a false "unregistered" S3 warning for 271 of 279 legitimately registered
 manufacturers. Worked example from the issue: `KODA` (Kodak, `0x4B4F4441`) is in
-the Manufacturer Signatures registry but in no private-tag range → false warn
+the Manufacturer Signatures registry but in no private-tag range -> false warn
 before, OK after.
 
 **Fix:** new exact-match `kIccManufacturerSignatures[]` table + a dedicated
@@ -34,29 +34,35 @@ through it. The private-tag table is unchanged and still (correctly) attributes
 private tags found in a profile *body* (`AssessPrivateTags`, checks S11/C6).
 
 **Permissiveness direction:** the fix makes S3 *more correct*, not blanket more
-permissive — it accepts the 271 genuinely-registered manufacturers it used to
-reject, while still warning on signatures absent from the registry (see §D).
+permissive - it accepts the 271 genuinely-registered manufacturers it used to
+reject, while still warning on signatures absent from the registry (see section D).
 
 ---
 
-## B. CMM signature field — DEFERRED (separate IccProfLib PR)
+## B. CMM signature field - RESOLVED by the issue-1724 IccProfLib update
 
 S3's CMM check uses `CIccInfo::GetCmmSigName()` (IccProfLib/IccUtil.cpp) and
-warns when it returns an "Unknown…" name. Two independent gaps, both in core
-IccProfLib (not PawgReport-local), so they are **flagged here only** and proposed
-for a separate PR per the #1459 plan:
+warns when it returns an "Unknown..." name. Issue #1724 carries the follow-up
+IccProfLib update requested by the #1459 review: the core CMM enum, name table,
+and profile validation allow-list now match the live CMM registry rows described
+below. No PawgReport-local CMM table was added; S3 continues to consume the core
+IccProfLib lookup.
 
-### B1. Enum entries with no `GetCmmSigName()` case → false WARN
+### B1. Enum entries with no `GetCmmSigName()` case - fixed
 The `icCmmSignature` enum (icProfileHeader.h, "as of Mar 6, 2018") defines these,
-but `GetCmmSigName()` has no `case` for them, so S3 reports them Unknown:
+but `GetCmmSigName()` had no `case` for them, so S3 reported them Unknown. The
+issue-1724 update adds both name-table cases and keeps the existing enum values:
 
 | Enum | Value | ASCII |
 |------|-------|-------|
 | `icSigWindowsCMS`   | `0x57435320` | `WCS ` |
 | `icSigOnyxGraphics` | `0x4F4E5958` | `ONYX` |
 
-### B2. Live CMM registry entries absent from the IccProfLib enum → WARN
-Present in registry.color.org/cmm-signatures (30 rows) but not in the enum:
+### B2. Live CMM registry entries absent from the IccProfLib enum - fixed
+These registry.color.org/cmm-signatures entries were present in the live CMM
+registry but absent from the enum snapshot. The issue-1724 update adds enum and
+`GetCmmSigName()` coverage for all three, and `CIccProfile::Validate()` now
+accepts `repr` and `iccd` as registered CMM signatures:
 
 | Value | ASCII | Vendor |
 |-------|-------|--------|
@@ -64,41 +70,39 @@ Present in registry.color.org/cmm-signatures (30 rows) but not in the enum:
 | `0x69636364` | `iccd` | ICC |
 | `0x72657072` | `repr` | Reprointelligence |
 
-### B3. Latent value/comment mismatch (discovered while diffing)
+### B3. Latent value/comment mismatch - fixed
 `icSigRefIccMAX = 0x52494343` (= ASCII `RICC`) but its comment says `/* 'RIMX' */`,
 and the registry lists RefIccMAX's CMM signature as `RIMX = 0x52494D58`. The enum
-*value* and the registry disagree. Flagging for a maintainer decision — likely
-the value should be `0x52494D58` (RIMX) — but this changes a public enum constant
-and must be a deliberate IccProfLib change, not part of the PawgReport fix.
+*value* and the registry disagreed. The issue-1724 update changes
+`icSigRefIccMAX` to `0x52494D58` (RIMX), matching the registry and the existing
+comment.
 
-> **Decision requested:** do you want a follow-up IccProfLib PR that (a) adds the
-> missing `GetCmmSigName()` cases for WCS/ONYX, (b) extends the enum with the 3
-> live-only CMMs, and (c) reconciles the RefIccMAX value/comment? None of this is
-> done here.
+**Permissiveness direction:** this is a targeted correction for registered CMM
+signatures. Unknown or unregistered CMM signatures still warn.
 
 ---
 
-## C. Private tag-signature ranges — refreshed (data only)
+## C. Private tag-signature ranges - refreshed (data only)
 
 The private-tag range table was regenerated from registry.color.org/tag-signatures
 (non-ICC rows). Prior in-source table: **171** ranges; live snapshot: **174**.
 Differences are minor and data-only (the code path is unchanged):
 
-- Adobe `AS00` narrowed from range `0x41533030–0x41533939` to the single
+- Adobe `AS00` narrowed from range `0x41533030-0x41533939` to the single
   signature `0x41533030` (registry now lists only `AS00`).
-- X-Rite `gbd0` expanded from range `0x67626430–0x67626433` to four explicit
+- X-Rite `gbd0` expanded from range `0x67626430-0x67626433` to four explicit
   single signatures `gbd0`,`gbd1`,`gbd2`,`gbd3`.
 
 Net effect on attribution is negligible; no behavioral flag.
 
 ---
 
-## D. Known still-warns (by design) — governance, not code
+## D. Known still-warns (by design) - governance, not code
 
 Some signatures appear in ICC-*published* and widely-used profiles yet are absent
 from the online Manufacturer Signatures registry, so S3 correctly continues to
 warn until the ICC adds/clarifies them. These require registry submission or a
-policy decision (ICC governance), not a strictness change — tracked as **Segment A**
+policy decision (ICC governance), not a strictness change - tracked as **Segment A**
 of #1459 (see `GOVERNANCE_SUBMISSIONS.md`). Found by validating a 95-profile local
 corpus with the #1459-fixed tool:
 
@@ -114,15 +118,15 @@ corpus with the #1459-fixed tool:
 distinct unregistered one.)
 
 **Code behavior (per #1459 review decision):** S3 still WARNs on all of the above
-(spec-correct under §7.2.17). For the two pervasive conventions `'none'` and
+(spec-correct under section 7.2.17). For the two pervasive conventions `'none'` and
 `'ICC '`, the WARN wording is *softened* (via `KnownUnregisteredConventionNote`)
 to identify them as known placeholders/consortium signatures rather than suspect
-data — but the verdict stays WARN and nothing is silently accepted. The other
+data - but the verdict stays WARN and nothing is silently accepted. The other
 sigs keep the plain "not in Manufacturer Signatures registry" wording.
 
 ---
 
-## E. Phase P2 (live registry check) — noted, not implemented
+## E. Phase P2 (live registry check) - noted, not implemented
 
 A pluggable live check against registry.color.org is recorded as a possible
 future direction only. The registries change extremely slowly, and a live query


### PR DESCRIPTION
**Resolves #1724.** Completes the Pawg Delta Report CMM-signature work off the staged `issue-1724` branch (@xsscx handoff).

### CMM allow-list catch-up (b37bad92, @xsscx)
Adds `icSigReprointelligence` + `icSigICC` to the CMM allow-list in `CIccProfile::CheckHeader` so the two registered CMMs `repr`/`iccd` — which #1473 already *named* but left out of the accept-list — stop emitting `"Unregistered CMM signature"` in `Validate()`. B1/B2/B3 in the report (the enum values + `GetCmmSigName()` names) landed earlier in **#1473** and are already in `master`; this PR's code delta is only the two-line allow-list catch-up (report §B4).

### Regression test (fa36ba2c)
New `.github/ci/regression/cmm-registry-allowlist.cpp` → CTest `iccdev.cmm-registry-allowlist`. Drives `CheckHeader` directly (reads only `m_Header`, no profile body) and pins:
- `repr`, `iccd` — registered → **no** CMM warning (the fix)
- `WCS `, `RIMX` — registered, already allow-listed → **no** warning (guards against dropping an existing entry)
- `MSFT` — the Microsoft *platform* signature, **not** a registered CMM → **still warns** (keeps the fix narrow)
- `ZZZZ` — unregistered → **still warns** (negative control)

Red-green verified locally: reverting the two `IccProfile.cpp` lines fails exactly the `repr`/`iccd` checks; the controls stay correct.

### Report accuracy
`PERMISSIVENESS_DELTAS.md` §B reworded — it previously credited the enum/name-table work to "the issue-1724 update"; that was #1473. §B now attributes B1/B2/B3 to #1473 and scopes issue-1724 to the allow-list catch-up (§B4), and records the CMM registry re-verification (2026-07-21): `repr`/`iccd`/`RIMX`/`WCS `/`ONYX` registered, `MSFT` deliberately excluded.
