### PR TITLE
fix(#1888): let regression tests link exported IccProfLib data on Windows

### DIFF
--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -28,6 +28,7 @@ Test 18 (Regression Bisect).
 | `iccdev.iccviz-degenerate-detection` | #1712 | `principalStdDevs` eigenvalues and the `s3 < 0.02*s1` flat predicate that flags a collapsed gamut cloud were unpinned | Header-only unit test over blob/plane/line and a rotated anisotropic cloud; calibrates the 0.02 constant and exercises the Smith-1961 trig branch (non-diagonal covariance) |
 | `iccdev.mpe-empty-identity` | #1809 | `CIccTagMultiProcessElement::Validate()` raised `icValidateWarning` for a zero-element tag with equal input and output channel counts, although `Read()`/`Write()`/`Begin()`/`Apply()` all define that shape as the identity transform; 79 reference profiles under `Testing/` (148 messages) sat in the warning cohort as a result | Validates a zero-element tag through a Lab/Lab profile and asserts the equal-channel case is `icValidateOK` reported at information level, the unequal-channel case stays a critical error, and the runtime behaviour that justifies the split (`Begin()` true / `Apply()` identity for equal channels, `Begin()` false for unequal) |
 | `iccdev.mpexml-unknown-reserved` | #1886 | `CIccMpeXmlUnknown::ToXml()` formatted the `Reserved` attribute into `line` but appended `buf`, which still held the element's type signature, so the value was dropped and the signature was injected into the attribute list before the start tag closed — the emitted document did not parse; `ParseXml()` had never read `Reserved` back either | Drives the writer on an element carrying a non-zero `Reserved`, parsing the output with libxml2 rather than grepping it (the defect produced text a substring check would accept), and asserts the value survives a parse/write round-trip, an out-of-range value is refused, and a document without the attribute still reads as zero |
+| `iccdev.proflib-exported-data-linkage` | #1888 | Exported IccProfLib global *variables* could not be linked from a regression executable on Windows shared builds — `WINDOWS_EXPORT_ALL_SYMBOLS` exports functions but not data, so the first test to reference `icMsgValidate*` failed with LNK2019 on the Windows leg alone | Links the exported globals through `${ICCDEV_TEST_LIB_ICCPROFLIB}` so the Windows leg fails here if that fallback is dropped, and pins the report prefixes, D50 constants, solver pointers and `icInfo` that IccXML-linking tests hard-code because they cannot link them |
 | `iccdev.iccviz-pdf-axis-labels` | #1712, #1777 | `DrawAxisPDF` axis-label and custom start/mid/end tick parameterization could regress silently; the CLI also confirmed nothing on a successful run | Runs `iccProfileVisualizePlot` on `sRGB_v4_ICC_preference.icc` in a freshly recreated scratch dir and asserts the emitted LUT PDF carries the axis titles plus the default (`50%`/`100%`) vs reversed (`100`/`50`) tick operators, and that the run prints a success line naming the written PDF (#1777) |
 
 | Script | Issue | Bug | Check |
@@ -52,6 +53,58 @@ Test 18 (Regression Bisect).
 |----------|-------|---------|-------|
 | `.github/workflows/ci-pr-win.yml` | MinGW toolchain | Keep normal Windows PR CI from regressing MinGW CMake/tool support | Runs a UCRT64 MinGW Release static build and the full registered MinGW CTest set, including `iccdev.windows-icc-dump-profile-smoke` and `iccdev.iccconnect-threaded-cmm` |
 | `.github/workflows/ci-pr-win.yml` | #1025, #1036 | Keep Windows ClangCL warning output focused on source signal instead of known CRT/deprecation noise | Runs the ClangCL smoke build with ClangCL-only noise-control flags, classifies warning categories, and uploads sanitized warning logs |
+
+## Referencing exported IccProfLib globals (#1888)
+
+A test may call any exported IccProfLib **function** freely. Referencing an
+exported global **variable** is different, and gets it wrong on Windows only.
+
+On a Windows shared build the library is `IccProfLib2.dll`, exported by CMake's
+`WINDOWS_EXPORT_ALL_SYMBOLS` rather than by `__declspec` annotations — MSVC is
+deliberately excluded from the `ICCPROFLIBDLL_EXPORTS` definition, a decision
+taken in #764. That mechanism auto-exports functions but **not global data**, and
+IccProfLib carries no `dllexport`/`dllimport` on its variables. A test compiling
+with `ICCPROFLIB_API` empty therefore emits a direct data reference with no
+`__imp_` indirection, and the link fails:
+
+```
+mpe-empty-identity.obj : error LNK2019: unresolved external symbol
+  "char const * const icMsgValidateWarning" (?icMsgValidateWarning@@3PEBDEB)
+fatal error LNK1120: 3 unresolved externals
+```
+
+Linux and macOS have no import-library model, so **a green local pre-flight will
+not catch this** — only the Windows CI leg will.
+
+The eight affected symbols:
+
+| Symbol | Header |
+|---|---|
+| `g_pIccMatrixSolver`, `g_pIccMatrixInverter` | `IccProfLib/IccSolve.h` |
+| `icD50XYZ[3]`, `icD50XYZxx[3]` | `IccProfLib/IccUtil.h` |
+| `icMsgValidateWarning`, `icMsgValidateNonCompliant`, `icMsgValidateCriticalError`, `icMsgValidateInformation` | `IccProfLib/IccUtil.h` |
+
+`IccUtil.h` declares a ninth, `icInfo`, but it is a **dangling declaration** —
+there is no definition anywhere in the tree, so referencing it fails to link on
+every platform rather than only on Windows. Nothing in-tree uses it. That is a
+separate defect from the export problem described here.
+
+Choose by what else the test links:
+
+- **IccProfLib only** — link `${ICCDEV_TEST_LIB_ICCPROFLIB}` instead of
+  `${TARGET_LIB_ICCPROFLIB}`. It resolves to the static library on Windows shared
+  builds, the same fallback `iccDumpProfile`, `iccProfilePlot` and
+  `wxProfileDump` already use.
+- **Also links IccXML or IccJson** — you cannot use that fallback. Those
+  libraries link `${TARGET_LIB_ICCPROFLIB}` `PUBLIC`, so pulling in the static
+  IccProfLib as well would load the library twice in one process, once inside
+  the DLL and once in the executable, giving two copies of its globals. Assert on
+  literal values instead, as `mpe-empty-identity.cpp` and
+  `pawg-q4-xyz-pcs-decode.cpp` do.
+
+Literals copied out of the library drift silently, so
+`iccdev.proflib-exported-data-linkage` pins the real globals. If it fails after a
+library change, update the hard-coded copies it names.
 
 ## Adding a new PoC
 

--- a/.github/ci/regression/proflib-exported-data-linkage.cpp
+++ b/.github/ci/regression/proflib-exported-data-linkage.cpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression: a test that references an exported IccProfLib global *variable*
+// could not be linked on a Windows shared build (#1888).
+//
+// The library is IccProfLib2.dll there, and its exports come from CMake's
+// WINDOWS_EXPORT_ALL_SYMBOLS rather than from __declspec annotations -- MSVC is
+// deliberately excluded from the ICCPROFLIBDLL_EXPORTS definition, a decision
+// taken in #764. That mechanism auto-exports functions but not global data, and
+// IccProfLib carries no dllexport/dllimport on its data, so a consumer emits a
+// direct data reference with no __imp_ indirection and the link fails:
+//
+//   mpe-empty-identity.obj : error LNK2019: unresolved external symbol
+//     "char const * const icMsgValidateWarning" (?icMsgValidateWarning@@3PEBDEB)
+//   fatal error LNK1120: 3 unresolved externals
+//
+// Functions in the same headers thunk normally, which is why this went
+// unnoticed until #1887 became the first regression test to touch library data.
+// Linux and macOS have no import-library model and are unaffected, so a green
+// local pre-flight proves nothing here -- only the Windows CI leg does.
+//
+// THIS TEST IS THE PROOF. Its value is that it links at all on Windows: it is
+// built against ${ICCDEV_TEST_LIB_ICCPROFLIB}, which falls back to the static
+// library on Windows shared builds exactly as the three affected tools already
+// do. If that fallback is removed or the export model changes, this stops
+// linking and the Windows leg goes red instead of the next author discovering it.
+//
+// It covers eight of the nine exported globals -- the four icMsgValidate*
+// prefixes, both icD50XYZ arrays, and both solver pointers. The ninth, icInfo,
+// is excluded because it has no definition at all; see the note in main().
+//
+// It also has a job on every platform. Because exported data cannot be linked
+// from a test that also links IccXML (that would load IccProfLib twice, once
+// inside the DLL and once in the executable), those tests assert on hard-coded
+// literals instead -- see mpe-empty-identity.cpp and pawg-q4-xyz-pcs-decode.cpp.
+// Hard-coded copies drift silently. Pinning the real globals here means a change
+// to icMsgValidateWarning or icD50XYZ fails HERE, naming the literals that must
+// be updated, rather than leaving those tests quietly asserting stale text.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccUtil.h"
+#include "IccSolve.h"
+#include "IccDefs.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[proflib-exported-data-linkage] FAIL: %s\n", what);
+  }
+}
+
+bool near(icFloatNumber a, double b)
+{
+  return std::fabs((double)a - b) < 1e-4;
+}
+
+} // namespace
+
+int main()
+{
+  // -----------------------------------------------------------------
+  // 1. Validation report prefixes. These exact strings are what a log
+  //    scan greps for and what the IccXML-linking tests hard-code.
+  // -----------------------------------------------------------------
+  check(icMsgValidateWarning != NULL && !std::strcmp(icMsgValidateWarning, "Warning! - "),
+        "1: icMsgValidateWarning changed -- update the literals in "
+        "mpe-empty-identity.cpp");
+  check(icMsgValidateNonCompliant != NULL &&
+          !std::strcmp(icMsgValidateNonCompliant, "NonCompliant! - "),
+        "1: icMsgValidateNonCompliant changed");
+  check(icMsgValidateCriticalError != NULL &&
+          !std::strcmp(icMsgValidateCriticalError, "Error! - "),
+        "1: icMsgValidateCriticalError changed -- update the literals in "
+        "mpe-empty-identity.cpp");
+  check(icMsgValidateInformation != NULL &&
+          !std::strcmp(icMsgValidateInformation, "Information - "),
+        "1: icMsgValidateInformation changed -- update the literals in "
+        "mpe-empty-identity.cpp");
+
+  // -----------------------------------------------------------------
+  // 2. D50 constants. pawg-q4-xyz-pcs-decode.cpp hard-codes the actual
+  //    triple because it cannot link this symbol; keep them in step.
+  // -----------------------------------------------------------------
+  check(near(icD50XYZ[0], 0.9642) && near(icD50XYZ[1], 1.0000) &&
+          near(icD50XYZ[2], 0.8249),
+        "2: icD50XYZ changed -- update the literal in pawg-q4-xyz-pcs-decode.cpp");
+  check(near(icD50XYZxx[0], 96.42) && near(icD50XYZxx[1], 100.00) &&
+          near(icD50XYZxx[2], 82.49),
+        "2: icD50XYZxx changed");
+
+  // -----------------------------------------------------------------
+  // 3. Solver extension points. These are the documented way a caller
+  //    installs its own matrix solver, so they are the exported data a
+  //    downstream consumer is most likely to reach for.
+  // -----------------------------------------------------------------
+  check(g_pIccMatrixSolver != NULL, "3: g_pIccMatrixSolver is null");
+  check(g_pIccMatrixInverter != NULL, "3: g_pIccMatrixInverter is null");
+
+  // icInfo (IccUtil.h) is deliberately NOT covered. It is declared
+  // `extern ICCPROFLIB_API CIccInfo icInfo;` but has no definition anywhere in
+  // the tree, so referencing it fails to link on every platform, not just
+  // Windows -- `nm -DC libIccProfLib2.so` lists the other exported globals and
+  // not this one. That is a dangling public declaration rather than the export
+  // problem this test covers, and nothing in-tree uses it. Adding it here would
+  // break the Linux build too.
+
+  if (!g_fail)
+    std::printf("[proflib-exported-data-linkage] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -49,6 +49,37 @@ function(iccdev_add_regression_executable TARGET_NAME)
   add_dependencies(build-test-binaries "${TARGET_NAME}")
 endfunction()
 
+# Link target for regression executables that reference an exported IccProfLib
+# global *variable* rather than only its functions (#1888).
+#
+# On a Windows shared build the library is IccProfLib2.dll, exported by CMake's
+# WINDOWS_EXPORT_ALL_SYMBOLS rather than by __declspec annotations: MSVC is
+# deliberately excluded from the ICCPROFLIBDLL_EXPORTS definition in
+# Build/Cmake/IccProfLib/CMakeLists.txt, a decision made in #764 and recorded in
+# the comment there. WINDOWS_EXPORT_ALL_SYMBOLS auto-exports functions; global
+# data still needs explicit dllexport/dllimport, which IccProfLib does not carry.
+# A consumer compiling with ICCPROFLIB_API empty therefore emits a direct data
+# reference with no __imp_ indirection and fails to link (LNK2019/LNK2001), while
+# every function in the same header thunks normally. Linux and macOS are immune,
+# so a green local pre-flight says nothing about this.
+#
+# The three tools with the same problem already resolve it this way -- see
+# Build/Cmake/Tools/{IccDumpProfile,IccProfilePlot,wxProfileDump}/CMakeLists.txt.
+#
+# USE THIS ONLY FOR TESTS THAT LINK IccProfLib ALONE. IccXML2 and IccJson link
+# ${TARGET_LIB_ICCPROFLIB} PUBLIC, so a test that links one of those *and* the
+# static IccProfLib pulls the library into the process twice -- once inside the
+# DLL, once in the executable -- giving two copies of its globals. Tests that
+# link IccXML/IccJson must keep using ${TARGET_LIB_ICCPROFLIB} and must not
+# reference exported library data at all; assert on literal values instead, as
+# .github/ci/regression/{mpe-empty-identity,pawg-q4-xyz-pcs-decode}.cpp do.
+if(WIN32 AND ENABLE_SHARED_LIBS AND TARGET IccProfLib2-static)
+  set(ICCDEV_TEST_LIB_ICCPROFLIB IccProfLib2-static)
+else()
+  set(ICCDEV_TEST_LIB_ICCPROFLIB ${TARGET_LIB_ICCPROFLIB})
+endif()
+message(STATUS "ICCDEV_TEST_LIB_ICCPROFLIB  = ${ICCDEV_TEST_LIB_ICCPROFLIB}")
+
 add_custom_target(check-fast
   COMMAND "${CMAKE_CTEST_COMMAND}"
           ${ICCDEV_CTEST_CONFIG_ARGS}
@@ -2118,6 +2149,53 @@ function(iccdev_add_mpexml_unknown_reserved_test)
   endif()
 endfunction()
 
+# #1888: proves a regression executable can link an exported IccProfLib global
+# *variable*. WINDOWS_EXPORT_ALL_SYMBOLS exports functions but not data, so on a
+# Windows shared build this only links via ${ICCDEV_TEST_LIB_ICCPROFLIB}; if that
+# fallback is dropped the Windows leg fails here rather than in whichever new
+# test next reaches for library data. Also pins the values that the tests which
+# cannot link these symbols -- anything co-linking IccXML -- hard-code instead.
+# Links IccProfLib only, by design: co-linking IccXML would load IccProfLib twice.
+function(iccdev_add_proflib_exported_data_linkage_test)
+  if(NOT TARGET "${ICCDEV_TEST_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccProfLibExportedDataLinkageTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/proflib-exported-data-linkage.cpp"
+  )
+  target_compile_features(iccProfLibExportedDataLinkageTest PRIVATE cxx_std_17)
+  target_include_directories(iccProfLibExportedDataLinkageTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccProfLibExportedDataLinkageTest PRIVATE
+    ${ICCDEV_TEST_LIB_ICCPROFLIB})
+  add_dependencies(check iccProfLibExportedDataLinkageTest)
+
+  add_test(
+    NAME iccdev.proflib-exported-data-linkage
+    COMMAND "$<TARGET_FILE:iccProfLibExportedDataLinkageTest>"
+  )
+  set_tests_properties(iccdev.proflib-exported-data-linkage PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;build;linkage;issue-1888;regression"
+  )
+  if(WIN32)
+    set(_exported_data_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccProfLibExportedDataLinkageTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${ICCDEV_TEST_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _exported_data_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.proflib-exported-data-linkage PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_exported_data_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1830: the JSON BCD version parser used atoi() per component, which accepts a
 # leading '-'; "-1" produced 0xFFFFFFFF and wrapped both the "<< 8" in
 # icJsonParseBCDVersionStr and the caller's "<< 16" (UBSan: "left shift of
@@ -2514,6 +2592,7 @@ if(WIN32)
   iccdev_add_json_sparsematrix_huaf_test()
   iccdev_add_xml_writer_graceful_degrade_test()
   iccdev_add_mpexml_unknown_reserved_test()
+  iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_json_bcd_version_test()
   iccdev_add_datetime_parse_test()
   iccdev_add_encoding_surround_test()
@@ -2736,6 +2815,7 @@ iccdev_add_pawg_compression_paths_test()
 iccdev_add_json_sparsematrix_huaf_test()
 iccdev_add_xml_writer_graceful_degrade_test()
 iccdev_add_mpexml_unknown_reserved_test()
+iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_json_bcd_version_test()
 iccdev_add_datetime_parse_test()
 iccdev_add_encoding_surround_test()

--- a/IccProfLib/IccSolve.h
+++ b/IccProfLib/IccSolve.h
@@ -111,6 +111,13 @@ public:
 * with the status of false.
 *****************************************************************************
 */
+// Exported DATA rather than a function: on a Windows shared build this does not
+// link from outside the library, because WINDOWS_EXPORT_ALL_SYMBOLS covers
+// functions but not global data and IccProfLib carries no dllexport/dllimport
+// on its variables (see #764 and the note in IccUtil.h). A downstream consumer
+// installing its own solver against IccProfLib2.dll gets LNK2019. Prefer the
+// IccSetMatrixSolver() setter below, which is a function and therefore links
+// normally. See #1888.
 ICCPROFLIB_API extern IIccMatrixSolver *g_pIccMatrixSolver;
 
 /**
@@ -173,6 +180,8 @@ public:
 * Purpose: Keep tracks of pointer to matrix inverter object.  
 *****************************************************************************
 */
+// Exported DATA: not linkable from outside the library on Windows shared
+// builds; prefer IccSetMatrixInverter(). See g_pIccMatrixSolver above and #1888.
 ICCPROFLIB_API extern IIccMatrixInverter *g_pIccMatrixInverter;
 
 /**

--- a/IccProfLib/IccUtil.h
+++ b/IccProfLib/IccUtil.h
@@ -133,6 +133,8 @@ ICCPROFLIB_API icFloatNumber icU16toF(icUInt16Number num);
 ICCPROFLIB_API icUInt8Number icABtoU8(icFloatNumber num);
 ICCPROFLIB_API icFloatNumber icU8toAB(icUInt8Number num);
 
+// Exported DATA: not linkable from outside the library on Windows shared
+// builds. See the note beside icMsgValidateWarning below and #1888.
 ICCPROFLIB_API extern icFloatNumber icD50XYZ[3];
 ICCPROFLIB_API extern icFloatNumber icD50XYZxx[3];
 
@@ -197,6 +199,18 @@ bool ICCPROFLIB_API icSameSpectralRange(const icSpectralRange &rng1, const icSpe
 
 ICCPROFLIB_API icUInt8Number icGetStorageTypeBytes(icUInt16Number nStorageType);
 
+// Exported DATA, not functions. On a Windows shared build these do not link
+// from outside the library: exports come from WINDOWS_EXPORT_ALL_SYMBOLS (see
+// Build/Cmake/IccProfLib/CMakeLists.txt and #764), which covers functions but
+// not global data, and IccProfLib carries no dllexport/dllimport annotation on
+// its variables. Referencing one from a tool or test gives LNK2019/LNK1120 on
+// MSVC while every function beside it links normally; Linux and macOS are
+// unaffected, so this does not show up in a local pre-flight. See #1888.
+// Tools work around it by linking IccProfLib2-static on Windows shared builds;
+// tests use ${ICCDEV_TEST_LIB_ICCPROFLIB}, or assert on literal values when
+// they also link IccXML. The literals are pinned by
+// .github/ci/regression/proflib-exported-data-linkage.cpp -- update it if these
+// strings change.
 ICCPROFLIB_API extern const char *icMsgValidateWarning;
 ICCPROFLIB_API extern const char *icMsgValidateNonCompliant;
 ICCPROFLIB_API extern const char *icMsgValidateCriticalError;
@@ -426,6 +440,11 @@ public:
 
 
 
+// NOTE: this declaration has no definition anywhere in the library, so any
+// reference to it fails to link on every platform, not only on Windows --
+// `nm -DC libIccProfLib2.so` lists the other exported globals and not this one.
+// Nothing in-tree uses it. Construct a CIccInfo where one is needed. Kept as
+// declared rather than removed because it is public API surface; see #1888.
 extern ICCPROFLIB_API CIccInfo icInfo;
 
 // ---------------------------------------------------------------------------

--- a/docs/build.md
+++ b/docs/build.md
@@ -255,6 +255,52 @@ and add DEB or RPM packages when the corresponding local CPack backend is
 available. The `ci-latest-release` workflow runs the Linux CPack runtime-package
 smoke and uploads the `reficcmax-runtime-packages-linux` artifact.
 
+## Shared library exports
+
+`ENABLE_SHARED_LIBS` defaults to `ON`, so a default Windows build links against
+`IccProfLib2.dll`. Its exports come from CMake's `WINDOWS_EXPORT_ALL_SYMBOLS`
+rather than from `__declspec` annotations: MSVC is deliberately excluded from the
+`ICCPROFLIBDLL_EXPORTS` definition in `Build/Cmake/IccProfLib/CMakeLists.txt`.
+That arrangement dates from #764, and the same file records why hidden visibility
+is not used on GCC/Clang — `ICCPROFLIB_API` annotations are incomplete
+(~308 partial uses across 43 headers) and `IccXML` has none at all.
+
+One consequence is worth knowing before it costs a CI round (#1888):
+
+> `WINDOWS_EXPORT_ALL_SYMBOLS` auto-exports **functions**. Exported global
+> **variables** still require explicit `dllexport`/`dllimport`, which IccProfLib
+> does not carry. Referencing one from outside the library fails to link on
+> Windows shared builds with `LNK2019`/`LNK1120`, while every function in the
+> same header links normally.
+
+Linux and macOS have no import-library model and are unaffected, so this never
+appears in a local pre-flight on those platforms.
+
+Affected symbols are `g_pIccMatrixSolver` and `g_pIccMatrixInverter`
+(`IccSolve.h`), and `icD50XYZ`, `icD50XYZxx` and the four `icMsgValidate*`
+message prefixes (`IccUtil.h`). Each declaration carries a note. `IccUtil.h`
+also declares `icInfo`, but that one has no definition anywhere in the tree and
+so fails to link on every platform — a dangling declaration rather than an export
+problem.
+
+Existing consumers handle it in one of two ways:
+
+- **Tools** link `IccProfLib2-static` on Windows shared builds — see
+  `Build/Cmake/Tools/{IccDumpProfile,IccProfilePlot,wxProfileDump}/CMakeLists.txt`.
+  Regression executables get the same fallback through
+  `${ICCDEV_TEST_LIB_ICCPROFLIB}`.
+- **Consumers that also link `IccXML`/`IccJson`** cannot use that fallback, since
+  those libraries link `IccProfLib` `PUBLIC` and the static copy would load the
+  library twice in one process. They avoid the symbol and use literal values.
+
+Prefer the setter functions where they exist: `IccSetMatrixSolver()` and
+`IccSetMatrixInverter()` are functions, so they link normally and are the
+supported way to install a custom solver against the DLL.
+
+See `.github/ci/regression/README.md` for the test-side rules and
+`iccdev.proflib-exported-data-linkage`, which pins both the linkage and the
+literal values that dependent tests hard-code.
+
 ## Instrumentation Builds
 
 Use CMake options instead of hand-written sanitizer flags. Clean the cache when


### PR DESCRIPTION
Fixes #1888. Implements paths (1) and (2) per your ruling on the issue; path (3), correcting the export model itself, is not attempted.

## The defect

A regression test that references an exported IccProfLib global **variable** could not be linked on a Windows shared build. `ENABLE_SHARED_LIBS` defaults `ON`, so the library is `IccProfLib2.dll`, and its exports come from `WINDOWS_EXPORT_ALL_SYMBOLS` rather than `__declspec` annotations — MSVC is deliberately excluded from the `ICCPROFLIBDLL_EXPORTS` definition (`Build/Cmake/IccProfLib/CMakeLists.txt:180-181`), the arrangement introduced in #764.

That mechanism auto-exports functions but **not global data**, and IccProfLib carries no `dllexport`/`dllimport` on its variables. A consumer compiling with `ICCPROFLIB_API` empty emits a direct data reference with no `__imp_` indirection:

```
mpe-empty-identity.obj : error LNK2019: unresolved external symbol
  "char const * const icMsgValidateWarning" (?icMsgValidateWarning@@3PEBDEB)
fatal error LNK1120: 3 unresolved externals
```

Functions in the same headers thunk normally, which is why this stayed hidden until #1887 became the first regression test to touch library data. Linux and macOS have no import-library model, so a local pre-flight cannot catch it — only the Windows CI leg can.

## The change

`ICCDEV_TEST_LIB_ICCPROFLIB` resolves to `IccProfLib2-static` on Windows shared builds and to the normal target everywhere else — the same fallback `iccDumpProfile`, `iccProfilePlot` and `wxProfileDump` already carry.

### One deliberate deviation from the wording in the issue

I proposed putting the fallback inside `iccdev_add_regression_executable`. On implementation that turned out to be unsafe, so it is a separate opt-in target instead.

`IccXML2` and `IccJson` link `${TARGET_LIB_ICCPROFLIB}` **`PUBLIC`** (`Build/Cmake/IccXML/CMakeLists.txt:139,174`). A test linking one of those *and* the static IccProfLib would pull the library into the process twice — once inside the DLL, once in the executable — giving two copies of its globals. Applying the fallback to every regression executable would have introduced that for the tests that co-link IccXML, including the two that exist today.

So the rule is: tests linking IccProfLib alone may use the fallback; tests co-linking IccXML/IccJson must keep asserting on literal values. The documentation says this explicitly at each point where someone would need it.

## Documentation (path 2)

Per your `Known Defect` note, the constraint is now recorded in four places rather than only in a CMake comment:

- beside each affected declaration in `IccProfLib/IccUtil.h` and `IccProfLib/IccSolve.h`
- a new section in `.github/ci/regression/README.md` covering which fallback to choose and why
- a new **Shared library exports** section in `docs/build.md`, citing #764 as the origin of the design
- the `ICCDEV_TEST_LIB_ICCPROFLIB` definition itself

`IccSolve.h` now also points at `IccSetMatrixSolver()` / `IccSetMatrixInverter()` as the linkable way to install a custom solver against the DLL — these are the exported data most likely to be reached for by a downstream consumer, and the setters are functions, so they link normally.

## Test

`iccdev.proflib-exported-data-linkage`. Its primary value is that **it links at all on Windows**: drop the fallback and that leg fails here, rather than in whichever test next reaches for library data.

It also earns its place on every platform. Because tests co-linking IccXML cannot reference these symbols, they hard-code the values instead (`mpe-empty-identity.cpp`, `pawg-q4-xyz-pcs-decode.cpp`), and hard-coded copies drift silently. This pins the real globals, so a change to `icMsgValidateWarning` or `icD50XYZ` fails in one place that names the literals needing an update.

## A correction to the issue text

I wrote that nine exported globals were affected. It is **eight**.

`IccUtil.h:429` declares `icInfo`, but it is defined nowhere in the tree — `nm -DC libIccProfLib2.so` lists the other exported globals and not that one — so referencing it fails to link on **every** platform, not only Windows. Nothing in-tree uses it. I found this because the test would not link on Linux.

That is a dangling public declaration rather than an export problem, so it is out of scope here. I left the declaration in place, since removing public API surface is a separate decision for you, and added a note recording what it is. Happy to file it separately if you want it addressed.

## Verification

- Full build: 0 warnings
- CI's own strict gate (`-Wall -Wextra -Wpedantic -Werror -std=c++17`, Release): 0 warnings, 0 errors
- `ctest`: 123/124; the sole failure is `iccdev.spectral-tiff-preview` (`ModuleNotFoundError: No module named 'imagecodecs'`), a known local environment gap unrelated to this change
- ASAN+UBSAN with `ASAN_OPTIONS=detect_leaks=1`: clean
- Both link paths exercised locally: default shared (`ICCDEV_TEST_LIB_ICCPROFLIB = IccProfLib2`) and `-DENABLE_SHARED_LIBS=OFF` (`= IccProfLib2-static`, the target the Windows fallback selects)

The Windows behaviour itself is the one thing that cannot be verified locally — that is the nature of the defect, and this PR's CI run is the check.
