### PR TITLE
fix(#1911): hand JSON payloads up the document by move instead of by copy

### DIFF
--- a/.github/ci/regression/json-writer-move-integrity.cpp
+++ b/.github/ci/regression/json-writer-move-integrity.cpp
@@ -1,0 +1,272 @@
+// Regression for #1911: the JSON writers hand large payloads up to the document
+// root by value, and the fix converts those hand-offs to std::move. This test pins
+// that the moves land on the right side of each hand-off.
+//
+// The writers built a payload in a local, copied it into the parent, and then
+// destroyed the local:
+//
+//     IccJson data = IccJson::array();
+//     for (...) data.push_back(...);      // no reserve(): O(log n) reallocations
+//     j["data"] = data;                   // full deep copy, then ~data
+//
+// For CLUT-bearing tags that repeated up the whole chain -- data -> clut -> tagData
+// -> tagObj -> entry -> Tags -> IccProfile -- so one CLUT's samples were duplicated
+// and freed several times over. Callgrind on APTEC_CMYKOGV_Coated_LinearCTV_2025.icc
+// attributed 22.71% + 6.76% of instructions to nlohmann json_value::destroy and a
+// further 4.43% to the copy constructor, with std::vector::_M_realloc_append at
+// 2.55% for the missing reserve().
+//
+// The risk the fix introduces is a misplaced std::move: nlohmann leaves a moved-from
+// basic_json as a null value, so moving a local one hand-off too early silently
+// yields "data": null or an empty array rather than an error. That failure mode is
+// invisible to a test that only checks the writer returned true, so this test walks
+// the emitted document and asserts the payload actually arrived -- correct element
+// counts, correct values, and no null where data belongs.
+//
+// Red-green: reverting any of the moves keeps this test green (a copy is still
+// correct, only slower), but moving a source that is read again afterwards -- e.g.
+// hoisting the std::move in icCLUTDataToJson above the gridPoints walk -- makes the
+// corresponding count/value assertion below fail. The test therefore guards the
+// correctness half of the change, not its performance.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccProfileJson.h"
+#include "IccTagJson.h"
+#include "IccTagJsonFactory.h"
+#include "IccUtilJson.h"
+#include "IccTagLut.h"
+
+#include <cstdio>
+#include <cstring>
+#include <cmath>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[json-writer-move] FAIL: %s\n", what);
+  }
+}
+
+// Build a CLUT whose every sample is a distinct, exactly-representable value, so a
+// dropped or duplicated element shows up as a value mismatch and not just a count
+// mismatch. i/1024.0 is exact in binary floating point for the sizes used here.
+CIccCLUT *makeCLUT(icUInt8Number nInput, icUInt16Number nOutput, icUInt8Number nGrid)
+{
+  CIccCLUT *pCLUT = new CIccCLUT(nInput, nOutput);
+  if (!pCLUT->Init(nGrid)) {
+    delete pCLUT;
+    return NULL;
+  }
+
+  icUInt32Number nTotal = pCLUT->NumPoints() * (icUInt32Number)nOutput;
+  icFloatNumber *pData = pCLUT->GetData(0);
+  for (icUInt32Number i = 0; i < nTotal; i++)
+    pData[i] = (icFloatNumber)(i / 1024.0);
+
+  return pCLUT;
+}
+
+// --- the CLUT hand-off chain: icCLUTDataToJson + icCLUTToJson ------------------
+// Four hand-offs live here (gridPoints, data, and the clut object itself), and the
+// data array is the one that carries the bulk of a real profile.
+void testCLUTChain()
+{
+  const icUInt8Number  nInput  = 3;
+  const icUInt16Number nOutput = 4;
+  const icUInt8Number  nGrid   = 5;
+
+  CIccCLUT *pCLUT = makeCLUT(nInput, nOutput, nGrid);
+  check(pCLUT != NULL, "test CLUT allocates");
+  if (!pCLUT)
+    return;
+
+  const icUInt32Number nPoints = pCLUT->NumPoints();
+  const icUInt32Number nTotal  = nPoints * (icUInt32Number)nOutput;
+
+  // 5^3 grid points, 4 output channels. Pinned as a literal so the test does not
+  // depend on library data (see the Windows linkage note in Testing/CMakeLists.txt).
+  check(nPoints == 125, "CLUT has 5^3 = 125 grid points");
+  check(nTotal  == 500, "CLUT has 125 * 4 = 500 samples");
+
+  IccJson j;
+  check(icCLUTToJson(j, pCLUT, icConvertFloat, true, "clut"),
+        "icCLUTToJson reports success");
+
+  // The outermost hand-off: j[szName] = std::move(clut).
+  check(j.contains("clut"), "emitted document contains the clut object");
+  check(j["clut"].is_object(), "clut survived the hand-off as an object, not null");
+
+  const IccJson &clut = j["clut"];
+
+  // gridPoints: written before the data walk, so moving it too late (or moving
+  // the enclosing object too early) drops it.
+  check(clut.contains("gridPoints"), "clut carries gridPoints");
+  check(clut["gridPoints"].is_array(), "gridPoints survived as an array");
+  check(clut["gridPoints"].size() == nInput, "gridPoints has one entry per input dim");
+  if (clut["gridPoints"].is_array() && clut["gridPoints"].size() == nInput) {
+    bool allGrid = true;
+    for (icUInt8Number i = 0; i < nInput; i++) {
+      if (!clut["gridPoints"][i].is_number() ||
+          clut["gridPoints"][i].get<int>() != (int)nGrid)
+        allGrid = false;
+    }
+    check(allGrid, "every gridPoints entry is the grid size, none null");
+  }
+
+  // data: the payload the whole change is about.
+  check(clut.contains("data"), "clut carries data");
+  check(clut["data"].is_array(), "data survived as an array, not null");
+  check(clut["data"].size() == nTotal, "data has one entry per CLUT sample");
+
+  if (clut["data"].is_array() && clut["data"].size() == nTotal) {
+    bool allNumbers = true;
+    bool allValues  = true;
+    for (icUInt32Number i = 0; i < nTotal; i++) {
+      const IccJson &v = clut["data"][i];
+      if (!v.is_number()) {
+        allNumbers = false;
+        continue;
+      }
+      // Written as (double)pData[k]; the source was built from an exact binary
+      // fraction, so this compares equal without a tolerance.
+      if (v.get<double>() != (double)(icFloatNumber)(i / 1024.0))
+        allValues = false;
+    }
+    check(allNumbers, "every data entry is a number, none null");
+    check(allValues,  "every data entry matches its source sample, in order");
+  }
+
+  delete pCLUT;
+}
+
+// --- the profile assembly chain: CIccProfileJson::ToJson -----------------------
+// tagData -> tagObj -> entry -> Tags -> root. Five hand-offs, all now moves.
+void testProfileChain()
+{
+  CIccProfileJson profile;
+
+  // A header alone is enough to exercise the Header hand-off; tags are added below
+  // so the Tags array hand-off is exercised too.
+  profile.m_Header.version     = 0x05000000;
+  profile.m_Header.deviceClass = icSigInputClass;
+  profile.m_Header.colorSpace  = icSigRgbData;
+  profile.m_Header.pcs         = icSigXYZData;
+  profile.m_Header.magic       = icMagicNumber;
+
+  // Two tags of different shapes: one text, one numeric array. Both go through the
+  // tagData -> tagObj -> entry -> Tags chain.
+  CIccTag *pDesc = CIccTagCreator::CreateTag(icSigMultiLocalizedUnicodeType);
+  if (pDesc)
+    profile.AttachTag(icSigProfileDescriptionTag, pDesc);
+
+  CIccTag *pWtpt = CIccTagCreator::CreateTag(icSigXYZType);
+  if (pWtpt)
+    profile.AttachTag(icSigMediaWhitePointTag, pWtpt);
+
+  IccJson root;
+  check(profile.ToJson(root), "CIccProfileJson::ToJson reports success");
+
+  // root["Header"] = std::move(header)
+  check(root.contains("Header"), "document carries Header");
+  check(root["Header"].is_object(), "Header survived the hand-off as an object");
+  check(root["Header"].contains("ProfileFileSignature"),
+        "Header kept a field written before the hand-off");
+  if (root["Header"].contains("DataColourSpace"))
+    check(root["Header"]["DataColourSpace"].is_string(),
+          "a Header field written mid-build is still a string, not null");
+
+  // root["Tags"] = std::move(tags), with each entry moved in turn
+  check(root.contains("Tags"), "document carries Tags");
+  check(root["Tags"].is_array(), "Tags survived the hand-off as an array, not null");
+  check(root["Tags"].size() >= 2, "both attached tags reached the Tags array");
+
+  if (root["Tags"].is_array()) {
+    bool allObjects = true;
+    bool allHaveData = true;
+    for (size_t i = 0; i < root["Tags"].size(); i++) {
+      const IccJson &entry = root["Tags"][i];
+      if (!entry.is_object() || entry.size() != 1) {
+        allObjects = false;
+        continue;
+      }
+      // Each entry is a one-member object { "<tagName>": { "data": {...} } }. The
+      // inner object is what tagObj was moved into. The iterator is held in its own
+      // named local: binding the reference straight to entry.begin().value() reads
+      // through a temporary iterator, which gcc rejects under -Wdangling-reference.
+      IccJson::const_iterator it = entry.begin();
+      const IccJson &tagObj = it.value();
+      if (!tagObj.is_object() || !(tagObj.contains("data") || tagObj.contains("sameAs")))
+        allHaveData = false;
+      else if (tagObj.contains("data") && !tagObj["data"].is_object())
+        allHaveData = false;
+    }
+    check(allObjects, "every Tags entry is a one-member object, none null");
+    check(allHaveData, "every Tags entry kept its data (or sameAs) member");
+  }
+
+  // The outermost hand-off in the string overload: root["IccProfile"] = move(profile).
+  std::string jsonString;
+  check(profile.ToJson(jsonString, 0), "ToJson(std::string&) reports success");
+  check(!jsonString.empty(), "serialized string is non-empty");
+  check(jsonString.find("\"IccProfile\"") != std::string::npos,
+        "serialized string carries the IccProfile wrapper");
+  check(jsonString.find("\"IccProfile\":null") == std::string::npos,
+        "the IccProfile wrapper is not null (document was not moved away early)");
+  check(jsonString.find("\"Header\"") != std::string::npos,
+        "serialized string still carries the Header after the wrapper move");
+}
+
+// --- a tag-level array hand-off ------------------------------------------------
+// CIccTagJsonNum<>::ToJson and friends build a "values" array the same way.
+void testTagValueArray()
+{
+  CIccTag *pTag = CIccTagCreator::CreateTag(icSigS15Fixed16ArrayType);
+  check(pTag != NULL, "s15Fixed16 tag allocates");
+  if (!pTag)
+    return;
+
+  IIccExtensionTag *pExt = pTag->GetExtension();
+  if (!pExt || strcmp(pExt->GetExtClassName(), "CIccTagJson") != 0) {
+    // The JSON factory is not registered in this build; nothing to assert.
+    delete pTag;
+    return;
+  }
+
+  IccJson j;
+  check(static_cast<CIccTagJson *>(pExt)->ToJson(j), "tag ToJson reports success");
+  check(j.contains("values"), "tag carries a values array");
+  check(j["values"].is_array(), "values survived the hand-off as an array, not null");
+
+  delete pTag;
+}
+
+} // namespace
+
+int main()
+{
+  // The JSON tag/element factories must be registered before any ToJson call, or
+  // GetExtension() returns nothing and the walks above have nothing to inspect.
+  CIccTagCreator::PushFactory(new CIccTagJsonFactory);
+
+  testCLUTChain();
+  testProfileChain();
+  testTagValueArray();
+
+  if (g_fail)
+    std::fprintf(stderr, "[json-writer-move] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[json-writer-move] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2424,6 +2424,56 @@ function(iccdev_add_json_bcd_version_test)
   endif()
 endfunction()
 
+# #1911: the JSON writers handed every payload up to the document root by value, so a
+# CLUT-bearing tag's samples were deep-copied and destroyed once per level of the
+# chain (data -> clut -> tagData -> tagObj -> entry -> Tags -> IccProfile). Those
+# hand-offs are now std::move, and the sample arrays reserve() their known size. The
+# risk that introduces is a misplaced move: nlohmann leaves a moved-from value as
+# null, which a writer that only reports success cannot detect. This test walks the
+# emitted document and asserts the payload actually arrived -- element counts, values
+# and no null where data belongs. Header + IccProfLib/IccJSON only, no fixture.
+function(iccdev_add_json_writer_move_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCJSON}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccJsonWriterMoveTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/json-writer-move-integrity.cpp"
+  )
+  target_compile_features(iccJsonWriterMoveTest PRIVATE cxx_std_17)
+  target_include_directories(iccJsonWriterMoveTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccJSON/IccLibJSON"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccJsonWriterMoveTest PRIVATE
+    ${TARGET_LIB_ICCJSON} ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccJsonWriterMoveTest)
+
+  add_test(
+    NAME iccdev.json-writer-move-integrity
+    COMMAND "$<TARGET_FILE:iccJsonWriterMoveTest>"
+  )
+  set_tests_properties(iccdev.json-writer-move-integrity PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;json;performance;issue-1911;regression"
+  )
+  if(WIN32)
+    set(_json_move_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccJsonWriterMoveTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCJSON}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _json_move_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.json-writer-move-integrity PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_json_move_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1831: icGetDateTimeValue discarded its sscanf conversion count and assigned every
 # field into the icUInt16Number members of icDateTimeNumber without a range check, so
 # "%u" turned "-1" into 4294967295 and a year of 590359881 was truncated to 11593
@@ -2821,6 +2871,7 @@ if(WIN32)
   iccdev_add_mpexml_unknown_reserved_test()
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_json_bcd_version_test()
+  iccdev_add_json_writer_move_test()
   iccdev_add_datetime_parse_test()
   iccdev_add_encoding_surround_test()
   iccdev_add_parser_restore_calls_test()
@@ -3049,6 +3100,7 @@ iccdev_add_xml_writer_graceful_degrade_test()
 iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_json_bcd_version_test()
+iccdev_add_json_writer_move_test()
 iccdev_add_datetime_parse_test()
 iccdev_add_encoding_surround_test()
 iccdev_add_parser_restore_calls_test()

--- a/Dockerfile.ci-regression
+++ b/Dockerfile.ci-regression
@@ -52,7 +52,7 @@ RUN apt-get update \
     libtiff-tools=4.7.0-3ubuntu4 \
     liblzma-dev=5.8.3-1 \
     libpng-dev=1.6.57-1 \
-    libssl-dev=3.5.5-1ubuntu3.2 \
+    libssl-dev=3.5.5-1ubuntu3.3 \
     libtiff-dev=4.7.0-3ubuntu4 \
     libwxgtk3.2-dev=3.2.9+dfsg-1 \
     zlib1g=1:1.3.dfsg+really1.3.1-1ubuntu3 \
@@ -67,7 +67,7 @@ RUN apt-get update \
     make=4.4.1-3 \
     nano=8.7.1-1ubuntu0.1 \
     nlohmann-json3-dev=3.12.0.really.3.12.0.really.3.11.3-3build1 \
-    openssl-provider-legacy=3.5.5-1ubuntu3.2 \
+    openssl-provider-legacy=3.5.5-1ubuntu3.3 \
     pkg-config=2.5.1-4 \
     python3=3.14.3-0ubuntu2 \
     python3-dev=3.14.3-0ubuntu2 \

--- a/IccJSON/CmdLine/IccToJson/IccToJson.cpp
+++ b/IccJSON/CmdLine/IccToJson/IccToJson.cpp
@@ -91,7 +91,9 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
       }
       IccJson wrapper;
