### PR TITLE
fix(#1860): resolve search-chain PCC before Begin() and tighten iccApplySearch argv parsing

### DIFF
--- a/.github/ci/regression/cmmsearch-init-pcc.cpp
+++ b/.github/ci/regression/cmmsearch-init-pcc.cpp
@@ -1,0 +1,148 @@
+/*
+    File:       cmmsearch-init-pcc.cpp
+
+    Contains:   CTest helper for CIccCmmSearch connection-condition resolution
+                across the -INIT initial-destination profile (issue #1860).
+
+    CIccCmmSearch::Begin() builds its sub-chains with two different
+    CIccCmm::AddXform overloads.  The src/mid/dst profiles go in by reference,
+    which copy-constructs the profile and then detaches the copy from its file
+    IO, while the -INIT initial-destination profile goes in by pointer and keeps
+    its IO.  A detached copy can no longer load spectralViewingConditions on
+    demand, so CheckPCSConnections()/pushXYZConvert() saw the D50/2-degree
+    default at one end of the chain and the profile's real PCC at the other.
+    isEquivalentPcc() then reported a mismatch and spliced a chromatic-adaptation
+    CIccPcsXform into mid_to_dst that the non--INIT chain does not have.
+
+    For a v5 profile that declares a non-D50 illuminant in 'svcn' this turned an
+    identity profile->itself search into a D50<->D65 adaptation.  Because the
+    search is fenced by a large out-of-gamut barrier cost, the corrupted starting
+    point could not be recovered from, and any color with a channel at 0.0 or 1.0
+    came back wrong while interior colors stayed exact.
+
+    This helper drives a profile->itself search with an initial-destination
+    profile attached and asserts the round trip is the identity at the gamut
+    corners.  Before the fix the corner samples miss by more than 0.04; after it
+    they land within search tolerance.
+
+    Usage:
+      cmmsearch-init-pcc <profile.icc>
+
+    Exit codes:
+      0 - identity round trip observed at every sample
+      1 - round trip diverged, or the CMM could not be built
+      2 - usage error
+*/
+
+#include "IccCmmSearch.h"
+#include "IccProfile.h"
+
+#include <cmath>
+#include <cstdio>
+#include <memory>
+
+// The search minimises a numerical cost rather than inverting analytically, so
+// an exact match is not expected and the residual depends on the profile: the
+// matrix/TRC v5 case lands within 0.0011 per channel, while inverting the v4
+// LUT profile leaves up to 0.0174 at the white corner.  The spurious PCS
+// adaptation this test guards against produced errors of 0.1386 to 0.5702, so a
+// bound of 0.05 separates legitimate search residual from the defect with room
+// on both sides.
+static const icFloatNumber kTolerance = 0.05f;
+
+int main(int argc, char** argv)
+{
+  if (argc != 2) {
+    std::fprintf(stderr, "usage: %s <profile.icc>\n",
+                 argv[0] ? argv[0] : "cmmsearch-init-pcc");
+    return 2;
+  }
+
+  const char* profilePath = argv[1];
+
+  // Gamut corners plus one interior sample.  Only the corners regressed: an
+  // interior color such as the last row stayed exact even with the spurious
+  // adaptation in place, which is why the defect survived the existing tests.
+  static const icFloatNumber kSamples[][3] = {
+    { 1.0f, 0.0f, 0.0f },
+    { 0.0f, 1.0f, 0.0f },
+    { 0.0f, 0.0f, 1.0f },
+    { 1.0f, 1.0f, 1.0f },
+    { 0.5f, 0.25f, 0.125f },
+  };
+  static const int kNumSamples = (int)(sizeof(kSamples) / sizeof(kSamples[0]));
+
+  std::unique_ptr<CIccCmmSearch> pCmm(new CIccCmmSearch());
+
+  // Two stages of the same profile: source and destination are identical, so the
+  // search must return the device values it was handed.
+  CIccProfile* pSrc = OpenIccProfile(profilePath);
+  CIccProfile* pDst = OpenIccProfile(profilePath);
+  if (!pSrc || !pDst) {
+    std::fprintf(stderr, "cmmsearch-init-pcc: unable to open '%s'\n", profilePath);
+    delete pSrc;
+    delete pDst;
+    return 1;
+  }
+
+  // AddXform owns the profile on every path, including rejection.
+  if (pCmm->AddXform(pSrc, icRelativeColorimetric) != icCmmStatOk ||
+      pCmm->AddXform(pDst, icRelativeColorimetric) != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-init-pcc: AddXform failed for '%s'\n", profilePath);
+    return 1;
+  }
+
+  // This is the -INIT path: a separately opened copy of the last profile that
+  // seeds the search's starting point.  Its presence is what used to change the
+  // shape of mid_to_dst.
+  CIccProfile* pInit = OpenIccProfile(profilePath);
+  if (!pInit) {
+    std::fprintf(stderr, "cmmsearch-init-pcc: unable to open initial destination '%s'\n",
+                 profilePath);
+    return 1;
+  }
+  pCmm->SetDstInitProfile(pInit, icRelativeColorimetric, icInterpLinear, NULL,
+                          icXformLutColor, true);
+
+  icStatusCMM rv = pCmm->Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-init-pcc: Begin() failed (status %d)\n", (int)rv);
+    return 1;
+  }
+
+  int failures = 0;
+  for (int i = 0; i < kNumSamples; i++) {
+    icFloatNumber dst[3] = { 0.0f, 0.0f, 0.0f };
+
+    rv = pCmm->Apply(dst, kSamples[i]);
+    if (rv != icCmmStatOk) {
+      std::fprintf(stderr, "cmmsearch-init-pcc: FAIL  Apply status %d for sample %d\n",
+                   (int)rv, i);
+      failures++;
+      continue;
+    }
+
+    icFloatNumber worst = 0.0f;
+    for (int j = 0; j < 3; j++) {
+      icFloatNumber diff = (icFloatNumber)std::fabs(dst[j] - kSamples[i][j]);
+      if (diff > worst)
+        worst = diff;
+    }
+
+    if (worst > kTolerance) {
+      std::fprintf(stderr,
+        "cmmsearch-init-pcc: FAIL  sample %d [%.4f %.4f %.4f] -> [%.4f %.4f %.4f] (max err %.4f)\n",
+        i, (double)kSamples[i][0], (double)kSamples[i][1], (double)kSamples[i][2],
+        (double)dst[0], (double)dst[1], (double)dst[2], (double)worst);
+      failures++;
+    }
+    else {
+      std::fprintf(stdout,
+        "cmmsearch-init-pcc: PASS  sample %d [%.4f %.4f %.4f] (max err %.4f)\n",
+        i, (double)kSamples[i][0], (double)kSamples[i][1], (double)kSamples[i][2],
+        (double)worst);
+    }
+  }
+
+  return failures ? 1 : 0;
+}

