### PR TITLE
fix(#1810): replace the unregistered RICC signature in the Testing fixture headers

### DIFF
--- a/.github/scripts/iccdev-issue-1810-ricc-header-signatures.sh
+++ b/.github/scripts/iccdev-issue-1810-ricc-header-signatures.sh
@@ -1,0 +1,214 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1810 - 'RICC' in the CMM and platform header fields of the
+#                      Testing fixtures
+###############################################################################
+#
+# 'RICC' was never a registered signature.  It was this project's own enum
+# typo: icSigRefIccMAX carried the value 0x52494343 ('RICC') while its comment
+# and registry.color.org/cmm-signatures both said 'RIMX' = 0x52494D58.  PR #1473
+# corrected the enum (recorded as row B3 in
+# Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md), but the
+# fixtures authored while the enum was wrong kept the bad value, so the
+# validator went on reporting them.
+#
+# Two header fields are actually checked, and they fail differently:
+#
+#   <PreferredCMMType>RICC   -> "Unregistered CMM signature."   IccProfile.cpp
+#   <PrimaryPlatform>RICC    -> "Unknown platform signature."   IccProfile.cpp
+#
+# A third field, <ProfileCreator>, also carried 'RICC' in 24 fixtures, but
+# CIccProfile::Validate never inspects the creator field -- it is read and
+# written only -- so those produce no finding and are deliberately NOT part of
+# this test.  Asserting on them would be asserting on nothing.
+#
+# The fix replaces the CMM value with the registered 'RIMX' and clears the
+# platform field to empty (the encoding 6 other Testing fixtures already use
+# for "unspecified"), per @PhilGreen736767's ruling on #1810:
+#
+#   "RICC is the iccMAX Reference Implementation.  The registered CMM for this
+#    is 'RIMX', not 'RICC'.  'RICC' is also not a platform signature."
+#
+# CONTROL -- run first, and the reason this test is not vacuous.  After the fix
+# there is no fixture left that SHOULD warn, so a validator that had stopped
+# emitting these findings altogether would let every assertion below pass.  The
+# control therefore synthesises a failure: it copies a fixture, injects an
+# unregistered CMM signature ('ZZZZ'), and requires the warning to appear.  If
+# it does not, the environment cannot observe the defect and the whole test
+# SKIPs rather than reporting a green it has not earned.
+#
+# CASE A -- text guard.  No tracked Testing XML may reintroduce 'RICC' into
+# either validated field.  Needs no build, so it still has teeth in jobs that
+# do not produce the command-line tools.
+#
+# CASE B -- functional.  Every fixture this issue touched must convert and
+# validate free of both findings.  The validator itself is the oracle, so the
+# registered-signature allow-list is never duplicated here and cannot drift.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1810}"
+mkdir -p "$OUTDIR"
+
+# The fixtures corrected by the #1810 change, relative to the repository root.
+# Listed explicitly rather than derived, so the set this test covers is exactly
+# the set the fix touched and stays reviewable in the diff.
+FIXTURES="
+Testing/CMYK-3DLUTs/CMYK-3DLUTs.xml
+Testing/CMYK-3DLUTs/CMYK-3DLUTs2.xml
+Testing/ICS/Lab_float-D65_2deg-Part1.xml
+Testing/ICS/Lab_float-IllumA_2deg-Part2.xml
+Testing/ICS/Lab_int-D65_2deg-Part1.xml
+Testing/ICS/Lab_int-IllumA_2deg-Part2.xml
+Testing/ICS/Rec2100HlgFull-Part1.xml
+Testing/ICS/Rec2100HlgFull-Part2.xml
+Testing/ICS/Rec2100HlgFull-Part3.xml
+Testing/ICS/Spec400_10_700-D50_2deg-Part1.xml
+Testing/ICS/Spec400_10_700-D93_2deg-Part2.xml
+Testing/ICS/XYZ_float-D65_2deg-Part1.xml
+Testing/ICS/XYZ_float-IllumA_2deg-Part2.xml
+Testing/ICS/XYZ_int-D65_2deg-Part1.xml
+Testing/ICS/XYZ_int-IllumA_2deg-Part2.xml
+"
+
+# Both findings are emitted by CIccProfile::Validate with this exact wording.
+CMM_MSG="Unregistered CMM signature"
+PLAT_MSG="Unknown platform signature"
+
+status=0
+
+# Print a captured block indented under the report line above it.  Written as a
+# read loop rather than `echo "$var" | sed 's/^/.../'` to keep the pre-flight
+# lint gate clean (SC2001); it also preserves blank lines within the block.
+indent() {
+  while IFS= read -r line; do
+    printf '       %s\n' "$line"
+  done <<< "$1"
+}
+
+# --- CASE A: no tracked fixture may carry 'RICC' in a validated field --------
+# Deliberately ordered first: it is the assertion that needs no tools, so a
+# build-less job still reports something meaningful instead of skipping whole.
+#
+# <ProfileCreator> is excluded on purpose -- see the header comment.  Only the
+# two fields CIccProfile::Validate actually inspects are guarded.
+hits=""
+if command -v git >/dev/null 2>&1 && git -C "$REPO_ROOT" rev-parse --git-dir >/dev/null 2>&1; then
+  hits="$(git -C "$REPO_ROOT" grep -n \
+      -e '<PreferredCMMType>RICC</PreferredCMMType>' \
+      -e '<PrimaryPlatform>RICC</PrimaryPlatform>' \
+      -- 'Testing/*' 2>/dev/null)"
+else
+  # Fall back to a plain walk when the tree is not a git checkout (release
+  # tarball, vendored copy), so the guard does not silently disappear.
+  hits="$(grep -rn \
+      -e '<PreferredCMMType>RICC</PreferredCMMType>' \
+      -e '<PrimaryPlatform>RICC</PrimaryPlatform>' \
+      --include='*.xml' "$REPO_ROOT/Testing" 2>/dev/null)"
+fi
+
+if [ -n "$hits" ]; then
+  echo "[FAIL] #1810 case A: 'RICC' reintroduced into a validated header field"
+  indent "$hits"
+  echo "       use the registered 'RIMX' for <PreferredCMMType>; leave"
+  echo "       <PrimaryPlatform> empty ('RICC' is not a platform signature)"
+  status=2
+else
+  echo "[PASS] #1810 case A: no tracked fixture carries 'RICC' in a validated field"
+fi
+
+# --- locate the tools; case B needs both -------------------------------------
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+DUMP="$(find "$TOOLS_DIR" -maxdepth 2 -name iccDumpProfile -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ] || [ -z "$DUMP" ] || [ ! -x "$DUMP" ]; then
+  echo "[SKIP] case B: iccFromXml / iccDumpProfile not found under $TOOLS_DIR"
+  exit "$status"
+fi
+
+# Convert $1 (repo-relative XML) to $2 (output .icc).
+#
+# Runs with the XML's own directory as the working directory: several of these
+# fixtures reference sibling data files (EOTF.txt, LUT tables) by relative path
+# and will not parse from anywhere else.
+convert() {
+  local xml="$1" out="$2"
+  ( cd "$REPO_ROOT/$(dirname "$xml")" && \
+    "$FROMXML" "$(basename "$xml")" "$out" ) >"$out.convert.log" 2>&1
+}
+
+# --- CONTROL: the validator must still be able to emit the CMM finding -------
+# Injects an unregistered signature into a copy of a real fixture.  The copy is
+# written beside the original because of the relative-path dependency above,
+# and is removed on every exit path.
+CONTROL_SRC="Testing/ICS/Rec2100HlgFull-Part1.xml"
+CONTROL_TMP="$REPO_ROOT/$(dirname "$CONTROL_SRC")/.iccdev-1810-control.xml"
+# Inlined rather than a cleanup() function so shellcheck can see the command is
+# reachable (SC2317 cannot follow a trap handler to its definition).  Single
+# quotes are deliberate: $CONTROL_TMP expands when the trap fires, not now.
+trap 'rm -f "$CONTROL_TMP"' EXIT
+
+if [ ! -f "$REPO_ROOT/$CONTROL_SRC" ]; then
+  echo "[SKIP] case B: control fixture missing: $CONTROL_SRC"
+  exit "$status"
+fi
+
+sed 's|<PreferredCMMType>[^<]*</PreferredCMMType>|<PreferredCMMType>ZZZZ</PreferredCMMType>|' \
+    "$REPO_ROOT/$CONTROL_SRC" > "$CONTROL_TMP"
+convert "$(dirname "$CONTROL_SRC")/.iccdev-1810-control.xml" "$OUTDIR/control.icc"
+if [ ! -f "$OUTDIR/control.icc" ]; then
+  echo "[SKIP] control profile did not convert; environment issue, not #1810"
+  sed -n '1,10p' "$OUTDIR/control.icc.convert.log" 2>/dev/null
+  exit "$status"
+fi
+"$DUMP" -v 26 "$OUTDIR/control.icc" > "$OUTDIR/control.validate.log" 2>&1
+if ! grep -q "$CMM_MSG" "$OUTDIR/control.validate.log"; then
+  # Without this the case B loop below would pass on a validator that had
+  # stopped checking the CMM field at all.
+  echo "[SKIP] control: validator did not flag an unregistered CMM ('ZZZZ');"
+  echo "       it cannot observe #1810 here, so case B would be a vacuous pass"
+  exit "$status"
+fi
+echo "[PASS] #1810 control: validator still flags an unregistered CMM signature"
+
+# --- CASE B: every corrected fixture validates free of both findings ---------
+checked=0
+for xml in $FIXTURES; do
+  [ -f "$REPO_ROOT/$xml" ] || { echo "[SKIP] fixture missing: $xml"; continue; }
+  base="$(basename "$xml" .xml)"
+  icc="$OUTDIR/$base.icc"
+  rm -f "$icc"
+  convert "$xml" "$icc"
+  if [ ! -f "$icc" ]; then
+    echo "[FAIL] #1810 case B: $xml no longer converts"
+    sed -n '1,5p' "$icc.convert.log" 2>/dev/null | sed 's/^/       /'
+    status=2
+    continue
+  fi
+  "$DUMP" -v 26 "$icc" > "$icc.validate.log" 2>&1
+  found="$(grep -E "$CMM_MSG|$PLAT_MSG" "$icc.validate.log")"
+  if [ -n "$found" ]; then
+    echo "[FAIL] #1810 case B: $base still reports an unregistered header signature"
+    indent "$found"
+    status=2
+  fi
+  checked=$((checked + 1))
+done
+
+if [ "$status" -eq 0 ]; then
+  echo "[PASS] #1810 case B: $checked corrected fixtures validate with no"
+  echo "       unregistered-CMM or unknown-platform finding"
+fi
+
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3025,6 +3025,26 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1851-parametriccurve-functiontype-regression.sh"
 )
 