-      wrapper["IccProfile"] = j;
+      // j is the whole document and is dead after this hand-off; copying it here
+      // doubled peak memory before the sort pass even started.
+      wrapper["IccProfile"] = std::move(j);
       nlohmann::ordered_json sorted = sortJsonKeys(wrapper);
       jsonStr = sorted.dump(indent);
     }

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -299,9 +299,10 @@ public:
     j["type"] = "SampledSegment";
     IccJson samples = IccJson::array();
     const icUInt32Number nCount = m_nCount;
+    samples.get_ref<IccJson::array_t &>().reserve(nCount);
     for (icUInt32Number i = 0; i < nCount; i++)
       samples.push_back((double)m_pSamples[i]);
-    j["samples"] = samples;
+    j["samples"] = std::move(samples);
     return true;
   }
 
@@ -349,9 +350,9 @@ bool CIccSegmentedCurveJson::ToJson(IccJson &j)
     else {
       return false;
     }
-    segs.push_back(jSeg);
+    segs.push_back(std::move(jSeg));
   }
-  j["segments"] = segs;
+  j["segments"] = std::move(segs);
   return true;
 }
 
@@ -411,9 +412,10 @@ public:
       j["reserved"] = (int)m_nReserved;
     IccJson samples = IccJson::array();
     const icUInt32Number nCount = m_nCount;
