### PR TITLE
fix(#1898): reject MPE channel and spectral-step counts that do not fit their 16-bit fields

### DIFF
--- a/.github/ci/test-data/mpe-channels-control-1898.xml
+++ b/.github/ci/test-data/mpe-channels-control-1898.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>scnr</ProfileDeviceClass>
+    <DataColourSpace>BCLR</DataColourSpace>
+    <PCS>rs0024</PCS>
+    <CreationDateTime>2026-07-29T07:51:49</CreationDateTime>
+    <ProfileFileSignature>acsp</ProfileFileSignature>
+    <RenderingIntent>Absolute</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </PCSIlluminant>
+    <SpectralPCS>rs0024</SpectralPCS>
+    <SpectralRange>
+      <Wavelengths start="380" end="730" steps="36"/>
+    </SpectralRange>
+  </Header>
+  <Tags>
+    <multiProcessElementType>
+      <TagSignature>D2B3</TagSignature>
+      <MultiProcessElements InputChannels="11" OutputChannels="36">
+        <CalculatorElement InputChannels="11" OutputChannels="11">
+          <MainFunction>{ in(0,11) out(0,11) }</MainFunction>
+        </CalculatorElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/mpe-channels-control-1902.json
+++ b/.github/ci/test-data/mpe-channels-control-1902.json
@@ -1,0 +1,54 @@
+{
+  "IccProfile": {
+    "Header": {
+      "ProfileVersion": "5.00",
+      "ProfileDeviceClass": "scnr",
+      "DataColourSpace": "BCLR",
+      "PCS": "rs0024",
+      "CreationDateTime": "2026-07-29T07:51:49",
+      "ProfileFileSignature": "acsp",
+      "PrimaryPlatform": "APPL",
+      "CMMFlags": {
+        "EmbeddedInFile": true,
+        "UseWithEmbeddedDataOnly": false
+      },
+      "DeviceAttributes": {
+        "ReflectiveOrTransparency": "reflective",
+        "GlossyOrMatte": "glossy",
+        "MediaPolarity": "negative",
+        "MediaColour": "colour"
+      },
+      "RenderingIntent": "Absolute",
+      "PCSIlluminant": [
+        0.96420288,
+        1.0,
+        0.8249054
+      ],
+      "SpectralPCS": "rs0024",
+      "SpectralRange": {
+        "start": 380,
+        "end": 730,
+        "steps": 36
+      }
+    },
+    "Tags": [
+      {
+        "DToB3Tag": {
+          "data": {
+            "type": "multiProcessElementType",
+            "inputChannels": 11,
+            "outputChannels": 36,
+            "elements": [
+              {
+                "type": "CalculatorElement",
+                "inputChannels": 11,
+                "outputChannels": 11,
+                "mainFunction": "{ in(0,11) out(0,11) }"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/.github/ci/test-data/mpe-channels-wrapped-control-1901.json
+++ b/.github/ci/test-data/mpe-channels-wrapped-control-1901.json
@@ -1,0 +1,54 @@
+{
+  "IccProfile": {
+    "Header": {
+      "ProfileVersion": "5.00",
+      "ProfileDeviceClass": "scnr",
+      "DataColourSpace": "BCLR",
+      "PCS": "rs0024",
+      "CreationDateTime": "2026-07-29T07:51:49",
+      "ProfileFileSignature": "acsp",
+      "PrimaryPlatform": "APPL",
+      "CMMFlags": {
+        "EmbeddedInFile": true,
+        "UseWithEmbeddedDataOnly": false
+      },
+      "DeviceAttributes": {
+        "ReflectiveOrTransparency": "reflective",
+        "GlossyOrMatte": "glossy",
+        "MediaPolarity": "negative",
+        "MediaColour": "colour"
+      },
+      "RenderingIntent": "Absolute",
+      "PCSIlluminant": [
+        0.96420288,
+        1.0,
+        0.8249054
+      ],
+      "SpectralPCS": "rs0024",
+      "SpectralRange": {
+        "start": 380,
+        "end": 730,
+        "steps": 36
+      }
+    },
+    "Tags": [
+      {
+        "DToB3Tag": {
+          "data": {
+            "type": "multiProcessElementType",
+            "inputChannels": 11,
+            "outputChannels": 32520,
+            "elements": [
+              {
+                "type": "CalculatorElement",
+                "inputChannels": 11,
+                "outputChannels": 3,
+                "mainFunction": "{ in(0,11) out(0,11) }"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/.github/ci/test-data/mpe-channels-wrapped-control-1901.xml
+++ b/.github/ci/test-data/mpe-channels-wrapped-control-1901.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>scnr</ProfileDeviceClass>
+    <DataColourSpace>BCLR</DataColourSpace>
+    <PCS>rs0024</PCS>
+    <CreationDateTime>2026-07-29T07:51:49</CreationDateTime>
+    <ProfileFileSignature>acsp</ProfileFileSignature>
+    <RenderingIntent>Absolute</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </PCSIlluminant>
+    <SpectralPCS>rs0024</SpectralPCS>
+    <SpectralRange>
+      <Wavelengths start="380" end="730" steps="36"/>
+    </SpectralRange>
+  </Header>
+  <Tags>
+    <multiProcessElementType>
+      <TagSignature>D2B3</TagSignature>
+      <MultiProcessElements InputChannels="11" OutputChannels="32520"/>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-mpe-channels-calc-launder-1898.xml
+++ b/.github/ci/test-data/ub-mpe-channels-calc-launder-1898.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>scnr</ProfileDeviceClass>
+    <DataColourSpace>BCLR</DataColourSpace>
+    <PCS>rs0024</PCS>
+    <CreationDateTime>2026-07-29T07:51:49</CreationDateTime>
+    <ProfileFileSignature>acsp</ProfileFileSignature>
+    <RenderingIntent>Absolute</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </PCSIlluminant>
+    <SpectralPCS>rs0024</SpectralPCS>
+    <SpectralRange>
+      <Wavelengths start="380" end="730" steps="36"/>
+    </SpectralRange>
+  </Header>
+  <Tags>
+    <multiProcessElementType>
+      <TagSignature>D2B3</TagSignature>
+      <MultiProcessElements InputChannels="11" OutputChannels="36">
+        <CalculatorElement InputChannels="11" OutputChannels="360200">
+          <MainFunction>{ in(0,11) out(0,11) }</MainFunction>
+        </CalculatorElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-mpe-channels-calc-launder-1902.json
+++ b/.github/ci/test-data/ub-mpe-channels-calc-launder-1902.json
@@ -1,0 +1,36 @@
+{
+  "IccProfile": {
+    "Header": {
+      "ProfileVersion": "5.00",
+      "ProfileDeviceClass": "scnr",
+      "DataColourSpace": "BCLR",
+      "PCS": "rs0024",
+      "CreationDateTime": "2026-07-29T07:51:49",
+      "ProfileFileSignature": "acsp",
+      "PrimaryPlatform": "APPL",
+      "CMMFlags": { "EmbeddedInFile": true, "UseWithEmbeddedDataOnly": false },
+      "DeviceAttributes": {
+        "ReflectiveOrTransparency": "reflective",
+        "GlossyOrMatte": "glossy",
+        "MediaPolarity": "negative",
+        "MediaColour": "colour"
+      },
+      "RenderingIntent": "Absolute",
+      "PCSIlluminant": [ 0.96420288, 1.0, 0.8249054 ],
+      "SpectralPCS": "rs0024",
+      "SpectralRange": { "start": 380, "end": 730, "steps": 36 }
+    },
+    "Tags": [
+      { "DToB3Tag": { "data": {
+            "type": "multiProcessElementType",
+            "inputChannels": 11,
+            "outputChannels": 36,
+            "elements": [
+              { "type": "CalculatorElement",
+                "inputChannels": 11,
+                "outputChannels": 360200,
+                "mainFunction": "{ in(0,11) out(0,11) }" } ]
+      } } }
+    ]
+  }
+}

--- a/.github/ci/test-data/ub-mpe-channels-clut-1899.xml
+++ b/.github/ci/test-data/ub-mpe-channels-clut-1899.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>scnr</ProfileDeviceClass>
+    <DataColourSpace>BCLR</DataColourSpace>
+    <PCS>rs0024</PCS>
+    <CreationDateTime>2026-07-29T07:51:49</CreationDateTime>
+    <ProfileFileSignature>acsp</ProfileFileSignature>
+    <RenderingIntent>Absolute</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </PCSIlluminant>
+    <SpectralPCS>rs0024</SpectralPCS>
+    <SpectralRange>
+      <Wavelengths start="380" end="730" steps="36"/>
+    </SpectralRange>
+  </Header>
+  <Tags>
+    <multiProcessElementType>
+      <TagSignature>D2B3</TagSignature>
+      <MultiProcessElements InputChannels="11" OutputChannels="36">
+        <CLutElement InputChannels="11" OutputChannels="360200"/>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-mpe-channels-tag-launder-1901.json
+++ b/.github/ci/test-data/ub-mpe-channels-tag-launder-1901.json
@@ -1,0 +1,54 @@
+{
+  "IccProfile": {
+    "Header": {
+      "ProfileVersion": "5.00",
+      "ProfileDeviceClass": "scnr",
+      "DataColourSpace": "BCLR",
+      "PCS": "rs0024",
+      "CreationDateTime": "2026-07-29T07:51:49",
+      "ProfileFileSignature": "acsp",
+      "PrimaryPlatform": "APPL",
+      "CMMFlags": {
+        "EmbeddedInFile": true,
+        "UseWithEmbeddedDataOnly": false
+      },
+      "DeviceAttributes": {
+        "ReflectiveOrTransparency": "reflective",
+        "GlossyOrMatte": "glossy",
+        "MediaPolarity": "negative",
+        "MediaColour": "colour"
+      },
+      "RenderingIntent": "Absolute",
+      "PCSIlluminant": [
+        0.96420288,
+        1.0,
+        0.8249054
+      ],
+      "SpectralPCS": "rs0024",
+      "SpectralRange": {
+        "start": 380,
+        "end": 730,
+        "steps": 36
+      }
+    },
+    "Tags": [
+      {
+        "DToB3Tag": {
+          "data": {
+            "type": "multiProcessElementType",
+            "inputChannels": 11,
+            "outputChannels": 360200,
+            "elements": [
+              {
+                "type": "CalculatorElement",
+                "inputChannels": 11,
+                "outputChannels": 3,
+                "mainFunction": "{ in(0,11) out(0,11) }"
+              }
+            ]
+          }
+        }
+      }
+    ]
+  }
+}

--- a/.github/ci/test-data/ub-mpe-channels-tag-launder-1901.xml
+++ b/.github/ci/test-data/ub-mpe-channels-tag-launder-1901.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>scnr</ProfileDeviceClass>
+    <DataColourSpace>BCLR</DataColourSpace>
+    <PCS>rs0024</PCS>
+    <CreationDateTime>2026-07-29T07:51:49</CreationDateTime>
+    <ProfileFileSignature>acsp</ProfileFileSignature>
+    <RenderingIntent>Absolute</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </PCSIlluminant>
+    <SpectralPCS>rs0024</SpectralPCS>
+    <SpectralRange>
+      <Wavelengths start="380" end="730" steps="36"/>
+    </SpectralRange>
+  </Header>
+  <Tags>
+    <multiProcessElementType>
+      <TagSignature>D2B3</TagSignature>
+      <MultiProcessElements InputChannels="11" OutputChannels="360200"/>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-mpe-steps-emission-1900.xml
+++ b/.github/ci/test-data/ub-mpe-steps-emission-1900.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>scnr</ProfileDeviceClass>
+    <DataColourSpace>BCLR</DataColourSpace>
+    <PCS>rs0024</PCS>
+    <CreationDateTime>2026-07-29T07:51:49</CreationDateTime>
+    <ProfileFileSignature>acsp</ProfileFileSignature>
+    <RenderingIntent>Absolute</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </PCSIlluminant>
+    <SpectralPCS>rs0024</SpectralPCS>
+    <SpectralRange>
+      <Wavelengths start="380" end="730" steps="36"/>
+    </SpectralRange>
+  </Header>
+  <Tags>
+    <multiProcessElementType>
+      <TagSignature>D2B3</TagSignature>
+      <MultiProcessElements InputChannels="11" OutputChannels="36">
+        <EmissionObserverElement InputChannels="11" OutputChannels="3">
+          <Wavelengths start="380" end="730" steps="360200"/>
+          <WhiteData>1 1 1</WhiteData>
+        </EmissionObserverElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/.github/ci/test-data/ub-mpe-steps-reflectance-1903.xml
+++ b/.github/ci/test-data/ub-mpe-steps-reflectance-1903.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>scnr</ProfileDeviceClass>
+    <DataColourSpace>BCLR</DataColourSpace>
+    <PCS>rs0024</PCS>
+    <CreationDateTime>2026-07-29T07:51:49</CreationDateTime>
+    <ProfileFileSignature>acsp</ProfileFileSignature>
+    <RenderingIntent>Absolute</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </PCSIlluminant>
+    <SpectralPCS>rs0024</SpectralPCS>
+    <SpectralRange>
+      <Wavelengths start="380" end="730" steps="36"/>
+    </SpectralRange>
+  </Header>
+  <Tags>
+    <multiProcessElementType>
+      <TagSignature>D2B3</TagSignature>
+      <MultiProcessElements InputChannels="11" OutputChannels="36">
+        <ReflectanceObserverElement InputChannels="11" OutputChannels="3">
+          <Wavelengths start="380" end="730" steps="360200"/>
+          <WhiteData>1 1 1</WhiteData>
+        </ReflectanceObserverElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/.github/scripts/iccdev-issue-1898-mpe-channel-narrowing-regression.sh
+++ b/.github/scripts/iccdev-issue-1898-mpe-channel-narrowing-regression.sh
@@ -1,0 +1,278 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issues #1898 #1899 #1900 #1901 #1902 #1903
+#   unbounded MPE channel counts and spectral step counts in the XML and JSON
+#   readers
+###############################################################################
+#
+# Six issues, one defect.  Every multi-process-element reader stores its channel
+# counts in an icUInt16Number, and every one of them parsed the attribute into a
+# signed int first:
+#
+#   m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));  // XML
+#   jGetValue(j, "outputChannels", nOut);                              // JSON
+#   m_nOutputChannels = (icUInt16Number)nOut;
+#
+# The guard that followed was "!nIn || !nOut", which rejects zero and nothing
+# else.  360200 therefore passed it and then changed value on the way into
+# storage -- 360200 & 0xFFFF == 32520.  Wavelength step counts (icSpectralRange
+# ::steps, also u16) were read the same way.
+#
+# On the XML side the narrowing is an implicit conversion, so UBSan reports it:
+#
+#   IccMpeXml.cpp:3422:11: runtime error: implicit conversion from type 'int' of
+#   value 360200 (32-bit, signed) to type 'icUInt16Number' (aka 'unsigned
+#   short') changed the value to 32520 (16-bit, unsigned)
+#
+# On the JSON side, and at IccTagXml.cpp:4748, the cast is explicit -- which
+# suppresses the sanitizer check while changing the value just the same.  That
+# is the half of the cluster #1901 was filed about, and it is why this test does
+# not rely on sanitizer output for its main assertions.
+#
+# All fixtures are the same profile with ONLY the one attribute changed, so
+# anything else they exercise is a known-good path.
+#
+# CASE A -- value laundering.  The case that matters on an ordinary build.  Four
+# documents were accepted, converted with exit 0, and written to disk carrying a
+# channel count the source never contained:
+#
+#   $ iccFromXml ub-mpe-channels-tag-launder-1901.xml out.icc; echo $?
+#   0
+#   $ iccToXml out.icc back.xml && grep MultiProcessElements back.xml
+#   <MultiProcessElements InputChannels="11" OutputChannels="32520">
+#
+#   $ iccFromJson ub-mpe-channels-calc-launder-1902.json out.icc; echo $?
+#   0
+#   ... round-trips "outputChannels": 360200 as 32520
+#
+# The document asked for 360200, the tool reported success, and the profile it
+# wrote says 32520.  The fixed readers must refuse the count instead.  No
+# sanitizer required -- the tell is the written file.
+#
+# CASE B -- the reported breadcrumbs that had no functional tell.  For the CLUT
+# and the two observer elements the narrowed value went on to fail a later
+# constraint (the CLUT could not be built at that size; steps != InputChannels),
+# so pre-fix these were already rejected and "no profile written" is equally
+# true on a broken build.  Asserting on it would be a vacuous pass, so case B is
+# gated on an integer/implicit-conversion sanitizer build and SKIPPED elsewhere.
+#
+# CONTROLS -- two of them, both required to convert:
+#   1. a legal count (OutputChannels="11" / "36"), which fails loudly if the fix
+#      over-rejects ordinary documents;
+#   2. OutputChannels="32520" -- the wrapped value itself.  This is the control
+#      that pins down what the fix actually changed: 32520 is a representable
+#      count and must still be accepted, so rejecting 360200 is about the value
+#      not fitting the field and NOT about a newly tightened channel cap.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1898}"
+DATA_DIR="$REPO_ROOT/.github/ci/test-data"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+# iccFromJson is optional: the JSON tools are behind ICCDEV_HAS_JSON_TOOLS, so
+# the JSON half of the cluster is skipped rather than failing where they are off.
+FROMJSON="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromJson -type f 2>/dev/null | head -1)"
+
+# Locate the build's CMakeCache.txt (walk up from the tool) to decide whether
+# case B's check is actually compiled in.
+#
+# As in the #1851 test the gate deliberately does NOT accept ENABLE_UBSAN or a
+# bare "undefined" in the flags: Build/Cmake/CMakeLists.txt maps ENABLE_UBSAN to
+# -fsanitize=undefined, and implicit-integer-truncation lives in the integer /
+# implicit-conversion groups, not in undefined.  A looser gate would report a
+# confident PASS on an -fsanitize=address,undefined build that cannot observe
+# the conversion at all.
+CACHE=""
+probe="$(dirname "$FROMXML")"
+for _ in 1 2 3 4 5; do
+  if [ -f "$probe/CMakeCache.txt" ]; then CACHE="$probe/CMakeCache.txt"; break; fi
+  probe="$(dirname "$probe")"
+done
+sanitized=0
+if [ -n "$CACHE" ]; then
+  if grep -qiE "ENABLE_INTEGER_SANITIZER:BOOL=ON" "$CACHE"; then
+    sanitized=1
+  elif grep -iE "CMAKE_(CXX|C)_FLAGS" "$CACHE" | grep -qiE "fsanitize=[^ ]*(integer|implicit)"; then
+    sanitized=1
+  fi
+fi
+
+TOOL_RC=0
+TOOL_LOG=""
+TOOL_ICC=""
+run_tool() {
+  # $1 = fixture basename including extension.  Chooses the converter from the
+  # extension.  Sets the globals TOOL_LOG / TOOL_ICC / TOOL_RC rather than
+  # echoing them: a caller using $(run_tool ...) would run this in a command
+  # substitution subshell and TOOL_RC would never reach the caller.
+  local fixture="$DATA_DIR/$1"
+  local base="${1%.*}"
+  local tool="$FROMXML"
+  case "$1" in
+    *.json) tool="$FROMJSON" ;;
+  esac
+  TOOL_LOG="$OUTDIR/$base.log"
+  TOOL_ICC="$OUTDIR/$base.icc"
+  rm -f "$TOOL_ICC"
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0:allocator_may_return_null=1" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$tool" "$fixture" "$TOOL_ICC" > "$TOOL_LOG" 2>&1
+  TOOL_RC=$?
+}
+
+status=0
+
+# --- CONTROLS ---------------------------------------------------------------
+# Run first.  A control that cannot convert means the environment is wrong, not
+# that #1898 regressed, so the affected half skips instead of blaming the fix.
+XML_CONTROL_ICC=""
+run_tool "mpe-channels-control-1898.xml"
+if [ -f "$TOOL_ICC" ]; then
+  XML_CONTROL_ICC="$OUTDIR/mpe-channels-control-1898.control.icc"
+  cp "$TOOL_ICC" "$XML_CONTROL_ICC"
+  echo "[PASS] control: legal XML channel counts still convert"
+else
+  if grep -qE "runtime error: |AddressSanitizer" "$TOOL_LOG"; then
+    echo "[FAIL] control: a legal XML channel count tripped a sanitizer"
+    grep -E "runtime error: |AddressSanitizer|IccMpeXml|IccTagXml" "$TOOL_LOG" | head
+    exit 2
+  fi
+  echo "[SKIP] XML control did not convert; environment issue, not #1898"
+  sed -n '1,10p' "$TOOL_LOG"
+  exit 0
+fi
+
+# The wrapped value must remain acceptable -- see the header.  A fix that
+# rejected 32520 too would pass every case-A assertion below while having
+# broken legitimate documents, so this control is what distinguishes
+# "refuses an unrepresentable count" from "lowered the channel ceiling".
+run_tool "mpe-channels-wrapped-control-1901.xml"
+if [ -f "$TOOL_ICC" ]; then
+  echo "[PASS] control: OutputChannels=\"32520\" (the wrapped value) still converts"
+else
+  echo "[FAIL] control: OutputChannels=\"32520\" was rejected -- the fix is"
+  echo "       refusing representable counts, not just unrepresentable ones"
+  sed -n '1,10p' "$TOOL_LOG"
+  status=2
+fi
+
+# --- CASE A: laundering, XML (functional, valid on every build) --------------
+for poc in ub-mpe-channels-calc-launder-1898.xml \
+           ub-mpe-channels-tag-launder-1901.xml; do
+  if [ ! -f "$DATA_DIR/$poc" ]; then
+    echo "[SKIP] PoC missing: $DATA_DIR/$poc"
+    continue
+  fi
+  run_tool "$poc"
+  if [ -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1898 case A: profile written for OutputChannels=\"360200\" from $poc (rc=$TOOL_RC)"
+    # Re-serialize to show the count that actually landed in the file.
+    TOXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccToXml -type f 2>/dev/null | head -1)"
+    if [ -n "$TOXML" ] && [ -x "$TOXML" ]; then
+      if "$TOXML" "$TOOL_ICC" "$OUTDIR/${poc%.xml}.roundtrip.xml" >/dev/null 2>&1; then
+        echo "       written profile re-serializes as:"
+        grep -oE '(MultiProcessElements|CalculatorElement) InputChannels="[0-9]+" OutputChannels="[0-9]+"' \
+          "$OUTDIR/${poc%.xml}.roundtrip.xml" | sed 's/^/         /'
+      fi
+    fi
+    status=2
+  elif [ "$sanitized" -eq 1 ] && grep -qE "runtime error: implicit conversion" "$TOOL_LOG"; then
+    echo "[FAIL] #1898 case A: implicit conversion of a channel count reappeared in $poc"
+    grep -E "runtime error: implicit conversion|IccMpeXml|IccTagXml" "$TOOL_LOG" | head
+    status=2
+  else
+    echo "[PASS] #1898 case A: $poc rejected, no profile written"
+  fi
+done
+
+# --- CASE A: laundering, JSON -----------------------------------------------
+if [ -z "$FROMJSON" ] || [ ! -x "$FROMJSON" ]; then
+  echo "[SKIP] iccFromJson not built; JSON half of the cluster (#1901/#1902) not exercised"
+else
+  run_tool "mpe-channels-control-1902.json"
+  if [ ! -f "$TOOL_ICC" ]; then
+    echo "[SKIP] JSON control did not convert; environment issue, not #1902"
+    sed -n '1,10p' "$TOOL_LOG"
+  else
+    echo "[PASS] control: legal JSON channel counts still convert"
+
+    run_tool "mpe-channels-wrapped-control-1901.json"
+    if [ -f "$TOOL_ICC" ]; then
+      echo "[PASS] control: JSON outputChannels 32520 still converts"
+    else
+      echo "[FAIL] control: JSON outputChannels 32520 was rejected"
+      status=2
+    fi
+
+    for poc in ub-mpe-channels-calc-launder-1902.json \
+               ub-mpe-channels-tag-launder-1901.json; do
+      if [ ! -f "$DATA_DIR/$poc" ]; then
+        echo "[SKIP] PoC missing: $DATA_DIR/$poc"
+        continue
+      fi
+      run_tool "$poc"
+      if [ -f "$TOOL_ICC" ]; then
+        echo "[FAIL] #1902 case A: profile written for outputChannels 360200 from $poc (rc=$TOOL_RC)"
+        TOJSON="$(find "$TOOLS_DIR" -maxdepth 2 -name iccToJson -type f 2>/dev/null | head -1)"
+        if [ -n "$TOJSON" ] && [ -x "$TOJSON" ]; then
+          if "$TOJSON" "$TOOL_ICC" "$OUTDIR/${poc%.json}.roundtrip.json" >/dev/null 2>&1; then
+            echo "       written profile re-serializes with:"
+            grep -oE '"outputChannels": *[0-9]+' \
+              "$OUTDIR/${poc%.json}.roundtrip.json" | sed 's/^/         /'
+          fi
+        fi
+        status=2
+      else
+        echo "[PASS] #1902 case A: $poc rejected, no profile written"
+      fi
+    done
+  fi
+fi
+
+# --- CASE B: reported breadcrumbs with no functional tell -------------------
+# Pre-fix each of these was already rejected by a later constraint, so a
+# "no profile written" assertion would hold on a broken build too.  Skipped
+# rather than passed where the conversion cannot be observed.
+for poc in ub-mpe-channels-clut-1899.xml \
+           ub-mpe-steps-emission-1900.xml \
+           ub-mpe-steps-reflectance-1903.xml; do
+  if [ ! -f "$DATA_DIR/$poc" ]; then
+    echo "[SKIP] PoC missing: $DATA_DIR/$poc"
+    continue
+  fi
+  if [ "$sanitized" -ne 1 ]; then
+    echo "[SKIP] case B ($poc): not an integer/implicit-conversion build (CMakeCache: ${CACHE:-none})"
+    continue
+  fi
+  run_tool "$poc"
+  if grep -qE "runtime error: implicit conversion" "$TOOL_LOG"; then
+    echo "[FAIL] #1898 case B: narrowing conversion reappeared in $poc (rc=$TOOL_RC)"
+    grep -E "runtime error: implicit conversion|IccMpeXml.cpp" "$TOOL_LOG" | head
+    status=2
+  elif [ -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1898 case B: profile written despite an out-of-range count in $poc"
+    status=2
+  else
+    echo "[PASS] #1898 case B: $poc parsed without a narrowing conversion"
+  fi
+done
+
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3692,6 +3692,26 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1851-parametriccurve-functiontype-regression.sh"
 )
 
+# #1898/#1899/#1900/#1901/#1902/#1903: unbounded MPE channel and spectral-step
+# counts in the XML and JSON readers.  Six issues, one defect -- the counts are
+# u16 and every reader parsed them into an int behind a "!nIn || !nOut" guard
+# that rejects zero and nothing else, so 360200 reached storage as 32520.  Case A
+# has teeth in the ordinary CI jobs: four documents converted with exit 0 and the
+# written profile re-serializes with a channel count the source never contained,
+# on the XML side and the JSON side both.  Case B covers the reported breadcrumbs
+# whose narrowed value was already caught by a later constraint (the CLUT and the
+# two observer elements), so it is gated on an integer/implicit-conversion build
+# rather than passing vacuously.  Two controls: a legal count, and 32520 itself --
+# the second is what shows the fix refuses unrepresentable counts rather than
+# having lowered the channel ceiling.
+iccdev_add_script_test(
+  iccdev.issue-1898-mpe-channel-narrowing-regression
+  120
+  "iccdev;xml;json;mpe;issue-1898;issue-1901;issue-1902;regression;ubsan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1898-mpe-channel-narrowing-regression.sh"
+)
+
 # #1810: 'RICC' in the CMM and platform header fields of 15 Testing fixtures.
 # 'RICC' was never registered -- icSigRefIccMAX itself carried 0x52494343
 # ('RICC') against a comment and a registry that both said 'RIMX', until #1473

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -86,6 +86,9 @@ static inline icUInt32Number icJsonSafeU32(size_t n, bool *overflow = nullptr)
 // Match the defensive cap used by CIccMpeMatrix::Read for user-controlled
 // matrix-family payloads before narrowing channel counts.
 static const int kIccJsonMaxMatrixChannels = 255;
+// kIccJsonMaxChannels / icJsonValidChannels are shared with the tag-level
+// reader and live in IccUtilJson.h. The matrix family is capped more tightly
+// than its u16 storage and keeps its own constant above.
 static const int kIccJsonMaxSpectralSteps = 65535;
 
 static bool icJsonValidMatrixChannels(int nIn, int nOut)
@@ -150,11 +153,16 @@ bool CIccMpeJsonUnknown::ToJson(IccJson &j)
   return true;
 }
 
-bool CIccMpeJsonUnknown::ParseJson(const IccJson &j, std::string & /*parseStr*/)
+bool CIccMpeJsonUnknown::ParseJson(const IccJson &j, std::string &parseStr)
 {
   int nIn = 0, nOut = 0;
   jGetValue(j, "inputChannels",  nIn);
   jGetValue(j, "outputChannels", nOut);
+
+  if (!icJsonValidChannels(nIn, nOut)) {
+    parseStr += "Invalid inputChannels or outputChannels in unknown element\n";
+    return false;
+  }
   m_nInputChannels  = (icUInt16Number)nIn;
   m_nOutputChannels = (icUInt16Number)nOut;
   if (j.contains("unknownData") && j["unknownData"].is_string()) {
@@ -617,7 +625,7 @@ bool CIccMpeJsonCurveSet::ParseJson(const IccJson &j, std::string &parseStr)
   jGetValue(j, "inputChannels",  nIn);
   jGetValue(j, "outputChannels", nOut);
 
-  if (!nIn || nIn != nOut) {
+  if (!icJsonValidChannels(nIn, nOut) || nIn != nOut) {
     parseStr += "Invalid inputChannels or outputChannels in CurveSetElement\n";
     return false;
   }
@@ -697,6 +705,11 @@ bool CIccMpeJsonTintArray::ParseJson(const IccJson &j, std::string &parseStr)
   int nIn = 0, nOut = 0;
   jGetValue(j, "inputChannels",  nIn);
   jGetValue(j, "outputChannels", nOut);
+
+  if (!icJsonValidChannels(nIn, nOut)) {
+    parseStr += "Invalid inputChannels or outputChannels in TintArrayElement\n";
+    return false;
+  }
   m_nInputChannels  = (icUInt16Number)nIn;
   m_nOutputChannels = (icUInt16Number)nOut;
 
@@ -905,7 +918,7 @@ bool CIccMpeJsonToneMap::ParseJson(const IccJson &j, std::string &parseStr)
   jGetValue(j, "inputChannels",  nIn);
   jGetValue(j, "outputChannels", nOut);
 
-  if (!nIn || !nOut || nIn != nOut + 1) {
+  if (!icJsonValidChannels(nIn, nOut) || nIn != nOut + 1) {
     parseStr += "Invalid inputChannels or outputChannels in ToneMapElement\n";
     return false;
   }
@@ -1093,7 +1106,7 @@ bool CIccMpeJsonCLUT::ParseJson(const IccJson &j, std::string &parseStr)
   jGetValue(j, "inputChannels",  nIn);
   jGetValue(j, "outputChannels", nOut);
 
-  if (!nIn || !nOut) {
+  if (!icJsonValidChannels(nIn, nOut)) {
     parseStr += "Invalid inputChannels or outputChannels in CLutElement\n";
     return false;
   }
@@ -1134,7 +1147,7 @@ bool CIccMpeJsonExtCLUT::ParseJson(const IccJson &j, std::string &parseStr)
   jGetValue(j, "storageType",    storageType);
   jGetValue(j, "reserved2",      reserved2);
 
-  if (!nIn || !nOut) {
+  if (!icJsonValidChannels(nIn, nOut)) {
     parseStr += "Invalid inputChannels or outputChannels in ExtCLutElement\n";
     return false;
   }
@@ -2044,7 +2057,7 @@ bool CIccMpeJsonCalculator::ParseJson(const IccJson &j, std::string &parseStr)
   int nIn = 0, nOut = 0;
   jGetValue(j, "inputChannels",  nIn);
   jGetValue(j, "outputChannels", nOut);
-  if (!nIn || !nOut) {
+  if (!icJsonValidChannels(nIn, nOut)) {
     parseStr += "Invalid inputChannels or outputChannels in CalculatorElement\n";
     return false;
   }
@@ -2284,7 +2297,7 @@ bool CIccMpeJsonEmissionMatrix::ParseJson(const IccJson &j, std::string &parseSt
   int nIn = 0, nOut = 0;
   jGetValue(j, "inputChannels", nIn);
   jGetValue(j, "outputChannels", nOut);
-  if (nIn < 1 || nOut != 3) {
+  if (!icJsonValidChannels(nIn, nOut) || nOut != 3) {
     parseStr += "Invalid inputChannels or outputChannels in EmissionMatrixElement\n";
     return false;
   }
@@ -2329,7 +2342,7 @@ static bool icSpectralCLUTParseJson(const IccJson &j, std::string &parseStr,
   flags       = (icUInt32Number)iFlags;
   storageType = (icUInt16Number)iStorageType;
 
-  if (!nIn || !nOut) {
+  if (!icJsonValidChannels(nIn, nOut)) {
     parseStr += "Invalid inputChannels or outputChannels in spectral CLUT element\n";
     return false;
   }
@@ -2448,7 +2461,7 @@ bool CIccMpeJsonEmissionObserver::ParseJson(const IccJson &j, std::string &parse
   jGetValue(j, "flags",          flags);
   m_flags = (icUInt16Number)flags;
 
-  if (!nIn || !nOut) {
+  if (!icJsonValidChannels(nIn, nOut)) {
     parseStr += "Invalid inputChannels or outputChannels in EmissionObserverElement\n";
     return false;
   }
@@ -2489,7 +2502,7 @@ bool CIccMpeJsonReflectanceObserver::ParseJson(const IccJson &j, std::string &pa
   jGetValue(j, "flags",          flags);
   m_flags = (icUInt16Number)flags;
 
-  if (!nIn || !nOut) {
+  if (!icJsonValidChannels(nIn, nOut)) {
     parseStr += "Invalid inputChannels or outputChannels in ReflectanceObserverElement\n";
     return false;
   }

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -2522,6 +2522,15 @@ bool CIccTagJsonMultiProcessElement::ParseJson(const IccJson &j, std::string &pa
   int nIn = 0, nOut = 0;
   jGetValue(j, "inputChannels",  nIn);
   jGetValue(j, "outputChannels", nOut);
+
+  // The tag-level counts were stored with no bound at all, so the narrowing
+  // cast below turned "outputChannels": 360200 into 32520 and the tag was
+  // built at that size (#1901). Mirrors the XML reader in
+  // CIccTagXmlMultiProcessElement::ParseXml.
+  if (!icJsonValidChannels(nIn, nOut)) {
+    parseStr += "Invalid inputChannels or outputChannels in multiProcessElementType\n";
+    return false;
+  }
   m_nInputChannels  = (icUInt16Number)nIn;
   m_nOutputChannels = (icUInt16Number)nOut;
 

--- a/IccJSON/IccLibJSON/IccUtilJson.cpp
+++ b/IccJSON/IccLibJSON/IccUtilJson.cpp
@@ -474,6 +474,15 @@ bool jsonExistsField(const IccJson &j, const char *field)
   return j.is_object() && j.contains(field);
 }
 
+// See IccUtilJson.h for the rationale -- bounds a channel-count pair before
+// the readers narrow it to icUInt16Number.
+bool icJsonValidChannels(int nIn, int nOut)
+{
+  return nIn > 0 && nOut > 0 &&
+         nIn <= kIccJsonMaxChannels &&
+         nOut <= kIccJsonMaxChannels;
+}
+
 template <typename T>
 bool jGetValue(const IccJson &j, const char *field, T &value)
 {

--- a/IccJSON/IccLibJSON/IccUtilJson.h
+++ b/IccJSON/IccLibJSON/IccUtilJson.h
@@ -140,6 +140,22 @@ bool jGetString(const IccJson &j, const char *field, std::string &value);
 template <typename T>
 bool jGetArray(const IccJson &j, const char *field, T *vals, int n);
 
+// Upper bound for a multi-process-element channel count. Both counts are
+// stored in an icUInt16Number, so this is the width of the destination rather
+// than a policy limit.
+const int kIccJsonMaxChannels = 0xFFFF;
+
+// True when a parsed inputChannels / outputChannels pair can be stored without
+// changing value. The readers pull both counts into an int and then cast to
+// u16; the "!nIn || !nOut" test they applied rejected zero and nothing else,
+// so "outputChannels": 360200 passed it and the explicit cast -- which UBSan
+// does not instrument -- stored 32520 in its place. The element was then built
+// at, and re-serialized with, a size the document never asked for (#1901,
+// #1902). A negative count wrapped through the same cast just as quietly.
+// Callers with a tighter constraint (nIn == nOut, nOut == 3, ...) still apply
+// it themselves; this only establishes that the narrowing is lossless.
+bool icJsonValidChannels(int nIn, int nOut);
+
 // ---------------------------------------------------------------------------
 // Typed array helpers (parallel to CIccXmlArrayType)
 // ---------------------------------------------------------------------------

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -87,6 +87,12 @@ namespace iccDEV {
 // Match the defensive cap used by CIccMpeMatrix::Read before narrowing
 // user-controlled matrix-family XML channel counts.
 static const icUInt16Number kIccXmlMaxMatrixChannels = 255;
+// Every MPE element stores its channel counts in an icUInt16Number, so this is
+// the type bound rather than a policy limit: a document asking for more than
+// this cannot be represented, whatever the element. Element families that are
+// bounded more tightly than their storage -- the matrix family above -- pass
+// their own cap instead.
+static const icUInt16Number kIccXmlMaxChannels = 0xFFFF;
 static const int kIccXmlMaxSpectralSteps = 65535;
 
 static int icXmlBoundedSpectralSteps(const icSpectralRange &range)
@@ -94,14 +100,25 @@ static int icXmlBoundedSpectralSteps(const icSpectralRange &range)
   return std::min<int>((int)range.steps, kIccXmlMaxSpectralSteps);
 }
 
-static bool icXmlParseMatrixChannels(xmlNode *pNode, icUInt16Number &nInputChannels,
-                                     icUInt16Number &nOutputChannels,
-                                     const char *elementName, std::string &parseStr)
+// Parses the InputChannels / OutputChannels attribute pair shared by the MPE
+// element readers. Serves every element family, not just the matrix one it was
+// introduced for, so it takes the cap as a parameter -- see kIccXmlMaxChannels.
+//
+// The range check is the point. atoi() returns int and the counts are u16, so
+// before this a document declaring OutputChannels="360200" was narrowed on
+// assignment to 32520 and that value -- one the document never asked for --
+// was stored in the element and written back out on save (#1898/#1899/#1900/
+// #1903). atoi() is equally blind to a negative count and to trailing garbage.
+// icXmlParseU16 refuses all three rather than substituting a different number.
+static bool icXmlParseChannels(xmlNode *pNode, icUInt16Number &nInputChannels,
+                               icUInt16Number &nOutputChannels,
+                               const char *elementName, std::string &parseStr,
+                               icUInt16Number maxChannels = kIccXmlMaxChannels)
 {
   if (!icXmlParseU16(icXmlAttrValue(pNode, "InputChannels"), nInputChannels,
-                     kIccXmlMaxMatrixChannels) ||
+                     maxChannels) ||
       !icXmlParseU16(icXmlAttrValue(pNode, "OutputChannels"), nOutputChannels,
-                     kIccXmlMaxMatrixChannels) ||
+                     maxChannels) ||
       !nInputChannels || !nOutputChannels) {
     parseStr += std::string("Invalid InputChannels or OutputChannels In ") + elementName + "\n";
     return false;
@@ -1324,9 +1341,14 @@ static icCurveSetCurvePtr ParseXmlCurve(xmlNode* pNode, std::string parseStr)
 
 bool CIccMpeXmlCurveSet::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  icUInt16Number nChannels = (icUInt16Number)atoi(icXmlAttrValue(pNode, "InputChannels"));
+  icUInt16Number nChannels = 0, nOutputChannels = 0;
+  if (!icXmlParseChannels(pNode, nChannels, nOutputChannels,
+                          "CurveSetElement", parseStr)) {
+    return false;
+  }
 
-  if (!nChannels || atoi(icXmlAttrValue(pNode, "OutputChannels")) != nChannels) {
+  // A curve set carries one curve per channel, so the two counts must agree.
+  if (nOutputChannels != nChannels) {
     parseStr += "Invalid InputChannels or OutputChannels In CurveSetElement\n";
     return false;
   }
@@ -1437,8 +1459,8 @@ bool CIccMpeXmlMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
   icUInt16Number nInputChannels = 0;
   icUInt16Number nOutputChannels = 0;
-  if (!icXmlParseMatrixChannels(pNode, nInputChannels, nOutputChannels,
-                                "MatrixElement", parseStr)) {
+  if (!icXmlParseChannels(pNode, nInputChannels, nOutputChannels,
+                          "MatrixElement", parseStr, kIccXmlMaxMatrixChannels)) {
     return false;
   }
 
@@ -1553,8 +1575,8 @@ bool CIccMpeXmlEmissionMatrix::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
   icUInt16Number nInputChannels = 0;
   icUInt16Number nOutputChannels = 0;
-  if (!icXmlParseMatrixChannels(pNode, nInputChannels, nOutputChannels,
-                                "EmissionMatrixElement", parseStr)) {
+  if (!icXmlParseChannels(pNode, nInputChannels, nOutputChannels,
+                          "EmissionMatrixElement", parseStr, kIccXmlMaxMatrixChannels)) {
     return false;
   }
   if (nOutputChannels != 3) {
@@ -1676,8 +1698,8 @@ bool CIccMpeXmlInvEmissionMatrix::ParseXml(xmlNode *pNode, std::string &parseStr
 {
   icUInt16Number nInputChannels = 0;
   icUInt16Number nOutputChannels = 0;
-  if (!icXmlParseMatrixChannels(pNode, nInputChannels, nOutputChannels,
-                                "InvEmissionMatrixElement", parseStr)) {
+  if (!icXmlParseChannels(pNode, nInputChannels, nOutputChannels,
+                          "InvEmissionMatrixElement", parseStr, kIccXmlMaxMatrixChannels)) {
     return false;
   }
   if (nInputChannels != 3 || nOutputChannels != 3) {
@@ -1777,10 +1799,9 @@ bool CIccMpeXmlTintArray::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlTintArray::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  icUInt16Number nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  icUInt16Number nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-  if (!nInputChannels || !nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In TintArrayElement\n";
+  icUInt16Number nInputChannels = 0, nOutputChannels = 0;
+  if (!icXmlParseChannels(pNode, nInputChannels, nOutputChannels,
+                          "TintArrayElement", parseStr)) {
     return false;
   }
   m_nInputChannels = nInputChannels;
@@ -1988,9 +2009,13 @@ bool CIccMpeXmlToneMap::ToXml(std::string& xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlToneMap::ParseXml(xmlNode* pNode, std::string& parseStr)
 {
-  icUInt16Number nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  icUInt16Number nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-  if (!nInputChannels || !nOutputChannels || nInputChannels!=nOutputChannels+1) {
+  icUInt16Number nInputChannels = 0, nOutputChannels = 0;
+  if (!icXmlParseChannels(pNode, nInputChannels, nOutputChannels,
+                          "ToneMapElement", parseStr)) {
+    return false;
+  }
+
+  if (nInputChannels!=nOutputChannels+1) {
     parseStr += "Invalid InputChannels or OutputChannels In ToneMapElement\n";
     return false;
   }
@@ -2096,11 +2121,8 @@ bool CIccMpeXmlCLUT::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  m_nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-
-  if (!m_nInputChannels || !m_nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In CLutElement\n";
+  if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
+                          "CLutElement", parseStr)) {
     return false;
   }
 
@@ -2140,11 +2162,8 @@ bool CIccMpeXmlExtCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
   m_storageType = (icUInt16Number)atoi(icXmlAttrValue(pNode, "StorageType", "0"));
   m_nReserved2 = atoi(icXmlAttrValue(pNode, "Reserved2", "0"));
 
-  m_nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-
-  if (!m_nInputChannels || !m_nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In ExtCLutElement\n";
+  if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
+                          "ExtCLutElement", parseStr)) {
     return false;
   }
 
@@ -2199,11 +2218,8 @@ bool CIccMpeXmlBAcs::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlBAcs::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  m_nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-
-  if (!m_nInputChannels || !m_nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In BAcsElement\n";
+  if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
+                          "BAcsElement", parseStr)) {
     return false;
   }
 
@@ -2255,11 +2271,8 @@ bool CIccMpeXmlEAcs::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlEAcs::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  m_nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-
-  if (!m_nInputChannels || !m_nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In EAcsElement\n";
+  if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
+                          "EAcsElement", parseStr)) {
     return false;
   }
 
@@ -2411,8 +2424,10 @@ bool CIccMpeXmlJabToXYZ::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlJabToXYZ::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  m_nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
+  if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
+                          "JabToXYZElement", parseStr)) {
+    return false;
+  }
 
   if (m_nInputChannels!=3 || m_nOutputChannels!=3) {
     parseStr += "Invalid InputChannels or OutputChannels In JabToXYZElement\n";
@@ -2463,8 +2478,10 @@ bool CIccMpeXmlXYZToJab::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlXYZToJab::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  m_nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
+  if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
+                          "XYZToJabElement", parseStr)) {
+    return false;
+  }
 
   if (m_nInputChannels!=3 || m_nOutputChannels!=3) {
     parseStr += "Invalid InputChannels or OutputChannels In XYZToJabElement\n";
@@ -3418,8 +3435,13 @@ bool CIccMpeXmlCalculator::ParseXml(xmlNode *pNode, std::string &parseStr)
   if (!pNode)
     return false;
 
-  SetSize(atoi(icXmlAttrValue(pNode, "InputChannels")),
-          atoi(icXmlAttrValue(pNode, "OutputChannels")));
+  icUInt16Number nInputChannels = 0, nOutputChannels = 0;
+  if (!icXmlParseChannels(pNode, nInputChannels, nOutputChannels,
+                          "CalculatorElement", parseStr)) {
+    return false;
+  }
+
+  SetSize(nInputChannels, nOutputChannels);
 
   clean();
 
@@ -3560,14 +3582,11 @@ bool CIccMpeXmlEmissionCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
   m_nStorageType = (icUInt16Number)atoi(icXmlAttrValue(pNode, "StorageType", "0"));
 
-  m_nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
-
-  if (!m_nInputChannels || !m_nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In CLutElement\n";
+  if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
+                          "CLutElement", parseStr)) {
     return false;
   }
+  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
 
   xmlNode *pData;
 
@@ -3575,9 +3594,9 @@ bool CIccMpeXmlEmissionCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
   if (pData) {
     icFloatNumber dStart = (icFloatNumber)atof(icXmlAttrValue(pData, "start"));
     icFloatNumber dEnd = (icFloatNumber)atof(icXmlAttrValue(pData, "end"));
-    icUInt16Number nSteps = atoi(icXmlAttrValue(pData, "steps"));
+    icUInt16Number nSteps = 0;
 
-    if (dStart >= dEnd ||!nSteps) {
+    if (dStart >= dEnd || !icXmlParseU16(icXmlAttrValue(pData, "steps"), nSteps) || !nSteps) {
       parseStr += "Invalid Spectral Range\n";
       return false;
     }
@@ -3669,14 +3688,11 @@ bool CIccMpeXmlReflectanceCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
   m_nStorageType = (icUInt16Number)atoi(icXmlAttrValue(pNode, "StorageType", "0"));
 
-  m_nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
-
-  if (!m_nInputChannels || !m_nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In CLutElement\n";
+  if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
+                          "CLutElement", parseStr)) {
     return false;
   }
+  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
 
   xmlNode *pData;
 
@@ -3684,9 +3700,9 @@ bool CIccMpeXmlReflectanceCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
   if (pData) {
     icFloatNumber dStart = (icFloatNumber)atof(icXmlAttrValue(pData, "start"));
     icFloatNumber dEnd = (icFloatNumber)atof(icXmlAttrValue(pData, "end"));
-    icUInt16Number nSteps = atoi(icXmlAttrValue(pData, "steps"));
+    icUInt16Number nSteps = 0;
 
-    if (dStart >= dEnd ||!nSteps) {
+    if (dStart >= dEnd || !icXmlParseU16(icXmlAttrValue(pData, "steps"), nSteps) || !nSteps) {
       parseStr += "Invalid Spectral Range\n";
       return false;
     }
@@ -3734,14 +3750,12 @@ bool CIccMpeXmlReflectanceCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
 
 bool CIccMpeXmlEmissionObserver::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  icUInt16Number nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  icUInt16Number nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
-
-  if (!nInputChannels || !nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In EmissionObserverElement\n";
+  icUInt16Number nInputChannels = 0, nOutputChannels = 0;
+  if (!icXmlParseChannels(pNode, nInputChannels, nOutputChannels,
+                          "EmissionObserverElement", parseStr)) {
     return false;
   }
+  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
 
   xmlNode *pData;
 
@@ -3749,9 +3763,10 @@ bool CIccMpeXmlEmissionObserver::ParseXml(xmlNode *pNode, std::string &parseStr)
   if (pData) {
     icFloatNumber dStart = (icFloatNumber)atof(icXmlAttrValue(pData, "start"));
     icFloatNumber dEnd = (icFloatNumber)atof(icXmlAttrValue(pData, "end"));
-    icUInt16Number nSteps = atoi(icXmlAttrValue(pData, "steps"));
+    icUInt16Number nSteps = 0;
 
-    if (dStart >= dEnd || nSteps != nInputChannels) {
+    if (dStart >= dEnd || !icXmlParseU16(icXmlAttrValue(pData, "steps"), nSteps) ||
+        nSteps != nInputChannels) {
       parseStr += "Invalid Spectral Range\n";
       return false;
     }
@@ -3817,14 +3832,12 @@ bool CIccMpeXmlEmissionObserver::ToXml(std::string &xml, std::string blanks/* = 
 
 bool CIccMpeXmlReflectanceObserver::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  icUInt16Number nInputChannels = atoi(icXmlAttrValue(pNode, "InputChannels"));
-  icUInt16Number nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
-  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
-
-  if (!nInputChannels || !nOutputChannels) {
-    parseStr += "Invalid InputChannels or OutputChannels In ReflectanceObserverElement\n";
+  icUInt16Number nInputChannels = 0, nOutputChannels = 0;
+  if (!icXmlParseChannels(pNode, nInputChannels, nOutputChannels,
+                          "ReflectanceObserverElement", parseStr)) {
     return false;
   }
+  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
 
   xmlNode *pData;
 
@@ -3832,9 +3845,10 @@ bool CIccMpeXmlReflectanceObserver::ParseXml(xmlNode *pNode, std::string &parseS
   if (pData) {
     icFloatNumber dStart = (icFloatNumber)atof(icXmlAttrValue(pData, "start"));
     icFloatNumber dEnd = (icFloatNumber)atof(icXmlAttrValue(pData, "end"));
-    icUInt16Number nSteps = atoi(icXmlAttrValue(pData, "steps"));
+    icUInt16Number nSteps = 0;
 
-    if (dStart >= dEnd || nSteps != nInputChannels) {
+    if (dStart >= dEnd || !icXmlParseU16(icXmlAttrValue(pData, "steps"), nSteps) ||
+        nSteps != nInputChannels) {
       parseStr += "Invalid Spectral Range\n";
       return false;
     }

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -4745,8 +4745,17 @@ bool CIccTagXmlMultiProcessElement::ParseXml(xmlNode *pNode, std::string &parseS
     return false;
   }
 
-  m_nInputChannels = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pInputChannels));
-  m_nOutputChannels = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pOutputChannels));
+  // icXmlAttrToUInt floors a negative to zero but returns icUInt32Number, and
+  // the explicit narrowing cast that followed both changed the value and
+  // suppressed the sanitizer check that would have reported it -- exactly the
+  // caller shape described at the helper's definition near the top of this
+  // file. InputChannels="360200" was therefore stored as 32520 and written
+  // back out on save (#1901). icXmlParseU16 refuses the count instead.
+  if (!icXmlParseU16(icXmlAttrValue(pInputChannels), m_nInputChannels) ||
+      !icXmlParseU16(icXmlAttrValue(pOutputChannels), m_nOutputChannels)) {
+    parseStr += "Invalid channels in MultiProcessElements\n";
+    return false;
+  }
 
   if (!m_list) {
     m_list = new (std::nothrow) CIccMultiProcessElementList();


### PR DESCRIPTION
## Summary

#1898, #1899, #1900, #1901, #1902 and #1903 are one defect reported from six call
sites. Every multi-process-element reader stores its channel counts in an
`icUInt16Number` and parsed the attribute into a signed `int` first, behind a guard
that only tested for zero:

```cpp
m_nOutputChannels = atoi(icXmlAttrValue(pNode, "OutputChannels"));
if (!m_nInputChannels || !m_nOutputChannels) ...
```

`360200` passes that test and then changes value on the way into storage —
`360200 & 0xFFFF` is `32520`. Wavelength step counts (`icSpectralRange::steps`,
also u16) were read the same way.

Worth noting for the review: the fix infrastructure already existed in master.
`icXmlParseU16`, `icXmlParseMatrixChannels` and `icXmlParseSpectralRange` were
added by #888 and adopted by three matrix readers and `CIccMpeXmlUnknown`. The
reported sites simply never adopted it. `IccTagXml.cpp:100-103` even documents
the remaining hole in its own comment — *"callers that target an 8- or 16-bit
member keep their explicit cast … which both narrows the value and suppresses
the implicit-integer-truncation check"* — which is precisely what #1901 reports.

## Not every site had a functional tell

This split is why the test is built the way it is.

For the CLUT and the two observer elements the narrowed value went on to fail a
*later* constraint, so those were already rejected pre-fix and surface only as the
sanitizer diagnostic each issue quotes. The other four were accepted, converted
with exit 0, and written to disk:

```
$ iccFromXml ub-mpe-channels-tag-launder-1901.xml out.icc; echo $?
0
$ iccToXml out.icc back.xml && grep MultiProcessElements back.xml
<MultiProcessElements InputChannels="11" OutputChannels="32520">
```

The document asked for `360200`, the tool reported success, and the profile it
wrote says `32520`. Same on the JSON path, which is the half #1901 was filed
about: there the narrowing cast is explicit, so UBSan never reported it while the
value changed just the same.

## The change

XML element readers now share `icXmlParseChannels()` — the existing
`icXmlParseMatrixChannels()` generalized to take the cap as a parameter so it
serves every element family rather than only the matrix one. The matrix readers
keep their tighter 255 cap by passing it explicitly; everything else bounds at
`0xFFFF`, the width of the field being written. The four inline `steps` parses go
through `icXmlParseU16` with their existing constraints unchanged. On the JSON
side `icJsonValidChannels()` moves to `IccUtilJson.h` so the tag-level reader in
`IccTagJson.cpp` shares one definition with the element readers.

Only the parse changes — each reader keeps its own additional constraint
(`nIn == nOut` for a curve set, `nIn == nOut + 1` for a tone map, `== 3` for the
appearance elements).

**Two behaviours are deliberately aligned rather than preserved:**
`CIccMpeXmlCalculator` and `CIccMpeJsonUnknown` had no channel validation at all,
and now reject a zero or absent count like their siblings.

## Regression evidence over the whole corpus

Byte comparison needs care here, and my first attempts at it were wrong in ways
worth stating so the numbers can be trusted. These profiles stamp a creation
`dateTime` in the header (bytes 24–35) and the profile ID is an MD5 over it
(84–99), so two runs of one *unchanged* binary differ unless they land in the same
second — a "same binary twice" control passes for the wrong reason. Comparing a
build from a detached worktree against the working tree is also invalid here: the
worktree lacks the untracked `third_party/`, so cmake configures differently and
the binary differs by more than source.

The sound method is a single build directory with the source toggled between
passes, those two fields zeroed, and any fixture that still varies at identical
source excluded as not attributable:

| corpus | master produced | identical | differ | newly rejected |
|---|---|---|---|---|
| 188 XML fixtures | 170 convert (18 fail on both, pre-existing) | **167** | **0** | **0** |
| 170 JSON documents | 169 import | **169** | **0** | **0** |

3 XML fixtures (`Testing/hybrid/*`) vary run-to-run at unchanged source and are
excluded rather than counted as passes.

**A coverage limitation to be explicit about:** the JSON corpus had to be
generated with `iccToJson`. 26 of the 27 `Testing/**/*.json` files are
`iccApplyNamedCmm` config documents (`profileSequence` / `iccEnvVars`), not
profile JSON — so the in-tree JSON *profile* corpus is a single file, too thin to
stand behind a change touching eleven JSON readers.

## One deliberate strictness increase

`icXmlParseU16` refuses trailing garbage that `atoi()` accepted:

| attribute | before | after |
|---|---|---|
| `"11 "` (trailing space) | 11 | rejected |
| `"11abc"` | 11 | rejected |
| `"1_1"` | 1 | rejected |
| `" 11"`, `"+11"` | 11 | 11 (unchanged) |

No corpus fixture relies on it — zero of the 336 documents above became newly
rejected — and master already applied this same parser to the three matrix
readers and `CIccMpeXmlUnknown`, so this extends an existing precedent rather
than introducing one.

## CTest

`iccdev.issue-1898-mpe-channel-narrowing-regression` covers both halves.

- **Case A** asserts on the written file, so it has teeth in the ordinary CI jobs
  — no sanitizer needed. On failure it re-serializes the profile and prints the
  channel count that actually landed.
- **Case B** covers the three breadcrumbs with no functional tell. Gated on an
  integer/implicit-conversion build and **skipped rather than passed** elsewhere,
  because "no profile written" is true on a broken build too and would be a
  vacuous green.
- **Two controls**, both required to convert: a legal count, and `32520` itself.
  The second is the one that matters — it distinguishes *refusing an
  unrepresentable count* from *having lowered the channel ceiling*. Without it
  every Case A assertion would still pass on a fix that had broken legitimate
  documents.

Verified red against master (exit 2, reproducing `IccMpeXml.cpp:3422:11`,
`2100:23`, `3752:29` and `3835:29` exactly as filed) and green with the fix, in
both an ordinary and an `-fsanitize=integer,implicit-conversion` build.

## Local pre-flight

| gate | result |
|---|---|
| gcc Release / gcc Debug / clang Release / clang Debug | **0** warnings, 0 errors each (`grep -cE 'warning:' build.log`) |
| GCC strict Release LTO (`-Wall -Wextra -Wpedantic -Werror`) | **0** warnings |
| `ctest` | 132/133; the one failure is the known local-only `iccdev.spectral-tiff-preview` (missing python `imagecodecs`), unrelated |

## Scope left for a follow-up

The wider `(icUInt8Number)`/`(icUInt16Number)` `icXmlAttrToUInt()` narrowing
family elsewhere in `IccTagXml.cpp`, and the header `spectralRange.steps` in
`IccProfileXml.cpp`, are the same class at a different surface. Some of those
sites have no error-reporting path today, so hard-failing them is a policy call
rather than a mechanical fix — happy to take it as a separate PR if wanted.

Closes #1898
Closes #1899
Closes #1900
Closes #1901
Closes #1902
Closes #1903
