### PR TITLE
fix(#1843): correct the .cube-to-CLUT axis order and long-line handling in iccFromCube

### DIFF
--- a/.github/scripts/iccdev-issue-1843-fromcube-clut-order-regression.sh
+++ b/.github/scripts/iccdev-issue-1843-fromcube-clut-order-regression.sh
@@ -1,0 +1,209 @@
+#!/bin/bash
+###############################################################################
+# iccFromCube issue-1843 CLUT axis-order and long-line regression
+###############################################################################
+#
+# Two defects in iccFromCube, both reachable from a legal .cube file:
+#
+#   1. CLUT axis order.  A .cube table runs the red index fastest and blue
+#      slowest; an ICC CLUT is laid out the other way round, with input channel
+#      0 carrying the largest stride.  iccFromCube streamed .cube rows into the
+#      CLUT in file order, which transposed the first and last input axes -- an
+#      identity .cube produced a profile that swapped red and blue, mapping
+#      source (1,0,0) to (0,0,1).  This test converts identity cubes and asserts
+#      that applying them is a no-op, plus an asymmetric red-only cube that
+#      pins which axis is which (an identity alone cannot distinguish a correct
+#      grid from one whose axes are transposed twice).
+#
+#   2. Long lines.  getNextLine() stopped after MAX_LINE_LEN characters without
+#      consuming the rest of the physical line, so the tail was returned as the
+#      next "line" and parsed as a keyword in its own right.  A 300-character
+#      comment -- legal, the format sets no line length limit -- was enough to
+#      make a valid .cube fail with "Unknown keyword".
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit codes: 0 pass or clean skip; 1 regression.
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1843-fromcube-clut-order}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+
+FROMCUBE="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromCube -type f 2>/dev/null | head -1)"
+APPLY="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplyNamedCmm -type f 2>/dev/null | head -1)"
+
+fail() {
+  echo "  [FAIL] issue-1843-fromcube-clut-order -- $1"
+  exit 1
+}
+
+echo "=== iccFromCube issue-1843 CLUT axis-order and long-line regression ==="
+
+if [ -z "$FROMCUBE" ] || [ ! -x "$FROMCUBE" ]; then
+  echo "  [SKIP] iccFromCube not built under $TOOLS_DIR"
+  exit 0
+fi
+if [ -z "$APPLY" ] || [ ! -x "$APPLY" ]; then
+  echo "  [SKIP] iccApplyNamedCmm not built under $TOOLS_DIR"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Compare iccApplyNamedCmm output against an expectation.
+#
+# Result rows are "<out r> <out g> <out b>\t; <src r> <src g> <src b>".  MODE
+# "identity" asserts the output equals the source; MODE "red-only" asserts the
+# output is (src r, 0, 0).  Both use a tolerance because the values come back
+# through a trilinear CLUT interpolation.
+# ---------------------------------------------------------------------------
+check_apply() {
+  local label="$1" profile="$2" data="$3" mode="$4"
+  local log="$OUTDIR/apply-$label.log"
+
+  if ! "$APPLY" "$data" 2 0 "$profile" 1 > "$log" 2>&1; then
+    sed -n '1,20p' "$log"
+    fail "iccApplyNamedCmm failed on $label"
+  fi
+
+  awk -v mode="$mode" -v label="$label" '
+    /;/ && !/^;/ {
+      split($0, halves, ";")
+      n = split(halves[1], out, "[ \t]+")
+      m = split(halves[2], src, "[ \t]+")
+      # split() on leading whitespace yields an empty first field.
+      oi = (out[1] == "" ? 1 : 0); si = (src[1] == "" ? 1 : 0)
+      if (n - oi < 3 || m - si < 3) next
+      for (i = 1; i <= 3; i++) { o[i] = out[i+oi] + 0; s[i] = src[i+si] + 0 }
+      if (mode == "red-only") { s[2] = 0; s[3] = 0 }
+      rows++
+      for (i = 1; i <= 3; i++) {
+        d = o[i] - s[i]; if (d < 0) d = -d
+        if (d > 0.001) {
+          printf("    row %d: got (%.4f %.4f %.4f) want (%.4f %.4f %.4f)\n",
+                 rows, o[1], o[2], o[3], s[1], s[2], s[3])
+          bad++
+          next
+        }
+      }
+    }
+    END {
+      if (rows == 0) { print "    no result rows parsed"; exit 2 }
+      if (bad > 0) { printf("    %d of %d rows wrong\n", bad, rows); exit 1 }
+      printf("    %s: %d/%d rows correct\n", label, rows, rows)
+    }
+  ' "$log"
+
+  local rc=$?
+  [ "$rc" -eq 0 ] || fail "$label did not survive the round trip through the CLUT (#1843)"
+}
+
+# ---------------------------------------------------------------------------
+# 1. Identity cube, 3x3x3, probed at every grid node.
+#
+# Rows are emitted in .cube order -- red fastest, blue slowest -- so this file
+# is an identity only under that convention.  Probing all 27 nodes means any
+# permutation of the input axes shows up, not just a red/blue swap.
+# ---------------------------------------------------------------------------
+IDENT_CUBE="$OUTDIR/identity3.cube"
+PROBE="$OUTDIR/grid27.txt"
+{
+  echo 'TITLE "issue-1843 identity"'
+  echo 'LUT_3D_SIZE 3'
+  for b in 0.0 0.5 1.0; do
+    for g in 0.0 0.5 1.0; do
+      for r in 0.0 0.5 1.0; do echo "$r $g $b"; done
+    done
+  done
+} > "$IDENT_CUBE"
+
+{
+  printf "'RGB '\t; Data Format\n"
+  printf "icEncodeUnitFloat\t; Encoding\n\n"
+  for r in 0.0 0.5 1.0; do
+    for g in 0.0 0.5 1.0; do
+      for b in 0.0 0.5 1.0; do echo "$r $g $b"; done
+    done
+  done
+} > "$PROBE"
+
+"$FROMCUBE" "$IDENT_CUBE" "$OUTDIR/identity3.icc" > "$OUTDIR/fromcube-identity.log" 2>&1 \
+  || { sed -n '1,20p' "$OUTDIR/fromcube-identity.log"; fail "iccFromCube rejected an identity cube"; }
+check_apply "identity-3x3x3" "$OUTDIR/identity3.icc" "$PROBE" "identity"
+
+# The tracked CI fixture is an identity under the same convention, so it must
+# behave identically -- this catches the fixture and the tool drifting apart.
+if [ -f "$REPO_ROOT/.github/ci/test-data/test-identity.cube" ]; then
+  "$FROMCUBE" "$REPO_ROOT/.github/ci/test-data/test-identity.cube" "$OUTDIR/identity-fixture.icc" \
+    > "$OUTDIR/fromcube-fixture.log" 2>&1 \
+    || { sed -n '1,20p' "$OUTDIR/fromcube-fixture.log"; fail "iccFromCube rejected test-identity.cube"; }
+  check_apply "identity-fixture" "$OUTDIR/identity-fixture.icc" "$PROBE" "identity"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Asymmetric cube: output depends on red alone, and only drives red.
+#
+# Under the old file-order copy this mapped input blue onto output red, so it
+# fails loudly if the axes are transposed in either direction.
+# ---------------------------------------------------------------------------
+RED_CUBE="$OUTDIR/red-only.cube"
+{
+  echo 'LUT_3D_SIZE 2'
+  for _b in 0 1; do
+    for _g in 0 1; do
+      for r in 0.0 1.0; do echo "$r 0.0 0.0"; done
+    done
+  done
+} > "$RED_CUBE"
+
+"$FROMCUBE" "$RED_CUBE" "$OUTDIR/red-only.icc" > "$OUTDIR/fromcube-red.log" 2>&1 \
+  || { sed -n '1,20p' "$OUTDIR/fromcube-red.log"; fail "iccFromCube rejected the red-only cube"; }
+check_apply "red-only" "$OUTDIR/red-only.icc" "$PROBE" "red-only"
+
+# ---------------------------------------------------------------------------
+# 3. Long lines must not be re-parsed as a following line.
+# ---------------------------------------------------------------------------
+LONG_CUBE="$OUTDIR/long-comment.cube"
+LONG_COMMENT="$(awk 'BEGIN { s = ""; while (length(s) < 300) s = s "x"; print s }')"
+{
+  echo 'TITLE "issue-1843 long line"'
+  echo "# $LONG_COMMENT"
+  echo 'LUT_3D_SIZE 2'
+  for _i in 1 2 3 4 5 6 7 8; do echo "0.0 0.0 0.0"; done
+} > "$LONG_CUBE"
+
+if ! "$FROMCUBE" "$LONG_CUBE" "$OUTDIR/long-comment.icc" > "$OUTDIR/fromcube-long.log" 2>&1; then
+  sed -n '1,20p' "$OUTDIR/fromcube-long.log"
+  fail "a 300-character comment line made a legal .cube fail to parse (#1843)"
+fi
+if grep -q "Unknown keyword" "$OUTDIR/fromcube-long.log"; then
+  sed -n '1,20p' "$OUTDIR/fromcube-long.log"
+  fail "the tail of a long comment line was parsed as a keyword (#1843)"
+fi
+[ -s "$OUTDIR/long-comment.icc" ] || fail "no profile written for the long-comment cube"
+echo "    long-comment: 300-character comment line accepted"
+
+echo "  [PASS] issue-1843-fromcube-clut-order -- CLUT axes preserved and long lines parse"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2916,6 +2916,14 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-fromcube-cli-args-regression.sh"
 )
 
