### PR TITLE
fix(#1868): replace the non-terminating hue normalization in CIccPRMG::GetChroma

### DIFF
--- a/.github/ci/regression/prmg-hue-normalization.cpp
+++ b/.github/ci/regression/prmg-hue-normalization.cpp
@@ -1,0 +1,164 @@
+// Regression for the non-terminating hue normalization in CIccPRMG::GetChroma.
+//
+// GetChroma reduces an arbitrary hue angle into [0, 360) before deriving the
+// icPRMG_Chroma row index. That reduction used to be a pair of loops:
+//
+//     while (h < 0.0)
+//       h += 360.0;
+//     while (h >= 360.0)
+//       h -= 360.0;
+//
+// which do not terminate for large-magnitude hue angles. Once |h| reaches about
+// 1e20, a step of 360 is smaller than the ULP of the float, so "h += 360.0"
+// rounds straight back to h: the loop condition never changes and the call spins
+// forever. Measured on the unfixed code, h = 1e20f, 1e30f and 3.4e38f all made
+// zero progress after 5e7 iterations, while h = -1e8f still terminated (277778
+// iterations) because 360 is still above the ULP there.
+//
+// The isfinite() guard at the top of GetChroma does not cover this. These inputs
+// are finite -- they are simply too large for a step of 360 to move, which is a
+// different failure than the NaN/infinity case that guard was written for.
+//
+// The fix replaces both loops with a single fmod() reduction. fmod is exact in
+// IEEE-754, so hue angles that already worked are unaffected, and it cannot loop.
+//
+// Reachability, stated honestly: no shipped tool reaches this with an unbounded
+// hue. Both in-tree callers (iccRoundTrip, wxProfileDump) go through
+// CIccPRMG::EvaluateProfile -> InGamut(Lab) -> icLab2Lch, and an atan2-derived
+// angle is already in [0, 360). This is a hang in the public API surface
+// (CIccPRMG::GetChroma and InGamut(L,c,h) are both public in IccPrmg.h), not an
+// attacker-reachable denial of service through a profile. The test drives the
+// public entry point directly, which is exactly the exposure being fixed.
+//
+// A hang has no return value to assert on, so the unfixed code fails this test by
+// exceeding the CTest TIMEOUT rather than by returning something wrong. The
+// value assertions below then cover the other half: that the reduction is the
+// mathematically correct one and not merely a bail-out.
+//
+// Returns 0 on success; non-zero on failure.
+
+#include "IccPrmg.h"
+
+#include <cmath>
+#include <cstdio>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_failures = 0;
+
+void fail(const char *what)
+{
+  std::fprintf(stderr, "[prmg-hue] FAIL: %s\n", what);
+  g_failures++;
+}
+
+// The reduction GetChroma is expected to perform, computed independently here so
+// the test checks the *result* of the normalization rather than just that the
+// call came back.
+icFloatNumber normalizeHue(icFloatNumber h)
+{
+  icFloatNumber r = (icFloatNumber)std::fmod((double)h, 360.0);
+  if (r < 0.0)
+    r += 360.0f;
+  if (r >= 360.0f)
+    r = 0.0f;
+  return r;
+}
+
+} // namespace
+
+int main()
+{
+  CIccPRMG prmg;
+
+  // A mid-gamut lightness, so every hue below lands on a real table row rather
+  // than one of the out-of-range rejections.
+  const icFloatNumber L = 50.0f;
+
+  // 1. The existing rejection contract must be untouched by the fix.
+  if (prmg.GetChroma((icFloatNumber)NAN, 0.0f) >= 0.0f)
+    fail("NaN L was not rejected");
+  if (prmg.GetChroma(L, (icFloatNumber)NAN) >= 0.0f)
+    fail("NaN h was not rejected");
+  if (prmg.GetChroma((icFloatNumber)INFINITY, 0.0f) >= 0.0f)
+    fail("infinite L was not rejected");
+  if (prmg.GetChroma(L, (icFloatNumber)INFINITY) >= 0.0f)
+    fail("infinite h was not rejected");
+  if (prmg.GetChroma(3.0f, 0.0f) >= 0.0f)
+    fail("L below 3.5 was not rejected");
+  if (prmg.GetChroma(101.0f, 0.0f) >= 0.0f)
+    fail("L above 100 was not rejected");
+
+  // 2. Ordinary in-range hues must still produce a usable chroma. These are the
+  //    only values the shipped tools ever supply, so they are the regression
+  //    surface that matters most.
+  const icFloatNumber ordinary[] = {0.0f, 45.0f, 180.0f, 359.9f};
+  for (icFloatNumber h : ordinary) {
+    icFloatNumber c = prmg.GetChroma(L, h);
+    if (!(c >= 0.0f) || !std::isfinite(c)) {
+      std::fprintf(stderr, "[prmg-hue] h=%g gave chroma %g\n", (double)h, (double)c);
+      fail("ordinary hue did not yield a finite non-negative chroma");
+    }
+  }
+
+  // 3. Hue is periodic, and the reduction must preserve that. Values in this
+  //    range terminated even before the fix, so this pins the behaviour the fix
+  //    had to keep rather than the behaviour it changed.
+  for (icFloatNumber h : ordinary) {
+    if (prmg.GetChroma(L, h) != prmg.GetChroma(L, h + 720.0f))
+      fail("hue + 720 did not match the base hue");
+    if (prmg.GetChroma(L, h) != prmg.GetChroma(L, h - 720.0f))
+      fail("hue - 720 did not match the base hue");
+  }
+
+  // 4. The regression itself. Every one of these hangs the unfixed loops; under
+  //    the fix each returns immediately, and must agree with the reduction
+  //    computed independently above.
+  const icFloatNumber huge[] = {
+    1.0e20f, -1.0e20f, 1.0e30f, -1.0e30f, 3.4e38f, -3.4e38f
+  };
+  for (icFloatNumber h : huge) {
+    icFloatNumber c = prmg.GetChroma(L, h);
+
+    if (!std::isfinite(c)) {
+      std::fprintf(stderr, "[prmg-hue] h=%g gave non-finite chroma %g\n",
+                   (double)h, (double)c);
+      fail("large-magnitude hue produced a non-finite chroma");
+      continue;
+    }
+    if (!(c >= 0.0f)) {
+      std::fprintf(stderr, "[prmg-hue] h=%g gave chroma %g\n", (double)h, (double)c);
+      fail("large-magnitude hue was rejected instead of reduced");
+      continue;
+    }
+
+    icFloatNumber expected = prmg.GetChroma(L, normalizeHue(h));
+    if (c != expected) {
+      std::fprintf(stderr,
+                   "[prmg-hue] h=%g -> chroma %g, but reduced hue %g -> %g\n",
+                   (double)h, (double)c, (double)normalizeHue(h), (double)expected);
+      fail("large-magnitude hue did not reduce to its fmod equivalent");
+    }
+  }
+
+  // 5. The smallest and largest finite floats, as a boundary check on the
+  //    reduction rather than on the table lookup.
+  for (icFloatNumber h : {1.4e-45f, -1.4e-45f, 1.17549435e-38f}) {
+    icFloatNumber c = prmg.GetChroma(L, h);
+    if (!std::isfinite(c) || !(c >= 0.0f))
+      fail("subnormal hue did not yield a finite non-negative chroma");
+  }
+
+  if (g_failures) {
+    std::fprintf(stderr, "[prmg-hue] %d check(s) failed\n", g_failures);
+    return 1;
+  }
+
+  std::fprintf(stdout,
+               "[prmg-hue] hue normalization terminates and reduces correctly\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1943,6 +1943,55 @@ function(iccdev_add_encoding_surround_test)
   endif()
 endfunction()
 
+# CIccPRMG::GetChroma normalized an arbitrary hue angle into [0, 360) with
+# "while (h < 0.0) h += 360.0;" / "while (h >= 360.0) h -= 360.0;". Those loops do
+# not terminate once |h| is large enough that 360 falls below the float's ULP
+# (around 1e20): the addition rounds back to the original value and the condition
+# never changes. The isfinite() guard at the top of the function does not catch it
+# because such values are finite. fmod performs the same reduction exactly and in
+# one step. The test drives the public GetChroma with hues that hang the old
+# loops, so the unfixed code fails by TIMEOUT; the value checks additionally
+# confirm the reduction matches an independently computed fmod, and that the
+# NaN/infinity/L-range rejections are unchanged. IccProfLib only.
+function(iccdev_add_prmg_hue_normalization_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccPrmgHueNormalizationTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/prmg-hue-normalization.cpp"
+  )
+  target_compile_features(iccPrmgHueNormalizationTest PRIVATE cxx_std_17)
+  target_include_directories(iccPrmgHueNormalizationTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccPrmgHueNormalizationTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccPrmgHueNormalizationTest)
+
+  add_test(
+    NAME iccdev.prmg-hue-normalization
+    COMMAND "$<TARGET_FILE:iccPrmgHueNormalizationTest>"
+  )
+  set_tests_properties(iccdev.prmg-hue-normalization PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;iccprofLib;prmg;regression"
+  )
+  if(WIN32)
+    set(_prmghue_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccPrmgHueNormalizationTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _prmghue_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.prmg-hue-normalization PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_prmghue_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_windows_iccdevcmm_smoke_test)
   if(NOT WIN32 OR NOT TARGET RefIccMAX)
     return()
@@ -2194,6 +2243,7 @@ if(WIN32)
   iccdev_add_iccprofileplot_exitcode_test()
   iccdev_add_applytolink_invalid_arg_test()
   iccdev_add_applytolink_v4_missing_desc_test()
+  iccdev_add_prmg_hue_normalization_test()
   iccdev_add_windows_iccdevcmm_smoke_test()
 
   return()
@@ -2407,6 +2457,7 @@ iccdev_add_iccviz_pdf_axis_test()
 iccdev_add_iccprofileplot_clut_oob_test()
 iccdev_add_iccprofileplot_pdf_leak_test()
 iccdev_add_iccprofileplot_exitcode_test()
+iccdev_add_prmg_hue_normalization_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/IccProfLib/IccPrmg.cpp
+++ b/IccProfLib/IccPrmg.cpp
@@ -144,11 +144,26 @@ icFloatNumber CIccPRMG::GetChroma(icFloatNumber L, icFloatNumber h)
   if (L < 3.5 || L > 100.0)
     return -1;
 
-  // Normalize h to the range [0, 360)
-  while (h < 0.0)
-    h += 360.0;
-  while (h >= 360.0)
-    h -= 360.0;
+  // Normalize h to the range [0, 360). The index arithmetic below relies on that
+  // invariant: nHIndex is derived as h/10 and indexes icPRMG_Chroma's 37 hue rows.
+  //
+  // This used to be a pair of "while (h < 0.0) h += 360.0;" / "while (h >= 360.0)
+  // h -= 360.0;" loops, which do not terminate for large-magnitude h. 360 falls
+  // below the ULP of a float once |h| is around 1e20 or greater, so h += 360.0
+  // rounds back to h and the loop spins forever making no progress. The isfinite
+  // check above does not help: values like 1e30f are perfectly finite, just too
+  // large for a step of 360 to move. fmod does the same reduction in one exact
+  // operation (fmod is exact in IEEE-754, so no accuracy is given up for the
+  // hue values that already worked), and it cannot loop.
+  h = (icFloatNumber)std::fmod((double)h, 360.0);
+  if (h < 0.0)
+    h += 360.0f;
+
+  // fmod keeps the sign of h, so a small negative hue lands just below zero and
+  // the correction above can round up to exactly 360.0f in float. Fold that back
+  // to 0 so the [0, 360) invariant holds for every input, not just most of them.
+  if (h >= 360.0f)
+    h = 0.0f;
 
   int nHIndex = (int)(h / 10.0);
   icFloatNumber dHFraction = (h - nHIndex * 10.0f) / 10.0f;


### PR DESCRIPTION
Fixes #1868.

## What

`CIccPRMG::GetChroma` normalized an arbitrary hue angle into `[0, 360)` with two loops:

```c
  while (h < 0.0)
    h += 360.0;
  while (h >= 360.0)
    h -= 360.0;
```

These do not terminate once `|h|` is large enough that a step of 360 falls below the float's ULP
(around `1e20`): the addition rounds back to the original value, the condition never changes, and
the call hangs.

Measured against master, capping the iteration count at 5e7 so the probe itself could not hang:

```
h=-1e+30    step-changes-value=NO  iterations(capped 5e7)=50000000 <-- DID NOT TERMINATE
h=-1e+20    step-changes-value=NO  iterations(capped 5e7)=50000000 <-- DID NOT TERMINATE
h=-1e+08    step-changes-value=yes iterations(capped 5e7)=277778
h= 1e+30    step-changes-value=NO  iterations(capped 5e7)=50000000 <-- DID NOT TERMINATE
h= 3.4e+38  step-changes-value=NO  iterations(capped 5e7)=50000000 <-- DID NOT TERMINATE
```

The `isfinite()` guard at `IccPrmg.cpp:141` does not cover this. It was written for the
NaN/infinity case and is correct for it; `1e30f` is finite, just too large for a step of 360 to
move.

## Fix

One `fmod` reduction in place of both loops. `fmod` is exact in IEEE-754, so hue angles that
already worked are unaffected, and it cannot loop.

The fold-back to 0 is not decorative: `fmod` preserves the sign of `h`, so a small negative hue
lands just below zero and the `+= 360.0f` correction can round to exactly `360.0f` in float, which
would break the `[0, 360)` invariant the index arithmetic below depends on.

## Reachability

No shipped tool reaches this with an unbounded hue. Both in-tree callers (`iccRoundTrip`,
`wxProfileDump`) go through `EvaluateProfile` -> `InGamut(Lab)` -> `icLab2Lch`, and an
`atan2`-derived angle is already in range. The exposure is the public `CIccPRMG::GetChroma` /
`InGamut(L, c, h)` API, which the regression drives directly. Severity is bounded accordingly —
this is an API robustness fix, not a profile-triggerable DoS.

The same idiom at `IccUtil.cpp:932` in `icLab2Lch` is safe for the same `atan2` reason and is left
alone.

## Test

`.github/ci/regression/prmg-hue-normalization.cpp`, registered as
`iccdev.prmg-hue-normalization` in **both** CTest call lists — the no-`bash` early-return path as
well as the normal one, so it is not silently skipped where `bash` is unavailable.

A hang has no return value to assert on, so the unfixed code fails by exceeding the CTest
`TIMEOUT`; the value checks cover the other half.

| | Result |
|---|---|
| Unfixed (`IccPrmg.cpp` reverted to master) | `iccdev.prmg-hue-normalization (Timeout)` — 60.03s |
| Fixed | `Passed` — 0.02s |

Beyond termination the test asserts the reduction agrees with an independently computed `fmod`,
that hue periodicity (`h ± 720`) still holds, and that the NaN / infinity / `L`-range rejections
are unchanged.

## Pre-flight

Against master `b99465e6`:

- Debug `check`: 114/115 pass, 0 warnings, 0 errors.
- Strict GCC (`-Wall -Wextra -Wpedantic -Werror -std=c++17`, Release + LTO): 0 warnings, 0 errors.
- Strict clang-18 (same flag set): 0 warnings, 0 errors; test passes there too.

The single local CTest failure is `iccdev.spectral-tiff-preview` -> `ModuleNotFoundError: No
module named 'imagecodecs'`, a gap in my local Python environment that CI installs in its own
step. It is unrelated to this change.

## Note for #1853 bucket 1/4

The `ci-qa-flags` branch touches this same function. Its patch adds
`if (!std::isfinite(h) || h < 0.0f) return -1;` **after** the loops plus a similar check before the
`:165` cast. Both are unreachable as written (`L` and `h` are already proven finite at :141, `L`
bounded at :144), and because the `h` check sits after the loops it does not fix the hang — the
loops never return to reach it. Its effect was to clear CodeQL alert #1085 by landing inside that
query's 5-line suppression window; #1085 has since been dismissed as a false positive, so that
motivation is gone. Flagging the overlap so the two do not collide.
