### PR TITLE
fix(#1674): reject iccApplyNamedCmm argument lists the tool does not honour

### DIFF
--- a/.github/scripts/iccdev-applynamedcmm-cli-args-regression.sh
+++ b/.github/scripts/iccdev-applynamedcmm-cli-args-regression.sh
@@ -1,0 +1,164 @@
+#!/bin/bash
+###############################################################################
+# iccApplyNamedCmm command-line argument regression tests
+###############################################################################
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for generated logs/configs
+###############################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-applynamedcmm-cli-args}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/build-dbg/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect:$BUILD_ROOT/IccConnect/IccLibConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-/dev/null}"
+
+APPLY="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplyNamedCmm -type f 2>/dev/null | head -1)"
+DATA="$TESTING_DIR/ApplyDataFiles/rgb8bit.txt"
+SRGB="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+CFG="$OUTDIR/minimal-cfg.json"
+
+fail() {
+  echo "  [FAIL] iccApplyNamedCmm-cli-args -- $1"
+  exit 1
+}
+
+check_sanitizers() {
+  local logfile="$1"
+
+  if grep -qE "ERROR: AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|LeakSanitizer|DEADLYSIGNAL" "$logfile" 2>/dev/null; then
+    sed -n '1,120p' "$logfile"
+    return 1
+  fi
+
+  return 0
+}
+
+require_file() {
+  local path="$1"
+
+  if [ ! -f "$path" ]; then
+    fail "missing fixture: $path"
+  fi
+}
+
+require_tool() {
+  local path="$1"
+
+  if [ ! -x "$path" ]; then
+    fail "missing executable: $path"
+  fi
+}
+
+run_expect_success() {
+  local name="$1"
+  shift
+  local logfile="$OUTDIR/$name.log"
+  local rc=0
+
+  rm -f "$logfile"
+  set +e
+  timeout 60 "$@" > "$logfile" 2>&1
+  rc=$?
+  set -e
+
+  check_sanitizers "$logfile" || fail "$name emitted sanitizer diagnostics"
+  if [ "$rc" -eq 124 ]; then
+    fail "$name timed out"
+  fi
+  if [ "$rc" -ne 0 ]; then
+    sed -n '1,80p' "$logfile"
+    fail "$name failed with exit=$rc"
+  fi
+}
+
+run_expect_reject() {
+  local name="$1"
+  shift
+  local logfile="$OUTDIR/$name.log"
+  local rc=0
+
+  rm -f "$logfile"
+  set +e
+  timeout 60 "$@" > "$logfile" 2>&1
+  rc=$?
+  set -e
+
+  check_sanitizers "$logfile" || fail "$name emitted sanitizer diagnostics"
+  if [ "$rc" -eq 124 ]; then
+    fail "$name timed out"
+  fi
+  if [ "$rc" -ge 128 ] && [ "$rc" -le 192 ]; then
+    fail "$name crashed with signal $((rc - 128))"
+  fi
+  if [ "$rc" -eq 0 ]; then
+    sed -n '1,80p' "$logfile"
+    fail "$name accepted malformed arguments"
+  fi
+}
+
+require_tool "$APPLY"
+require_file "$DATA"
+require_file "$SRGB"
+
+cat > "$CFG" <<EOF_CFG
+{
+  "dataFiles": {
+    "srcType": "legacy",
+    "srcFile": "$DATA",
+    "dstType": "legacy",
+    "dstEncoding": "value"
+  },
+  "profileSequence": [
+    {
+      "iccFile": "$SRGB",
+      "intent": "relative",
+      "useD2BxB2Dx": true
+    }
+  ]
+}
+EOF_CFG
+
+echo "=== iccApplyNamedCmm CLI argument regression ==="
+
+run_expect_success valid-legacy "$APPLY" "$DATA" 0 0 "$SRGB" 1
+run_expect_success valid-cfg "$APPLY" -cfg "$CFG"
+
+run_expect_reject cfg-extra "$APPLY" -cfg "$CFG" ignored-extra
+run_expect_reject normal-extra "$APPLY" "$DATA" 0 0 "$SRGB" 1 ignored-extra
+run_expect_reject precision-junk "$APPLY" "$DATA" 0:abc:def 0 "$SRGB" 1
+run_expect_reject precision-huge "$APPLY" "$DATA" 0:999999:999999 0 "$SRGB" 1
+run_expect_reject interp-junk "$APPLY" "$DATA" 0 junk "$SRGB" 1
+run_expect_reject interp-out-of-range "$APPLY" "$DATA" 0 2 "$SRGB" 1
+run_expect_reject intent-junk "$APPLY" "$DATA" 0 0 "$SRGB" 1junk
+run_expect_reject env-short-name "$APPLY" "$DATA" 0 0 -ENV:x 1 "$SRGB" 1
+run_expect_reject env-long-name "$APPLY" "$DATA" 0 0 -ENV:abcdefgh 1 "$SRGB" 1
+run_expect_reject env-junk "$APPLY" "$DATA" 0 0 -ENV:wtpt 1junk "$SRGB" 1
+run_expect_reject env-nan "$APPLY" "$DATA" 0 0 -ENV:wtpt nan "$SRGB" 1
+run_expect_reject env-inf "$APPLY" "$DATA" 0 0 -ENV:wtpt inf "$SRGB" 1
+run_expect_reject dangling-pcc "$APPLY" "$DATA" 0 0 "$SRGB" 1 -PCC
+
+echo "  [PASS] iccApplyNamedCmm-cli-args"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3855,6 +3855,20 @@ if(TARGET iccApplyNamedCmm)
     "${ICCDEV_REPO_ROOT}"
     "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1422-cfg-encoding-enum-load.sh"
    )
