### PR TITLE
fix(#1845,#1846,#1847): validate ProfileVersion and CountOfDeviceCoords in the XML importers

### DIFF
--- a/.github/ci/test-data/ub-namedcolor-devicecoords-huge-1846.xml
+++ b/.github/ci/test-data/ub-namedcolor-devicecoords-huge-1846.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.20</ProfileVersion>
+    <ProfileDeviceClass>nmcl</ProfileDeviceClass>
+    <DataColourSpace></DataColourSpace>
+	  <PCS>Lab </PCS>
+    <DataColourSpace>CMYK</DataColourSpace>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ccox</ProfileCreator>
+    <ProfileID>1</ProfileID>
+  </Header>
+
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Named Color Example v4]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+
+    <namedColor2Tag> <namedColor2Type>
+      <NamedColors VendorFlag="0" CountOfDeviceCoords="2000000000" DeviceEncoding="int16" Prefix="" Suffix="">
+        <LabNamedColor Name="Violet-Red" L="48" a="74" b="15">3932 65535 29490 1311</LabNamedColor>
+        <LabNamedColor Name="Red" L="46" a="68" b="38">1966 65535 65535 3277</LabNamedColor>
+        <LabNamedColor Name="Red-Orange" L="59" a="66.49" b="59.38">0 58982 65535 0</LabNamedColor>
+        <LabNamedColor Name="Orange" L="69" a="54.07" b="77.99">0 39976 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow-Orange" L="73" a="46.39" b="82.9">0 32768 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow" L="91" a="-4.59" b="97.38">3232 0 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow-Green" L="74.53" a="-41.67" b="69.34">36699 0 65535 0</LabNamedColor>
+        <LabNamedColor Name="Green" L="43.27" a="-57.85" b="21.37">65535 10486 65535 8520</LabNamedColor>
+        <LabNamedColor Name="Aquamarine" L="67.93" a="-43.01" b="-19.61">57671 0 15728 0</LabNamedColor>
+        <LabNamedColor Name="Blue" L="36.9" a="-2.15" b="-58.41">65535 44564 13762 3932</LabNamedColor>
+        <LabNamedColor Name="Indigo" L="25.44" a="27.95" b="-58.05">65535 50462 20316 27525</LabNamedColor>
+        <LabNamedColor Name="Magenta" L="45.65" a="71.53" b="-8.47">17694 65535 5243 0</LabNamedColor>
+        <LabNamedColor Name="Turquoise" L="58.92" a="-39.95" b="-33.66">65535 1311 11796 0</LabNamedColor>
+        <LabNamedColor Name="Goldenrod" L="80.08" a="15.22" b="82.38">1966 15073 65535 0</LabNamedColor>
+        <LabNamedColor Name="Spring Green" L="84.69" a="-15.72" b="63.82">14418 0 58326 0</LabNamedColor>
+        <LabNamedColor Name="Caribbean Green" L="68.37" a="-63.34" b="1.57">63569 0 33423 0</LabNamedColor>
+        <LabNamedColor Name="Ocean Deep Blue" L="38.95" a="-20.88" b="-36.61">65535 38010 17694 9175</LabNamedColor>
+        <LabNamedColor Name="Cerulean" L="40.63" a="-14.9" b="-55.44">65535 36044 9830 2621</LabNamedColor>
+        <LabNamedColor Name="Fuchsia" L="43.64" a="69.35" b="-31.29">31457 65535 0 0</LabNamedColor>
+        <LabNamedColor Name="Violet" L="31.79" a="43.76" b="-43.42">59637 65535 7864 12452</LabNamedColor>
+       </NamedColors>
+    </namedColor2Type> </namedColor2Tag>
+
+	<XYZType>
+      <TagSignature>wtpt</TagSignature>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZType>
+
+	<multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-namedcolor-devicecoords-overflow-1846.xml
+++ b/.github/ci/test-data/ub-namedcolor-devicecoords-overflow-1846.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.20</ProfileVersion>
+    <ProfileDeviceClass>nmcl</ProfileDeviceClass>
+    <DataColourSpace></DataColourSpace>
+	  <PCS>Lab </PCS>
+    <DataColourSpace>CMYK</DataColourSpace>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ccox</ProfileCreator>
+    <ProfileID>1</ProfileID>
+  </Header>
+
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Named Color Example v4]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+
+    <namedColor2Tag> <namedColor2Type>
+      <NamedColors VendorFlag="0" CountOfDeviceCoords="333333333333" DeviceEncoding="int16" Prefix="" Suffix="">
+        <LabNamedColor Name="Violet-Red" L="48" a="74" b="15">3932 65535 29490 1311</LabNamedColor>
+        <LabNamedColor Name="Red" L="46" a="68" b="38">1966 65535 65535 3277</LabNamedColor>
+        <LabNamedColor Name="Red-Orange" L="59" a="66.49" b="59.38">0 58982 65535 0</LabNamedColor>
+        <LabNamedColor Name="Orange" L="69" a="54.07" b="77.99">0 39976 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow-Orange" L="73" a="46.39" b="82.9">0 32768 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow" L="91" a="-4.59" b="97.38">3232 0 65535 0</LabNamedColor>
+        <LabNamedColor Name="Yellow-Green" L="74.53" a="-41.67" b="69.34">36699 0 65535 0</LabNamedColor>
+        <LabNamedColor Name="Green" L="43.27" a="-57.85" b="21.37">65535 10486 65535 8520</LabNamedColor>
+        <LabNamedColor Name="Aquamarine" L="67.93" a="-43.01" b="-19.61">57671 0 15728 0</LabNamedColor>
+        <LabNamedColor Name="Blue" L="36.9" a="-2.15" b="-58.41">65535 44564 13762 3932</LabNamedColor>
+        <LabNamedColor Name="Indigo" L="25.44" a="27.95" b="-58.05">65535 50462 20316 27525</LabNamedColor>
+        <LabNamedColor Name="Magenta" L="45.65" a="71.53" b="-8.47">17694 65535 5243 0</LabNamedColor>
+        <LabNamedColor Name="Turquoise" L="58.92" a="-39.95" b="-33.66">65535 1311 11796 0</LabNamedColor>
+        <LabNamedColor Name="Goldenrod" L="80.08" a="15.22" b="82.38">1966 15073 65535 0</LabNamedColor>
+        <LabNamedColor Name="Spring Green" L="84.69" a="-15.72" b="63.82">14418 0 58326 0</LabNamedColor>
+        <LabNamedColor Name="Caribbean Green" L="68.37" a="-63.34" b="1.57">63569 0 33423 0</LabNamedColor>
+        <LabNamedColor Name="Ocean Deep Blue" L="38.95" a="-20.88" b="-36.61">65535 38010 17694 9175</LabNamedColor>
+        <LabNamedColor Name="Cerulean" L="40.63" a="-14.9" b="-55.44">65535 36044 9830 2621</LabNamedColor>
+        <LabNamedColor Name="Fuchsia" L="43.64" a="69.35" b="-31.29">31457 65535 0 0</LabNamedColor>
+        <LabNamedColor Name="Violet" L="31.79" a="43.76" b="-43.42">59637 65535 7864 12452</LabNamedColor>
+       </NamedColors>
+    </namedColor2Type> </namedColor2Tag>
+
+	<XYZType>
+      <TagSignature>wtpt</TagSignature>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZType>
+
+	<multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-profileversion-negative-1845.xml
+++ b/.github/ci/test-data/ub-profileversion-negative-1845.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType></PreferredCMMType>
+    <ProfileVersion>-12.</ProfileVersion>
+    <ProfileDeviceClass>spac</ProfileDeviceClass>
+	<ProfileDeviceSubClass>PCC </ProfileDeviceSubClass>
+	<ProfileSubClassVersion>1.0</ProfileSubClassVersion>
+    <DataColourSpace>Lab </DataColourSpace>
+	  <PCS>Lab </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
+    </PCSIlluminant>
+    <ProfileCreator></ProfileCreator>
+    <ProfileID>1</ProfileID>
+  </Header>
+
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Floating point encoding CIELAB D50 and standard 2deg observer]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+
+	<!--MPE based transforms use floating point PCS so integer device encoding needs to be converted to PCS encoding!-->
+    <multiProcessElementType>
+      <TagSignature>A2B3</TagSignature>
+	  <MultiProcessElements InputChannels="3" OutputChannels="3">
+			<MatrixElement InputChannels="3" OutputChannels="3">
+				<MatrixData>
+				 100.0 0 0
+				 0 256.0 0
+				 0 0 256.0
+				</MatrixData>
+				<OffsetData>0 -128.0 -128.0</OffsetData>
+			</MatrixElement>
+	  </MultiProcessElements>
+    </multiProcessElementType>
+	
+	<!--MPE based transforms use floating point PCS so PCS encoding needs to be converted to integer device encoding!-->
+    <multiProcessElementType>
+      <TagSignature>B2A3</TagSignature>
+	    <MultiProcessElements InputChannels="3" OutputChannels="3"/>
+	  <MultiProcessElements InputChannels="3" OutputChannels="3">
+			<MatrixElement InputChannels="3" OutputChannels="3">
+				<MatrixData>
+				 0.01 0 0
+				 0 0.0039062 0
+				 0 0 0.0039062
+				</MatrixData>
+				<OffsetData>0 0.5 0.5</OffsetData>
+			</MatrixElement>
+	  </MultiProcessElements>
+    </multiProcessElementType>
+	
+    <multiProcessElementType>
+      <TagSignature>c2sp</TagSignature>
+	    <MultiProcessElements InputChannels="3" OutputChannels="3">
+				<MatrixElement InputChannels="3" OutputChannels="3">
+					<MatrixData>
+					 1.0 0.0 0.0
+					 0.0 1.0 0.0
+					 0.0 0.0 1.0
+					</MatrixData>
+				</MatrixElement>
+			</MultiProcessElements>
+    </multiProcessElementType>
+	
+    <multiProcessElementType>
+      <TagSignature>s2cp</TagSignature>
+	    <MultiProcessElements InputChannels="3" OutputChannels="3">
+				<MatrixElement InputChannels="3" OutputChannels="3">
+					<MatrixData>
+					 1.0 0.0 0.0
+					 0.0 1.0 0.0
+					 0.0 0.0 1.0
+					</MatrixData>
+				</MatrixElement>
+			</MultiProcessElements>
+    </multiProcessElementType>
+	
+	  <spectralViewingConditionsType>
+			<TagSignature>svcn</TagSignature>
+				<StdObserver>CIE 1931 standard colorimetric observer</StdObserver>
+			<IlluminantXYZ X="482.1227825641230" Y="500.0000000000000" Z="412.3395470459833"/>
+			<ObserverFuncs start="380" end="780" steps="81">
+				0.001368    0.002236    0.004243    0.007650    0.014310    0.023190    0.043510
+				0.077630    0.134380    0.214770    0.283900    0.328500    0.348280    0.348060
+				0.336200    0.318700    0.290800    0.251100    0.195360    0.142100    0.095640
+				0.057950    0.032010    0.014700    0.004900    0.002400    0.009300    0.029100
+				0.063270    0.109600    0.165500    0.225750    0.290400    0.359700    0.433450
+				0.512050    0.594500    0.678400    0.762100    0.842500    0.916300    0.978600
+				1.026300    1.056700    1.062200    1.045600    1.002600    0.938400    0.854450
+				0.751400    0.642400    0.541900    0.447900    0.360800    0.283500    0.218700
+				0.164900    0.121200    0.087400    0.063600    0.046770    0.032900    0.022700
+				0.015840    0.011359    0.008111    0.005790    0.004109    0.002899    0.002049
+				0.001440    0.001000    0.000690    0.000476    0.000332    0.000235    0.000166
+				0.000117    0.000083    0.000059    0.000042
+				0.000039    0.000064    0.000120    0.000217    0.000396    0.000640    0.001210
+				0.002180    0.004000    0.007300    0.011600    0.016840    0.023000    0.029800
+				0.038000    0.048000    0.060000    0.073900    0.090980    0.112600    0.139020
+				0.169300    0.208020    0.258600    0.323000    0.407300    0.503000    0.608200
+				0.710000    0.793200    0.862000    0.914850    0.954000    0.980300    0.994950
+				1.000000    0.995000    0.978600    0.952000    0.915400    0.870000    0.816300
+				0.757000    0.694900    0.631000    0.566800    0.503000    0.441200    0.381000
+				0.321000    0.265000    0.217000    0.175000    0.138200    0.107000    0.081600
+				0.061000    0.044580    0.032000    0.023200    0.017000    0.011920    0.008210
+				0.005723    0.004102    0.002929    0.002091    0.001484    0.001047    0.000740
+				0.000520    0.000361    0.000249    0.000172    0.000120    0.000085    0.000060
+				0.000042    0.000030    0.000021    0.000015
+				0.006450    0.010550    0.020050    0.036210    0.067850    0.110200    0.207400
+				0.371300    0.645600    1.039050    1.385600    1.622960    1.747060    1.782600
+				1.772110    1.744100    1.669200    1.528100    1.287640    1.041900    0.812950
+				0.616200    0.465180    0.353300    0.272000    0.212300    0.158200    0.111700
+				0.078250    0.057250    0.042160    0.029840    0.020300    0.013400    0.008750
+				0.005750    0.003900    0.002750    0.002100    0.001800    0.001650    0.001400
+				0.001100    0.001000    0.000800    0.000600    0.000340    0.000240    0.000190
+				0.000100    0.000050    0.000030    0.000020    0.000010    0.000000    0.000000
+				0.000000    0.000000    0.000000    0.000000    0.000000    0.000000    0.000000
+				0.000000    0.000000    0.000000    0.000000    0.000000    0.000000    0.000000
+				0.000000    0.000000    0.000000    0.000000    0.000000    0.000000    0.000000
+				0.000000    0.000000    0.000000    0.000000
+			</ObserverFuncs>
+			<StdIlluminant>Illuminant D50</StdIlluminant>
+			<ColorTemperature>5000</ColorTemperature>
+			<IlluminantSPD start="380" end="780" steps="81">
+				 24.457147   27.147280   29.837414   39.547443   49.257472   52.859364   56.461255
+				 58.222678   59.984100   58.878685   57.773270   66.274622   74.775973   80.987003
+				 87.198034   88.882488   90.566943   90.947782   91.328622   93.200755   95.072887
+				 93.503707   91.934527   93.817670   95.700813   96.147589   96.594366   96.854869
+				 97.115372   99.602130  102.088888  101.418624  100.748359  101.531110  102.313861
+				101.156931  100.000000   98.868725   97.737450   98.330520   98.923589   96.216919
+				 93.510248   95.607997   97.705746   98.498795   99.291845   99.179895   99.067945
+				 97.409311   95.750676   97.322057   98.893438   97.299430   95.705421   96.969799
+				 98.234177  100.644248  103.054319  101.119636   99.184954   93.304566   87.424178
+				 89.538557   91.652935   92.293256   92.933577   84.912496   76.891415   81.721450
+				 86.551486   89.586840   92.622195   85.443791   78.265387   67.992302   57.719217
+				 70.340670   82.962124   80.636096   78.310068
+   	 </IlluminantSPD>
+			<SurroundXYZ X="482.1227825641230" Y="500.0000000000000" Z="412.3395470459833"/>
+    </spectralViewingConditionsType>
+    
+    
+	<XYZType>
+      <TagSignature>wtpt</TagSignature>
+      <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
+    </XYZType>
+	
+	<multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2015 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+
+  </Tags>
+</IccProfile>

