### PR TITLE
fix(#1677): reject a bi-spectral illuminant range the PCS steps cannot map

### DIFF
--- a/.github/ci/regression/pcs-birefl-illuminant-range.cpp
+++ b/.github/ci/regression/pcs-birefl-illuminant-range.cpp
@@ -1,0 +1,254 @@
+// Regression for #1677 (and the #1675 family): the bi-spectral PCS connection steps
+// copied a Profile Connection Conditions illuminant into a buffer sized by the source
+// profile's header, without checking that the two could be related.
+//
+// CIccPcsXform::rangeMap() answers with NULL in two different situations:
+//
+//   * the ranges are identical, so no conversion matrix is needed;
+//   * a conversion is needed but SetRange() refused to build one -- it rejects any pair
+//     carrying <= 1 step, a non-finite endpoint or a zero-width span.
+//
+// pushBiRef2Rad() read NULL as only the first, and fell back to
+//
+//     memcpy(pMtx->data(), illuminant, illuminantRange.steps*sizeof(icFloatNumber));
+//
+// where pMtx->data() was allocated as new icFloatNumber[biSpectralRange.steps]. A header
+// declaring biSpectralRange.steps == 0 therefore pushed a whole illuminant into a
+// zero-length array: with the reproducer from #1677 that is a 324-byte write into a
+// 1-byte region (CWE-787), reached from CIccCmm::Begin() through CheckPCSConnections()
+// and Connect() before any pixel is applied. pushBiRef2Ref() has the mirror image of the
+// same fault -- its fallback walks illuminant[] to spectralRange.steps, past the end of
+// an array holding only illuminantRange.steps entries, so it reads out of bounds instead.
+//
+// The fix screens the identical-range case up front with icSameSpectralRange(), the way
+// the neighbouring pushSpecToRange() already did, which leaves a refused map as an
+// unambiguous reject. These assertions are therefore visible without a sanitizer: on
+// unfixed sources the calls return icCmmStatOk (having corrupted the heap on the way),
+// and here they must return a failure status.
+//
+// The controls at the end matter as much as the rejections: only one bi-spectral profile
+// exists in the whole Testing corpus, so an over-eager guard here would go unnoticed by
+// the rest of the suite. They pin that identical ranges and merely-different-but-mappable
+// ranges both still succeed.
+//
+// Header + IccProfLib only, no fixture and no I/O.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccCmm.h"
+#include "IccPcc.h"
+#include "IccProfile.h"
+#include "IccTagBasic.h"
+#include "IccUtil.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[pcs-birefl-range] FAIL: %s\n", what);
+  }
+}
+
+icSpectralRange makeRange(icFloat16Number start, icFloat16Number end, icUInt16Number steps)
+{
+  icSpectralRange r;
+  r.start = start;
+  r.end = end;
+  r.steps = steps;
+  return r;
+}
+
+// The push* helpers only ever ask the connection conditions for the viewing conditions
+// tag, so the remaining three interface methods are stubs.
+class StubPcc : public IIccProfileConnectionConditions
+{
+public:
+  explicit StubPcc(const icSpectralRange &illumRange)
+  {
+    std::vector<icFloatNumber> spd(illumRange.steps ? illumRange.steps : 1, 1.0f);
+    m_svc.setIlluminant(icIlluminantD50, illumRange, &spd[0]);
+  }
+
+  virtual const CIccTagSpectralViewingConditions *getPccViewingConditions() { return &m_svc; }
+  virtual CIccTagMultiProcessElement *getCustomToStandardPcc() { return NULL; }
+  virtual CIccTagMultiProcessElement *getStandardToCustomPcc() { return NULL; }
+
+  virtual void getNormIlluminantXYZ(icFloatNumber *pXYZ) { pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f; }
+  virtual void getLumIlluminantXYZ(icFloatNumber *pXYZ) { pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f; }
+  virtual bool getMediaWhiteXYZ(icFloatNumber *pXYZ)
+  {
+    pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f;
+    return true;
+  }
+
+  // Reports what getIlluminant() will actually hand the code under test, which is not
+  // always what was asked for: the tag falls back to a known standard SPD when the
+  // custom illuminant did not take.
+  icUInt16Number effectiveIlluminantSteps()
+  {
+    icSpectralRange got;
+    return m_svc.getIlluminant(got) ? got.steps : 0;
+  }
+
+private:
+  CIccTagSpectralViewingConditions m_svc;
+};
+
+// pushBiRef2Rad()/pushBiRef2Ref() are protected; subclassing is the supported way in.
+class PcsXformProbe : public CIccPcsXform
+{
+public:
+  using CIccPcsXform::pushBiRef2Rad;
+  using CIccPcsXform::pushBiRef2Ref;
+
+  size_t stepCount() const { return m_list ? m_list->size() : 0; }
+};
+
+// A header-only profile: the push* helpers under test read m_Header and nothing else.
+void setHeader(CIccProfile &prof, icColorSpaceSignature spectralPCS,
+               const icSpectralRange &spectralRange, const icSpectralRange &biSpectralRange)
+{
+  std::memset(&prof.m_Header, 0, sizeof(prof.m_Header));
+  prof.m_Header.version = icVersionNumberV5;
+  prof.m_Header.deviceClass = icSigColorSpaceClass;
+  prof.m_Header.spectralPCS = spectralPCS;
+  prof.m_Header.spectralRange = spectralRange;
+  prof.m_Header.biSpectralRange = biSpectralRange;
+}
+
+// #1677: a bi-spectral header whose biSpectralRange cannot be mapped from the illuminant
+// must be refused, not copied into.
+void testBiRefRadRejectsUnmappableBiSpectralRange()
+{
+  const icSpectralRange illumRange = makeRange(icRange380nm, icRange780nm, 81);
+
+  struct Case {
+    icColorSpaceSignature type;
+    const char *what;
+  } cases[] = {
+    { icSigBiSpectralReflectanceData,   "bi-spectral reflectance" },
+    { icSigSparseMatrixReflectanceData, "sparse matrix reflectance" },
+  };
+
+  for (size_t c = 0; c < sizeof(cases)/sizeof(cases[0]); c++) {
+    char msg[200];
+    StubPcc pcc(illumRange);
+
+    CIccProfile prof;
+    setHeader(prof, icNColorSpaceSig(cases[c].type, 36),
+              makeRange(icRange380nm, icRange780nm, 36),
+              // steps == 0: SetRange() refuses the pair, and the buffer this would have
+              // been copied into is new icFloatNumber[0].
+              makeRange(icRange380nm, icRange780nm, 0));
+
+    PcsXformProbe probe;
+    icStatusCMM stat = probe.pushBiRef2Rad(&prof, &pcc);
+
+    std::snprintf(msg, sizeof(msg),
+                  "%s: pushBiRef2Rad refuses a zero-step biSpectralRange instead of "
+                  "copying %u illuminant entries into a zero-length buffer",
+                  cases[c].what, (unsigned)pcc.effectiveIlluminantSteps());
+    check(stat != icCmmStatOk, msg);
+
+    std::snprintf(msg, sizeof(msg), "%s: no PCS step is left behind on the reject path",
+                  cases[c].what);
+    check(probe.stepCount() == 0, msg);
+  }
+}
+
+// The mirror image in pushBiRef2Ref(): here the refused map makes the fallback read past
+// the end of the illuminant rather than write past the end of its own buffer.
+void testBiRefRefRejectsUnmappableSpectralRange()
+{
+  // A single-step illuminant is storable but cannot be resampled from, so
+  // rangeMap(illuminantRange, spectralRange) is refused for any spectralRange.
+  const icSpectralRange illumRange = makeRange(icRange380nm, icRange780nm, 1);
+
+  StubPcc pcc(illumRange);
+  const icUInt16Number illumSteps = pcc.effectiveIlluminantSteps();
+
+  CIccProfile prof;
+  setHeader(prof, icNColorSpaceSig(icSigBiSpectralReflectanceData, 41),
+            // Wider than the illuminant, so the unfixed fallback loop overruns it.
+            makeRange(icRange380nm, icRange780nm, 41),
+            // Identical to the illuminant range, so pushBiRef2Rad() -- which runs first
+            // -- takes its exact-fit copy and this test isolates pushBiRef2Ref().
+            illumRange);
+
+  PcsXformProbe probe;
+  icStatusCMM stat = probe.pushBiRef2Ref(&prof, &pcc);
+
+  char msg[220];
+  std::snprintf(msg, sizeof(msg),
+                "pushBiRef2Ref refuses a spectralRange of 41 steps it cannot map from a "
+                "%u-step illuminant, instead of reading past the illuminant's end",
+                (unsigned)illumSteps);
+  check(stat != icCmmStatOk, msg);
+}
+
+// Controls. The corpus carries a single bi-spectral profile, so nothing else in the suite
+// would catch a guard that rejects too much.
+void testConformantRangesStillAccepted()
+{
+  // 1. Identical illuminant and biSpectralRange: no matrix is needed and the wholesale
+  //    copy is an exact fit. This is the case the NULL return originally meant.
+  {
+    const icSpectralRange illumRange = makeRange(icRange380nm, icRange780nm, 81);
+    StubPcc pcc(illumRange);
+
+    CIccProfile prof;
+    setHeader(prof, icNColorSpaceSig(icSigBiSpectralReflectanceData, 36),
+              makeRange(icRange380nm, icRange780nm, 36), illumRange);
+
+    PcsXformProbe probe;
+    icStatusCMM stat = probe.pushBiRef2Rad(&prof, &pcc);
+
+    check(stat == icCmmStatOk, "identical illuminant and biSpectralRange still accepted");
+    check(probe.stepCount() == 1, "identical ranges still push exactly one PCS step");
+  }
+
+  // 2. Different but mappable, which is the shape of the one bi-spectral profile in
+  //    Testing/ (Named/FluorescentNamedColor.icc: spectralRange 31, biSpectralRange 41
+  //    against an 81-step illuminant). A matrix is built and used.
+  {
+    const icSpectralRange illumRange = makeRange(icRange380nm, icRange780nm, 81);
+    StubPcc pcc(illumRange);
+
+    CIccProfile prof;
+    setHeader(prof, icNColorSpaceSig(icSigBiSpectralReflectanceData, 31),
+              makeRange(icRange380nm, icRange780nm, 31),
+              makeRange(icRange380nm, icRange780nm, 41));
+
+    PcsXformProbe probe;
+    icStatusCMM stat = probe.pushBiRef2Rad(&prof, &pcc);
+
+    check(stat == icCmmStatOk,
+          "mappable illuminant and biSpectralRange still accepted (Fluorescent shape)");
+    check(probe.stepCount() == 1, "mappable ranges still push exactly one PCS step");
+  }
+}
+
+} // namespace
+
+int main()
+{
+  testBiRefRadRejectsUnmappableBiSpectralRange();
+  testBiRefRefRejectsUnmappableSpectralRange();
+  testConformantRangesStillAccepted();
+
+  if (g_fail)
+    std::fprintf(stderr, "[pcs-birefl-range] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[pcs-birefl-range] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -987,6 +987,51 @@ function(iccdev_add_rangemap_uninitialized_test)
   endif()
 endfunction()
 
+# #1677: the bi-spectral PCS connection steps treated CIccPcsXform::rangeMap()'s NULL as
+# "the ranges are identical" when it also means "a conversion was needed but SetRange()
+# refused it". pushBiRef2Rad() then copied illuminantRange.steps floats into a buffer sized
+# to biSpectralRange.steps -- a 324-byte write into a 1-byte region for the reported
+# reproducer (CWE-787), reached from CIccCmm::Begin() before any pixel is applied.
+# pushBiRef2Ref() has the mirror fault and overruns the illuminant on read instead.
+#
+# Also pins the controls: only one bi-spectral profile exists in Testing/ and it is not
+# usable as a colour xform, so nothing else in the suite would notice a guard here that
+# rejected conformant spectral profiles. Header + IccProfLib only, no fixture.
+function(iccdev_add_pcs_birefl_illuminant_range_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccPcsBiReflIlluminantRangeTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/pcs-birefl-illuminant-range.cpp"
+  )
+  target_link_libraries(iccPcsBiReflIlluminantRangeTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccPcsBiReflIlluminantRangeTest)
+
+  add_test(
+    NAME iccdev.pcs-birefl-illuminant-range
+    COMMAND "$<TARGET_FILE:iccPcsBiReflIlluminantRangeTest>"
+  )
+  set_tests_properties(iccdev.pcs-birefl-illuminant-range PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;security;spectral;issue-1677;regression"
+  )
+  if(WIN32)
+    set(_pcs_birefl_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccPcsBiReflIlluminantRangeTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _pcs_birefl_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.pcs-birefl-illuminant-range PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_pcs_birefl_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1853: CIccProfile::calcMediaWhiteXYZ() read the spectral white point tag with
 # GetValues()'s default nVectorSize of 1, so all but the first sample of the white vector
 # were uninitialized heap by the time they reached the returned XYZ. Builds its profiles
@@ -2794,6 +2839,7 @@ if(WIN32)
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
   iccdev_add_rangemap_uninitialized_test()
+  iccdev_add_pcs_birefl_illuminant_range_test()
   iccdev_add_spectral_media_white_test()
   iccdev_add_gbd_zero_pcs_test()
   iccdev_add_mpe_empty_identity_test()
@@ -3021,6 +3067,7 @@ iccdev_add_reflectance_observer_illum_range_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
 iccdev_add_rangemap_uninitialized_test()
+iccdev_add_pcs_birefl_illuminant_range_test()
 iccdev_add_spectral_media_white_test()
 iccdev_add_gbd_zero_pcs_test()
 iccdev_add_mpe_empty_identity_test()

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -2466,7 +2466,13 @@ icStatusCMM CIccPcsXform::Connect(CIccXform *pFromXform, CIccXform *pToXform)
       case icSigSparseMatrixSpectralPcsData:
         switch (m_dstSpace) {
           case icSigLabPcsData:
-            pushBiRef2Xyz(pFromXform->m_pProfile, pFromXform->m_pConnectionConditions);
+            // This was the one call among the nine status-returning push* helpers whose
+            // result was discarded; the bi-spectral cases below it, and pushXYZConvert()
+            // on the next line, all propagate. Swallowing it let a refused illuminant
+            // step leave the chain a step short and Begin() still report success.
+            if ((stat=pushBiRef2Xyz(pFromXform->m_pProfile, pFromXform->m_pConnectionConditions))!=icCmmStatOk) {
+              return stat;
+            }
             if ((stat=pushXYZConvert(pFromXform, pToXform))!=icCmmStatOk) {
               return stat;
             }
@@ -3668,12 +3674,26 @@ icStatusCMM CIccPcsXform::pushBiRef2Rad(CIccProfile *pProfile, IIccProfileConnec
       if (!pMtx)
         return icCmmStatAllocErr;
 
-      CIccPcsStepMatrix *illumMtx = rangeMap(illuminantRange, pProfile->m_Header.biSpectralRange);
-      if (illumMtx) {
+      // rangeMap() folds two different answers into NULL: "no conversion is needed
+      // because the ranges are identical", and "a conversion is needed but cannot be
+      // built". SetRange() refuses any pair carrying <= 1 step, a non-finite endpoint or
+      // a zero-width span, all of which a malformed header can ask for. Only the first
+      // answer makes the wholesale copy below correct -- it writes illuminantRange.steps
+      // floats into m_vals, which the constructor sized to biSpectralRange.steps. Testing
+      // the identical case up front, the way pushSpecToRange() already does, leaves a
+      // failed map as an unambiguous reject rather than a copy past the end of m_vals.
+      if (!icSameSpectralRange(illuminantRange, pProfile->m_Header.biSpectralRange)) {
+        CIccPcsStepMatrix *illumMtx = rangeMap(illuminantRange, pProfile->m_Header.biSpectralRange);
+        if (!illumMtx) {
+          delete pMtx;
+          return icCmmStatInvalidProfile;
+        }
         illumMtx->Apply(NULL, pMtx->data(), illuminant);
-        delete illumMtx; 
+        delete illumMtx;
       }
       else {
+        // The ranges match, so illuminantRange.steps == biSpectralRange.steps and the
+        // copy is an exact fit for the buffer.
         memcpy(pMtx->data(), illuminant, illuminantRange.steps*sizeof(icFloatNumber));
       }
 
@@ -3687,10 +3707,18 @@ icStatusCMM CIccPcsXform::pushBiRef2Rad(CIccProfile *pProfile, IIccProfileConnec
       if (!pMtx)
         return icCmmStatAllocErr;
 
-      CIccPcsStepMatrix *illumMtx = rangeMap(illuminantRange, pProfile->m_Header.biSpectralRange);
-      if (illumMtx) {
+      // Same NULL ambiguity as the sparse branch above, and the same buffer contract:
+      // m_vals holds biSpectralRange.steps floats. This is the site reached by the #1677
+      // reproducer, where a header declaring biSpectralRange.steps == 0 made SetRange()
+      // refuse the pair, so the copy pushed a whole illuminant into a zero-length array.
+      if (!icSameSpectralRange(illuminantRange, pProfile->m_Header.biSpectralRange)) {
+        CIccPcsStepMatrix *illumMtx = rangeMap(illuminantRange, pProfile->m_Header.biSpectralRange);
+        if (!illumMtx) {
+          delete pMtx;
+          return icCmmStatInvalidProfile;
+        }
         illumMtx->Apply(NULL, pMtx->data(), illuminant);
-        delete illumMtx; 
+        delete illumMtx;
       }
       else {
         memcpy(pMtx->data(), illuminant, illuminantRange.steps*sizeof(icFloatNumber));
@@ -3777,18 +3805,26 @@ icStatusCMM CIccPcsXform::pushBiRef2Ref(CIccProfile *pProfile, IIccProfileConnec
 
     if (pScale) {
       icFloatNumber *pData = pScale->data();
-      CIccPcsStepMatrix *illumMtx = rangeMap(illuminantRange, pProfile->m_Header.spectralRange);
       int i;
 
-      if (illumMtx) {
+      // Third instance of the NULL ambiguity described in pushBiRef2Rad(). Here the
+      // fallback walks illuminant[] to spectralRange.steps, but that array only holds
+      // illuminantRange.steps entries, so a refused map reads past its end rather than
+      // writing past one. pData is sized spectralRange.steps either way.
+      if (!icSameSpectralRange(illuminantRange, pProfile->m_Header.spectralRange)) {
+        CIccPcsStepMatrix *illumMtx = rangeMap(illuminantRange, pProfile->m_Header.spectralRange);
+        if (!illumMtx) {
+          delete pScale;
+          return icCmmStatInvalidProfile;
+        }
         illumMtx->Apply(NULL, pData, illuminant);
         for (i=0; i<pProfile->m_Header.spectralRange.steps; i++)
           pData[i] = 1.0f / pData[i];
 
         delete illumMtx;
-
       }
       else {
+        // Ranges match, so this reads exactly illuminantRange.steps entries.
         for (i=0; i<pProfile->m_Header.spectralRange.steps; i++) {
           pData[i] = 1.0f / illuminant[i];
         }


### PR DESCRIPTION
Fixes #1677.

## Summary

`CIccPcsXform::rangeMap()` answers `NULL` for two unrelated reasons — "the ranges are
identical so no conversion matrix is needed" and "a conversion is needed but `SetRange()`
refused to build one". `SetRange()` refuses any pair carrying `<= 1` step, a non-finite
endpoint or a zero-width span, all of which a profile header can ask for.

The three bi-spectral connection helpers read `NULL` as only the first reason and fell back
to a wholesale copy sized from the *other* range:

```cpp
memcpy(pMtx->data(), illuminant, illuminantRange.steps*sizeof(icFloatNumber));
```

`pMtx->data()` is `new icFloatNumber[biSpectralRange.steps]`. A header declaring
`biSpectralRange.steps == 0` therefore copied an entire illuminant into a zero-length array.

This is the same NULL-ambiguity defect fixed for the `CIccMatrixMath::rangeMap()` sibling in
#1904; the `CIccPcsXform` one never got the same treatment.

## Reproduction

A note for anyone re-running the repro in the issue: the two attached files named `.icc` are
actually **TIFFs with embedded profiles** — which is why the command line passes `-embedded`.
Current libtiff rejects the fuzzed container (`Requested memory size for StripArray of 522736
is greater than filesize 48334`) before the CMM is ever reached, so the issue's command no
longer gets there. Extracting the embedded v5.1 profile and driving `CIccCmm::Begin()`
directly reproduces it exactly:

```
WRITE of size 324 at 0x502000000231   SCARINESS: 45 (multi-byte-write-heap-buffer-overflow)
  #1 CIccPcsXform::pushBiRef2Rad   IccProfLib/IccCmm.cpp:3696
  #2 CIccPcsXform::pushBiRef2Xyz   IccProfLib/IccCmm.cpp:3723
  #3 CIccPcsXform::Connect         IccProfLib/IccCmm.cpp:2469
  #4 CIccCmm::CheckPCSConnections  IccProfLib/IccCmm.cpp:9218
  #5 CIccCmm::Begin                IccProfLib/IccCmm.cpp:9456

0x502000000231 is located 0 bytes after 1-byte region [0x502000000230,0x502000000231)
allocated by thread T0 here:
  #1 CIccPcsStepSrcMatrix::CIccPcsStepSrcMatrix  IccProfLib/IccCmm.cpp:5149
  #2 CIccPcsXform::pushBiRef2Rad                 IccProfLib/IccCmm.cpp:3686
```

The embedded profile carries `spectralPCS = 0x0024ChannelBiSpectralReflectanceData` with
`spectralRange.steps = 0` and `biSpectralRange.steps = 0`, against an 81-step illuminant
(380–780 nm at 5 nm) from the `-pcc` profile. `new icFloatNumber[0]` yields a 1-byte region
and the copy writes 324 bytes into it.

**The severity in the issue is understated**: it records a `READ of size 4` at `SCARINESS: 17`.
It is a 324-byte **write** at `SCARINESS: 45`, reached from `Begin()` before any pixel is
applied (CWE-787).

## The change

Each of the three sites now screens the identical-range case with `icSameSpectralRange()`
first — the way the neighbouring `pushSpecToRange()` already did — which leaves a refused map
as an unambiguous `icCmmStatInvalidProfile`. The surviving fallback provably has matching
ranges, so its copy is an exact fit.

Two things came out of the investigation that were not in the issue:

1. **`pushBiRef2Ref()` carries the mirror image of the same fault.** Its fallback walks
   `illuminant[]` to `spectralRange.steps`, past the end of an array holding only
   `illuminantRange.steps` entries — so it reads out of bounds rather than writing.

2. **`Connect()` discarded `pushBiRef2Xyz()`'s status** at the `icSigLabPcsData` case. That is
   the only unchecked call among the nine status-returning `push*` helpers — its three
   bi-spectral siblings at `:2488`, `:2507`, `:2517` and `pushXYZConvert()` on the very next
   line all propagate. It is also why the new rejection was initially still reported as
   `Begin() = icCmmStatOk`. It now propagates like its siblings.

## Regression

`.github/ci/regression/pcs-birefl-illuminant-range.cpp`, registered as
`iccdev.pcs-birefl-illuminant-range` in both CMake call lists. Header + IccProfLib only, no
fixture and no I/O — it builds its profiles in memory.

Red without a sanitizer, because the unfixed calls return `icCmmStatOk`:

```
[pcs-birefl-range] FAIL: bi-spectral reflectance: pushBiRef2Rad refuses a zero-step
  biSpectralRange instead of copying 81 illuminant entries into a zero-length buffer
[pcs-birefl-range] FAIL: bi-spectral reflectance: no PCS step is left behind on the reject path
Segmentation fault (core dumped)
```

The segfault is the sparse-matrix case corrupting the heap for real. Green after.

**The controls matter as much as the rejections.** `Testing/` holds 252 profiles of which
exactly **one** is bi-spectral (`Named/FluorescentNamedColor.icc`) and one sparse-matrix — and
the bi-spectral one returns `4` from `AddXform`, so it is not usable as a colour xform. Nothing
else in the suite would notice a guard here that rejected conformant spectral profiles, so the
test pins that identical ranges and merely-different-but-mappable ranges are both still
accepted, using the Fluorescent profile's range shape (31 / 41 against an 81-step illuminant).

## Verification

- Strict `gcc -Wall -Wextra -Wpedantic -Werror -std=c++17`, `ENABLE_LTO=ON` (the `ci-pr-gcc15`
  gate): **0 warnings, 0 errors**.
- 134 CTests: 133 pass, the only failure being the pre-existing
  `iccdev.spectral-tiff-preview` environment failure (missing python `imagecodecs`).
- Reproducer and regression both clean under ASan + UBSan with `detect_leaks=1`, which
  confirms the new reject paths release `pMtx` / `pScale`.

## Scope left for follow-ups

Kept out of this PR deliberately:

- `pushBiRef2Ref()` computes `1.0f / illuminant[i]` and `1.0f / pData[i]` with no zero check,
  on lines adjacent to this change. Relevant to the `-fsanitize=float-divide-by-zero` profile.
- `icSpectralColorSpaceSig()` in `icProfileHeader.h` casts to `icSpectralColorSignature`, a
  type that exists nowhere in the tree, so the macro cannot compile — while five comments in
  that header document it as the way to build `rs`/`ts`/`bs`/`sm` signatures. This regression
  test appears to be the first thing to try using it; it uses `icNColorSpaceSig()` instead.
  Left alone because `icProfileHeader.h` is spec surface.
- The single-bi-spectral-profile coverage gap above is direct evidence for #1883.

Findings on #1675 and on the `ci-qa-cli-iccapplyprofiles-hbo` draft will follow as a comment
on that issue, so they can reference this PR.
