### PR TITLE
fix(#1843): report an unsupported profile class distinctly from an invalid profile

### DIFF
--- a/.github/ci/regression/unsupported-profile-class-status.cpp
+++ b/.github/ci/regression/unsupported-profile-class-status.cpp
@@ -1,0 +1,219 @@
+// Regression for #1843 (claim 1): a profile whose class carries no device<->PCS
+// transform pair must be refused with icCmmStatUnsupportedProfileClass, not with
+// icCmmStatInvalidProfile.
+//
+// CIccEvalCompare::EvaluateProfile builds a device->PCS transform and its inverse and
+// compares the result; CIccPRMG::EvaluateProfile drives a Lab->device->Lab chain over
+// the PRMG boundary. Both are meaningful only for the four classes that carry that
+// transform pair -- input, display, output and colorSpace -- and both open with the
+// same four-way class test. That test used to return icCmmStatInvalidProfile, a status
+// otherwise reserved for a profile that is actually broken, which CIccCmm::GetStatusText
+// renders as "Invalid profile". iccRoundTrip therefore reported
+//
+//   Unable to perform round trip on 'RefDecC.icc': Invalid profile
+//
+// for an abstract profile that validates cleanly -- and, because the two conditions
+// shared one status code, a caller had no way to tell "this profile is damaged" from
+// "this operation does not apply to this kind of profile". Both evaluators now return
+// the distinct icCmmStatUnsupportedProfileClass.
+//
+// The test drives the CIccProfile* overloads directly rather than the file-path ones,
+// so it needs no fixture on disk: the class test runs before anything reads tag data,
+// so a default-constructed profile with only m_Header.deviceClass set reaches exactly
+// the branch under test. That also makes CIccPRMG's copy of the branch reachable at
+// all -- every in-tree caller (iccRoundTrip, wxProfileDump) runs the PRMG evaluation
+// only after the round-trip evaluation has already succeeded, so a class-refusal never
+// reaches CIccPRMG through a tool.
+//
+// The unsupported cases assert both the positive (is the new status) and the negative
+// (is no longer the old one), because the point of the change is the distinction
+// between the two, not the value of either. The supported classes are asserted only
+// NOT to be refused for their class: an empty profile has no transform to build, so
+// they legitimately fail further along with some other status, and pinning which one
+// would tie this test to unrelated CMM internals.
+//
+// Red-green: restoring either return to icCmmStatInvalidProfile fails that evaluator's
+// assertions; widening the class test to reject a device class fails the guards below.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccCmm.h"
+#include "IccEval.h"
+#include "IccPrmg.h"
+#include "IccProfile.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <cstring>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[unsupported-profile-class] FAIL: %s\n", what);
+  }
+}
+
+// CIccEvalCompare::Compare is pure virtual -- the caller supplies the comparison it
+// wants over each sampled colour (iccRoundTrip accumulates min/mean/max dE). Nothing
+// here samples anything: the class test returns before the sampling loop, and the
+// supported-class guards fail while building the transform, so the body is never
+// reached and can stay empty.
+class CIccNullEval : public CIccEvalCompare
+{
+public:
+  virtual void Compare(icFloatNumber * /*pPixel*/, icFloatNumber * /*deviceLab*/,
+                       icFloatNumber * /*destLab1*/, icFloatNumber * /*destLab2*/) {}
+};
+
+// Only the header class matters to the branch under test, so the profile is left
+// otherwise empty. Each case gets a fresh profile so no evaluator can carry state
+// from a previous one.
+void evaluateClass(icProfileClassSignature nClass, icStatusCMM &evalStat, icStatusCMM &prmgStat)
+{
+  CIccProfile profile;
+  profile.m_Header.deviceClass = nClass;
+
+  CIccNullEval eval;
+  evalStat = eval.EvaluateProfile(&profile);
+
+  CIccPRMG prmg;
+  prmgStat = prmg.EvaluateProfile(&profile);
+}
+
+// Both the wire signature and the human name, so a failure report says which class
+// tripped rather than only a hex value.
+struct ClassCase {
+  icProfileClassSignature nClass;
+  const char *szName;
+};
+
+// Every class the specification defines that is not one of the four the evaluators
+// accept. Six of the seven have fixtures in the Testing corpus ('abst', 'cenc', 'link',
+// 'mid ', 'mvis', 'nmcl'); only 'mlnk' has none, so it is covered here on the strength
+// of the specification alone. The class test treats all seven identically, so a gap in
+// the corpus is no reason to leave one of them untested.
+const ClassCase kUnsupported[] = {
+  { icSigLinkClass,                    "deviceLink" },
+  { icSigAbstractClass,                "abstract" },
+  { icSigNamedColorClass,              "namedColor" },
+  { icSigColorEncodingClass,           "colorEncoding" },
+  { icSigMultiplexIdentificationClass, "multiplexIdentification" },
+  { icSigMultiplexLinkClass,           "multiplexLink" },
+  { icSigMultiplexVisualizationClass,  "multiplexVisualization" },
+};
+
+const ClassCase kSupported[] = {
+  { icSigInputClass,      "input" },
+  { icSigDisplayClass,    "display" },
+  { icSigOutputClass,     "output" },
+  { icSigColorSpaceClass, "colorSpace" },
+};
+
+} // namespace
+
+int main()
+{
+  char szWhat[160];
+
+  // --- classes outside the evaluators' domain ---------------------------------
+
+  for (size_t i = 0; i < sizeof(kUnsupported) / sizeof(kUnsupported[0]); i++) {
+    icStatusCMM evalStat, prmgStat;
+    evaluateClass(kUnsupported[i].nClass, evalStat, prmgStat);
+
+    std::snprintf(szWhat, sizeof(szWhat), "%s class should be refused by the round-trip evaluator as an unsupported class", kUnsupported[i].szName);
+    check(evalStat == icCmmStatUnsupportedProfileClass, szWhat);
+
+    std::snprintf(szWhat, sizeof(szWhat), "%s class must no longer be reported as an invalid profile by the round-trip evaluator (#1843)", kUnsupported[i].szName);
+    check(evalStat != icCmmStatInvalidProfile, szWhat);
+
+    std::snprintf(szWhat, sizeof(szWhat), "%s class should be refused by the PRMG evaluator as an unsupported class", kUnsupported[i].szName);
+    check(prmgStat == icCmmStatUnsupportedProfileClass, szWhat);
+
+    std::snprintf(szWhat, sizeof(szWhat), "%s class must no longer be reported as an invalid profile by the PRMG evaluator (#1843)", kUnsupported[i].szName);
+    check(prmgStat != icCmmStatInvalidProfile, szWhat);
+  }
+
+  // --- the four classes the evaluators do accept ------------------------------
+  // Guards: the refusal must be about the class only. These profiles are empty, so
+  // both evaluators fail somewhere later -- just not here.
+
+  for (size_t i = 0; i < sizeof(kSupported) / sizeof(kSupported[0]); i++) {
+    icStatusCMM evalStat, prmgStat;
+    evaluateClass(kSupported[i].nClass, evalStat, prmgStat);
+
+    std::snprintf(szWhat, sizeof(szWhat), "%s class must not be refused by the round-trip evaluator as an unsupported class", kSupported[i].szName);
+    check(evalStat != icCmmStatUnsupportedProfileClass, szWhat);
+
+    std::snprintf(szWhat, sizeof(szWhat), "%s class must not be refused by the PRMG evaluator as an unsupported class", kSupported[i].szName);
+    check(prmgStat != icCmmStatUnsupportedProfileClass, szWhat);
+  }
+
+  // --- a null profile keeps its own distinct status ----------------------------
+  // The class test sits directly after the null check, so this pins that the new
+  // return did not swallow the "cannot open" case.
+
+  {
+    CIccNullEval eval;
+    check(eval.EvaluateProfile((CIccProfile *)NULL) == icCmmStatCantOpenProfile,
+          "a null profile should still report that it cannot be opened");
+
+    CIccPRMG prmg;
+    check(prmg.EvaluateProfile((CIccProfile *)NULL) == icCmmStatCantOpenProfile,
+          "a null profile should still report that it cannot be opened (PRMG)");
+  }
+
+  // --- the status decodes to text ---------------------------------------------
+  // icStatusCMM's declaration in IccCmm.h asks for GetStatusText to be kept in sync,
+  // and the note is there because it has been missed before -- icCmmStatUnsupported
+  // was added without a case and fell through to the default. That text is what
+  // iccRoundTrip prints, so an undecoded status would leave the user-visible message
+  // no better than the one this change set out to fix.
+
+  {
+    const char *szNew = CIccCmm::GetStatusText(icCmmStatUnsupportedProfileClass);
+    const char *szOld = CIccCmm::GetStatusText(icCmmStatInvalidProfile);
+
+    // The reference for "fell through to the default" is a status one past the last
+    // enumerator. It must stay inside the enum's valid value range: icStatusCMM is an
+    // unscoped enum with no fixed underlying type, so its values span only the smallest
+    // bit-field holding -1..19 (a signed 6-bit field, i.e. -32..31). Loading anything
+    // outside that is undefined behaviour, which UBSan's enum check flags at the switch
+    // in GetStatusText -- a far-out sentinel such as 0x7FFFFFFF fails the sanitizer CI
+    // jobs. If a future status does take 20 it will have its own text, so the assertion
+    // below stays meaningful either way.
+    const char *szUnknown = CIccCmm::GetStatusText((icStatusCMM)20);
+
+    check(szNew != NULL && strcmp(szNew, szUnknown) != 0,
+          "icCmmStatUnsupportedProfileClass should decode to text rather than fall through to the default");
+    check(szNew != NULL && szOld != NULL && strcmp(szNew, szOld) != 0,
+          "the unsupported-class text must differ from the invalid-profile text (#1843)");
+  }
+
+  // --- the enum stays append-only ----------------------------------------------
+  // icStatusCMM values cross the IccProfLib ABI and appear in saved QA output, so a
+  // new status has to be appended rather than inserted. Pinning the last previously
+  // defined value alongside the new one catches a renumbering that would silently
+  // change what every existing status means.
+
+  check((int)icCmmStatUnsupported == 18,
+        "icCmmStatUnsupported must keep its value -- icStatusCMM is append-only");
+  check((int)icCmmStatUnsupportedProfileClass == 19,
+        "icCmmStatUnsupportedProfileClass must be appended after icCmmStatUnsupported");
+
+  if (g_fail)
+    std::fprintf(stderr, "[unsupported-profile-class] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[unsupported-profile-class] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1060,6 +1060,49 @@ function(iccdev_add_extended_device_colorspace_test)
   endif()
 endfunction()
 
+# #1843: the round-trip and PRMG evaluators accept only the four device classes that
+# carry a device<->PCS transform pair, and used to refuse every other class with
+# icCmmStatInvalidProfile -- so iccRoundTrip called a cleanly-validating abstract or
+# namedColor profile "Invalid profile", and no caller could tell a damaged profile from
+# an inapplicable one. Both now return icCmmStatUnsupportedProfileClass. The test drives
+# the CIccProfile* overloads directly, which needs no fixture and is the only way to
+# reach CIccPRMG's copy of the class test (every tool runs it after the round-trip
+# evaluation has already succeeded). Header + IccProfLib only.
+function(iccdev_add_unsupported_profile_class_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccUnsupportedProfileClassTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/unsupported-profile-class-status.cpp"
+  )
+  target_link_libraries(iccUnsupportedProfileClassTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccUnsupportedProfileClassTest)
+
+  add_test(
+    NAME iccdev.unsupported-profile-class-status
+    COMMAND "$<TARGET_FILE:iccUnsupportedProfileClassTest>"
+  )
+  set_tests_properties(iccdev.unsupported-profile-class-status PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;cmm;status;issue-1843;regression"
+  )
+  if(WIN32)
+    set(_unsupclass_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccUnsupportedProfileClassTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _unsupclass_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.unsupported-profile-class-status PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_unsupclass_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_dpcc_pcc_replacement_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -2297,6 +2340,7 @@ if(WIN32)
   iccdev_add_xyz_negative_z_test()
   iccdev_add_utf8_textarray_test()
   iccdev_add_extended_device_colorspace_test()
+  iccdev_add_unsupported_profile_class_test()
   iccdev_add_dpcc_pcc_replacement_test()
   iccdev_add_iccviz_metrics_test()
   iccdev_add_iccviz_degenerate_test()
@@ -2514,6 +2558,7 @@ iccdev_add_gbd_zero_pcs_test()
 iccdev_add_xyz_negative_z_test()
 iccdev_add_utf8_textarray_test()
 iccdev_add_extended_device_colorspace_test()
+iccdev_add_unsupported_profile_class_test()
 iccdev_add_dpcc_pcc_replacement_test()
 iccdev_add_iccviz_metrics_test()
 iccdev_add_iccviz_degenerate_test()

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -8531,6 +8531,12 @@ const icChar* CIccCmm::GetStatusText(icStatusCMM stat)
   // messages for issues #1322/#1323 so every enum value decodes to text.
   case icCmmStatUnsupported:
     return "Unsupported operation";
+  // The evaluators refuse a profile whose class carries no device<->PCS
+  // transform pair rather than reporting it as damaged; keep the text about the
+  // *class* so the caller can tell "this profile is broken" from "this
+  // operation does not apply to this kind of profile" (#1843).
+  case icCmmStatUnsupportedProfileClass:
+    return "Unsupported profile class";
   default:
     return "Unknown CMM Status value";
 

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -104,6 +104,15 @@ typedef enum {
   icCmmStatTooManySamples     = 16,
   icCmmStatBadMCSLink         = 17,
   icCmmStatUnsupported        = 18,
+  // Reported when a profile is well formed but its class is outside the domain
+  // of the requested operation -- e.g. the round-trip and PRMG evaluators accept
+  // only the four device classes that carry a device<->PCS transform pair
+  // (input, display, output, colorSpace), so an abstract, deviceLink, namedColor
+  // or encoding profile is refused here.  Distinct from icCmmStatInvalidProfile,
+  // which means the profile itself is broken; conflating the two made
+  // iccRoundTrip report a perfectly valid profile as "Invalid profile" (#1843).
+  // Appended at the end of the enum so no existing value is renumbered.
+  icCmmStatUnsupportedProfileClass = 19,
 } icStatusCMM;
 
 /// CMM Interpolation types

--- a/IccProfLib/IccEval.cpp
+++ b/IccProfLib/IccEval.cpp
@@ -121,12 +121,18 @@ icStatusCMM CIccEvalCompare::EvaluateProfile(CIccProfile *pProfile, icUInt8Numbe
     return icCmmStatCantOpenProfile;
   }
 
+  // The round trip below builds a device->PCS transform and its inverse, so it is
+  // defined only for the four classes that carry that pair.  An abstract,
+  // deviceLink, namedColor or encoding profile is perfectly valid, it simply has
+  // nothing to round trip -- reporting icCmmStatInvalidProfile here made
+  // iccRoundTrip print "Invalid profile" for such profiles and left no way to
+  // tell that apart from a genuinely damaged one (#1843).
   if (pProfile->m_Header.deviceClass!=icSigInputClass &&
     pProfile->m_Header.deviceClass!=icSigDisplayClass &&
     pProfile->m_Header.deviceClass!=icSigOutputClass &&
     pProfile->m_Header.deviceClass!=icSigColorSpaceClass)
   {
-    return icCmmStatInvalidProfile;
+    return icCmmStatUnsupportedProfileClass;
   }
 
   // Connect the round-trip CMMs through the profile's native PCS.  Forcing the

--- a/IccProfLib/IccPrmg.cpp
+++ b/IccProfLib/IccPrmg.cpp
@@ -226,12 +226,20 @@ icStatusCMM CIccPRMG::EvaluateProfile(CIccProfile *pProfile, icRenderingIntent n
     return icCmmStatCantOpenProfile;
   }
 
+  // Same domain restriction as CIccEvalCompare::EvaluateProfile(): the gamut
+  // evaluation below drives a Lab->device->Lab chain, which only the four device
+  // classes provide.  Report the class as unsupported rather than the profile as
+  // invalid, for the reasons given there (#1843).  The in-tree callers reach this
+  // evaluation only once the round-trip one has already succeeded, so in practice
+  // only a direct library caller sees this particular return -- but the two copies
+  // of the test have to agree, or the same profile would be described one way by
+  // one entry point and another way by the other.
   if (pProfile->m_Header.deviceClass!=icSigInputClass &&
     pProfile->m_Header.deviceClass!=icSigDisplayClass &&
     pProfile->m_Header.deviceClass!=icSigOutputClass &&
     pProfile->m_Header.deviceClass!=icSigColorSpaceClass)
   {
-    return icCmmStatInvalidProfile;
+    return icCmmStatUnsupportedProfileClass;
   }
 
   m_bPrmgImplied = false;


### PR DESCRIPTION
Third of the fixes for #1843, and the one that addresses its **claim 1** — the misleading `iccRoundTrip` message. Independent of #1871 (the `iccFromCube` CLUT axis order) and #1872 (the zero-signature serializers); the only file all three touch is `Build/Cmake/Testing/CMakeLists.txt`, where the hunks are hundreds of lines apart and merge cleanly in any order.

## The defect

`CIccEvalCompare::EvaluateProfile` builds a device→PCS transform and its inverse; `CIccPRMG::EvaluateProfile` drives a Lab→device→Lab chain over the PRMG boundary. Both are meaningful only for the four classes that carry that transform pair — input, display, output, colorSpace — and both open with the same four-way class test.

That test returned `icCmmStatInvalidProfile`, which `GetStatusText` renders as `Invalid profile`. So:

```
$ iccRoundTrip Testing/SpecRef/RefDecC.icc
Unable to perform round trip on 'Testing/SpecRef/RefDecC.icc': Invalid profile
```

`RefDecC.icc` is an abstract profile that validates cleanly — `iccDumpProfile` reports warnings only, no non-compliance. Every profile class in the corpus outside those four behaved the same way:

| fixture | class | before |
|---|---|---|
| `Testing/SpecRef/RefDecC.icc` | `abst` | `Invalid profile` |
| `Testing/Named/FluorescentNamedColor.icc` | `nmcl` | `Invalid profile` |
| `Testing/Display/RgbGSDF.icc` | `link` | `Invalid profile` |
| `Testing/Encoding/sRgbEncoding.icc` | `cenc` | `Invalid profile` |
| `Testing/mcs/6ChanSelect-MID.icc` | `mid ` | `Invalid profile` |
| `Testing/mcs/17ChanWithSpots-MVIS.icc` | `mvis` | `Invalid profile` |

The wording is the visible half. The substantive half is that one status code covered two different conditions, so a caller could not distinguish **this profile is damaged** from **this operation does not apply to this kind of profile** — which in batch QA is the difference between a finding and a skip.

## The fix

`icCmmStatUnsupportedProfileClass`, appended to `icStatusCMM` and returned by both evaluators. All six fixtures above now report `Unsupported profile class`.

Why a new enumerator rather than the existing `icCmmStatUnsupported` (18, "Unsupported operation")? Because `CIccEvalCompare::EvaluateProfile` already returns that one, forty lines further down, for a device space with no samples (`IccEval.cpp:178`). Reusing it would rebuild the same conflation this change removes — two unrelated refusals sharing a status — inside a single function.

Appended at the end (19, after `icCmmStatUnsupported` at 18) so no existing status is renumbered — the values cross the IccProfLib ABI and appear in saved QA output. A matching `GetStatusText` case goes in with it: the enum's own declaration asks for the two to be kept in sync, and that note is there because `icCmmStatUnsupported` was once added without a case and fell through to the default.

Nothing else in the tree compares against `icCmmStatInvalidProfile` — the only two references are its own definition and its `GetStatusText` case — so no behaviour outside these two evaluators changes. `GetStatusText` is the only `switch` over `icStatusCMM` in the tree, and it has a `default`, so appending cannot make any other translation unit non-exhaustive.

## Verification

New CTest `iccdev.unsupported-profile-class-status`.

It drives the `CIccProfile*` overloads directly. That needs no fixture on disk — the class test runs before any tag data is read, so a profile with only `m_Header.deviceClass` set reaches exactly the branch under test — and it is **the only way to reach `CIccPRMG`'s copy of the branch at all**: both in-tree callers (`iccRoundTrip`, `wxProfileDump`) run the PRMG evaluation only after the round-trip evaluation has already succeeded, so a class refusal never reaches `CIccPRMG` through a tool. A CLI-level test would have covered one of the two changed lines.

Coverage: all seven refused classes × both evaluators, asserted both positively (is the new status) and negatively (is no longer the old one), since the point of the change is the distinction rather than either value; the four accepted classes asserted **not** refused for their class, guarding against over-rejection; a null profile still reporting `icCmmStatCantOpenProfile`; the new status decoding to text distinct from the invalid-profile text; and the enum pinned as append-only.

Red-green, measured rather than reasoned:

| reverted | failing assertions |
|---|---|
| both evaluators | 28 round-trip + PRMG |
| `CIccPRMG` only | 14 PRMG, 0 round-trip |
| neither | 0 |

## Pre-flight

- GCC 15.2 strict Release LTO, run **inside `iccdev-ci-regression:ci-qa-pr-docker-testing`** so the toolchain matches the gcc15 job exactly — 0 warnings, 0 errors, full tree plus `build-test-binaries`
- clang-18 strict ASAN+UBSAN Debug (`-Wall -Wextra -Wpedantic -Werror -g -O0 -std=c++17`, `-DENABLE_SANITIZERS=ON`) — 0 warnings
- Full `ctest` — 113/116. The three failures are environmental and reproduce without this change:
  - `iccdev.tool-coverage` — fails only under parallel load, passes standalone
  - `iccdev.spectral-tiff-preview` — local Python is missing `imagecodecs`, which CI installs
  - `iccdev.hybrid-pipeline` — the script caps `BuildAndTest.sh` at `HYBRID_TIMEOUT`, default 840s. Under clang + ASAN/UBSAN the run sits right on that line: **609s standalone on an idle machine (passes)**, over 840s under `-j4`. Nothing in this change is on its path — it never calls either evaluator.
- New test passes under ASAN + UBSAN, and standalone after a clean rebuild
- No shell script added, so the pre-flight lint gate has nothing new to lint

UBSan caught one defect in the test itself during this pass: it originally probed the `GetStatusText` default arm with `(icStatusCMM)0x7FFFFFFF`, which is outside the enum's valid value range and therefore UB — `runtime error: load of value 2147483647, which is not a valid value for type 'icStatusCMM'`. It now uses an in-range value one past the last enumerator.

## Note for review

This touches a public enum in `IccProfLib`, so it wants a maintainer eye — @maxderhak in particular. The append-only placement and the unchanged numbering of everything before it are the ABI-relevant parts; the test pins both.

The four-way class test is duplicated verbatim in `IccEval.cpp` and `IccPrmg.cpp`. I left it that way rather than hoisting a shared predicate, since that would add public surface to fix a two-site duplication — happy to follow up if you would prefer it factored.

One thing I deliberately did **not** change: `iccRoundTrip` still exits `-1` for this status. `icCmmStatTooManySamples` exits `0` so batch QA can classify a deliberate refusal as a soft skip (#1405), and the same argument applies here — but exit-code semantics for non-failure outcomes are already under discussion in #1809, so it seemed wrong to settle that unilaterally in a message fix. Say the word and I will add it.