--- a/.github/scripts/iccdev-issue-1845-profileversion-bcd-regression.sh
+++ b/.github/scripts/iccdev-issue-1845-profileversion-bcd-regression.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1845 - negative <ProfileVersion> component in the XML importer
+###############################################################################
+#
+# parseVersion() in IccXML/IccLibXML/IccProfileXml.cpp read a version component
+# with atoi(), which accepts a leading '-'.  For <ProfileVersion>-12.</...> that
+# gave val == -12; ((val/10)%10)*16 + (val%10) then evaluated to -18, and storing
+# that in the function's unsigned char return produced 238 (0xEE):
+#
+#   IccProfileXml.cpp:343:8: runtime error: implicit conversion from type 'int'
+#   of value -18 (32-bit, signed) to type 'unsigned char' changed the value to
+#   238 (8-bit, unsigned)
+#
+# 0xE is not a valid BCD digit, so the resulting header version is one
+# CIccInfo::GetVersionName can only render back as "Invalid BCD version".  The
+# tool nevertheless reported "Profile parsed and saved correctly" and wrote the
+# byte to disk, which is what makes this worth a functional check and not just a
+# sanitizer check.
+#
+# The fix routes the component through icXmlParseU32(s, out, 99), the strict
+# attribute parser in IccUtilXml.h, and rejects the whole version if any
+# component is malformed -- leaving the memset-zeroed 0, which renders as a
+# plain "0.00".  This mirrors icJsonParseBCDByte in IccProfileJson.cpp, the same
+# defect fixed for #1830 on the JSON side.
+#
+# This test therefore keys on TWO signals:
+#
+#   1. Functional (every build): if a profile is written, its major-version byte
+#      must be a valid BCD pair.  Pre-fix that byte is 0xEE; post-fix it is 0x00.
+#   2. Sanitizer (integer/implicit-conversion builds only): the UBSan
+#      implicit-conversion diagnostic must not reappear.
+#
+# Signal 1 is the reason this test is useful in the ordinary CI jobs; signal 2
+# only fires where the sanitizer is enabled, exactly as for #1346.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1845}"
+DATA_DIR="$REPO_ROOT/.github/ci/test-data"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+
+POC="$DATA_DIR/ub-profileversion-negative-1845.xml"
+if [ ! -f "$POC" ]; then
+  echo "[SKIP] PoC XML missing: $POC"
+  exit 0
+fi
+
+LOG="$OUTDIR/profileversion-negative-1845.log"
+OUT_ICC="$OUTDIR/profileversion-negative-1845.icc"
+rm -f "$OUT_ICC"
+
+# Keep ASan quiet about unrelated leaks, and let UBSan report without aborting so
+# both signals can be inspected from one run.
+ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0" \
+UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+  "$FROMXML" "$POC" "$OUT_ICC" > "$LOG" 2>&1
+
+status=0
+
+# --- Signal 1: the saved header must not carry a non-BCD version byte --------
+# The ICC header version is at offset 8; its first byte packs the major version
+# as two BCD digits, so each nibble must be 0-9.
+if [ -f "$OUT_ICC" ]; then
+  ver_byte="$(od -An -tx1 -j 8 -N 1 "$OUT_ICC" 2>/dev/null | tr -d ' \n')"
+  case "$ver_byte" in
+    [0-9][0-9])
+      echo "[PASS] #1845: saved major-version byte 0x$ver_byte is valid BCD"
+      ;;
+    "")
+      echo "[WARN] #1845: could not read the version byte from $OUT_ICC"
+      ;;
+    *)
+      echo "[FAIL] #1845: saved major-version byte 0x$ver_byte is not valid BCD"
+      echo "       a negative <ProfileVersion> component wrapped into the header again"
+      status=2
+      ;;
+  esac
+else
+  # Not a failure on its own: a build may reject the profile before saving.
+  echo "[INFO] #1845: no profile written; relying on the sanitizer signal alone"
+fi
+
+# --- Signal 2: no implicit-conversion diagnostic in the version parse --------
+# Only claim this signal on a build that can actually produce it.
+# Build/Cmake/CMakeLists.txt maps ENABLE_UBSAN to -fsanitize=undefined and only
+# ENABLE_INTEGER_SANITIZER to -fsanitize=integer, and implicit-integer-sign-change
+# lives in the integer group -- so accepting a bare "undefined" here would report
+# a confident PASS on a build that cannot observe the defect.
+CACHE=""
+probe="$(dirname "$FROMXML")"
+for _ in 1 2 3 4 5; do
+  if [ -f "$probe/CMakeCache.txt" ]; then CACHE="$probe/CMakeCache.txt"; break; fi
+  probe="$(dirname "$probe")"
+done
+sanitized=0
+if [ -n "$CACHE" ]; then
+  if grep -qiE "ENABLE_INTEGER_SANITIZER:BOOL=ON" "$CACHE"; then
+    sanitized=1
+  elif grep -iE "CMAKE_(CXX|C)_FLAGS" "$CACHE" | grep -qiE "fsanitize=[^ ]*(integer|implicit)"; then
+    sanitized=1
+  fi
+fi
+
+if [ "$sanitized" -ne 1 ]; then
+  echo "[SKIP] sanitizer signal: not an integer/implicit-conversion build (CMakeCache: ${CACHE:-none})"
+elif grep -qE "runtime error: implicit conversion" "$LOG"; then
+  echo "[FAIL] #1845: implicit-conversion diagnostic reappeared in the version parse"
+  grep -E "runtime error: implicit conversion|IccProfileXml|parseVersion|ParseBasic" "$LOG" | head
+  status=2
+else
+  echo "[PASS] #1845: negative version component parsed without a signed->unsigned conversion"
+fi
+
+exit "$status"

