### PR TITLE
fix(#1909): reject XML attribute values that do not fit their 8- and 16-bit tag fields

### DIFF
--- a/.github/scripts/iccdev-issue-1346-imageparse-atoi-unsigned-regression.sh
+++ b/.github/scripts/iccdev-issue-1346-imageparse-atoi-unsigned-regression.sh
@@ -96,7 +96,13 @@ run_case() {
   local log
   log="$OUTDIR/$(basename "$xml").log"
   # Keep ASan quiet about any unrelated leaks so UBSan's conversion diagnostic
-  # is the only thing we key on; the tool itself exits 0 on this valid profile.
+  # is the only thing we key on. The exit status is deliberately not asserted:
+  # what this test pins is the absence of a signed->unsigned conversion, and the
+  # tool's verdict on the profile has since changed. #1346 floored the negative
+  # ColorPrimaries to 0 and saved the profile; #1909 refuses the attribute
+  # instead, because storing 0 for a document that said -1 is the same
+  # substitution of a value the document never contained. Either way no
+  # conversion is performed, which is the property under test here.
   ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0" \
   UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
     "$FROMXML" "$xml" "$OUTDIR/$(basename "$xml").out" > "$log" 2>&1

--- a/.github/scripts/iccdev-issue-1909-xml-narrowing-regression.sh
+++ b/.github/scripts/iccdev-issue-1909-xml-narrowing-regression.sh
@@ -1,0 +1,293 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #1909
+#   (icUInt8Number)/(icUInt16Number) icXmlAttrToUInt() narrowing family in
+#   IccTagXml.cpp -- buckets 1 and 2
+###############################################################################
+#
+# The follow-up surface of #1908.  Tag-level readers parsed an XML attribute
+# into a wider integer and then narrowed it with an explicit cast:
+#
+#   m_nColorPrimaries = (icUInt8Number)icXmlAttrToUInt(icXmlAttrValue(attr));
+#   m_spectralRange.steps = (icUInt16Number)icXmlAttrToUInt(...);
+#   nRows = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(rows));
+#
+# Being explicit, the cast also suppresses UBSan's implicit-integer-truncation
+# check, so nothing reported it.  The document was accepted, the tool exited 0,
+# and the profile written to disk carried a value the document never contained:
+#
+#   ColorPrimaries="265"    stored and re-serialized as 9
+#   steps="65937"           stored and re-serialized as 401
+#   channels="65539"        stored and re-serialized as 3
+#   rows="65567"            stored and re-serialized as 31
+#   outputChannels="66304"  stored and re-serialized as 768
+#   GridGranularity="258"   produced a profile byte-identical to "2"
+#
+# Every case is the tracked fixture named beside it with ONE attribute changed,
+# so everything else each document exercises is a known-good path.  The mutation
+# is applied here rather than checked in, and the script FAILS if a mutation did
+# not apply -- a silently-unmutated fixture would convert cleanly and every
+# assertion below would pass while testing nothing.
+#
+# CONTROLS.  Each laundering case is paired with the wrapped value itself as a
+# legal document: 9, 401, 3, 31, 768, 2.  These must still convert.  That pairing
+# is what separates "refuses a value that does not fit the field" from "lowered
+# the ceiling": a fix that rejected both would satisfy every rejection assertion
+# here while having broken ordinary profiles.
+#
+# CRASH.  One case is not laundering.  CIccSparseMatrix::Init() enforces its own
+# dimension ceiling and returns false having left the matrix empty --
+# GetRowStart() NULL, GetMaxEntries() 0.  CIccTagXmlSparseMatrixArray::ParseXml
+# discarded that result, so a <SparseMatrix> declaring more rows than Init()
+# accepts and carrying no <SparseRow> children fell through to the row-start fill
+# and wrote through the NULL pointer:
+#
+#   Program received signal SIGSEGV, Segmentation fault.
+#   0x... in CIccTagXmlSparseMatrixArray::ParseXml(_xmlNode*, std::string&)
+#   $1 = (void *) 0x0
+#
+# That one asserts on the exit status, not on the absence of an output file: a
+# rejection and a crash both leave no profile behind, so only the status tells
+# them apart.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1909}"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+TOXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccToXml -type f 2>/dev/null | head -1)"
+
+status=0
+
+# mutate <donor-relative-path> <output-name> <find> <replace> [<find> <replace>]...
+#
+# Applies literal substitutions to a tracked fixture and writes the result to
+# OUTDIR. Refuses to write a fixture a substitution did not change, which is what
+# keeps a donor edited upstream from turning this test into a silent no-op.
+mutate() {
+  local donor="$REPO_ROOT/$1" out="$OUTDIR/$2"
+  local rel="$1"
+  shift 2
+  if [ ! -f "$donor" ]; then
+    echo "[SKIP] donor fixture missing: $rel"
+    return 1
+  fi
+  python3 - "$donor" "$out" "$@" <<'PYEOF'
+import sys
+donor, out = sys.argv[1], sys.argv[2]
+pairs = sys.argv[3:]
+src = open(donor, encoding="utf-8", errors="surrogateescape").read()
+for find, repl in zip(pairs[0::2], pairs[1::2]):
+    if find not in src:
+        sys.stderr.write(find[:70] + "\n")
+        sys.exit(3)
+    # Only the first occurrence: several donors repeat the same element, and one
+    # changed attribute is enough to reach the reader under test.
+    src = src.replace(find, repl, 1)
+open(out, "w", encoding="utf-8", errors="surrogateescape").write(src)
+PYEOF
+  local rc=$?
+  if [ $rc -eq 3 ]; then
+    echo "[FAIL] fixture drift: a literal no longer appears in $rel --"
+    echo "       the case below would have run against an unmutated document"
+    status=2
+    return 1
+  elif [ $rc -ne 0 ]; then
+    echo "[SKIP] could not build $2 from $rel"
+    return 1
+  fi
+  return 0
+}
+
+TOOL_RC=0
+TOOL_LOG=""
+TOOL_ICC=""
+run_tool() {
+  # Sets globals rather than echoing: a caller using $(run_tool ...) would run
+  # this in a subshell and TOOL_RC would never reach the caller.
+  local xml="$OUTDIR/$1" base="${1%.xml}"
+  TOOL_LOG="$OUTDIR/$base.log"
+  TOOL_ICC="$OUTDIR/$base.icc"
+  rm -f "$TOOL_ICC"
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0:allocator_may_return_null=1" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$FROMXML" "$xml" "$TOOL_ICC" > "$TOOL_LOG" 2>&1
+  TOOL_RC=$?
+}
+
+# A laundering case: the document must be refused, and no profile written.
+# $1 = fixture  $2 = description  $3 = grep pattern showing the value that landed
+expect_reject() {
+  run_tool "$1"
+  if [ -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1909: $2 -- profile written (rc=$TOOL_RC)"
+    if [ -n "${TOXML:-}" ] && [ -x "${TOXML:-}" ] && \
+       "$TOXML" "$TOOL_ICC" "$OUTDIR/${1%.xml}.roundtrip.xml" >/dev/null 2>&1; then
+      echo "       written profile re-serializes as:"
+      grep -oE "$3" "$OUTDIR/${1%.xml}.roundtrip.xml" | head -2 | sed 's/^/         /'
+    fi
+    status=2
+  else
+    echo "[PASS] $2 -- refused"
+  fi
+  rm -f "$TOOL_ICC"
+}
+
+# A control: the wrapped value is representable and must still be accepted.
+expect_accept() {
+  run_tool "$1"
+  if [ -f "$TOOL_ICC" ]; then
+    echo "[PASS] control: $2 still converts"
+  else
+    echo "[FAIL] control: $2 was rejected -- the fix is refusing representable"
+    echo "       values, not just unrepresentable ones"
+    sed -n '1,6p' "$TOOL_LOG"
+    status=2
+  fi
+  rm -f "$TOOL_ICC"
+}
+
+echo "=================================================================="
+echo " XML attribute narrowing regression (issue #1909)"
+echo "=================================================================="
+
+# --- bucket 1: 8-bit fields -------------------------------------------------
+
+# cicp code points are 8-bit syntax elements in ITU-T H.273. 265 & 0xFF == 9,
+# which is BT.2020 -- a different and entirely valid set of primaries.
+CICP=Testing/HDR/BT2100PQFullScene.xml
+if mutate "$CICP" cicp-launder-1909.xml 'ColorPrimaries="9"' 'ColorPrimaries="265"'; then
+  expect_reject cicp-launder-1909.xml 'cicp ColorPrimaries="265"' 'ColorPrimaries="[0-9]+"'
+fi
+# The donor already carries ColorPrimaries="9", the wrapped value, so it is its
+# own control -- copied through mutate so donor drift is caught here as well.
+if mutate "$CICP" cicp-control-1909.xml 'ColorPrimaries="9"' 'ColorPrimaries="9"'; then
+  expect_accept cicp-control-1909.xml 'ColorPrimaries="9" (the wrapped value)'
+fi
+# Negative code points are refused rather than floored to 0. #1346 floored them,
+# which kept the arithmetic well-defined but still wrote a value -- 0, meaning
+# BT.709 primaries -- that the document did not ask for.
+if mutate "$CICP" cicp-negative-1909.xml 'ColorPrimaries="9"' 'ColorPrimaries="-1"'; then
+  expect_reject cicp-negative-1909.xml 'cicp ColorPrimaries="-1"' 'ColorPrimaries="[0-9]+"'
+fi
+
+# A CLUT holds one grid point count per input channel in an icUInt8Number.
+# 258 & 0xFF == 2, and Init(2) is a perfectly ordinary grid, so pre-fix this
+# produced a profile byte-identical to the one GridGranularity="2" gives. The
+# GridPoints element has to go: the reader only consults GridGranularity when
+# no explicit grid is present.
+CLUT=Testing/CalcTest/calcExercizeOps.xml
+CLUT_OPEN='<CLutElement Name="clutElem" InputChannels="2" OutputChannels="2">'
+CLUT_GRID='<GridPoints>2 2</GridPoints>'
+if mutate "$CLUT" gridgran-launder-1909.xml \
+     "$CLUT_OPEN" '<CLutElement Name="clutElem" InputChannels="2" OutputChannels="2" GridGranularity="258">' \
+     "$CLUT_GRID" ''; then
+  expect_reject gridgran-launder-1909.xml 'CLUT GridGranularity="258"' 'GridPoints>[0-9 ]+<'
+fi
+if mutate "$CLUT" gridgran-control-1909.xml \
+     "$CLUT_OPEN" '<CLutElement Name="clutElem" InputChannels="2" OutputChannels="2" GridGranularity="2">' \
+     "$CLUT_GRID" ''; then
+  expect_accept gridgran-control-1909.xml 'GridGranularity="2" (the wrapped value)'
+fi
+
+# --- bucket 2: 16-bit counts ------------------------------------------------
+
+# Tag-level spectral step counts, the tag-side siblings of the MPE step counts
+# #1908 fixed. 65937 & 0xFFFF == 401, the donor's own step count.
+SDIN=Testing/Display/Rec2020rgbSpectral.xml
+SDIN_WL='<Wavelengths start="380.000000" end="780.000000" steps="401"/>'
+if mutate "$SDIN" sdin-launder-1909.xml \
+     "$SDIN_WL" '<Wavelengths start="380.000000" end="780.000000" steps="65937"/>'; then
+  expect_reject sdin-launder-1909.xml 'spectralDataInfo steps="65937"' 'steps="[0-9]+"'
+fi
+if mutate "$SDIN" sdin-control-1909.xml "$SDIN_WL" "$SDIN_WL"; then
+  expect_accept sdin-control-1909.xml 'steps="401" (the wrapped value)'
+fi
+
+# GamutBoundaryDesc channel counts divide the parsed value list into vertices,
+# so a wrapped count yields a different geometry rather than an error.
+# 65539 & 0xFFFF == 3.
+GBD=Testing/Display/sRGB_D65_MAT.xml
+if mutate "$GBD" gbd-launder-1909.xml '<PCSValues channels="3"' '<PCSValues channels="65539"'; then
+  expect_reject gbd-launder-1909.xml 'GamutBoundaryDesc PCSValues channels="65539"' 'PCSValues channels="[0-9]+"'
+fi
+if mutate "$GBD" gbd-control-1909.xml '<PCSValues channels="3"' '<PCSValues channels="3"'; then
+  expect_accept gbd-control-1909.xml 'PCSValues channels="3" (the wrapped value)'
+fi
+
+# SparseMatrix dimensions and the array's own channel count.
+# 65567 & 0xFFFF == 31; 66304 & 0xFFFF == 768.
+SPM=Testing/Named/SparseMatrixNamedColor.xml
+SPM_FULL='<FullMatrix rows="31" cols="41">'
+if mutate "$SPM" spm-rows-launder-1909.xml "$SPM_FULL" '<FullMatrix rows="65567" cols="41">'; then
+  expect_reject spm-rows-launder-1909.xml 'FullMatrix rows="65567"' 'rows="[0-9]+" cols="[0-9]+"'
+fi
+if mutate "$SPM" spm-chan-launder-1909.xml \
+     '<SparseMatrixArray outputChannels="768"' '<SparseMatrixArray outputChannels="66304"'; then
+  expect_reject spm-chan-launder-1909.xml 'SparseMatrixArray outputChannels="66304"' 'outputChannels="[0-9]+"'
+fi
+# The unmutated donor controls both of the above at once: it carries rows="31"
+# and outputChannels="768", which are exactly the wrapped values.
+if mutate "$SPM" spm-control-1909.xml "$SPM_FULL" "$SPM_FULL"; then
+  expect_accept spm-control-1909.xml 'rows="31" / outputChannels="768" (the wrapped values)'
+fi
+
+# --- the NULL row-start write ------------------------------------------------
+# One FullMatrix element is preceded by an empty SparseMatrix declaring more rows
+# than CIccSparseMatrix::Init() accepts. Pre-fix this reached the row-start fill
+# with a NULL pointer; a rejection and a segfault both leave no profile behind,
+# so this case keys on the exit status.
+if mutate "$SPM" spm-nullrow-1909.xml \
+     "$SPM_FULL" '<SparseMatrix rows="5000" cols="41"></SparseMatrix><FullMatrix rows="31" cols="41">'; then
+  run_tool spm-nullrow-1909.xml
+  if [ "$TOOL_RC" -ge 128 ]; then
+    echo "[FAIL] #1909: unchecked CIccSparseMatrix::Init() -- iccFromXml died on"
+    echo "       signal $((TOOL_RC - 128)) parsing an over-large <SparseMatrix>"
+    sed -n '1,6p' "$TOOL_LOG"
+    status=2
+  elif [ -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1909: over-large <SparseMatrix> dimensions produced a profile (rc=$TOOL_RC)"
+    status=2
+  else
+    echo "[PASS] over-large <SparseMatrix> rows refused without a crash (rc=$TOOL_RC)"
+  fi
+  rm -f "$TOOL_ICC"
+fi
+
+# Honouring Init() also refuses an array whose outputChannels is too small to
+# hold its own declared row count -- Init() sizes the row-start table out of
+# GetBytesPerMatrix(), so the two are coupled. Pre-fix this converted with exit 0
+# while the tool itself printed "Profile is invalid, but saved correctly", and
+# the matrix was absent from the profile it wrote. Pinned here because it is a
+# deliberate acceptance change, not a side effect: rows="31" needs 132 bytes of
+# row-start table, which outputChannels="32" cannot provide.
+if mutate "$SPM" spm-undersized-1909.xml \
+     '<SparseMatrixArray outputChannels="768"' '<SparseMatrixArray outputChannels="32"'; then
+  expect_reject spm-undersized-1909.xml \
+    'SparseMatrixArray outputChannels="32" too small for rows="31"' 'outputChannels="[0-9]+"'
+fi
+
+echo "------------------------------------------------------------------"
+if [ "$status" -ne 0 ]; then
+  echo "RESULT: FAIL"
+else
+  echo "RESULT: PASS"
+fi
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3827,6 +3827,33 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1898-mpe-channel-narrowing-regression.sh"
 )
 
+# #1909: the same narrowing at the tag-level readers #1908 left behind -- cicp
+# code points, CLUT grid granularity, tag spectral step counts, SparseMatrix
+# dimensions and GamutBoundaryDesc channel counts.  Here the cast is explicit at
+# every site, so UBSan never saw it and the tell is entirely functional: six
+# documents converted with exit 0 and re-serialize carrying a value the source
+# never contained (265 -> 9, 65937 -> 401, 65539 -> 3, 65567 -> 31, 66304 -> 768),
+# and GridGranularity="258" produced a profile byte-identical to "2".  Each is
+# paired with the wrapped value itself as a control, which is what shows the fix
+# refuses values that do not fit the field rather than having lowered a ceiling.
+# Two further cases are not laundering at all, both from the same unchecked
+# CIccSparseMatrix::Init() return: an over-large <SparseMatrix> reached the
+# row-start fill with a NULL pointer (that one keys on the exit status, since a
+# rejection and a segfault both leave no profile behind), and an array whose
+# outputChannels cannot hold its own declared row count used to convert with
+# exit 0 while the tool printed "Profile is invalid, but saved correctly".
+# The latter is pinned because honouring Init() changes acceptance on purpose.
+# Fixtures are mutated from tracked Testing/ XML
+# at run time and the script fails if a mutation did not apply, so a donor
+# edited upstream cannot turn this into a silent no-op.
+iccdev_add_script_test(
+  iccdev.issue-1909-xml-narrowing-regression
+  120
+  "iccdev;xml;tags;issue-1909;regression;asan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1909-xml-narrowing-regression.sh"
+)
+
 # #1810: 'RICC' in the CMM and platform header fields of 15 Testing fixtures.
 # 'RICC' was never registered -- icSigRefIccMAX itself carried 0x52494343
 # ('RICC') against a comment and a registry that both said 'RIMX', until #1473

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -107,6 +107,30 @@ static icUInt32Number icXmlAttrToUInt(const char *szValue)
   return nValue < 0 ? 0u : (icUInt32Number)nValue;
 }
 
+// Reads the "steps" attribute of a <Wavelengths> element into the
+// icUInt16Number field of an icSpectralRange.
+//
+// The count is what tells every consumer how many samples the range holds, so
+// narrowing it modulo 65536 substitutes a different spectrum rather than
+// failing: steps="65937" was stored -- and written back out on save -- as 401
+// (#1909). This is the same defect #1908 fixed for the MPE elements, at the
+// tag-level readers those elements sit beside.
+//
+// The attribute defaults to "0" rather than "" so that an absent "steps" still
+// yields a zero-step range exactly as it did before. Only a value that is
+// present and cannot be represented stops the parse; existing documents that
+// omit the attribute keep loading.
+static bool icXmlParseSpectralSteps(xmlNode *pNode, icUInt16Number &steps,
+                                    const char *szRangeName, std::string &parseStr)
+{
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "steps", "0"), steps)) {
+    parseStr += std::string("Invalid ") + szRangeName + " Wavelengths steps\n";
+    return false;
+  }
+
+  return true;
+}
+
 static void icXmlCopyFixedString(char *dst, size_t dstSize, const char *src)
 {
   if (!dst || !dstSize) {
@@ -855,7 +879,8 @@ bool CIccTagXmlSpectralDataInfo::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   m_spectralRange.start = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "start")));
   m_spectralRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "end")));