+# #1810: 'RICC' in the CMM and platform header fields of 15 Testing fixtures.
+# 'RICC' was never registered -- icSigRefIccMAX itself carried 0x52494343
+# ('RICC') against a comment and a registry that both said 'RIMX', until #1473
+# corrected the enum.  Fixtures authored in the meantime kept the bad value, so
+# 13 reported "Unregistered CMM signature" and 2 reported "Unknown platform
+# signature".  Case A is a text guard against reintroduction and needs no build,
+# so it still asserts in jobs that do not produce the tools.  Case B converts
+# every corrected fixture and uses the validator itself as the oracle, so the
+# registered-signature allow-list is not duplicated in shell.  Because nothing
+# should warn after the fix, a control first injects an unregistered 'ZZZZ' and
+# requires the finding to appear -- otherwise a validator that had stopped
+# checking the field would make case B a vacuous pass.
+iccdev_add_script_test(
+  iccdev.issue-1810-ricc-header-signatures
+  120
+  "iccdev;xml;header;signatures;issue-1810;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1810-ricc-header-signatures.sh"
+)
+
 # #1356: XML serializer corrupts a zero (NoData) header colour-space signature
 # on round-trip.  iccToXml wrote the literal "NULL" for a 0x00000000 data
 # colour space / PCS; iccFromXml then reparsed "NULL" to 0x4E554C4C, so the