--- a/.github/scripts/iccdev-issue-1846-namedcolor-devicecoords-regression.sh
+++ b/.github/scripts/iccdev-issue-1846-namedcolor-devicecoords-regression.sh
@@ -1,0 +1,181 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issues #1846 / #1847 - unvalidated CountOfDeviceCoords in the XML
+#                               namedColor2 reader
+###############################################################################
+#
+# CIccTagXmlNamedColor2::ParseXml read the attribute with atoi():
+#
+#   icUInt32Number newDeviceCoords = atoi(szDeviceCoords);   // IccTagXml.cpp
+#   icUInt32Number n = icXmlNodeCount3(...);
+#   SetSize(n, newDeviceCoords);                             // result discarded
+#
+# That is wrong in two independent ways, and this test covers both.
+#
+# CASE A -- the reported one.  atoi() is undefined on a value that does not fit
+# an int.  CountOfDeviceCoords="333333333333" truncated to -1674115755, which
+# then changed value again converting into the icUInt32Number:
+#
+#   IccTagXml.cpp:1014:42: runtime error: implicit conversion from type 'int' of
+#   value -1674115755 (32-bit, signed) to type 'icUInt32Number' changed the
+#   value to 2620851541 (32-bit, unsigned)
+#
+# Arriving back at SetSize()'s signed nDeviceCoords parameter, the negative
+# value is that function's "keep the existing count" sentinel, so the attribute
+# was silently ignored.  Detectable only under an integer/implicit-conversion
+# sanitizer build; the script skips this case cleanly elsewhere.
+#
+# CASE B -- the one the issues do not mention, and the reason this test matters
+# in the ordinary sanitizer jobs.  A large POSITIVE count is not sentinelled
+# away.  SetSize(n, 2000000000) computes a per-entry size of roughly 8 GB, the
+# calloc() fails, and SetSize() returns false -- but the result was discarded,
+# leaving m_NamedColor pointing at the single-entry buffer the constructor
+# allocated while the loop below still wrote one entry per XML node:
+#
+#   ERROR: AddressSanitizer: heap-buffer-overflow
+#   WRITE of size 4 ... CIccTagXmlNamedColor2::ParseXml IccTagXml.cpp
+#   located 32 bytes after 48-byte region
+#   allocated by CIccTagNamedColor2::CIccTagNamedColor2(int, int)
+#
+# That is CWE-787, reachable from iccFromXml on attacker-supplied XML, and it
+# needs only a plain ASan build.  Case B also carries a functional assertion
+# that holds without any sanitizer: the fixed reader must REJECT the profile,
+# because the count exceeds the kMaxNamedColorDeviceCoords bound that
+# CIccTagNamedColor2::Read and both writers already enforce.  Pre-fix the tag
+# "parsed" (the loop returns i==n) and the profile was written.
+#
+# Both PoCs are Testing/Named/NamedColorV4.xml with only CountOfDeviceCoords
+# changed, so anything else they exercise is a known-good path.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1846}"
+DATA_DIR="$REPO_ROOT/.github/ci/test-data"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+
+# Locate the build's CMakeCache.txt (walk up from the tool) to decide whether the
+# sign-change check of case A is actually compiled in.
+#
+# The gate deliberately does NOT accept ENABLE_UBSAN / a bare "undefined" in the
+# flags.  Build/Cmake/CMakeLists.txt maps ENABLE_UBSAN to -fsanitize=undefined
+# and only ENABLE_INTEGER_SANITIZER to -fsanitize=integer, and
+# implicit-integer-sign-change lives in the integer group, not in undefined.  A
+# looser test reports a confident PASS on an -fsanitize=address,undefined build
+# that cannot observe the defect at all.
+CACHE=""
+probe="$(dirname "$FROMXML")"
+for _ in 1 2 3 4 5; do
+  if [ -f "$probe/CMakeCache.txt" ]; then CACHE="$probe/CMakeCache.txt"; break; fi
+  probe="$(dirname "$probe")"
+done
+sanitized=0
+if [ -n "$CACHE" ]; then
+  if grep -qiE "ENABLE_INTEGER_SANITIZER:BOOL=ON" "$CACHE"; then
+    sanitized=1
+  elif grep -iE "CMAKE_(CXX|C)_FLAGS" "$CACHE" | grep -qiE "fsanitize=[^ ]*(integer|implicit)"; then
+    sanitized=1
+  fi
+fi
+
+status=0
+
+TOOL_RC=0
+TOOL_LOG=""
+TOOL_ICC=""
+run_tool() {
+  # $1 = PoC basename (without .xml).
+  #
+  # Sets the globals TOOL_LOG / TOOL_ICC / TOOL_RC rather than echoing the log
+  # path: a caller writing LOG=$(run_tool ...) would run this in a command
+  # substitution subshell, and TOOL_RC would never reach the caller -- it would
+  # read as 0 no matter how the tool died, quietly disabling the exit-status half
+  # of the crash check below.
+  local poc="$DATA_DIR/$1.xml"
+  TOOL_LOG="$OUTDIR/$1.log"
+  TOOL_ICC="$OUTDIR/$1.icc"
+  rm -f "$TOOL_ICC"
+  # allocator_may_return_null keeps ASan from turning the deliberately huge
+  # allocation into an allocator abort, so the heap-overflow check is what fires.
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0:allocator_may_return_null=1" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$FROMXML" "$poc" "$TOOL_ICC" > "$TOOL_LOG" 2>&1
+  TOOL_RC=$?
+}
+
+# --- CASE A: sign-change on an out-of-int-range count ------------------------
+POC_A="ub-namedcolor-devicecoords-overflow-1846"
+if [ ! -f "$DATA_DIR/$POC_A.xml" ]; then
+  echo "[SKIP] PoC XML missing: $DATA_DIR/$POC_A.xml"
+elif [ "$sanitized" -ne 1 ]; then
+  echo "[SKIP] case A: not an integer/implicit-conversion build (CMakeCache: ${CACHE:-none})"
+else
+  run_tool "$POC_A"
+  LOG_A="$TOOL_LOG"
+  if grep -qE "runtime error: implicit conversion" "$LOG_A"; then
+    echo "[FAIL] #1846: implicit conversion of CountOfDeviceCoords reappeared"
+    grep -E "runtime error: implicit conversion|IccTagXml" "$LOG_A" | head
+    status=2
+  else
+    echo "[PASS] #1846 case A: out-of-range CountOfDeviceCoords parsed without a sign change"
+  fi
+fi
+
+# --- CASE B: large positive count -> heap-buffer-overflow write --------------
+POC_B="ub-namedcolor-devicecoords-huge-1846"
+if [ ! -f "$DATA_DIR/$POC_B.xml" ]; then
+  echo "[SKIP] PoC XML missing: $DATA_DIR/$POC_B.xml"
+else
+  run_tool "$POC_B"
+  LOG_B="$TOOL_LOG"
+  rc_b="$TOOL_RC"
+  ICC_B="$TOOL_ICC"
+
+  # Any abnormal termination is a failure, however it is reported.  On an ASan
+  # build the overflow surfaces as heap-buffer-overflow; without ASan the same
+  # write corrupts glibc's heap metadata and the process dies later inside
+  # malloc ("SEGV ... in unlink_chunk"), so keying only on the ASan string would
+  # miss the unsanitized build entirely.  A signal death gives rc >= 128.
+  crashed=0
+  if grep -qE "AddressSanitizer|LeakSanitizer|runtime error: |ABORTING|SEGV|Segmentation fault" "$LOG_B"; then
+    crashed=1
+  elif [ "$rc_b" -ge 128 ]; then
+    crashed=1
+  fi
+
+  if [ "$crashed" -eq 1 ]; then
+    echo "[FAIL] #1847: huge CountOfDeviceCoords crashed the parser (rc=$rc_b)"
+    grep -E "AddressSanitizer|WRITE of size|IccTagXml.cpp|located .* bytes|allocated by|SEGV|ABORTING" "$LOG_B" | head
+    status=2
+  # Functional assertion, valid on every build: the count is far above the
+  # kMaxNamedColorDeviceCoords bound the binary reader and both writers enforce,
+  # so the reader must reject the tag rather than write a profile.  Checked only
+  # once the run is known to have terminated normally, otherwise "no profile
+  # written" would read as success when the process merely died first.
+  elif [ -f "$ICC_B" ]; then
+    echo "[FAIL] #1847: profile written despite CountOfDeviceCoords=2000000000"
+    echo "       the XML reader accepted a count the binary reader rejects"
+    status=2
+  else
+    echo "[PASS] #1847 case B: out-of-bounds CountOfDeviceCoords rejected cleanly (rc=$rc_b), no profile written"
+  fi
+fi
+
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2976,6 +2976,36 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh"
 )
 