+    samples.get_ref<IccJson::array_t &>().reserve(nCount);
     for (icUInt32Number i = 0; i < nCount; i++)
       samples.push_back((double)m_pSamples[i]);
-    j["samples"] = samples;
+    j["samples"] = std::move(samples);
     return true;
   }
 
@@ -613,9 +615,9 @@ bool CIccMpeJsonCurveSet::ToJson(IccJson &j)
     else if (!icToJsonCurve(jCurve, m_curve[i])) {
       return false;
     }
-    curves.push_back(jCurve);
+    curves.push_back(std::move(jCurve));
   }
-  j["curves"] = curves;
+  j["curves"] = std::move(curves);
   return true;
 }
 
@@ -774,7 +776,7 @@ bool CIccMpeJsonTintArray::ParseJson(const IccJson &j, std::string &parseStr)
       delete[] buf;
 
       IccJson jValues;
-      jValues["values"] = jArr;
+      jValues["values"] = std::move(jArr);
       if (!pTagJson->ParseJson(jValues, parseStr)) { delete pTag; return false; }
     }
     else if (format == "binary") {
@@ -789,7 +791,7 @@ bool CIccMpeJsonTintArray::ParseJson(const IccJson &j, std::string &parseStr)
       delete pIO;
 
       IccJson jValues;
-      jValues["values"] = jArr;
+      jValues["values"] = std::move(jArr);
       if (!pTagJson->ParseJson(jValues, parseStr)) { delete pTag; return false; }
     }
     else {
@@ -993,9 +995,10 @@ bool CIccMpeJsonMatrix::ToJson(IccJson &j)
     IccJson matrix = IccJson::array();
     icUInt64Number nEntries64 = (icUInt64Number)m_nInputChannels * m_nOutputChannels;
     icUInt32Number nEntries = (icUInt32Number)nEntries64;
+    matrix.get_ref<IccJson::array_t &>().reserve(nEntries);
     for (icUInt32Number i = 0; i < nEntries; i++)
       matrix.push_back((double)m_pMatrix[i]);
-    j["matrix"] = matrix;
+    j["matrix"] = std::move(matrix);
   }
   // Preserve serialized matrix constants even when they are all zero.
   if (m_pConstants) {
@@ -1003,7 +1006,7 @@ bool CIccMpeJsonMatrix::ToJson(IccJson &j)
     const icUInt16Number nOutputChannels = m_nOutputChannels;
     for (icUInt16Number i = 0; i < nOutputChannels; i++)
       constants.push_back((double)m_pConstants[i]);
-    j["constants"] = constants;
+    j["constants"] = std::move(constants);
   }
   return true;
 }