--- a/Testing/CMYK-3DLUTs/CMYK-3DLUTs.xml
+++ b/Testing/CMYK-3DLUTs/CMYK-3DLUTs.xml
@@ -7,7 +7,7 @@
   	<DataColourSpace>CMYK</DataColourSpace>
   	<PCS>Lab </PCS>
   	<CreationDateTime>now</CreationDateTime>
-  	<PrimaryPlatform>RICC</PrimaryPlatform>
+  	<PrimaryPlatform></PrimaryPlatform>
   	<ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
   	<DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
   	<RenderingIntent>Perceptual</RenderingIntent>

--- a/Testing/CMYK-3DLUTs/CMYK-3DLUTs2.xml
+++ b/Testing/CMYK-3DLUTs/CMYK-3DLUTs2.xml
@@ -7,7 +7,7 @@
   	<DataColourSpace>CMYK</DataColourSpace>
   	<PCS>Lab </PCS>
   	<CreationDateTime>now</CreationDateTime>
-  	<PrimaryPlatform>RICC</PrimaryPlatform>
+  	<PrimaryPlatform></PrimaryPlatform>
   	<ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
   	<DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
   	<RenderingIntent>Perceptual</RenderingIntent>

--- a/Testing/ICS/Lab_float-D65_2deg-Part1.xml
+++ b/Testing/ICS/Lab_float-D65_2deg-Part1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>
     <ProfileDeviceSubClass>pcc </ProfileDeviceSubClass>

