### PR TITLE
fix(#2335): reject non-finite seed-grid count before size_t cast in RoundTripDE

### DIFF
--- a/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
+++ b/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
@@ -1759,11 +1759,15 @@ RoundTripResult RoundTripDE(CIccProfile* pIcc, icRenderingIntent intent,
   // clamp on the line above, so it is positive and at least 3, and the exponent N is a
   // positive integer in [1, kMaxInkChannels] from the channel-count check earlier in
   // this function. A positive base raised to a positive integral exponent is an exact
-  // finite product or, on overflow, +inf - never NaN, never negative. The ceiling test
-  // on the next line then rejects +inf (inf > 3000000.0 is true), so total lands in
-  // [3, 3000000] at the cast (the minimum is N == 1 giving 3^1, not 9).
+  // finite product or, on overflow, +inf - never NaN, never negative. Even though NaN
+  // is therefore unreachable, the guard below rejects any non-finite total explicitly
+  // with std::isfinite rather than leaning on the ceiling test alone to catch +inf:
+  // that makes the cast's precondition local and executable (and clears the
+  // float-to-int-cast scanner at #2335, which recognises an isfinite/isnan call as the
+  // guard but cannot follow the pow() argument above). total thus lands in [3, 3000000]
+  // at the cast (the minimum is N == 1 giving 3^1, not 9).
   double total = std::pow((double)S + 1.0, N);
-  if (total > 3000000.0) { delete xA; delete xB; return fail("seed grid too large"); }
+  if (!std::isfinite(total) || total > 3000000.0) { delete xA; delete xB; return fail("seed grid too large"); }
 
   icStatusCMM st = icCmmStatOk;
   CIccApplyXform* apA = xA->GetNewApply(st);


### PR DESCRIPTION
## Summary

Clears code-scanning alert **#2335** (`iccdev/float-to-int-cast`) at
`Tools/CmdLine/IccProfilePlot/IccVizModel.cpp` in `RoundTripDE`, where
`des.reserve((size_t)total)` casts `double total = std::pow((double)S + 1.0, N)`
to `size_t`.

## Triage

The cast is provably safe today — `total` cannot be NaN — but the safety lived
only in a proof comment, not in code the scanner (or a future editor) can see:

- `S >= 2` (clamped by `if (S < 2) S = 2`), so the base `(double)S + 1.0 >= 3.0`,
  finite and positive.
- `N` is a positive integer in `[1, kMaxInkChannels]` (`kMaxInkChannels == 15`),
  enforced by the earlier channel-count check.
- `pow(finite-positive, positive-integer)` is a finite product or, on overflow,
  `+inf` — **never NaN, never negative**.
- The pre-existing ceiling test `total > 3000000.0` already rejected `+inf`
  (`inf > 3000000.0` is true).

So substantively this is a query false positive: `iccdev/float-to-int-cast`
recognises only an `isfinite`/`isnan` **call** as a guard and cannot follow the
`pow()` argument. The one honest gap is that the *relational* ceiling test does
not itself exclude NaN (`NaN > x` is false) — the NaN-exclusion rested entirely
on `pow()` semantics argued in prose.

## Fix

Rather than dismiss the alert, make the precondition **local and executable** by
adding an explicit `std::isfinite` term to the existing guard — the same
"make the precondition local" approach as #1742:

```cpp
-  if (total > 3000000.0) { ... return fail("seed grid too large"); }
+  if (!std::isfinite(total) || total > 3000000.0) { ... return fail("seed grid too large"); }
```

This converts the prose proof into a checked precondition, closes the
(unreachable) NaN gap, and lets the alert auto-resolve on the next scan instead
of being hand-dismissed. The proof comment above the guard is updated to explain
why the explicit `isfinite` is present.

## Testing / pre-flight

- `iccProfileVisualizePlot` + `IccProfLib2` compile clean.
- All three iccviz CTests pass, including `iccdev.iccviz-gamut-roundtrip-metrics`,
  which drives `RoundTripDE` on `sRGB_v4_ICC_preference.icc` — confirming no
  behaviour change on the valid path (the new term is a strict superset of the
  old ceiling test, firing only on a non-finite `total`).

No new test: the guarded branch is defensive and unreachable — a NaN `total`
cannot be produced through the public interface, so it cannot be exercised from
a test. The existing metrics CTest covers the live path.
