### PR TITLE
fix(#1843): stop the XML and JSON writers encoding a zero signature as "NULL"

### DIFF
--- a/.github/scripts/iccdev-issue-1843-zero-signature-roundtrip-regression.sh
+++ b/.github/scripts/iccdev-issue-1843-zero-signature-roundtrip-regression.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+###############################################################################
+# Zero-signature XML/JSON round-trip regression (issue #1843)
+###############################################################################
+#
+# icGetSigStr() renders a zero signature as the literal text "NULL".  That is a
+# *display* convention -- it is what iccDumpProfile prints for an absent
+# signature -- but several XML and JSON writers used it as a *serialisation*
+# primitive.  The inverse, icGetSigVal("NULL"), packs the ASCII bytes
+# 'N','U','L','L' into 0x4E554C4C, so a legitimately zero signature does not
+# survive a round trip through either text format.
+#
+# Two ways that bites:
+#
+#   1. profileSequenceDescType.  A technology of zero is the named value
+#      icSigUndefined, and iccFromCube emits exactly that.  The reparsed profile
+#      picked up a 0x4E554C4C technology and failed validation with
+#      "NonCompliant! - profileSequenceDescTag: - Unknown 'NULL' = 4E554C4C",
+#      which is what made #1843 read as an iccFromCube defect.  iccFromCube's
+#      own output is clean; the corruption is introduced by the serializer.
+#
+#   2. signatureType tags and BAcs/EAcs elements.  Here the damage is silent:
+#      0x4E554C4C is merely an *unrecognised* signature, not a malformed one, so
+#      the validator still reports the round-tripped profile as valid while four
+#      payload bytes have changed underneath it.
+#
+# Commit 751a0c6b (PR #1365) fixed this same defect class for the profile header
+# fields by writing an empty element for zero.  This test covers the writers that
+# were missed.  Readers on both sides already map empty text back to zero, so the
+# fix is writer-only and the assertions below are all "what comes back out".
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit codes: 0 pass or clean skip; 1 regression.
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1843-zero-signature-roundtrip}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+
+find_tool() {
+  find "$TOOLS_DIR" -maxdepth 2 -name "$1" -type f 2>/dev/null | head -1
+}
+
+FROMCUBE="$(find_tool iccFromCube)"
+TOXML="$(find_tool iccToXml)"
+FROMXML="$(find_tool iccFromXml)"
+TOJSON="$(find_tool iccToJson)"
+FROMJSON="$(find_tool iccFromJson)"
+DUMP="$(find_tool iccDumpProfile)"
+
+fail() {
+  echo "  [FAIL] issue-1843-zero-signature-roundtrip -- $1"
+  exit 1
+}
+
+echo "=== Zero-signature XML/JSON round-trip regression (issue #1843) ==="
+
+for tool in "$FROMCUBE" "$TOXML" "$FROMXML" "$TOJSON" "$FROMJSON" "$DUMP"; do
+  if [ -z "$tool" ] || [ ! -x "$tool" ]; then
+    echo "  [SKIP] XML/JSON round-trip tools not all built under $TOOLS_DIR"
+    exit 0
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# run <label> <tool> <args...> -- run a tool, showing its log if it fails.
+# ---------------------------------------------------------------------------
+run() {
+  local label="$1"; shift
+  local log="$OUTDIR/$label.log"
+
+  if ! "$@" > "$log" 2>&1; then
+    sed -n '1,20p' "$log"
+    fail "$label failed"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# The corruption always shows up as the four characters NULL where an empty
+# value belongs, so each assertion is "this field did not come back as NULL".
+# grep -F keeps the pattern literal -- the JSON forms contain quotes and colons.
+# ---------------------------------------------------------------------------
+assert_absent() {
+  local file="$1" pattern="$2" what="$3"
+  if grep -qF "$pattern" "$file"; then
+    grep -nF "$pattern" "$file" | sed -n '1,4p' | sed 's/^/    /'
+    fail "$what round-tripped through the \"NULL\" text encoding (#1843)"
+  fi
+}
+
+assert_present() {
+  local file="$1" pattern="$2" what="$3"
+  grep -qF "$pattern" "$file" || fail "$what was not written as an empty value (#1843)"
+}
+
+# ===========================================================================
+# 1. profileSequenceDescType -- the failure reported in #1843.
+#
+# iccFromCube records no manufacturer, model or technology, so all three
+# signatures in the profileSequenceDesc struct are zero.  Both text formats must
+# preserve that, and the reparsed profile must still validate.
+# ===========================================================================
+CUBE="$REPO_ROOT/.github/ci/test-data/test-identity.cube"
+[ -f "$CUBE" ] || fail "missing fixture $CUBE"
+
+run fromcube "$FROMCUBE" "$CUBE" "$OUTDIR/pseq.icc"
+
+run pseq-toxml "$TOXML" "$OUTDIR/pseq.icc" "$OUTDIR/pseq.xml"
+assert_absent  "$OUTDIR/pseq.xml" "<Technology>NULL</Technology>" "profileSequenceDesc Technology"
+assert_absent  "$OUTDIR/pseq.xml" "<DeviceManufacturerSignature>NULL<" "profileSequenceDesc DeviceManufacturerSignature"
+assert_absent  "$OUTDIR/pseq.xml" "<DeviceModelSignature>NULL<" "profileSequenceDesc DeviceModelSignature"
+assert_present "$OUTDIR/pseq.xml" "<Technology></Technology>" "profileSequenceDesc Technology"
+
+run pseq-tojson "$TOJSON" "$OUTDIR/pseq.icc" "$OUTDIR/pseq.json"
+assert_absent  "$OUTDIR/pseq.json" '"technology": "NULL"' "profileSequenceDesc technology"
+assert_absent  "$OUTDIR/pseq.json" '"deviceManufacturerSignature": "NULL"' "profileSequenceDesc deviceManufacturerSignature"
+assert_absent  "$OUTDIR/pseq.json" '"deviceModelSignature": "NULL"' "profileSequenceDesc deviceModelSignature"
+assert_present "$OUTDIR/pseq.json" '"technology": ""' "profileSequenceDesc technology"
+
+# The profile that comes back must validate.  Before the fix this reported
+# "NonCompliant! - profileSequenceDescTag: - Unknown 'NULL' = 4E554C4C".
+for fmt in xml json; do
+  case "$fmt" in
+    xml)  run "pseq-fromxml"  "$FROMXML"  "$OUTDIR/pseq.xml"  "$OUTDIR/pseq-rt-xml.icc" ;;
+    json) run "pseq-fromjson" "$FROMJSON" "$OUTDIR/pseq.json" "$OUTDIR/pseq-rt-json.icc" ;;
+  esac
+
+  "$DUMP" -v "$OUTDIR/pseq-rt-$fmt.icc" > "$OUTDIR/pseq-validate-$fmt.log" 2>&1
+  if grep -q "4E554C4C" "$OUTDIR/pseq-validate-$fmt.log"; then
+    grep -n "4E554C4C" "$OUTDIR/pseq-validate-$fmt.log" | sed -n '1,4p' | sed 's/^/    /'
+    fail "the $fmt round trip left a 0x4E554C4C technology in profileSequenceDescTag (#1843)"
+  fi
+  grep -q "NonCompliant" "$OUTDIR/pseq-validate-$fmt.log" \
+    && fail "the $fmt round trip made a valid profile non-compliant (#1843)"
+done
+
+# A clean validation report is necessary but not sufficient -- 0x4E554C4C was
+# only ever flagged because the *technology* enumeration is checked by name, and
+# a wrong value in a field with no such check would pass silently.  The XML round
+# trip reproduces the profile byte for byte, so assert that directly.
+if ! cmp -s "$OUTDIR/pseq.icc" "$OUTDIR/pseq-rt-xml.icc"; then
+  cmp -l "$OUTDIR/pseq.icc" "$OUTDIR/pseq-rt-xml.icc" 2>/dev/null | sed -n '1,6p' | sed 's/^/    /'
+  fail "an ICC -> XML -> ICC round trip changed the bytes of a zero-signature profileSequenceDesc (#1843)"
+fi
+echo "    profileSequenceDesc: zero signatures survive both round trips, XML byte-exact"
+
+# ===========================================================================
+# 2. signatureType tags -- the silent case.
+#
+# Zeroing the imst signature of a tracked fixture gives a profile whose
+# signatureType payload is legitimately 0.  The round trip must be byte-exact:
+# before the fix exactly four bytes changed from 00 00 00 00 to 'N','U','L','L'
+# and the validator still called the result valid, so a byte comparison is the
+# only assertion that catches it.
+# ===========================================================================
+SRC_XML="$REPO_ROOT/Testing/Encoding/ISO22028-Encoded-sRGB.xml"
+if [ -f "$SRC_XML" ]; then
+  sed 's|<Signature>dorc</Signature>|<Signature></Signature>|' "$SRC_XML" > "$OUTDIR/sig-zero-in.xml"
+  assert_present "$OUTDIR/sig-zero-in.xml" "<Signature></Signature>" "the zeroed input signature"
+
+  run sig-build "$FROMXML" "$OUTDIR/sig-zero-in.xml" "$OUTDIR/sig-zero.icc"
+
+  run sig-toxml "$TOXML" "$OUTDIR/sig-zero.icc" "$OUTDIR/sig-zero.xml"
+  assert_absent  "$OUTDIR/sig-zero.xml" "<Signature>NULL</Signature>" "signatureType Signature"
+  assert_present "$OUTDIR/sig-zero.xml" "<Signature></Signature>" "signatureType Signature"
+
+  run sig-tojson "$TOJSON" "$OUTDIR/sig-zero.icc" "$OUTDIR/sig-zero.json"
+  assert_absent  "$OUTDIR/sig-zero.json" '"signature": "NULL"' "signatureType signature"
+
+  # Assert on the bytes that come back, not just on the text that went out.
+  # Checking only the serialized text is too weak here: it passes as soon as the
+  # writer stops emitting "NULL", even if the reader then restores some *other*
+  # wrong value.  That is a live hazard on the JSON side, where the
+  # CIccTagSignature constructor seeds m_nSig with 0x3F3F3F3F ("????") -- a
+  # reader that treats an empty string as "field absent" leaves that sentinel in
+  # place and corrupts the tag just as thoroughly as "NULL" did.
+  run sig-fromxml  "$FROMXML"  "$OUTDIR/sig-zero.xml"  "$OUTDIR/sig-zero-rt-xml.icc"
+  run sig-fromjson "$FROMJSON" "$OUTDIR/sig-zero.json" "$OUTDIR/sig-zero-rt-json.icc"
+  for fmt in xml json; do
+    if ! cmp -s "$OUTDIR/sig-zero.icc" "$OUTDIR/sig-zero-rt-$fmt.icc"; then
+      cmp -l "$OUTDIR/sig-zero.icc" "$OUTDIR/sig-zero-rt-$fmt.icc" 2>/dev/null | sed -n '1,6p' | sed 's/^/    /'
+      fail "an ICC -> ${fmt} -> ICC round trip changed the bytes of a zero signatureType (#1843)"
+    fi
+  done
+  echo "    signatureType: zero signature is byte-exact across both round trips"
+else
+  echo "    [note] $SRC_XML absent -- signatureType section skipped"
+fi
+
+# ===========================================================================
+# 3. BAcs / EAcs elements.
+#
+# Zero is a named, legal acs signature -- IccProfLib calls it icSigAcsZero -- so
+# an element carrying it must not acquire one on the way through either format.
+# The element is grafted onto a tracked MPE fixture because the corpus has no
+# profile with an acs bookend of its own.
+# ===========================================================================
+MPE_XML="$REPO_ROOT/Testing/Display/sRGB_D65_MAT-300lx.xml"
+if [ -f "$MPE_XML" ]; then
+  awk '{
+    print
+    if (!done && $0 ~ /<MultiProcessElements InputChannels="3" OutputChannels="3">/) {
+      print "        <BAcsElement InputChannels=\"3\" OutputChannels=\"3\" Signature=\"\"/>"
+      done = 1
+    }
+  }' "$MPE_XML" > "$OUTDIR/acs-in.xml"
+  assert_present "$OUTDIR/acs-in.xml" "<BAcsElement" "the grafted BAcsElement"
+
+  run acs-build "$FROMXML" "$OUTDIR/acs-in.xml" "$OUTDIR/acs.icc"
+
+  run acs-toxml "$TOXML" "$OUTDIR/acs.icc" "$OUTDIR/acs.xml"
+  assert_absent  "$OUTDIR/acs.xml" 'Signature="NULL"' "BAcsElement Signature"
+  assert_present "$OUTDIR/acs.xml" 'Signature=""' "BAcsElement Signature"
+
+  run acs-tojson "$TOJSON" "$OUTDIR/acs.icc" "$OUTDIR/acs.json"
+  assert_absent "$OUTDIR/acs.json" '"signature": "NULL"' "BAcsElement signature"
+
+  # As above, assert on the bytes that come back rather than only on the text
+  # that went out.  Only the XML round trip is checked this way: the JSON parser
+  # for acs elements does not restore the element's input/output channel counts,
+  # so an ICC -> JSON -> ICC profile is not byte-identical for reasons that have
+  # nothing to do with the signature.  That is a separate defect; asserting
+  # byte-equality here would tie this test to it.
+  run acs-fromxml "$FROMXML" "$OUTDIR/acs.xml" "$OUTDIR/acs-rt.icc"
+  if ! cmp -s "$OUTDIR/acs.icc" "$OUTDIR/acs-rt.icc"; then
+    cmp -l "$OUTDIR/acs.icc" "$OUTDIR/acs-rt.icc" 2>/dev/null | sed -n '1,6p' | sed 's/^/    /'
+    fail "an ICC -> XML -> ICC round trip changed the bytes of an icSigAcsZero element (#1843)"
+  fi
+  echo "    BAcsElement: icSigAcsZero survives both writers, XML byte-exact"
+else
+  echo "    [note] $MPE_XML absent -- BAcs section skipped"
+fi
+
+echo "  [PASS] issue-1843-zero-signature-roundtrip -- zero signatures are not written as \"NULL\""
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3230,6 +3230,27 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1361-header-sig-roundtrip-regression.sh"
 )
 