--- a/Testing/ICS/Lab_float-IllumA_2deg-Part2.xml
+++ b/Testing/ICS/Lab_float-IllumA_2deg-Part2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>2.00</ProfileSubClassVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>

--- a/Testing/ICS/Lab_int-D65_2deg-Part1.xml
+++ b/Testing/ICS/Lab_int-D65_2deg-Part1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>
     <ProfileDeviceSubClass>pcc </ProfileDeviceSubClass>

--- a/Testing/ICS/Lab_int-IllumA_2deg-Part2.xml
+++ b/Testing/ICS/Lab_int-IllumA_2deg-Part2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>2.00</ProfileSubClassVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>

--- a/Testing/ICS/Rec2100HlgFull-Part1.xml
+++ b/Testing/ICS/Rec2100HlgFull-Part1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>1.00</ProfileSubClassVersion>
     <ProfileDeviceClass>mntr</ProfileDeviceClass>

--- a/Testing/ICS/Rec2100HlgFull-Part2.xml
+++ b/Testing/ICS/Rec2100HlgFull-Part2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>2.00</ProfileSubClassVersion>
     <ProfileDeviceClass>mntr</ProfileDeviceClass>

--- a/Testing/ICS/Rec2100HlgFull-Part3.xml
+++ b/Testing/ICS/Rec2100HlgFull-Part3.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>3.00</ProfileSubClassVersion>
     <ProfileDeviceClass>mntr</ProfileDeviceClass>

--- a/Testing/ICS/Spec400_10_700-D50_2deg-Part1.xml
+++ b/Testing/ICS/Spec400_10_700-D50_2deg-Part1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>1.00</ProfileSubClassVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>

--- a/Testing/ICS/Spec400_10_700-D93_2deg-Part2.xml
+++ b/Testing/ICS/Spec400_10_700-D93_2deg-Part2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>2.00</ProfileSubClassVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>

--- a/Testing/ICS/XYZ_float-D65_2deg-Part1.xml
+++ b/Testing/ICS/XYZ_float-D65_2deg-Part1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>1.00</ProfileSubClassVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>

--- a/Testing/ICS/XYZ_float-IllumA_2deg-Part2.xml
+++ b/Testing/ICS/XYZ_float-IllumA_2deg-Part2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>2.00</ProfileSubClassVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>

