### PR TITLE
ci: silence libstdc++ integer sanitizer noise

### DIFF
--- a/.github/ci/ubsan-ignorelist.txt
+++ b/.github/ci/ubsan-ignorelist.txt
@@ -14,5 +14,15 @@
 [unsigned-integer-overflow]
 fun:*MD5Transform*
 
+# libstdc++ 15 container internals use unsigned decrement / subtract idioms at
+# loop and capacity boundaries. IntegerSanitizer reports these implementation
+# details before iccDEV code has an actionable frame. Keep this scoped to
+# standard-library source paths; do not add project-owned Icc*, Tools,
+# IccConnect, AFL, or CFL paths here for this noise class.
+src:*/include/c++/*/bits/basic_string.h
+src:*/include/c++/*/bits/basic_string.tcc
+src:*/include/c++/*/bits/stl_bvector.h
+src:*/include/c++/*/bits/stl_uninitialized.h
+
 [unsigned-shift-base]
 fun:*MD5Transform*

--- a/.github/scripts/iccdev-calculator-regression-tests.sh
+++ b/.github/scripts/iccdev-calculator-regression-tests.sh
@@ -66,11 +66,11 @@ check_log() {
   fi
 
   if grep -q "runtime error:" "$logfile" 2>/dev/null; then
-    if grep "runtime error:" "$logfile" | grep -v "/IccProfLib/IccMD5.cpp:" >/dev/null 2>&1; then
+    if grep "runtime error:" "$logfile" | grep -Ev '(/IccProfLib/IccMD5.cpp:|/include/c\+\+/[^/]+/bits/(basic_string\.h|basic_string\.tcc|stl_bvector\.h|stl_uninitialized\.h):)' >/dev/null 2>&1; then
       fail_case "$name" "undefined behavior"
       return 1
     fi
-    echo "  [WARN] $name -- ignored known MD5 unsigned-shift instrumentation noise"
+    echo "  [WARN] $name -- ignored known MD5/libstdc++ UBSAN instrumentation noise"
   fi
 
   return 0

--- a/.github/scripts/iccdev-mluc-setter-regression-tests.sh
+++ b/.github/scripts/iccdev-mluc-setter-regression-tests.sh
@@ -42,12 +42,12 @@ check_log() {
   fi
 
   if grep -q "runtime error:" "$logfile" 2>/dev/null; then
-    if grep "runtime error:" "$logfile" | grep -v "/IccProfLib/IccMD5.cpp:" >/dev/null 2>&1; then
+    if grep "runtime error:" "$logfile" | grep -Ev '(/IccProfLib/IccMD5.cpp:|/include/c\+\+/[^/]+/bits/(basic_string\.h|basic_string\.tcc|stl_bvector\.h|stl_uninitialized\.h):)' >/dev/null 2>&1; then
       echo "  [FAIL] $name -- undefined behavior"
       FAIL=$((FAIL + 1))
       return 1
     fi
-    echo "  [WARN] $name -- ignored known MD5 unsigned-shift instrumentation noise"
+    echo "  [WARN] $name -- ignored known MD5/libstdc++ UBSAN instrumentation noise"
   fi
 
   return 0

--- a/.github/scripts/iccdev-stdobserver-regression-tests.sh
+++ b/.github/scripts/iccdev-stdobserver-regression-tests.sh
@@ -41,12 +41,12 @@ check_log() {
   fi
 
   if grep -q "runtime error:" "$logfile" 2>/dev/null; then
-    if grep "runtime error:" "$logfile" | grep -v "/IccProfLib/IccMD5.cpp:" >/dev/null 2>&1; then
+    if grep "runtime error:" "$logfile" | grep -Ev '(/IccProfLib/IccMD5.cpp:|/include/c\+\+/[^/]+/bits/(basic_string\.h|basic_string\.tcc|stl_bvector\.h|stl_uninitialized\.h):)' >/dev/null 2>&1; then
       echo "  [FAIL] $name -- undefined behavior"
       FAIL=$((FAIL + 1))
       return 1
     fi
-    echo "  [WARN] $name -- ignored known MD5 unsigned-shift instrumentation noise"
+    echo "  [WARN] $name -- ignored known MD5/libstdc++ UBSAN instrumentation noise"
   fi
 
   return 0

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -747,10 +747,16 @@ jobs:
             for d in "$ICCDEV_BUILD_DIR"/Tools/*; do
               [ -d "$d" ] && export PATH="$(realpath "$d"):$PATH"
             done
-            printf "%s\n%s\n%s\n" \
+            printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
               "unsigned-integer-overflow:*/IccMD5.cpp" \
               "shift-base:*/IccMD5.cpp" \
-              "shift-exponent:*/IccMD5.cpp" > silence.txt
+              "shift-exponent:*/IccMD5.cpp" \
+              "# Recoverable runtime UBSAN noise from libstdc++ implementation internals." \
+              "# Fatal IntegerSanitizer builds require the compile-time ignorelist instead." \
+              "unsigned-integer-overflow:*/include/c++/*/bits/basic_string.h" \
+              "unsigned-integer-overflow:*/include/c++/*/bits/basic_string.tcc" \
+              "unsigned-integer-overflow:*/include/c++/*/bits/stl_bvector.h" \
+              "unsigned-integer-overflow:*/include/c++/*/bits/stl_uninitialized.h" > silence.txt
             test -x ./CreateAllProfiles.sh
             test -x ./RunTests.sh
             test -x ./HDR/mkprofiles.sh