+# #1845: negative <ProfileVersion> component in the XML importer.  parseVersion()
+# used atoi(), so "-12" produced the non-BCD version byte 0xEE, and iccFromXml
+# reported "parsed and saved correctly" while writing it.  Unlike the #1342/#1346
+# tests this one carries a functional assertion as well as the sanitizer one --
+# the saved major-version byte must be a valid BCD pair -- so it is meaningful on
+# every build, not only an integer/implicit-conversion one.
+iccdev_add_script_test(
+  iccdev.issue-1845-profileversion-bcd-regression
+  60
+  "iccdev;xml;header;issue-1845;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1845-profileversion-bcd-regression.sh"
+)
+
+# #1846/#1847: unvalidated CountOfDeviceCoords in the XML namedColor2 reader.
+# Case A replays the reported out-of-int-range count and needs the
+# integer/implicit-conversion sanitizer.  Case B replays a large POSITIVE count,
+# which is the memory-unsafe half the issues do not describe: SetSize() failed,
+# its result was discarded, and the entry loop then wrote past the constructor's
+# single-entry buffer.  Case B needs no sanitizer at all to be meaningful -- with
+# ASan it reports heap-buffer-overflow, without it the corrupted heap metadata
+# SEGVs inside malloc -- so this test has teeth in the ordinary CI jobs.
+iccdev_add_script_test(
+  iccdev.issue-1846-1847-namedcolor-devicecoords-regression
+  60
+  "iccdev;xml;namedcolor;issue-1846;issue-1847;regression;asan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1846-namedcolor-devicecoords-regression.sh"
+)
+
 # #1356: XML serializer corrupts a zero (NoData) header colour-space signature
 # on round-trip.  iccToXml wrote the literal "NULL" for a 0x00000000 data
 # colour space / PCS; iccFromXml then reparsed "NULL" to 0x4E554C4C, so the

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -336,13 +336,34 @@ bool CIccProfileXml::ToXmlWithBlanks(std::string &xml, std::string blanks)
   return true;
 }
 