--- a/Testing/ICS/XYZ_int-D65_2deg-Part1.xml
+++ b/Testing/ICS/XYZ_int-D65_2deg-Part1.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>1.00</ProfileSubClassVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>

--- a/Testing/ICS/XYZ_int-IllumA_2deg-Part2.xml
+++ b/Testing/ICS/XYZ_int-IllumA_2deg-Part2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
   <Header>
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
     <ProfileVersion>5.00</ProfileVersion>
     <ProfileSubClassVersion>2.00</ProfileSubClassVersion>
     <ProfileDeviceClass>spac</ProfileDeviceClass>


### PR DESCRIPTION
Fixes #1810.

## Defect

15 `Testing` fixtures carry `RICC` in a header field the validator checks:

```
Warning! - Unknown 'RICC' = 52494343: Unregistered CMM signature.
Warning! - Unknown 'RICC' = 52494343: Unknown platform signature.
```

`RICC` was never a registered signature — **it was this project's own enum typo.** `icSigRefIccMAX` carried the value `0x52494343` (ASCII `RICC`) while its own comment and registry.color.org/cmm-signatures both said `RIMX = 0x52494D58`. PR #1473 corrected the enum; it is recorded as row **B3** in `Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md`:

> **B3 — latent value/comment mismatch corrected.** `icSigRefIccMAX` had value `0x52494343` (ASCII `RICC`) while its comment and the registry said `RIMX = 0x52494D58`; #1473 changed the value to `0x52494D58` to match.

The fixtures were hand-authored while the enum was still wrong (`1f0a9dd2` "Initial REFIccMAX Repository Creation" 2015, `4628668d` "RefIccMAX v2.1.17" 2019) and kept the bad value after the library stopped using it.

This matches @PhilGreen736767's ruling on the issue:

> Max can confirm, but I believe RICC is the iccMAX Reference Implementation. The registered CMM for this is 'RIMX', not 'RICC'. 'RICC' is also not a platform signature.

## Scope — measured over all 252 profiles in `Testing/`

| Field | Files | Validation effect | Emitting site |
|---|---|---|---|
| `<PreferredCMMType>RICC` | **13** | `Unregistered CMM signature` | `IccProfile.cpp:1995` |
| `<PrimaryPlatform>RICC` | **2** | `Unknown platform signature` | `IccProfile.cpp:1863` |
| `<ProfileCreator>RICC` | 24 | **none** | — |

15 fixture fields, 15 warnings, one-to-one. Nothing else in the corpus emits it.

## Fix

```diff
-    <PreferredCMMType>RICC</PreferredCMMType>
+    <PreferredCMMType>RIMX</PreferredCMMType>
```

```diff
-  	<PrimaryPlatform>RICC</PrimaryPlatform>
+  	<PrimaryPlatform></PrimaryPlatform>
```

`RIMX` is the registered CMM. The platform field has no correct signature to substitute — `RICC` is not a platform signature — so it clears to empty, which is already how six other `Testing` fixtures encode "unspecified".

15 files, 15 changed lines, and the diff is identical under `git diff -w`: no whitespace or line-ending churn.

**The 24 `<ProfileCreator>` occurrences are deliberately untouched.** `CIccProfile::Validate` never inspects the creator field — it is read and written only — so changing them would assert on nothing while churning 24 more files. (The same fossil exists there in a second flavour: 27 fixtures carry `<ProfileCreator>DICC</ProfileCreator>` against `icSigDemoIccMAX = 0x44494d58 /* 'DIMX' */`. Also invisible to the validator; noted on the issue as an optional follow-up.)

## Regression

`iccdev.issue-1810-ricc-header-signatures`, three parts:

| Part | Needs a build? | Asserts |
|---|---|---|
| **case A** | no | no tracked `Testing` XML carries `RICC` in either validated field |
| **control** | yes | the validator *still flags* an injected unregistered CMM (`ZZZZ`) |
| **case B** | yes | all 15 corrected fixtures convert and validate free of both findings |

