### PR TITLE
fix(#1851): validate ParametricCurve FunctionType in the XML importer

### DIFF
--- a/.github/ci/test-data/param-functiontype-control-1851.xml
+++ b/.github/ci/test-data/param-functiontype-control-1851.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #1851 control.  A well-formed RGB matrix/TRC display profile whose three TRC
+  tags are parametricCurveType with the legal FunctionType="4" (7 parameters).
+
+  This file must ALWAYS convert cleanly.  The two ub-parametriccurve-* PoCs
+  beside it are byte-identical to this one except for the redTRCTag
+  FunctionType attribute, so anything they exercise other than that attribute
+  is a known-good path, and the regression script skips rather than fails if
+  this control does not convert.
+-->
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.30</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+    <ProfileID>0</ProfileID>
+  </Header>
+
+  <Tags>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[iccDEV #1851 ParametricCurve control]]></LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZArrayType> </mediaWhitePointTag>
+
+    <redColorantTag> <XYZArrayType>
+      <XYZNumber X="0.43606567" Y="0.22248840" Z="0.01391602"/>
+    </XYZArrayType> </redColorantTag>
+
+    <greenColorantTag> <XYZArrayType>
+      <XYZNumber X="0.38514709" Y="0.71687317" Z="0.09707642"/>
+    </XYZArrayType> </greenColorantTag>
+
+    <blueColorantTag> <XYZArrayType>
+      <XYZNumber X="0.14306641" Y="0.06060791" Z="0.71409607"/>
+    </XYZArrayType> </blueColorantTag>
+
+    <redTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </redTRCTag>
+
+    <greenTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </greenTRCTag>
+
+    <blueTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </blueTRCTag>
+
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-parametriccurve-functiontype-launder-1851.xml
+++ b/.github/ci/test-data/ub-parametriccurve-functiontype-launder-1851.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #1851 case A: value laundering through the icUInt16Number narrowing.
+
+  Identical to param-functiontype-control-1851.xml except that redTRCTag
+  carries FunctionType="65540".  atoi() returns 65540; narrowing that to
+  SetFunctionType()'s icUInt16Number parameter yields 65540 minus 65536 == 4,
+  a LEGAL function type taking 7 parameters, which is exactly how many follow.
+
+  So before the fix this file converted successfully and iccFromXml wrote a
+  profile whose red TRC claims function type 4, silently inventing a value the
+  source document never contained.  The fix must reject it: 65540 is outside
+  the 0..4 range ICC.1 defines.  Observable on ANY build, sanitizer or not.
+-->
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.30</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+    <ProfileID>0</ProfileID>
+  </Header>
+
+  <Tags>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[iccDEV #1851 ParametricCurve control]]></LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZArrayType> </mediaWhitePointTag>
+
+    <redColorantTag> <XYZArrayType>
+      <XYZNumber X="0.43606567" Y="0.22248840" Z="0.01391602"/>
+    </XYZArrayType> </redColorantTag>
+
+    <greenColorantTag> <XYZArrayType>
+      <XYZNumber X="0.38514709" Y="0.71687317" Z="0.09707642"/>
+    </XYZArrayType> </greenColorantTag>
+
+    <blueColorantTag> <XYZArrayType>
+      <XYZNumber X="0.14306641" Y="0.06060791" Z="0.71409607"/>
+    </XYZArrayType> </blueColorantTag>
+
+    <redTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="65540">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </redTRCTag>
+
+    <greenTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </greenTRCTag>
+
+    <blueTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </blueTRCTag>
+
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-parametriccurve-functiontype-overflow-1851.xml
+++ b/.github/ci/test-data/ub-parametriccurve-functiontype-overflow-1851.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #1851 case B: the breadcrumb exactly as reported, from the AFL corpus.
+
+  Identical to param-functiontype-control-1851.xml except that redTRCTag
+  carries FunctionType="96948242 1.23 0.44994".  atoi() stops at the first
+  non-digit and returns 96948242, which narrowing to icUInt16Number changes to
+  20498:
+
+    IccTagXml.cpp:3538:30: runtime error: implicit conversion from type 'int'
+    of value 96948242 (32-bit, signed) to type 'icUInt16Number' (aka 'unsigned
+    short') changed the value to 20498 (16-bit, unsigned)
+
+  20498 is not a legal function type, so the tag was rejected downstream by the
+  parameter-count check even before the fix.  This case therefore has no
+  functional tell and is only observable under an integer/implicit-conversion
+  sanitizer build; the regression script skips it cleanly elsewhere.  Case A
+  is the one that fails on an ordinary build.
+-->
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.30</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+    <ProfileID>0</ProfileID>
+  </Header>
+
+  <Tags>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[iccDEV #1851 ParametricCurve control]]></LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZArrayType> </mediaWhitePointTag>
+
+    <redColorantTag> <XYZArrayType>
+      <XYZNumber X="0.43606567" Y="0.22248840" Z="0.01391602"/>
+    </XYZArrayType> </redColorantTag>
+
+    <greenColorantTag> <XYZArrayType>
+      <XYZNumber X="0.38514709" Y="0.71687317" Z="0.09707642"/>
+    </XYZArrayType> </greenColorantTag>
+
+    <blueColorantTag> <XYZArrayType>
+      <XYZNumber X="0.14306641" Y="0.06060791" Z="0.71409607"/>
+    </XYZArrayType> </blueColorantTag>
+
+    <redTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="96948242 1.23 0.44994">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </redTRCTag>
+
+    <greenTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </greenTRCTag>
+
+    <blueTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </blueTRCTag>
+
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/scripts/iccdev-issue-1851-parametriccurve-functiontype-regression.sh
+++ b/.github/scripts/iccdev-issue-1851-parametriccurve-functiontype-regression.sh
@@ -1,0 +1,189 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1851 - unvalidated ParametricCurve FunctionType in the XML
+#                      parametricCurveType reader
+###############################################################################
+#
+# CIccTagXmlParametricCurve::ParseXml read the attribute with atoi():
+#
+#   if (!SetFunctionType(atoi(functionType))){      // IccTagXml.cpp
+#     return false;
+#   }
+#
+# ICC.1 defines the parametric curve function type as 0-4, and
+# CIccTagParametricCurve::SetFunctionType takes an icUInt16Number.  atoi()
+# returns a signed int, so every value outside 0..65535 narrowed on the way in,
+# and the guard could not catch it: SetFunctionType is documented
+# "Return: always true!!" and ends in an unconditional `return true`, so
+# `if (!SetFunctionType(...))` has never rejected anything.
+#
+# Both PoCs are param-functiontype-control-1851.xml with ONLY the redTRCTag
+# FunctionType attribute changed, so anything else they exercise is a
+# known-good path.  The control is converted first and the whole test skips if
+# it does not convert, which keeps an unrelated environment problem from being
+# reported as a #1851 regression.
+#
+# CASE A -- value laundering.  This is the case that matters on an ordinary
+# build.  FunctionType="65540" is not a legal type, but 65540 narrowed to
+# icUInt16Number is 4, which IS legal and takes 7 parameters -- exactly how many
+# the PoC supplies.  So the malformed attribute was laundered into a valid one:
+#
+#   $ iccFromXml ub-parametriccurve-functiontype-launder-1851.xml out.icc
+#   Profile parsed and saved correctly
+#   $ cmp out.icc control.icc && echo identical
+#   identical
+#
+# iccFromXml wrote a profile whose red TRC claims function type 4 while the
+# source document said 65540 - a value the file never contained.  The fixed
+# reader must reject it.  No sanitizer required.
+#
+# CASE B -- the breadcrumb exactly as filed.  FunctionType="96948242 1.23
+# 0.44994"; atoi() stops at the first non-digit and returns 96948242, which
+# narrows to 20498:
+#
+#   IccTagXml.cpp:3538:30: runtime error: implicit conversion from type 'int'
+#   of value 96948242 (32-bit, signed) to type 'icUInt16Number' (aka 'unsigned
+#   short') changed the value to 20498 (16-bit, unsigned)
+#
+# 20498 is not a legal type, so the parameter-count check below already rejected
+# the tag pre-fix.  Case B therefore has NO functional tell and is meaningful
+# only under an integer/implicit-conversion sanitizer build; it is skipped
+# cleanly elsewhere rather than reported as a vacuous pass.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1851}"
+DATA_DIR="$REPO_ROOT/.github/ci/test-data"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+
+# Locate the build's CMakeCache.txt (walk up from the tool) to decide whether
+# case B's check is actually compiled in.
+#
+# The gate deliberately does NOT accept ENABLE_UBSAN / a bare "undefined" in the
+# flags.  Build/Cmake/CMakeLists.txt maps ENABLE_UBSAN to -fsanitize=undefined,
+# and implicit-integer-truncation lives in the integer/implicit-conversion
+# groups, not in undefined.  A looser test reports a confident PASS on an
+# -fsanitize=address,undefined build that cannot observe the defect at all.
+CACHE=""
+probe="$(dirname "$FROMXML")"
+for _ in 1 2 3 4 5; do
+  if [ -f "$probe/CMakeCache.txt" ]; then CACHE="$probe/CMakeCache.txt"; break; fi
+  probe="$(dirname "$probe")"
+done
+sanitized=0
+if [ -n "$CACHE" ]; then
+  if grep -qiE "ENABLE_INTEGER_SANITIZER:BOOL=ON" "$CACHE"; then
+    sanitized=1
+  elif grep -iE "CMAKE_(CXX|C)_FLAGS" "$CACHE" | grep -qiE "fsanitize=[^ ]*(integer|implicit)"; then
+    sanitized=1
+  fi
+fi
+
+TOOL_RC=0
+TOOL_LOG=""
+TOOL_ICC=""
+run_tool() {
+  # $1 = PoC basename (without .xml).
+  #
+  # Sets the globals TOOL_LOG / TOOL_ICC / TOOL_RC rather than echoing the log
+  # path: a caller writing LOG=$(run_tool ...) would run this in a command
+  # substitution subshell, and TOOL_RC would never reach the caller.
+  local poc="$DATA_DIR/$1.xml"
+  TOOL_LOG="$OUTDIR/$1.log"
+  TOOL_ICC="$OUTDIR/$1.icc"
+  rm -f "$TOOL_ICC"
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0:allocator_may_return_null=1" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$FROMXML" "$poc" "$TOOL_ICC" > "$TOOL_LOG" 2>&1
+  TOOL_RC=$?
+}
+
+# --- CONTROL: a legal FunctionType="4" curve must still convert --------------
+# Run first.  If the fix ever over-rejects, this fails loudly instead of the
+# two PoCs passing for the wrong reason; if the control cannot convert for an
+# unrelated reason, the whole test skips rather than blaming #1851.
+CONTROL="param-functiontype-control-1851"
+if [ ! -f "$DATA_DIR/$CONTROL.xml" ]; then
+  echo "[SKIP] control XML missing: $DATA_DIR/$CONTROL.xml"
+  exit 0
+fi
+run_tool "$CONTROL"
+CONTROL_ICC="$TOOL_ICC"
+if [ ! -f "$CONTROL_ICC" ]; then
+  if grep -qE "runtime error: |AddressSanitizer" "$TOOL_LOG"; then
+    echo "[FAIL] #1851 control: legal FunctionType=\"4\" curve tripped a sanitizer"
+    grep -E "runtime error: |AddressSanitizer|IccTagXml" "$TOOL_LOG" | head
+    exit 2
+  fi
+  echo "[SKIP] control profile did not convert; environment issue, not #1851"
+  sed -n '1,10p' "$TOOL_LOG"
+  exit 0
+fi
+echo "[PASS] #1851 control: legal FunctionType=\"4\" curve still converts"
+
+status=0
+
+# --- CASE A: laundering (functional, valid on every build) -------------------
+POC_A="ub-parametriccurve-functiontype-launder-1851"
+if [ ! -f "$DATA_DIR/$POC_A.xml" ]; then
+  echo "[SKIP] PoC XML missing: $DATA_DIR/$POC_A.xml"
+else
+  run_tool "$POC_A"
+  if [ -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1851 case A: profile written for FunctionType=\"65540\" (rc=$TOOL_RC)"
+    if cmp -s "$TOOL_ICC" "$CONTROL_ICC"; then
+      echo "       output is byte-identical to the FunctionType=\"4\" control:"
+      echo "       the out-of-range attribute was laundered into a legal type"
+    fi
+    status=2
+  elif [ "$sanitized" -eq 1 ] && grep -qE "runtime error: implicit conversion" "$TOOL_LOG"; then
+    echo "[FAIL] #1851 case A: implicit conversion of FunctionType reappeared"
+    grep -E "runtime error: implicit conversion|IccTagXml" "$TOOL_LOG" | head
+    status=2
+  else
+    echo "[PASS] #1851 case A: out-of-range FunctionType rejected, no profile written"
+  fi
+fi
+
+# --- CASE B: the reported breadcrumb (sanitizer builds only) -----------------
+POC_B="ub-parametriccurve-functiontype-overflow-1851"
+if [ ! -f "$DATA_DIR/$POC_B.xml" ]; then
+  echo "[SKIP] PoC XML missing: $DATA_DIR/$POC_B.xml"
+elif [ "$sanitized" -ne 1 ]; then
+  # Deliberately a SKIP, not a PASS.  Pre-fix this PoC was already rejected by
+  # the parameter-count check, so "no profile written" is true on a broken
+  # build too and would be a vacuous green.
+  echo "[SKIP] case B: not an integer/implicit-conversion build (CMakeCache: ${CACHE:-none})"
+else
+  run_tool "$POC_B"
+  if grep -qE "runtime error: implicit conversion" "$TOOL_LOG"; then
+    echo "[FAIL] #1851 case B: ParametricCurve FunctionType sanitizer finding reappeared (rc=$TOOL_RC)"
+    grep -E "runtime error: implicit conversion|IccTagXml.cpp" "$TOOL_LOG" | head
+    status=2
+  elif [ -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1851 case B: profile written despite malformed FunctionType"
+    status=2
+  else
+    echo "[PASS] #1851 case B: malformed FunctionType parsed without a narrowing conversion"
+  fi
+fi
+
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3006,6 +3006,25 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1846-namedcolor-devicecoords-regression.sh"
 )
 
+# #1851: unvalidated ParametricCurve FunctionType in the XML parametricCurveType
+# reader.  atoi() fed SetFunctionType(icUInt16Number), and the surrounding
+# `if (!SetFunctionType(...))` could never reject anything because that function
+# always returns true.  Case A is the half that has teeth in the ordinary CI
+# jobs: FunctionType="65540" narrows to the legal type 4, so the malformed
+# attribute was laundered into a valid one and iccFromXml wrote a profile
+# byte-identical to the FunctionType="4" control.  Case B replays the reported
+# breadcrumb (96948242 -> 20498), which the parameter-count check already
+# rejected pre-fix, so it is gated on an integer/implicit-conversion build
+# rather than passing vacuously.  A control profile guards against over-
+# rejection of legitimate type-4 curves.
+iccdev_add_script_test(
+  iccdev.issue-1851-parametriccurve-functiontype-regression
+  60
+  "iccdev;xml;parametriccurve;issue-1851;regression;ubsan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1851-parametriccurve-functiontype-regression.sh"
+)
+
 # #1356: XML serializer corrupts a zero (NoData) header colour-space signature
 # on round-trip.  iccToXml wrote the literal "NULL" for a 0x00000000 data
 # colour space / PCS; iccFromXml then reparsed "NULL" to 0x4E554C4C, so the

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -3535,7 +3535,34 @@ bool CIccTagXmlParametricCurve::ParseXml(xmlNode *pNode, std::string & /*parseSt
         if (!functionType)
           return false;    
 
-        if (!SetFunctionType(atoi(functionType))){
+        // ICC.1 encodes the parametric curve function type as 0-4 (see the
+        // switch in CIccTagParametricCurve::SetFunctionType), so parse it as a
+        // bounded unsigned value rather than through atoi().
+        //
+        // atoi() returned a signed int that was then narrowed to
+        // SetFunctionType()'s icUInt16Number parameter, which is undefined for
+        // anything outside 0..65535 and silently truncating inside it (#1851):
+        //
+        //   IccTagXml.cpp:3538:30: runtime error: implicit conversion from type
+        //   'int' of value 96948242 (32-bit, signed) to type 'icUInt16Number'
+        //   (aka 'unsigned short') changed the value to 20498 (16-bit, unsigned)
+        //
+        // Truncation is the part that matters beyond the sanitizer diagnostic:
+        // any input congruent to a legal type mod 65536 was laundered into that
+        // legal type, so "65540" was accepted as function type 4 and the profile
+        // was written as though the file had said 4.  atoi() also stops at the
+        // first non-digit, so "96948242 1.23 0.44994" parsed as a number at all.
+        //
+        // The existing `if (!SetFunctionType(...))` guard could not catch either
+        // case: SetFunctionType is documented "Return: always true!!" and ends in
+        // an unconditional `return true`, so this test has never rejected
+        // anything.  Out-of-range types fell through its switch to nNumParam = 0,
+        // leaving the truncated value stored in m_nFunctionType and written back
+        // out by Write16().  icXmlParseU16 rejects trailing garbage, a leading
+        // '-', and anything above the bound, which makes the guard live.
+        icUInt16Number nFunctionType = 0;
+        if (!icXmlParseU16(functionType, nFunctionType, 4) ||
+            !SetFunctionType(nFunctionType)){
           return false;
         }
         CIccFloatArray data;


### PR DESCRIPTION
Fixes #1851.

## Defect

`CIccTagXmlParametricCurve::ParseXml` passed `atoi()` straight into `SetFunctionType(icUInt16Number)`:

```cpp
if (!SetFunctionType(atoi(functionType))){
  return false;
}
```

ICC.1 defines the parametric curve function type as **0-4**. Two things go wrong:

**1. The narrowing** — the reported symptom. Anything outside `0..65535` changes value converting into the `icUInt16Number` parameter:

```
IccTagXml.cpp:3538:30: runtime error: implicit conversion from type 'int' of value
96948242 (32-bit, signed) to type 'icUInt16Number' (aka 'unsigned short') changed
the value to 20498 (16-bit, unsigned)
```

**2. The guard was dead code** — and this is why the value was never range-checked either. `CIccTagParametricCurve::SetFunctionType` is documented *"Return: always true!!"* and ends in an unconditional `return true`, so `if (!SetFunctionType(...))` has never rejected anything in the history of this code. Out-of-range types fall through its `switch` to `default: nNumParam = 0`, leaving the truncated value stored in `m_nFunctionType` and written back out by `Write16()` at `IccTagLut.cpp:884`.

## Why this is worth more than the sanitizer diagnostic

The truncation **launders malformed input into valid input**. Any value congruent to a legal type mod 65536 narrows to that legal type. `FunctionType="65540"` becomes 4, which takes 7 parameters — exactly how many a crafted file supplies:

```console
$ iccFromXml ub-parametriccurve-functiontype-launder-1851.xml out.icc
Profile parsed and saved correctly
$ cmp out.icc control.icc && echo identical
identical
```

The written profile's `para` tag encodes function type `0004` while the source document said `65540`:

```
000001a0: 0000 b6cf 7061 7261 0000 0000 0004 0000  ....para........
                    ^^^^ ^^^^           ^^^^
                    'para'              function type 4
```

That is a value the input never contained, and **no sanitizer is required to observe it** — it reproduces on a plain Release build.

`atoi()` also stops at the first non-digit, which is why the AFL artifact's `FunctionType="96948242 1.23 0.44994"` parsed as a number at all.

## Fix

```cpp
icUInt16Number nFunctionType = 0;
if (!icXmlParseU16(functionType, nFunctionType, 4) ||
    !SetFunctionType(nFunctionType)){
  return false;
}
```

`icXmlParseU16` (`IccUtilXml.cpp:1275`, already on master) rejects a leading `-`, trailing garbage, `ERANGE`, and anything above the bound. The bound of 4 comes from `SetFunctionType`'s own doc comment and `switch`. This makes the existing guard live rather than decorative.

## Regression

`iccdev.issue-1851-parametriccurve-functiontype-regression`, three fixtures, all byte-identical apart from the `redTRCTag` `FunctionType` attribute:

| Fixture | `FunctionType` | Role |
|---|---|---|
| `param-functiontype-control-1851.xml` | `4` | must still convert — guards against over-rejection |
| `ub-parametriccurve-functiontype-launder-1851.xml` | `65540` | laundering; fails on **any** build |
| `ub-parametriccurve-functiontype-overflow-1851.xml` | `96948242 1.23 0.44994` | the reported breadcrumb |

The control runs first: if it does not convert, the test **skips** rather than blaming #1851 for an unrelated environment problem.

Case B is deliberately gated on an integer/implicit-conversion build and reports `[SKIP]`, not `[PASS]`, elsewhere. Pre-fix that PoC was already rejected downstream by the parameter-count check, so "no profile written" is true on a broken build too — an ungated assertion would be a vacuous green. Case A carries the teeth in the ordinary CI jobs.

Verified red/green, both directions, both builds:

| PoC | plain, pre-fix | plain, post-fix | UBSan, pre-fix | UBSan, post-fix |
|---|---|---|---|---|
| control (`4`) | written | **written** | written, 0 findings | written, 0 findings |
| launder (`65540`) | **WRITTEN — defect** | rejected | written + `65540 -> 4` | rejected, 0 findings |
| overflow (`96948242 ...`) | rejected | rejected | rejected + `96948242 -> 20498` | rejected, 0 findings |

Script exit status is **2 on unfixed source in a plain Release build** and 0 after the fix.

## Pre-flight

- `-Wall -Wextra -Wpedantic -Werror -std=c++17`, LTO, shared+static, zlib — **gcc: 0 warnings**, **clang: 0 warnings**
- `clang -fsanitize=integer,implicit-conversion,undefined` — clean on all three fixtures post-fix
- Full CTest **111/112**; the single failure is `iccdev.spectral-tiff-preview`, a missing local `imagecodecs` Python module, unrelated to this change

## Relationship to #1853

This is the first item carved out of the `ci-qa-flags` harvest, and it follows the process that branch's own fuzz-patch README prescribes:

> These patches are experimental fuzz-run stabilizers, not source changes being proposed for direct merge from this directory. […] **durable fixes still need normal review as source changes in the affected component.**

The #1851 change currently lives on `ci-qa-flags` as `.github/ci/fuzz-patches/{afl,cfl}/005-fromxml-parametriccurve-functiontype-bounds.patch` — it was moved off the source path in `b2329edc`, so nothing was landing it on master. The precedent is one commit old: #1849 landed the durable #1817 fix **and** deleted `003-applyprofiles-cam-encoding-div-zero.patch` from both stacks in the same commit, which is exactly the "Retired patches" note in that README. @xsscx — patch 005 can be retired the same way once this merges.

Worth being precise about scope: #1851 is a good exemplar of the *process* for #1853, not of its *bulk*. It is one issue, one function, one bounded source change with a regression. The larger items on that branch (notably the `IccMatrixMath.cpp` line-ending conversion, which shows 992 changed lines but only 78 under `git diff -w`, and the +548-line `IccCmm.cpp` change) need their own review on their own terms.

One heads-up on branch mechanics: `e75b543f` on `ci-qa-flags` deletes `.github/scripts/iccdev-issue-1851-parametriccurve-functiontype-regression.sh` and its CTest entry, consolidating coverage into the AFL transaction path. This PR adds a file of that same name to master. When `ci-qa-flags` next rebases onto master, that deletion will apply cleanly and silently remove this regression — worth dropping the deletion hunk at that point rather than resolving it in the branch's favour.
