### PR TITLE
fix(#1853): read plain <TextData> in the compressed-text XML tag readers

### DIFF
--- a/.github/ci/test-data/zip-text-hexdata-control-1853.xml
+++ b/.github/ci/test-data/zip-text-hexdata-control-1853.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #1853 control.  The same v5 profile as zut8-plaintext-1853.xml, but with the
+  charTargetTag authored in the <HexCompressedData> form: the branch of
+  CIccTagXmlZipUtf8Text::ParseXml that the fix does NOT touch, and the form
+  iccToXml emits.
+
+  It exists to catch over-rejection: the fix only changes which node list the
+  plain-text fallback walks, so this file must keep converting and must keep
+  decompressing to the same marker.  If it ever stops, the failure is in the
+  hex path or the environment rather than in the plain-text path, and the
+  regression script skips instead of blaming #1853.
+
+  The hex payload is a zlib stream of the marker string produced by
+  CIccTagZipUtf8Text::SetText.  Only inflate has to reproduce it, so a zlib
+  build that would deflate the same input differently does not invalidate it.
+-->
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+    <ProfileID>0</ProfileID>
+  </Header>
+
+  <Tags>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[iccDEV #1853 zip-text hex control]]></LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZArrayType> </mediaWhitePointTag>
+
+    <redColorantTag> <XYZArrayType>
+      <XYZNumber X="0.43606567" Y="0.22248840" Z="0.01391602"/>
+    </XYZArrayType> </redColorantTag>
+
+    <greenColorantTag> <XYZArrayType>
+      <XYZNumber X="0.38514709" Y="0.71687317" Z="0.09707642"/>
+    </XYZArrayType> </greenColorantTag>
+
+    <blueColorantTag> <XYZArrayType>
+      <XYZNumber X="0.14306641" Y="0.06060791" Z="0.71409607"/>
+    </XYZArrayType> </blueColorantTag>
+
+    <redTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </redTRCTag>
+
+    <greenTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </greenTRCTag>
+
+    <blueTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </blueTRCTag>
+
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright (c) 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+
+    <charTargetTag> <utf8ZipType>
+      <HexCompressedData>
+       789ccb4c4e76710dd335b43035d68df20c08718d08d10df20ff5730909f20cd0
+       f5750cf2760d620000ca2c0a55
+      </HexCompressedData>
+    </utf8ZipType> </charTargetTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/zut8-plaintext-1853.xml
+++ b/.github/ci/test-data/zut8-plaintext-1853.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #1853 case A PoC.  A v5 RGB matrix/TRC display profile whose charTargetTag is
+  a utf8ZipType ('zut8') tag authored in the PLAIN-TEXT form: a <TextData>
+  element rather than <HexCompressedData>.
+
+  Byte-identical to zip-text-hexdata-control-1853.xml except for the body of
+  charTargetTag, so anything it exercises other than the plain-text branch of
+  CIccTagXmlZipUtf8Text::ParseXml is a known-good path.
+
+  Pre-fix this converted "correctly" and stored an EMPTY string: the tag's
+  ParseXml walked pNode to NULL looking for <HexCompressedData>, then handed
+  that NULL to icXmlParseTextString(), which opens with its own `while (pNode)`
+  and so returned true having appended nothing.  The marker text below must
+  survive into the written profile.
+-->
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+    <ProfileID>0</ProfileID>
+  </Header>
+
+  <Tags>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[iccDEV #1853 zut8 plain-text PoC]]></LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZArrayType> </mediaWhitePointTag>
+
+    <redColorantTag> <XYZArrayType>
+      <XYZNumber X="0.43606567" Y="0.22248840" Z="0.01391602"/>
+    </XYZArrayType> </redColorantTag>
+
+    <greenColorantTag> <XYZArrayType>
+      <XYZNumber X="0.38514709" Y="0.71687317" Z="0.09707642"/>
+    </XYZArrayType> </greenColorantTag>
+
+    <blueColorantTag> <XYZArrayType>
+      <XYZNumber X="0.14306641" Y="0.06060791" Z="0.71409607"/>
+    </XYZArrayType> </blueColorantTag>
+
+    <redTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </redTRCTag>
+
+    <greenTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </greenTRCTag>
+
+    <blueTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </blueTRCTag>
+
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright (c) 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+
+    <charTargetTag> <utf8ZipType>
+      <TextData><![CDATA[iccDEV-1853-ZIPTEXT-ROUNDTRIP-MARKER]]></TextData>
+    </utf8ZipType> </charTargetTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/zxml-plaintext-1853.xml
+++ b/.github/ci/test-data/zxml-plaintext-1853.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #1853 case B PoC.  The zipXmlType ('zxml') half of the same defect.
+
+  CIccTagXmlZipXml::ParseXml carried a byte-for-byte copy of the consumed-pNode
+  bug fixed in CIccTagXmlZipUtf8Text::ParseXml (case A, zut8-plaintext-1853.xml),
+  so a zxml tag authored as plain <TextData> was silently stored as an empty
+  string too.
+
+  This profile is v4 rather than v5 because CIccProfile::CheckTagTypes accepts
+  zxml under CxfTag only below icVersionNumberV5; at v5 that tag is restricted
+  to utf8Type/utf8ZipType.
+-->
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.30</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+    <ProfileID>0</ProfileID>
+  </Header>
+
+  <Tags>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[iccDEV #1853 zxml plain-text PoC]]></LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZArrayType> </mediaWhitePointTag>
+
+    <redColorantTag> <XYZArrayType>
+      <XYZNumber X="0.43606567" Y="0.22248840" Z="0.01391602"/>
+    </XYZArrayType> </redColorantTag>
+
+    <greenColorantTag> <XYZArrayType>
+      <XYZNumber X="0.38514709" Y="0.71687317" Z="0.09707642"/>
+    </XYZArrayType> </greenColorantTag>
+
+    <blueColorantTag> <XYZArrayType>
+      <XYZNumber X="0.14306641" Y="0.06060791" Z="0.71409607"/>
+    </XYZArrayType> </blueColorantTag>
+
+    <redTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </redTRCTag>
+
+    <greenTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </greenTRCTag>
+
+    <blueTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </blueTRCTag>
+
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright (c) 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+
+    <CxfTag> <zipXmlType>
+      <TextData><![CDATA[iccDEV-1853-ZIPTEXT-ROUNDTRIP-MARKER]]></TextData>
+    </zipXmlType> </CxfTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/scripts/iccdev-issue-1853-zip-text-plaintext-regression.sh
+++ b/.github/scripts/iccdev-issue-1853-zip-text-plaintext-regression.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1853 - plain <TextData> silently dropped by the compressed-text
+#                      XML readers (zut8 / zxml)
+###############################################################################
+#
+# CIccTagXmlZipUtf8Text::ParseXml and CIccTagXmlZipXml::ParseXml both scanned
+# the sibling list for <HexCompressedData> and then fell through to the
+# plain-text reader:
+#
+#   while (pNode) {                          // IccXML/IccLibXML/IccTagXml.cpp
+#     ... if (HexCompressedData) { ...; return true; }
+#     pNode = pNode->next;
+#   }
+#   std::string outStr;
+#   if( !icXmlParseTextString(pNode, parseStr, outStr, false) )   // pNode NULL
+#     return false;
+#   return SetText(outStr.c_str());
+#
+# The loop returns from inside itself on a match, so the only way to reach the
+# call below it is with pNode already walked to NULL.  icXmlParseTextString()
+# opens with its own `while (pNode)`, so it never dereferenced the NULL -- it
+# appended nothing and returned true.  The tag was then SetText("").
+#
+# That is fail-open data loss rather than a crash: iccFromXml printed "Profile
+# parsed and saved correctly" and wrote a profile whose compressed text tag is
+# an empty string.  Nothing in the corpus exercised it -- no committed fixture
+# authors a zut8 or zxml tag at all -- so the three XML files this script uses
+# were written for it.
+#
+# CASE A -- zut8.  charTargetTag as utf8ZipType with <TextData>.  v5, because
+# CIccProfile::CheckTagTypes only accepts zut8 under charTargetTag at v5.
+#
+# CASE B -- zxml.  CxfTag as zipXmlType with <TextData>.  v4, because that tag
+# accepts zxml only below v5.  Same defect, separate copy of the code, so a fix
+# applied to one call site and not the other still fails here.
+#
+# CASE C -- round-trip closure.  iccToXml re-emits these tags in the
+# <HexCompressedData> form, so case C converts case A's profile back to XML and
+# forward again, proving the two authoring forms agree rather than only that
+# one of them survived a single pass.
+#
+# All three assert on the decompressed text, using iccDumpProfile's
+# "ZLib Compressed String=" line as the oracle.  Comparing written bytes would
+# not work: every fixture stamps <CreationDateTime>now</CreationDateTime>, which
+# feeds the profile ID.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1853}"
+DATA_DIR="$REPO_ROOT/.github/ci/test-data"
+mkdir -p "$OUTDIR"
+
+MARKER="iccDEV-1853-ZIPTEXT-ROUNDTRIP-MARKER"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+TOXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccToXml -type f 2>/dev/null | head -1)"
+DUMP="$(find "$TOOLS_DIR" -maxdepth 2 -name iccDumpProfile -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ] || [ -z "$DUMP" ] || [ ! -x "$DUMP" ]; then
+  echo "[SKIP] iccFromXml / iccDumpProfile not found under $TOOLS_DIR"
+  exit 0
+fi
+
+# Convert $1.xml (from the test-data directory) into $OUTDIR/$1.icc.
+#
+# Sets the globals rather than echoing a path: a caller using $(convert ...)
+# would run this in a command-substitution subshell and CONV_RC would not
+# escape it.
+CONV_RC=0
+CONV_LOG=""
+CONV_ICC=""
+convert_fixture() {
+  local name="$1"
+  CONV_LOG="$OUTDIR/$name.log"
+  CONV_ICC="$OUTDIR/$name.icc"
+  rm -f "$CONV_ICC"
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0:allocator_may_return_null=1" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$FROMXML" "$DATA_DIR/$name.xml" "$CONV_ICC" > "$CONV_LOG" 2>&1
+  CONV_RC=$?
+}
+
+# Decompressed text of the first compressed-text tag in $1, or the empty string.
+#
+# iccDumpProfile prints it as:  ZLib Compressed String="<text>
+# The trailing quote sits on the following line because SetText() compresses the
+# NUL terminator along with the text, so the sed below takes everything after
+# the opening quote on the matching line and nothing else.
+zip_text_of() {
+  "$DUMP" "$1" ALL 2>/dev/null |
+    sed -n 's/^ZLib Compressed String="//p' |
+    head -1
+}
+
+# A build without zlib cannot represent these tags at all: SetText() returns
+# false unconditionally and Describe() prints BEGIN_COMPRESSED_DATA instead of
+# the decompressed string, so every case below would report a false failure.
+# Detect it from the control's dump rather than from CMakeCache, which is not
+# reachable from an installed-tools run.
+uses_zlib() {
+  "$DUMP" "$1" ALL 2>/dev/null | grep -q "ZLib Compressed String="
+}
+
+# --- CONTROL: the <HexCompressedData> branch, which the fix does not touch ----
+# Run first.  If the fix ever over-rejects, or the environment cannot handle
+# these tags, this fails/skips here instead of the two PoCs passing or failing
+# for the wrong reason.
+CONTROL="zip-text-hexdata-control-1853"
+if [ ! -f "$DATA_DIR/$CONTROL.xml" ]; then
+  echo "[SKIP] control XML missing: $DATA_DIR/$CONTROL.xml"
+  exit 0
+fi
+convert_fixture "$CONTROL"
+CONTROL_ICC="$CONV_ICC"
+if [ ! -f "$CONTROL_ICC" ]; then
+  echo "[SKIP] control profile did not convert (rc=$CONV_RC); environment issue, not #1853"
+  sed -n '1,10p' "$CONV_LOG"
+  exit 0
+fi
+if ! uses_zlib "$CONTROL_ICC"; then
+  echo "[SKIP] tools built without ICC_USE_ZLIB; compressed text tags cannot be decoded"
+  exit 0
+fi
+CONTROL_TEXT="$(zip_text_of "$CONTROL_ICC")"
+case "$CONTROL_TEXT" in
+  *"$MARKER"*)
+    echo "[PASS] #1853 control: HexCompressedData charTargetTag still decodes to the marker"
+    ;;
+  *)
+    echo "[SKIP] control HexCompressedData did not decode to the marker; environment issue, not #1853"
+    echo "       got: '$CONTROL_TEXT'"
+    exit 0
+    ;;
+esac
+
+status=0
+
+# assert_marker <label> <icc> <failure text>
+assert_marker() {
+  local label="$1" icc="$2" what="$3" text
+  text="$(zip_text_of "$icc")"
+  case "$text" in
+    *"$MARKER"*)
+      echo "[PASS] #1853 $label: $what survived the conversion"
+      return 0
+      ;;
+    "")
+      echo "[FAIL] #1853 $label: $what was stored as an EMPTY string"
+      echo "       the plain-text fallback was handed a NULL node list again"
+      status=2
+      return 1
+      ;;
+    *)
+      echo "[FAIL] #1853 $label: $what decoded to unexpected content"
+      echo "       got: '$text'"
+      status=2
+      return 1
+      ;;
+  esac
+}
+
+# --- CASE A: zut8 authored as plain <TextData> -------------------------------
+POC_A="zut8-plaintext-1853"
+CASE_A_ICC=""
+if [ ! -f "$DATA_DIR/$POC_A.xml" ]; then
+  echo "[SKIP] PoC XML missing: $DATA_DIR/$POC_A.xml"
+else
+  convert_fixture "$POC_A"
+  if [ ! -f "$CONV_ICC" ]; then
+    echo "[FAIL] #1853 case A: plain <TextData> zut8 tag no longer converts (rc=$CONV_RC)"
+    sed -n '1,10p' "$CONV_LOG"
+    status=2
+  else
+    assert_marker "case A (zut8)" "$CONV_ICC" "charTargetTag plain <TextData>" &&
+      CASE_A_ICC="$CONV_ICC"
+  fi
+fi
+
+# --- CASE B: zxml authored as plain <TextData> -------------------------------
+POC_B="zxml-plaintext-1853"
+if [ ! -f "$DATA_DIR/$POC_B.xml" ]; then
+  echo "[SKIP] PoC XML missing: $DATA_DIR/$POC_B.xml"
+else
+  convert_fixture "$POC_B"
+  if [ ! -f "$CONV_ICC" ]; then
+    echo "[FAIL] #1853 case B: plain <TextData> zxml tag no longer converts (rc=$CONV_RC)"
+    sed -n '1,10p' "$CONV_LOG"
+    status=2
+  else
+    assert_marker "case B (zxml)" "$CONV_ICC" "CxfTag plain <TextData>" || true
+  fi
+fi
+
+# --- CASE C: XML -> ICC -> XML -> ICC closure --------------------------------
+# Only meaningful if case A produced a profile carrying the marker; otherwise it
+# would re-report the same failure a second time.
+if [ -z "$TOXML" ] || [ ! -x "$TOXML" ]; then
+  echo "[SKIP] case C: iccToXml not found under $TOOLS_DIR"
+elif [ -z "$CASE_A_ICC" ]; then
+  echo "[SKIP] case C: case A did not produce a usable profile"
+else
+  RT_XML="$OUTDIR/$POC_A-roundtrip.xml"
+  RT_ICC="$OUTDIR/$POC_A-roundtrip.icc"
+  rm -f "$RT_XML" "$RT_ICC"
+  if ! "$TOXML" "$CASE_A_ICC" "$RT_XML" > "$OUTDIR/$POC_A-roundtrip.log" 2>&1 || [ ! -f "$RT_XML" ]; then
+    echo "[FAIL] #1853 case C: iccToXml could not re-emit the zut8 tag"
+    sed -n '1,10p' "$OUTDIR/$POC_A-roundtrip.log"
+    status=2
+  elif ! grep -q "HexCompressedData" "$RT_XML"; then
+    echo "[FAIL] #1853 case C: re-emitted XML carries no <HexCompressedData> for the zut8 tag"
+    status=2
+  elif ! "$FROMXML" "$RT_XML" "$RT_ICC" >> "$OUTDIR/$POC_A-roundtrip.log" 2>&1 || [ ! -f "$RT_ICC" ]; then
+    echo "[FAIL] #1853 case C: re-emitted XML no longer converts back to a profile"
+    sed -n '1,10p' "$OUTDIR/$POC_A-roundtrip.log"
+    status=2
+  else
+    assert_marker "case C (round-trip)" "$RT_ICC" "the marker after XML -> ICC -> XML -> ICC" || true
+  fi
+fi
+
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3045,6 +3045,25 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1810-ricc-header-signatures.sh"
 )
 
