### PR TITLE
fix(#1775): IccPawgReport compression-path measurement (S14) + in-memory fuzz hooks

### DIFF
--- a/.github/ci/regression/pawg-compression-paths.cpp
+++ b/.github/ci/regression/pawg-compression-paths.cpp
@@ -1,0 +1,133 @@
+// Regression: IccPawgReport compression-path measurement (S14, issue #1775).
+//
+// Follow-up to #1774/#1723: the PAWG report classified tags by *signature* and
+// never noticed when a tag's *type* was DEFLATE-compressed (zut8/zxml/compressed
+// data). PawgCompressionVerdict() is the new measurement, exercised here through
+// its in-memory entry point -- the same "up to the point of Output, not for
+// Output" boundary the overnight fuzzing harness uses.
+//
+// Detection is raw-bytes based (a tag's 4-byte TYPE signature at its data offset,
+// plus the icCompressedData flag word at data+8 for a 'data' tag), so this test
+// hand-builds minimal profile images rather than constructing full profiles.
+//
+// The measurement is build-independent (compression On/Off, "not gzip"); only the
+// VERDICT differs: a compressed tag is Ok when zlib is linked (content
+// assessable) and Gap otherwise (content retained but not decodable here). The
+// detection assertions below hold in every configuration; the verdict-value
+// assertions self-gate on ICC_USE_ZLIB.
+//
+// Exit code 0 = pass, 1 = a case regressed.
+#include "PawgReport.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+static int g_fail = 0;
+#define CHECK(c) do { if(!(c)){ std::printf("FAIL line %d: %s\n", __LINE__, #c); g_fail=1; } } while(0)
+
+// Tag TYPE signatures (byte-for-byte, per icProfileHeader.h) exercised here.
+static const uint32_t kZut8 = 0x7a757438u;  // zipUtf8Text
+static const uint32_t kZxml = 0x7a786d6cu;  // zipXml
+static const uint32_t kData = 0x64617461u;  // 'data'
+static const uint32_t kText = 0x74657874u;  // 'text' (uncompressed control)
+static const uint32_t kCompressedDataFlag = 0x00010000u;  // icCompressedData
+
+static void putU32BE(std::vector<uint8_t> &b, size_t off, uint32_t v)
+{
+  b[off + 0] = (uint8_t)(v >> 24);
+  b[off + 1] = (uint8_t)(v >> 16);
+  b[off + 2] = (uint8_t)(v >> 8);
+  b[off + 3] = (uint8_t)(v);
+}
+
+// Build a minimal single-tag ICC image: 128-byte header ('acsp' magic), a
+// one-entry tag table, and tag data beginning with `typeSig`. When `dataFlag` is
+// nonzero the tag data also carries a flags word at +8 (for the 'data' case).
+static std::vector<uint8_t> makeProfile(uint32_t tagSig, uint32_t typeSig, uint32_t dataFlag)
+{
+  const size_t tagOffset = 144;                      // 132 + 12 (one table entry)
+  const size_t tagDataLen = dataFlag ? 12 : 4;       // need +8 flags word only for 'data'
+  const size_t total = tagOffset + tagDataLen;
+
+  std::vector<uint8_t> b(total, 0);
+  putU32BE(b, 0, (uint32_t)total);                   // profile size
+  b[36] = 'a'; b[37] = 'c'; b[38] = 's'; b[39] = 'p'; // header magic
+  putU32BE(b, 128, 1);                               // tag count = 1
+  putU32BE(b, 132, tagSig);                          // tag signature
+  putU32BE(b, 136, (uint32_t)tagOffset);             // tag data offset
+  putU32BE(b, 140, (uint32_t)tagDataLen);            // tag data size
+  putU32BE(b, tagOffset, typeSig);                   // tag TYPE signature
+  if (dataFlag)
+    putU32BE(b, tagOffset + 8, dataFlag);            // [type][reserved][flags]
+  return b;
+}
+
+static bool contains(const std::string &s, const char *needle)
+{
+  return s.find(needle) != std::string::npos;
+}
+
+// A compressed tag: Ok when zlib is linked, Gap otherwise.
+static int expectedCompressedVerdict()
+{
+#ifdef ICC_USE_ZLIB
+  return kPawgOk;
+#else
+  return kPawgGap;
+#endif
+}
+
+// Assert the measurement flags a buffer as carrying a compressed tag.
+static void checkCompressed(const std::vector<uint8_t> &buf, const char *label, const char *sigText)
+{
+  std::string detail;
+  int v = PawgCompressionVerdict(buf.data(), buf.size(), &detail);
+  CHECK(v == expectedCompressedVerdict());
+  CHECK(contains(detail, "compressed tag"));   // "... N compressed tag(s): ..."
+  CHECK(contains(detail, sigText));            // names the offending type
+  CHECK(!contains(detail, "no DEFLATE"));      // must NOT read as the empty case
+  std::printf("  %-18s v=%d detail=\"%s\"\n", label, v, detail.c_str());
+}
+
+// Assert the measurement reports no compressed tags (Ok, the empty case).
+static void checkUncompressed(const std::vector<uint8_t> &buf, const char *label)
+{
+  std::string detail;
+  int v = PawgCompressionVerdict(buf.data(), buf.size(), &detail);
+  CHECK(v == kPawgOk);
+  CHECK(contains(detail, "no DEFLATE-compressed tags"));
+  std::printf("  %-18s v=%d detail=\"%s\"\n", label, v, detail.c_str());
+}
+
+int main()
+{
+  // --- Compressed tag TYPES are detected regardless of build ------------------
+  checkCompressed(makeProfile(0x74617267u /*'targ'*/, kZut8, 0), "zut8 type", "zut8");
+  checkCompressed(makeProfile(0x4d533130u /*'MS10'*/, kZxml, 0), "zxml type", "zxml");
+
+  // --- A 'data' tag is compressed iff the icCompressedData flag is set --------
+  checkCompressed(makeProfile(0x64657363u /*'desc'*/, kData, kCompressedDataFlag),
+                  "compressed data", "data");
+
+  // --- Controls: uncompressed tags must read as the empty case ----------------
+  checkUncompressed(makeProfile(0x63707274u /*'cprt'*/, kText, 0), "text control");
+  checkUncompressed(makeProfile(0x64657363u /*'desc'*/, kData, 0), "plain data ctrl");
+
+  // --- Robustness: a too-small / header-only buffer must not crash ------------
+  {
+    std::string detail;
+    std::vector<uint8_t> tiny(64, 0);
+    int v = PawgCompressionVerdict(tiny.data(), tiny.size(), &detail);
+    CHECK(v == kPawgOk);   // no tag table -> nothing to measure, no crash
+    std::printf("  %-18s v=%d detail=\"%s\"\n", "tiny buffer", v, detail.c_str());
+  }
+
+  if (g_fail) {
+    std::printf("RESULT: FAIL\n");
+    return 1;
+  }
+  std::printf("RESULT: PASS (S14 compression measurement holds)\n");
+  return 0;
+}

--- a/.github/scripts/iccdev-pawg-report-regression-tests.sh
+++ b/.github/scripts/iccdev-pawg-report-regression-tests.sh
@@ -127,7 +127,7 @@ assert_report_truth() {
   gap_count="$(summary_value "$logfile" "GAP")"
   not_run_count="$(summary_value "$logfile" "NOT RUN")"
 
-  if [ "$rendered_total" != "31" ] || [ "$summary_total" != "31" ]; then
+  if [ "$rendered_total" != "32" ] || [ "$summary_total" != "32" ]; then
     echo "    $name rendered $rendered_total item(s), summary reports $summary_total"
     return 1
   fi
@@ -158,7 +158,7 @@ assert_report_truth() {
   fi
 
   summary_sum=$((ok_count + warn_count + fail_count + na_count + gap_count + not_run_count))
-  if [ "$summary_sum" -ne 31 ]; then
+  if [ "$summary_sum" -ne 32 ]; then
     echo "    $name summary counts add to $summary_sum"
     return 1
   fi
@@ -327,7 +327,7 @@ run_good_profile() {
     return
   fi
 
-  pass_case "$name" "31-item PAWG report is internally consistent"
+  pass_case "$name" "32-item PAWG report is internally consistent"
 }
 
 generate_truncated_profile() {
@@ -1212,12 +1212,12 @@ with open(sys.argv[1], "r", encoding="utf-8") as handle:
 summary = report.get("summary", {})
 items = report.get("items", [])
 refs = report.get("references", [])
-assert summary.get("total") == 31
-assert len(items) == 31
+assert summary.get("total") == 32
+assert len(items) == 32
 assert items[0]["id"] == "S1"
 assert items[-1]["id"] == "Q4"
 assert any("registry.color.org/tag-signatures" in ref for ref in refs)
-assert sum(summary[k] for k in ("pass", "warn", "fail", "notApplicable", "gap", "notRun")) == 31
+assert sum(summary[k] for k in ("pass", "warn", "fail", "notApplicable", "gap", "notRun")) == 32
 PY
   then
     fail_case "$name" "JSON evidence shape is invalid"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1640,6 +1640,56 @@ function(iccdev_add_compression_describe_labels_test)
   endif()
 endfunction()
 
+# Guards IccPawgReport's compression-path measurement (S14, issue #1775): the
+# report classified tags by signature and never noticed a tag whose *type* was
+# DEFLATE-compressed (zut8/zxml/compressed data), the gap #1774 flagged. The test
+# drives PawgCompressionVerdict() -- the in-memory, output-free entry the fuzzing
+# harness uses -- over hand-built minimal profile images and pins: zut8/zxml and a
+# flagged 'data' tag are measured as compressed (Ok with zlib, Gap without), while
+# uncompressed controls read as the empty case. Detection is build-independent, so
+# it runs in every configuration; only the verdict value self-gates on
+# ICC_USE_ZLIB inside the test. Links PawgReport.cpp in (the entry lives in the
+# tool, not a library) plus the IccPawgReport include dir and IccProfLib.
+function(iccdev_add_pawg_compression_paths_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccPawgCompressionPathsTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/pawg-compression-paths.cpp"
+    "${ICCDEV_REPO_ROOT}/Tools/CmdLine/IccPawgReport/PawgReport.cpp"
+  )
+  target_compile_features(iccPawgCompressionPathsTest PRIVATE cxx_std_17)
+  target_include_directories(iccPawgCompressionPathsTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/Tools/CmdLine/IccPawgReport"
+  )
+  target_link_libraries(iccPawgCompressionPathsTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccPawgCompressionPathsTest)
+
+  add_test(
+    NAME iccdev.pawg-compression-paths
+    COMMAND "$<TARGET_FILE:iccPawgCompressionPathsTest>"
+  )
+  set_tests_properties(iccdev.pawg-compression-paths PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;pawg;compression;issue-1775;regression"
+  )
+  if(WIN32)
+    set(_pawg_compression_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccPawgCompressionPathsTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _pawg_compression_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.pawg-compression-paths PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_pawg_compression_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_windows_iccdevcmm_smoke_test)
   if(NOT WIN32 OR NOT TARGET RefIccMAX)
     return()
@@ -1858,6 +1908,7 @@ if(WIN32)
   iccdev_add_tagdata_zlib_roundtrip_test()
   iccdev_add_ziputf8_settext_contract_test()
   iccdev_add_compression_describe_labels_test()
+  iccdev_add_pawg_compression_paths_test()
   iccdev_add_parser_restore_calls_test()
   iccdev_add_tag_layout_shared_data_test()
   iccdev_add_pawg_q2_tonecurves_test()
@@ -2066,6 +2117,7 @@ iccdev_add_fileio_seek_tell_test()
 iccdev_add_tagdata_zlib_roundtrip_test()
 iccdev_add_ziputf8_settext_contract_test()
 iccdev_add_compression_describe_labels_test()
+iccdev_add_pawg_compression_paths_test()
 iccdev_add_parser_restore_calls_test()
 iccdev_add_tag_layout_shared_data_test()
 iccdev_add_pawg_q2_tonecurves_test()

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1840,7 +1840,7 @@ if(WIN32)
         "-DICCDEV_BUILD_DIR=${CMAKE_BINARY_DIR}"
         "-DICCDEV_PAWG_EXE=$<TARGET_FILE:iccPawgReport>"
         "-DICCDEV_PROFILE=${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc"
-        "-DICCDEV_EXPECTED_ITEM_COUNT=31"
+        "-DICCDEV_EXPECTED_ITEM_COUNT=32"
         -P "${CMAKE_CURRENT_LIST_DIR}/RunWindowsPawgReportSmokeTest.cmake"
     )
     set_tests_properties(iccdev.windows-pawg-report-smoke PROPERTIES

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -169,41 +169,13 @@ uint32_t ReadU32BE(const unsigned char *p)
          (uint32_t)p[3];
 }
 
-bool LoadRawProfile(const char *szFilename, RawProfile &raw)
+// Parse the ICC header fields and the tag table out of an already-populated
+// raw.data.  Factored out of LoadRawProfile so the file loader and the in-memory
+// loader (LoadRawProfileFromMemory, used by the #1775 assessment-only fuzz
+// entries) apply byte-for-byte identical header/bounds handling -- the CLI and
+// the overnight fuzzing harness must see the same view of a profile.
+static bool ParseRawProfile(RawProfile &raw)
 {
-  std::ifstream in(szFilename, std::ios::binary);
-  if (!in) {
-    raw.readError = "unable to open file";
-    return false;
-  }
-
-  in.seekg(0, std::ios::end);
-  std::streamoff end = in.tellg();
-  // A directory (or other non-regular path) can be opened by std::ifstream
-  // successfully, yet tellg() then reports a nonsensical length: libstdc++
-  // returns LLONG_MAX (0x7fffffffffffffff) for a directory such as "/tmp".
-  // That value flowed straight into raw.data.resize() below, requesting a ~9 EB
-  // allocation that aborts under AddressSanitizer ("requested allocation size
-  // 0x7fffffffffffffff", #1519).  An ICC profile carries its size in a uint32
-  // header field, so any length that cannot fit a conformant profile is not one
-  // we could ever load; reject it here exactly like an unreadable file so the
-  // caller degrades to the same graceful "parse failed" report it already emits
-  // for a missing path, instead of crashing.
-  if (end < 0 || (uint64_t)end > 0xFFFFFFFFull) {
-    raw.readError = "input is not a readable regular file";
-    return false;
-  }
-  in.seekg(0, std::ios::beg);
-
-  raw.data.resize((size_t)end);
-  if (!raw.data.empty()) {
-    in.read((char*)raw.data.data(), (std::streamsize)raw.data.size());
-    if (!in) {
-      raw.readError = "unable to read complete file";
-      return false;
-    }
-  }
-
   raw.opened = true;
   raw.hasHeader = raw.data.size() >= 128;
   if (!raw.hasHeader) {
@@ -245,6 +217,60 @@ bool LoadRawProfile(const char *szFilename, RawProfile &raw)
   }
 
   return true;
+}
+
+bool LoadRawProfile(const char *szFilename, RawProfile &raw)
+{
+  std::ifstream in(szFilename, std::ios::binary);
+  if (!in) {
+    raw.readError = "unable to open file";
+    return false;
+  }
+
+  in.seekg(0, std::ios::end);
+  std::streamoff end = in.tellg();
+  // A directory (or other non-regular path) can be opened by std::ifstream
+  // successfully, yet tellg() then reports a nonsensical length: libstdc++
+  // returns LLONG_MAX (0x7fffffffffffffff) for a directory such as "/tmp".
+  // That value flowed straight into raw.data.resize() below, requesting a ~9 EB
+  // allocation that aborts under AddressSanitizer ("requested allocation size
+  // 0x7fffffffffffffff", #1519).  An ICC profile carries its size in a uint32
+  // header field, so any length that cannot fit a conformant profile is not one
+  // we could ever load; reject it here exactly like an unreadable file so the
+  // caller degrades to the same graceful "parse failed" report it already emits
+  // for a missing path, instead of crashing.
+  if (end < 0 || (uint64_t)end > 0xFFFFFFFFull) {
+    raw.readError = "input is not a readable regular file";
+    return false;
+  }
+  in.seekg(0, std::ios::beg);
+
+  raw.data.resize((size_t)end);
+  if (!raw.data.empty()) {
+    in.read((char*)raw.data.data(), (std::streamsize)raw.data.size());
+    if (!in) {
+      raw.readError = "unable to read complete file";
+      return false;
+    }
+  }
+
+  return ParseRawProfile(raw);
+}
+
+// In-memory counterpart of LoadRawProfile, used by the assessment-only entries
+// (AssessPawgFromMemory / PawgCompressionVerdict, #1775) so a fuzzer can drive
+// the report straight from a byte buffer with no filesystem round-trip.  Applies
+// the same uint32 profile-size ceiling as the file loader (#1519): a conformant
+// profile carries its length in a uint32 header field, so a larger buffer cannot
+// be one we could load.
+bool LoadRawProfileFromMemory(const unsigned char *data, size_t size, RawProfile &raw)
+{
+  if (!data || (uint64_t)size > 0xFFFFFFFFull) {
+    raw.readError = "input is not a readable profile buffer";
+    return false;
+  }
+  raw.data.assign(data, data + size);
+  return ParseRawProfile(raw);
 }
 
 std::string SigString(uint32_t sig)
@@ -1339,6 +1365,79 @@ PawgVerdict TagTypeAllowedVerdict(CIccProfile *pIcc, std::string &detail)
   return ValidationStatusVerdict(status);
 }
 
+// True for the three DEFLATE-backed tag TYPE signatures.  The compression
+// measurement keys on the tag *type*, so it reads identically whether or not this
+// build links zlib (issue #1775: "Compression On or Off, not gzip") -- detection
+// never depends on being able to inflate.  Deliberately distinct from
+// ValidateGzipHeader()'s gzip *malware* scan, which hunts a gzip magic inside
+// private-tag payloads; here we recognise legitimate compressed ICC tag types.
+bool IsCompressedTagTypeSig(uint32_t typeSig)
+{
+  return typeSig == (uint32_t)icSigZipUtf8TextType ||   // 'zut8'
+         typeSig == (uint32_t)icSigZipXmlType ||         // 'zxml'
+         typeSig == (uint32_t)icSigZipXMLType;           // 'ZXML' (X-Rite CxF)
+}
+
+// Measures the profile's compression surface for PAWG item S14.  Enumerates
+// compressed tags from the RAW bytes -- so the measurement still runs when
+// IccProfLib could not parse the profile (fuzz robustness): a tag's 4-byte TYPE
+// signature lives at its data offset, and a 'data' tag additionally carries an
+// icCompressedData bit in its flags word at data+8.  The measurement is
+// build-independent; only how much can be *said* about the content depends on
+// zlib, which is why a compressed tag on a no-zlib build is reported as a Gap
+// (measured, but content not decodable here) rather than a silent pass.
+PawgVerdict CompressionPathVerdict(const RawProfile &raw, CIccProfile *pIcc, std::string &detail)
+{
+  (void)pIcc;  // detection is raw-bytes based; pIcc reserved for future content checks
+  const uint64_t fileSize = raw.data.size();
+  std::vector<std::string> compressed;
+
+  for (const RawTag &tag : raw.tags) {
+    const uint64_t typeOff = tag.offset;
+    if (typeOff + 4 > fileSize)
+      continue;                       // truncated/out-of-bounds tag: S6/S7 report it
+    const uint32_t typeSig = ReadU32BE(raw.data.data() + (size_t)typeOff);
+
+    bool isCompressed = IsCompressedTagTypeSig(typeSig);
+    if (!isCompressed && typeSig == (uint32_t)icSigDataType && typeOff + 12 <= fileSize) {
+      // 'data' tag on disk is [type][reserved][flags]; icCompressedData -> compressed.
+      const uint32_t flags = ReadU32BE(raw.data.data() + (size_t)typeOff + 8);
+      if (flags & (uint32_t)icCompressedData)
+        isCompressed = true;
+    }
+    if (isCompressed)
+      compressed.push_back(SigString(tag.sig) + " (" + SigString(typeSig) + ")");
+  }
+
+  if (compressed.empty()) {
+    detail = "no DEFLATE-compressed tags (zut8/zxml/compressed data) present";
+    return PawgVerdict::Ok;
+  }
+
+  std::ostringstream oss;
+  oss << compressed.size() << " compressed tag(s): ";
+  for (size_t i = 0; i < compressed.size(); ++i) {
+    if (i)
+      oss << ", ";
+    oss << compressed[i];
+  }
+#ifdef ICC_USE_ZLIB
+  // zlib linked: Describe()/GetText() can inflate and inspect the content, so the
+  // mere presence of compressed tags is not itself a finding.
+  oss << "; zlib linked in this build - compressed content is assessable";
+  detail = oss.str();
+  return PawgVerdict::Ok;
+#else
+  // No zlib: the compressed bytes are retained losslessly (Read/Write are
+  // passthrough) but cannot be decoded here, so the content is unassessed.  Flag
+  // it as a Gap so a no-zlib assessment run never implies it examined content it
+  // could not decompress.
+  oss << "; no zlib in this build - compressed content not assessed (bytes retained losslessly)";
+  detail = oss.str();
+  return PawgVerdict::Gap;
+#endif
+}
+
 bool IsKnownProfileClass(uint32_t cls)
 {
   return cls == icSigInputClass ||
@@ -1934,6 +2033,18 @@ std::vector<PawgItem> EvaluatePawg(const RawProfile &raw, CIccProfile *pIcc)
           nops ? PawgVerdict::Fail : PawgVerdict::Ok,
           nopDetail);
 
+  // S14 measures the DEFLATE compression surface (zut8/zxml/compressed data),
+  // the gap #1774 flagged and #1775 asked to close: the report keyed off tag
+  // signatures and never noticed a tag's *type* was compressed.  The measurement
+  // is build-independent (compression On/Off, not gzip); a compressed tag on a
+  // no-zlib build resolves to a Gap because its content cannot be decoded here.
+  std::string compressionDetail;
+  PawgVerdict compressionVerdict = CompressionPathVerdict(raw, pIcc, compressionDetail);
+  AddItem(items, "S14",
+          "Are DEFLATE-compressed tags (zut8/zxml/compressed data) measured, and is their content assessable in this build?",
+          compressionVerdict,
+          compressionDetail);
+
   std::string tagValueDetail;
   PawgVerdict tagValueVerdict = TagValueEncodingVerdict(pIcc, tagValueDetail);
   AddItem(items, "C1",
@@ -2284,4 +2395,51 @@ int DumpPawgReport(const char *szFilename, bool bUseRead, bool bJson)
   delete pIcc;
 
   return HasFail(items) ? 1 : 0;
+}
+
+// --- Assessment-only entry points (issue #1775) ----------------------------
+// These run the PAWG evaluation "up to the point of Output, not for Output" so
+// the overnight CI fuzzing harness can drive the report from an in-memory
+// profile image with no filesystem round-trip and no report emission.
+
+// The kPawg* codes the header exposes (so callers need not see the PawgVerdict
+// enum type) must stay in lockstep with PawgVerdict's order.
+static_assert((int)PawgVerdict::Ok == kPawgOk, "kPawgOk out of sync with PawgVerdict");
+static_assert((int)PawgVerdict::Warn == kPawgWarn, "kPawgWarn out of sync with PawgVerdict");
+static_assert((int)PawgVerdict::Fail == kPawgFail, "kPawgFail out of sync with PawgVerdict");
+static_assert((int)PawgVerdict::NotApplicable == kPawgNotApplicable, "kPawgNotApplicable out of sync");
+static_assert((int)PawgVerdict::Gap == kPawgGap, "kPawgGap out of sync with PawgVerdict");
+static_assert((int)PawgVerdict::NotRun == kPawgNotRun, "kPawgNotRun out of sync with PawgVerdict");
+
+int AssessPawgFromMemory(const unsigned char *data, size_t size)
+{
+  RawProfile raw;
+  LoadRawProfileFromMemory(data, size, raw);
+
+  // Parse a full CIccProfile from the same buffer when possible so the parsed-
+  // profile checks (C1/C3, quality) also exercise; the buffer must outlive pIcc
+  // and it does -- `data` is owned by the caller for the whole call.
+  std::string sReport;
+  icValidateStatus nStatus = icValidateOK;
+  CIccProfile *pIcc = (data && size <= 0xFFFFFFFFull)
+      ? ValidateIccProfile((const icUInt8Number *)data, (icUInt32Number)size, sReport, nStatus)
+      : nullptr;
+
+  std::vector<PawgItem> items = EvaluatePawg(raw, pIcc);
+  const bool fail = HasFail(items);
+  delete pIcc;
+  return fail ? 1 : 0;
+}
+
+int PawgCompressionVerdict(const unsigned char *data, size_t size, std::string *outDetail)
+{
+  // Focused entry: runs ONLY the S14 compression measurement.  Detection is
+  // raw-bytes based, so this needs no parsed profile -- cheap and fuzz-robust.
+  RawProfile raw;
+  LoadRawProfileFromMemory(data, size, raw);
+  std::string detail;
+  const PawgVerdict v = CompressionPathVerdict(raw, nullptr, detail);
+  if (outDetail)
+    *outDetail = detail;
+  return (int)v;
 }

--- a/Tools/CmdLine/IccPawgReport/PawgReport.h
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.h
@@ -62,6 +62,38 @@
 #ifndef ICC_PAWG_REPORT_H
 #define ICC_PAWG_REPORT_H
 
+#include <cstddef>
+#include <string>
+
 int DumpPawgReport(const char *szFilename, bool bUseRead, bool bJson);
+
+// Assessment-only entry points (issue #1775): run the PAWG evaluation "up to the
+// point of Output, not for Output" over an in-memory profile image, so the
+// overnight CI fuzzing harness can drive the code path with no filesystem
+// round-trip and no report emission.
+
+// Runs the full PAWG evaluation (all S/C/Q checks, including the S14 compression
+// measurement) over the buffer and returns 1 if any check FAILs, else 0.
+// Intended as a libFuzzer target:
+//   extern "C" int LLVMFuzzerTestOneInput(const uint8_t *d, size_t n)
+//   { AssessPawgFromMemory(d, n); return 0; }
+int AssessPawgFromMemory(const unsigned char *data, size_t size);
+
+// Runs ONLY the S14 compression-path measurement over the buffer, returning one
+// of the kPawg* codes below and (if outDetail != nullptr) the human-readable
+// detail string.  Detection is raw-bytes based, so it needs no parsed profile.
+int PawgCompressionVerdict(const unsigned char *data, size_t size, std::string *outDetail);
+
+// Verdict codes returned by PawgCompressionVerdict.  Kept as plain ints (not the
+// internal PawgVerdict enum) so consumers need not include the report internals;
+// PawgReport.cpp static_asserts they match PawgVerdict's ordering.
+enum {
+  kPawgOk            = 0,
+  kPawgWarn          = 1,
+  kPawgFail          = 2,
+  kPawgNotApplicable = 3,
+  kPawgGap           = 4,
+  kPawgNotRun        = 5
+};
 
 #endif

--- a/Tools/CmdLine/IccPawgReport/Readme.md
+++ b/Tools/CmdLine/IccPawgReport/Readme.md
@@ -15,9 +15,9 @@ Options:
 - `--json` out instead of text report
 - `--read` eager `ReadIccProfile()` loading after validation parse failure
 
-The report prints 31 checklist items:
+The report prints 32 checklist items:
 
-- `S1` through `S13`: security checks
+- `S1` through `S14`: security checks
 - `C1` through `C14`: conformance checks
 - `Q1` through `Q4`: quality checks
 
@@ -34,7 +34,7 @@ The report prints 31 checklist items:
 
 ## Checklist coverage
 
-Security checks cover the PAWG goals for channel counts, 128-byte header encoding, registered or zero header signatures, D50 illuminant, PCS rules, tag-table bounds and layout, EOF placement, iccMAX calculator-element cost, private-tag presence, private-tag malware scans, and private-tag NOP-sled detection.
+Security checks cover the PAWG goals for channel counts, 128-byte header encoding, registered or zero header signatures, D50 illuminant, PCS rules, tag-table bounds and layout, EOF placement, iccMAX calculator-element cost, private-tag presence, private-tag malware scans, private-tag NOP-sled detection, and DEFLATE-compressed tag (`zut8`/`zxml`/compressed `data`) measurement.
 - Note that malware-signature scans are not implemented
 
 Conformance checks cover tag value encoding, `cprt`/`desc` text encoding, allowed tag types, required tags for profile class, unexpected additional tags, private-tag registration and documentation status, undocumented private-tag identification, profile-class and data-colour-space consistency, header conformance, profile-version/tag consistency, media white point encoding, reserved header bytes, and four-byte tag boundaries.

--- a/Tools/CmdLine/IccPawgReport/registry/COMPRESSION_PATHS.md
+++ b/Tools/CmdLine/IccPawgReport/registry/COMPRESSION_PATHS.md
@@ -103,37 +103,45 @@ so — unlike the zlib-gated #1521/#1743 tests — it runs in **every** configur
 
 ---
 
-## D. PAWG code path — compression un-contemplated (flag-and-wait)
+## D. PAWG code path — compression measurement (S14, implemented for #1775)
 
-xsscx's note 2 is **substantiated**. `IccPawgReport` has no compression-specific
-logic anywhere (`IccPawgReport.cpp`, `PawgReport.cpp`, `IccQualityMetrics.h`,
-`IccSignatureRegistry.h`): a search for `zut8`/`zxml`/`icSigDataType`/
-`icCompressedData`/`deflate`/`inflate`/`compress` matches only prose comments
-about *gamut* compression.
+xsscx's note 2 was **substantiated** and, per the #1775 handoff ("add any needed
+compression-specific code paths then will add to overnight CI Fuzzing Harness"),
+is now closed with a dedicated measurement. Before it, `IccPawgReport` had no
+compression-specific logic: a compressed tag reached the report only indirectly —
+`TagTypeAllowedVerdict()`/`TagValueEncodingVerdict()` delegate to
+`CIccProfile::Validate()` (which already *accepts* `zut8`/`zxml`), and the
+known-vs-unknown classification (`IsSpecTag`, `AssessPrivateTags`) keys off tag
+**signature** names, never tag **type**, so a tag's compressed nature never
+entered PAWG's own classification.
 
-A compressed tag reaches the report only **indirectly**:
+**What was added (`PawgReport.cpp`):**
 
-- `TagTypeAllowedVerdict()` (`PawgReport.cpp:1324`) delegates entirely to
-  `CIccProfile::Validate()` — no tag-TYPE enumeration of its own. `Validate`
-  already *accepts* `zut8`/`zxml` for the CharTarget and CxF tags
-  (`IccProfile.cpp:2491`,`2570`), so compressed tags are not rejected.
-- `TagValueEncodingVerdict()` (`PawgReport.cpp:1283`) calls each tag's
-  `Validate()`. For a `zut8`/`zxml` tag on a no-zlib PAWG build this surfaces only
-  the generic "Zip compression not supported by CMM" Warning, not a content
-  assessment; a compressed `data` tag gets no compression-specific validation at
-  all.
-- Known-vs-unknown classification (`IsSpecTag`, `AssessPrivateTags`) keys off tag
-  **signature** names, never tag **type** — so the compressed nature of a tag
-  never enters PAWG's own classification.
+- **`CompressionPathVerdict()`** — a new measurement wired into `EvaluatePawg()` as
+  security item **S14**. It enumerates compressed tags from the **raw bytes** (a
+  tag's 4-byte TYPE signature at its data offset, plus the `icCompressedData` flag
+  word at `data+8` for a `data` tag), so it runs even when IccProfLib could not
+  parse the profile. The measurement is **build-independent** — it reports the
+  compression state (On/Off) regardless of whether zlib is linked, deliberately
+  distinct from the gzip-*malware* header scan in `ValidateGzipHeader()` (xsscx:
+  "Compression On or Off, not gzip").
+- **Verdict policy** (the decision §D previously deferred): no compressed tags →
+  `Ok` ("none present"); compressed tags **with** zlib linked → `Ok` (content is
+  decodable via `Describe()`/`GetText()`, so presence is not itself a finding);
+  compressed tags **without** zlib → **`Gap`** — the bytes are retained losslessly
+  (Read/Write are passthrough) but their content cannot be decoded in this build,
+  so the report must not imply it examined content it never inflated.
+- **Assessment-only entries** (`PawgReport.h`) for the overnight fuzzing harness —
+  "up to the point of Output, not for Output": `AssessPawgFromMemory(data, size)`
+  runs the full evaluation over an in-memory image and returns fail/ok with no
+  report emission (libFuzzer-shaped); `PawgCompressionVerdict(data, size, detail)`
+  runs only the S14 measurement. Both reuse `LoadRawProfileFromMemory()`, the
+  in-memory twin of `LoadRawProfile()` factored out via `ParseRawProfile()` so the
+  CLI and the harness apply identical header/bounds handling.
 
-**What is NOT decided here:** whether PAWG should emit a dedicated note/verdict
-for a compressed tag (e.g. "tag X is DEFLATE-compressed; CMM zlib support
-required to assess content"), and whether a compressed tag on a no-zlib report
-build should downgrade a verdict. That is a report-policy decision analogous to
-the `PERMISSIVENESS_DELTAS.md` items — recorded here for a maintainer, changed by
-nobody automatically. The library-side dump correctness (C1/C2) is fixed
-regardless, so a compressed tag now at least *labels itself* correctly wherever
-`Describe()` output feeds a report or a diagnostic scan.
+The library-side dump correctness (C1/C2) remains fixed regardless, so a
+compressed tag both *labels itself* correctly under `Describe()` and is now
+*measured* by the report.
 
 ---
 
@@ -143,8 +151,11 @@ regardless, so a compressed tag now at least *labels itself* correctly wherever
   round-trip; zlib-gated.
 - `iccdev.ziputf8-settext-contract` (#1743) — `CIccTagZipUtf8Text::SetText`
   success/failure contract; zlib-gated.
-- `iccdev.compression-describe-labels` (#1723, **new**) — dump labelling for C1/C2;
+- `iccdev.compression-describe-labels` (#1723) — dump labelling for C1/C2;
   runs in all configurations.
-
-No regression exercises `IccPawgReport` against a compressed-tag profile, matching
-the section D finding that PAWG has no compression-specific code path to pin.
+- `iccdev.pawg-compression-paths` (#1775, **new**) — the S14 measurement via the
+  in-memory `PawgCompressionVerdict()` entry: `zut8`/`zxml`/flagged-`data` tags are
+  measured as compressed (`Ok` with zlib, `Gap` without), uncompressed controls
+  read as the empty case, and a truncated buffer does not crash. Detection is
+  build-independent so it runs in **every** configuration; only the verdict value
+  self-gates on `ICC_USE_ZLIB`.

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -180,7 +180,7 @@ includes malformed curve gamma and out-of-range numeric narrowing coverage, and
 must reject invalid numeric fields before conversion without sanitizer findings.
 
 `iccdev.pawg-report-regressions` builds the standalone `iccPawgReport` tool,
-checks the 31-item PAWG report structure, verifies summary counts against the
+checks the 32-item PAWG report structure, verifies summary counts against the
 rendered item lines, runs malformed and malware-signature dynamic inputs, and
 fails on sanitizer findings.
 

--- a/python/tests/test_proflib_parity.py
+++ b/python/tests/test_proflib_parity.py
@@ -137,7 +137,7 @@ def test_icc_pawg_report_known_srgb_profile_smoke():
     result = run_tool(pawg, profile_path, timeout=60)
     result.assert_success(f"iccPawgReport {profile_path.name}")
     assert "ICC PROFILE ASSESSMENT REPORT (PAWG)" in result.output
-    assert "Total checklist items:  31" in result.output
+    assert "Total checklist items:  32" in result.output
     assert "FAIL:                   0" in result.output
     assert "NOT RUN:                0" in result.output
     assert "Overall:" in result.output


### PR DESCRIPTION
Closes #1775. Follow-up to #1774/#1723: `IccPawgReport` classified tags by *signature* and never noticed when a tag's *type* was DEFLATE-compressed (`zut8`/`zxml`/compressed `data`). Per xsscx's #1775 handoff ("add any needed compression-specific code paths then will add to overnight CI Fuzzing Harness"), this adds the missing code path plus the harness hooks.

### 1. Compression measurement — "On/Off, not gzip"
- New `CompressionPathVerdict()` wired into `EvaluatePawg` as security item **S14**. Detection is **raw-bytes based** (tag TYPE signature at the tag offset, plus the `icCompressedData` flag word at `data+8` for a `data` tag), so it runs even when IccProfLib could not parse the profile. The measurement is **build-independent** — deliberately distinct from the gzip-*malware* header scan in `ValidateGzipHeader()`.
- **Verdict policy** (the report-policy call `COMPRESSION_PATHS.md` §D had deferred): no compressed tags → `Ok`; compressed **with** zlib → `Ok` (content decodable via `Describe()`/`GetText()`); compressed **without** zlib → `Gap` (bytes retained losslessly but content not decodable here, so the report never implies it inspected content it could not inflate).

### 2. Fuzz hooks — "up to the point of Output, not for Output"
- `AssessPawgFromMemory(data, size)` — full evaluation over an in-memory image, **no report emission** (libFuzzer-shaped).
- `PawgCompressionVerdict(data, size, detail)` — the S14 measurement only.
- Both reuse the output-free `EvaluatePawg` seam plus a new `LoadRawProfileFromMemory()`, the in-memory twin of `LoadRawProfile()` factored out via `ParseRawProfile()` so the CLI and the harness apply identical header/bounds handling. `kPawg*` codes in `PawgReport.h` avoid leaking the internal `PawgVerdict` enum (static_asserts pin them to its ordering).

### 3. QA & CTest
- `.github/ci/regression/pawg-compression-paths.cpp` → CTest `iccdev.pawg-compression-paths`: hand-builds minimal profile images and asserts `zut8`/`zxml`/flagged-`data` tags are measured as compressed (`Ok` with zlib, `Gap` without), uncompressed controls read as the empty case, and a truncated buffer does not crash. Detection is build-independent so it runs in **every** configuration; only the verdict value self-gates on `ICC_USE_ZLIB`.
- `COMPRESSION_PATHS.md` §D/§E updated (gap → implemented).

### Verification
- **Red-green, both configs:** green in a zlib build (compressed → `Ok`) and a no-zlib build (compressed → `Gap`); controls read as empty. Red = neutering the type-sig detection fails the `zut8`/`zxml` assertions.
- **Real tool driven:** `iccPawgReport` on sRGB → `[OK] S14 "none present"`; on a crafted `zut8` profile → `[GAP] S14` naming the tag; JSON path emits `S14` too.
- **8/8 pawg+compression CTests pass.**

No change to parsing, validation verdicts of existing checks, or on-disk bytes — S14 is a new measurement item; the assessment-only entries are additive.
