### PR TITLE
fix(#2335): clear float-to-int-cast findings in RoundTripDE (guard window + integer p90 index)

### DIFF
--- a/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
+++ b/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
@@ -1768,6 +1768,11 @@ RoundTripResult RoundTripDE(CIccProfile* pIcc, icRenderingIntent intent,
   // at the cast (the minimum is N == 1 giving 3^1, not 9).
   double total = std::pow((double)S + 1.0, N);
   if (!std::isfinite(total) || total > 3000000.0) { delete xA; delete xB; return fail("seed grid too large"); }
+  // Reserve the delta-E accumulator now, while the (size_t)total cast still sits within
+  // a few lines of the isfinite guard above (the float-to-int-cast scanner, #2335, ties
+  // a guard to a cast only when it is <=5 lines above). total is finite, in [3,3000000].
+  std::vector<double> des;
+  des.reserve((size_t)total);
 
   icStatusCMM st = icCmmStatOk;
   CIccApplyXform* apA = xA->GetNewApply(st);
@@ -1775,8 +1780,6 @@ RoundTripResult RoundTripDE(CIccProfile* pIcc, icRenderingIntent intent,
   if (!apA || !apB || st != icCmmStatOk) { delete apA; delete apB; delete xA; delete xB; return fail("transform apply init failed"); }
 
   // Seed in-gamut Lab from a device interior grid via A2B, then round-trip each.
-  std::vector<double> des;
-  des.reserve((size_t)total);
   // Value-initialised, not fill-constructed - see the note in buildNeutralAxisGraph
   // (#1777). RoundTripDE carries a second instance of the same diagnostic.
   std::vector<icFloatNumber> dev(N), pcs1(nPcs), dev2(N), pcs2(nPcs);
@@ -1803,7 +1806,11 @@ RoundTripResult RoundTripDE(CIccProfile* pIcc, icRenderingIntent intent,
   const double mean = sum / des.size();
   double var = 0.0; for (double d : des) var += (d - mean) * (d - mean);
   var /= des.size();
-  const std::size_t p90i = (std::size_t)std::floor(0.90 * (des.size() - 1));
+  // 90th-percentile index = floor(0.90 * (n-1)) for integer n = des.size(). Compute it
+  // as exact integer arithmetic (9*(n-1))/10 rather than std::floor on a double: it is
+  // the same index for every n (des.size() <= 3,000,000 here, so 9*(n-1) cannot
+  // overflow), and it avoids a float-to-int cast the scanner would flag as NaN-unsafe.
+  const std::size_t p90i = (9 * (des.size() - 1)) / 10;
 
   r.ok = true;
   r.n = (int)des.size();


### PR DESCRIPTION
## Summary

Actually clears code-scanning alert **#2335** (`iccdev/float-to-int-cast`) in
`RoundTripDE` (`Tools/CmdLine/IccProfilePlot/IccVizModel.cpp`). PR #1816 added a
correct `std::isfinite` guard for the `des.reserve((size_t)total)` cast but placed
it **9 lines above** the cast, and the query only ties an `isfinite`/`isnan` guard
to a cast when it is **within 5 lines above** (same-function line window):

```ql
guard.getLocation().getStartLine() >= cast.getLocation().getStartLine() - 5 and
guard.getLocation().getStartLine() <= cast.getLocation().getStartLine()
```

So the alert re-flagged on #1816's own merge commit. This PR places the cast inside
that window and removes a second, adjacent float-to-int cast in the same function.

## Changes (both in `RoundTripDE`)

1. **`des.reserve((size_t)total)`** — hoist the `std::vector<double> des;` +
   `des.reserve(...)` to immediately after the `isfinite`/ceiling guard, so the cast
   sits 5 lines below its guard (inside the window). Also marginally cleaner: the
   result accumulator is reserved as soon as its size is known, before the transforms
   are built.
2. **p90-percentile index** — replace `(std::size_t)std::floor(0.90 * (n - 1))` with
   the exact integer form `(9 * (n - 1)) / 10`, removing the float-to-int cast
   entirely rather than guarding it. This is the same index for every `n`
   (`des.size() <= 3,000,000` from the seed-grid cap, so `9*(n-1)` cannot overflow),
   and it expresses the true integer intent of a percentile index.

## Verification

- Build clean; the iccviz CTests pass, including `iccdev.iccviz-gamut-roundtrip-metrics`,
  which drives `RoundTripDE` on `sRGB_v4_ICC_preference.icc` — `p90DE` stays finite and
  ordered (`mean <= p90 <= max`), confirming the integer index is equivalent.
- **Local CodeQL run of `float-to-int-cast.ql`**: no float-to-int findings remain in
  the `RoundTripDE` region (both the `des.reserve` and p90i casts are gone). Pre-existing
  casts elsewhere in the file (other functions) are out of scope and untouched.

No behaviour change: both edits are provably index/size-equivalent to the originals.
