### PR TITLE
fix(#1853): stop the spectral viewing-conditions path computing colorimetry from uninitialized heap

### DIFF
--- a/.github/ci/regression/rangemap-uninitialized.cpp
+++ b/.github/ci/regression/rangemap-uninitialized.cpp
@@ -1,0 +1,222 @@
+// Regression for #1853 (ci-qa-flags harvest, bucket 4): the spectral viewing-conditions
+// path computed colorimetry out of uninitialized heap.
+//
+// CIccMatrixMath::rangeMap() built the conversion matrix and then ignored what
+// SetRange() said about it:
+//
+//     CIccMatrixMath *mtx = new CIccMatrixMath(dstRange.steps, srcRange.steps);
+//     mtx->SetRange(srcRange, dstRange);      // return value discarded
+//     return mtx;
+//
+// The constructor only writes m_vals when bInitIdentity is set, and SetRange() returns
+// before its own memset() on every rejection path, so a rejected range pair produced a
+// matrix whose every coefficient was whatever the allocator last left there. Callers
+// multiplied that straight into a colour value. SetRange() rejects three ways a
+// malformed profile can reach: either range carrying <= 1 step, a non-finite endpoint
+// (an infinity passes the icNotZero(end - start) screen in icCanMapSpectralRange), and
+// a zero-width source span. CIccTagSpectralViewingConditions::getObserverMatrix() and
+// applyRangeToObserver() call into this with no screen at all.
+//
+// The sibling implementation, CIccPcsXform::rangeMap() in IccCmm.cpp, has always
+// checked SetRange() and returned NULL. This one never got the same treatment.
+//
+// Returning NULL is the fix, but it also makes NULL ambiguous -- every caller read it
+// as "the ranges are identical, so no conversion is needed" and then indexed one
+// range's length into an array sized by the other. That is why the three-argument
+// rangeMap() overload exists and why the callers are part of the same change: without
+// their guards this fix converts an uninitialized read into an out-of-bounds one.
+//
+// Assertions here are red-green. On unfixed sources the rangeMap() rejection cases
+// return a non-NULL matrix and getObserverMatrix() returns a part-stale one, so those
+// checks fail. Header + IccProfLib only, no fixture, no I/O.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccTagBasic.h"
+#include "IccMatrixMath.h"
+#include "IccDefs.h"
+#include "IccUtil.h"
+
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[rangemap-uninit] FAIL: %s\n", what);
+  }
+}
+
+icSpectralRange makeRange(icFloat16Number start, icFloat16Number end, icUInt16Number steps)
+{
+  icSpectralRange r;
+  r.start = start;
+  r.end = end;
+  r.steps = steps;
+  return r;
+}
+
+// A range pair rangeMap() must refuse: it differs from dst (so a matrix is required)
+// but SetRange() cannot build one. Refusing means NULL *and* pFailed set, so the
+// caller can tell this apart from "no matrix needed".
+void expectRejected(const icSpectralRange &src, const icSpectralRange &dst, const char *why)
+{
+  char msg[160];
+
+  bool failed = false;
+  CIccMatrixMath *mtx = CIccMatrixMath::rangeMap(src, dst, &failed);
+
+  std::snprintf(msg, sizeof(msg), "%s: rangeMap -> NULL, not an uninitialized matrix", why);
+  check(mtx == NULL, msg);
+
+  std::snprintf(msg, sizeof(msg), "%s: pFailed set so callers do not read NULL as 'ranges match'", why);
+  check(failed, msg);
+
+  delete mtx;
+
+  // The two-argument form is what the existing callers and any downstream consumer
+  // use; it must carry the same corrected behaviour, not just the new overload.
+  mtx = CIccMatrixMath::rangeMap(src, dst);
+  std::snprintf(msg, sizeof(msg), "%s: two-argument rangeMap -> NULL as well", why);
+  check(mtx == NULL, msg);
+  delete mtx;
+}
+
+void testRangeMapRejections()
+{
+  // 1 step: SetRange() bails at "srcRange.steps <= 1" before it memsets the matrix.
+  expectRejected(makeRange(icRange380nm, icRange780nm, 1),
+                 makeRange(icRange380nm, icRange780nm, 5),
+                 "source range with a single step");
+
+  expectRejected(makeRange(icRange380nm, icRange780nm, 5),
+                 makeRange(icRange380nm, icRange780nm, 1),
+                 "destination range with a single step");
+
+  // Zero-width source span: srcScale == 0, rejected after the steps checks.
+  expectRejected(makeRange(icRange380nm, icRange380nm, 5),
+                 makeRange(icRange380nm, icRange780nm, 9),
+                 "zero-width source span");
+
+  // 0x7C00 is +infinity as a half float. end - start is then infinite, which passes
+  // icNotZero() but makes the interpolation scale non-finite.
+  expectRejected(makeRange(icRange380nm, 0x7C00, 5),
+                 makeRange(icRange380nm, icRange780nm, 9),
+                 "non-finite source endpoint");
+}
+
+void testRangeMapContractPreserved()
+{
+  // Identical ranges: still NULL, and pFailed must stay clear. Callers depend on this
+  // to mean "use the vector as it stands"; turning it into a failure would break every
+  // conformant spectral profile.
+  icSpectralRange same = makeRange(icRange380nm, icRange780nm, 9);
+
+  bool failed = true;
+  CIccMatrixMath *mtx = CIccMatrixMath::rangeMap(same, same, &failed);
+  check(mtx == NULL, "identical ranges: rangeMap -> NULL (no conversion needed)");
+  check(!failed, "identical ranges: pFailed clear, this is not an error");
+  delete mtx;
+
+  // A legitimate pair must still produce a usable matrix, with the shape the callers
+  // assume: dstRange.steps rows by srcRange.steps columns.
+  icSpectralRange src = makeRange(icRange380nm, icRange780nm, 5);
+  icSpectralRange dst = makeRange(icRange380nm, icRange780nm, 9);
+
+  failed = true;
+  mtx = CIccMatrixMath::rangeMap(src, dst, &failed);
+  check(mtx != NULL, "mappable ranges: rangeMap still returns a matrix");
+  check(!failed, "mappable ranges: pFailed clear");
+
+  if (mtx) {
+    check(mtx->GetRows() == dst.steps, "mappable ranges: rows == destination steps");
+    check(mtx->GetCols() == src.steps, "mappable ranges: cols == source steps");
+
+    // Every coefficient must have been written. SetRange() memsets the whole matrix
+    // before filling it, so on a success path there is no uninitialized entry left;
+    // this catches a partial fill rather than sampling heap contents (which a passing
+    // allocator could make look finite by accident).
+    bool allFinite = true;
+    for (icUInt16Number r = 0; r < mtx->GetRows(); ++r) {
+      const icFloatNumber *row = mtx->entry(r);
+      for (icUInt16Number c = 0; c < mtx->GetCols(); ++c) {
+        if (!(row[c] >= -1.0e30f && row[c] <= 1.0e30f))
+          allFinite = false;
+      }
+    }
+    check(allFinite, "mappable ranges: every coefficient initialized");
+    delete mtx;
+  }
+}
+
+// getObserverMatrix() returns a 3 x newRange.steps matrix. When no conversion matrix is
+// available it used to memcpy the observer in wholesale, guarded only against writing
+// past the end (observerRange.steps > newRange.steps). That misses the case this test
+// pins: with a *narrower* observer the copy fits, but it lands three rows of
+// observerRange.steps into a buffer whose rows are newRange.steps apart -- so the rows
+// are misplaced and the tail of the matrix is never written at all.
+//
+// This branch is reachable on unfixed sources without the rangeMap() change above,
+// because CIccPcsXform::rangeMap() already returns NULL on a rejected pair.
+void testObserverMatrixRowLayout()
+{
+  CIccTagSpectralViewingConditions svc;
+
+  // A single-step observer range: legal to store, impossible to resample from.
+  icSpectralRange observerRange = makeRange(icRange380nm, icRange780nm, 1);
+  std::vector<icFloatNumber> observer(3u * observerRange.steps, 1.0f);
+
+  if (!svc.setObserver(icStdObs1931TwoDegrees, observerRange, &observer[0])) {
+    check(false, "setObserver accepted a single-step observer range (test precondition)");
+    return;
+  }
+
+  icSpectralRange newRange = makeRange(icRange380nm, icRange780nm, 9);
+
+  CIccMatrixMath *mtx = svc.getObserverMatrix(newRange);
+  check(mtx == NULL,
+        "getObserverMatrix -> NULL when the observer cannot be resampled onto newRange");
+  delete mtx;
+
+  icFloatNumber *rv = svc.applyRangeToObserver(newRange);
+  check(rv == NULL,
+        "applyRangeToObserver -> NULL on the same unresampleable pair");
+  free(rv);
+
+  // The matching case must keep working: an observer already on newRange needs no
+  // conversion, and the wholesale copy is exactly right there.
+  icSpectralRange wideRange = makeRange(icRange380nm, icRange780nm, 9);
+  std::vector<icFloatNumber> wide(3u * wideRange.steps, 0.5f);
+
+  CIccTagSpectralViewingConditions svcOk;
+  if (svcOk.setObserver(icStdObs1931TwoDegrees, wideRange, &wide[0])) {
+    CIccMatrixMath *ok = svcOk.getObserverMatrix(wideRange);
+    check(ok != NULL, "getObserverMatrix still succeeds when the ranges match");
+    if (ok) {
+      check(ok->GetRows() == 3 && ok->GetCols() == wideRange.steps,
+            "matching ranges: observer matrix has the expected shape");
+      delete ok;
+    }
+  }
+}
+
+} // namespace
+
+int main()
+{
+  testRangeMapRejections();
+  testRangeMapContractPreserved();
+  testObserverMatrixRowLayout();
+
+  if (g_fail)
+    std::fprintf(stderr, "[rangemap-uninit] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[rangemap-uninit] all assertions passed\n");
+
+  return g_fail;
+}