+# #1843: carries #1356/#1361 past the profile header into the tag and element
+# writers that had the same unguarded icGetSig*(0) -> "NULL" -> 0x4E554C4C hole
+# on BOTH the XML and JSON sides -- profileSequenceDescType's manufacturer/model/
+# technology, signatureType tags, and BAcs/EAcs elements.  The pseq case is what
+# made #1843 look like an iccFromCube defect: iccFromCube leaves the technology
+# as icSigUndefined, so every profile it wrote came back NonCompliant with
+# "Unknown 'NULL' = 4E554C4C".  The signatureType case is silent -- four payload
+# bytes change and the profile still validates -- so that section asserts a
+# byte-exact round trip rather than a clean validation report.  Note the two
+# earlier tests only had to cover XML: for those header fields JSON already
+# guarded the zero case, which is exactly the asymmetry the companion CodeQL
+# query keys off.  Here neither serializer guarded, so both are exercised.
+# Plain functional test -- skips cleanly if the tools/fixtures are absent.
+iccdev_add_script_test(
+  iccdev.issue-1843-zero-signature-roundtrip
+  90
+  "iccdev;xml;json;signature;roundtrip;issue-1843;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1843-zero-signature-roundtrip-regression.sh"
+)
+
 # #1355 - matrix/TRC (PCSXYZ) profiles must round-trip near-exactly. Guards the
 # two CMM/eval fixes (ConnectFirst actual->internal XYZ rescale; native-PCS
 # round-trip connection): iccRoundTrip RT1 mean dE was ~20 before, ~0 after.

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1161,8 +1161,16 @@ bool CIccMpeJsonExtCLUT::ParseJson(const IccJson &j, std::string &parseStr)
 
 bool CIccMpeJsonBAcs::ToJson(IccJson &j)
 {
-  char buf[32]; icGetSigStr(buf, sizeof(buf), m_signature);
-  j["signature"] = buf;
+  // Zero is a legal BAcs signature -- IccProfLib names it icSigAcsZero -- but
+  // icGetSigStr(0) renders it as the literal text "NULL", and ParseJson() below
+  // inverts the text with icGetSigVal(), which packs "NULL" into 0x4E554C4C.
+  // Emit an empty string for zero instead; ParseJson() already skips an empty
+  // signature and leaves m_signature at its zero-initialised value (#1843).
+  // The helper call sits inside the conditional rather than above it so this
+  // matches the `field ? helper(...) : ""` idiom that the project's own CodeQL
+  // query signature-serialized-without-zero-guard.ql recognises as a guard.
+  char buf[32];
+  j["signature"] = m_signature ? std::string(icGetSigStr(buf, sizeof(buf), m_signature)) : std::string();
   j["data"] = icJsonDumpHexData(m_pData, m_nDataSize);
   return true;
 }
