### PR TITLE
fix(#1808): treat negative XYZ Z as legal (Warning), keep X/Y NonCompliant

### DIFF
--- a/.github/ci/regression/xyznumber-negative-z-legal.cpp
+++ b/.github/ci/regression/xyznumber-negative-z-legal.cpp
@@ -1,0 +1,171 @@
+// Regression for #1808: a negative Z component of an XYZNumber is legal and must
+// validate as a Warning, while a negative X or Y must stay NonCompliant.
+//
+// iccV5DspObsToV4Dsp integrates against a custom observer and then applies a
+// custom->standard (D65->D50) PCC, which emits a redColorantTag whose Z is slightly
+// negative. CIccInfo::CheckData classified that as icValidateNonCompliant, so a
+// correctly-generated profile was reported as violating the specification. Per Phil
+// Green (ICC, #1808): "Negative z-values can arise in some computations (e.g.
+// chromatic adaptation) and are legal." The generator is right; the validator was
+// wrong, and only its Z branch was relaxed to icValidateWarning.
+//
+// The asymmetry is the whole point of this test, so it pins both directions. A direct
+// CIE integral cannot go negative (the 1931 2-deg / 1964 10-deg observers are
+// non-negative at every wavelength), so any negative component implies a non-CIE
+// basis, a signed transform applied after the integral (chromatic adaptation / PCC
+// matrices -- the #1808 case), or non-physical spectral input. Those mechanisms are
+// not channel-specific in principle, but their incidence is: zbar's narrow support
+// plus the strong short-wave scaling of D65<->D50 adaptation make a negative Z
+// common, a negative X rare and usually a bad matrix or input, and a negative Y
+// (negative luminance) effectively always corruption. Hence Z warns and X/Y reject.
+//
+// Both CheckData overloads are covered. Legality is a property of the physical
+// quantity rather than its encoding, so the fixed-point icXYZNumber and float
+// icFloatXYZNumber paths must return the same verdict for the same colour --
+// otherwise a value would validate differently depending only on how the tag stores
+// it. The test calls CheckData directly, so it needs no profile fixture and is fast.
+//
+// Red-green: reverting the Z branch to icValidateNonCompliant fails the "negative Z
+// warns" assertions; over-applying the downgrade to X or Y fails the guard
+// assertions that keep those NonCompliant.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccUtil.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[xyz-negative-z] FAIL: %s\n", what);
+  }
+}
+
+// Build a fixed-point XYZNumber from doubles. icDtoF applies the s15Fixed16
+// encoding used on the wire, which is signed -- a negative component is
+// representable, which is why the validator (not the encoding) is what decides
+// whether such a value is acceptable.
+icXYZNumber makeXYZ(double x, double y, double z)
+{
+  icXYZNumber v;
+  v.X = icDtoF((icFloatNumber)x);
+  v.Y = icDtoF((icFloatNumber)y);
+  v.Z = icDtoF((icFloatNumber)z);
+  return v;
+}
+
+icFloatXYZNumber makeFloatXYZ(double x, double y, double z)
+{
+  icFloatXYZNumber v;
+  v.X = (icFloat32Number)x;
+  v.Y = (icFloat32Number)y;
+  v.Z = (icFloat32Number)z;
+  return v;
+}
+
+// A plausible D50 media white point, used as the all-positive control and as the
+// base the sign-flipped cases perturb one component of.
+const double kWpX = 0.9642;
+const double kWpY = 1.0000;
+const double kWpZ = 0.8249;
+
+// Each case re-runs against a fresh report string so one verdict cannot be
+// contaminated by a previous case's appended text.
+icValidateStatus checkFixed(const icXYZNumber &v, std::string &sReport)
+{
+  CIccInfo info;
+  sReport.clear();
+  return info.CheckData(sReport, v, "test");
+}
+
+icValidateStatus checkFloat(const icFloatXYZNumber &v, std::string &sReport)
+{
+  CIccInfo info;
+  sReport.clear();
+  return info.CheckData(sReport, v, "test");
+}
+
+// The reports are prefixed with icMsgValidateWarning / icMsgValidateNonCompliant, so
+// asserting on the severity word as well as the return code catches a change that
+// updates one but not the other (the report text is what users actually read).
+bool mentions(const std::string &sReport, const char *needle)
+{
+  return sReport.find(needle) != std::string::npos;
+}
+
+} // namespace
+
+int main()
+{
+  std::string report;
+
+  // --- fixed-point icXYZNumber ------------------------------------------------
+
+  check(checkFixed(makeXYZ(kWpX, kWpY, kWpZ), report) == icValidateOK,
+        "all-positive XYZNumber should validate OK");
+  check(!mentions(report, "Negative"),
+        "all-positive XYZNumber should not report a negative component");
+
+  // The #1808 case: legal per ICC, so a Warning and explicitly NOT NonCompliant.
+  check(checkFixed(makeXYZ(kWpX, kWpY, -0.05), report) == icValidateWarning,
+        "negative Z XYZNumber should validate as Warning (#1808)");
+  check(mentions(report, "Negative Z value!"),
+        "negative Z XYZNumber should report the negative Z message");
+  check(mentions(report, "Warning"),
+        "negative Z XYZNumber report should carry the Warning prefix");
+  check(!mentions(report, "NonCompliant"),
+        "negative Z XYZNumber must not be reported as NonCompliant (#1808)");
+
+  // Guards: the downgrade must not have leaked to the other two channels.
+  check(checkFixed(makeXYZ(-0.05, kWpY, kWpZ), report) == icValidateNonCompliant,
+        "negative X XYZNumber should stay NonCompliant");
+  check(mentions(report, "Negative X value!") && mentions(report, "NonCompliant"),
+        "negative X XYZNumber should report NonCompliant");
+
+  check(checkFixed(makeXYZ(kWpX, -0.05, kWpZ), report) == icValidateNonCompliant,
+        "negative Y XYZNumber should stay NonCompliant");
+  check(mentions(report, "Negative Y value!") && mentions(report, "NonCompliant"),
+        "negative Y XYZNumber should report NonCompliant");
+
+  // A negative X combined with a negative Z must still reject: icMaxStatus takes the
+  // most severe verdict, so the Z warning cannot mask the X violation.
+  check(checkFixed(makeXYZ(-0.05, kWpY, -0.05), report) == icValidateNonCompliant,
+        "negative X and Z together should stay NonCompliant");
+
+  // --- float icFloatXYZNumber -------------------------------------------------
+  // Same expectations: the verdict must not depend on the encoding.
+
+  check(checkFloat(makeFloatXYZ(kWpX, kWpY, kWpZ), report) == icValidateOK,
+        "all-positive FloatXYZNumber should validate OK");
+
+  check(checkFloat(makeFloatXYZ(kWpX, kWpY, -0.05), report) == icValidateWarning,
+        "negative Z FloatXYZNumber should validate as Warning (#1808)");
+  check(mentions(report, "Negative Z value!"),
+        "negative Z FloatXYZNumber should report the negative Z message");
+  check(!mentions(report, "NonCompliant"),
+        "negative Z FloatXYZNumber must not be reported as NonCompliant (#1808)");
+
+  check(checkFloat(makeFloatXYZ(-0.05, kWpY, kWpZ), report) == icValidateNonCompliant,
+        "negative X FloatXYZNumber should stay NonCompliant");
+  check(checkFloat(makeFloatXYZ(kWpX, -0.05, kWpZ), report) == icValidateNonCompliant,
+        "negative Y FloatXYZNumber should stay NonCompliant");
+
+  if (g_fail)
+    std::fprintf(stderr, "[xyz-negative-z] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[xyz-negative-z] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -888,6 +888,46 @@ function(iccdev_add_gbd_zero_pcs_test)
   endif()
 endfunction()
 
+# #1808: a negative Z in an XYZNumber is legal (it arises from chromatic adaptation,
+# e.g. the custom-observer -> D50 PCC in iccV5DspObsToV4Dsp) and must validate as a
+# Warning, while a negative X or Y stays NonCompliant. The test drives
+# CIccInfo::CheckData directly over both the fixed-point and float overloads, so it
+# needs no profile fixture and pins the asymmetry in both directions.
+function(iccdev_add_xyz_negative_z_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccXyzNegativeZTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/xyznumber-negative-z-legal.cpp"
+  )
+  target_link_libraries(iccXyzNegativeZTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccXyzNegativeZTest)
+
+  add_test(
+    NAME iccdev.xyznumber-negative-z-legal
+    COMMAND "$<TARGET_FILE:iccXyzNegativeZTest>"
+  )
+  set_tests_properties(iccdev.xyznumber-negative-z-legal PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;validation;issue-1808;regression"
+  )
+  if(WIN32)
+    set(_xyz_negz_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccXyzNegativeZTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _xyz_negz_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.xyznumber-negative-z-legal PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_xyz_negz_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_utf8_textarray_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -2015,6 +2055,7 @@ if(WIN32)
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
   iccdev_add_gbd_zero_pcs_test()
+  iccdev_add_xyz_negative_z_test()
   iccdev_add_utf8_textarray_test()
   iccdev_add_extended_device_colorspace_test()
   iccdev_add_dpcc_pcc_replacement_test()
@@ -2226,6 +2267,7 @@ iccdev_add_reflectance_observer_illum_range_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
 iccdev_add_gbd_zero_pcs_test()
+iccdev_add_xyz_negative_z_test()
 iccdev_add_utf8_textarray_test()
 iccdev_add_extended_device_colorspace_test()
 iccdev_add_dpcc_pcc_replacement_test()

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -2481,6 +2481,69 @@ const icChar *CIccInfo::GetColorantEncoding(icColorantEncoding colorant)
   }
 }
 
+/**
+******************************************************************************
+* Name: CIccInfo::CheckData
+*
+* Purpose: Validates the components of an XYZNumber.
+*
+*  Sign policy (#1808): a negative X or Y is reported as NonCompliant, but a
+*  negative Z is only a Warning. The asymmetry is deliberate and follows from
+*  how tristimulus values are produced.
+*
+*  A direct CIE integral cannot go negative. X/Y/Z are integrals of S(l)*R(l)
+*  against the colour-matching functions, and the CIE 1931 2-deg / 1964 10-deg
+*  observers have xbar, ybar, zbar >= 0 at every wavelength (by design -- unlike
+*  the CIE RGB functions r/g/b, which carry large negative lobes near 440-550nm).
+*  With a physical illuminant and a physical reflectance each integrand is a
+*  product of non-negatives, so a negative component can only appear when one of
+*  those assumptions is broken. Three mechanisms do so:
+*
+*   1. A non-CIE basis. Custom observers, cone-fundamental-derived CMFs or the
+*      raw CIE RGB functions have negative lobes, so a stimulus carrying energy
+*      in such a lobe integrates negative.
+*   2. A signed linear transform applied after the integral. Chromatic
+*      adaptation (Bradford / CAT02 / von Kries) and PCS/PCC matrices all have
+*      negative off-diagonal terms, so the result is a signed combination rather
+*      than an integral against a non-negative basis. Adapting a saturated,
+*      gamut-boundary primary between two different white points can push a
+*      component just below zero. This is the #1808 case: iccV5DspObsToV4Dsp
+*      integrates against a custom observer and then applies a custom->standard
+*      (D65->D50) PCC, and the red colorant emerges with Z < 0.
+*   3. Non-physical spectral input. Measurement noise near the floor, or
+*      least-squares spectral reconstruction overshoot, can yield a reflectance
+*      that dips below zero in some band.
+*
+*  Those mechanisms are not channel-specific in principle, but their practical
+*  incidence is very uneven, which is why only Z is relaxed:
+*
+*   Z - common. zbar has the narrowest support (~400-500nm, ~0 above 560nm), so
+*       most colorants have a near-zero Z that a small signed correction flips,
+*       and D65<->D50 adaptation applies its strongest signed scaling to the
+*       short-wave channel. Both mechanisms load onto Z.
+*   X - rarer. xbar's secondary red lobe, combined with certain adaptation
+*       matrices, can make an X row net-negative for a saturated cyan/green at
+*       the gamut boundary. Possible, but in practice a negative X much more
+*       often signals a bad matrix or bad input than legitimate colorimetry.
+*   Y - effectively never. ybar is the luminance channel: broad support, and
+*       adaptation transforms are constructed to preserve luminance. A negative
+*       Y is negative luminance, i.e. corruption.
+*
+*  So Z warns and X/Y stay NonCompliant. Should a real profile ever exhibit a
+*  legitimately negative X arising from a documented adaptation or custom-observer
+*  path, extending the same treatment to X would be justified -- but that should
+*  be driven by such evidence rather than relaxed pre-emptively.
+*
+* Args:
+*  sReport - string to add validation report to
+*  XYZ - the XYZNumber to validate
+*  sDesc - description of the item being validated (prefixed to any message)
+*
+* Return:
+*  icValidateOK, icValidateWarning (negative Z) or icValidateNonCompliant
+*  (negative X or Y)
+******************************************************************************
+*/
 icValidateStatus CIccInfo::CheckData(std::string &sReport, const icXYZNumber &XYZ, std::string sDesc/*=""*/)
 {
   icValidateStatus rv = icValidateOK;
@@ -2499,11 +2562,15 @@ icValidateStatus CIccInfo::CheckData(std::string &sReport, const icXYZNumber &XY
     rv = icMaxStatus(rv, icValidateNonCompliant);
   }
 
+  // "Negative z-values can arise in some computations (e.g. chromatic adaptation)
+  // and are legal" -- Phil Green, ICC (#1808). Warn rather than reject, so such a
+  // profile is no longer marked NonCompliant; see the sign-policy note above for
+  // why this applies to Z but not to the X and Y checks preceding it.
   if (XYZ.Z < 0) {
-    sReport += icMsgValidateNonCompliant;
+    sReport += icMsgValidateWarning;
     sReport += sDesc;
     sReport += " - XYZNumber: Negative Z value!\n";
-    rv = icMaxStatus(rv, icValidateNonCompliant);
+    rv = icMaxStatus(rv, icValidateWarning);
   }
 
   return rv;
@@ -2527,11 +2594,15 @@ icValidateStatus CIccInfo::CheckData(std::string &sReport, const icFloatXYZNumbe
     rv = icMaxStatus(rv, icValidateNonCompliant);
   }
 
+  // Same sign policy as the fixed-point XYZNumber overload above (#1808): negative
+  // Z warns, negative X/Y stay NonCompliant. Legality is a property of the physical
+  // quantity rather than its encoding, so both paths must agree or the same colour
+  // would validate differently depending only on how the tag stores it.
   if (XYZ.Z < 0) {
-    sReport += icMsgValidateNonCompliant;
+    sReport += icMsgValidateWarning;
     sReport += sDesc;
     sReport += " - FloatXYZNumber: Negative Z value!\n";
-    rv = icMaxStatus(rv, icValidateNonCompliant);
+    rv = icMaxStatus(rv, icValidateWarning);
   }
 
   return rv;


### PR DESCRIPTION
Closes #1808.

## Summary

`iccV5DspObsToV4Dsp` produces a `redColorantTag` with a negative Z, which validation
reported as a hard spec violation:

```
NonCompliant! - redColorantTag::XYZ - XYZNumber: Negative Z value!
```

The issue was originally framed as a missing range check on the write into
`CIccTagXYZ`. That framing is incorrect, and this PR does **not** change the
generator. Per @PhilGreen736767 on #1808:

> Negative z-values can arise in some computations (e.g. chromatic adaptation) and are legal.

The negative Z is a correct result of the adaptation math, so clamping it in
`IccV5DspObsToV4Dsp.cpp` would corrupt legitimate colorimetry. The defect is in the
validator: `CIccInfo::CheckData` classified a legal value as `NonCompliant`.

## Change

`IccProfLib/IccUtil.cpp`, both XYZ-number overloads of `CIccInfo::CheckData`
(fixed-point `icXYZNumber` and float `icFloatXYZNumber`):

- negative **Z** -> `icValidateWarning` (message text unchanged)
- negative **X** and **Y** -> unchanged, still `icValidateNonCompliant`

Both encodings are treated identically: legality is a property of the physical
quantity, not of how the tag stores it, so the same colour must not validate
differently depending on encoding.

## Why only Z

Tristimulus values are integrals of `S(l)*R(l)` against the colour-matching
functions, and the CIE 1931 2-deg / 1964 10-deg observers have `xbar, ybar, zbar >= 0`
at every wavelength (by design -- unlike the CIE RGB functions, which carry large
negative lobes). With a physical illuminant and a physical reflectance, every
integrand is a product of non-negatives, so **a direct CIE integral cannot go
negative**. A negative component therefore requires breaking one of those
assumptions, which happens three ways:

1. **A non-CIE basis** -- custom observers, cone-fundamental-derived CMFs or the raw
   CIE RGB functions have negative lobes, so a stimulus with energy in such a lobe
   integrates negative.
2. **A signed linear transform after the integral** -- chromatic adaptation
   (Bradford / CAT02 / von Kries) and PCS/PCC matrices all carry negative
   off-diagonal terms, so the result is a signed combination, not an integral
   against a non-negative basis. Adapting a saturated, gamut-boundary primary
   between two different white points can push a component just below zero.
   **This is the #1808 case**: `iccV5DspObsToV4Dsp` integrates against a custom
   observer and then applies a custom->standard (D65->D50) PCC.
3. **Non-physical spectral input** -- measurement noise near the floor, or
   least-squares spectral reconstruction overshoot, yielding a reflectance that
   dips below zero in some band.

These mechanisms are not channel-specific in principle, but their practical
incidence is very uneven, which is what justifies relaxing Z alone:

| Channel | Why it can go negative | Incidence |
|---|---|---|
| **Z** | `zbar` has the narrowest support (~400-500nm, ~0 above 560nm), so most colorants have a near-zero Z that a small signed correction flips; and D65<->D50 adaptation applies its strongest signed scaling to the short-wave channel. Both mechanisms load onto Z. | **Common** |
| **X** | `xbar`'s secondary red lobe, with certain adaptation matrices, can make an X row net-negative for a saturated cyan/green at the gamut boundary. Physically possible, mechanism-identical to Z. | Rarer -- in practice more often a bad matrix or bad input |
| **Y** | `ybar` is the luminance channel: broad support, and adaptation transforms are constructed to preserve luminance. Negative Y is negative luminance. | Effectively never (legitimately) -- corruption |

So the relaxation is deliberately narrow: it covers the case that legitimately and
routinely occurs, without weakening validation where a negative value is far more
likely to indicate a real defect. If a profile ever shows a legitimately negative X
from a documented adaptation or custom-observer path, extending the same treatment to
X would be justified -- but driven by that evidence, not pre-emptively.

This rationale is recorded in full as a doc-block on `CIccInfo::CheckData` in
`IccUtil.cpp`, so the next person to see a negative-XYZ report has the reasoning at
the point of decision rather than only in this PR.

## Regression test

Adds `.github/ci/regression/xyznumber-negative-z-legal.cpp`, registered as
`iccdev.xyznumber-negative-z-legal`. It drives `CIccInfo::CheckData` directly over
both overloads -- no profile fixture needed, so it runs in ~0.01s -- and pins the
asymmetry in *both* directions:

- negative Z -> `icValidateWarning`, report carries the `Warning` prefix, and
  explicitly **not** `NonCompliant`
- negative X and negative Y -> still `icValidateNonCompliant`
- negative X *and* Z together -> `NonCompliant` (the Z warning must not mask the X
  violation via `icMaxStatus`)
- all-positive -> `icValidateOK`

**Red-green verified:** reverting either Z branch to `icValidateNonCompliant` fails
5 assertions across the two overloads; with the fix in place it passes. The X/Y
assertions are the guard against over-applying the downgrade.

## Verification

- **Unit/CTest:** full local suite on a fresh Release build -- **105/106 pass**. The
  single failure is `iccdev.spectral-tiff-preview`, which is environmental
  (`ModuleNotFoundError: No module named 'imagecodecs'` in my WSL environment) and
  unrelated to this change -- it is a TIFF-preview script test that does not touch
  XYZ validation.
- **End to end:** built `IccProfLib` + `iccDumpProfile`/`iccFromXml`/`iccToXml` and
  round-tripped `Testing/Display/sRGB_D65_MAT.icc` through XML with a single
  component sign-flipped on `mediaWhitePointTag` (an `XYZType` tag reaching the same
  `CheckData` path):

| Case | Result |
|---|---|
| baseline (unmodified) | no negative-XYZ message, no violation |
| negative **Z** | `Warning! - mediaWhitePointTag::XYZ - XYZNumber: Negative Z value!`, **no** "violates ICC specification" line -- profile compliant |
| negative **X** (control) | `NonCompliant! - ... Negative X value!` **and** `Profile violates ICC specification` -- unchanged |

The X control confirms the downgrade was not over-applied.
