### PR TITLE
fix(#1830,#1831): validate string->numeric parses in the JSON and date-time headers

### DIFF
--- a/.github/ci/regression/datetime-parse-strict.cpp
+++ b/.github/ci/regression/datetime-parse-strict.cpp
@@ -1,0 +1,159 @@
+// Regression for #1831: icGetDateTimeValue must not narrow an out-of-range field
+// into the icUInt16Number members of icDateTimeNumber.
+//
+// The parser was a bare sscanf("%u-%02u-%02uT%02u:%02u:%02u") whose return value was
+// discarded. Three things went wrong, all reachable from iccFromXml/iccFromJson on
+// attacker-supplied input:
+//
+//   1. The conversion count was ignored, so a partially-matching string left the
+//      remaining fields at whatever they already held.
+//   2. "%u" accepts a leading '-' and negates the result into a large unsigned
+//      value, so "-1" parsed as 4294967295.
+//   3. Each field was assigned into an icUInt16Number before any range check, so an
+//      out-of-range value was silently truncated. UBSan reported exactly this for
+//      the year: "implicit conversion from ... 590359881 ... changed the value to
+//      11593" (IccUtil.cpp, #1831).
+//
+// The parser is now explicit: every field must be a run of decimal digits that fits
+// in icUInt16Number, every separator must be present, and the whole string must be
+// consumed apart from surrounding whitespace. A malformed string yields an all-zero
+// icDateTimeNumber -- the conventional ICC "date unknown" value, which
+// CIccInfo::CheckData already reports on, so a bad date still surfaces to the user
+// instead of becoming a plausible-looking wrong one.
+//
+// Two properties matter beyond "rejects garbage", and both are pinned here:
+//
+//   * Structurally valid but calendar-nonsensical dates are still passed through
+//     (month 59, day 0) so CheckData can name the offending field. The repository's
+//     own #1343 fuzz fixture contains 59881-59-00T00:00:00, and the existing
+//     iccdev-issue-1342-1343 regression asserts that file still round-trips, so
+//     over-tightening here would break it.
+//   * The all-zero sentinel 0-00-00T00:00:00 must keep parsing as all zeros.
+//
+// Red-green: reverting to the sscanf form makes the truncation cases fail (year
+// 590359881 arrives as 11593 rather than 0, and "-1" arrives as 65535).
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccUtil.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[datetime-parse] FAIL: %s\n", what);
+  }
+}
+
+bool isZero(const icDateTimeNumber &d)
+{
+  return !d.year && !d.month && !d.day && !d.hours && !d.minutes && !d.seconds;
+}
+
+// Compare against expected field values; prints the mismatch so a failure says what
+// was actually parsed rather than just which case failed.
+void checkFields(const char *str, unsigned y, unsigned mo, unsigned d,
+                 unsigned h, unsigned mi, unsigned s, const char *what)
+{
+  icDateTimeNumber v = icGetDateTimeValue(str);
+  bool ok = v.year == y && v.month == mo && v.day == d &&
+            v.hours == h && v.minutes == mi && v.seconds == s;
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr,
+                 "[datetime-parse] FAIL: %s -- \"%s\" gave %u-%02u-%02uT%02u:%02u:%02u,"
+                 " expected %u-%02u-%02uT%02u:%02u:%02u\n",
+                 what, str, v.year, v.month, v.day, v.hours, v.minutes, v.seconds,
+                 y, mo, d, h, mi, s);
+  }
+}
+
+} // namespace
+
+int main()
+{
+  // --- well-formed input is unchanged -----------------------------------------
+
+  checkFields("2026-07-25T12:34:56", 2026, 7, 25, 12, 34, 56, "canonical date parses");
+  checkFields("0-00-00T00:00:00", 0, 0, 0, 0, 0, 0, "all-zero sentinel parses as zero");
+
+  // The #1343 fuzz fixture. Structurally valid and every field fits icUInt16Number,
+  // so it must survive intact for CheckData to flag month 59 -- see the file header.
+  checkFields("59881-59-00T00:00:00", 59881, 59, 0, 0, 0, 0,
+              "#1343 fixture (5-digit year, month 59) passes through");
+
+  // Boundary: 65535 is representable, so it is accepted rather than zeroed.
+  checkFields("65535-12-31T23:59:59", 65535, 12, 31, 23, 59, 59,
+              "icUInt16Number-max year accepted");
+
+  // Writers emit text nodes that can carry surrounding whitespace.
+  checkFields("  2026-07-25T12:34:56  ", 2026, 7, 25, 12, 34, 56,
+              "surrounding whitespace tolerated");
+
+  // A bare ISO-8601 date is a complete instant (midnight that day) and is what the
+  // old sscanf already produced for this input, so it must keep working -- these are
+  // authoring tools and a hand-written date without a time is reasonable input.
+  checkFields("2026-07-25", 2026, 7, 25, 0, 0, 0,
+              "date without a time means midnight that day");
+
+  // --- the #1831 truncation cases ---------------------------------------------
+
+  // The exact value from the UBSan report: it must not arrive as 11593.
+  icDateTimeNumber v = icGetDateTimeValue("590359881-07-25T00:00:00");
+  check(v.year != 11593, "year 590359881 must not be truncated to 11593 (#1831)");
+  check(isZero(v), "out-of-range year yields the all-zero date (#1831)");
+
+  // "%u" negated this into 4294967295, which truncated to 65535.
+  v = icGetDateTimeValue("-1-07-25T00:00:00");
+  check(v.year != 65535, "negative year must not become 65535 (#1831)");
+  check(isZero(v), "negative year yields the all-zero date (#1831)");
+
+  // Just past the icUInt16Number bound.
+  check(isZero(icGetDateTimeValue("65536-01-01T00:00:00")),
+        "year 65536 is rejected rather than wrapping to 0");
+
+  // --- structural rejection ----------------------------------------------------
+  // The discarded sscanf return count meant these left fields partly assigned.
+
+  check(isZero(icGetDateTimeValue("")), "empty string is rejected");
+  check(isZero(icGetDateTimeValue("garbage")), "non-numeric string is rejected");
+  check(isZero(icGetDateTimeValue("2026/07/25T00:00:00")), "wrong separators rejected");
+  check(isZero(icGetDateTimeValue("2026-07-25T00:00:00trailing")),
+        "trailing garbage is rejected");
+
+  // A 'T' promises a time, so an incomplete one after it is rejected rather than
+  // zero-filled -- the old sscanf turned this into 12:34:00.
+  check(isZero(icGetDateTimeValue("2026-07-25T12:34")),
+        "incomplete time after 'T' is rejected");
+
+  // Reduced-precision dates are not accepted: a zero day is not a calendar date,
+  // and the old code turned these into dates that never existed (2026-07-00).
+  check(isZero(icGetDateTimeValue("2026-07")), "year-month without a day rejected");
+  check(isZero(icGetDateTimeValue("2026")), "year alone rejected");
+  check(isZero(icGetDateTimeValue(NULL)), "NULL is rejected without dereferencing");
+
+  // "now" is the documented alias for the current local time; it must still produce
+  // a populated date rather than being caught by the stricter parse.
+  v = icGetDateTimeValue("now");
+  check(v.year >= 2020 && v.month >= 1 && v.month <= 12,
+        "\"now\" still resolves to the current date");
+
+  if (g_fail)
+    std::fprintf(stderr, "[datetime-parse] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[datetime-parse] all assertions passed\n");
+
+  return g_fail;
+}