-  m_spectralRange.steps = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pChild, "steps"));
+  if (!icXmlParseSpectralSteps(pChild, m_spectralRange.steps, "SpectralRange", parseStr))
+    return false;
 
   pChild = icXmlFindNode(pNode, "BiSpectralRange");
 
@@ -863,7 +888,8 @@ bool CIccTagXmlSpectralDataInfo::ParseXml(xmlNode *pNode, std::string &parseStr)
     if ((pChild = icXmlFindNode(pChild->children, "Wavelengths"))) {
       m_biSpectralRange.start = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "start")));
       m_biSpectralRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "end")));
-      m_biSpectralRange.steps = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pChild, "steps"));
+      if (!icXmlParseSpectralSteps(pChild, m_biSpectralRange.steps, "BiSpectralRange", parseStr))
+        return false;
     }
   }
 
@@ -908,7 +934,8 @@ bool CIccTagXmlSpectralRange::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   m_spectralRange.start = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "start")));
   m_spectralRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "end")));
-  m_spectralRange.steps = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pChild, "steps"));
+  if (!icXmlParseSpectralSteps(pChild, m_spectralRange.steps, "SpectralRange", parseStr))
+    return false;
 
   pChild = icXmlFindNode(pNode, "BiSpectralRange");
 
@@ -916,7 +943,8 @@ bool CIccTagXmlSpectralRange::ParseXml(xmlNode *pNode, std::string &parseStr)
     if ((pChild = icXmlFindNode(pChild->children, "Wavelengths"))) {
       m_biSpectralRange.start = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "start")));
       m_biSpectralRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(pChild, "end")));