+iccdev_add_script_test(
+  iccdev.issue-1843-fromcube-clut-order
+  60
+  "iccdev;tools;fromcube;clut;issue-1843;asan;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1843-fromcube-clut-order-regression.sh"
+)
+
 if(TARGET iccApplyNamedCmm AND TARGET iccDumpProfile)
   iccdev_add_script_test(
     iccdev.calculator-regressions

--- a/Tools/CmdLine/IccFromCube/iccFromCube.cpp
+++ b/Tools/CmdLine/IccFromCube/iccFromCube.cpp
@@ -266,6 +266,8 @@ public:
     if ((uint64_t)nSizeLut != temp*3)
       return false;
 
+    const icUInt32Number nGrid = (icUInt32Number)m_sizeLut3D;
+
     icUInt32Number n = 0;
     for (; n < num && !isEOF();) {
       std::string line = getNextLine();
@@ -274,15 +276,32 @@ public:
       if (line.empty() || line[0] == '#')
         continue;
       const char* cursor = line.c_str();
-      if (!parseNextFloat(cursor, *toLut++)) {
+
+      // A .cube table and an ICC CLUT disagree about which input axis varies
+      // fastest, so the rows cannot be copied across in file order.  A .cube
+      // table runs the red index fastest and blue slowest, while CIccCLUT::Init()
+      // lays the grid out the other way round: m_DimSize[] shrinks as the channel
+      // index rises, so input channel 0 (red) carries the largest stride and
+      // varies slowest.  Streaming row n into entry n therefore transposes the
+      // first and last input axes, which is why an identity .cube used to swap
+      // red and blue -- source (1,0,0) came back as (0,0,1) (#1843).  Recover the
+      // row's (r,g,b) grid coordinate from its ordinal and write the triplet at
+      // the matching ICC offset instead.  num is bounded by 255^3 above, so the
+      // offset cannot overflow icUInt32Number.
+      const icUInt32Number r = n % nGrid;
+      const icUInt32Number g = (n / nGrid) % nGrid;
+      const icUInt32Number b = n / (nGrid * nGrid);
+      icFloatNumber* pEntry = toLut + 3 * ((r * nGrid + g) * nGrid + b);
+
+      if (!parseNextFloat(cursor, pEntry[0])) {
         printf("Invalid 3DLUT entry\n");
         return false;
       }
-      if (!parseNextFloat(cursor, *toLut++)) {
+      if (!parseNextFloat(cursor, pEntry[1])) {
         printf("Invalid 3DLUT entry\n");
         return false;
       }
-      if (!parseNextFloat(cursor, *toLut++)) {
+      if (!parseNextFloat(cursor, pEntry[2])) {
         printf("Invalid 3DLUT entry\n");
         return false;
       }
@@ -420,21 +439,33 @@ protected:
 
   bool isEOF() { return m_f ? feof(m_f)!=0 : true; }
 
-#define MAX_LINE_LEN 255
+// Longest line iccFromCube keeps the text of.  The .cube format sets no line
+// length limit, but reading a line unbounded would let one pathological line
+// drive an unbounded allocation, so a cap stays -- sized so that real titles,
+// comment blocks and table rows all fit well inside it rather than sitting just
+// above the longest row seen in practice.
+#define MAX_LINE_LEN 8192u
 
   std::string getNextLine()
   {
     std::string rv;
-    for (int n=0; n<MAX_LINE_LEN && !isEOF(); n++) {
-      int c = fgetc(m_f);
+    int c;
 
-      if (c == EOF || c == '\n')
-        break;
-
+    // Consume to the end of the physical line, not merely to MAX_LINE_LEN.  The
+    // previous loop stopped once it had taken MAX_LINE_LEN characters *without*
+    // consuming the rest of the line, so the tail came back as the following
+    // call's "line" and was then parsed as a keyword or a table row in its own
+    // right.  A 300-character comment was enough to make a legal .cube fail with
+    // "Unknown keyword 'xxx...'" (#1843).  Characters past the cap are dropped
+    // from the returned text instead of being re-read: that leaves an over-long
+    // table row short of its three floats, so it is rejected explicitly by
+    // parse3DTable() rather than silently misread as a different row.
+    while ((c = fgetc(m_f)) != EOF && c != '\n') {
       if (c == '\r') //skip unsupported carriage returns
         continue;
 
-      rv += static_cast<char>(static_cast<unsigned char>(c));
+      if (rv.size() < MAX_LINE_LEN)
+        rv += static_cast<char>(static_cast<unsigned char>(c));
     }
 
     return rv;


### PR DESCRIPTION
Fixes the `.cube` CLUT ordering finding in #1843, plus a parser defect found while
reproducing it.

## 1. `.cube` rows were written into the CLUT with two input axes transposed

`iccFromCube` produced device links that swapped red and blue. An identity `.cube`
converted to a profile that mapped source `(1,0,0)` to `(0,0,1)`, and any
non-symmetric cube was wrong the same way. Every profile the tool has produced from
a non-symmetric `.cube` is affected.

The two formats disagree about which input axis varies fastest:

- a `.cube` table runs the **red** index fastest and blue slowest;
- an ICC CLUT is laid out the other way round. `CIccCLUT::Init()` assigns
  `m_DimSize[nInput-1] = m_nOutput` and then grows the stride as the channel index
  falls (`IccProfLib/IccTagLut.cpp:1951-1958`), so input channel 0 carries the
  largest stride and varies **slowest**.

`parse3DTable()` streamed rows straight into `pCLUT->GetData(0)`, so row *n* landed
at entry *n* and the first and last input axes were transposed. Each row's `(r,g,b)`
grid coordinate is now recovered from its ordinal and the triplet written at the
matching ICC offset. The row count is already capped at 255^3 upstream, so the
computed offset cannot overflow `icUInt32Number`.

The `.cube` convention is pinned by this repo's own fixture rather than by reading
the format spec: `.github/ci/test-data/test-identity.cube` is an identity **only**
when red varies fastest — interpreted the other way it would be a red/blue swapper.
There is no `.cube` writer in the tree, so no inverse path relied on the previous
ordering, and the per-channel `DOMAIN_MIN`/`DOMAIN_MAX` curves are unaffected
(curve *i* maps input channel *i* both before and after).

### Before / after

Applying a profile built from `test-identity.cube`:

| source | before | after |
|---|---|---|
| `1.00 0.00 0.00` | `0.00 0.00 1.00` | `1.00 0.00 0.00` |
| `0.25 0.50 0.75` | `0.75 0.50 0.25` | `0.25 0.50 0.75` |

## 2. Long lines made legal `.cube` files fail to parse

`getNextLine()` stopped after `MAX_LINE_LEN` characters **without consuming the rest
of the physical line**, so the tail was returned as the following call's "line" and
parsed as a keyword in its own right. A 300-character comment — legal, the format
sets no line length limit — was enough to reject the file:

```
$ iccFromCube long-comment.cube out.icc
Unknown keyword 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
Unable to parse 'long-comment.cube'
```

The reader now runs through to end-of-line and caps only the text it retains. An
over-long table row therefore arrives short of its three floats and is rejected
explicitly by `parse3DTable()` rather than being silently misread as a different
row. A 400-character `TITLE` now survives intact instead of being truncated at ~247
characters and taking the file down with it.

## Test

`iccdev.issue-1843-fromcube-clut-order` converts a 3x3x3 identity cube and the
tracked `test-identity.cube`, probes **all 27 grid nodes**, and asserts the
transform is a no-op. An asymmetric red-only cube pins which axis is which — an
identity alone cannot distinguish a correct grid from one transposed twice. The test
also converts a cube carrying a 300-character comment.

Red-tested against the unfixed source: the identity probe reports **18 of 27 rows
wrong** and the long-comment cube fails to parse.

## Pre-flight

- GCC 15 strict Release LTO, `-Wall -Wextra -Wpedantic -Werror`, full tree: 0 warnings, 0 errors
- clang-18, same flags: 0 warnings
- ASAN+UBSAN Debug with `ICCDEV_ENABLE_QA_FLAGS=ON -DICCDEV_ENABLE_STRICT_WARNINGS=ON`, full tree plus `build-test-binaries`: 0 warnings
- regression re-run under ASAN with `detect_leaks=1` forced on (the CTest default is `detect_leaks=0`): pass
- `shellcheck` on the new script at default severity: clean
- `ctest -R fromcube`: 5/5 in both the Debug and sanitizer builds
- `iccdev.tool-coverage`, which also consumes a `.cube`, passes

## Scope note

This PR deliberately does **not** touch the `profileSequenceDescTag` technology item
from #1843. That one does not reproduce as described: `iccFromCube`'s output
validates cleanly — `iccdev.issue-1379-fromcube-conformance` already asserts exactly
that and is green — and `(icTechnologySignature)0` **is** `icSigUndefined`
(`icProfileHeader.h:505`). The `NonCompliant` only appears **after** an XML or JSON
round trip, because `icGetSigStr()` returns the literal text `"NULL"` for a zero
signature and the inverse `icGetSigVal("NULL")` packs it back as `0x4E554C4C`. That
is a serializer defect in `IccXML`/`IccJSON`, and a surviving sibling of the same
fix commit 751a0c6b (#1365) applied to the header fields. It needs its own PR; I
will write up the details on the issue.