**The control is why this test is not vacuous.** After the fix there is no fixture left that *should* warn, so a validator that had stopped emitting these findings altogether would let every case B assertion pass. The control synthesises a failure — it copies a real fixture, injects `<PreferredCMMType>ZZZZ</PreferredCMMType>`, and requires the warning to appear. If it doesn't, the test **SKIPs** rather than reporting a green it hasn't earned.

Case B uses the validator itself as the oracle, so the registered-signature allow-list is never duplicated in shell and cannot drift from `IccProfile.cpp`.

Case A needs no tools, so the guard against reintroduction still asserts in jobs that don't build the command-line tools.

Verified both directions:

```
$ bash .github/scripts/iccdev-issue-1810-ricc-header-signatures.sh     # fixed tree
[PASS] #1810 case A: no tracked fixture carries 'RICC' in a validated field
[PASS] #1810 control: validator still flags an unregistered CMM signature
[PASS] #1810 case B: 15 corrected fixtures validate with no
       unregistered-CMM or unknown-platform finding
exit=0

$ bash .github/scripts/iccdev-issue-1810-ricc-header-signatures.sh     # fixtures reverted
[FAIL] #1810 case A: 'RICC' reintroduced into a validated header field
       ... 15 files listed ...
[PASS] #1810 control: validator still flags an unregistered CMM signature
[FAIL] #1810 case B: CMYK-3DLUTs still reports an unregistered header signature
       ... 15 fixtures listed ...
exit=2
```

The tool-less path also verified: case A passes, case B reports `[SKIP]`, exit 0.

## No stale-ID hazard

The two platform-`RICC` fixtures are also the only two carrying a literal `<ProfileID>62CFD288…`, so this change was checked for a stale-ID trap. There is none: `iccFromXml` stamps wall-clock creation time, so two conversions of the *same unmodified* XML already produce different profile IDs (`c5fe6d98…` vs `a9eb368d…`). The generated `.icc` are untracked, and the literal `<ProfileID>` is overwritten on every build. Nothing in the repository can pin these bytes.

## Pre-flight

Clean Release build of this branch, `Unix Makefiles`, tools + tests + IccXML:

- **Build: 0 warnings, 0 errors**, including the `build-test-binaries` target
- **CTest: 112 of 113 passed.** The single failure is `iccdev.spectral-tiff-preview` — `ModuleNotFoundError: No module named 'imagecodecs'`, a missing local Python module, unrelated and pre-existing (same failure recorded on #1854)
- **The fixture-consuming tests specifically pass**, which is the real risk in a fixture change — other scripts build profiles from these same XMLs:
  - `iccdev.tool-coverage` (uses `CMYK-3DLUTs2.xml`) — Passed
  - `iccdev.issue-1395-profileclass-signame` (uses `Rec2100HlgFull-Part1.icc`) — Passed
- `bash -n` clean; **`shellcheck` 0.9.0 clean at default severity** (the version and invocation the pre-flight gate uses); script mode `100644`, matching the recent siblings

**This diff touches no compilable source** — 15 XML fixtures, one shell script, and one CMake test registration; zero `.cpp`/`.h`. The four strict compile profiles are therefore not exercised by the change, and I have not claimed a run of them; the ordinary build above is at zero warnings.

## Relationship to #1809 / #1811

These three issues are one cohort over the same fixtures, all descended from #1724. After this change the residual warnings on the very files it touches are precisely the other two:

```
XYZ_float-D65_2deg-Part1:  AToB1Tag: No processing elements.        <- #1809
                           BToA1Tag: No processing elements.        <- #1809
                           illuminantXYZ ... appears normalized!    <- #1811
```

#1810 is the only one of the three with a settled maintainer ruling, so it moves first. Neither of the others is touched here.

One finding worth carrying to #1809: its proposed QA manifest includes a per-profile `sha256` field. That is not achievable for generated profiles as things stand, for the wall-clock reason above — it would need a `SOURCE_DATE_EPOCH`-style deterministic-build switch first.