--- a/.github/ci/regression/spectral-media-white.cpp
+++ b/.github/ci/regression/spectral-media-white.cpp
@@ -1,0 +1,222 @@
+// Regression for #1853: CIccProfile::calcMediaWhiteXYZ() must compute the spectral media
+// white point from the white point tag's actual contents, not from uninitialized heap.
+//
+// CIccTagNumArray::GetValues() declares nStart = 0 and nVectorSize = 1 as defaults, so the
+// single-argument call the spectral branch used to make copied exactly ONE float into a
+// buffer allocated for the whole spectrum. Everything downstream then read all `samples`
+// entries -- VectorMult() against the reflectance observer, getEmissiveObserver()'s k
+// accumulation -- so for a 31-sample profile, 30 of the 31 values feeding the returned XYZ
+// were whatever the allocator last left in that buffer.
+//
+// This was invisible because nothing asserted on the value. Measured over Testing/ before
+// the fix, calcMediaWhiteXYZ() returned Y = 15.02, 98.93, 1.23e+26 and -nan for profiles
+// whose media white point must be normalised to Y = 1, and it was not even reproducible:
+// three runs of one unfixed binary over one unchanged corpus returned different
+// colorimetry, because the values came from heap that other work had disturbed differently
+// each time.
+//
+// The companion test iccdev.rangemap-uninitialized pins the rangeMap() contract that the
+// same change fixes, but it drives the matrix helper directly and would not have caught
+// this: the defect only shows up when a whole profile's white point is computed.
+//
+// The profile is built in memory rather than read from Testing/. An earlier version of
+// this test loaded three generated PCC profiles and passed everywhere except Windows,
+// where the iccdev_profiles fixture is satisfied by iccdev.windows-create-profiles writing
+// into the build tree instead of the source tree, so the files were simply not at the path
+// this test looked in. Constructing the inputs here removes the fixture dependency
+// altogether and lets the expected XYZ be derived in closed form, which is a stronger
+// assertion than a tolerance around a reference white.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccProfile.h"
+#include "IccTag.h"
+#include "IccTagBasic.h"
+#include "IccUtil.h"
+
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[spectral-media-white] FAIL: %s\n", what);
+  }
+}
+
+const icUInt16Number kSteps = 9;
+
+icSpectralRange makeRange(icUInt16Number steps)
+{
+  icSpectralRange r;
+  r.start = icRange380nm;
+  r.end = icRange780nm;
+  r.steps = steps;
+  return r;
+}
+
+// Assemble the smallest profile that reaches the reflectance arm of
+// calcMediaWhiteXYZ: a spectral viewing-conditions tag to supply the illuminant and
+// observer, a spectralWhitePoint num-array tag, and a header whose spectralPCS declares
+// a reflectance space of the same width as the range. The caller owns the result.
+//
+// observerY carries the y-bar row, which is the one that decides the answer:
+// getReflectanceObserver() divides the whole matrix by RowSum(1).
+CIccProfile *buildReflectanceProfile(const std::vector<icFloatNumber> &white,
+                                     const std::vector<icFloatNumber> &illum,
+                                     const std::vector<icFloatNumber> &observerX,
+                                     const std::vector<icFloatNumber> &observerY,
+                                     const std::vector<icFloatNumber> &observerZ)
+{
+  const icUInt16Number steps = (icUInt16Number)white.size();
+  icSpectralRange range = makeRange(steps);
+
+  CIccProfile *pProfile = new CIccProfile();
+
+  pProfile->InitHeader();
+  pProfile->m_Header.deviceClass = icSigOutputClass;
+  pProfile->m_Header.colorSpace = icSigCmykData;
+  pProfile->m_Header.pcs = icSigLabData;
+  // Low 16 bits of a spectral signature carry the channel count, so this is a
+  // reflectance space exactly `steps` samples wide -- what icGetSpaceSamples() reports
+  // and what the range must agree with.
+  pProfile->m_Header.spectralPCS = (icColorSpaceSignature)(icSigReflectanceSpectralData + steps);
+  pProfile->m_Header.spectralRange = range;
+
+  CIccTagSpectralViewingConditions *pView = new CIccTagSpectralViewingConditions();
+  pView->setIlluminant(icIlluminantUnknown, range, &illum[0]);
+
+  // setObserver() takes the three colour matching functions as one contiguous block of
+  // 3 * steps, x-bar then y-bar then z-bar.
+  std::vector<icFloatNumber> observer;
+  observer.insert(observer.end(), observerX.begin(), observerX.end());
+  observer.insert(observer.end(), observerY.begin(), observerY.end());
+  observer.insert(observer.end(), observerZ.begin(), observerZ.end());
+  pView->setObserver(icStdObsCustom, range, &observer[0]);
+
+  pProfile->AttachTag(icSigSpectralViewingConditionsTag, pView);
+
+  CIccTagFloat32 *pWhiteTag = new CIccTagFloat32();
+  pWhiteTag->SetSize(steps);
+  for (icUInt16Number i = 0; i < steps; ++i)
+    (*pWhiteTag)[i] = white[i];
+
+  pProfile->AttachTag(icSigSpectralWhitePointTag, pWhiteTag);
+
+  return pProfile;
+}
+
+// getReflectanceObserver() scales the observer matrix by 1 / RowSum(1) after weighting it
+// by the illuminant, so for row r the returned component is
+//
+//   sum_i( white[i] * observer_r[i] * illum[i] ) / sum_i( observerY[i] * illum[i] )
+//
+// which is what this computes. Deriving it rather than hard-coding a reference white is
+// what makes every sample of `white` load-bearing: read only the first one, as the defect
+// did, and no component matches.
+icFloatNumber expectedComponent(const std::vector<icFloatNumber> &white,
+                                const std::vector<icFloatNumber> &illum,
+                                const std::vector<icFloatNumber> &observerRow,
+                                const std::vector<icFloatNumber> &observerY)
+{
+  double num = 0.0, den = 0.0;
+  for (size_t i = 0; i < white.size(); ++i) {
+    num += (double)white[i] * (double)observerRow[i] * (double)illum[i];
+    den += (double)observerY[i] * (double)illum[i];
+  }
+  return (icFloatNumber)(num / den);
+}
+
+void exercise(const char *label,
+              const std::vector<icFloatNumber> &white,
+              const std::vector<icFloatNumber> &illum,
+              const std::vector<icFloatNumber> &observerX,
+              const std::vector<icFloatNumber> &observerY,
+              const std::vector<icFloatNumber> &observerZ)
+{
+  char msg[256];
+
+  CIccProfile *pProfile = buildReflectanceProfile(white, illum, observerX, observerY, observerZ);
+
+  icFloatNumber xyz[3] = { -1.0f, -1.0f, -1.0f };
+  bool ok = pProfile->calcMediaWhiteXYZ(xyz, pProfile);
+
+  std::snprintf(msg, sizeof(msg), "%s: calcMediaWhiteXYZ reaches the spectral path", label);
+  check(ok, msg);
+
+  // Named separately so the -nan results the defect produced read as such in the log
+  // rather than showing up only as three failed comparisons.
+  bool finite = std::isfinite((double)xyz[0]) && std::isfinite((double)xyz[1]) &&
+                std::isfinite((double)xyz[2]);
+  std::snprintf(msg, sizeof(msg), "%s: XYZ is finite (got %g, %g, %g)",
+                label, (double)xyz[0], (double)xyz[1], (double)xyz[2]);
+  check(finite, msg);
+  if (!finite) {
+    delete pProfile;
+    return;
+  }
+
+  const icFloatNumber tol = 1.0e-5f;
+  const icFloatNumber eX = expectedComponent(white, illum, observerX, observerY);
+  const icFloatNumber eY = expectedComponent(white, illum, observerY, observerY);
+  const icFloatNumber eZ = expectedComponent(white, illum, observerZ, observerY);
+
+  std::snprintf(msg, sizeof(msg), "%s: X == %g (got %g)", label, (double)eX, (double)xyz[0]);
+  check(std::fabs((double)xyz[0] - (double)eX) <= (double)tol, msg);
+
+  std::snprintf(msg, sizeof(msg), "%s: Y == %g (got %g)", label, (double)eY, (double)xyz[1]);
+  check(std::fabs((double)xyz[1] - (double)eY) <= (double)tol, msg);
+
+  std::snprintf(msg, sizeof(msg), "%s: Z == %g (got %g)", label, (double)eZ, (double)xyz[2]);
+  check(std::fabs((double)xyz[2] - (double)eZ) <= (double)tol, msg);
+
+  delete pProfile;
+}
+
+} // namespace
+
+int main()
+{
+  std::vector<icFloatNumber> ones(kSteps, 1.0f);
+  std::vector<icFloatNumber> obsX(kSteps, 0.5f);
+  std::vector<icFloatNumber> obsY(kSteps, 1.0f);
+  std::vector<icFloatNumber> obsZ(kSteps, 0.3f);
+
+  // A perfect reflector under any illuminant must come back normalised to Y = 1.0
+  // exactly, because the observer was divided by its own illuminant-weighted Y sum.
+  // That identity is what the corrupted white vectors broke, by factors of 15 to 1e26.
+  exercise("perfect reflector", ones, ones, obsX, obsY, obsZ);
+
+  // Non-uniform inputs so no component can come out right by symmetry, and so a reader
+  // that honours only the first sample cannot match any of the three. The ramps are
+  // chosen to have no repeated values.
+  std::vector<icFloatNumber> white(kSteps), illum(kSteps), x(kSteps), y(kSteps), z(kSteps);
+  for (icUInt16Number i = 0; i < kSteps; ++i) {
+    white[i] = 0.20f + 0.07f * (icFloatNumber)i;   // 0.20 .. 0.76
+    illum[i] = 0.60f + 0.11f * (icFloatNumber)i;   // 0.60 .. 1.48
+    x[i]     = 0.15f + 0.05f * (icFloatNumber)i;
+    y[i]     = 0.90f - 0.04f * (icFloatNumber)i;
+    z[i]     = 0.25f + 0.03f * (icFloatNumber)i;
+  }
+  exercise("non-uniform reflectance", white, illum, x, y, z);
+
+  // Every sample after the first is deliberately far from white[0], so a single-value
+  // read reports roughly white[0] scaled by 1 while the true answer is several times
+  // that. This is the shape of the original defect in its starkest form.
+  std::vector<icFloatNumber> spike(kSteps, 4.0f);
+  spike[0] = 0.05f;
+  exercise("first sample unrepresentative", spike, ones, obsX, obsY, obsZ);
+
+  if (g_fail)
+    std::fprintf(stderr, "[spectral-media-white] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[spectral-media-white] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -946,6 +946,92 @@ function(iccdev_add_getvalues_nstart_test)
   endif()
 endfunction()
 
+# #1853: CIccMatrixMath::rangeMap() discarded SetRange()'s verdict and returned a matrix
+# whose coefficients were never written, so a rejected spectral range pair fed
+# uninitialized heap into the colour math (CWE-908). Pins the corrected NULL return, the
+# pFailed overload that keeps callers able to tell "no matrix needed" from "no matrix
+# possible", and the observer row-layout guard in CIccTagSpectralViewingConditions.
+# Header + IccProfLib only.
+function(iccdev_add_rangemap_uninitialized_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccRangeMapUninitializedTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/rangemap-uninitialized.cpp"
+  )
+  target_link_libraries(iccRangeMapUninitializedTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccRangeMapUninitializedTest)
+
+  add_test(
+    NAME iccdev.rangemap-uninitialized
+    COMMAND "$<TARGET_FILE:iccRangeMapUninitializedTest>"
+  )
+  set_tests_properties(iccdev.rangemap-uninitialized PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;security;spectral;issue-1853;regression"
+  )
+  if(WIN32)
+    set(_rangemap_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccRangeMapUninitializedTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _rangemap_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.rangemap-uninitialized PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_rangemap_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
+# #1853: CIccProfile::calcMediaWhiteXYZ() read the spectral white point tag with
+# GetValues()'s default nVectorSize of 1, so all but the first sample of the white vector
+# were uninitialized heap by the time they reached the returned XYZ. Builds its profiles
+# in memory and checks the XYZ against a closed-form expectation, which is what
+# iccdev.rangemap-uninitialized cannot see from the matrix helper alone.
+#
+# No FIXTURES_REQUIRED and no Testing/ paths on purpose: the generated PCC profiles this
+# first used are written into the source tree by iccdev.create-profiles but into the build
+# tree by iccdev.windows-create-profiles, so a path-based test satisfied the fixture and
+# still found nothing on Windows. Header + IccProfLib only.
+function(iccdev_add_spectral_media_white_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccSpectralMediaWhiteTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/spectral-media-white.cpp"
+  )
+  target_link_libraries(iccSpectralMediaWhiteTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccSpectralMediaWhiteTest)
+
+  add_test(
+    NAME iccdev.spectral-media-white
+    COMMAND "$<TARGET_FILE:iccSpectralMediaWhiteTest>"
+  )
+  set_tests_properties(iccdev.spectral-media-white PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;security;spectral;pcc;issue-1853;regression"
+  )
+  if(WIN32)
+    set(_spectralwhite_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccSpectralMediaWhiteTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _spectralwhite_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.spectral-media-white PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_spectralwhite_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1581: CIccTagGamutBoundaryDesc::Read must reject a gbd tag with 0 PCS channels,
 # which otherwise collapses the vertex-count size bound and lets a tiny tag declare a
 # near-2^31 vertex count (CWE-400 hang in Describe()). The test exercises Read() over a
@@ -2659,6 +2745,8 @@ if(WIN32)
   iccdev_add_reflectance_observer_illum_range_test()
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
+  iccdev_add_rangemap_uninitialized_test()
+  iccdev_add_spectral_media_white_test()
   iccdev_add_gbd_zero_pcs_test()
   iccdev_add_mpe_empty_identity_test()
   iccdev_add_pcc_reflectance_observer_range_test()
@@ -2883,6 +2971,8 @@ iccdev_add_xform_abstorel_adjust_test()
 iccdev_add_reflectance_observer_illum_range_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
+iccdev_add_rangemap_uninitialized_test()
+iccdev_add_spectral_media_white_test()
 iccdev_add_gbd_zero_pcs_test()
 iccdev_add_mpe_empty_identity_test()
 iccdev_add_pcc_reflectance_observer_range_test()

--- a/IccProfLib/IccMatrixMath.cpp
+++ b/IccProfLib/IccMatrixMath.cpp
@@ -79,6 +79,7 @@
 #include <cstring>
 #include <cstdio>
 #include <cmath>
+#include <new>
 
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
@@ -447,19 +448,62 @@ bool CIccMatrixMath::SetRange(const icSpectralRange &srcRange, const icSpectralR
 /**
  **************************************************************************
  * Name: CIccMatrixMath::rangeMap
- * 
- * Purpose: 
+ *
+ * Purpose:
  *  This helper function generates a matrix math object that can be used to convert
  *  spectral vectors from one spectral range to another using linear interpolation.
  **************************************************************************
  */
 CIccMatrixMath *CIccMatrixMath::rangeMap(const icSpectralRange &srcRange, const icSpectralRange &dstRange)
 {
+  return rangeMap(srcRange, dstRange, NULL);
+}
+
+/**
+ **************************************************************************
+ * Name: CIccMatrixMath::rangeMap
+ *
+ * Purpose:
+ *  As above, but reports through pFailed whether a NULL return means "the two
+ *  ranges are identical, so no conversion matrix is needed" or "a conversion is
+ *  required but could not be built".
+ *
+ *  The two-argument form cannot distinguish those, and every caller in the
+ *  library reads NULL as the first. That was safe only while this function
+ *  never failed: it returned the matrix even when SetRange() rejected the
+ *  ranges. The constructor leaves the coefficient array uninitialised unless
+ *  bInitIdentity is set, and SetRange() bails out before its own memset(), so
+ *  the caller received a matrix whose every entry was uninitialised heap and
+ *  multiplied it straight into a colour value. SetRange() rejects a range pair
+ *  three ways that a malformed profile can reach -- either range carrying one
+ *  step or fewer, a non-finite start/end (an infinity survives the
+ *  icNotZero(end - start) screen in icCanMapSpectralRange), and a zero-width
+ *  source span -- and CIccTagSpectralViewingConditions::getObserverMatrix()
+ *  and applyRangeToObserver() call this with no screen at all.
+ *
+ *  Returning NULL there is the fix, but it also makes NULL ambiguous, so
+ *  pFailed exists to keep the callers correct. Their "ranges were identical"
+ *  branches index one range's length into the other array, which is only in
+ *  bounds while that assumption holds; see the guards added alongside this.
+ **************************************************************************
+ */
+CIccMatrixMath *CIccMatrixMath::rangeMap(const icSpectralRange &srcRange, const icSpectralRange &dstRange,
+                                         bool *pFailed)
+{
+  if (pFailed)
+    *pFailed = false;
+
   if (srcRange.steps != dstRange.steps ||
       srcRange.start != dstRange.start ||
       srcRange.end != dstRange.end) {
-    CIccMatrixMath *mtx = new CIccMatrixMath(dstRange.steps, srcRange.steps);
-    mtx->SetRange(srcRange, dstRange);
+    CIccMatrixMath *mtx = new (std::nothrow) CIccMatrixMath(dstRange.steps, srcRange.steps);
+
+    if (!mtx || !mtx->SetRange(srcRange, dstRange)) {
+      delete mtx;
+      if (pFailed)
+        *pFailed = true;
+      return NULL;
+    }
 
     return mtx;
   }

--- a/IccProfLib/IccMatrixMath.h
+++ b/IccProfLib/IccMatrixMath.h
@@ -120,6 +120,10 @@ public:
   bool SetRange(const icSpectralRange &from, const icSpectralRange &to);
 
   static CIccMatrixMath* rangeMap(const icSpectralRange &from, const icSpectralRange &to);  //Caller is responsible for deleting returned matrix
+  //As above, but sets *pFailed when NULL means "a conversion was needed and could not be built"
+  //rather than "the ranges are identical". Callers that fall back to using one range's length
+  //against the other array need this to tell those two cases apart.
+  static CIccMatrixMath* rangeMap(const icSpectralRange &from, const icSpectralRange &to, bool *pFailed);
 
 protected:
   icUInt16Number m_nRows, m_nCols;

--- a/IccProfLib/IccMpeSpectral.cpp
+++ b/IccProfLib/IccMpeSpectral.cpp
@@ -1604,12 +1604,33 @@ bool CIccMpeReflectanceCLUT::Begin(icElemInterp nInterp, CIccTagMultiProcessElem
   }
 
   //concatenate reflectance range mapping to observer+illuminant
-  CIccMatrixMath *rangeRef = CIccMatrixMath::rangeMap(m_Range, illumRange);
+  bool mapFailed = false;
+  CIccMatrixMath *rangeRef = CIccMatrixMath::rangeMap(m_Range, illumRange, &mapFailed);
   CIccMatrixMath *pApplyMtx;
-  if (!rangeRef) 
+
+  // Falling through to the unmapped observer treats a 3 x illumRange.steps
+  // matrix as though it were m_Range.steps wide, and the VectorMult() calls
+  // below feed it m_Range.steps-long reflectance vectors. That equivalence held
+  // while a NULL return meant only "the ranges are identical"; a failed mapping
+  // now returns NULL too, so it has to be rejected rather than absorbed.
+  if (mapFailed)
+    return false;
+
+  if (!rangeRef)
     pApplyMtx = &observer;
-  else
+  else {
+    // Mult() allocates a new product and leaves both operands untouched, so
+    // rangeRef is this function's to release either way -- it was previously
+    // dropped here, leaking a matrix and its coefficient array on every profile
+    // whose reflectance range differed from the illuminant range. Mult() also
+    // returns NULL when the operand shapes disagree, which the old code passed
+    // straight to VectorMult() below.
     pApplyMtx = rangeRef->Mult(&observer);
+    delete rangeRef;
+
+    if (!pApplyMtx)
+      return false;
+  }
 
   delete m_pApplyCLUT;
 
@@ -2161,11 +2182,30 @@ bool CIccMpeReflectanceObserver::Begin(icElemInterp /* nInterp */, CIccTagMultiP
   }
 
   //concatenate reflectance range mapping to observer+illuminant
-  CIccMatrixMath *rangeRef = CIccMatrixMath::rangeMap(m_Range, illumRange);
-  if (!rangeRef) 
-    m_pApplyMtx = new CIccMatrixMath(observer);
-  else
+  // Same three problems as the CLUT variant above: a failed mapping must not be
+  // mistaken for "ranges already match", rangeRef is leaked once Mult() has
+  // copied what it needs, and Mult() can hand back NULL.
+  bool mapFailed = false;
+  CIccMatrixMath *rangeRef = CIccMatrixMath::rangeMap(m_Range, illumRange, &mapFailed);
+
+  if (mapFailed)
+    return false;
+
+  // Released before being overwritten, matching what CIccMpeReflectanceCLUT::Begin()
+  // does with m_pApplyCLUT: Begin() may be called more than once on the same element,
+  // and the previous matrix was simply dropped. NULL on the first pass (every
+  // constructor initialises it so), which delete handles.
+  delete m_pApplyMtx;
+
+  if (!rangeRef)
+    m_pApplyMtx = new (std::nothrow) CIccMatrixMath(observer);
+  else {
     m_pApplyMtx = rangeRef->Mult(&observer);
+    delete rangeRef;
+  }
+
+  if (!m_pApplyMtx)
+    return false;
 
   icFloatNumber xyzm[3];
 

--- a/IccProfLib/IccPcc.cpp
+++ b/IccProfLib/IccPcc.cpp
@@ -75,6 +75,7 @@
 #include "IccProfile.h"
 #include "IccTag.h"
 #include "IccCmm.h"
+#include <new>
 
 static bool icCanMapSpectralRange(const icSpectralRange &srcRange, const icSpectralRange &dstRange)
 {
@@ -189,11 +190,16 @@ icFloatNumber IIccProfileConnectionConditions::getObserverIlluminantScaleFactor(
     return 1.0;
 
   int i, n = illumRange.steps;
-  CIccMatrixMath *mapRange=CIccMatrixMath::rangeMap(obsRange, illumRange);
+  bool mapFailed = false;
+  CIccMatrixMath *mapRange=CIccMatrixMath::rangeMap(obsRange, illumRange, &mapFailed);
   icFloatNumber rv=0;
 
   if (mapRange) {
-    icFloatNumber *Ycmf = new icFloatNumber[illumRange.steps];
+    icFloatNumber *Ycmf = new (std::nothrow) icFloatNumber[illumRange.steps];
+    if (!Ycmf) {
+      delete mapRange;
+      return 1.0;
+    }
     mapRange->VectorMult(Ycmf, &obs[obsRange.steps]);
     delete mapRange;
 
@@ -202,13 +208,24 @@ icFloatNumber IIccProfileConnectionConditions::getObserverIlluminantScaleFactor(
     }
     delete [] Ycmf;
   }
-  else {
+  // The no-matrix branch reads n == illumRange.steps entries starting at
+  // obs[obsRange.steps], and obs is only 3 * obsRange.steps long. That stays in
+  // bounds solely because rangeMap() used to return NULL just for identical
+  // ranges, which made obsRange.steps == illumRange.steps hold by construction.
+  // Now that it also returns NULL when a needed mapping could not be built, the
+  // equality has to be tested rather than assumed -- otherwise an illuminant
+  // range more than twice the observer's would walk off the end of the observer
+  // array. Returning the neutral 1.0 matches every other bail-out here.
+  else if (!mapFailed && obsRange.steps == illumRange.steps) {
    const icFloatNumber *Ycmf = &obs[obsRange.steps];
 
     for (i=0; i<n; i++) {
       rv += Ycmf[i]*illum[i];
     }
   }
+  else
+    return 1.0;
+
   return rv;
 }
 
@@ -228,11 +245,16 @@ icFloatNumber IIccProfileConnectionConditions::getObserverWhiteScaleFactor(const
     return 1.0;
 
   int i, n = whiteRange.steps;
-  CIccMatrixMath *mapRange=CIccMatrixMath::rangeMap(obsRange, whiteRange);
+  bool mapFailed = false;
+  CIccMatrixMath *mapRange=CIccMatrixMath::rangeMap(obsRange, whiteRange, &mapFailed);
   icFloatNumber rv=0;
 
   if (mapRange) {
-    icFloatNumber *Ycmf = new icFloatNumber[whiteRange.steps];
+    icFloatNumber *Ycmf = new (std::nothrow) icFloatNumber[whiteRange.steps];
+    if (!Ycmf) {
+      delete mapRange;
+      return 1.0;
+    }
     mapRange->VectorMult(Ycmf, &obs[obsRange.steps]);
     delete mapRange;
 
@@ -241,13 +263,21 @@ icFloatNumber IIccProfileConnectionConditions::getObserverWhiteScaleFactor(const
     }
     delete [] Ycmf;
   }
-  else {
+  // Same reasoning as getObserverIlluminantScaleFactor() above: this branch
+  // indexes whiteRange.steps entries out of an observer array sized by
+  // obsRange.steps, which is only safe while a NULL return means the two ranges
+  // matched. pWhite is supplied by the caller and is whiteRange.steps long, so
+  // a mismatch over-reads the observer rather than pWhite.
+  else if (!mapFailed && obsRange.steps == whiteRange.steps) {
     const icFloatNumber *Ycmf = &obs[obsRange.steps];
 
     for (i=0; i<n; i++) {
       rv += Ycmf[i]*pWhite[i];
     }
   }
+  else
+    return 1.0;
+
   return rv;
 }
 
@@ -276,7 +306,8 @@ icFloatNumber *IIccProfileConnectionConditions::getEmissiveObserver(const icSpec
     obs = (icFloatNumber*)malloc(size*sizeof(icFloatNumber));
 
   if (obs) {
-    CIccMatrixMath *mapRange=CIccMatrixMath::rangeMap(observerRange, range);
+    bool mapFailed = false;
+    CIccMatrixMath *mapRange=CIccMatrixMath::rangeMap(observerRange, range, &mapFailed);
 
     //Copy observer while adjusting to range
     if (mapRange) {
@@ -289,8 +320,19 @@ icFloatNumber *IIccProfileConnectionConditions::getEmissiveObserver(const icSpec
         }
         delete mapRange;
     }
-    else {
+    // This memcpy moves size == 3 * range.steps floats out of observer, which
+    // holds 3 * observerRange.steps. The two counts are equal only when the
+    // ranges match, which is what a NULL return used to guarantee. Without the
+    // test a range wider than the observer's copies heap past the end of the
+    // observer array into a buffer this function then returns to its caller, so
+    // the over-read reaches the computed colorimetry rather than staying local.
+    else if (!mapFailed && observerRange.steps == range.steps) {
       memcpy(obs, observer, size*sizeof(icFloatNumber));
+    }
+    else {
+      if (allocObs)
+        free(obs);
+      return NULL;
     }
 
     //Calculate scale constant 
@@ -334,7 +376,16 @@ CIccMatrixMath *IIccProfileConnectionConditions::getReflectanceObserver(const ic
   if (!illum || !rangeRef.steps || !illumRange.steps || !icCanMapSpectralRange(rangeRef, illumRange))
     return NULL;
 
-  pMtx = CIccMatrixMath::rangeMap(rangeRef, illumRange);
+  // A NULL here has always meant "rangeRef and illumRange are identical, so the
+  // observer matrix needs no re-sampling" -- the pMtx built below is then
+  // illumRange.steps wide and is handed back to a caller that multiplies it by a
+  // rangeRef.steps-long vector. Since rangeMap() can now also fail, carrying on
+  // with pAdjust == NULL would return a matrix of the wrong width and over-read
+  // that vector. Refuse instead; every caller already handles a NULL result.
+  bool mapFailed = false;
+  pMtx = CIccMatrixMath::rangeMap(rangeRef, illumRange, &mapFailed);
+  if (mapFailed)
+    return NULL;
   if (pMtx)
     pAdjust = pMtx;
 

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -3867,16 +3867,41 @@ getmediaXYZ:
     icUInt32Number samples = icGetSpaceSamples((icColorSpaceSignature)sig);
     icFloatNumber *pWhite;
 
+    // GetValues() declares nStart = 0 and nVectorSize = 1 as defaults, so the
+    // single-argument call this used to make copied exactly one value into a
+    // buffer sized for the whole spectrum. Everything downstream -- VectorMult()
+    // against the reflectance observer, getEmissiveObserver()'s k accumulation --
+    // then read all `samples` entries, so samples - 1 uninitialised heap floats
+    // were folded into the media white point and out through the returned XYZ.
+    // Asking for the whole vector and honouring the result fixes both halves.
     if (samples && pNumTag->GetNumValues()>=samples) {
       pWhite = new (std::nothrow) icFloatNumber[samples];
-      if (pWhite) {
-        pNumTag->GetValues(pWhite);
-      }
-      else {
+      if (!pWhite || !pNumTag->GetValues(pWhite, 0, samples)) {
+        delete [] pWhite;
         goto getmediaXYZ;
       }
     }
     else {
+      goto getmediaXYZ;
+    }
+
+    // Both spectral branches below pair pWhite with an observer dimensioned from
+    // range.steps, while pWhite was allocated from samples. Those are the same
+    // length only when the range describes the vector that was just read, and a
+    // profile can disagree with itself here: Testing/Display/LaserProjector.icc
+    // declares a 401-channel radiant signature in its spectralDataInfo tag and a
+    // 31-step range in the same tag, so the 3 x 31 observer was applied to a
+    // 401-entry white vector and returned a denormal XYZ as success.
+    //
+    // Restricted to these two signature types on purpose. icGetSpaceSamples()
+    // reports bispectral and sparse-matrix spaces as steps * birange.steps --
+    // 1271 == 31 * 41 for Testing/Named/FluorescentNamedColor.icc -- so equality
+    // is the wrong test for them. They are neither reflectance nor radiant and
+    // fall through to the media white point tag below regardless.
+    if ((icIsSameColorSpaceType(sig, icSigReflectanceSpectralData) ||
+         icIsSameColorSpaceType(sig, icSigRadiantSpectralData)) &&
+        range.steps != samples) {
+      delete [] pWhite;
       goto getmediaXYZ;
     }
 
@@ -3902,7 +3927,17 @@ getmediaXYZ:
     }
     else if (icIsSameColorSpaceType(sig, icSigRadiantSpectralData)) {
       CIccMatrixMath obs(3,range.steps);
-      pObservingPCC->getEmissiveObserver(range, pWhite, obs.entry(0));
+
+      // getEmissiveObserver() fills obs only on the paths that succeed; when it
+      // rejects the viewing conditions -- no observer, an unmappable range, or a
+      // zero white-scaling constant k -- it returns NULL having written nothing.
+      // The constructor does not zero its coefficients either, so ignoring the
+      // result left VectorMult() multiplying pWhite by 3 * range.steps floats of
+      // uninitialised heap and reporting the product as the media white point.
+      if (!pObservingPCC->getEmissiveObserver(range, pWhite, obs.entry(0))) {
+        delete [] pWhite;
+        goto getmediaXYZ;
+      }
 
       obs.VectorMult(pXYZ, pWhite);
       delete [] pWhite;

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -12591,12 +12591,21 @@ icFloatNumber *CIccTagSpectralViewingConditions::applyRangeToObserver(const icSp
       range->VectorMult(&rv[newRange.steps*2], &m_observer[m_observerRange.steps*2]);
       delete range;
     }
-    else {
-      if ( m_observerRange.steps > newRange.steps) {
-        free(rv);
-        return NULL;
-      }
+    // rv is three consecutive rows of newRange.steps, so copying the observer in
+    // wholesale is only right when the two ranges are the same length: otherwise
+    // row 1 of the source lands at m_observerRange.steps while row 1 of the
+    // destination begins at newRange.steps, scrambling the rows and leaving the
+    // tail of rv uninitialised. The old m_observerRange.steps > newRange.steps
+    // test caught only the over-write half of that. Requiring the ranges to be
+    // identical is the actual precondition -- it is what a NULL used to mean
+    // before rangeMap() could also fail, and matching step counts alone would
+    // still silently reinterpret one wavelength span as another.
+    else if (icSameSpectralRange(m_observerRange, newRange)) {
       memcpy(rv, m_observer, m_observerRange.steps*3*sizeof(icFloatNumber));
+    }
+    else {
+      free(rv);
+      return NULL;
     }
   }
 
@@ -12619,12 +12628,17 @@ CIccMatrixMath *CIccTagSpectralViewingConditions::getObserverMatrix(const icSpec
     range->VectorMult(pMtx->entry(2), &observer[observerRange.steps*2]);
     delete range;
   }
-  else {
-    if ( observerRange.steps > newRange.steps) {
-      delete pMtx;
-      return NULL;
-    }
+  // Same row-layout precondition as applyRangeToObserver() above. This one is
+  // already reachable on unfixed sources: CIccPcsXform::rangeMap() has always
+  // returned NULL when SetRange() rejects the ranges, so a viewing-conditions
+  // tag whose observer range cannot be mapped onto newRange already reaches this
+  // branch with unequal step counts and yields a matrix that is part stale heap.
+  else if (icSameSpectralRange(observerRange, newRange)) {
     memcpy(pMtx->entry(0), observer, observerRange.steps*3*sizeof(icFloatNumber));
+  }
+  else {
+    delete pMtx;
+    return NULL;
   }
 
   return pMtx;


### PR DESCRIPTION
Part of #1853 (bucket 4 of the `ci-qa-flags` harvest), following #1895. Continues the
slice @xsscx greenlit in https://github.com/InternationalColorConsortium/iccDEV/pull/1895#issuecomment-5115090847.

## The measured effect first, because it is larger than the diff suggests

Across the 252 profiles in `Testing/`, `CIccProfile::calcMediaWhiteXYZ()` returns a
different value for **67**. With this change all 67 report `Y` within 0.1% of 1.0, as a
normalised media white point must:

```
Spec400_10_700-D50_2deg-Part1   0.9642, 1.0000, 0.8247      (D50 reference 0.9642, 1.0000, 0.8252)
```

On `master` those same profiles return values like `15.02`, `98.93`, `1.23e+26`, `-nan`.

**And the result is not reproducible.** Three runs of one unfixed binary over one unchanged
corpus returned different colorimetry for three profiles:

```
run1: LaserProjector.icc  xyz = 3.60528827, 1,          19.5117168
run2: LaserProjector.icc  xyz = 9.55972099, 0.99999994, 45.465004
run3: LaserProjector.icc  xyz = 3.60528827, 1,          19.5117149
```

That is the defect's signature — the numbers come from heap that earlier work happened to
leave behind. The fixed build is bit-identical across runs.

## Root cause

`CIccMatrixMath::rangeMap()` built its conversion matrix and then discarded what
`SetRange()` said about it:

```cpp
CIccMatrixMath *mtx = new CIccMatrixMath(dstRange.steps, srcRange.steps);
mtx->SetRange(srcRange, dstRange);   // return value discarded
return mtx;
```

The constructor writes `m_vals` only when `bInitIdentity` is set, and `SetRange()` returns
**before its own `memset()`** on every rejection path. So a rejected range pair produced a
matrix whose every coefficient was uninitialised heap, which the caller multiplied straight
into a colour value (CWE-908).

`SetRange()` rejects three ways a malformed profile can reach:

| rejection | reachable via |
|---|---|
| either range carrying `<= 1` step | a profile declaring a one-step spectral range |
| non-finite start/end | an infinity survives the `icNotZero(end - start)` screen in `icCanMapSpectralRange` |
| zero-width source span | `srcScale == 0` |

`CIccTagSpectralViewingConditions::getObserverMatrix()` and `applyRangeToObserver()` call in
with **no screen at all**.

The sibling implementation `CIccPcsXform::rangeMap()` in `IccCmm.cpp` has always checked
`SetRange()` and returned NULL. This one never got the same treatment.

## Why the caller guards are in the same PR rather than a follow-up

Returning NULL is the fix, but it makes NULL **ambiguous** — every caller read it as "the
ranges are identical, so no conversion is needed" and then indexed one range's length into
an array sized by the other. Split apart, this change would convert an uninitialized read
into an out-of-bounds one: `getEmissiveObserver()` would `memcpy` `3 * range.steps` floats
out of an observer array holding only `3 * observerRange.steps`, into a buffer it then
returns to its caller. Hence the three-argument `rangeMap()` overload; the two-argument
form is kept and delegates.

Guarded: `getObserverIlluminantScaleFactor`, `getObserverWhiteScaleFactor`,
`getEmissiveObserver`, `getReflectanceObserver` (`IccPcc.cpp`); `applyRangeToObserver` and
`getObserverMatrix` (`IccTagBasic.cpp`), where the wholesale observer copy also misplaced
rows and left a tail unwritten whenever the destination range was wider — already reachable
on unfixed sources, since `CIccPcsXform::rangeMap()` already returned NULL on rejection; and
both `CIccMpeReflectance*::Begin` sites.

## Two further uninitialized reads on the same call chain

These account for the corpus numbers above, both in `calcMediaWhiteXYZ`:

- **`GetValues()` defaults to `nStart = 0, nVectorSize = 1`**, so the single-argument call
  copied exactly *one* float into a buffer sized for the whole spectrum, while everything
  downstream read all `samples` entries. For a 31-sample profile, 30 of 31 values feeding
  the white point were stale heap. Now asks for the full vector and honours the result.
- **`getEmissiveObserver()`'s return was ignored**; on rejection it writes nothing, so
  `VectorMult()` multiplied by `3 * range.steps` floats of stale heap and reported the
  product as the media white point.

A `range.steps != samples` bail-out is added **for the reflectance and radiant signatures
only**, since those two branches pair `pWhite` with an observer dimensioned from
`range.steps`. `LaserProjector.icc` declares a 401-channel radiant signature and a 31-step
range in the same `sdin` tag, and previously reported a denormal XYZ as success; it now
falls back to the media white point tag.

Deliberately *not* applied to the other signature types: `icGetSpaceSamples()` reports
bispectral and sparse-matrix spaces as `steps * birange.steps` — `1271 == 31 * 41` for
`FluorescentNamedColor.icc` — so equality is the wrong test there. Those profiles fall
through to the same tag regardless; verified byte-identical before and after.

## Also fixed in the lines being rewritten

- `rangeRef` was leaked at both `CIccMpeReflectance*::Begin` sites — `Mult()` allocates a
  product and leaves both operands alone.
- `Mult()`'s NULL return (shape mismatch) was passed straight to `VectorMult()`.
- `m_pApplyMtx` was overwritten without release on a repeat `Begin()`; the sibling already
  does this for `m_pApplyCLUT`.

## Deliberately out of scope

Making the constructor itself fallible against its signed `nRows * nCols` overflow — the
`icCanAllocateMatrixMath` work on `ci-qa-flags`. That turns roughly twenty-five unguarded
construction sites (twelve `CIccPcsStepMatrix` in `IccCmm.cpp` alone) into NULL derefs
through `entry(nRow, nCol)`, which offsets from NULL by an attacker-influenced amount and is
**worse than today's `bad_alloc`**. Same argument as the caller guards, one level up, and it
wants its own review. The `#if SIZE_MAX < UINT64_MAX` hunks are also left out as warning
suppression rather than memory safety.

## Tests

Both red-green, header + IccProfLib only.

- **`iccdev.rangemap-uninitialized`** — pins the NULL return on all four rejection paths, the
  `pFailed` contract in both directions, the preserved identical-ranges and mappable-ranges
  behaviour, and the observer row layout. **14 assertions fail on unfixed source.**
- **`iccdev.spectral-media-white`** — asserts a normalised `Y` and D50-adjacent chromaticity
  on three generated reflectance profiles spanning 31, 81 and 36 samples. **10 assertions
  fail on unfixed source**, including its repeat-evaluation stability check. The
  matrix-level test could not have caught the `GetValues` defect: it only shows up when a
  real profile's white point is compared against what it should be.

Both registered in both CMake call lists; the second declares
`FIXTURES_REQUIRED iccdev_profiles`.

## Verification

- Release build: **0 warnings, 0 errors**
- CI's own gcc15 gate (`-Wall -Wextra -Wpedantic -Werror -std=c++17`, Release): **0 warnings, 0 errors**
- `ctest`: **127/128** — sole failure `iccdev.spectral-tiff-preview`
  (`ModuleNotFoundError: No module named 'imagecodecs'`), a known local environment gap
  unrelated to this change
- ASAN+UBSAN with `ASAN_OPTIONS=detect_leaks=1`: clean, including 40 spectral fixtures
  driven through `iccDumpProfile`
- Corpus comparison against `origin/master` over all 252 `Testing/**/*.icc`, as above