@@ -1186,8 +1194,10 @@ bool CIccMpeJsonBAcs::ParseJson(const IccJson &j, std::string & /*parseStr*/)
 
 bool CIccMpeJsonEAcs::ToJson(IccJson &j)
 {
-  char buf[32]; icGetSigStr(buf, sizeof(buf), m_signature);
-  j["signature"] = buf;
+  // Guard the zero case exactly as in CIccMpeJsonBAcs::ToJson above -- icSigAcsZero
+  // must not be written as the text "NULL", which reparses to 0x4E554C4C.
+  char buf[32];
+  j["signature"] = m_signature ? std::string(icGetSigStr(buf, sizeof(buf), m_signature)) : std::string();
   j["data"] = icJsonDumpHexData(m_pData, m_nDataSize);
   return true;
 }

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -406,15 +406,31 @@ bool CIccTagJsonTextDescription::ParseJson(const IccJson &j, std::string & /*par
 
 bool CIccTagJsonSignature::ToJson(IccJson &j)
 {
-  j["signature"] = sigToStr(m_nSig);
+  // Zero is a legal signatureType payload (icSigUndefined), but sigToStr() wraps
+  // icGetSigStr(), which renders zero as the literal text "NULL".  ParseJson()
+  // below inverts the text with icGetSigVal(), and icGetSigVal("NULL") packs the
+  // ASCII bytes into 0x4E554C4C -- so a zero signature does not survive an
+  // ICC -> JSON -> ICC round trip, and the result still validates because
+  // 0x4E554C4C is only an unrecognised signature, not a malformed one (#1843).
+  // Emit an empty string for zero; ParseJson() below maps that back to 0.
+  j["signature"] = m_nSig ? sigToStr(m_nSig) : std::string();
   return true;
 }
 
 bool CIccTagJsonSignature::ParseJson(const IccJson &j, std::string & /*parseStr*/)
 {
   std::string sig;
-  jGetString(j, "signature", sig);
-  if (!sig.empty())
+
+  // Distinguish "no signature field at all" from "a field holding the empty
+  // string".  Only the latter means a zero signature, and it is what ToJson()
+  // above now writes for one.  Testing the *string* for emptiness instead of the
+  // field's presence would leave m_nSig at the CIccTagSignature constructor's
+  // 0x3F3F3F3F ("????") sentinel, which is no more correct than the 0x4E554C4C
+  // this fix set out to remove -- it would merely change which wrong value a
+  // zero signature came back as (#1843).  icGetSigVal("") returns 0, so passing
+  // the empty string straight through restores the original value, while an
+  // absent field still leaves the constructor's sentinel untouched.
+  if (jGetString(j, "signature", sig))
     m_nSig = (icSignature)icGetSigVal(sig.c_str());
   return true;
 }