+# #1853: plain <TextData> silently dropped by the compressed-text XML readers.
+# CIccTagXmlZipUtf8Text::ParseXml and CIccTagXmlZipXml::ParseXml scanned the
+# sibling list for <HexCompressedData> and, on falling out of that loop, passed
+# the now-NULL walking pointer to the plain-text reader.  icXmlParseTextString()
+# starts with its own `while (pNode)`, so it did not crash -- it returned true
+# having read nothing, and the tag became SetText("").  Fail-open data loss:
+# iccFromXml reported success and wrote an empty tag.  Case A covers zut8, case
+# B the separate copy of the same code in zxml, and case C closes the loop
+# through iccToXml, which re-emits both in the hex form.  A HexCompressedData
+# control runs first so over-rejection or a no-zlib build is reported as a skip
+# rather than as a #1853 regression.  No sanitizer required.
+iccdev_add_script_test(
+  iccdev.issue-1853-zip-text-plaintext-regression
+  60
+  "iccdev;xml;compression;roundtrip;issue-1853;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1853-zip-text-plaintext-regression.sh"
+)
+
 # #1356: XML serializer corrupts a zero (NoData) header colour-space signature
 # on round-trip.  iccToXml wrote the literal "NULL" for a 0x00000000 data
 # colour space / PCS; iccFromXml then reparsed "NULL" to 0x4E554C4C, so the

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -433,6 +433,13 @@ bool CIccTagXmlUtf8Text::ParseXml(xmlNode *pNode, std::string &parseStr)
 
 bool CIccTagXmlZipUtf8Text::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
