### PR TITLE
fix(#1853): keep +INF saturation in the SparseMatrix clamps, finish the viz value-init sweep

### DIFF
--- a/.github/ci/regression/iccsparsematrix-set-roundtrip.cpp
+++ b/.github/ci/regression/iccsparsematrix-set-roundtrip.cpp
@@ -15,11 +15,19 @@
 // The set()/get() methods are inline, so this exercises the exact shipped code.
 // Assertions are mutation-verified: reverting either fix makes a case below fail
 // (NaN -> nonzero garbage; UInt16 0.5 -> raw 0 -> get() 0.0).
+//
+// The +INF cases were added later, and are the reason set() tests saturation
+// before it tests isfinite(). A guard written the other way round --
+// `if (!isfinite(value) || value < 0) 0; else if (value > 1) MAX; ...` -- is
+// NaN-safe and passes every other case here, but sends +INF to 0 instead of full
+// scale, silently inverting the stored value. Nothing else in this file catches
+// that, so without these four checks the reordering is invisible.
 
 #include "IccSparseMatrix.h"
 
 #include <cmath>
 #include <cstdio>
+#include <limits>
 
 static int g_fails = 0;
 
@@ -28,9 +36,12 @@ static void check(bool ok, const char *what) {
 }
 
 int main(void) {
+  const float kPosInf =  std::numeric_limits<float>::infinity();
+  const float kNegInf = -std::numeric_limits<float>::infinity();
+
   // ---- CIccSparseMatrixUInt8 ----
   {
-    icUInt8Number buf[4] = {0};
+    icUInt8Number buf[6] = {0};
     CIccSparseMatrixUInt8 e;
     e.init(buf);
 
@@ -45,11 +56,19 @@ int main(void) {
 
     e.set(3, 5.0f);
     check(buf[3] == 255, "UInt8 set(>1) -> 255");
+
+    // +INF is out-of-range HIGH, so it saturates like any other value > 1.
+    e.set(4, kPosInf);
+    check(buf[4] == 255, "UInt8 set(+INF) -> 255 (saturates, not 0)");
+
+    // -INF is out-of-range LOW and shares the NaN branch.
+    e.set(5, kNegInf);
+    check(buf[5] == 0, "UInt8 set(-INF) -> 0");
   }
 
   // ---- CIccSparseMatrixUInt16 (also guards the truncation fix) ----
   {
-    icUInt16Number buf[4] = {0};
+    icUInt16Number buf[5] = {0};
     CIccSparseMatrixUInt16 e;
     e.init(buf);
 
@@ -63,6 +82,12 @@ int main(void) {
 
     e.set(2, 1.0f);
     check(buf[2] == 65535, "UInt16 set(1.0) -> 65535");
+
+    e.set(3, kPosInf);
+    check(buf[3] == 65535, "UInt16 set(+INF) -> 65535 (saturates, not 0)");
+
+    e.set(4, kNegInf);
+    check(buf[4] == 0, "UInt16 set(-INF) -> 0");
   }
 
   if (g_fails == 0)

--- a/IccProfLib/IccSparseMatrix.h
+++ b/IccProfLib/IccSparseMatrix.h
@@ -68,6 +68,11 @@ Copyright:  (c) see Software License
 #ifndef _ICCSPARSEMATRIX_H
 #define _ICCSPARSEMATRIX_H
 
+// For std::isfinite in the UInt8/UInt16 set() guards below. This header is
+// installed and included on its own, so it cannot rely on a translation unit
+// pulling <cmath> in first.
+#include <cmath>
+
 #include "IccDefs.h"
 #include "IccUtil.h"
 
@@ -105,10 +110,29 @@ public:
   CIccSparseMatrixUInt8() {}
 
   virtual icFloatNumber get(int index) const {return (icFloatNumber)m_pData[index]/255.0f;}
-  // !(value > 0.0) rejects NaN and value<=0 (both -> 0) BEFORE the cast. A plain
-  // value<0.0 test lets a NaN fall through to (icUInt8Number)(NaN*255+0.5), which is
-  // undefined behavior on the float->int cast (CWE-681, alert #1061).
-  virtual void set(int index, icFloatNumber value) {m_pData[index] = !(value > 0.0) ? 0 : (value > 1.0 ? 255 : (icUInt8Number)(value*255.0f+0.5f));}
+
+  // Saturation is tested FIRST so that +INF clamps to full scale like any other
+  // out-of-range positive. Leading with !isfinite() instead would store 0 for +INF,
+  // silently inverting the value.
+  //
+  // The second branch then routes NaN, -INF and value<=0 to 0 BEFORE the cast. A
+  // plain value<0.0 test lets a NaN reach (icUInt8Number)(NaN*255+0.5), undefined
+  // behaviour on the float->int cast (CWE-681, alert #1061).
+  //
+  // isfinite() is spelt as a call rather than as the equally correct relational
+  // guard !(value > 0.0) because iccdev/float-to-int-cast only recognises
+  // isnan/isinf/isfinite calls within five lines above a cast; the relational form
+  // leaves this cast flagged on every scan (alerts #2318/#2317, dismissed as
+  // query-blind false positives).
+  virtual void set(int index, icFloatNumber value)
+  {
+    if (value > 1.0f)
+      m_pData[index] = 255;
+    else if (!std::isfinite(value) || value <= 0.0f)
+      m_pData[index] = 0;
+    else
+      m_pData[index] = (icUInt8Number)(value*255.0f+0.5f);
+  }
 
 };
 
@@ -118,11 +142,23 @@ public:
   CIccSparseMatrixUInt16() {}
 
   virtual icFloatNumber get(int index) const {return (icFloatNumber)m_pData[index]/65535.0f;}
-  // Same NaN guard as the UInt8 entry (alert #2260). Also fixes a data-loss bug: the
-  // cast is (icUInt16Number), not (icUInt8Number) -- the 8-bit cast truncated the
+
+  // Same branch order and the same isfinite() call as the UInt8 entry above; see
+  // the note there for why saturation is tested first and why the guard is a call
+  // (alert #2260 is this entry's counterpart to #1061).
+  //
+  // The cast is (icUInt16Number), not (icUInt8Number): the 8-bit cast truncated the
   // scaled value into the 16-bit slot (e.g. 0.5 -> 32768 & 0xff == 0), breaking the
   // set()/get() round-trip against get()'s /65535.0f above.
-  virtual void set(int index, icFloatNumber value) {m_pData[index] = !(value > 0.0) ? 0 : (value > 1.0 ? 65535 : (icUInt16Number)(value*65535.0f+0.5f));}
+  virtual void set(int index, icFloatNumber value)
+  {
+    if (value > 1.0f)
+      m_pData[index] = 65535;
+    else if (!std::isfinite(value) || value <= 0.0f)
+      m_pData[index] = 0;
+    else
+      m_pData[index] = (icUInt16Number)(value*65535.0f+0.5f);
+  }
 
 };
 

--- a/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
+++ b/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
@@ -1210,7 +1210,13 @@ double voxelEnclosedVolume(const std::vector<float>& lab, double vs,
     return ((std::size_t)l * nA + a) * nB + b;
   };
   auto cl = [](int v, int hi) { return v < 0 ? 0 : (v >= hi ? hi - 1 : v); };
-  std::vector<unsigned char> g((std::size_t)nL * nA * nB, 0);  // 0 empty, 1 solid, 2 exterior
+  // Value-initialised, not fill-constructed - see the note in buildNeutralAxisGraph
+  // (#1777), whose "applied to every fill-construction below" missed this one. It
+  // is the last two-argument vector construction in this file. `(n)` and `(n, 0)`
+  // both zero every element for unsigned char, so the stored grid is unchanged;
+  // only the libstdc++ path differs, and the one-argument overload avoids the
+  // decrement-past-zero loop that -fsanitize=integer reports on the other.
+  std::vector<unsigned char> g((std::size_t)nL * nA * nB);  // 0 empty, 1 solid, 2 exterior
 
   const int nPts = (int)(lab.size() / 3);
   for (int i = 0; i < nPts; ++i) {


### PR DESCRIPTION
Bucket 3 of #1853 — the two files where the `ci-qa-flags` change is right in motive and
wrong in one detail. @xsscx asked for the corrected form rather than the harvest
("that is only the first go around for an attempted fuzzing patch, please ignore! Make the
correct adjustment ... and PR"), so this is that.

## 1. `IccSparseMatrix.h` — keep the isfinite() call, keep +INF saturation

The branch leads both `set()` clamps with the range test:

```cpp
if (!std::isfinite(value) || value < 0.0f) m_pData[index] = 0;
else if (value > 1.0f)                     m_pData[index] = MAX;
else                                       ...cast...
```

**The motive is real.** `iccdev/float-to-int-cast` suppresses a finding only when it sees an
`isnan`/`isinf`/`isfinite` **call** in the same function within five lines above the cast:

```ql
guard.getTarget().getName().regexpMatch("(?i)(isnan|isinf|isfinite|fpclassify|__builtin_isnan)") and
guard.getEnclosingFunction() = cast.getEnclosingFunction() and
guard.getLocation().getStartLine() >= cast.getLocation().getStartLine() - 5 and
```

Master's `!(value > 0.0)` is equally correct but is a relational guard, so both casts are
flagged on every scan — that is alerts #2318 and #2317, dismissed as query-blind false
positives.

**The detail is the branch order.** `+INF` is not finite, so testing that first stores **0**
for `+INF`, where master saturates to full scale. An out-of-range HIGH value silently becomes
the minimum. Testing saturation first keeps master's behaviour and still puts the call where
the query wants it:

```cpp
if (value > 1.0f)                                m_pData[index] = MAX;
else if (!std::isfinite(value) || value <= 0.0f) m_pData[index] = 0;
else                                             ...cast...
```

NaN reaches the second branch because every NaN comparison is false, so it still routes to 0
before the cast.

| input | master | branch | this PR |
|---|---|---|---|
| NaN | 0 | 0 | 0 |
| `+INF` | **MAX** | **0** | **MAX** |
| `-INF` | 0 | 0 | 0 |
| < 0 | 0 | 0 | 0 |
| 0 | 0 | 0 | 0 |
| in range | round | round | round |
| > 1 | MAX | MAX | MAX |

The comments carrying the #1061/#2260 alert references and the UInt16 truncation rationale are
kept — the branch dropped them — and extended with why the guard is spelt as a call.

## 2. Regression — the gap that made this invisible

`iccsparsematrix-set-roundtrip.cpp` had no `±INF` coverage, which is precisely why the
reordering passed everything. Four checks added, and mutation-verified against the branch's
ordering:

```
FAIL: UInt8  set(+INF) -> 255   (saturates, not 0)
FAIL: UInt16 set(+INF) -> 65535 (saturates, not 0)
```

Green against this PR.

## 3. `IccVizModel.cpp` — one of the eight sites is real

The branch routes eight vector constructions through a new `makeValueInitializedVector<T>(n)`.
**Seven are exact no-ops**: `std::vector<T>(n)` already *is* the value-initialising overload, so
the wrapper returns what the call site already produced.

The eighth is a genuine fix — `g(nL*nA*nB, 0)` is the two-argument **fill** constructor, the
form whose libstdc++ decrement-past-zero loop `-fsanitize=integer` reports (#1777). It is also
the site my own #1807 comment claimed to have covered ("applied to every fill-construction
below") and missed, and a scan confirms it is the last two-argument vector construction in the
file.

Fixed by dropping the `, 0` — no wrapper, since the other seven were already correct. `(n)` and
`(n, 0)` both zero every element for `unsigned char`, so the grid contents are unchanged.

## Verification

CodeQL `iccdev/float-to-int-cast`, same query file, local database built before and after:

| | total findings | `IccSparseMatrix.h` |
|---|---:|---|
| before | 68 | **flagged at :111 and :125** |
| after | 66 | **clean** |

Lines 111 and 125 are exactly alerts #2318/#2317, so the local run reproduces the CI finding
and the delta is precisely those two casts. `IccVizModel.cpp` keeps its five pre-existing
findings (lines 1233/1348/1380 — the already-dismissed #2313/#2312/#2311, shifted by the added
comment); the changed line is not among them and no new finding appears.

| gate | result |
|---|---|
| gcc Release + LTO, `-Wall -Wextra -Wpedantic -Werror` | rc=0, **0 warnings** |
| clang Debug ASAN+UBSAN, same flags | rc=0, **0 warnings** |
| full `ctest` via the `check` target | see below |
| `iccdev.iccsparsematrix-set-roundtrip` | pass, mutation-verified |

No shell scripts are touched, so the `shellcheck` pre-flight gate does not apply here.

## Relationship to `ci-qa-flags`

Both hunks should be **dropped from that branch on its next rebase**, the same as the
`pFirstNode` hunk in #1862.