@@ -1456,10 +1472,19 @@ static bool icProfDescToJson(IccJson &jDesc, const CIccProfileDescStruct &p)
   const size_t bufSize = 16;
   char buf[bufSize];
 
-  jDesc["deviceManufacturerSignature"] = icGetSigStr(buf, bufSize, p.m_deviceMfg);
-  jDesc["deviceModelSignature"]        = icGetSigStr(buf, bufSize, p.m_deviceModel);
+  // All three signatures below are legitimately zero for a profile whose origin is
+  // unrecorded -- a technology of zero is the named value icSigUndefined, and
+  // iccFromCube emits exactly that.  icGetSigStr(0) returns the literal text
+  // "NULL" as a *display* convention, but icJsonParseProfDesc() inverts the text
+  // with icGetSigVal(), which packs "NULL" into 0x4E554C4C, so writing it here
+  // rewrites the value on round trip and the reparsed profile fails validation
+  // with an unknown technology (#1843).  Emit an empty string for zero: the parser
+  // below already special-cases the empty string and restores 0.  This mirrors the
+  // guard commit 751a0c6b (PR #1365) added to the header signatures.
+  jDesc["deviceManufacturerSignature"] = p.m_deviceMfg   ? std::string(icGetSigStr(buf, bufSize, p.m_deviceMfg))   : std::string();
+  jDesc["deviceModelSignature"]        = p.m_deviceModel ? std::string(icGetSigStr(buf, bufSize, p.m_deviceModel)) : std::string();
   jDesc["deviceAttributes"]            = icJsonGetDeviceAttr(p.m_attributes);