--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -185,7 +185,7 @@ bool CIccProfileJson::ToJson(IccJson &root)
   if (m_Header.mcs)
     header["MCS"] = icGetColorSigStr(buf, bufSize, m_Header.mcs);
 
-  root["Header"] = header;
+  root["Header"] = std::move(header);
 
   // Tags -- stored as a JSON array to preserve tag order.
   // Each element is a single-member object: { "<tagName>": { ... } }
@@ -223,8 +223,8 @@ bool CIccProfileJson::ToJson(IccJson &root)
     if (prevIt != ptrToFirstKey.end()) {
       tagObj["sameAs"] = prevIt->second;
       IccJson entry;
-      entry[key] = tagObj;
-      tags.push_back(entry);
+      entry[key] = std::move(tagObj);
+      tags.push_back(std::move(entry));
       continue;
     }
 
@@ -247,14 +247,18 @@ bool CIccProfileJson::ToJson(IccJson &root)
 
     if (pTag->m_nReserved)
       tagObj["Reserved"] = (unsigned int)pTag->m_nReserved;
-    tagObj["data"] = tagData;
+    // Each of these hand-offs used to deep-copy the whole tag payload and then
+    // destroy the source. For a tag carrying a large CLUT that is the dominant
+    // cost of serialization, and it happened three times per tag on the way up
+    // to the root: tagData -> tagObj -> entry -> tags.
+    tagObj["data"] = std::move(tagData);
 
     IccJson entry;
