### PR TITLE
fix(#2343): cap the JSON fixed-point array writer like its Num, FloatNum and XML siblings

### DIFF
--- a/.github/ci/regression/json-fixednum-size-cap.cpp
+++ b/.github/ci/regression/json-fixednum-size-cap.cpp
@@ -1,0 +1,157 @@
+// Regression for CodeQL alert #2343: CIccTagJsonFixedNum::ToJson walked m_nSize
+// without asserting an upper bound, and was the only m_nSize-driven serialization
+// walk in the JSON writer still missing one.
+//
+// Every sibling writer asserts a cap before walking: CIccTagJsonNum::ToJson and
+// CIccTagJsonFloatNum::ToJson use 0xffffff (added by #1543 and #1535),
+// CIccTagJsonSparseMatrixArray::ToJson uses 0xffffff, CIccTagJsonXYZ::ToJson and
+// CIccTagJsonCurve::ToJson use 65536. The direct XML mirror,
+// CIccTagXmlFixedNum::ToXml, has carried the 0xffffff guard since it was the first
+// site fixed on that side -- the sibling XML guards say so in their own comments.
+// The JSON port simply never covered FixedNum.
+//
+// m_nSize is derived from the tag byte size in CIccTagFixedNum::Read() and m_Num is
+// allocated to match, so the walk is proportional to its input rather than amplified
+// without bound. The cost the cap actually bounds is the expansion factor: each
+// 4-byte fixed-point value becomes a 16-byte nlohmann json node, and #1918 added a
+// reserve() that commits all of them in a single allocation. Measured on this
+// harness, an uncapped 64 MB tag drove ~581 MB peak RSS; capped, it is ~68 MB.
+//
+// Red-green: against the pre-fix ToJson, case 3 below fails -- the writer returns
+// true and emits 16777216 elements instead of rejecting. Cases 1 and 2 pass both
+// before and after; they are here so that a guard written with the wrong comparison
+// (>= rather than >) or applied at the wrong size cannot pass by rejecting more than
+// it should. Case 2 in particular pins that the last legal size is still serialized
+// in full, which is the failure mode that would silently drop real tag data.
+//
+// Case 2 allocates a 64 MB backing array and builds ~256 MB of json nodes, so this
+// test peaks near 600 MB for roughly a second. The cases run smallest-first and each
+// payload is released before the next, so that is a peak and not a sum.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccTagJson.h"
+#include "IccUtilJson.h"
+
+#include <cstdio>
+#include <cmath>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[json-fixednum-size-cap] FAIL: %s\n", what);
+  }
+}
+
+// The cap asserted by CIccTagJsonFixedNum::ToJson, spelled the same way the writer
+// spells it. A count equal to this is legal; the first rejected count is one more.
+const icUInt32Number kMaxNumValues = 0xffffff;
+
+// Fill the tag with distinct, exactly-representable values so a dropped or duplicated
+// element shows up as a value mismatch and not only as a count mismatch. icFtoD/icDtoF
+// round-trip s15Fixed16 exactly for multiples of 1/65536.
+void fillDistinct(CIccTagJsonS15Fixed16 &tag, icUInt32Number n)
+{
+  for (icUInt32Number i = 0; i < n; i++)
+    tag[i] = icDtoF((icFloatNumber)((i % 1024) / 1024.0));
+}
+
+// Case 1: an ordinary small array must still serialize, and its values must survive.
+// A guard that rejected everything, or that ran before the payload was built, would
+// show up here rather than in the boundary cases.
+void ordinarySizeStillSerializes()
+{
+  const icUInt32Number n = 64;
+  CIccTagJsonS15Fixed16 tag;
+  if (!tag.SetSize(n)) {
+    check(false, "SetSize(64) failed");
+    return;
+  }
+  fillDistinct(tag, n);
+
+  IccJson j;
+  check(tag.ToJson(j), "ordinary 64-entry array was rejected");
+  check(j.contains("values") && j["values"].is_array(), "ordinary array emitted no values array");
+  if (!j.contains("values") || !j["values"].is_array())
+    return;
+
+  check(j["values"].size() == n, "ordinary array emitted the wrong element count");
+  if (j["values"].size() != n)
+    return;
+
+  for (icUInt32Number i = 0; i < n; i++) {
+    double got = j["values"][i].get<double>();
+    double want = (double)icFtoD(tag[i]);
+    if (std::fabs(got - want) > 1e-12) {
+      check(false, "ordinary array value mismatch");
+      return;
+    }
+  }
+}
+
+// Case 2: m_nSize == kMaxNumValues is the largest legal count and must still be
+// serialized in full. This is what a guard written as `>=` would break, silently
+// truncating the last representable tag rather than reporting anything.
+void boundarySizeIsAccepted()
+{
+  CIccTagJsonS15Fixed16 tag;
+  if (!tag.SetSize(kMaxNumValues)) {
+    // A 64 MB allocation failing is an environment limit, not a regression in the
+    // writer. Say so rather than reporting a false failure.
+    std::fprintf(stderr,
+                 "[json-fixednum-size-cap] SKIP: could not allocate %u entries for the "
+                 "boundary case\n", kMaxNumValues);
+    return;
+  }
+
+  IccJson j;
+  check(tag.ToJson(j), "the largest legal count (0xffffff) was rejected");
+  check(j.contains("values") && j["values"].is_array() &&
+        j["values"].size() == kMaxNumValues,
+        "the largest legal count was not serialized in full");
+}
+
+// Case 3: one past the cap must be rejected. This is the assertion that fails against
+// the pre-fix writer. Returning false skips only this tag -- CIccProfileJson::ToJson
+// continues past a failed tag rather than discarding the document (#1779/#1884) -- so
+// rejection here degrades the output gracefully instead of losing the profile.
+void oversizeIsRejected()
+{
+  const icUInt32Number n = kMaxNumValues + 1;
+  CIccTagJsonS15Fixed16 tag;
+  if (!tag.SetSize(n)) {
+    std::fprintf(stderr,
+                 "[json-fixednum-size-cap] SKIP: could not allocate %u entries for the "
+                 "oversize case\n", n);
+    return;
+  }
+
+  IccJson j;
+  check(!tag.ToJson(j), "a count past 0xffffff was serialized instead of rejected");
+  check(!j.contains("values"), "a rejected tag still emitted a values array");
+}
+
+} // namespace
+
+int main()
+{
+  ordinarySizeStillSerializes();
+  boundarySizeIsAccepted();
+  oversizeIsRejected();
+
+  if (g_fail)
+    std::fprintf(stderr, "[json-fixednum-size-cap] %d assertion(s) failed\n", g_fail);
+  else
+    std::printf("[json-fixednum-size-cap] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2474,6 +2474,54 @@ function(iccdev_add_json_writer_move_test)
   endif()
 endfunction()
 
+# CodeQL #2343: CIccTagJsonFixedNum::ToJson was the only m_nSize-driven walk in the
+# JSON writer without an explicit upper bound -- its Num/FloatNum siblings and its XML
+# mirror CIccTagXmlFixedNum::ToXml all cap at 0xffffff. This pins the cap in both
+# directions: the largest legal count still serializes in full, and one past it is
+# rejected. The boundary case builds a 64 MB tag, so allow more time than the 60s the
+# lighter regressions use.
+function(iccdev_add_json_fixednum_size_cap_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCJSON}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccJsonFixedNumSizeCapTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/json-fixednum-size-cap.cpp"
+  )
+  target_compile_features(iccJsonFixedNumSizeCapTest PRIVATE cxx_std_17)
+  target_include_directories(iccJsonFixedNumSizeCapTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccJSON/IccLibJSON"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccJsonFixedNumSizeCapTest PRIVATE
+    ${TARGET_LIB_ICCJSON} ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccJsonFixedNumSizeCapTest)
+
+  add_test(
+    NAME iccdev.json-fixednum-size-cap
+    COMMAND "$<TARGET_FILE:iccJsonFixedNumSizeCapTest>"
+  )
+  set_tests_properties(iccdev.json-fixednum-size-cap PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 180
+    LABELS "iccdev;json;codeql;alert-2343;regression"
+  )
+  if(WIN32)
+    set(_json_fixednum_cap_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccJsonFixedNumSizeCapTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCJSON}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _json_fixednum_cap_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.json-fixednum-size-cap PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_json_fixednum_cap_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1831: icGetDateTimeValue discarded its sscanf conversion count and assigned every
 # field into the icUInt16Number members of icDateTimeNumber without a range check, so
 # "%u" turned "-1" into 4294967295 and a year of 590359881 was truncated to 11593
@@ -2872,6 +2920,7 @@ if(WIN32)
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_json_bcd_version_test()
   iccdev_add_json_writer_move_test()
+  iccdev_add_json_fixednum_size_cap_test()
   iccdev_add_datetime_parse_test()
   iccdev_add_encoding_surround_test()
   iccdev_add_parser_restore_calls_test()
@@ -3101,6 +3150,7 @@ iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_json_bcd_version_test()
 iccdev_add_json_writer_move_test()
+iccdev_add_json_fixednum_size_cap_test()
 iccdev_add_datetime_parse_test()
 iccdev_add_encoding_surround_test()
 iccdev_add_parser_restore_calls_test()

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -1263,6 +1263,20 @@ const char* CIccTagJsonFixedNum<T, Tsig>::GetClassName() const
 template <class T, icTagTypeSignature Tsig>
 bool CIccTagJsonFixedNum<T, Tsig>::ToJson(IccJson &j)
 {
+  // CWE-400/CWE-834: m_nSize is derived from the tag byte size in
+  // CIccTagFixedNum::Read() and m_Num is allocated to match; assert the same explicit
+  // upper limit the CIccTagJsonNum and CIccTagJsonFloatNum siblings below already use,
+  // and that the XML mirror CIccTagXmlFixedNum::ToXml applies, so a corrupted count
+  // can't drive an unbounded serialization walk. This was the only m_nSize-driven walk
+  // in the JSON writer left without a cap. Assert it before the reserve() as well as
+  // the loop: reserve() commits m_nSize json nodes in one allocation, and each node is
+  // wider than the 4-byte fixed-point value it carries, so that is the larger cost.
+  // Returning false skips just this tag -- CIccProfileJson::ToJson continues past a
+  // failed tag rather than discarding the document.
+  const icUInt32Number nMaxNumValues = 0xffffff;
+  if (this->m_nSize > nMaxNumValues)
+    return false;
+
   IccJson arr = IccJson::array();
   arr.get_ref<IccJson::array_t &>().reserve(this->m_nSize);
   for (icUInt32Number i = 0; i < this->m_nSize; i++)


### PR DESCRIPTION
## Summary

`CIccTagJsonFixedNum::ToJson` walked `m_nSize` over `m_Num[]` with no explicit upper
bound. It was the only `m_nSize`-driven serialization walk left in the JSON writer
without one. CodeQL reports it as alert
[#2343](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/2343)
(`iccdev/unbounded-profile-loop`).

This is a port gap rather than a new defect. Every sibling asserts a cap before
walking, and the direct XML mirror has done so since it was the first site fixed on
that side:

| writer | cap | asserted? |
|---|---|---|
| `CIccTagJsonNum::ToJson` | `0xffffff` | yes — #1543 |
| `CIccTagJsonFloatNum::ToJson` | `0xffffff` | yes — #1535 |
| `CIccTagJsonSparseMatrixArray::ToJson` | `0xffffff` | yes |
| `CIccTagJsonXYZ::ToJson` | `65536` | yes |
| `CIccTagJsonCurve::ToJson` | `65536` | yes |
| **`CIccTagJsonFixedNum::ToJson`** | — | **no — this PR** |
| `CIccTagXmlFixedNum::ToXml` (XML mirror) | `0xffffff` | yes — first site fixed on that side |

The XML siblings say as much in their own comments: `CIccTagXmlNum::ToXml` carries
*"Mirrors the guard already applied to the sibling `CIccTagXmlFixedNum::ToXml` above."*
On the JSON side the order ran the other way — `Num` was guarded first, `FloatNum`
mirrored it, and `FixedNum` was never reached. #1543 described itself as *"completing
the family"*, which is likely why the remaining site went unnoticed until #1918 touched
the function and CodeQL re-scanned it.

## Why the cap is still worth asserting

`m_nSize` is derived from the tag byte size in `CIccTagFixedNum::Read()` and `m_Num` is
allocated to match, so the walk is proportional to its input rather than amplified
without bound. That is the same reasoning under which this class of alert is usually
dismissed, and it is why this is filed as hardening and consistency rather than as a
reachable DoS.

What the cap does bound is the expansion factor. Each 4-byte fixed-point value becomes
a 16-byte `nlohmann` json node, and #1918 added a `reserve()` that commits all of them
in a single allocation — so the guard is asserted before the `reserve()`, not just
before the loop. Measured on a 64 MB tag (`m_nSize = 0x1000000`):

```
before:  ToJson true,   16777216 elements emitted,   peak RSS 594,884 KB,  0.62s
after:   ToJson false,                               peak RSS  70,144 KB,  0.03s
```

Returning `false` skips only this tag: `CIccProfileJson::ToJson` continues past a
failed tag rather than discarding the document, the graceful-degrade policy settled in
#1779 / #1884. I checked the reader before assuming the writer could skip.

## Regression coverage

Neither sibling fix shipped a test, so the cap was only ever asserted by a source
comment. `iccdev.json-fixednum-size-cap` covers three cases:

1. an ordinary 64-entry array still serializes, values intact;
2. `m_nSize == 0xffffff` — the largest legal count — is still serialized **in full**;
3. `m_nSize == 0x1000000` is rejected.

Case 2 is the one that earns its keep. A guard written `>=` rather than `>` would
silently truncate the largest legal tag, and a test asserting only the rejection side
would pass anyway.

Red-green verified: against the pre-fix writer, case 3 fails 2 assertions; cases 1 and
2 pass on both sides, so the test cannot pass by rejecting more than it should.

**Cost note for reviewers:** case 2 builds a 64 MB backing array and ~256 MB of json
nodes, so the test peaks near 600 MB for ~1.2s. Cases run smallest-first and each
payload is released before the next, so that is a peak and not a sum. `TIMEOUT` is 180s
rather than the 60s the lighter regressions use, and a failed `SetSize` is reported as
a skip so a memory-constrained runner cannot produce a false red. If that footprint is
unwelcome in the routine gate, dropping case 2 or labelling the test `slow` is a
one-line change — say the word.

## Verification

Local pre-flight run against `ac03e0ff`, using CI's own gate:

| check | result |
|---|---|
| Build, `ci-pr-gcc15` flags (`-Wall -Wextra -Wpedantic -Werror -std=c++17`, LTO ON) | exit 0, **0 warnings**, 0 errors |
| `cmake --build --target build-test-binaries` | exit 0, 0 warnings |
| `ctest --label-exclude slow` | **136/136 passed**, exit 0 (135 before this PR, +1 new) |
| `iccToJson` A/B over `git ls-files '*.icc'` | **104/104 byte-identical** before vs after |
| Boundary exactness | `0xffffff` accepted identically by both builds; `0x1000000` rejected only after the fix |

The A/B compared `libIccJSON2.so` between two builds of an otherwise identical tree —
the `iccToJson` executable is byte-identical either way, since the changed code lives
in the shared library. A first pass that compared the executable produced a false
"identical" result and was discarded.

## Scope

Held to the alert. Line 3002 (`CIccTagJsonArray`) walks `m_TagVals` on a different
class, was not flagged, and is not claimed here.

Alert #2343 closes automatically on merge, so no closing keyword is used.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes — none; a rejected tag is skipped, and no tracked profile changes output
- [ ] Ran sanitizer coverage for memory-safety or parser changes — writer-side bound only; no parser or allocation-shape change
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed `docs/python-packaging-release.md` — n/a
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [ ] New source files include the ICC copyright and BSD 3-Clause license header — new file is a CI regression harness under `.github/ci/regression/`, matching the headerless convention of its siblings there
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