+  // The scan below consumes pNode: it only falls out of the loop once pNode is
+  // NULL (the <HexCompressedData> match returns from inside the loop), so the
+  // plain-text fallback after it cannot reuse the walking pointer.  Keep the
+  // head of the sibling list for icXmlParseTextString(), which does its own
+  // walk and would otherwise be handed a guaranteed-NULL list.
+  xmlNode *pFirstNode = pNode;
+
   while (pNode) {
     if (pNode->type==XML_ELEMENT_NODE) {
       if (!icXmlStrCmp(pNode->name, "HexCompressedData") && pNode->children && pNode->children->content) {
@@ -452,7 +459,7 @@ bool CIccTagXmlZipUtf8Text::ParseXml(xmlNode *pNode, std::string &parseStr)
   }
 
   std::string outStr;
-  if( !icXmlParseTextString(pNode, parseStr, outStr, false) )
+  if( !icXmlParseTextString(pFirstNode, parseStr, outStr, false) )
     return false;
 
   return SetText(outStr.c_str());
@@ -460,6 +467,11 @@ bool CIccTagXmlZipUtf8Text::ParseXml(xmlNode *pNode, std::string &parseStr)
 
 bool CIccTagXmlZipXml::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
+  // Same consumed-pointer problem as CIccTagXmlZipUtf8Text::ParseXml above; see
+  // the note there.  This is a separate copy of the code rather than a shared
+  // helper, so it needed the same correction.
+  xmlNode *pFirstNode = pNode;
+
   while (pNode) {
     if (pNode->type==XML_ELEMENT_NODE) {
       if (!icXmlStrCmp(pNode->name, "HexCompressedData") && pNode->children && pNode->children->content) {
@@ -479,7 +491,7 @@ bool CIccTagXmlZipXml::ParseXml(xmlNode *pNode, std::string &parseStr)
   }
 
   std::string outStr;
-  if( !icXmlParseTextString(pNode, parseStr, outStr, false) )
+  if( !icXmlParseTextString(pFirstNode, parseStr, outStr, false) )
     return false;
 
   return SetText(outStr.c_str());


### PR DESCRIPTION
Bucket 2 of #1853, as a standalone change.

## The defect

`CIccTagXmlZipUtf8Text::ParseXml` and `CIccTagXmlZipXml::ParseXml` scan the sibling
list for `<HexCompressedData>` and fall through to the plain-text reader when there
is none:

```cpp
while (pNode) {
  ... if (HexCompressedData) { ...; return true; }
  pNode = pNode->next;
}
std::string outStr;
if( !icXmlParseTextString(pNode, parseStr, outStr, false) )   // pNode is NULL here
  return false;
return SetText(outStr.c_str());
```

The loop returns from inside itself on a match, so the only way to reach the call
below it is with `pNode` already walked to NULL. Both call sites passed a
guaranteed-NULL node list to `icXmlParseTextString`.

That function opens with its own `while (pNode)`, so nothing dereferenced the NULL.
It appended nothing and returned `true`, and the tag was then `SetText("")`.

A `zut8` or `zxml` tag authored as plain `<TextData>` therefore round-tripped to an
empty string while `iccFromXml` printed `Profile parsed and saved correctly` and
wrote the profile. Fail-open data loss rather than a crash, which is why it has
gone unnoticed.

Measured on master before the fix:

```
$ iccFromXml zut8-plaintext-1853.xml out.icc
Profile parsed and saved correctly
$ iccDumpProfile out.icc ALL | grep -A3 'charTargetTag tag'
Contents of charTargetTag tag ('targ' = 74617267)
Type: utf8ZipType ('zut8' = 7A757438)
ZLib Compressed String="
```

The tag is 17 bytes on disk: 8 bytes of tag header plus the 9-byte deflate stream
of the empty string. The 36-character source text is gone.

## The fix

Keep the head of the sibling list in `pFirstNode` and pass that to the fallback.
The `<HexCompressedData>` branch is untouched.

### One consequence worth stating explicitly

Restoring the fallback also makes the rest of `icXmlParseTextString` reachable for
these two tag types — `<HexTextData>`, and `<TextData File="...">`.

The file-include path is the one worth checking, and it is already gated:
`IccXmlSafeOpenFileIO` returns NULL unless `g_IccXmlAllowFileIncludes` is set, which
defaults to **false** library-wide and is opt-in from `iccFromXml`'s argv, and
`IccXmlIsPathSafe` additionally rejects absolute paths and any `..` component.
`CIccTagXmlText`, `CIccTagXmlUtf8Text` and `CIccTagXmlUtf16Text` all reach the same
helper today, so this is existing policy applied consistently rather than new
surface. Flagging it rather than leaving it to be discovered in review.

Behaviour is otherwise unchanged: a tag with neither element still ends at
`SetText("")`, and `<HexCompressedData>` still wins when both are present.

## Regression

No committed fixture authors a `zut8` or `zxml` tag in either form, so the corpus
covered none of this. Three XML files were written for it, and the CTest case
`iccdev.issue-1853-zip-text-plaintext-regression` runs:

| | what | why |
|---|---|---|
| control | `charTargetTag` as `<HexCompressedData>` | the branch the fix does not change; over-rejection or a build without `ICC_USE_ZLIB` is reported as a **skip**, not as a #1853 failure |
| case A | `charTargetTag` as `zut8` with plain `<TextData>`, v5 | the reported defect |
| case B | `CxfTag` as `zxml` with plain `<TextData>`, v4 | a separate copy of the same code, so a one-site fix still fails here |
| case C | case A's profile back through `iccToXml` and forward again | the writer re-emits both tags in the hex form, so this closes the loop |

Each case asserts on the decompressed text, using `iccDumpProfile`'s
`ZLib Compressed String=` line as the oracle. Comparing written bytes would not
work: every fixture stamps `<CreationDateTime>now</CreationDateTime>`, which feeds
the profile ID.

Case A is v5 and case B is v4 because `CIccProfile::CheckTagTypes` accepts `zut8`
under `charTargetTag` only at v5, and `zxml` under `CxfTag` only below v5.

Red/green against master:

```
pre-fix                                        post-fix
[PASS] control: HexCompressedData ... marker   [PASS] control
[FAIL] case A (zut8): stored as EMPTY string   [PASS] case A (zut8)
[FAIL] case B (zxml): stored as EMPTY string   [PASS] case B (zxml)
[SKIP] case C: case A produced nothing usable  [PASS] case C (round-trip)
exit 2                                         exit 0
```

## Local pre-flight

| gate | result |
|---|---|
| `shellcheck` 0.9.0, default and `-S style` | rc=0 |
| gcc Release + LTO, `-Wall -Wextra -Wpedantic -Werror` | rc=0, **0 warnings** |
| clang Debug ASAN+UBSAN, same flags | rc=0, **0 warnings** |
| full `ctest` via the `check` target | 113/114 |
| `-L xml` (15 tests) under ASAN+UBSAN, `detect_leaks=1` | 100% |
| `ICC_USE_ZLIB=OFF` build | test skips cleanly |
| `preflight-safety-checks.sh` | 0 failures |

The single `ctest` failure is `iccdev.spectral-tiff-preview`
(`ModuleNotFoundError: No module named 'imagecodecs'`) — a missing Python module in
my environment, untouched by this change.

## Relationship to `ci-qa-flags`

`ci-qa-flags` carries the same `pFirstNode` correction, so **on the next rebase of
that branch this hunk will already be in master and should be dropped** — same shape
as the #1851 script collision already cleaned up in `82f38c9f` / `5acd2f07`.

What that branch bundles into the same hunk — `icXmlValidateHexBlob` /
`icXmlParseCompressedData` — is deliberately **not** included here, because it is a
no-zlib regression as written. It ends with:

```cpp
std::string text;
if (!pTag->GetText(text)) {
  parseStr += "Invalid HexCompressedData zlib stream in compressed tag\n";
  return false;
}
```

and under `#ifndef ICC_USE_ZLIB`, `CIccTagZipUtf8Text::GetText` returns `false`
unconditionally. Built that version against `-DICC_USE_ZLIB=OFF` and ran the
**valid** `HexCompressedData` control fixture from this PR through it:

```
$ iccFromXml zip-text-hexdata-control-1853.xml out.icc
Invalid HexCompressedData zlib stream in compressed tag
Unable to Parse "utf8ZipType" (charTargetTag) Tag on line 77
Unable to Parse 'zip-text-hexdata-control-1853.xml'
rc=1
```

Master converts that same file fine. Separately, rejecting a blob that does not
inflate is a fail-open → fail-closed change for existing profiles, which is a policy
call rather than a bug fix and deserves discussion alongside the `icFaultyXmlZipData`
allowance already in `GetText`.

Neither point affects the `pFirstNode` correction, which is why this PR is only that.