-  jDesc["technology"]                  = icGetSigStr(buf, bufSize, p.m_technology);
+  jDesc["technology"]                  = p.m_technology  ? std::string(icGetSigStr(buf, bufSize, p.m_technology))  : std::string();
 
   auto serializeDescText = [](IccJson &jField, const CIccProfileDescText &descText) -> bool {
     CIccTag *pTag = descText.GetTag();

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2133,8 +2133,16 @@ bool CIccMpeXmlBAcs::ToXml(std::string &xml, std::string blanks/* = ""*/)
   char buf[bufSize/2];
   std::string fix;
 
+  // The BAcs signature is legitimately zero -- IccProfLib names that value
+  // icSigAcsZero.  icGetSigStr(0) renders zero as the literal text "NULL", which
+  // is a display convention; ParseXml() below inverts the attribute through
+  // icXmlStrToSig() -> icGetSigVal(), and icGetSigVal("NULL") packs the ASCII
+  // bytes into 0x4E554C4C.  Writing "NULL" would therefore turn an icSigAcsZero
+  // element into a bogus one on round trip (#1843).  Emit an empty attribute for
+  // zero: icXmlAttrValue() hands the empty string to icGetSigVal(), which
+  // returns 0.
   snprintf(line, bufSize*2, "<BAcsElement InputChannels=\"%d\" OutputChannels=\"%d\" Signature=\"%s\"", NumInputChannels(), NumOutputChannels(),
-                icFixXml(fix, icGetSigStr(buf, bufSize/2, m_signature)));
+                m_signature ? icFixXml(fix, icGetSigStr(buf, bufSize/2, m_signature)) : "");
   xml += blanks + line;
 
   if (m_nReserved) {
@@ -2189,8 +2197,10 @@ bool CIccMpeXmlEAcs::ToXml(std::string &xml, std::string blanks/* = ""*/)
   char buf[bufSize/2];
   std::string fix;
 
+  // Guard the zero case exactly as in CIccMpeXmlBAcs::ToXml above -- icSigAcsZero
+  // must not be written as the text "NULL", which reparses to 0x4E554C4C.
   snprintf(line, bufSize*2, "<EAcsElement InputChannels=\"%d\" OutputChannels=\"%d\" Signature=\"%s\"", NumInputChannels(), NumOutputChannels(),
-    icFixXml(fix, icGetSigStr(buf, bufSize/2, m_signature)));
+    m_signature ? icFixXml(fix, icGetSigStr(buf, bufSize/2, m_signature)) : "");
   xml += blanks + line;
 
   if (m_nReserved) {

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -779,7 +779,17 @@ bool CIccTagXmlSignature::ToXml(std::string &xml, std::string blanks/* = ""*/)
   const size_t lineSize = 256;
   char line[lineSize];
 
-  snprintf(line, lineSize, "<Signature>%s</Signature>\n", icFixXml(fix, icGetSigStr(buf, 40, m_nSig)));
+  // A signatureType tag holds one four-character signature and zero is a legal
+  // value for it -- the technologyTag of a profile with no recorded technology is
+  // icSigUndefined, which is 0.  icGetSigStr(0) returns the literal text "NULL" as
+  // a display convention, but the inverse used by ParseXml() below,
+  // icGetSigVal("NULL"), packs the ASCII bytes into 0x4E554C4C.  Writing "NULL"
+  // here therefore silently rewrites the tag's four payload bytes on round trip,
+  // and because 0x4E554C4C is merely an unrecognised signature rather than a
+  // malformed one the validator still reports the profile as valid, so the
+  // corruption is invisible (#1843).  Emit an empty element for zero: ParseXml()
+  // passes empty content to icGetSigVal(), which returns 0.
+  snprintf(line, lineSize, "<Signature>%s</Signature>\n", m_nSig ? icFixXml(fix, icGetSigStr(buf, 40, m_nSig)) : "");
 
   xml += blanks + line;
   return true;
@@ -2631,10 +2641,21 @@ bool icProfDescToXml(std::string &xml, CIccProfileDescStruct &p, std::string bla
   snprintf(buf, bufSize, "<ProfileDesc>\n");
   xml += blanks + buf;
 
-  snprintf(buf, bufSize, "<DeviceManufacturerSignature>%s</DeviceManufacturerSignature>\n", icFixXml(fix, icGetSigStr(data, bufSize, p.m_deviceMfg)));
+  // Each profileSequenceDescType entry carries three four-character signatures,
+  // and all three are legitimately zero for a profile whose origin is unrecorded
+  // -- a technology of zero is the named value icSigUndefined.  icGetSigStr(0)
+  // returns the literal text "NULL", which is a *display* convention: the inverse
+  // icGetSigVal("NULL") packs the ASCII bytes 'N','U','L','L' into 0x4E554C4C, so
+  // a zero written here comes back as a bogus signature and the reparsed profile
+  // fails validation ("Unknown technology") even though the original was clean
+  // (#1843).  Emit an empty element for zero instead -- the reader below runs the
+  // content through icXmlStrToSig(), and icGetSigVal("") returns 0, restoring the
+  // original value.  Commit 751a0c6b (PR #1365) applied this same guard to the
+  // header signatures; the profileSequenceDesc struct was missed.
+  snprintf(buf, bufSize, "<DeviceManufacturerSignature>%s</DeviceManufacturerSignature>\n", p.m_deviceMfg ? icFixXml(fix, icGetSigStr(data, bufSize, p.m_deviceMfg)) : "");
   xml += blanks + blanks + buf;
 
-  snprintf(buf, bufSize, "<DeviceModelSignature>%s</DeviceModelSignature>\n", icFixXml(fix, icGetSigStr(data, bufSize, p.m_deviceModel)));
+  snprintf(buf, bufSize, "<DeviceModelSignature>%s</DeviceModelSignature>\n", p.m_deviceModel ? icFixXml(fix, icGetSigStr(data, bufSize, p.m_deviceModel)) : "");
   xml += blanks + blanks + buf;
 
   std::string szAttributes = icGetDeviceAttrName(p.m_attributes);
@@ -2642,7 +2663,10 @@ bool icProfDescToXml(std::string &xml, CIccProfileDescStruct &p, std::string bla
   //xml += buf;
   xml += blanks + blanks + icGetDeviceAttrName(p.m_attributes);
 
-  snprintf(buf, bufSize, "<Technology>%s</Technology>\n", icFixXml(fix, icGetSigStr(data, bufSize, p.m_technology)));
+  // Guard the zero case as above.  This is the field the round trip actually trips
+  // over in practice: iccFromCube leaves the technology as icSigUndefined, so every
+  // profile it writes used to acquire a 0x4E554C4C technology on the way back in.
+  snprintf(buf, bufSize, "<Technology>%s</Technology>\n", p.m_technology ? icFixXml(fix, icGetSigStr(data, bufSize, p.m_technology)) : "");
   xml += blanks + blanks + buf;
 
   CIccTag *pTag = p.m_deviceMfgDesc.GetTag();


### PR DESCRIPTION
Second of the fixes for #1843. Companion to #1871, which corrects `iccFromCube` itself; this one corrects the serializers. The two are independent — no shared files beyond `Build/Cmake/Testing/CMakeLists.txt`, where the hunks are ~240 lines apart and merge cleanly in either order.

## The defect

`icGetSigStr(0)` returns the literal text `NULL`. That is a **display** convention — it is what `iccDumpProfile` prints for an absent signature — but several XML and JSON writers used it as a **serialisation** primitive. The inverse cannot invert it: `icGetSigVal("NULL")` packs the ASCII bytes `'N','U','L','L'` into `0x4E554C4C`, so a legitimately zero signature does not survive a round trip through either text format.

Commit 751a0c6b (#1365) fixed this class for the profile **header** fields. Three groups of writers were missed, all carrying values that are legally zero.

### 1. `profileSequenceDescType` — this is the failure reported in #1843

A technology of zero is the named value `icSigUndefined`, and `iccFromCube` emits exactly that. Every profile it wrote came back from an XML **or** JSON round trip as:

```
NonCompliant! - profileSequenceDescTag: - Unknown 'NULL' = 4E554C4C: Unknown Technology.
```

**`iccFromCube`'s own output validates clean** — the corruption is introduced by the serializer, not by the tool. CTest `iccdev.issue-1379-fromcube-conformance` already asserts the direct output is conformant, and it has been green throughout. So the tool-side framing in the issue does not reproduce; the defect is here.

### 2. `signatureType` tags — silent

`0x4E554C4C` is an *unrecognised* signature, not a *malformed* one, so the validator still reports the round-tripped profile as **valid** while four payload bytes have changed underneath it. Measured on a fixture with a zeroed `imst`: exactly 4 bytes differed before, 0 after.

### 3. `BAcs`/`EAcs` elements

Zero is a named, legal acs signature — IccProfLib calls it `icSigAcsZero`.

## The fix

Twelve writer sites, guarded with the same `field ? helper(...) : ""` idiom #1365 used:

| | XML | JSON |
|---|---|---|
| pseq mfg / model / technology | `IccTagXml.cpp` 2634 / 2637 / 2645 | `IccTagJson.cpp` 1459 / 1460 / 1462 |
| `signatureType` tag | `IccTagXml.cpp` 782 | `IccTagJson.cpp` 409 |
| `BAcs` / `EAcs` | `IccMpeXml.cpp` 2137 / 2193 | `IccMpeJson.cpp` 1164 / 1189 |

Plus **one reader fix**, which is the part worth reviewing closely.

### `CIccTagJsonSignature::ParseJson` — why writer-only was not enough

The XML readers all map empty text back to zero, as do the JSON readers for `profileSequenceDesc` (explicit empty-string case) and for `BAcs`/`EAcs` (whose constructor seeds `m_signature` with `icSigAcsZero`). `CIccTagJsonSignature::ParseJson` was the exception: it tested the parsed **string** for emptiness rather than the field's **presence**.

`CIccTagSignature`'s constructor seeds `m_nSig = 0x3F3F3F3F` (`'????'`), **not** zero (`IccTagBasic.cpp:2811`). So guarding only the writer would have changed *which* wrong value a zero signature came back as — `0x4E554C4C` → `0x3F3F3F3F` — rather than fixing it. Verified by measurement: with the writer guard in place but this reader untouched, the ICC → JSON → ICC round trip still corrupted 4 bytes.

That reader now keys off `jGetString()`'s return value, which is false only when the field is genuinely absent. `icGetSigVal("")` returns 0, so present-but-empty restores the original value while an absent field still leaves the constructor's sentinel alone.

## Verification

New CTest `iccdev.issue-1843-zero-signature-roundtrip`, registered beside its `#1356` / `#1361` siblings.

The assertions compare **the bytes that come back**, not only the text that goes out. A text-only check passes as soon as the writer stops emitting `NULL`, even when the reader then restores a different wrong value — which is exactly how the `ParseJson` defect above hid. All three XML round trips are now byte-identical to the source profile.

Each of the three sections was verified to fail independently against `master`'s sources, and the byte assertion was verified to fail with the writer fix present but the reader fix reverted.

| Case | Before | After |
|---|---|---|
| pseq technology, XML and JSON | `NonCompliant … 'NULL' = 4E554C4C` | valid, XML byte-identical |
| `signatureType`, XML | 4 bytes `00 00 00 00` → `4E 55 4C 4C`, still "valid" | byte-identical |
| `signatureType`, JSON | 4 bytes → `4E 55 4C 4C` | byte-identical |
| `BAcs` `icSigAcsZero` | `Signature="NULL"` | `Signature=""`, XML byte-identical |

## Pre-flight

- GCC 15 strict Release LTO (`-Wall -Wextra -Wpedantic -Werror -std=c++17`) — 0 warnings, 0 errors, full tree
- clang strict, same flags — 0 warnings
- ASAN+UBSAN Debug with `ICCDEV_ENABLE_QA_FLAGS=ON` and `ICCDEV_ENABLE_STRICT_WARNINGS=ON`, full tree plus `build-test-binaries` — 0 warnings
- `shellcheck` on the new script — clean
- Regression re-run under `ASAN_OPTIONS=detect_leaks=1` (CI's default is `detect_leaks=0`) — clean
- Full `ctest` — 114/116. The two failures are not attributable to this change: `iccdev.tool-coverage` is a parallel-load flake that passes standalone (47s), and `iccdev.spectral-tiff-preview` fails on a locally missing Python `imagecodecs`, which CI installs. The `#1356` and `#1361` sibling round-trip tests both still pass.

## Notes for review

**The companion CodeQL query could not have caught any of this.** `signature-serialized-without-zero-guard.ql` fires only when the JSON serializer *already* guards a field and XML lags — that asymmetry was the `#1356` / `#1361` shape. Here **neither** side guarded, so `jsonGuardsField` was never satisfied. The JSON guards in this PR are written in the `field ? helper(...) : ""` form the query recognises, which arms it for these fields going forward. Genuinely extending the query to catch never-guarded sites is a separate change: dropping that predicate would flag every tag- and type-signature write in the tree and needs its own FP triage.

**Audited and deliberately left alone:**

- XML `privateStruct` (`IccTagXml.cpp:5020`) / `privateArray` (`:5425`). A zero-guard here would be cosmetic — that round trip is already broken for an unrelated reason: the writer emits a `StructSignature` / `ArraySignature` **attribute** on `<privateStruct>` / `<privateArray>`, while the reader (`:5371`, `:5495`) looks for a `StructureSignature` / `ArraySignature` **child element**. Separate defect; happy to file it if useful.
- `spectralDataInfo`'s spectral colour-space signature is unguarded on both paths, but unlike the fields above I could not establish that zero is a meaningful value for it, so I left it rather than guess.

**Pre-existing defect found next door, not fixed here:** `CIccMpeJsonBAcs::ParseJson` and `CIccMpeJsonEAcs::ParseJson` never restore `m_nInputChannels` / `m_nOutputChannels` — `ToJson` writes them, `ParseJson` reads only `signature` and `data`. An ICC → JSON → ICC round trip turns `InputChannels="3" OutputChannels="3"` into `0` / `0`. The XML parser reads them correctly. This is why the test byte-compares only the XML acs round trip: asserting byte-equality on the JSON one would tie this test to an unrelated bug. Also happy to file separately.

Closes nothing on its own — #1843 also needs the status-code work for its claim 1, which I will raise separately.