-    entry[key] = tagObj;
-    tags.push_back(entry);
+    entry[key] = std::move(tagObj);
+    tags.push_back(std::move(entry));
     ptrToFirstKey[pTag] = key;
   }
-  root["Tags"] = tags;
+  root["Tags"] = std::move(tags);
 
   return true;
 }
@@ -265,7 +269,9 @@ bool CIccProfileJson::ToJson(std::string &jsonString, int indent)
   IccJson profile;
   if (!ToJson(profile))
     return false;
-  root["IccProfile"] = profile;
+  // profile is the entire document; copying it here doubled peak memory for the
+  // whole serialized profile immediately before the dump.
+  root["IccProfile"] = std::move(profile);
   
   // dump the json data to string, but replace bad text/utf8 data with valid data instead of throwing exceptions
   jsonString = root.dump( indent,' ',true, nlohmann::detail::error_handler_t::replace );

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -693,10 +693,12 @@ bool CIccTagJsonSpectralViewingConditions::ToJson(IccJson &j)
       obs["Reserved"] = (int)m_reserved2;
     IccJson data = IccJson::array();
     icUInt32Number nTotal = (icUInt32Number)m_observerRange.steps * 3;
+    // Sample count is known before the walk, so size the backing vector once.
+    data.get_ref<IccJson::array_t &>().reserve(nTotal);
     for (icUInt32Number i = 0; i < nTotal; i++)
       data.push_back((double)m_observer[i]);
