### PR TITLE
ci: fix regression container

### DIFF
--- a/.github/scripts/iccdev-json-sort-regression.sh
+++ b/.github/scripts/iccdev-json-sort-regression.sh
@@ -32,7 +32,7 @@ TOOLS_DIR="${ICCDEV_TOOLS_DIR:-build/Tools}"
 BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
 export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export ASAN_OPTIONS=halt_on_error=0,detect_leaks=0
-export UBSAN_OPTIONS=halt_on_error=0,print_stacktrace=1,silence_unsigned_overflow=1
+export UBSAN_OPTIONS=halt_on_error=0,print_stacktrace=1
 
 TOJSON="$TOOLS_DIR/IccToJson/iccToJson"
 FROMJSON="$TOOLS_DIR/IccFromJson/iccFromJson"

--- a/.github/scripts/iccdev-json-sort-regression.sh
+++ b/.github/scripts/iccdev-json-sort-regression.sh
@@ -32,10 +32,11 @@ TOOLS_DIR="${ICCDEV_TOOLS_DIR:-build/Tools}"
 BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
 export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 export ASAN_OPTIONS=halt_on_error=0,detect_leaks=0
-export UBSAN_OPTIONS=halt_on_error=0,print_stacktrace=1
+export UBSAN_OPTIONS=halt_on_error=0,print_stacktrace=1,silence_unsigned_overflow=1
 
 TOJSON="$TOOLS_DIR/IccToJson/iccToJson"
 FROMJSON="$TOOLS_DIR/IccFromJson/iccFromJson"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-Testing}"
 
 PASS=0
 FAIL=0
@@ -64,9 +65,9 @@ fi
 # Entries are <profile>|<comma separated indents>; commas rather than spaces so
 # that each entry survives word splitting as a single token.
 PROFILE_MATRIX="
-Testing/SpecRef/srgbRef.icc|0,2,4
-Testing/CMYK-3DLUTs/CMYK-3DLUTs.icc|2
-Testing/Display/LaserProjector.icc|2
+SpecRef/srgbRef.icc|0,2,4
+CMYK-3DLUTs/CMYK-3DLUTs.icc|2
+Display/LaserProjector.icc|2
 "
 
 # Recursively assert ascending key order, and compare sorted against unsorted
@@ -121,7 +122,8 @@ echo " iccToJson -sort regression (issue #1920)"
 echo "=================================================================="
 
 for entry in $PROFILE_MATRIX; do