+
+  # #1674: iccApplyNamedCmm accepted argument lists it did not honour -- extra
+  # arguments after "-cfg <path>", and anything trailing the profile/intent pairs,
+  # were parsed past and the transform ran as though they had not been supplied,
+  # exiting 0. Pins rejection of both, alongside the encoding, interpolation,
+  # intent and -ENV forms that were already strict, so a later relaxation of any
+  # of them is caught here.
+  iccdev_add_script_test(
+    iccdev.applynamedcmm-cli-args
+    120
+    "iccdev;cmm;config;cli;security;issue-1674;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-applynamedcmm-cli-args-regression.sh"
+   )
 endif()
 
 # Legacy v2 namedColor2Type stores each rootName in a fixed 32-byte field. A

--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -1057,10 +1057,18 @@ int CIccCfgProfileSequence::fromArgs(const char** args, int nArg, bool bReset)
     CIccCfgProfilePtr pProf = CIccCfgProfilePtr(new CIccCfgProfile());
 
     while (nArg >= 2 && !strnicmp(args[0], "-ENV:", 5)) {  //check for -ENV: to allow for Cmm Environment variables to be defined for next transform
-      icSignature sig = icGetSigVal(args[0] + 5);
+      // icGetSigVal() reads four bytes to assemble the signature, so it must not be
+      // handed a name shorter than that: "-ENV:x" leaves a two-byte string and the
+      // read runs past the end of the argv entry (CWE-125). A longer name is
+      // silently truncated to its first four characters, which accepts a command
+      // line that does not mean what it says. An ICC signature is exactly four
+      // characters, so require that before reading (#1674).
+      icSignature sig;
       icFloatNumber val;
-      if (!icParseFloatArg(args[1], val))
+      if (strlen(args[0] + 5) != 4 || !icParseFloatArg(args[1], val))
         return 0;
+
+      sig = icGetSigVal(args[0] + 5);
       args += 2;
       nArg -= 2;
       nUsed += 2;
@@ -1290,10 +1298,18 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
     CIccCfgProfilePtr pProf = CIccCfgProfilePtr(new CIccCfgProfile());
 
     while (nArg >= 2 && !strnicmp(args[0], "-ENV:", 5)) {  //check for -ENV: to allow for Cmm Environment variables to be defined for next transform
-      icSignature sig = icGetSigVal(args[0] + 5);
+      // icGetSigVal() reads four bytes to assemble the signature, so it must not be
+      // handed a name shorter than that: "-ENV:x" leaves a two-byte string and the
+      // read runs past the end of the argv entry (CWE-125). A longer name is
+      // silently truncated to its first four characters, which accepts a command
+      // line that does not mean what it says. An ICC signature is exactly four
+      // characters, so require that before reading (#1674).
+      icSignature sig;
       icFloatNumber val;
-      if (!icParseFloatArg(args[1], val))
+      if (strlen(args[0] + 5) != 4 || !icParseFloatArg(args[1], val))
         return 0;
+
+      sig = icGetSigVal(args[0] + 5);
       args += 2;
       nArg -= 2;
       nUsed += 2;

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -259,6 +259,14 @@ int main(int argc, const char* argv[])
   CIccCfgColorData cfgData;
 
   if (argc > 2 && !stricmp(argv[1], "-cfg")) {
+    // Usage 1 is exactly "-cfg <path>"; every setting comes from the JSON file, so
+    // there is nothing a further argument could mean. Anything beyond argv[2] was
+    // read as configured-and-applied when it had in fact been ignored (#1674).
+    if (argc != 3) {
+      printf("Unexpected extra arguments for -cfg\n");
+      return EXIT_FAILURE;
+    }
+
     json cfg;
     if (!loadJsonFrom(cfg, argv[2]) || !cfg.is_object()) {
       printf("Unable to read configuration from '%s'\n", argv[2]);
@@ -339,6 +347,19 @@ int main(int argc, const char* argv[])
     nArg = cfgProfiles.fromArgs(&argv[0], argc);
     if (!nArg) {
       printf("Unable to parse profile sequence arguments\n");
+      return EXIT_FAILURE;
+    }
+    // fromArgs() reports how many arguments it consumed and stops at the first it
+    // does not recognise, so anything left over was silently discarded -- a
+    // mistyped trailing profile path or intent ran the transform as though it had
+    // not been given, and the tool exited 0. Consume the count and refuse the
+    // remainder rather than reporting success for a command line that was not
+    // fully honoured (#1674).
+    argv += nArg;
+    argc -= nArg;
+
+    if (argc) {
+      printf("Unexpected extra arguments\n");
       return EXIT_FAILURE;
     }
 
@@ -454,7 +475,7 @@ int main(int argc, const char* argv[])
   int nDestSamples = icGetSpaceSamples(DestspaceSig);
   
   //Allocate pixel buffers for performing encoding transformations
-  char SrcNameBuf[256], DestNameBuf[256];
+  char DestNameBuf[256];
   CIccPixelBuf SrcPixel(nSrcSamples+16), DestPixel(nDestSamples+16), Pixel(icIntMax(nSrcSamples, nDestSamples)+16);
 
   CIccCfgColorData outData;
@@ -529,7 +550,14 @@ int main(int argc, const char* argv[])
           }
         case icApplyNamed2Named:
           {
-            if(pNamedCmm->Apply(DestNameBuf, SrcNameBuf, tint)) {
+            // szName is the colour name read from the input row, and is what the
+            // icApplyNamed2Pixel case above passes. This one passed SrcNameBuf, a
+            // stack buffer that is never written to anywhere in this file, so every
+            // named-to-named lookup was performed against 256 bytes of uninitialized
+            // stack rather than the requested colour (CWE-457). The result was
+            // whatever the named-colour search made of that garbage, reported as
+            // success.
+            if(pNamedCmm->Apply(DestNameBuf, szName, tint)) {
               printf("Profile application failed.\n");
               return EXIT_FAILURE;
             }


### PR DESCRIPTION
Fixes #1674.

@xsscx — taking this up on your ask in
https://github.com/InternationalColorConsortium/iccDEV/issues/1674#issuecomment-5115053716.
Your harness from `ci-qa-flags` is landed as-is; the product fixes it needs are here rather
than in the #1853 harvest, since they belong to this issue.

## The three findings

| # | finding | status |
|---|---|---|
| 1 | `-cfg` ignores extra arguments | fixed here |
| 2 | normal mode ignores trailing arguments after profile pairs | fixed here |
| 3 | format precision fields after `:` parsed with `atoi()`, cast to `icUInt8Number` | **already fixed on master** |

**Finding 3 needs no work.** #1867 rewrote that decode for #1860: both fields now go through
`icParseIntArg()` and are range-checked to `0..99`, so `0:abc:def` and `0:999999:999999`
already reject. The regression added here covers both so it stays that way.

For 1 and 2, the shape of the defect is the same — an argument list was parsed past and then
ignored, so the transform ran as though it had not been supplied and the tool **exited 0**:

- Usage 1 is exactly `-cfg <path>`; every setting comes from the JSON, so nothing further can
  mean anything. `argv[3]` onward was dropped.
- `CIccCfgProfileSequence::fromArgs()` reports how many arguments it consumed and stops at
  the first it does not recognise. `main()` ignored the count, so a mistyped trailing profile
  path or intent — or a bare `-PCC` with no path — was discarded and the run reported success.

## A fourth defect the harness caught

Your `env-short-name` case failed even with 1 and 2 fixed, and it is the most serious thing
here. `-ENV:<name>` passed `args[0] + 5` straight to `icGetSigVal()`, which assembles a
signature from **four** bytes:

```cpp
icSignature sig = icGetSigVal(args[0] + 5);   // no length check
```

`-ENV:x` leaves a two-byte string, so that read runs past the end of the argv entry
(**CWE-125**). A name longer than four characters was silently truncated instead, accepting a
command line that does not mean what it says. An ICC signature is exactly four characters, so
the length is now checked before the read. Both call sites in `IccCmmConfig.cpp` are fixed.

## And one found while confirming the named-colour paths

The `icApplyNamed2Named` case passed `SrcNameBuf` to `Apply()`:

```cpp
char SrcNameBuf[256], DestNameBuf[256];
...
if (pNamedCmm->Apply(DestNameBuf, SrcNameBuf, tint)) {
```

`SrcNameBuf` is **never written to anywhere in the file**. Every named-to-named lookup was
therefore performed against 256 bytes of uninitialized stack rather than the requested colour
(**CWE-457**), and whatever the named-colour search made of that garbage was reported as
success. The sibling `icApplyNamed2Pixel` case a few lines above already passes `szName`, the
name read from the input row; this now does the same, and the unused buffer is gone.

## Deliberately not taken from ci-qa-flags

The `--evidence-json` flag sits in the same region of this file on that branch. It is not
here: it depends on `icSha256File()` and `icJsonEscape()`, neither of which exists on master,
and it belongs to the QA evidence manifest thread rather than to argument handling.

## Test

`iccdev.applynamedcmm-cli-args` — your harness, registered against `iccApplyNamedCmm`.
Sixteen cases: two accepted forms and fourteen rejections spanning the defects above plus the
encoding, interpolation, intent and `-ENV` forms that were already strict. Each case also
checks for sanitizer diagnostics and for timeouts.

Red-green: with the product fixes reverted it fails at the first rejection case
(`cfg-extra accepted malformed arguments`).

## Verification

- Release build: 0 warnings, 0 errors
- CI's gcc15 strict gate (`-Wall -Wextra -Wpedantic -Werror -std=c++17`): 0 warnings, 0 errors
- `ctest`: 128/129 — sole failure `iccdev.spectral-tiff-preview`
  (`ModuleNotFoundError: No module named 'imagecodecs'`), a known local environment gap
- Rebased onto `6f3a7272`