--- a/.github/ci/regression/json-bcd-version-parse.cpp
+++ b/.github/ci/regression/json-bcd-version-parse.cpp
@@ -1,0 +1,148 @@
+// Regression for #1830: the JSON BCD version parser must reject a malformed version
+// component instead of wrapping it through the header's shift arithmetic.
+//
+// CIccProfileJson::ParseBasic decodes "ProfileVersion" / "ProfileSubClassVersion"
+// with icJsonParseBCDVersionStr, which used atoi() per component:
+//
+//     int v = atoi(s);
+//     return (icUInt32Number)(((v / 10) % 10) * 16 + (v % 10));
+//
+// atoi() accepts a leading '-', so "-1" gave v == -1, and the BCD expression then
+// evaluated to -1, which reinterpreted as icUInt32Number is 0xFFFFFFFF. That value
+// wrapped both shifts downstream, which UBSan reported on the #1830 PoC as:
+//
+//   IccProfileJson.cpp:293: runtime error: left shift of 4294967295 by 8 places
+//                           cannot be represented in type 'icUInt32Number'
+//   IccProfileJson.cpp:308: runtime error: left shift of 4294967040 by 16 places
+//                           cannot be represented in type 'icUInt32Number'
+//
+// atoi() is additionally undefined on an out-of-range input, which a digit-by-digit
+// parse of at most two digits cannot reach.
+//
+// Each component is now required to be one or two decimal digits with no sign, so
+// the encoded byte is always a valid BCD byte (<= 0x99) and the packed pair is at
+// most 0x9999 -- the caller's further "<< 16" therefore cannot overflow. A malformed
+// version parses as 0, which is what the zeroed header already carries.
+//
+// The test drives the public CIccProfileJson::ParseJson so it exercises the real
+// header path rather than the file-static helpers. Red-green: restoring the atoi()
+// form makes the "-1" cases fail (version becomes 0xFFFF0000 rather than 0) and, in
+// a UBSan build, reintroduces the shift diagnostics above.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccProfileJson.h"
+#include "IccTagJsonFactory.h"
+
+#include <cstdio>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[json-bcd-version] FAIL: %s\n", what);
+  }
+}
+
+// Build the smallest JSON profile ParseJson accepts (it requires both a Header and a
+// Tags member) carrying the supplied version strings, parse it, and hand back the
+// resulting packed header version.
+icUInt32Number parseVersion(const char *szVersion, const char *szSubClassVersion)
+{
+  IccJson root;
+  IccJson header;
+
+  if (szVersion)
+    header["ProfileVersion"] = szVersion;
+  if (szSubClassVersion)
+    header["ProfileSubClassVersion"] = szSubClassVersion;
+
+  root["Header"] = header;
+  root["Tags"] = IccJson::object();
+
+  CIccProfileJson profile;
+  std::string parseStr;
+  profile.ParseJson(root, parseStr);
+
+  return profile.m_Header.version;
+}
+
+void checkVersion(const char *szVersion, icUInt32Number expected, const char *what)
+{
+  icUInt32Number got = parseVersion(szVersion, NULL);
+  if (got != expected) {
+    ++g_fail;
+    std::fprintf(stderr,
+                 "[json-bcd-version] FAIL: %s -- \"%s\" gave 0x%08X, expected 0x%08X\n",
+                 what, szVersion ? szVersion : "(none)",
+                 (unsigned int)got, (unsigned int)expected);
+  }
+}
+
+} // namespace
+
+int main()
+{
+  // --- well-formed versions are unchanged --------------------------------------
+  // CIccInfo::GetVersionName writes "%.2lf", so "4.30" is the canonical round-trip
+  // form and must still encode as BCD 0x0430 in the high half of the header word.
+
+  checkVersion("4.30", 0x04300000u, "\"4.30\" encodes as 0x0430");
+  checkVersion("5.00", 0x05000000u, "\"5.00\" encodes as 0x0500");
+  checkVersion("2.20", 0x02200000u, "\"2.20\" encodes as 0x0220");
+
+  // A missing minor component keeps its previous meaning ("4" == "4.0"), and a
+  // single-digit minor keeps its previous (quirky but unchanged) encoding: atoi("3")
+  // was 3, giving 0x03 rather than 0x30. Pinned so this fix stays behaviour-neutral
+  // for input that already parsed.
+  checkVersion("4", 0x04000000u, "\"4\" encodes as 0x0400");
+  checkVersion("4.3", 0x04030000u, "\"4.3\" encodes as 0x0403 (unchanged quirk)");
+
+  // --- the #1830 cases ---------------------------------------------------------
+
+  // The PoC input. Previously atoi("-1") == -1 -> 0xFFFFFFFF -> wrapped shifts.
+  checkVersion("-1", 0u, "negative major version rejected (#1830)");
+  checkVersion("-1.-1", 0u, "negative major and minor rejected (#1830)");
+  checkVersion("4.-1", 0u, "negative minor rejected (#1830)");
+
+  // A component wider than two digits cannot be a BCD byte.
+  checkVersion("999.99", 0u, "three-digit major rejected");
+  checkVersion("4.999", 0u, "three-digit minor rejected");
+
+  // Non-numeric text. Note ToJson emits "Invalid BCD version 0x..." for a corrupt
+  // header, so a re-parsed document can legitimately contain such a string.
+  checkVersion("abc", 0u, "non-numeric version rejected");
+  checkVersion("Invalid BCD version 0x00000000", 0u,
+               "ToJson's invalid-version text re-parses as 0");
+  checkVersion("", 0u, "empty version rejected");
+  checkVersion(" 4.30", 0u, "leading space rejected (no whitespace skipping)");
+
+  // --- the subclass path shares the same helper --------------------------------
+  // It occupies the low half of the header word, so a wrapped value there would
+  // corrupt the version half too.
+
+  // ParseBasic ORs the subclass pair straight into the low 16 bits (no further
+  // shift, unlike the main version's "<< 16"), so "1.20" lands as 0x0120.
+  icUInt32Number v = parseVersion("4.30", "1.20");
+  check(v == 0x04300120u, "subclass version encodes into the low half");
+
+  v = parseVersion("4.30", "-1");
+  check(v == 0x04300000u, "negative subclass version rejected, major preserved (#1830)");
+  check((v & 0x0000ffffu) == 0u, "rejected subclass version leaves the low half zero");
+
+  if (g_fail)
+    std::fprintf(stderr, "[json-bcd-version] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[json-bcd-version] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1819,6 +1819,95 @@ function(iccdev_add_json_sparsematrix_huaf_test)
   endif()
 endfunction()
 
+# #1830: the JSON BCD version parser used atoi() per component, which accepts a
+# leading '-'; "-1" produced 0xFFFFFFFF and wrapped both the "<< 8" in
+# icJsonParseBCDVersionStr and the caller's "<< 16" (UBSan: "left shift of
+# 4294967295 by 8 places"). Each component must now be one or two digits, so the
+# packed pair is at most 0x9999 and neither shift can overflow. The test drives the
+# public CIccProfileJson::ParseJson, so it needs IccJSON + IccProfLib and is skipped
+# where IccJSON is not built.
+function(iccdev_add_json_bcd_version_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCJSON}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccJsonBcdVersionTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/json-bcd-version-parse.cpp"
+  )
+  target_compile_features(iccJsonBcdVersionTest PRIVATE cxx_std_17)
+  target_include_directories(iccJsonBcdVersionTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccJSON/IccLibJSON"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccJsonBcdVersionTest PRIVATE
+    ${TARGET_LIB_ICCJSON} ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccJsonBcdVersionTest)
+
+  add_test(
+    NAME iccdev.json-bcd-version-parse
+    COMMAND "$<TARGET_FILE:iccJsonBcdVersionTest>"
+  )
+  set_tests_properties(iccdev.json-bcd-version-parse PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;json;header;issue-1830;regression"
+  )
+  if(WIN32)
+    set(_json_bcd_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccJsonBcdVersionTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCJSON}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _json_bcd_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.json-bcd-version-parse PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_json_bcd_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
+# #1831: icGetDateTimeValue discarded its sscanf conversion count and assigned every
+# field into the icUInt16Number members of icDateTimeNumber without a range check, so
+# "%u" turned "-1" into 4294967295 and a year of 590359881 was truncated to 11593
+# (UBSan implicit-conversion). The parse is now explicit and a malformed string
+# yields the all-zero "date unknown" value. Pure IccProfLib, no fixture needed.
+function(iccdev_add_datetime_parse_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccDateTimeParseTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/datetime-parse-strict.cpp"
+  )
+  target_link_libraries(iccDateTimeParseTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccDateTimeParseTest)
+
+  add_test(
+    NAME iccdev.datetime-parse-strict
+    COMMAND "$<TARGET_FILE:iccDateTimeParseTest>"
+  )
+  set_tests_properties(iccdev.datetime-parse-strict PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;validation;issue-1831;regression"
+  )
+  if(WIN32)
+    set(_datetime_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccDateTimeParseTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _datetime_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.datetime-parse-strict PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_datetime_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_windows_iccdevcmm_smoke_test)
   if(NOT WIN32 OR NOT TARGET RefIccMAX)
     return()
@@ -2039,6 +2128,8 @@ if(WIN32)
   iccdev_add_compression_describe_labels_test()
   iccdev_add_pawg_compression_paths_test()
   iccdev_add_json_sparsematrix_huaf_test()
+  iccdev_add_json_bcd_version_test()
+  iccdev_add_datetime_parse_test()
   iccdev_add_parser_restore_calls_test()
   iccdev_add_tag_layout_shared_data_test()
   iccdev_add_pawg_q2_tonecurves_test()
@@ -2251,6 +2342,8 @@ iccdev_add_ziputf8_settext_contract_test()
 iccdev_add_compression_describe_labels_test()
 iccdev_add_pawg_compression_paths_test()
 iccdev_add_json_sparsematrix_huaf_test()
+iccdev_add_json_bcd_version_test()
+iccdev_add_datetime_parse_test()
 iccdev_add_parser_restore_calls_test()
 iccdev_add_tag_layout_shared_data_test()
 iccdev_add_pawg_q2_tonecurves_test()

--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -276,20 +276,59 @@ bool CIccProfileJson::ToJson(std::string &jsonString, int indent)
 // Parsing: JSON object -> profile
 // ---------------------------------------------------------------------------
 
-static icUInt32Number icJsonParseBCDByte(const char *s)
+// Convert one decimal version component (0-99) to the BCD byte the ICC header
+// stores. Returns false for an empty component, more than two digits, or any
+// character that is not a digit -- notably a sign (#1830). This used to be
+// atoi(), which accepts a leading '-': "-1" produced v == -1, and
+// ((v/10)%10)*16 + (v%10) then evaluated to -1, which reinterpreted as
+// icUInt32Number is 0xFFFFFFFF. That value went on to wrap both shifts below,
+// which UBSan reported as "left shift of 4294967295 by 8 places cannot be
+// represented in type icUInt32Number". atoi() is also undefined on an
+// out-of-range input, which a digit-by-digit parse of at most two digits cannot
+// hit.
+static bool icJsonParseBCDByte(const std::string &sPart, icUInt32Number &nOut)
 {
-  int v = atoi(s);
-  return (icUInt32Number)(((v / 10) % 10) * 16 + (v % 10));
+  if (sPart.empty() || sPart.size() > 2)
+    return false;
+
+  unsigned int v = 0;
+  for (size_t i = 0; i < sPart.size(); i++) {
+    if (sPart[i] < '0' || sPart[i] > '9')
+      return false;
+    v = v * 10 + (unsigned int)(sPart[i] - '0');
+  }
+
+  nOut = (icUInt32Number)(((v / 10) % 10) * 16 + (v % 10));
+  return true;
 }
 
+// Parse "<major>.<minor>" (as written by CIccInfo::GetVersionName, e.g. "4.30")
+// into the packed BCD pair 0xMMmm. A malformed string yields 0, which is the
+// version the zeroed header already carries, and which GetVersionName renders
+// back as a plain "0.00" rather than a wrapped value. Because each component is
+// now guaranteed to be a valid BCD byte (<= 0x99), the result is at most 0x9999
+// and the caller's further "<< 16" cannot overflow either.
 static icUInt32Number icJsonParseBCDVersionStr(const char *szVer)
 {
+  if (!szVer)
+    return 0;
+
   std::string part;
   for (; *szVer && *szVer != '.'; szVer++) part += *szVer;
-  icUInt32Number hi = icJsonParseBCDByte(part.c_str()); part.clear();
+
+  icUInt32Number hi = 0, lo = 0;
+  if (!icJsonParseBCDByte(part, hi))
+    return 0;
+
+  part.clear();
   if (*szVer) szVer++;
   for (; *szVer; szVer++) part += *szVer;
-  icUInt32Number lo = part.empty() ? 0 : icJsonParseBCDByte(part.c_str());
+
+  // A missing minor component stays 0 ("4" == "4.0"), matching the previous
+  // behaviour; a present but malformed one rejects the whole version.
+  if (!part.empty() && !icJsonParseBCDByte(part, lo))
+    return 0;
+
   return (hi << 8) | lo;
 }
 

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -3108,10 +3108,94 @@ const char *icWCharToUtf8(std::string &buf, const wchar_t *szSrc, size_t sizeSrc
 // Date/time and rendering intent string parsing
 // ---------------------------------------------------------------------------
 
+// Consume up to nMaxDigits ASCII decimal digits into nOut. Returns false if there
+// is no digit at all, or if the value could not be stored in the icUInt16Number
+// fields of icDateTimeNumber without changing it (#1831). Only '0'-'9' advance the
+// cursor: no sign and no whitespace is accepted, which is the point -- the "%u" this
+// replaces took a leading '-' and negated it into a huge unsigned value.
+static bool icParseDateTimeField(const icChar *&p, int nMaxDigits, unsigned int &nOut)
+{
+  unsigned int v = 0;
+  int nDigits = 0;
+
+  // nMaxDigits is at most 5 here, so v stays <= 99999 and the accumulation itself
+  // cannot overflow before the range test below rejects the value.
+  while (nDigits < nMaxDigits && *p >= '0' && *p <= '9') {
+    v = v * 10 + (unsigned int)(*p - '0');
+    ++p;
+    ++nDigits;
+  }
+
+  if (!nDigits || v > 65535u)
+    return false;
+
+  nOut = v;
+  return true;
+}
+
+static bool icParseDateTimeSep(const icChar *&p, icChar sep)
+{
+  if (*p != sep)
+    return false;
+  ++p;
+  return true;
+}
+
+/**
+******************************************************************************
+* Name: icGetDateTimeValue
+*
+* Purpose: Parses an ISO-8601-style "YYYY-MM-DDTHH:MM:SS" string (or "now") into
+*  an icDateTimeNumber.
+*
+*  This used to be a bare sscanf("%u-%02u-%02uT%02u:%02u:%02u") whose return value
+*  was discarded (#1831). That was unsafe in three ways, all reachable from
+*  iccFromXml/iccFromJson on attacker-supplied input:
+*
+*   1. The conversion count was ignored, so a string that matched only part of the
+*      format left the remaining fields holding whatever the previous iteration or
+*      initialisation had put there.
+*   2. "%u" accepts a leading '-' and negates the result into a large unsigned
+*      value, so "-1" parsed as 4294967295.
+*   3. Every field was assigned into the icUInt16Number members of
+*      icDateTimeNumber before anything checked its range, so an out-of-range value
+*      was silently truncated -- UBSan reported year 590359881 arriving as 11593.
+*
+*  Parsing is now explicit: each field must be a run of decimal digits that fits in
+*  icUInt16Number, each separator must be present, and the whole string must be
+*  consumed apart from surrounding whitespace. Anything else yields an all-zero
+*  icDateTimeNumber, which is the conventional ICC "date unknown" value and is what
+*  CIccInfo::CheckData already reports on (as an "Invalid month/day" warning), so a
+*  malformed date still surfaces to the user rather than becoming a plausible-looking
+*  wrong one.
+*
+*  The accepted grammar is "YYYY-MM-DD" optionally followed by "THH:MM:SS". Both
+*  denote a complete instant -- a date alone means midnight on that day, which is
+*  what the old sscanf produced for it -- so both are kept. Reduced-precision forms
+*  such as "YYYY-MM" are not accepted, because a zero day is not a calendar date;
+*  the old code turned those into 2026-07-00, a date that never existed. Once a 'T'
+*  appears it promises a time, so an incomplete one after it is rejected rather than
+*  silently zero-filled.
+*
+*  Note the range test is deliberately only the icUInt16Number bound, not the
+*  calendar bounds: a structurally valid but nonsensical date such as month 59 is
+*  still passed through so that CheckData can report precisely which field is wrong.
+*  Tightening it here would replace that specific diagnostic with a bare zeroed date.
+*
+* Args:
+*  str - the string to parse, or "now" for the current local time
+*
+* Return:
+*  the parsed icDateTimeNumber, or an all-zero value if str is null or malformed
+******************************************************************************
+*/
 icDateTimeNumber icGetDateTimeValue(const icChar *str)
 {
   unsigned int day=0, month=0, year=0, hours=0, minutes=0, seconds=0;
   icDateTimeNumber dateTime = {};
+
+  if (!str)
+    return dateTime;
 
   if (!stricmp(str, "now")) {
     time_t rawtime;
@@ -3126,14 +3210,53 @@ icDateTimeNumber icGetDateTimeValue(const icChar *str)
     minutes = timeinfo->tm_min;
     seconds = timeinfo->tm_sec;
   } else {
-    sscanf(str, "%u-%02u-%02uT%02u:%02u:%02u", &year, &month, &day, &hours, &minutes, &seconds);
+    const icChar *p = str;
+
+    // XML/JSON text nodes can carry surrounding whitespace, which the old sscanf
+    // skipped implicitly; keep accepting it so existing documents still parse.
+    while (*p==' ' || *p=='\t' || *p=='\r' || *p=='\n')
+      ++p;
+
+    // The year is written with a variable width ("%d"/"%04u" across the writers,
+    // and the fuzz corpus contains 5-digit years), so allow up to 5 digits there
+    // and exactly the 2 the writers emit for the remaining fields.
+    bool bOk = icParseDateTimeField(p, 5, year) &&
+               icParseDateTimeSep(p, '-') &&
+               icParseDateTimeField(p, 2, month) &&
+               icParseDateTimeSep(p, '-') &&
+               icParseDateTimeField(p, 2, day);
+
+    // The time part is optional: a bare "YYYY-MM-DD" is a valid ISO-8601 date and
+    // already meant midnight on that day under the old sscanf (it matched three
+    // fields and left the rest at their zero initialisation), so it keeps that
+    // meaning here -- iccFromXml/iccFromJson are authoring tools and a hand-written
+    // date without a time is entirely reasonable input. The 'T' designator is what
+    // promises a time, so once it appears the whole HH:MM:SS must follow.
+    if (bOk && *p == 'T') {
+      ++p;
+      bOk = icParseDateTimeField(p, 2, hours) &&
+            icParseDateTimeSep(p, ':') &&
+            icParseDateTimeField(p, 2, minutes) &&
+            icParseDateTimeSep(p, ':') &&
+            icParseDateTimeField(p, 2, seconds);
+    }
+
+    if (bOk) {
+      while (*p==' ' || *p=='\t' || *p=='\r' || *p=='\n')
+        ++p;
+      bOk = (*p == '\0');
+    }
+
+    if (!bOk)
+      return dateTime;
   }
-  dateTime.year    = year;
-  dateTime.month   = month;
-  dateTime.day     = day;
-  dateTime.hours   = hours;
-  dateTime.minutes = minutes;
-  dateTime.seconds = seconds;
+
+  dateTime.year    = (icUInt16Number)year;
+  dateTime.month   = (icUInt16Number)month;
+  dateTime.day     = (icUInt16Number)day;
+  dateTime.hours   = (icUInt16Number)hours;
+  dateTime.minutes = (icUInt16Number)minutes;
+  dateTime.seconds = (icUInt16Number)seconds;
   return dateTime;
 }
 


### PR DESCRIPTION
Closes #1830. Closes #1831.

## Summary

Two UB reports from the `iccFromJson`/`iccFromXml` fuzzers share one root cause: a
permissive string→numeric conversion whose result was used without checking either
the conversion itself or the range of the value it produced. They are fixed together
because the defect, the reasoning and the test shape are the same; both are reachable
from a single malformed header.

## #1831 — `icGetDateTimeValue` (`IccProfLib/IccUtil.cpp`)

The parser was a bare `sscanf("%u-%02u-%02uT%02u:%02u:%02u")` with its return value
discarded. This matches @xsscx's QA exactly:

1. **The conversion count was ignored**, so a partially-matching string left the
   remaining fields holding whatever they already had.
2. **`%u` accepts a leading `-`** and negates it, so `"-1"` parsed as `4294967295`.
3. **Every field was assigned into the `icUInt16Number` members of
   `icDateTimeNumber` before anything checked its range**, so an out-of-range value
   was silently truncated — UBSan reported year `590359881` arriving as `11593`.

Parsing is now explicit: each field must be a run of decimal digits that fits in
`icUInt16Number`, each separator must be present, and the whole string must be
consumed apart from surrounding whitespace.

**Accepted grammar:** `YYYY-MM-DD`, optionally followed by `THH:MM:SS`. Both denote a
complete instant — a date alone means midnight that day, which is what the old
`sscanf` already produced for it — so both keep working. These are authoring tools
and a hand-written date without a time is reasonable input. Reduced-precision forms
like `YYYY-MM` are rejected because a zero day is not a calendar date (the old code
turned those into `2026-07-00`, a date that never existed), and an incomplete time
after the `T` designator is rejected rather than silently zero-filled.

Anything rejected yields the all-zero `icDateTimeNumber` — the conventional ICC
"date unknown" value, which `CIccInfo::CheckData` already reports on — so a malformed
date still surfaces to the user instead of becoming a plausible-looking wrong one.

### A deliberate limit on the range check

The range test is **only** the `icUInt16Number` bound, not the calendar bounds. A
structurally valid but nonsensical date such as month 59 still passes through, so
`CheckData` can name the offending field rather than the report collapsing to a bare
zeroed date.

This is load-bearing: the repository's own #1343 fuzz fixture contains
`59881-59-00T00:00:00`, and `iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh`
asserts that file still round-trips. Tightening further would have broken it. That
regression was run against this branch and passes.

## #1830 — `icJsonParseBCDVersionStr` (`IccJSON/IccLibJSON/IccProfileJson.cpp`)

Each version component was decoded with `atoi()`, which accepts a leading `-`. `"-1"`
gave `v == -1`, and `((v/10)%10)*16 + (v%10)` then evaluated to `-1`, which
reinterpreted as `icUInt32Number` is `0xFFFFFFFF`. That wrapped both the `<< 8` here
and the caller's `<< 16`:

```
IccProfileJson.cpp:293: runtime error: left shift of 4294967295 by 8 places
                        cannot be represented in type 'icUInt32Number'
IccProfileJson.cpp:308: runtime error: left shift of 4294967040 by 16 places
                        cannot be represented in type 'icUInt32Number'
```

`atoi()` is additionally undefined on out-of-range input, which a digit-by-digit parse
of at most two digits cannot reach.

Each component must now be one or two decimal digits, so the encoded byte is always a
valid BCD byte (`<= 0x99`) and the packed pair is at most `0x9999` — which makes both
shifts **unable to overflow by construction** rather than by a range check. A
malformed version parses as `0`, the value the zeroed header already carries.

Input that previously parsed is unaffected, including the `"4"` == `"4.0"` shorthand
and the pre-existing single-digit-minor quirk (`"4.3"` → `0x0403`); both are pinned by
the new test so this stays behaviour-neutral.

## Regression tests

`iccdev.datetime-parse-strict` and `iccdev.json-bcd-version-parse`. The JSON test
drives the public `CIccProfileJson::ParseJson` rather than the file-static helpers, so
it exercises the real header path.

**Red-green:** against the previous code they fail 9 and 8 assertions respectively,
reporting the actual wrapped values (`0xFFFF0000`) and the truncated year (`11593`).

## Verification

**Sanitizers.** Built with `clang -fsanitize=integer,implicit-conversion,undefined
-fno-sanitize-recover=all`. Both PoC inputs reproduce the exact reported diagnostics
before the fix and are clean after.

**No regression vs. previous behaviour.** Pre-fix binaries were built from pristine
`master` and compared against the fixed ones:

| Corpus | Result |
|---|---|
| XML fixtures (171 parsed profiles) | 169 byte-identical; 2 accounted for below |
| JSON round-trip (199 real profiles from `Testing/**/*.icc`) | **199/199 byte-identical** |
| Valid date forms (input matrix) | all identical |
| Valid version forms (`5.00`, `4.30`, `4.20`, `5.10`, `2.20`, `4`, `4.3`, `0.00`) | all identical |

The two XML differences are (a) `Spec400_10_700-D50_2deg-Abs.xml`, which uses
`<CreationDateTime>now</CreationDateTime>` — the same binary run twice also differs,
since `now` embeds the current timestamp; and (b) the `#1342` fuzz fixture
`59881-59881-59881T59881:57833:59881`, where only the date and profileID differ.

Every changed case is malformed input, and in each the old behaviour was worse — it
either produced the reported UB or silently fabricated a plausible-but-wrong value:

| Input | Old | New |
|---|---|---|
| `590359881-...` | `11593-07-25` (the UB) | zeroed |
| `-1-07-25...` | `65535-07-25` (the UB) | zeroed |
| `65536-01-01...` | `0-01-01` — year wrapped but kept Jan 1 | zeroed |
| `2026-07` | `2026-07-00` — a day that never existed | zeroed |
| `2026-07-25T12:34` | `12:34:00` — fabricated seconds | zeroed |
| version `-1` | `Invalid BCD version 0xFF000000` — a corrupt header | `0.00` |
| version `999.99` | `99.99` — silently dropped a digit | `0.00` |
| version `4.999` | `4.99` — silently truncated | `0.00` |

Note `2026-13-45T99:99:99` is **unchanged**, which confirms the deliberate limit on
the range check described above.

**Existing regressions.** `iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh`
passes on both cases under the sanitizer build.

**Full suite.** 107/108 locally (106 → 108 with the two new tests). The single failure
is the pre-existing `iccdev.spectral-tiff-preview`, which needs the Python
`imagecodecs` module that is absent from this environment; it touches neither path.
