### PR TITLE
more codeQL fixes

### DIFF
--- a/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/iccProfileVisualize.cpp
@@ -1193,7 +1193,7 @@ void processMBBType(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
   // multiply out by tile size
   int imageWidth = tilesWide * tileWidth;
   int imageHeight = tilesHigh * tileHeight;
-  if (imageWidth <= 0 || imageHeight <= 0 || bytes <= 0) {
+  if (imageWidth <= 0 || imageHeight <= 0) {
     LogAnError(stderr, "%s: Skipping %s: invalid image geometry\n", basename.c_str(), sigDesc.c_str());
     return;
   }
@@ -1219,7 +1219,7 @@ void processMBBType(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
   std::string tiffPath2 = basename + "_" + sigDesc;
   int tiffColor = TIFFColorModelFromICCModel( outputSpace );
   imageData *image = new imageData( tiffPath2, imageBuffer.release(),
-                          imageWidth, imageHeight, outputChannels, 8*bytes, tiffColor, bytes>=4 );
+                          imageWidth, imageHeight, outputChannels, 8*bytes, tiffColor, false );
   data.addPage( image );
 
   if (doEdges) {
@@ -1256,7 +1256,7 @@ void processMBBType(CIccProfile *pIcc, CIccTag *tag, const std::string &sigDesc,
     std::string tiffPath3 = basename + "_" + sigDesc + "_edges";
     int edgeColor = TIFFEdgeColorModelFromICCModel( outputSpace );
     imageData *edgeImage = new imageData( tiffPath3, imageBuffer.release(),
-                          imageWidth, imageHeight, outputChannels, 8*bytes, edgeColor, bytes>=4 );
+                          imageWidth, imageHeight, outputChannels, 8*bytes, edgeColor, false );
     data.addPage( edgeImage );
 
   }   // end if doEdges

--- a/Tools/CmdLine/IccProfileVisualize/vizShared.hpp
+++ b/Tools/CmdLine/IccProfileVisualize/vizShared.hpp
@@ -83,7 +83,7 @@
 
 /******************************************************************************/
 
-const float inch2mm = 25.4f;                 // 25.4 millimeters per inch, international standard
+//const float inch2mm = 25.4f;                 // 25.4 millimeters per inch, international standard   NOTE - currently unused
 //const float mm2point = 72.0f / inch2mm;      // 2.834645669 (Shows up several places)  NOTE - Currently unused.
 const float inch2point = 72.0f;              // 72 points per inch, DTP and W3C standard
 


### PR DESCRIPTION
First fix exposed more stuff downstream.

## Checklist

- [ ] Signed all Commits in PR
- [ ] Built locally according to `docs/build.md`
- [ ] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [ ] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes
- [ ] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed `docs/python-packaging-release.md` for PR and merge requirements
- [ ] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [ ] New source files include the ICC copyright and BSD 3-Clause license header
- [ ] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