--- a/IccProfLib/IccColorimetry.cpp
+++ b/IccProfLib/IccColorimetry.cpp
@@ -223,9 +223,10 @@ static void resampleCore(const Grid &src, const std::vector<double> &v,
     // CWE-681 (#2230): the isfinite(t) guard above already prevents a non-finite
     // t from reaching this float->int conversion, and t is in (0, n-1) here, but
     // clamp the cast operand to the valid segment range [0, n-2] right at the
-    // conversion so the NaN/range check is local to the cast (a float->int cast
-    // of a non-finite or out-of-range value is undefined behaviour). For any
-    // valid t this is a no-op: floor(t) is already in [0, n-2]. Mirrors the
+    // conversion so the finite-range precondition is local to the cast. A
+    // float->int cast of a non-finite or out-of-range value is undefined
+    // behaviour. For any valid t this is a no-op: floor(t) is already in
+    // [0, n-2]. Mirrors the
     // adjacent-guard form used in #1478.
     double tf = std::floor(t);                      // source segment index (base sample v[i])
     if (!std::isfinite(tf)) tf = 0.0;               // explicit NaN/Inf guard local to the cast (CWE-681)

--- a/IccProfLib/IccSparseMatrix.h
+++ b/IccProfLib/IccSparseMatrix.h
@@ -119,11 +119,8 @@ public:
   // plain value<0.0 test lets a NaN reach (icUInt8Number)(NaN*255+0.5), undefined
   // behaviour on the float->int cast (CWE-681, alert #1061).
   //
-  // isfinite() is spelt as a call rather than as the equally correct relational
-  // guard !(value > 0.0) because iccdev/float-to-int-cast only recognises
-  // isnan/isinf/isfinite calls within five lines above a cast; the relational form
-  // leaves this cast flagged on every scan (alerts #2318/#2317, dismissed as
-  // query-blind false positives).
+  // Keep the finiteness guard local to the cast so the conversion precondition
+  // remains obvious during review.
   virtual void set(int index, icFloatNumber value)
   {
     if (value > 1.0f)
@@ -143,9 +140,9 @@ public:
 
   virtual icFloatNumber get(int index) const {return (icFloatNumber)m_pData[index]/65535.0f;}
 
-  // Same branch order and the same isfinite() call as the UInt8 entry above; see
-  // the note there for why saturation is tested first and why the guard is a call
-  // (alert #2260 is this entry's counterpart to #1061).
+  // Same branch order and local isfinite() guard as the UInt8 entry above; see
+  // the note there for why saturation is tested first (alert #2260 is this
+  // entry's counterpart to #1061).
   //
   // The cast is (icUInt16Number), not (icUInt8Number): the 8-bit cast truncated the
   // scaled value into the 16-bit slot (e.g. 0.5 -> 32768 & 0xff == 0), breaking the

--- a/Testing/silence.txt
+++ b/Testing/silence.txt
@@ -1,3 +1,9 @@
 unsigned-integer-overflow:*/IccMD5.cpp
 shift-base:*/IccMD5.cpp
 shift-exponent:*/IccMD5.cpp
+# Recoverable runtime UBSAN noise from libstdc++ implementation internals.
+# Fatal IntegerSanitizer builds require the compile-time ignorelist instead.
+unsigned-integer-overflow:*/include/c++/*/bits/basic_string.h
+unsigned-integer-overflow:*/include/c++/*/bits/basic_string.tcc
+unsigned-integer-overflow:*/include/c++/*/bits/stl_bvector.h
+unsigned-integer-overflow:*/include/c++/*/bits/stl_uninitialized.h

--- a/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
+++ b/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp
@@ -1768,15 +1768,13 @@ RoundTripResult RoundTripDE(CIccProfile* pIcc, icRenderingIntent intent,
   // finite product or, on overflow, +inf - never NaN, never negative. Even though NaN
   // is therefore unreachable, the guard below rejects any non-finite total explicitly
   // with std::isfinite rather than leaning on the ceiling test alone to catch +inf:
-  // that makes the cast's precondition local and executable (and clears the
-  // float-to-int-cast scanner at #2335, which recognises an isfinite/isnan call as the
-  // guard but cannot follow the pow() argument above). total thus lands in [3, 3000000]
-  // at the cast (the minimum is N == 1 giving 3^1, not 9).
+  // that makes the cast's precondition local and executable instead of relying
+  // on the pow() argument proof above. total thus lands in [3, 3000000] at the
+  // cast (the minimum is N == 1 giving 3^1, not 9).
   double total = std::pow((double)S + 1.0, N);
   if (!std::isfinite(total) || total > 3000000.0) { delete xA; delete xB; return fail("seed grid too large"); }
-  // Reserve the delta-E accumulator now, while the (size_t)total cast still sits within
-  // a few lines of the isfinite guard above (the float-to-int-cast scanner, #2335, ties
-  // a guard to a cast only when it is <=5 lines above). total is finite, in [3,3000000].
+  // Reserve the delta-E accumulator now, while the (size_t)total cast still sits
+  // close to the isfinite guard above. total is finite, in [3,3000000].
   std::vector<double> des;
   des.reserve((size_t)total);
 
@@ -1815,7 +1813,7 @@ RoundTripResult RoundTripDE(CIccProfile* pIcc, icRenderingIntent intent,
   // 90th-percentile index = floor(0.90 * (n-1)) for integer n = des.size(). Compute it
   // as exact integer arithmetic (9*(n-1))/10 rather than std::floor on a double: it is
   // the same index for every n (des.size() <= 3,000,000 here, so 9*(n-1) cannot
-  // overflow), and it avoids a float-to-int cast the scanner would flag as NaN-unsafe.
+  // overflow), and it avoids an unnecessary float-to-int cast.
   const std::size_t p90i = (9 * (des.size() - 1)) / 10;
 
   r.ok = true;

--- a/docker/iccdev-generate-profiles.sh
+++ b/docker/iccdev-generate-profiles.sh
@@ -9,10 +9,16 @@ for d in "$tools_root"/*; do
   fi
 done
 
-printf '%s\n%s\n%s\n' \
+printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
   'unsigned-integer-overflow:*/IccMD5.cpp' \
   'shift-base:*/IccMD5.cpp' \
-  'shift-exponent:*/IccMD5.cpp' > silence.txt
+  'shift-exponent:*/IccMD5.cpp' \
+  '# Recoverable runtime UBSAN noise from libstdc++ implementation internals.' \
+  '# Fatal IntegerSanitizer builds require the compile-time ignorelist instead.' \
+  'unsigned-integer-overflow:*/include/c++/*/bits/basic_string.h' \
+  'unsigned-integer-overflow:*/include/c++/*/bits/basic_string.tcc' \
+  'unsigned-integer-overflow:*/include/c++/*/bits/stl_bvector.h' \
+  'unsigned-integer-overflow:*/include/c++/*/bits/stl_uninitialized.h' > silence.txt
 
 ASAN_OPTIONS='print_scariness=1:halt_on_error=1:detect_leaks=0' \
   UBSAN_OPTIONS="halt_on_error=0:suppressions=$PWD/silence.txt" \


### PR DESCRIPTION
Draft stacked PR layer 2/3. Base is the CodeQL-removal branch.

Adds scoped libstdc++ 15 IntegerSanitizer suppressions and keeps runtime silence generation aligned.
Refs #1833.