### PR TITLE
fix(#1928): stop sanitizer stack traces stalling on debuginfod in CI

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3267,6 +3267,20 @@ set(ICCDEV_TEST_ENV
   "CXX=${CMAKE_CXX_COMPILER}"
   "ASAN_OPTIONS=halt_on_error=0,detect_leaks=0"
   "UBSAN_OPTIONS=halt_on_error=0,print_stacktrace=1"
+  # print_stacktrace=1 above makes every sanitizer report symbolize its stack.
+  # llvm-symbolizer consults DEBUGINFOD_URLS while doing so, and the regression
+  # container inherits Ubuntu's default (https://debuginfod.ubuntu.com) because
+  # ci-docker.yml runs ctest under a login shell, which sources /etc/profile.d.
+  # That host resolves from the container but never completes a connection, so
+  # each report blocks on the fetch for roughly 90 seconds - time attributed to
+  # whichever test happened to trip the report, not to the network. That is
+  # what timed out
+  # iccdev.json-sort-regression (issue #1928): a single benign libstdc++
+  # unsigned-overflow report inside std::sort turned a ~4s run into a >300s one.
+  # Emptying the variable keeps stack traces fully symbolized - our binaries
+  # carry their own -g DWARF, and debuginfod only ever supplied *system*
+  # library debug info - while removing the network dependency from every test.
+  "DEBUGINFOD_URLS="
   "LLVM_PROFILE_FILE=/dev/null"
   "ICCDEV_TOOLS_DIR=${ICCDEV_TOOLS_DIR}"
   "ICCDEV_TESTING_DIR=${ICCDEV_TESTING_DIR}"


### PR DESCRIPTION
Fixes #1928.

`iccdev.json-sort-regression` times out at CTest's 300s limit in the Docker
regression lane. The test's own work is not the cost: the same test passes in
**91s** inside the same container once one environment variable is set.

## What is actually happening

Every script test is registered with `UBSAN_OPTIONS=...,print_stacktrace=1`
(`Build/Cmake/Testing/CMakeLists.txt`). When a sanitizer report fires, the
stack is symbolized by `llvm-symbolizer`, which consults `DEBUGINFOD_URLS`.
`ci-docker.yml` runs ctest under a **login shell** (`docker run ... bash -lc`),
so the container picks up Ubuntu's default
`https://debuginfod.ubuntu.com` from `/etc/profile.d`. That host resolves from
the container but never completes a connection, so the symbolizer waits out its
timeout — roughly **90 seconds per report**, charged to whichever test happened
to trip the report rather than to the network.

`iccToJson -sort` is what trips it. `sortJsonKeys` runs `std::sort` over the
object keys, and libstdc++'s `_S_compare(n1, n2)` computes `n1 - n2` on
`size_type`, which `-fsanitize=unsigned-integer-overflow` reports as
`unsigned integer overflow: 3 - 13`. That arithmetic is deliberate and well
defined. Notably `ci-docker.yml` already lists that exact header in the
`silence.txt` it writes at line 759 — but nothing ever consumes that file, so
the suppression has no effect (separate observation, not changed here).

## Measurements, in the published regression image

Same binary, same profile, only the environment differs:

| condition | wall |
|---|---|
| `print_stacktrace=1` (what CI uses today) | **93s** |
| `print_stacktrace=0` | 4s |
| `print_stacktrace=1` + `DEBUGINFOD_URLS=""` | **3s** |

The cost is per *report*, not per byte — which is why this reads as a hang
rather than as a slow test:

| profile | scalars | `-sort` |
|---|---|---|
| Rec2100HlgNarrow | 454 | 91s |
| srgbRef | 238,083 | 95s |
| 17ChanWithSpots-MVIS | 268,037 | **4s** (never trips the report) |
| LaserProjector | 541,850 | 97s |
| CMYK-3DLUTs | 894,661 | 101s |

A 454-scalar profile costs the same 91s as an 894,661-scalar one, while the
one profile that does not trip the report costs 4s.

## The change

Emptying `DEBUGINFOD_URLS` in the CTest environment removes the network
dependency from every script test. Stack traces stay **fully symbolized** —
iccDEV binaries carry their own `-g` DWARF, and debuginfod only ever supplied
*system* library debug info. Verified: the `sortJsonKeys` /
`IccToJson.cpp:23` frames still resolve with file and line after the change.

## Verification

In the published regression image
(`ghcr.io/internationalcolorconsortium/iccdev-ci-regression`), with this
patched `CMakeLists.txt` mounted in and the build reconfigured, while the login
shell still exports the debuginfod URL:

```
before   82 - iccdev.json-sort-regression ***Timeout 300.02 sec
after    82 - iccdev.json-sort-regression   Passed    91.42 sec
```

The guard reaches 85 of the 138 registered tests — every test that goes
through `ICCDEV_TEST_ENV`. The remaining 53 register their command directly
without that env block and stay exposed to the same stall if they ever emit a
sanitizer report; none does today (all run under 2s in CI). Raising that is
left as a follow-up rather than bundled here, since it means touching test
registrations well outside this defect.

`DEBUGINFOD_URLS=` is a plain `NAME=VALUE` entry rather than
`cmake -E env --unset=`, so it works on the project's full supported CMake
range (floor is 3.18; `ENVIRONMENT_MODIFICATION` would need 3.22 and would
silently no-op below that).
