### PR TITLE
fix(#1920): sort JSON keys without round-tripping every scalar through text

### DIFF
--- a/.github/scripts/iccdev-json-sort-regression.sh
+++ b/.github/scripts/iccdev-json-sort-regression.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# Issue #1920 -- regression coverage for iccToJson -sort.
+#
+# -sort had no test of any kind, which is how a 2.5x-3.4x cost in its scalar
+# path went unnoticed. The performance is not asserted here (timings are not a
+# stable gate); what is asserted is every correctness property the sort pass
+# has to preserve, so that a future rewrite of it cannot silently change data:
+#
+#   1. keys really are in ascending order, recursively        (the -sort contract)
+#   2. sorted output carries the SAME data as unsorted output (no value corruption)
+#   3. the same input twice gives byte-identical output        (determinism)
+#   4. sorted output is still readable by iccFromJson          (round-trip)
+#   5. all of the above hold at -indent=0, 2 and 4
+#
+# Property 2 is the load-bearing one. The sort pass has to copy every scalar
+# from one nlohmann instantiation into another, and that copy is exactly where
+# a float can lose precision or an integer can change signedness without any
+# structural difference to show for it.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+if [ -d "$SCRIPT_DIR/../../IccProfLib" ]; then
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+elif [ -d "$SCRIPT_DIR/../../../IccProfLib" ]; then
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+else
+  REPO_ROOT="$(pwd)"
+fi
+cd "$REPO_ROOT" || exit 1
+
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-build/Tools}"
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export ASAN_OPTIONS=halt_on_error=0,detect_leaks=0
+export UBSAN_OPTIONS=halt_on_error=0,print_stacktrace=1
+
+TOJSON="$TOOLS_DIR/IccToJson/iccToJson"
+FROMJSON="$TOOLS_DIR/IccFromJson/iccFromJson"
+
+PASS=0
+FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+ok()   { PASS=$((PASS+1)); echo "[PASS] $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "[FAIL] $1"; }
+
+if [ ! -x "$TOJSON" ]; then
+  echo "iccToJson not found at $TOJSON -- nothing to verify"
+  exit 1
+fi
+
+# Profiles chosen for shape, not size: a CLUT-heavy CMYK profile (mixed integer
+# and float scalars), a 100%-float display profile, and a smaller profile that
+# puts proportionally more weight on the object path than the array path.
+#
+# The indent list is per profile on purpose. Indentation is handled by the final
+# dump() and is orthogonal to document shape, so the full 0/2/4 sweep only needs
+# the cheapest profile; the large ones would just buy the same coverage at many
+# times the cost. Running the whole matrix on all three took 97s of the 300s
+# timeout under ASAN on a developer machine, which is too little headroom for a
+# loaded runner, and held 175MB of intermediates at once.
+# Entries are <profile>|<comma separated indents>; commas rather than spaces so
+# that each entry survives word splitting as a single token.
+PROFILE_MATRIX="
+Testing/SpecRef/srgbRef.icc|0,2,4
+Testing/CMYK-3DLUTs/CMYK-3DLUTs.icc|2
+Testing/Display/LaserProjector.icc|2
+"
+
+# Recursively assert ascending key order, and compare sorted against unsorted
+# for data equality. Python is already a hard dependency of the JSON test group.
+check_json() {
+  python3 - "$1" "$2" <<'PYEOF'
+import json, sys
+
+def keys_ordered(node, path="$"):
+    if isinstance(node, dict):
+        ks = list(node.keys())
+        if ks != sorted(ks):
+            for a, b in zip(ks, sorted(ks)):
+                if a != b:
+                    return "%s: keys not ascending (saw '%s', expected '%s')" % (path, a, b)
+        for k, v in node.items():
+            err = keys_ordered(v, "%s.%s" % (path, k))
+            if err:
+                return err
+    elif isinstance(node, list):
+        for i, v in enumerate(node):
+            err = keys_ordered(v, "%s[%d]" % (path, i))
+            if err:
+                return err
+    return None
+
+sorted_path, plain_path = sys.argv[1], sys.argv[2]
+
+with open(sorted_path) as f:
+    s = json.load(f)
+with open(plain_path) as f:
+    p = json.load(f)
+
+err = keys_ordered(s)
+if err:
+    print("ORDER " + err)
+    sys.exit(1)
+
+# dict == dict ignores insertion order, so this compares content alone. Floats
+# must match exactly: both sides originate from the same double, so any
+# difference here means the sort pass altered a value rather than moved it.
+if s != p:
+    print("DATA sorted and unsorted documents differ in content")
+    sys.exit(1)
+
+print("OK")
+PYEOF
+}
+
+echo "=================================================================="
+echo " iccToJson -sort regression (issue #1920)"
+echo "=================================================================="
+
+for entry in $PROFILE_MATRIX; do
+  icc="${entry%%|*}"
+  indents="$(echo "${entry#*|}" | tr ',' ' ')"
+  if [ ! -f "$icc" ]; then
+    echo "[SKIP] $icc not present"
+    continue
+  fi
+  name="$(basename "$icc" .icc)"
+
+  for indent in $indents; do
+    s1="$WORK/$name.$indent.sorted.json"
+    s2="$WORK/$name.$indent.sorted2.json"
+    pl="$WORK/$name.$indent.plain.json"
+
+    if ! "$TOJSON" "$icc" "$s1" -sort "-indent=$indent" >/dev/null 2>&1; then
+      bad "$name indent=$indent: iccToJson -sort exited non-zero"
+      continue
+    fi
+    if [ ! -s "$s1" ]; then
+      bad "$name indent=$indent: -sort produced an empty file"
+      continue
+    fi
+    if ! "$TOJSON" "$icc" "$pl" "-indent=$indent" >/dev/null 2>&1; then
+      bad "$name indent=$indent: iccToJson without -sort exited non-zero"
+      continue
+    fi
+
+    result="$(check_json "$s1" "$pl" 2>&1)"
+    if [ "$result" = "OK" ]; then
+      ok "$name indent=$indent: keys ascending, content identical to unsorted"
+    else
+      bad "$name indent=$indent: $result"
+    fi
+
+    # Determinism: a second run of the same input must be byte-identical.
+    "$TOJSON" "$icc" "$s2" -sort "-indent=$indent" >/dev/null 2>&1
+    if cmp -s "$s1" "$s2"; then
+      ok "$name indent=$indent: -sort is deterministic"
+    else
+      bad "$name indent=$indent: -sort output differs between runs"
+    fi
+
+    rm -f "$s2" "$pl"
+
+    # Round-trip the sorted document back to a profile, at the default indent.
+    # Sorting moves the keys out of the writer's emission order, so this is the
+    # check that the reader is not quietly depending on that order.
+    if [ "$indent" = "2" ] && [ -x "$FROMJSON" ]; then
+      if "$FROMJSON" "$s1" "$WORK/$name.roundtrip.icc" >/dev/null 2>&1; then
+        ok "$name: sorted JSON round-trips through iccFromJson"
+      else
+        bad "$name: iccFromJson rejected the sorted document"
+      fi
+      rm -f "$WORK/$name.roundtrip.icc"
+    fi
+
+    # These documents run to tens of MB each. Release every intermediate as soon
+    # as it has been checked rather than accumulating the whole matrix on disk.
+    rm -f "$s1"
+  done
+done
+
+echo "------------------------------------------------------------------"
+echo "PASS=$PASS FAIL=$FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+if [ "$PASS" -eq 0 ]; then
+  echo "no profiles were exercised"
+  exit 1
+fi
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3400,6 +3400,22 @@ if(ICCDEV_HAS_JSON_TOOLS)
   set_tests_properties(iccdev.json-parser-regressions PROPERTIES
     FIXTURES_REQUIRED iccdev_profiles
   )
+
+  # Issue #1920. iccToJson -sort had no coverage at all, so nothing objected when
+  # its scalar path became the most expensive part of the conversion. This pins
+  # the properties the sort pass must preserve - ascending keys, content equal to
+  # the unsorted document, deterministic and still readable by iccFromJson - so
+  # that the scalar copy it performs can be changed without silently altering data.
+  iccdev_add_script_test(
+    iccdev.json-sort-regression
+    300
+    "iccdev;json;sort;regression;issue-1920;asan"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-json-sort-regression.sh"
+  )
+  set_tests_properties(iccdev.json-sort-regression PROPERTIES
+    FIXTURES_REQUIRED iccdev_profiles
+  )
 endif()
 
 iccdev_add_script_test(

--- a/IccJSON/CmdLine/IccToJson/IccToJson.cpp
+++ b/IccJSON/CmdLine/IccToJson/IccToJson.cpp
@@ -29,12 +29,20 @@ static nlohmann::ordered_json sortJsonKeys(const IccJson &j)
   }
   if (j.is_array()) {
     nlohmann::ordered_json arr = nlohmann::ordered_json::array();
+    // Element count is known up front, so size the backing vector once instead of
+    // letting push_back reallocate and copy its way up. CLUT-bearing tags dominate
+    // the document, and those arrays are where nearly all of the elements live.
+    arr.get_ref<nlohmann::ordered_json::array_t &>().reserve(j.size());
     for (const auto &elem : j)
       arr.push_back(sortJsonKeys(elem));
     return arr;
   }
-  // Primitives: convert via dump/parse to cross nlohmann type boundary
-  return nlohmann::ordered_json::parse(j.dump());
+  // Primitives: nlohmann converts directly between two basic_json instantiations.
+  // Its converting constructor dispatches on the source's value_t and moves the
+  // scalar across by type, so there is no need to serialize to text and re-parse.
+  // When IccJson already IS ordered_json that constructor is excluded (same type)
+  // and the ordinary copy constructor runs, so this is correct in both builds.
+  return nlohmann::ordered_json(j);
 }
 
 int main(int argc, char* argv[])


### PR DESCRIPTION
## PR Summary

Fixes #1920.

`sortJsonKeys()` converted every primitive leaf with
`nlohmann::ordered_json::parse(j.dump())` — each number, string and bool in the profile was
turned into a `std::string` and run back through the JSON parser. For a CLUT-heavy profile
that is millions of allocations plus a parser invocation per scalar, spent to move a value
between two `basic_json` instantiations holding the identical scalar representation.

nlohmann already converts directly between instantiations. Its converting constructor
switches on the source `value_t` and hands the scalar across by type, so the text detour is
unnecessary:

```cpp
-  // Primitives: convert via dump/parse to cross nlohmann type boundary
-  return nlohmann::ordered_json::parse(j.dump());
+  return nlohmann::ordered_json(j);
```

One expression is correct in both builds: when `IccJson` *is* `ordered_json` the converting
constructor is excluded by `!is_same` and the ordinary copy constructor runs. That also
disposes of the old comment's rationale — there is no type boundary to cross in the
`ICC_JSON_ORDERED` build, yet the cost was paid there anyway, which the measurements below
confirm.

The array branch additionally reserves its backing store up front. The element count is known
before the walk starts and CLUT-bearing tags hold nearly all of the document's elements.

### Measurements

Best-of-9, output written to a real file — `/dev/null` is not usable here, since
`CIccFileIO::Open` rejects a non-regular file and the tool exits before the write.

| profile | config | plain | `-sort` before | `-sort` after | speedup | cost of `-sort` |
|---|---|---|---|---|---|---|
| `CMYK-3DLUTs.icc` | default | 125 ms | 413 ms | **201 ms** | **2.05x** | 3.30x → 1.61x |
| `LaserProjector.icc` | default | 106 ms | 362 ms | **222 ms** | **1.63x** | 3.42x → 2.09x |
| `18ChanWithSpots-MVIS.icc` | default | 141 ms | 415 ms | **206 ms** | **2.01x** | 2.94x → 1.46x |
| `srgbRef.icc` | default | 75 ms | 198 ms | **93 ms** | **2.13x** | 2.64x → 1.24x |
| `CMYK-3DLUTs.icc` | ordered | 163 ms | 458 ms | **232 ms** | **1.97x** | 2.81x → 1.42x |
| `LaserProjector.icc` | ordered | 114 ms | 341 ms | **227 ms** | **1.50x** | 2.99x → 1.99x |
| `18ChanWithSpots-MVIS.icc` | ordered | 157 ms | 413 ms | **217 ms** | **1.90x** | 2.63x → 1.38x |
| `srgbRef.icc` | ordered | 80 ms | 201 ms | **100 ms** | **2.01x** | 2.51x → 1.25x |

Output is **byte-identical** across four tracked profiles × both JSON configurations ×
`-indent=0, 2, 4`.

Relevant to #1911: before this change `-sort` gave back the whole of that fix and more —
`CMYK-3DLUTs.icc` took 413 ms sorted against 272 ms for the *unfixed* tool unsorted.

### Edge cases where the text detour used to normalise values

Both were checked rather than assumed, since removing a `dump()`/`parse()` cycle can change
more than speed:

- **NaN / infinity** — previously substituted to `null` inside the tree; now carried to the
  final `dump()` as a number, which writes `null` for it regardless. Emitted text is
  unchanged.
- **Binary values** — the one case the converting constructor and `dump()` genuinely treat
  differently. No iccDEV writer creates one, so the path is unreachable.

### Regression coverage

`-sort` had **no test of any kind**, which is how a 2.5x–3.4x cost in its scalar path went
unnoticed. This adds `iccdev.json-sort-regression`.

It deliberately asserts no timings — those are not a stable gate. It pins the properties the
sort pass has to preserve, so the scalar copy can be changed again without silently altering
data:

1. keys really are in ascending order, recursively (the `-sort` contract);
2. the sorted document carries the **same content** as the unsorted one;
3. the same input twice produces byte-identical output;
4. the sorted document is still readable by `iccFromJson`.

Property 2 is the load-bearing one: copying scalars between instantiations is exactly where a
value can change with no structural difference to show for it. Both assertions were
red-tested against deliberately broken builds — a corrupted scalar copy raises 5 `DATA`
failures, a reversed key sort raises 5 `ORDER` failures — and re-red-tested after the test
itself was restructured.

The `-indent` 0/2/4 sweep runs on the cheapest profile only. Indentation is applied by the
final `dump()` and is independent of document shape, so sweeping the large profiles bought no
extra coverage; doing so cost 97 s of the 300 s timeout under ASAN and held 175 MB of
intermediates at once. As scoped it runs in **49 s** holding **56 MB**.

### Verification

| gate | result |
|---|---|
| clang-18 Release, `-Wall -Wextra -Wpedantic -Werror` | **0 warnings, 0 errors** |
| GCC **15.2.0** in `iccdev-ci-regression:ci-qa-pr-docker-testing`, strict + LTO | **0 warnings, 0 errors** |
| ASAN + UBSAN Debug, `detect_leaks=1` | clean |
| `shellcheck` 0.9.0 | rc=0 |
| `ctest -R json`, default | **11/11** |
| `ctest -R json`, `-DICC_JSON_ORDERED=ON` | **11/11** |
| full suite | **135/136** |

For the GCC 15 leg I confirmed the strict set is actually live — `strict warnings ENABLED
(GNU 15.2.0)` with `-Wshadow -Werror=uninitialized -Wnull-dereference -Wundef
-Wpointer-arith` on the compile line — rather than inferring it from the absence of a
"DISABLED" message, since the local `g++` is 13.3 and silently skips those flags.

The one full-suite failure is `iccdev.spectral-tiff-preview` →
`ModuleNotFoundError: No module named 'imagecodecs'`, a missing local Python dependency that
CI installs. It fails identically on unmodified `master`.

Reproduction note: the regression binaries are `EXCLUDE_FROM_ALL`, so a plain
`cmake --build .` leaves several JSON tests reporting `Not Run` rather than failing. Build
`--target build-test-binaries` first.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes — no user-visible behaviour change; `-sort` output is byte-identical
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed `docs/python-packaging-release.md` — not applicable
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer — no harness change; this registers one new regression test alongside the existing JSON ones, per the issue assignment
- [x] New source files include the ICC copyright and BSD 3-Clause license header — no new source files; the added file is a test script
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