-    obs["data"] = data;
-    j["ObserverFuncs"] = obs;
+    obs["data"] = std::move(data);
+    j["ObserverFuncs"] = std::move(obs);
   }
 
   j["StdIlluminant"]    = info.GetIlluminantName(m_stdIlluminant);
@@ -710,10 +712,11 @@ bool CIccTagJsonSpectralViewingConditions::ToJson(IccJson &j)
     if (m_reserved3)
       illum["Reserved"] = (int)m_reserved3;
     IccJson data = IccJson::array();
+    data.get_ref<IccJson::array_t &>().reserve(m_illuminantRange.steps);
     for (int i = 0; i < (int)m_illuminantRange.steps; i++)
       data.push_back((double)m_illuminant[i]);
-    illum["data"] = data;
-    j["IlluminantSPD"] = illum;
+    illum["data"] = std::move(data);
+    j["IlluminantSPD"] = std::move(illum);
   }
 
   j["SurroundXYZ"] = IccJson::array({ (double)m_surroundXYZ.X,
@@ -872,13 +875,14 @@ bool CIccTagJsonNamedColor2::ToJson(IccJson &j)
       c["name"] = icJsonFixedAsciiString(pColor->rootName, sizeof(pColor->rootName));
       c["pcsCoords"] = IccJson::array({ pColor->pcsCoords[0], pColor->pcsCoords[1], pColor->pcsCoords[2] });
       IccJson dev = IccJson::array();
+      dev.get_ref<IccJson::array_t &>().reserve(m_nDeviceCoords);
       for (icUInt32Number d = 0; d < m_nDeviceCoords; d++)
         dev.push_back(icJsonDeviceCoordToU16(pColor->deviceCoords[d]));
-      c["deviceCoords"] = dev;
-      colors.push_back(c);
+      c["deviceCoords"] = std::move(dev);
+      colors.push_back(std::move(c));
     }
   }
-  j["colors"] = colors;
+  j["colors"] = std::move(colors);
   return true;
 }
 
@@ -1100,18 +1104,21 @@ bool CIccTagJsonSparseMatrixArray::ToJson(IccJson &j)
 
       icUInt16Number *cols = mtx.GetColumnsForRow(r);
       icFloatNumber  *data = (icFloatNumber*)mtx.GetData()->getPtr(mtx.GetRowOffset(r));
+      // The stored column count for this row bounds both walks.
+      jIdx.get_ref<IccJson::array_t &>().reserve(n);
+      jData.get_ref<IccJson::array_t &>().reserve(n);
       for (int k = 0; k < n; k++) {
         jIdx.push_back(cols[k]);
         jData.push_back(data[k]);
       }
-      jRow["colIndices"] = jIdx;
-      jRow["colData"]    = jData;
-      jRows.push_back(jRow);
+      jRow["colIndices"] = std::move(jIdx);
+      jRow["colData"]    = std::move(jData);
+      jRows.push_back(std::move(jRow));
     }
-    jMtx["sparseRows"] = jRows;
-    matrices.push_back(jMtx);
+    jMtx["sparseRows"] = std::move(jRows);
+    matrices.push_back(std::move(jMtx));
   }
-  j["matrices"] = matrices;
+  j["matrices"] = std::move(matrices);
   return true;
 }
 
@@ -1257,9 +1264,10 @@ template <class T, icTagTypeSignature Tsig>
 bool CIccTagJsonFixedNum<T, Tsig>::ToJson(IccJson &j)
 {
   IccJson arr = IccJson::array();
+  arr.get_ref<IccJson::array_t &>().reserve(this->m_nSize);
   for (icUInt32Number i = 0; i < this->m_nSize; i++)
     arr.push_back(icFtoD(this->m_Num[i]));
-  j["values"] = arr;
+  j["values"] = std::move(arr);
   return true;
 }
 
@@ -1306,9 +1314,10 @@ bool CIccTagJsonNum<T, A, Tsig>::ToJson(IccJson &j)
   const icUInt32Number nMaxNumValues = 0xffffff;
   if (this->m_nSize > nMaxNumValues)
     return false;