-static unsigned char parseVersion(const char *szVer)
+// Convert one decimal version component (0-99) into the BCD byte the ICC header
+// stores.  Returns false for an empty component, a sign, a non-digit, or a value
+// too large to fit one BCD byte.
+//
+// This used to be atoi(), which accepts a leading '-'.  The #1845 PoC carries
+// <ProfileVersion>-12.</ProfileVersion>: atoi gave -12, ((val/10)%10)*16 +
+// (val%10) then evaluated to -18, and storing that in an unsigned char produced
+// 238 (0xEE) -- UBSan reports it as "implicit conversion from type 'int' of
+// value -18 ... changed the value to 238".  0xE is not a valid BCD digit, so
+// CIccInfo::GetVersionName can only render the result back as "Invalid BCD
+// version", yet iccFromXml still wrote the profile out carrying that byte.
+// Values above 99 were silently truncated by the same expression ("100" became
+// 0x00), and atoi() is undefined outright on an input too large for an int.
+//
+// icXmlParseU32 is the existing strict attribute parser (IccUtilXml.h): it
+// rejects the sign, non-digits and trailing garbage, and its max_value argument
+// performs the range check.  This is the XML twin of the JSON defect fixed for
+// #1830, whose icJsonParseBCDByte in IccProfileJson.cpp now carries the same
+// contract.
+static bool parseVersion(const std::string &sPart, unsigned long &rv)
 {
-  unsigned char rv;
-  int val = atoi(szVer);
-  rv = ((val / 10) % 10) * 16 + (val % 10);
+  icUInt32Number v = 0;
 
-  return rv;
+  if (!icXmlParseU32(sPart.c_str(), v, 99))
+    return false;
+
+  rv = ((v / 10) % 10) * 16 + (v % 10);
+  return true;
 }
 
 /**
@@ -376,44 +397,58 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
       const char *szVer = (const char*)pNode->children->content;
       std::string ver;
       unsigned long verMajor=0, verMinor=0, verClassMajor=0, verClassMinor=0;
+      // A malformed component now rejects the whole version rather than letting a
+      // wrapped or partly-parsed value reach the header, matching the policy
+      // icJsonParseBCDVersionStr applies on the JSON side (#1830).
+      bool bVerOk = false;
 
       for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
         ver += *szVer;
       }
-      verMajor = parseVersion(ver.c_str());
+      bVerOk = parseVersion(ver, verMajor);
       ver.clear();
       if (*szVer)
         szVer++;
 
-      if (*szVer) {
+      if (bVerOk && *szVer) {
         for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
           ver += *szVer;
         }
-        verMinor = parseVersion(ver.c_str());
+        bVerOk = parseVersion(ver, verMinor);
         ver.clear();
         if (*szVer)
           szVer++;
 
-        if (*szVer) {
+        if (bVerOk && *szVer) {
           for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
             ver = *szVer;
           }
-          verClassMajor = parseVersion(ver.c_str());
+          bVerOk = parseVersion(ver, verClassMajor);
           ver.clear();
           if (*szVer)
             szVer++;
 
-          if (*szVer) {
+          if (bVerOk && *szVer) {
             for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
               ver = *szVer;
             }
-            verClassMinor = parseVersion(ver.c_str());
+            bVerOk = parseVersion(ver, verClassMinor);
             ver.clear();
           }
         }
       }
 
-      m_Header.version = icUInt32Number( (verMajor << 24) | (verMinor << 16) | (verClassMajor << 8) | verClassMinor );
+      if (!bVerOk) {
+        // Leave the memset-zeroed header version in place.  0 is what
+        // GetVersionName renders as a plain "0.00", where the old wrapped byte
+        // rendered as "Invalid BCD version" -- and the profile was still saved.
+        parseStr += "Cannot parse ProfileVersion '";
+        parseStr += (const char*)pNode->children->content;
+        parseStr += "'\n";
+      }
+      else {
+        m_Header.version = icUInt32Number( (verMajor << 24) | (verMinor << 16) | (verClassMajor << 8) | verClassMinor );
+      }
     }
     else if (!icXmlStrCmp((const char*)pNode->name, "ProfileSubClassVersion")) {
       if (!pNode->children || !pNode->children->content) {

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -1011,9 +1011,43 @@ bool CIccTagXmlNamedColor2::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
 
         icXmlCopyFixedString(m_szSufix, sizeof(m_szSufix), icUtf8ToAnsi(str, szSufix));
 
-        icUInt32Number newDeviceCoords = atoi(szDeviceCoords);
+        // CountOfDeviceCoords is attacker-controlled text, and atoi() is the wrong
+        // tool for it twice over: it accepts a leading '-', and it is undefined on
+        // a value that does not fit an int.  The #1846/#1847 PoC carries
+        // CountOfDeviceCoords="333333333333", which truncates to -1674115755 and
+        // then changes value again on the way into this icUInt32Number -- the
+        // "implicit conversion from type 'int' of value -1674115755 ... changed
+        // the value to 2620851541" that UBSan reports here.
+        //
+        // icXmlAttrToUInt() (the #1346 helper near the top of this file) is
+        // deliberately not used: it floors negatives to 0 but passes large
+        // positive counts through untouched, and this attribute sizes an
+        // allocation.  Bound it instead with the same two constants
+        // CIccTagNamedColor2::Read (IccTagBasic.cpp) and CIccTagXmlNamedColor2::
+        // ToXml above already enforce, so the XML reader stops being the one
+        // entry point able to install counts that the binary reader and both
+        // writers reject.
+        const icUInt32Number kMaxNamedColorEntries = 65536;
+        const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+
+        icUInt32Number newDeviceCoords = 0;
+        if (!icXmlParseU32(szDeviceCoords, newDeviceCoords, kMaxNamedColorDeviceCoords))
+          return false;
+
         icUInt32Number n = icXmlNodeCount3(pNode->children, "NamedColor", "LabNamedColor", "XYZNamedColor");
-        SetSize(n, newDeviceCoords);
+        if (n > kMaxNamedColorEntries)
+          return false;
+
+        // SetSize allocates the entry array that the loop below walks in
+        // m_nColorEntrySize strides, and it returns false when that allocation
+        // fails.  Discarding the result left m_NamedColor pointing at the
+        // single-entry buffer the constructor allocated while the loop still
+        // wrote one entry per XML node -- a heap-buffer-overflow write (CWE-787)
+        // that ASan catches at the pcsCoords store below.  The bound above makes
+        // the huge-count case unreachable, but the allocation can still fail, so
+        // the result is checked rather than assumed.
+        if (!SetSize(n, (icInt32Number)newDeviceCoords))
+          return false;
 
         icUInt32Number i;
 
@@ -1104,8 +1138,12 @@ bool CIccTagXmlNamedColor2::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
 
                 // CWE-400/CWE-834: clamp the field to the same load-time bound as
                 // the float branch below (deviceCoords[] is sized to it) so a
-                // corrupted count can't drive an out-of-range copy.
-                const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+                // corrupted count can't drive an out-of-range copy.  All three
+                // encoding branches share the single kMaxNamedColorDeviceCoords
+                // declared at the top of this parse block -- the same bound
+                // CountOfDeviceCoords was accepted against above -- rather than
+                // each redeclaring its own, which would shadow it (-Wshadow is
+                // -Werror in the strict build profiles).
                 icUInt32Number nDevCoords = (m_nDeviceCoords > kMaxNamedColorDeviceCoords)
                                               ? kMaxNamedColorDeviceCoords : m_nDeviceCoords;
                 icUInt32Number j;
@@ -1121,8 +1159,9 @@ bool CIccTagXmlNamedColor2::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
 
                 // CWE-400/CWE-834: clamp the field to the same load-time bound as
                 // the float branch below (deviceCoords[] is sized to it) so a
-                // corrupted count can't drive an out-of-range copy.
-                const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+                // corrupted count can't drive an out-of-range copy.  Shares the
+                // single kMaxNamedColorDeviceCoords declared at the top of this
+                // parse block, as the int8 branch above does.
                 icUInt32Number nDevCoords = (m_nDeviceCoords > kMaxNamedColorDeviceCoords)
                                               ? kMaxNamedColorDeviceCoords : m_nDeviceCoords;
                 icUInt32Number j;
@@ -1139,8 +1178,9 @@ bool CIccTagXmlNamedColor2::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
                 // CWE-400/CWE-834: m_nDeviceCoords is capped at
                 // kMaxNamedColorDeviceCoords on load and sizes deviceCoords[];
                 // clamp to that bound so a corrupted count can't drive an
-                // unbounded or out-of-range copy.
-                const icUInt32Number kMaxNamedColorDeviceCoords = 256;
+                // unbounded or out-of-range copy.  Shares the single
+                // kMaxNamedColorDeviceCoords declared at the top of this parse
+                // block, as the int8/int16 branches above do.
                 icUInt32Number nDevCoords = (m_nDeviceCoords > kMaxNamedColorDeviceCoords)
                                               ? kMaxNamedColorDeviceCoords : m_nDeviceCoords;
                 icUInt32Number j;


### PR DESCRIPTION
Closes #1845. Closes #1846. Refs #1847.

> **#1847 is deliberately not auto-closed.** Its titled site, `IccUtil.cpp:3062`, is the
> opening brace of `icUtf8ToUtf16` on master and is not a conversion site; this PR changes
> nothing there. The PoC attached to #1847 reproduces #1846's site instead (see the table
> below). Recommend closing #1847 as a duplicate of #1846 rather than as fixed.

Two unvalidated `atoi()` reads in the XML importers, both reachable from `iccFromXml` on attacker-supplied XML, plus a regression for each.

## #1845 — negative `<ProfileVersion>` component

`parseVersion()` used `atoi()`, which accepts a leading `-`. The attached PoC carries `<ProfileVersion>-12.</ProfileVersion>`:

```
IccProfileXml.cpp:343:8: runtime error: implicit conversion from type 'int'
of value -18 (32-bit, signed) to type 'unsigned char' changed the value to 238
```

`0xE` is not a valid BCD digit, so `CIccInfo::GetVersionName` can only render the header back as `"Invalid BCD version"` — yet the tool reported **`Profile parsed and saved correctly`** and wrote `0xEE` to disk. Components above 99 were silently truncated by the same expression (`"100"` became `0x00`), and `atoi()` is undefined outright on an input too large for an `int`.

The component now goes through `icXmlParseU32(s, out, 99)`, the existing strict attribute parser, and a malformed component rejects the whole version — leaving the memset-zeroed `0`, which renders as a plain `"0.00"`. This is the XML twin of the JSON defect fixed for #1830; `icJsonParseBCDByte` already carries the same contract.

## #1846 / #1847 — `CountOfDeviceCoords`

`CIccTagXmlNamedColor2::ParseXml` read the attribute with `atoi()` **and discarded `SetSize()`'s result**. Two distinct problems:

**The reported one.** `atoi()` is undefined on an out-of-`int`-range value. `CountOfDeviceCoords="333333333333"` truncated to `-1674115755` and changed value again converting into the `icUInt32Number`. Arriving at `SetSize()`'s *signed* `nDeviceCoords` parameter as a negative number, it hit that function's "keep the existing count" sentinel — so the attribute was silently ignored.

**One the issues do not mention, and the more serious of the two.** A large *positive* count is not sentinelled away. `SetSize(n, 2000000000)` computes a per-entry size of roughly 8 GB, the `calloc()` fails, `SetSize()` returns `false` — and the discarded result left `m_NamedColor` pointing at the constructor's single-entry buffer while the loop below still wrote one entry per XML node:

```
ERROR: AddressSanitizer: heap-buffer-overflow
WRITE of size 4 ... CIccTagXmlNamedColor2::ParseXml IccTagXml.cpp:1065
located 32 bytes after 48-byte region
allocated by CIccTagNamedColor2::CIccTagNamedColor2(int, int)
```

That is CWE-787. **Without ASan the same write corrupts glibc's heap metadata and the process dies inside `malloc`'s `unlink_chunk`** — this is live memory corruption in ordinary builds, not only a sanitizer diagnostic.

The count is now parsed with `icXmlParseU32` and bounded by the same `kMaxNamedColorDeviceCoords` / `kMaxNamedColorEntries` limits that `CIccTagNamedColor2::Read` and both the XML and JSON writers already apply — the XML reader was the one entry point able to install counts the others reject — and `SetSize()`'s result is checked.

`icXmlAttrToUInt()` (the #1346 helper in this file) is deliberately **not** used here: it floors negatives but passes large positive counts through untouched, and this attribute sizes an allocation. Worth noting that line 1014 is a missed site of the #1346 sweep.

## Note on the two issues' PoCs

The attachments appear crossed, and it affects triage:

| Issue | Titled site | Its PoC actually reproduces |
|---|---|---|
| #1846 | `IccTagXml.cpp:1014` | nothing at 1014 — the file contains no `DeviceCoords`. Only a libstdc++-internal unsigned wrap in `std::map<std::string,…>::find` (`basic_string.h:490`), which is defined behaviour and not iccDEV code |
| #1847 | `IccUtil.cpp:3062` | `IccTagXml.cpp:1014` — i.e. #1846's site (`CountOfDeviceCoords="333333333333"`) |

`IccUtil.cpp:3062` on master is the bare `{` of `icUtf8ToUtf16`, and neither PoC reaches it. This PR fixes the one real defect at `IccTagXml.cpp:1014`, which is what both issues quote. If there is a genuine `IccUtil.cpp:3062` trace it would need re-filing.

## Testing

Two script tests replaying committed PoCs through `iccFromXml`, each a stock `Testing/` fixture with a single attribute changed. Both carry a **functional** assertion that holds with no sanitizer — the saved major-version byte must be valid BCD, and the huge count must be rejected without writing a profile — so they have teeth in the ordinary CI jobs, not only under `-fsanitize=integer`. The heap-overflow case additionally fails on any abnormal termination, since without ASan the defect surfaces as a SEGV rather than a sanitizer report.

Their sanitizer gate requires `ENABLE_INTEGER_SANITIZER` or an explicit `integer`/`implicit` flag rather than accepting a bare `-fsanitize=undefined`, which cannot observe an `implicit-integer-sign-change` and would otherwise report a confident pass.

Red/green verified locally across two sanitizer configurations:

| | pristine | fixed |
|---|---|---|
| 1845 saved version byte | `0xee`, "saved correctly" | `0x00`, valid BCD |
| 1845 UBSan | `IccProfileXml.cpp:343` | clean |
| 1846 case A UBSan | `IccTagXml.cpp:1014` | clean |
| 1847 case B, ASan | heap-buffer-overflow WRITE | rejected, `rc=1` |
| 1847 case B, no ASan | SEGV in `malloc/unlink_chunk` | rejected, `rc=1` |

## No behaviour change on valid input

All 188 `Testing/*.xml` fixtures produce byte-identical output before and after — 170 profiles written identical, 18 rejected identically. The comparison masks the header creation date and profileID, which `iccFromXml` stamps from the clock on every run, including inside embedded sub-profiles; a same-binary control confirms the remaining variance is entirely those fields.

Full CI-mirror suite (`ENABLE_SANITIZERS=ON`, 111 tests) is clean apart from three pre-existing environment failures: `hybrid-pipeline` passes when run serially (`-j2` flake), `tool-coverage` hits one `RoundTrip CMYK >60s` timeout under Debug+ASan on WSL2, and `spectral-tiff-preview` needs the Python `imagecodecs` module. None touch IccXML. The fuzz-patch stack dry-runs clean; no patch touches either file.