-  icc="${entry%%|*}"
+  profile="${entry%%|*}"
+  icc="$TESTING_DIR/$profile"
   indents="$(echo "${entry#*|}" | tr ',' ' ')"
   if [ ! -f "$icc" ]; then
     echo "[SKIP] $icc not present"

--- a/.github/workflows/_build-test-unix.yml
+++ b/.github/workflows/_build-test-unix.yml
@@ -848,7 +848,6 @@ jobs:
           PY_TAG="cp${PYTHON_VERSION//./}"
           export CIBW_BUILD="${PY_TAG}-*"
           export CIBW_ARCHS="auto"
-          export CIBW_DEPENDENCY_VERSIONS="latest"
           rm -rf build iccdev/*.so iccdev/*.pyd
           cp ../LICENSE.md LICENSE.md
           python vendor_iccproflib.py

--- a/.github/workflows/_build-test-unix.yml
+++ b/.github/workflows/_build-test-unix.yml
@@ -848,6 +848,7 @@ jobs:
           PY_TAG="cp${PYTHON_VERSION//./}"
           export CIBW_BUILD="${PY_TAG}-*"
           export CIBW_ARCHS="auto"
+          export CIBW_DEPENDENCY_VERSIONS="latest"
           rm -rf build iccdev/*.so iccdev/*.pyd
           cp ../LICENSE.md LICENSE.md
           python vendor_iccproflib.py

--- a/.github/workflows/ci-preflight-safety.yml
+++ b/.github/workflows/ci-preflight-safety.yml
@@ -382,7 +382,11 @@ jobs:
             local label="$1"
             local value="unavailable"
             if [[ -n "$output_file" && -f "$output_file" ]]; then
-              value="$(awk -v prefix="${label}: " 'index($0, prefix) == 1 { value = substr($0, length(prefix) + 1) } END { print value }' "$output_file")"
+              value="$(
+                awk -v prefix="${label}: " \
+                  'index($0, prefix) == 1 { value = substr($0, length(prefix) + 1) } END { print value }' \
+                  "$output_file"
+              )"
               if [[ -z "$value" ]]; then
                 value="unavailable"
               fi

--- a/.github/workflows/ci-preflight-safety.yml
+++ b/.github/workflows/ci-preflight-safety.yml
@@ -382,7 +382,7 @@ jobs:
             local label="$1"
             local value="unavailable"
             if [[ -n "$output_file" && -f "$output_file" ]]; then
-              value="$(grep -E "^${label}: " "$output_file" | tail -n 1 | sed -E "s/^${label}: //" || true)"
+              value="$(awk -v prefix="${label}: " 'index($0, prefix) == 1 { value = substr($0, length(prefix) + 1) } END { print value }' "$output_file")"
               if [[ -z "$value" ]]; then
                 value="unavailable"
               fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,9 +88,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libpng16-16t64=1.6.57-1 \
     libasan8=16-20260322-1ubuntu1 \
     libubsan1=16-20260322-1ubuntu1 \
-    libssl3t64=3.5.5-1ubuntu3.2 \
+    libssl3t64=3.5.5-1ubuntu3.3 \
     llvm-21=1:21.1.8-6ubuntu1 \
-    openssl-provider-legacy=3.5.5-1ubuntu3.2 \
+    openssl-provider-legacy=3.5.5-1ubuntu3.3 \
     zlib1g=1:1.3.dfsg+really1.3.1-1ubuntu3 \
     python3=3.14.3-0ubuntu2 \
  && rm -rf /var/lib/apt/lists/*

--- a/IccProfLib/IccPcc.cpp
+++ b/IccProfLib/IccPcc.cpp
@@ -492,7 +492,8 @@ CIccCombinedConnectionConditions::~CIccCombinedConnectionConditions()
 
 const CIccTagSpectralViewingConditions *CIccCombinedConnectionConditions::getPccViewingConditions()
 {
-  return m_pViewingConditions;
+  if (m_pViewingConditions)
+    return m_pViewingConditions;
   if (m_pPCC)
     return m_pPCC->getPccViewingConditions();
   return NULL;

--- a/python/setup.py
+++ b/python/setup.py
@@ -372,7 +372,8 @@ if sys.platform == "win32":
     define_macros = [("WIN32", "1")]
 elif sys.platform == "darwin":
     extra_compile_args = ["-std=c++17", "-stdlib=libc++",
-                          "-fstack-protector-strong", "-D_FORTIFY_SOURCE=2"]
+                          "-fstack-protector-strong", "-D_FORTIFY_SOURCE=2",
+                          "-Wno-unreachable-code-fallthrough"]
     extra_link_args = ["-stdlib=libc++"]
 else:
     extra_compile_args = ["-std=c++17",


### PR DESCRIPTION
## PR Summary

Related: #1924

This PR fixes the regression-container and CI guardrail follow-up work for the current PR branch:

- updates the regression container OpenSSL runtime package pins;
- keeps the JSON sort regression script portable while preserving UBSAN unsigned overflow diagnostics;
- fixes pre-flight summary metric extraction for labels containing slash characters;
- removes the unbounded cibuildwheel dependency override so Python build tooling stays reproducible;
- keeps the macOS extension build warning suppression and PCC viewing-condition fallback from the original patch.

This PR does not depend on a custom virtualenv/pip download workaround; the current CI matrix passes with the bounded cibuildwheel configuration.

## Checklist

- [ ] Signed all Commits in PR
- [ ] Built locally according to `docs/build.md`
- [ ] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [ ] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes
- [ ] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed `docs/python-packaging-release.md` for PR and merge requirements
- [ ] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [ ] New source files include the ICC copyright and BSD 3-Clause license header
- [ ] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consoritum (ICC)
follows the open source software best practice policies. The [International Color Consoritum IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).