--- a/.github/ci/regression/iccconnect-config-parser.cpp
+++ b/.github/ci/regression/iccconnect-config-parser.cpp
@@ -85,6 +85,91 @@ int main()
                       "search apply rejects non-finite PCC weight");
   }
 
+  // #1860: -INIT was matched with stricmp where the profile loop breaks out of
+  // the sequence but with strcmp where the initializer is consumed.  A lowercase
+  // "-init" therefore ended the profile loop and then fell through to the
+  // weighted-PCC loop, where it was taken as a PCC path and its intent as the
+  // weight.  Both tests are stricmp now, so either spelling parses identically.
+  {
+    CIccCfgSearchApply search;
+    const char* args[] = {
+      "1", "target.icc", "1", "src.icc", "101", "-init", "1"
+    };
+    failures += check(search.fromArgs(args, 7, true) == 7,
+                      "search apply accepts lowercase -init");
+  }
+
+  {
+    CIccCfgSearchApply search;
+    const char* argsUpper[] = {
+      "1", "target.icc", "1", "src.icc", "101", "-INIT", "1"
+    };
+    CIccCfgSearchApply searchLower;
+    const char* argsLower[] = {
+      "1", "target.icc", "1", "src.icc", "101", "-init", "1"
+    };
+    failures += check(search.fromArgs(argsUpper, 7, true) ==
+                        searchLower.fromArgs(argsLower, 7, true) &&
+                      search.isInitialized() && searchLower.isInitialized(),
+                      "search apply treats -INIT and -init identically");
+  }
+
+  // #1860: every loop in CIccCfgSearchApply::fromArgs consumes tokens in pairs,
+  // so a leftover odd token is one the caller wrote and the parser never read.
+  // It used to be dropped silently and the run exited 0 as if fully honoured.
+  {
+    CIccCfgSearchApply search;
+    const char* args[] = {
+      "1", "target.icc", "1", "src.icc", "101", "-INIT", "1", "TRAILING"
+    };
+    failures += check(search.fromArgs(args, 8, true) == 0,
+                      "search apply rejects unconsumed trailing argument");
+  }
+
+  {
+    CIccCfgSearchApply search;
+    const char* args[] = {
+      "1", "target.icc", "1", "src.icc", "101", "-INIT", "1", "pcc.icc"
+    };
+    failures += check(search.fromArgs(args, 8, true) == 0,
+                      "search apply rejects PCC path with no weight");
+  }
+
+  // #1860: the digits field of encoding[:precision[:digits]] was read with the
+  // cursor still on its ':' separator, so atoi(":8") silently yielded 0 and the
+  // requested total width was discarded.
+  {
+    CIccCfgDataApply data;
+    const char* args[] = { "data.txt", "0:2:8" };
+    failures += check(data.fromArgs(args, 2, true) == 2 &&
+                        data.m_dstPrecision == 2 && data.m_dstDigits == 8,
+                      "data apply decodes encoding:precision:digits");
+  }
+
+  {
+    CIccCfgDataApply data;
+    const char* args[] = { "data.txt", "3:6" };
+    failures += check(data.fromArgs(args, 2, true) == 2 &&
+                        data.m_dstPrecision == 6 && data.m_dstDigits == 11,
+                      "data apply defaults digits to 5 + precision");
+  }
+
+  // #1860: both fields used bare atoi(), which cannot fail -- malformed text
+  // became 0 and an out-of-range value was truncated by the icUInt8Number cast.
+  {
+    CIccCfgDataApply data;
+    const char* args[] = { "data.txt", "0:x:y" };
+    failures += check(data.fromArgs(args, 2, true) == 0,
+                      "data apply rejects malformed precision and digits");
+  }
+
+  {
+    CIccCfgDataApply data;
+    const char* args[] = { "data.txt", "0:2:999" };
+    failures += check(data.fromArgs(args, 2, true) == 0,
+                      "data apply rejects out-of-range digits");
+  }
+
   {
     CIccCfgProfile profile;
     failures += check(!profile.fromJson("{\"iccFile\":\"profile.icc\",\"transform\":\"missing\"}", true),

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -197,6 +197,68 @@ function(iccdev_add_iccconnect_config_parser_test)
   endif()
 endfunction()
 
+function(iccdev_add_cmmsearch_init_pcc_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCmmSearchInitPccTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/cmmsearch-init-pcc.cpp"
+  )
+  target_link_libraries(iccCmmSearchInitPccTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+
+  add_dependencies(check iccCmmSearchInitPccTest)
+
+  # sRGB_D65_MAT.icc is the regression case: a tracked v5 profile carrying an
+  # 'svcn' tag that declares D65, so a PCC that fails to resolve falls back to
+  # the D50 default and a spurious adaptation is spliced in (issue #1860).
+  # sRGB_v4_ICC_preference.icc is the control: it has no 'svcn', both ends of the
+  # chain default to D50 either way, and its results must not move.
+  set(_cmmsearch_init_pcc_cases
+    "d65-svcn=${ICCDEV_TESTING_DIR}/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc"
+    "v4-no-svcn=${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc"
+  )
+
+  foreach(_case IN LISTS _cmmsearch_init_pcc_cases)
+    string(REGEX REPLACE "=.*$" "" _case_name "${_case}")
+    string(REGEX REPLACE "^[^=]*=" "" _case_profile "${_case}")
+
+    if(WIN32)
+      add_test(
+        NAME iccdev.cmmsearch-init-pcc.${_case_name}
+        COMMAND "$<TARGET_FILE:iccCmmSearchInitPccTest>" "${_case_profile}"
+      )
+    else()
+      add_test(
+        NAME iccdev.cmmsearch-init-pcc.${_case_name}
+        COMMAND
+          "${CMAKE_COMMAND}" -E env
+          ${ICCDEV_TEST_ENV}
+          "$<TARGET_FILE:iccCmmSearchInitPccTest>"
+          "${_case_profile}"
+      )
+    endif()
+    set_tests_properties(iccdev.cmmsearch-init-pcc.${_case_name} PROPERTIES
+      WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+      TIMEOUT 120
+      LABELS "iccdev;iccprofLib;cmmsearch;pcc;regression"
+    )
+    if(WIN32)
+      set(_cmmsearch_init_pcc_windows_env_mods
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCmmSearchInitPccTest>"
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      )
+      foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+        list(APPEND _cmmsearch_init_pcc_windows_env_mods
+          "PATH=path_list_prepend:${_runtime_path}")
+      endforeach()
+      set_tests_properties(iccdev.cmmsearch-init-pcc.${_case_name} PROPERTIES
+        ENVIRONMENT_MODIFICATION "${_cmmsearch_init_pcc_windows_env_mods}"
+      )
+    endif()
+  endforeach()
+endfunction()
+
 function(iccdev_add_embedio_read8_bounds_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -2203,6 +2265,7 @@ if(WIN32)
 
   iccdev_add_iccconnect_thread_test()
   iccdev_add_iccconnect_config_parser_test()
+  iccdev_add_cmmsearch_init_pcc_test()
   iccdev_add_embedio_read8_bounds_test()
   iccdev_add_fileio_getlength_position_test()
   iccdev_add_profile_write_failure_test()
@@ -2419,6 +2482,7 @@ set(ICCDEV_TEST_ENV
 
 iccdev_add_iccconnect_thread_test()
 iccdev_add_iccconnect_config_parser_test()
+iccdev_add_cmmsearch_init_pcc_test()
 iccdev_add_embedio_read8_bounds_test()
 iccdev_add_fileio_getlength_position_test()
 iccdev_add_profile_write_failure_test()

--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -379,14 +379,33 @@ int CIccCfgDataApply::fromArgs(const char** args, int nArg, bool bReset)
     return 0;
   m_dstEncoding = (icFloatColorEncoding)nDstEncoding;
 
+  // Decode the optional encoding[:precision[:digits]] formatting suffix.
+  // Two defects here (#1860): the digits field was read with the cursor still
+  // parked ON its ':' separator, so "0:2:8" ran atoi(":8") and silently produced
+  // 0 -- the requested total width was discarded and output came out unpadded.
+  // And both fields used bare atoi(), which cannot fail: "0:x:y" quietly became
+  // precision 0 / digits 0 rather than being rejected, and a value above 255 was
+  // truncated by the narrowing cast to icUInt8Number.  Parse and range-check both
+  // fields the same way the encoding selector above is handled, and bound them to
+  // what the "%<digits>.<precision>lf " format string can meaningfully carry.
   const char *colon = strchr(args[1], ':');
   if (colon) {
+    int nPrecision;
+
     colon++;
-    m_dstPrecision = (icUInt8Number)atoi(colon);
-    m_dstDigits = 5 + m_dstPrecision;
+    if (!icParseIntArg(colon, nPrecision, true) || nPrecision < 0 || nPrecision > 99)
+      return 0;
+    m_dstPrecision = (icUInt8Number)nPrecision;
+    m_dstDigits = (icUInt8Number)(5 + m_dstPrecision);
+
     colon = strchr(colon, ':');
     if (colon) {
-      m_dstDigits = (icUInt8Number)atoi(colon);
+      int nDigits;
+
+      colon++;
+      if (!icParseIntArg(colon, nDigits) || nDigits < 0 || nDigits > 99)
+        return 0;
+      m_dstDigits = (icUInt8Number)nDigits;
     }
   }
   
@@ -1355,7 +1374,13 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
     m_profiles.push_back(pProf);
   }
 
-  if (nArg >= 2 && !strcmp(args[0], "-INIT")) {
+  // Match -INIT case-insensitively, exactly as the profile loop above does when
+  // it breaks out on this token (#1860).  The two tests used to disagree --
+  // stricmp there, strcmp here -- so "-init 1" ended the profile loop but was
+  // then not consumed as the initializer.  It fell through to the weighted-PCC
+  // loop below, where "-init" became a PCC path and "1" its weight, and the run
+  // died with "unable to open or read PCC tags from '-init'".
+  if (nArg >= 2 && !stricmp(args[0], "-INIT")) {
     int nIntent;
     int nType;
     if (!icParseIntArg(args[1], nIntent) || nIntent == INT_MIN)
@@ -1408,6 +1433,15 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
     nArg -= 2;
     nUsed += 2;
   }
+
+  // Every loop above consumes tokens in pairs, so an odd token left over is one
+  // the caller wrote and this parser never interpreted (#1860).  Returning nUsed
+  // regardless meant the caller silently dropped it: a stray trailing argument,
+  // or a "-PCC path" with no weight, ran to completion and exited 0 as though the
+  // whole command line had been honoured.  Reject instead -- iccApplySearch turns
+  // a 0 return into "Unable to parse profile sequence arguments".
+  if (nArg > 0)
+    return 0;
 
   return m_profiles.size() > 0 ? nUsed : 0;
 }

--- a/IccProfLib/IccCmmSearch.cpp
+++ b/IccProfLib/IccCmmSearch.cpp
@@ -131,7 +131,13 @@ icFloatNumber CIccApplyCmmSearch::costFunc(CIccSearchVec& point)
   if (nApply > pCmm->m_weight.size())
     nApply = pCmm->m_weight.size();
   for (size_t i = 0; i < nApply; i++) {
-    pCmm->m_dst_to_mid[i]->Apply(&m_pixel[0], &point.vec()[0]);
+    // A failed reverse transform leaves m_pixel holding the previous candidate's
+    // values, which would silently score this point against stale data (#1860).
+    // costFunc has no status channel, so report the point as infeasible instead:
+    // the same sentinel the bounds barrier uses keeps the optimizer away from it
+    // rather than letting it converge on a garbage minimum.
+    if (pCmm->m_dst_to_mid[i]->Apply(&m_pixel[0], &point.vec()[0]) != icCmmStatOk)
+      return overBoundsCost;
 
     if (m_bNeedPcsToLab) {
       icLabFromPcs(&m_pixel[0]);
@@ -203,11 +209,20 @@ icStatusCMM CIccApplyCmmSearch::Apply(icFloatNumber* DstPixel, const icFloatNumb
     if (nApply > pCmm->m_src_to_mid.size())
       nApply = pCmm->m_src_to_mid.size();
     for (size_t i = 0; i < nApply; i++) {
-      pCmm->m_src_to_mid[i]->Apply(&m_mid_data[i][0], SrcPixel);
+      // Propagate the per-PCC forward transform status (#1860).  Swallowing it
+      // left m_mid_data[i] holding whatever the previous pixel wrote, so the
+      // search then optimised against a stale target and still reported success.
+      icStatusCMM statMid = pCmm->m_src_to_mid[i]->Apply(&m_mid_data[i][0], SrcPixel);
+      if (statMid != icCmmStatOk)
+        return statMid;
     }
   }
 
-  pCmm->m_mid_to_dst->Apply(&m_startPixel[0], &m_mid_data[0][0]);
+  // Same for the transform that seeds the search's starting point: if it fails
+  // m_startPixel is stale and every subsequent simplex vertex derives from it.
+  icStatusCMM statStart = pCmm->m_mid_to_dst->Apply(&m_startPixel[0], &m_mid_data[0][0]);
+  if (statStart != icCmmStatOk)
+    return statStart;
 
   //Cost function needs delteEab so convert from PCS encoding to Lab for comparisons
   if (m_bNeedPcsToLab) {
@@ -233,7 +248,13 @@ icStatusCMM CIccApplyCmmSearch::Apply(icFloatNumber* DstPixel, const icFloatNumb
   icUInt32Number nDstSamples = pCmm->GetDestSamples();
 
   for (icUInt32Number i = 0; i < nPixels; i++) {
-    Apply(DstPixel, SrcPixel);
+    // Stop on the first failing pixel and report it (#1860).  The single-pixel
+    // overload above now returns real statuses, but discarding them here would
+    // still hand the caller a buffer of partially-transformed pixels alongside
+    // icCmmStatOk -- the same masking the per-stage Apply() calls had.
+    icStatusCMM stat = Apply(DstPixel, SrcPixel);
+    if (stat != icCmmStatOk)
+      return stat;
     DstPixel += nDstSamples;
     SrcPixel += nSrcSamples;
   }
@@ -374,6 +395,33 @@ icStatusCMM CIccCmmSearch::Begin(bool /* bAllocNewApply */, bool /* bUsePcsConve
 
   if (m_nAttached < 2)
     return icCmmStatBadXform;
+
+  // Resolve every attached profile's connection conditions before any sub-CMM is
+  // built (#1860).  The sub-chains below mix the two CIccCmm::AddXform overloads:
+  // the src/mid/dst profiles go in by reference, which copy-constructs the profile
+  // and then detaches the copy from its file IO (CopyAttach(nullptr)), while the
+  // -INIT initial-destination profile goes in by pointer and keeps its IO.  A
+  // detached copy can no longer load spectralViewingConditions on demand, so when
+  // CIccCmm::Begin() reaches CheckPCSConnections()/pushXYZConvert() it reads the
+  // D50/2-degree default for one end of the chain and the profile's real PCC for
+  // the other.  isEquivalentPcc() then reports a mismatch and splices a bogus
+  // chromatic-adaptation CIccPcsXform into mid_to_dst.  For a v5 profile carrying
+  // a non-D50 'svcn' (e.g. Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc,
+  // which declares D65) that turned an identity sRGB->sRGB search into a D50<->D65
+  // adaptation, and because the search is fenced by a 1e6 out-of-gamut barrier the
+  // resulting start point could not be recovered from.  Loading the three PCC tags
+  // here means the reference-overload copies inherit them, so both ends of every
+  // sub-chain agree and only genuinely differing PCCs get an adaptation.
+  // CIccConnectCmm::CreateSearch() already does exactly this for the weighted PCC
+  // profiles it attaches; this extends the same treatment to the chain profiles.
+  if (m_pSrcProfile)
+    m_pSrcProfile->ReadPccTags();
+  if (m_pMidProfile)
+    m_pMidProfile->ReadPccTags();
+  if (m_pDstProfile)
+    m_pDstProfile->ReadPccTags();
+  if (m_pDstInitProfile)
+    m_pDstInitProfile->ReadPccTags();
 
   if (m_nAttached == 2) {
     //mid_to_dst


### PR DESCRIPTION
Closes part of #1860.

Reviewing the Rev.A/Rev.B matrices found that the headline symptom has **two independent root
causes**, and that the framing in the issue ("search output is input-independent") does not hold:
feeding five distinct colors produces five distinct outputs. The apparent constancy in
`srgbCalcTest.txt` comes from a separate, cross-tool defect that is **not** fixed here and is
reported separately on the issue.

## 1. Search chain resolved its connection conditions asymmetrically

`CIccCmmSearch::Begin()` builds its sub-chains with two different `CIccCmm::AddXform` overloads.
The src/mid/dst profiles go in **by reference**, which copy-constructs the profile and then
detaches the copy from its file IO; the `-INIT` initial-destination profile goes in **by pointer**
and keeps its IO. A detached copy can no longer load `spectralViewingConditions` on demand, so
`CheckPCSConnections()`/`pushXYZConvert()` read the D50/2-degree default at one end of the chain
and the profile's real PCC at the other:

```
DBG pushXYZConvert: srcIllum=1 srcObs=1 srcStd=1 | dstIllum=1 dstObs=1 dstStd=1 | equiv=1   <- no -INIT
DBG pushXYZConvert: srcIllum=1 srcObs=1 srcStd=1 | dstIllum=2 dstObs=1 dstStd=0 | equiv=0   <- with -INIT
```

`isEquivalentPcc()` reports a mismatch and splices a chromatic-adaptation `CIccPcsXform` into
`mid_to_dst` that the non-`-INIT` chain does not have (3 xforms vs 2). For a v5 profile declaring
a non-D50 illuminant in `svcn` this turns an identity profile-to-itself search into a D50/D65
adaptation. Because the search is fenced by a `1e6` out-of-gamut barrier cost, the corrupted
starting point cannot be recovered from.

`Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc`, sRGB to itself, intent 1, `-INIT 1`:

| input | before | after | `iccApplyNamedCmm` reference |
|---|---|---|---|
| 1.0 0.0 0.0 | **0.9553 -0.0162 0.1386** | 1.0000 0.0002 0.0000 | 1.0000 -0.0000 0.0000 |
| 0.0 1.0 0.0 | **-0.5702 1.0319 0.1481** | 0.0000 1.0000 0.0000 | 0.0000 1.0000 0.0000 |
| 0.0 0.0 1.0 | **-0.2018 -0.0431 1.0708** | 0.0000 0.0000 1.0000 | 0.0000 0.0000 1.0000 |
| 1.0 1.0 1.0 | **0.9229 1.0108 1.1477** | 1.0000 1.0000 1.0000 | 1.0000 1.0000 1.0000 |
| 0.5 0.25 0.125 | 0.5000 0.2500 0.1250 | 0.5000 0.2500 0.1250 | 0.5000 0.2500 0.1250 |

Only gamut corners regressed; interior colors stayed exact. Combined with the fact that a profile
without an `svcn` tag is byte-identical either way, that is why the existing tests and the whole
v2/v4 fixture corpus never caught this.

`Begin()` now calls `ReadPccTags()` on every attached profile before any sub-CMM is built, so both
ends of each sub-chain agree. This mirrors what `CIccConnectCmm::CreateSearch()` already does for
the weighted PCC profiles it attaches.

Note the fix is deliberately *not* "make `-INIT` use the reference overload too". That equalises
the two ends by discarding real PCC data, and would suppress legitimate cross-PCC adaptations.

## 2. Status masking in `CIccApplyCmmSearch`

Confirmed as reported. Both `Apply()` overloads discarded the status of every transform they drove
and returned `icCmmStatOk` unconditionally, so a failed stage left stale data in
`m_mid_data`/`m_startPixel` and still reported success. Both overloads now propagate.
`costFunc()`, which has no status channel, reports a failed reverse transform as infeasible via the
bounds sentinel instead of scoring against a stale `m_pixel`.

## 3. argv parsing

- `-INIT` was matched with `stricmp` where the profile loop breaks out on it, but `strcmp` where
  the initializer is consumed. `-init 1` therefore ended the profile loop and fell through to the
  weighted-PCC loop, where `-init` became a PCC path and `1` its weight, dying with
  `unable to open or read PCC tags from '-init'` (exit 255). Rev.A case 23.
- Every loop consumes tokens in pairs, but a leftover odd token was dropped silently and the run
  exited 0 as though the whole command line had been honoured. This is the originally reported
  symptom, Rev.A case 25. A `-PCC path` with no weight was swallowed the same way.
- The digits field of `encoding[:precision[:digits]]` was read with the cursor still on its `:`
  separator, so `0:2:8` ran `atoi(":8")` and yielded 0, silently discarding the requested width
  (Rev.A case 26). Both fields also used bare `atoi()`, which cannot fail, so `0:x:y` became 0/0
  (case 27) and values above 255 were truncated by the narrowing cast to `icUInt8Number`. Both
  fields are now parsed and range-checked.

## Tests

`cmmsearch-init-pcc` drives a profile-to-itself search with an initial-destination profile attached
and asserts identity at the gamut corners. It runs over two profiles:

- `sRGB_D65_MAT.icc` — has `svcn`, the regression case; fails on the unfixed tree at all four
  corners with per-channel errors of 0.1386 to 0.5702.
- `sRGB_v4_ICC_preference.icc` — no `svcn`, the control; **passes with and without the fix**, so
  the test isolates the PCC defect rather than search accuracy in general.

`iccconnect-config-parser` gains eight argv assertions covering the three parser defects; six fail
on the unfixed tree.

## Verification

Zero compiler warnings (`grep -cE 'warning:' build.log` = 0) on all four strict profiles, rebuilt
after rebasing onto `7de60f86`:

| profile | result |
|---|---|
| clang-18 Debug (project default flags) | 0 warnings |
| GCC 15 Release + LTO, `-Wall -Wextra -Wpedantic -Werror` | 0 warnings |
| clang-18 Release, `-Wall -Wextra -Wpedantic -Werror` | 0 warnings |
| GCC ASAN+UBSAN Debug, `-Werror=type-limits -Werror=attributes` | 0 warnings |

Full CTest 115/116. The single failure is `iccdev.spectral-tiff-preview`, which needs the
`imagecodecs` Python module that is absent locally and installed in CI; it is unrelated to this
change and fails identically on an unmodified tree.

New tests and the tool's changed argv paths are clean under ASAN+UBSAN with `detect_leaks=1`
(CI runs `detect_leaks=0`, so this is the stricter check).

## Deliberately not in this PR

- **The 8-bit legacy-data saturation.** `CIccCmm::ToInternalEncoding` decodes `icEncode8Bit` as
  `icU8toF(icFtoU8(x))`, and `icFtoU8` clamps `> 1.0` to 1.0 — but every legacy `.txt` fixture in
  the tree writes raw 0..255, and `FromInternalEncoding` *emits* 0..255 for the same encoding, so
  the two are not inverses. This affects `iccApplyNamedCmm` identically and touches the core CMM,
  so it is reported separately on #1860 rather than folded in here.
- **Making `-INIT` mandatory** (Rev.B case 24) — a behaviour change worth its own decision.
- **BPC / hint / PCC forwarding.** `CIccCmmSearch::AddXform` drops both `pPc` and `pHintManager`,
  and there is no `m_useBPCInitial`, so `-INIT 41` loses BPC at parse time. Real, but fixing it
  needs an ownership decision on the hint manager across `Begin()`, so it deserves separate review.