-      m_biSpectralRange.steps = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pChild, "steps"));
+      if (!icXmlParseSpectralSteps(pChild, m_biSpectralRange.steps, "BiSpectralRange", parseStr))
+        return false;
     }
   }
 
@@ -1344,35 +1372,51 @@ bool CIccTagXmlCicp::ToXml(std::string& xml, std::string blanks/* = ""*/)
 }
 
 
-bool CIccTagXmlCicp::ParseXml(xmlNode* pNode, std::string& /*parseStr*/)
+// Reads one cicp code point. All four are 8-bit syntax elements in ITU-T H.273
+// and are stored in icUInt8Number members, so a value above 255 is not a code
+// point the document could have meant. The (icUInt8Number) cast that used to
+// stand here narrowed it instead and, being explicit, hid the truncation from
+// UBSan too: ColorPrimaries="265" was stored -- and written back out on save --
+// as 9, a different and entirely valid primary (#1909). A missing attribute is
+// still defaulted to 0 by the caller, exactly as before; only a value that is
+// present and unrepresentable now stops the parse.
+static bool icXmlParseCicpField(xmlNode *pNode, const char *szName,
+                                icUInt8Number &out, std::string &parseStr)
+{
+  xmlAttr *attr = icXmlFindAttr(pNode, szName);
+
+  if (!attr) {
+    out = 0;
+    return true;
+  }
+
+  if (!icXmlParseU8(icXmlAttrValue(attr), out)) {
+    parseStr += std::string("Invalid ") + szName + " in cicpFields\n";
+    return false;
+  }
+
+  return true;
+}
+
+bool CIccTagXmlCicp::ParseXml(xmlNode* pNode, std::string& parseStr)
 {
 
   pNode = icXmlFindNode(pNode, "cicpFields");
 
   if (pNode) {
-    xmlAttr* attr;
-    if ((attr = icXmlFindAttr(pNode, "ColorPrimaries")))
-      m_nColorPrimaries = (icUInt8Number)icXmlAttrToUInt(icXmlAttrValue(attr));
-    else
-      m_nColorPrimaries = 0;
-
-    if ((attr = icXmlFindAttr(pNode, "TransferCharacteristics")))
-      m_nTransferCharacteristics = (icUInt8Number)icXmlAttrToUInt(icXmlAttrValue(attr));
-    else
-      m_nTransferCharacteristics = 0;
-
-    if ((attr = icXmlFindAttr(pNode, "MatrixCoefficients")))
-      m_nMatrixCoefficients = (icUInt8Number)icXmlAttrToUInt(icXmlAttrValue(attr));
-    else
-      m_nMatrixCoefficients = 0;
-
-    if ((attr = icXmlFindAttr(pNode, "VideoFullRangeFlag")))
-      m_nVideoFullRangeFlag = (icUInt8Number)icXmlAttrToUInt(icXmlAttrValue(attr));
-    else
-      m_nVideoFullRangeFlag = 0;
+    // parseStr was previously unnamed here, so this reader had no way to say why
+    // it had refused a tag. It now reports through the same channel every other
+    // ParseXml uses, which is what makes the rejections above visible to callers.
+    if (!icXmlParseCicpField(pNode, "ColorPrimaries", m_nColorPrimaries, parseStr) ||
+        !icXmlParseCicpField(pNode, "TransferCharacteristics", m_nTransferCharacteristics, parseStr) ||
+        !icXmlParseCicpField(pNode, "MatrixCoefficients", m_nMatrixCoefficients, parseStr) ||
+        !icXmlParseCicpField(pNode, "VideoFullRangeFlag", m_nVideoFullRangeFlag, parseStr))
+      return false;
   }
-  else
+  else {
+    parseStr += "Cannot find cicpFields\n";
     return false;
+  }
 
   return true;
 }
