### PR TITLE
fix(#1789): avoid unsigned->signed char conversion in CIccTagZipUtf8Text::GetText

### DIFF
--- a/.github/ci/regression/ziputf8-settext-contract.cpp
+++ b/.github/ci/regression/ziputf8-settext-contract.cpp
@@ -17,6 +17,20 @@
 // green before and after the fix on a machine where allocation succeeds; they are
 // contract and regression guards, not a red-green reproduction of the OOM path.
 //
+// Also relates to #1789: GetText() appends the inflated bytes to a std::string;
+// the previous per-byte `str += buf[i]` implicitly converted each unsigned-char
+// byte to signed char, which UBSan's implicit-integer-sign-change check flags for
+// any byte >= 128 (e.g. 0xC0 -> -64). The byte VALUE was always preserved, so the
+// high-byte round trip below does NOT detect a #1789 regression on its own: the old
+// per-byte code produced the identical bytes, so this case passes on both the buggy
+// and the fixed implementation. It is a byte-preservation contract guard - it pins
+// that the bulk append keeps every high byte intact - not a red-green reproduction.
+// The actual #1789 finding is a sign-conversion diagnostic with no behavioural
+// difference, observable only under an -fsanitize=implicit-conversion build with
+// -fno-sanitize-recover (that check is recoverable by default, and it is not part
+// of iccDEV's default CI sanitizer matrix, which is address,undefined). Red-green
+// for the fix was verified locally under that build; see #1789.
+//
 // Built and registered only when ICC_USE_ZLIB is enabled (the option added in
 // #1530); without zlib SetText() always returns false and none of this applies.
 #include "IccTag.h"
@@ -90,6 +104,21 @@ int main()
     // copy leaves a truncated deflate stream that fails to inflate or inflates to
     // the wrong text.
     checkRoundTrip(tag, plain, "5000-byte plaintext");
+  }
+
+  // #1789 contract guard (not a regression gate - see the header note): high bytes
+  // (>= 128) must round-trip exactly through GetText()'s append. Each byte here is
+  // >= 0x80, which is what triggered the implicit unsigned->signed char conversion
+  // the fix removes. The bytes were always preserved, so this passes with or without
+  // the fix; it only pins that the bulk append keeps every high byte intact.
+  {
+    std::string high;
+    for (int i = 0; i < 2000; i++)
+      high += (char)(0x80 + (i % 0x60));   // 0x80..0xDF: all >= 128, none NUL
+    CIccTagZipUtf8Text tag;
+    const bool ok = tag.SetText((const icChar *)high.c_str());
+    checkStoredOnSuccess(tag, ok, "2000-byte high-byte string (#1789)");
+    checkRoundTrip(tag, high, "2000-byte high-byte string (#1789)");
   }
 
   // Empty and NULL input: SetText treats NULL as "", and deflate still emits a

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -1536,7 +1536,7 @@ bool CIccTagZipUtf8Text::GetText(std::string &str) const
   }
 
   do {
-    unsigned int i, n;
+    unsigned int n;
 
     zstr.next_out = buf.data();
     zstr.avail_out = (uInt)buf.size();
@@ -1550,9 +1550,13 @@ bool CIccTagZipUtf8Text::GetText(std::string &str) const
 
     n = (unsigned int)buf.size() - zstr.avail_out;
 
-    for (i = 0; i < n; i++) {
-      str += buf[i];
-    }
+    // Append the inflated bytes wholesale. The previous per-byte `str += buf[i]`
+    // implicitly converted each icUtf8Vector element (unsigned char) to
+    // std::string's signed char, which UBSan's implicit-integer-sign-change check
+    // flags for any byte >= 128 (e.g. 0xC0 -> -64) even though the byte value is
+    // preserved (#1789). Appending through a char* keeps
+    // the exact bytes with no per-element conversion, and is faster.
+    str.append(reinterpret_cast<const char *>(buf.data()), n);
   } while (zstat != Z_STREAM_END);
 
   inflateEnd(&zstr);


### PR DESCRIPTION
Closes #1789 (bisected to `1f0a9dd`).

### The finding
`CIccTagZipUtf8Text::GetText` appended the inflated bytes one at a time:

```cpp
for (i = 0; i < n; i++)
  str += buf[i];
```

`buf` is an `icUtf8Vector` (element type `unsigned char`) and `str` is a `std::string` (signed `char`). For any inflated byte ≥ 128 — e.g. a UTF-8 lead/continuation byte `0xC0` — this implicit `unsigned char → char` conversion changes the value (`0xC0 → -64`), which UBSan's `implicit-integer-sign-change` check flags as undefined behavior:

```
IccTagBasic.cpp:1554:14: runtime error: implicit conversion from type 'value_type'
(aka 'unsigned char') of value 192 (8-bit, unsigned) to type 'char' changed the value
to -64 (8-bit, signed)
```

The byte *pattern* is preserved (the string still holds `0xC0`), so this is UB-hygiene, not data corruption.

### The fix
Append the inflated bytes wholesale:

```cpp
str.append(reinterpret_cast<const char *>(buf.data()), n);
```

Same bytes, no per-element conversion, and faster (no per-byte append or per-byte sanitizer instrumentation on the decode hot path).

### Regression
Extends the existing `.github/ci/regression/ziputf8-settext-contract.cpp` (#1743, already-registered `iccdev.ziputf8-settext-contract`) with a 2000-byte all-high-byte (≥ 0x80) `SetText → GetText` round trip asserting every byte is preserved. Like the rest of that suite it's a contract/refactor guard (green before and after on a normal build, since the value was always preserved).

### Verification
- **`-fsanitize=implicit-conversion` build:** `iccPawgReport --json <PoC>` prints the exact `IccTagBasic.cpp:1554` diagnostic **before** this change and **zero** findings **after**.
- Regression green in normal, ASAN+UBSan, and non-sanitizer builds.