+  arr.get_ref<IccJson::array_t &>().reserve(this->m_nSize);
   for (icUInt32Number i = 0; i < this->m_nSize; i++)
     arr.push_back(this->m_Num[i]);
-  j["values"] = arr;
+  j["values"] = std::move(arr);
   return true;
 }
 
@@ -1356,9 +1365,10 @@ bool CIccTagJsonFloatNum<T, A, Tsig>::ToJson(IccJson &j)
   const icUInt32Number nMaxNumValues = 0xffffff;
   if (this->m_nSize > nMaxNumValues)
     return false;
+  arr.get_ref<IccJson::array_t &>().reserve(this->m_nSize);
   for (icUInt32Number i = 0; i < this->m_nSize && i < nMaxNumValues; i++)
     arr.push_back((double)this->m_Num[i]);
-  j["values"] = arr;
+  j["values"] = std::move(arr);
   return true;
 }
 
@@ -1821,6 +1831,7 @@ bool CIccTagJsonCurve::ToJson(IccJson &j, icConvertType nType)
     } else {
       j["curveType"] = "table";
       IccJson arr = IccJson::array();
+      arr.get_ref<IccJson::array_t &>().reserve(m_nSize);
       for (icUInt32Number i = 0; i < m_nSize; i++) {
         switch (nType) {
           case icConvert8Bit:
@@ -1836,7 +1847,7 @@ bool CIccTagJsonCurve::ToJson(IccJson &j, icConvertType nType)
         j["precision"] = 1;
       else if (nType == icConvert16Bit || nType == icConvertVariable)
         j["precision"] = 2;
-      j["table"] = arr;
+      j["table"] = std::move(arr);
     }
   }
   return true;

--- a/IccJSON/IccLibJSON/IccUtilJson.cpp
+++ b/IccJSON/IccLibJSON/IccUtilJson.cpp
@@ -162,7 +162,9 @@ bool icCLUTDataToJson(IccJson &j, CIccCLUT *pCLUT, icConvertType nType, bool bSa
     IccJson gridPts = IccJson::array();
     for (i = 0; i < nInput; i++)
       gridPts.push_back((int)pCLUT->GridPoint(i));
-    j["gridPoints"] = gridPts;
+    // gridPts is dead after this hand-off, so transfer the array rather than
+    // deep-copying it and then destroying the original.
+    j["gridPoints"] = std::move(gridPts);
   }
 
   // Resolve variable precision the same way IccXML does
@@ -179,6 +181,11 @@ bool icCLUTDataToJson(IccJson &j, CIccCLUT *pCLUT, icConvertType nType, bool bSa
   icUInt32Number nTotal = pCLUT->NumPoints() * (icUInt32Number)nOutput;
   icFloatNumber *pData  = pCLUT->GetData(0);
 
+  // The sample count is known exactly before the loop. A JSON array is backed by
+  // a std::vector, so without this the push_back below reallocates and moves the
+  // whole array O(log nTotal) times; large CLUTs make that the visible cost.
+  data.get_ref<IccJson::array_t &>().reserve(nTotal);
+
   for (icUInt32Number k = 0; k < nTotal; k++) {
     switch (nType) {
       case icConvert8Bit:
@@ -192,7 +199,9 @@ bool icCLUTDataToJson(IccJson &j, CIccCLUT *pCLUT, icConvertType nType, bool bSa
         break;
     }
   }
-  j["data"] = data;
+  // data holds every CLUT sample and is dead after this hand-off. Copying it here
+  // duplicated the entire sample array and then freed the original.
+  j["data"] = std::move(data);
   return true;
 }
 
@@ -202,7 +211,9 @@ bool icCLUTToJson(IccJson &j, CIccCLUT *pCLUT, icConvertType nType,
   IccJson clut;
   if (!icCLUTDataToJson(clut, pCLUT, nType, bSaveGridPoints))
     return false;
-  j[szName] = clut;
+  // Second copy of the same payload on the old path: clut carries the sample array
+  // just built above, and is dead once it has been handed to j.
+  j[szName] = std::move(clut);
   return true;
 }
 


### PR DESCRIPTION
## PR Summary

Fixes #1911.

The JSON writers built each payload in a local, **copied** it into its parent, and then destroyed the local. For a CLUT-bearing tag that repeated at every level of the chain:

```
data -> clut -> tagData -> tagObj -> entry -> Tags -> IccProfile
```

so one CLUT's samples were deep-copied and freed several times over before the document was dumped. The arrays were also grown by `push_back` with no `reserve()`, despite the element count being known before the loop. There was not one `std::move` or `reserve()` anywhere in the JSON writer layer.

That accounts for the hotspots in your Callgrind table directly: `json_value::destroy` at 22.71% + 6.76%, the copy constructor at 4.43%, `_M_realloc_append` at 2.55% — all of it work on payloads that had no further reader.

Every such hand-off is now `std::move`, and every array whose count is known before its walk `reserve()`s it.

### On the 51.97% `assert_invariant` line

That one needs a correction, because it changes where the cost actually is.

`assert_invariant` is `JSON_ASSERT`, which is `assert()` — it compiles out under `NDEBUG`, so it is **already absent from any Release build**. I isolated it with the same `-O3`, asserts on vs off:

| build | wall |
|---|---|
| `-O3 -DNDEBUG` | 1.16s |
| `-O3`, asserts live | 2.16s |

Your "optimized direct run" at 2.63s tracks the asserts-live column, not Release — so those numbers came from a build without `NDEBUG`.

It is not an independent cost either. `assert_invariant` runs once per `basic_json` construction, so cutting the redundant copies removes it as a side effect. Same profile, asserts left live: **2.16s -> 0.55s**, level with Release. So the copies were the real defect and the assert line was a symptom of them.

### Measured

`APTEC_CMYKOGV_Coated_LinearCTV_2025.icc`, Release, five interleaved runs writing a real output file, medians:

| metric | before | after | |
|---|---|---|---|
| wall | 1.46s | 0.57s | **2.6x** |
| user | 0.88s | 0.28s | **3.1x** |
| peak RSS | 336.7 MB | 259.8 MB | **-23%** |

Across the 252 profiles in `Testing/`, `iccToJson` total wall time falls from **~6.0s to ~3.9s (-38%)**.

### Output is unchanged

- all **252** profiles emit **byte-identical** JSON to master (same sha256), exit codes match
- the **164** profiles that survive an `icc -> json -> icc` round trip produce byte-identical profiles
- re-verified identically under `ICC_JSON_ORDERED=ON`

### Regression coverage

The risk this change introduces is a *misplaced* move: nlohmann leaves a moved-from value as `null`, which a writer that only reports success cannot detect. `iccdev.json-writer-move-integrity` walks the emitted document and asserts the payload actually arrived — element counts, values in order, and no `null` where data belongs — across the CLUT chain, the profile assembly chain and a tag-level values array.

Red-green verified: injecting a use-after-move into `icCLUTDataToJson` fails it 2/2. Header + IccProfLib/IccJSON only, no fixture, 0.01s.

### Verification

- `gcc -Wall -Wextra -Wpedantic -Werror -std=c++17` with `ENABLE_LTO=ON` — **zero warnings**
- **134/135** CTests pass; the one failure is the pre-existing `spectral-tiff-preview` environment skip (missing python `imagecodecs`)
- clean under **ASan+UBSan with `detect_leaks=1`** across all 252 profiles (CI's ctest runs `detect_leaks=0`, so this was run explicitly)
- `clang-tidy bugprone-use-after-move` and `clang-analyzer-cplusplus.Move` report nothing on any changed file
- also built and re-verified with **`ICC_JSON_ORDERED=ON`** — what `ci-codeql-security.yml` builds, and what auto-enables on libstdc++<11 — zero warnings, CTest passes, 252 profiles byte-identical

Each reserved count is bounded by data already resident in memory (the source array is allocated to match), and an exact `reserve()` peaks lower than geometric `push_back` growth, so this reduces rather than adds allocation exposure — consistent with the measured drop in peak RSS.

### Two things found but deliberately not fixed here

1. **`iccFromJson` refuses files > 64 MB**, so APTEC's 89.5 MB JSON cannot be round-tripped at all — `iccToJson` output for large profiles is currently un-reimportable. Identical on master; this looks like it belongs to #1856 rather than here.
2. **`sortJsonKeys` round-trips every primitive through `dump()` + `parse()`.** `-sort` costs 2.9x on a 950 KB profile and 3.4x on APTEC (0.68s -> 2.31s) — i.e. with `-sort` the tool is slower than it was before this PR without it. No CI path uses `-sort`, so I left it alone rather than widen scope. Happy to take it as a follow-up if you want it.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes — n/a, no user-visible behaviour change (output byte-identical)
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes — n/a
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [ ] New source files include the ICC copyright and BSD 3-Clause license header — the new test matches the convention of `.github/ci/regression/` (49 of 59 existing tests, including the #1904 and #1912 ones, open with the defect explanation instead). Say the word and I will add the header.
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