@@ -1439,7 +1483,16 @@ bool CIccTagXmlSparseMatrixArray::ParseXml(xmlNode *pNode, std::string &parseStr
     xmlAttr *matrixType = icXmlFindAttr(pNode, "matrixType");
 
     if (outputChan && matrixType) {
-      icUInt32Number nChannelsPerMatrix = icXmlAttrToUInt(icXmlAttrValue(outputChan));
+      // Reset() below takes the channel count as an icUInt16Number, so parsing
+      // it wider and casting on the way in narrowed it modulo 65536:
+      // outputChannels="66304" was stored -- and written back out on save -- as
+      // 768 (#1909). It also sizes GetBytesPerMatrix(), which is what the raw
+      // data buffer for every matrix in the array is allocated from.
+      icUInt16Number nChannelsPerMatrix = 0;
+      if (!icXmlParseU16(icXmlAttrValue(outputChan), nChannelsPerMatrix)) {
+        parseStr += "Invalid SparseMatrixArray outputChannels\n";
+        return false;
+      }
       icSparseMatrixType nMatrixType = (icSparseMatrixType)atoi(icXmlAttrValue(matrixType));
 
       xmlNode *pChild;
@@ -1451,7 +1504,7 @@ bool CIccTagXmlSparseMatrixArray::ParseXml(xmlNode *pNode, std::string &parseStr
           n++;
 
       }
-      Reset(n, (icUInt16Number)nChannelsPerMatrix);
+      Reset(n, nChannelsPerMatrix);
       m_nMatrixType = (icSparseMatrixType)nMatrixType;
 
       icUInt32Number bytesPerMatrix = GetBytesPerMatrix();
@@ -1466,12 +1519,29 @@ bool CIccTagXmlSparseMatrixArray::ParseXml(xmlNode *pNode, std::string &parseStr
             xmlAttr *cols = icXmlFindAttr(pChild, "cols");
 
             if (rows && cols) {
-              icUInt16Number nRows, nCols;
+              icUInt16Number nRows = 0, nCols = 0;
 
-              nRows = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(rows));
-              nCols = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(cols));
+              // Dimensions are icUInt16Number throughout CIccSparseMatrix, so
+              // the casts that stood here wrapped anything larger back into
+              // range: rows="65567" was stored -- and written back out on save
+              // -- as 31 (#1909).
+              if (!icXmlParseU16(icXmlAttrValue(rows), nRows) ||
+                  !icXmlParseU16(icXmlAttrValue(cols), nCols)) {
+                parseStr += "Invalid SparseMatrix rows or cols\n";
+                return false;
+              }
 
-              mtx.Init(nRows, nCols, true);
+              // Init() enforces CIccSparseMatrix's own dimension ceiling and
+              // returns false having left the matrix empty -- GetRowStart()
+              // NULL and GetMaxEntries() 0. Its result was discarded here, so a
+              // matrix that declared more rows than Init() accepts and carried
+              // no SparseRow children fell straight through to the row-start
+              // fill below and wrote through the NULL pointer. Representable
+              // but out-of-domain dimensions are refused here instead.
+              if (!mtx.Init(nRows, nCols, true)) {
+                parseStr += "Invalid SparseMatrix dimensions\n";
+                return false;
+              }
 
               icUInt16Number *rowstart = mtx.GetRowStart();
               icUInt32Number nMaxEntries = mtx.GetMaxEntries();
@@ -1527,12 +1597,26 @@ bool CIccTagXmlSparseMatrixArray::ParseXml(xmlNode *pNode, std::string &parseStr
             xmlAttr *cols = icXmlFindAttr(pChild, "cols");
 
             if (rows && cols) {
-              icUInt16Number nRows, nCols;
+              icUInt16Number nRows = 0, nCols = 0;
 
-              nRows = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(rows));
-              nCols = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(cols));
+              // Same narrowing as the SparseMatrix branch above. Here the
+              // laundered value also has to agree with the element count for
+              // the data to be accepted, so it is the wrapped dimensions that
+              // survive: rows="65567" with 31x41 values loaded as 31 rows.
+              if (!icXmlParseU16(icXmlAttrValue(rows), nRows) ||
+                  !icXmlParseU16(icXmlAttrValue(cols), nCols)) {
+                parseStr += "Invalid FullMatrix rows or cols\n";
+                return false;
+              }
 
-              mtx.Init(nRows, nCols, true);
+              // FillFromFullMatrix() below checks for the empty matrix a failed
+              // Init() leaves behind, so this branch does not have the NULL
+              // write the SparseMatrix branch did -- but it silently produced a
+              // profile with an unpopulated matrix. Refuse the dimensions.
+              if (!mtx.Init(nRows, nCols, true)) {
+                parseStr += "Invalid FullMatrix dimensions\n";
+                return false;
+              }
 
               CIccFloatArray data;
               data.ParseTextArray(pChild);
@@ -3964,12 +4048,22 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
     }
   }
   else {
-    icUInt8Number nGridGranularity;
+    icUInt8Number nGridGranularity = 0;
 
     xmlAttr *gridGranularity = icXmlFindAttr(pNode, "GridGranularity");
 
     if (gridGranularity) {
-      nGridGranularity = (icUInt8Number)icXmlAttrToUInt(icXmlAttrValue(gridGranularity));
+      // A CLUT stores one grid point count per input channel in an
+      // icUInt8Number, so 255 is what the field can hold and the cast that
+      // stood here silently reduced anything larger modulo 256 --
+      // GridGranularity="258" became 2, an ordinary grid that pCLUT->Init()
+      // accepted, producing a profile byte-identical to the one "2" gives
+      // (#1909). Refuse the count rather than substitute one.
+      if (!icXmlParseU8(icXmlAttrValue(gridGranularity), nGridGranularity)) {
+        parseStr += "Invalid GridGranularity value.\n";
+        delete pCLUT;
+        return NULL;
+      }
     }
     else {
       delete pCLUT;
@@ -5726,9 +5820,14 @@ bool CIccTagXmlGamutBoundaryDesc::ParseXml(xmlNode *pNode, std::string &parseStr
   subNode = icXmlFindNode(childNode->children, "PCSValues");
 
   if (subNode) {
-    m_nPCSChannels = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(subNode, "channels", "0"));
-
-    if (!m_nPCSChannels) {
+    // The count divides the parsed value list into vertices below, so wrapping
+    // it produces a different vertex geometry rather than an error:
+    // channels="65539" was stored -- and written back out on save -- as 3, and
+    // the value list was then read as three-channel vertices (#1909). The zero
+    // check that follows already rejected the exact multiples of 65536; every
+    // other out-of-range count reached it as a plausible small number.
+    if (!icXmlParseU16(icXmlAttrValue(subNode, "channels", "0"), m_nPCSChannels) ||
+        !m_nPCSChannels) {
       parseStr += "Bad PCSValues channels\n";
       return false;
     }
@@ -5762,9 +5861,9 @@ bool CIccTagXmlGamutBoundaryDesc::ParseXml(xmlNode *pNode, std::string &parseStr
   subNode = icXmlFindNode(childNode->children, "DeviceValues");
 
   if (subNode) {
-    m_nDeviceChannels = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(subNode, "channels", "0"));
-
-    if (!m_nDeviceChannels) {
+    // Same narrowing as PCSValues above, on the device side of the same tag.
+    if (!icXmlParseU16(icXmlAttrValue(subNode, "channels", "0"), m_nDeviceChannels) ||
+        !m_nDeviceChannels) {
       parseStr += "Bad DeviceValues channels\n";
       return false;
     }

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -1305,6 +1305,17 @@ const std::string icGetPadSpace(double value)
 
 // See IccUtilXml.h for rationale — safe integer parsers to replace
 // `atoi(icXmlAttrValue(...))` patterns that silently narrow to u8/u16.
+bool icXmlParseU8(const char *s, icUInt8Number &out, icUInt8Number max_value)
+{
+  // Delegates so that the accept/reject rules stay in one place; the u16 result
+  // is already known to fit an icUInt8Number because max_value caps it there.
+  icUInt16Number v = 0;
+  if (!icXmlParseU16(s, v, max_value))
+    return false;
+  out = static_cast<icUInt8Number>(v);
+  return true;
+}
+
 bool icXmlParseU16(const char *s, icUInt16Number &out, icUInt16Number max_value)
 {
   if (!s || !*s) return false;

--- a/IccXML/IccLibXML/IccUtilXml.h
+++ b/IccXML/IccLibXML/IccUtilXml.h
@@ -177,6 +177,8 @@ const std::string icGetPadSpace(double value);
 //   if (!icXmlParseU16(icXmlAttrValue(node, "Rows"), nRows))
 //     return false;
 //
+bool icXmlParseU8(const char *s, icUInt8Number &out,
+                  icUInt8Number max_value = 0xFFu);
 bool icXmlParseU16(const char *s, icUInt16Number &out,
                    icUInt16Number max_value = 0xFFFFu);
 bool icXmlParseU32(const char *s, icUInt32Number &out,


### PR DESCRIPTION
## PR Summary

Part of #1909 — buckets 1 and 2 of the resolution plan. Deliberately **not** a closing
reference: bucket 3 is still open, so #1909 should outlive this PR. Bucket 3 (the header
`spectralRange` blocks in `IccProfileXml.cpp`) is untouched and still waits on the
compatibility ruling; bucket 4 (the three reserved fields) is untouched as well.

Fifteen tag-level readers in `IccTagXml.cpp` parsed an attribute into a wider integer
and narrowed it with an explicit cast:

```cpp
m_nColorPrimaries = (icUInt8Number)icXmlAttrToUInt(icXmlAttrValue(attr));
m_spectralRange.steps = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(pChild, "steps"));
nRows = (icUInt16Number)icXmlAttrToUInt(icXmlAttrValue(rows));
```

Being explicit, the cast also suppresses UBSan's implicit-integer-truncation check, so
nothing reported it. The document was accepted, the tool exited 0, and the profile
written to disk carried a value the document never contained. Measured against
`d9dae2d9`, each on the tracked fixture named beside it with one attribute changed:

| attribute | fixture | master writes | now |
|---|---|---|---|
| `ColorPrimaries="265"` | `Testing/HDR/BT2100PQFullScene.xml` | `9` — BT.2020, a valid primary | refused |
| `steps="65937"` | `Testing/Display/Rec2020rgbSpectral.xml` | `401` | refused |
| `channels="65539"` | `Testing/Display/sRGB_D65_MAT.xml` | `3` | refused |
| `rows="65567"` | `Testing/Named/SparseMatrixNamedColor.xml` | `31` | refused |
| `outputChannels="66304"` | `Testing/Named/SparseMatrixNamedColor.xml` | `768` | refused |
| `GridGranularity="258"` | `Testing/CalcTest/calcExercizeOps.xml` | a profile **byte-identical** to `="2"` | refused |

The grid-granularity row is the sharpest of the six: the laundered document and the
legitimate one are indistinguishable after conversion, so nothing downstream can tell
that 258 was ever asked for.

The readers now use the `icXmlParseU16` idiom #1908 introduced. `icXmlParseU8` is added
alongside it for the four cicp code points and the CLUT grid granularity — all 8-bit
fields — and delegates to `icXmlParseU16` so the accept/reject rules stay in one place.

## A NULL-pointer write at the same site

Not laundering, and not something the issue anticipated — found while probing the
SparseMatrix dimensions. `CIccSparseMatrix::Init()` enforces its own dimension ceiling
and returns false having left the matrix empty (`GetRowStart()` NULL,
`GetMaxEntries()` 0). `CIccTagXmlSparseMatrixArray::ParseXml` discarded that result, so
a `<SparseMatrix>` declaring more rows than `Init()` accepts and carrying no
`<SparseRow>` children fell through to the row-start fill and wrote through the NULL
pointer:

```
Program received signal SIGSEGV, Segmentation fault.
0x... in CIccTagXmlSparseMatrixArray::ParseXml(_xmlNode*, std::string&)
#1  ... in CIccTagXmlStruct::ParseTag(...)
$1 = (void *) 0x0
```

`iccFromXml` exits 139 on `d9dae2d9`. The PoC is one `<FullMatrix>` element of
`Testing/Named/SparseMatrixNamedColor.xml` replaced by an empty `<SparseMatrix rows="5000">`.
The row-entry guard immediately below happens to catch the case where `<SparseRow>`
children *are* present, which is why this only shows up on the empty variant.

The `FullMatrix` branch discarded the same result but `FillFromFullMatrix()` checks for
the empty matrix, so it did not crash — it silently produced a profile with an
unpopulated matrix. Both branches now honour `Init()`.

## Behaviour changes, all three deliberate

**Negative values are refused rather than floored to 0.** #1346 floored them, which made
the arithmetic well-defined but still wrote a value — 0, meaning BT.709 primaries — that
the document did not ask for. That is the same substitution this issue is about, and
`icXmlParseU16` has rejected a leading `-` since #1908, so this makes the two consistent.
The #1346 regression asserts only the absence of a signed→unsigned conversion, which
still holds; its comment claimed the tool "exits 0 on this valid profile", which is no
longer true, so the comment is corrected. That script and its fixture came from #1350.

**`CIccTagXmlCicp::ParseXml` reports through `parseStr`.** Its parameter was unnamed
(`std::string& /*parseStr*/`), so the reader could not say why it had refused a tag —
one of the three readers I flagged in the #1909 comment. Refusing a code point without
a message would have been worse than the narrowing, so it is named here. Its
`cicpFields`-missing branch, previously a bare `return false`, now carries a message too.

**Honouring `Init()` also refuses a self-inconsistent `SparseMatrixArray`.** `Init()`
sizes the row-start table out of `GetBytesPerMatrix()`, so `rows` and `outputChannels`
are coupled: `rows="31"` needs 132 bytes of row-start table, which `outputChannels="32"`
cannot provide. Pre-fix that converted with exit 0 — while the tool itself printed
`Profile parsed.  Profile is invalid, but saved correctly`, and the matrix was absent
from the profile it wrote. This is the narrowest of the three changes in reach (no
conformant profile can be undersized for its own matrix) and the clearest on the merits,
but it is an acceptance change rather than a crash fix, so it has its own test case.

A missing attribute keeps its existing meaning everywhere. The spectral `steps` reads
default to `"0"` rather than `""` so that an absent attribute still yields a zero-step
range exactly as before; only a value that is present and unrepresentable stops the
parse. Nothing here converts existing tolerance into failure.

## Regression coverage

`iccdev.issue-1909-xml-narrowing-regression`, seven laundering cases plus the crash and
the undersized array.

Each is paired with the wrapped value itself as a legal document — 9, 401, 3, 31, 768, 2.
Those must still convert. That pairing is what separates *refuses a value that does not
fit the field* from *lowered the ceiling*: a fix that rejected both would satisfy every
rejection assertion in the file while having broken ordinary profiles. The
`SparseMatrixNamedColor` donor is its own control for two cases at once, since it already
carries `rows="31"` and `outputChannels="768"`.

The crash case keys on the **exit status**, not on the absence of an output file — a
rejection and a segfault both leave no profile behind, so only the status tells them apart.

Fixtures are mutated from tracked `Testing/` XML at run time rather than checked in, and
the script **fails** if a substitution did not apply. Without that, a donor edited
upstream would leave the case running against an unmutated document and every assertion
would pass while testing nothing.

Red/green, both directions:

```
against d9dae2d9    9 FAIL (each printing the value that landed), 6 controls PASS, RESULT: FAIL (rc=2)
against this branch 14 PASS, RESULT: PASS (rc=0)
```

The controls passing on master matters as much as the failures: it shows the red run is
detecting the defect, not simply rejecting everything.

**What the test does not reach.** It exercises 8 of the 15 changed sites directly; the
rest are the mirrored halves of the same readers — the other three cicp code points go
through the one shared helper, `DeviceValues` mirrors `PCSValues`, and `biSpectralRange`
mirrors `spectralRange`. Two of the fifteen sit in `CIccTagXmlSpectralRange::ParseXml`,
for which **no fixture exists anywhere in the repository**, so nothing exercises that
reader before or after this change; its body is line-for-line identical to
`CIccTagXmlSpectralDataInfo::ParseXml`, which the test does cover, and both now call the
same helper.

## Verification

| gate | result |
|---|---|
| clang-18 Release, `-Wall -Wextra -Wpedantic -Werror` | **0 warnings, 0 errors** |
| GCC **15.2.0** strict + LTO, `iccdev-ci-regression:ci-qa-pr-docker-testing` | **0 warnings, 0 errors** |
| Clang **22.1.2** strict (the container default) | **0 warnings, 0 errors** |
| ASAN + UBSAN Debug, `detect_leaks=1`, all 12 cases | clean |
| `shellcheck` 0.9.0, both scripts | rc=0 |
| `ctest --output-on-failure` | **135/136** |
| every tracked `*.xml` converted against master | **194 byte-identical, 13 refused by both, 1 intended change** (208) |

For the GCC leg the configure line reported `Linux: strict warnings ENABLED (GNU 15.2.0)`
rather than the flags being inferred from the absence of a "DISABLED" message — the local
`g++` is 13.3 and silently skips that set.

The corpus comparison covers all 208 tracked `.xml` files — 188 under `Testing/` and the
20 under `.github/ci/test-data/` that the CTests feed to `iccFromXml`. Of those, **194
convert byte-identically**, **13 are refused identically by both builds** (10 are the
deliberately-malformed `ub-*` PoCs; the other 3 are `Calc/calcImport.xml`,
`Calc/calcVars.xml` and `SpecRef/RefEstimationImport.xml`, which need import files this
harness does not stage), and **1 is the intended change** —
`ub-cicp-colorprimaries-1346.xml`, the negative-value case described above.

Masking is limited to the creation `dateTime` (bytes 24–35) and the profile ID (84–99),
which differ between any two runs. Two controls confirm the mask is not hiding the result:
two different profiles compare unequal, and a single flipped byte at offset 500 compares
unequal. Fifteen `Testing/` fixtures resolve their data files relative to their own
directory and are run from there rather than from the repo root; run from the wrong cwd
they fail on both builds and would have been scored as "refused by both" rather than
compared.

The one CTest failure is `iccdev.spectral-tiff-preview` →
`ModuleNotFoundError: No module named 'imagecodecs'`, a missing local Python dependency
that CI installs. It fails identically on unmodified master.

## Not in this PR

The JSON reader has the same family, which the #1909 inventory did not cover. Both
measured, not read off the source: `"colourPrimaries": 265` is accepted by `iccFromJson`
with exit 0 and round-trips as **0**, and `"spectralRange": [380, 780, 65937]` is accepted
and round-trips as **65535** — clamped rather than wrapped, a different failure mode but
still a value the document did not contain. Happy to take it as a follow-up; it is a
different helper (`jGetValue`) and wants its own analysis rather than being folded in here.

`CIccTagXmlSpectralViewingConditions` and `CIccTagXmlParametricCurve` still `return false`
without appending to `parseStr` — the other two readers from that #1909 note. Left alone
because neither is on a path this PR changes.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes — the two behaviour changes are described above; no user-facing doc states the previous behaviour
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed `docs/python-packaging-release.md` — not applicable
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer — registers one new regression test alongside the existing XML ones, per the issue assignment; the one edited script (`iccdev-issue-1346-...`) is a comment correction to a test I authored in #1350
- [x] New source files include the ICC copyright and BSD 3-Clause license header — no new source files; the added file is a test script
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
