### PR TITLE
fix(#1723): correct compressed-tag Describe labelling + compression-paths cross-check

### DIFF
--- a/.github/ci/regression/compression-describe-labels.cpp
+++ b/.github/ci/regression/compression-describe-labels.cpp
@@ -1,0 +1,110 @@
+// Regression: compressed-tag Describe() labelling (#1723 Compression Paths).
+//
+// Two output-only defects on the compression dump path, both in IccTagBasic.cpp:
+//
+//  1. CIccTagData::Describe() appended a "Compressed " marker for a
+//     compressed-flagged data tag, then the very next line reassigned
+//     sDescription with `=` (the data-kind label), silently discarding the
+//     marker. So a compressed data tag was never labelled "Compressed" in any
+//     dump, on either an ICC_USE_ZLIB or a no-zlib build (Describe does not
+//     inflate; it only formats m_pData). The fix appends the label instead of
+//     overwriting. This assertion is zlib-agnostic.
+//
+//  2. CIccTagZipUtf8Text::Describe() on a *no-zlib* build emitted the marker
+//     "BEGIN_COMPESSED_DATA[\"" (missing the R, and an unbalanced ["...]
+//     delimiter) while the closing line spelled "END_COMPRESSED_DATA". The fix
+//     spells it "BEGIN_COMPRESSED_DATA" and balances the quotes. That branch is
+//     compiled out when ICC_USE_ZLIB is defined, so the string assertion below
+//     is guarded to the no-zlib configuration; in a zlib build only defect (1)
+//     is exercised.
+//
+// Building the tags in memory (SetDataType/SetSize/GetData) needs no zlib, so
+// this test runs in every build configuration.
+//
+// Exit code 0 = pass, 1 = a case regressed.
+#include "IccTag.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+static int g_fail = 0;
+#define CHECK(c) do { if(!(c)){ std::printf("FAIL line %d: %s\n", __LINE__, #c); g_fail=1; } } while(0)
+
+// True iff `haystack` contains `needle`.
+static bool has(const std::string &haystack, const char *needle) {
+  return haystack.find(needle) != std::string::npos;
+}
+
+int main()
+{
+  // ---- Defect 1: the "Compressed " marker must survive into the dump ----------
+  // A compressed *binary* data tag: IsTypeCompressed() and IsTypeBinary() are both
+  // true (icCompressedData is a bit above icDataTypeMask).
+  {
+    CIccTagData tag;
+    tag.SetDataType(icCompressedBinaryData);   // icCompressedData | icBinaryData
+    CHECK(tag.IsTypeCompressed());
+    CHECK(tag.IsTypeBinary());
+    CHECK(tag.SetSize(4, false));
+    tag[0] = 0xde; tag[1] = 0xad; tag[2] = 0xbe; tag[3] = 0xef;
+
+    std::string d;
+    tag.Describe(d, 100);
+    CHECK(has(d, "Compressed"));       // the marker that used to be clobbered
+    CHECK(has(d, "Binary Data:"));     // the data-kind label still present
+  }
+
+  // A compressed *ascii* data tag must likewise be labelled "Compressed".
+  {
+    CIccTagData tag;
+    tag.SetDataType(icCompressedAsciiData);    // icCompressedData | icAsciiData
+    CHECK(tag.IsTypeCompressed());
+    CHECK(tag.IsTypeAscii());
+    CHECK(tag.SetSize(3, false));
+    tag[0] = 'a'; tag[1] = 'b'; tag[2] = 'c';
+
+    std::string d;
+    tag.Describe(d, 100);
+    CHECK(has(d, "Compressed"));
+    CHECK(has(d, "Ascii Data:"));
+  }
+
+  // Control: an *uncompressed* data tag must NOT be labelled "Compressed".
+  {
+    CIccTagData tag;
+    tag.SetDataType(icBinaryData);
+    CHECK(!tag.IsTypeCompressed());
+    CHECK(tag.SetSize(2, false));
+    tag[0] = 0x00; tag[1] = 0x01;
+
+    std::string d;
+    tag.Describe(d, 100);
+    CHECK(!has(d, "Compressed"));
+    CHECK(has(d, "Binary Data:"));
+  }
+
+  // ---- Defect 2: no-zlib zut8/zxml marker is spelled/balanced correctly --------
+#ifndef ICC_USE_ZLIB
+  {
+    // On a no-zlib build, Describe() dumps the raw compressed bytes wrapped in a
+    // BEGIN_COMPRESSED_DATA["<n>"] ... END_COMPRESSED_DATA marker.
+    CIccTagZipUtf8Text tag;
+    std::string d;
+    tag.Describe(d, 100);
+    CHECK(has(d, "BEGIN_COMPRESSED_DATA"));   // was the typo "BEGIN_COMPESSED_DATA"
+    CHECK(has(d, "END_COMPRESSED_DATA"));
+    CHECK(!has(d, "COMPESSED"));              // the misspelling must be gone
+  }
+#else
+  std::printf("note: ICC_USE_ZLIB set; defect-2 (no-zlib marker) branch not exercised\n");
+#endif
+
+  if (g_fail) {
+    std::printf("RESULT: FAIL\n");
+    return 1;
+  }
+  std::printf("RESULT: PASS (compressed-tag Describe labelling invariants held)\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1511,6 +1511,50 @@ function(iccdev_add_parser_restore_calls_test)
   endif()
 endfunction()
 
+# Compressed-tag Describe() labelling (#1723 Compression Paths). Two output-only
+# defects: CIccTagData::Describe() dropped the "Compressed " marker (a following
+# `=` assignment overwrote it), and the no-zlib CIccTagZipUtf8Text::Describe()
+# marker was misspelled "COMPESSED" with an unbalanced delimiter. Unlike the
+# #1521/#1743 zlib tests this needs no deflate/inflate -- the tags are built in
+# memory and only their dump strings are inspected -- so it is NOT gated on
+# ICC_USE_ZLIB and runs in every configuration (the defect-2 assertion inside the
+# test self-gates to no-zlib builds).
+function(iccdev_add_compression_describe_labels_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCompressionDescribeLabelsTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/compression-describe-labels.cpp"
+  )
+  target_compile_features(iccCompressionDescribeLabelsTest PRIVATE cxx_std_17)
+  target_link_libraries(iccCompressionDescribeLabelsTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccCompressionDescribeLabelsTest)
+
+  add_test(
+    NAME iccdev.compression-describe-labels
+    COMMAND "$<TARGET_FILE:iccCompressionDescribeLabelsTest>"
+  )
+  set_tests_properties(iccdev.compression-describe-labels PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;tag;compression;issue-1723;regression"
+  )
+  if(WIN32)
+    set(_compression_describe_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCompressionDescribeLabelsTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _compression_describe_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.compression-describe-labels PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_compression_describe_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_windows_iccdevcmm_smoke_test)
   if(NOT WIN32 OR NOT TARGET RefIccMAX)
     return()
@@ -1728,6 +1772,7 @@ if(WIN32)
   iccdev_add_fileio_seek_tell_test()
   iccdev_add_tagdata_zlib_roundtrip_test()
   iccdev_add_ziputf8_settext_contract_test()
+  iccdev_add_compression_describe_labels_test()
   iccdev_add_parser_restore_calls_test()
   iccdev_add_tag_layout_shared_data_test()
   iccdev_add_pawg_q2_tonecurves_test()
@@ -1933,6 +1978,7 @@ iccdev_add_profile_write_failure_test()
 iccdev_add_fileio_seek_tell_test()
 iccdev_add_tagdata_zlib_roundtrip_test()
 iccdev_add_ziputf8_settext_contract_test()
+iccdev_add_compression_describe_labels_test()
 iccdev_add_parser_restore_calls_test()
 iccdev_add_tag_layout_shared_data_test()
 iccdev_add_pawg_q2_tonecurves_test()

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -1471,9 +1471,13 @@ void CIccTagZipUtf8Text::Describe(std::string &sDescription, int /* nVerboseness
   const size_t sizeSize = 30;
   char size[sizeSize];
   snprintf(size, sizeSize, "%u", (unsigned int) m_nBufSize);
-  sDescription += "BEGIN_COMPESSED_DATA[\"";
+  // Marker spelled "COMPRESSED" (was the typo "COMPESSED") to match the
+  // END_COMPRESSED_DATA line below, and the ["..."] delimiter is balanced so the
+  // byte count is quoted symmetrically. This no-zlib branch dumps the raw
+  // compressed bytes as hex because the CMM cannot inflate them here.
+  sDescription += "BEGIN_COMPRESSED_DATA[\"";
   sDescription += size;
-  sDescription += "]\n";
+  sDescription += "\"]\n";
   if (m_nBufSize) {
     icMemDump(str, m_pZipBuf, m_nBufSize);
     sDescription += str;
@@ -8986,23 +8990,27 @@ void CIccTagData::Describe(std::string &sDescription, int /* nVerboseness */)
   if (IsTypeCompressed())
     sDescription += "Compressed ";  // If data is compressed, prepend appropriate text
 
+  // Each branch below must append (+=) rather than assign (=): assigning would
+  // overwrite the leading newline and, more importantly, the "Compressed " marker
+  // set just above, so a compressed data tag would never be labelled as such in
+  // any dump. Keep the "\n"/"Compressed " prefix and add the data-kind label to it.
   if (IsTypeAscii()) {
-    sDescription = "Ascii Data:\n";
+    sDescription += "Ascii Data:\n";
 
     for (int i=0; i<(int)m_nSize; i++)
       sDescription += (icChar)m_pData[i];
   }
   else if (IsTypeUtf()) {
-    if (m_nSize>2 && 
+    if (m_nSize>2 &&
         ((m_pData[0]==0xff && m_pData[1]==0xfe) ||  //UTF-16LE
          (m_pData[0]==0xfe && m_pData[1]==0xff))) { //UTF-16BE
       snprintf(buf, bufSize, "UTF-16%s Data:", m_pData[0]==0xff ? "LE" : "BE" );
-      sDescription = buf;
+      sDescription += buf;
 
       icMemDump(sDescription, m_pData, m_nSize);
     }
     else { //UTF-8
-      sDescription = "UTF-8 Data:\n";
+      sDescription += "UTF-8 Data:\n";
 
       for (int i=0; i<(int)m_nSize; i++)
         sDescription += (icChar)m_pData[i];
@@ -9010,10 +9018,10 @@ void CIccTagData::Describe(std::string &sDescription, int /* nVerboseness */)
   }
   else {
     if (IsTypeBinary()) {
-      sDescription = "Binary Data:\n";
+      sDescription += "Binary Data:\n";
     }
     else {
-      sDescription = "Other Data:\n";
+      sDescription += "Other Data:\n";
     }
 
     icMemDump(sDescription, m_pData, m_nSize);

--- a/Tools/CmdLine/IccPawgReport/registry/COMPRESSION_PATHS.md
+++ b/Tools/CmdLine/IccPawgReport/registry/COMPRESSION_PATHS.md
@@ -1,0 +1,150 @@
+# Compression-paths cross-check (issue #1723)
+
+Cross-check of every zlib-backed "compression path" in iccDEV — the compressed
+ICC tag types and the CLI tools / PAWG report that touch them — prompted by the
+#1722 diagnostic scan (which surfaced `zip` / `compressed` / `created` messages
+across the profile corpus) and xsscx's #1723 notes:
+
+> 1. CLI Tools need cross-check for Compression Paths
+> 2. Pawg Code Path — Missing — Rev.A didn't contemplate Compression
+
+Two concrete defects were found and fixed (section C); the PAWG gap in note 2 is
+substantiated and recorded as **flag-and-wait** (section D) because what the
+report *should say* about a compressed tag is a maintainer design decision, not a
+mechanical correction.
+
+---
+
+## A. The compression surface
+
+iccDEV has exactly three compressed tag representations, all zlib/DEFLATE and all
+compiled behind `ICC_USE_ZLIB`:
+
+| Type | Signature | Class | Payload |
+|------|-----------|-------|---------|
+| zipUtf8Text | `zut8` `0x7a757438` | `CIccTagZipUtf8Text` | DEFLATE-compressed UTF-8 text |
+| zipXml | `zxml` `0x7a786d6c`, `ZXML` `0x5a584d4c` (X-Rite CxF) | `CIccTagZipXml` (subclass of the above) | DEFLATE-compressed XML |
+| data (compressed) | `data` `0x64617461` + `icCompressedData` flag `0x00010000` | `CIccTagData` | DEFLATE-compressed byte block |
+
+`CIccTagZipXml` adds no compression code of its own — it inherits the whole
+inflate/deflate implementation from `CIccTagZipUtf8Text` and only overrides the
+type signature. XML/JSON mirrors (`CIccTagXmlZipUtf8Text` etc.) round-trip the raw
+compressed bytes as hex and need **no** zlib.
+
+---
+
+## B. Build split — the source of two-mode behaviour
+
+`ICC_USE_ZLIB` has two independent defaults:
+
+- **Header default: OFF** — `IccProfLib/IccProfLibConf.h:187` ships
+  `//#define ICC_USE_ZLIB` commented out. Any consumer that compiles IccProfLib
+  *without* CMake (raw source include) gets the no-zlib path.
+- **CMake option: ON** — `Build/Cmake/CMakeLists.txt:514`
+  `option(ICC_USE_ZLIB "Enable zlib-backed compressed ICC text tags" ON)`, applied
+  as a **PUBLIC** compile definition to both IccProfLib targets
+  (`Build/Cmake/IccProfLib/CMakeLists.txt:183`,`234`). Every CLI tool and
+  regression binary built through CMake therefore inherits `ICC_USE_ZLIB=1`.
+
+Behaviour of each path with zlib **on** vs **off**:
+
+| Operation | zlib on | zlib off |
+|-----------|---------|----------|
+| `zut8`/`zxml` Read/Write | raw compressed bytes stored/written verbatim (no inflate on Read) | identical — passthrough, lossless |
+| `zut8`/`zxml` `GetText`/`SetText` | inflate / deflate | return `false` (no text available) |
+| `zut8`/`zxml` `Describe` | decompressed string | hex dump wrapped in `BEGIN_COMPRESSED_DATA["<n>"]` … `END_COMPRESSED_DATA` |
+| `zut8`/`zxml` `Validate` | flags corrupt / faulty-XML-encoded data | Warning "Zip compression not supported by CMM" |
+| `data` (compressed) Read/Write | inflate in place / re-deflate (256 MB cap, CWE-400 guard) | passthrough — raw compressed bytes retained, lossless |
+| `data` `Describe`/`Validate` | labelled/validated (256 MB cap) | same, minus decompression |
+
+Net: profile *bytes* survive a no-zlib build losslessly (Read/Write are
+passthrough); only the *decoded view* (`GetText`/`Describe` content) is
+unavailable without zlib.
+
+---
+
+## C. CLI-tool cross-check + defects fixed
+
+**The CLI tools are type-agnostic.** No tool (`iccDumpProfile`, `IccToXml`,
+`iccApplyProfiles`, `IccPawgReport`) switches on `zut8`/`zxml`/`data` signatures;
+they dispatch through the tag factory to the virtual `Describe()`/`Validate()`.
+`iccDumpProfile` prints the type name via `GetTagTypeSigName()` and dumps content
+via `Describe()`, so a compressed tag is decompressed-and-dumped when built with
+zlib and hex-dumped otherwise — there is no "Unknown tag type" fallthrough for
+these registered types. (The only `compress` references in `iccApplyProfiles` /
+`TiffImg` are TIFF LZW *image* compression, unrelated to zlib tag compression.)
+
+The two defects were therefore in the **library dump code**, not the tools:
+
+- **C1 — `CIccTagData::Describe()` dropped the "Compressed" label**
+  (`IccProfLib/IccTagBasic.cpp`). The method appended `"Compressed "` for a
+  compressed-flagged tag, then every data-kind branch reassigned the string with
+  `=` (e.g. `sDescription = "Binary Data:\n";`), overwriting the marker. A
+  compressed data tag was thus **never** labelled as compressed in any dump, on
+  either build. Fixed by appending (`+=`) the data-kind label so the
+  `"\n"`/`"Compressed "` prefix survives. Build-independent.
+
+- **C2 — no-zlib `CIccTagZipUtf8Text::Describe()` marker malformed**
+  (`IccProfLib/IccTagBasic.cpp`). The opening marker read
+  `BEGIN_COMPESSED_DATA["` (missing the R, and an unbalanced `["…]` delimiter)
+  while the closing marker correctly read `END_COMPRESSED_DATA`. Fixed to
+  `BEGIN_COMPRESSED_DATA["<n>"]` (correct spelling, balanced quotes). This branch
+  is compiled out under `ICC_USE_ZLIB`.
+
+Both are output/formatting only — no change to parsing, validation verdicts, or
+on-disk bytes.
+
+**Regression:** `.github/ci/regression/compression-describe-labels.cpp`
+(CTest `iccdev.compression-describe-labels`) builds compressed `data` tags in
+memory and asserts the `"Compressed"` label survives (C1, plus an uncompressed
+control that must *not* be labelled), and asserts the corrected no-zlib marker
+spelling/balance (C2, self-gated to no-zlib builds). It needs no deflate/inflate,
+so — unlike the zlib-gated #1521/#1743 tests — it runs in **every** configuration.
+
+---
+
+## D. PAWG code path — compression un-contemplated (flag-and-wait)
+
+xsscx's note 2 is **substantiated**. `IccPawgReport` has no compression-specific
+logic anywhere (`IccPawgReport.cpp`, `PawgReport.cpp`, `IccQualityMetrics.h`,
+`IccSignatureRegistry.h`): a search for `zut8`/`zxml`/`icSigDataType`/
+`icCompressedData`/`deflate`/`inflate`/`compress` matches only prose comments
+about *gamut* compression.
+
+A compressed tag reaches the report only **indirectly**:
+
+- `TagTypeAllowedVerdict()` (`PawgReport.cpp:1324`) delegates entirely to
+  `CIccProfile::Validate()` — no tag-TYPE enumeration of its own. `Validate`
+  already *accepts* `zut8`/`zxml` for the CharTarget and CxF tags
+  (`IccProfile.cpp:2491`,`2570`), so compressed tags are not rejected.
+- `TagValueEncodingVerdict()` (`PawgReport.cpp:1283`) calls each tag's
+  `Validate()`. For a `zut8`/`zxml` tag on a no-zlib PAWG build this surfaces only
+  the generic "Zip compression not supported by CMM" Warning, not a content
+  assessment; a compressed `data` tag gets no compression-specific validation at
+  all.
+- Known-vs-unknown classification (`IsSpecTag`, `AssessPrivateTags`) keys off tag
+  **signature** names, never tag **type** — so the compressed nature of a tag
+  never enters PAWG's own classification.
+
+**What is NOT decided here:** whether PAWG should emit a dedicated note/verdict
+for a compressed tag (e.g. "tag X is DEFLATE-compressed; CMM zlib support
+required to assess content"), and whether a compressed tag on a no-zlib report
+build should downgrade a verdict. That is a report-policy decision analogous to
+the `PERMISSIVENESS_DELTAS.md` items — recorded here for a maintainer, changed by
+nobody automatically. The library-side dump correctness (C1/C2) is fixed
+regardless, so a compressed tag now at least *labels itself* correctly wherever
+`Describe()` output feeds a report or a diagnostic scan.
+
+---
+
+## E. Existing coverage
+
+- `iccdev.tagdata-zlib-roundtrip` (#1521) — `CIccTagData` deflate/inflate
+  round-trip; zlib-gated.
+- `iccdev.ziputf8-settext-contract` (#1743) — `CIccTagZipUtf8Text::SetText`
+  success/failure contract; zlib-gated.
+- `iccdev.compression-describe-labels` (#1723, **new**) — dump labelling for C1/C2;
+  runs in all configurations.
+
+No regression exercises `IccPawgReport` against a compressed-tag profile, matching
+the section D finding that PAWG has no compression-specific code path to pin.


### PR DESCRIPTION
Resolves #1723 (Research: Compression Paths), the follow-up to the #1722 diagnostic scan. xsscx's handoff notes were:

> 1. CLI Tools need cross-check for Compression Paths
> 2. Pawg Code Path — Missing — Rev.A didn't contemplate Compression

This is the research resolution: a documented cross-check of every zlib-backed compression path, the two concrete defects it surfaced (fixed), a regression test, and the substantiated PAWG gap recorded as flag-and-wait. Shaped like the #1724 resolution — findings doc + targeted fix + test in one in-repo PR.

## The cross-check

**Compression surface:** three zlib/DEFLATE tag representations — `zut8` (`CIccTagZipUtf8Text`), `zxml`/`ZXML` (`CIccTagZipXml`, a subclass with no compression code of its own), and compressed `data` (`CIccTagData` + the `icCompressedData` flag). All `#ifdef ICC_USE_ZLIB`.

**Build split:** the header default (`IccProfLibConf.h:187`) ships `//#define ICC_USE_ZLIB` commented **out**; the CMake option (`Build/Cmake/CMakeLists.txt:514`) defaults it **ON** and applies it PUBLIC, so all CMake-built tools decompress. Read/Write are passthrough in both modes (profile bytes survive losslessly without zlib); only the decoded `GetText`/`Describe` view needs zlib.

**CLI tools:** type-agnostic — `iccDumpProfile` and friends dispatch through the tag factory to virtual `Describe()`/`Validate()`; no tool special-cases compressed signatures and there is no "Unknown type" fallthrough for these registered types. So the defects were in the **library dump code**, not the tools.

## Defects fixed (both `IccProfLib/IccTagBasic.cpp`, output-only)

- **C1 — `CIccTagData::Describe()` dropped the "Compressed" label.** It appended `"Compressed "` for a compressed tag, then every data-kind branch reassigned the string with `=` (e.g. `sDescription = "Binary Data:\n";`), overwriting the marker. A compressed data tag was therefore **never** labelled compressed in any dump, on either build. Fixed by appending (`+=`) the label so the `"\n"`/`"Compressed "` prefix survives. Build-independent.
- **C2 — no-zlib `CIccTagZipUtf8Text::Describe()` marker malformed.** The opener read `BEGIN_COMPESSED_DATA["` (missing the R, unbalanced `["…]` delimiter) while the closer correctly read `END_COMPRESSED_DATA`. Fixed to `BEGIN_COMPRESSED_DATA["<n>"]`. Compiled out under `ICC_USE_ZLIB`.

Neither touches parsing, validation verdicts, or on-disk bytes.

## Test

`.github/ci/regression/compression-describe-labels.cpp` → CTest `iccdev.compression-describe-labels`. Builds compressed `data` tags in memory and asserts the `"Compressed"` label survives (plus an uncompressed control that must **not** be labelled), and asserts the corrected no-zlib marker (self-gated to no-zlib builds). Needs no deflate/inflate, so — unlike the zlib-gated #1521/#1743 tests — it runs in **every** configuration.

Red-green verified locally (Unix Makefiles): C1 fails with the fix reverted in a zlib build; C2 fails in isolation in a no-zlib build (on the marker assertions); both green fixed; siblings #1521/#1743 still pass.

## PAWG gap — flag-and-wait (note 2)

Substantiated: `IccPawgReport` has **no** compression-specific code path. A compressed tag reaches the report only indirectly through `CIccProfile::Validate()` (which already *accepts* `zut8`/`zxml`); its own classification (`IsSpecTag`, `AssessPrivateTags`) keys off tag **signature** names, never tag **type**. What the report *should say* about a compressed tag (a dedicated note/verdict? a no-zlib verdict downgrade?) is a report-policy decision analogous to the `PERMISSIVENESS_DELTAS.md` items — recorded in the new `Tools/CmdLine/IccPawgReport/registry/COMPRESSION_PATHS.md` (§D) for a maintainer, changed by nobody automatically. The library-side dump correctness (C1/C2) is fixed regardless, so a compressed tag now labels itself correctly wherever `Describe()` feeds a report or diagnostic scan.
