### PR TITLE
fix(#1932): reject a spectral PCS header whose channel count and range disagree

### DIFF
--- a/.github/ci/regression/spectral-pcs-range-consistency.cpp
+++ b/.github/ci/regression/spectral-pcs-range-consistency.cpp
@@ -1,0 +1,354 @@
+// Regression for #1932: CIccPcsXform::Connect() built a spectral PCS step chain from the
+// profile header's spectralRange while the pixel buffers those steps run in were sized
+// from the header's spectralPCS signature, and never checked that the two agreed.
+//
+// A spectral PCS signature carries its channel count in its low 16 bits. That count is
+// what CIccXform::GetNumSrcSamples()/GetNumDstSamples() report, and in turn what
+// CIccApplyCmm::InitPixel() uses to malloc m_Pixel/m_Pixel2. Every spectral branch of
+// Connect() instead sizes the steps it pushes from spectralRange.steps. For a conformant
+// reflectance, transmission or radiant PCS the two are the same number written twice.
+//
+// The reproducer writes them differently. Its embedded v5 sub-profile declares
+// spectralPCS "rs" + 36 channels alongside spectralRange.steps == 184, so:
+//
+//   * the pixel buffer is malloc(36 * sizeof(icFloatNumber)) = 144 bytes;
+//   * pushRef2Xyz() -> pushRad2Cie() -> pushMatrix(3, 184, observer) builds a 3x184
+//     observer matrix, which CIccPcsStepMatrix::reduce() converts to a sparse matrix.
+//
+// CIccSparseMatrix::MultiplyVector() then walks that matrix's column indices - every one
+// of them in range for a 184-column matrix, the matrix is well formed and IsValid()
+// passes - against a 36-float vector, reading past its end on the 37th column
+// (CWE-125, ASan heap-buffer-overflow, 4-byte read 0 bytes after a 144-byte region).
+// Nothing in the sparse matrix is wrong; the caller handed it a vector shorter than the
+// matrix it was built for.
+//
+// CIccProfile::Validate() already reports the same disagreement as a critical error, in
+// the spectralPCS switch of CheckHeader(). Nothing on the apply path consults it -
+// neither iccApplyProfiles nor CIccCmm calls Validate() - so Connect() has to make the
+// check itself. It now does, returning icCmmStatInvalidProfile before any step is pushed.
+//
+// Rejection is the only correct outcome. There is no way to tell which of the two numbers
+// the producer meant, and honouring either one silently reinterprets the pixel data.
+//
+// The scoping is deliberately identical to the validator's, and testSparseMatrixPcsIsOutOfScope()
+// below pins the part that is easy to get wrong: the sparse-matrix PCS is NOT covered,
+// because there the channel count is the size of the encoded matrix blob carried in the
+// pixel rather than a sample count, so it is independent of the ranges by design (see
+// CIccPcsStepSrcSparseMatrix, which is handed the two separately).
+//
+// Red-green: on unfixed sources testMismatchedSpectralRangeIsRejected() fails, because
+// Connect() returns icCmmStatOk having built the chain that overflows at apply time. The
+// assertions are all on returned status, so they are visible without a sanitizer.
+//
+// Header + IccProfLib only, no fixture and no I/O.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccCmm.h"
+#include "IccPcc.h"
+#include "IccProfile.h"
+#include "IccTagBasic.h"
+#include "IccUtil.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[spectral-pcs-range] FAIL: %s\n", what);
+  }
+}
+
+icSpectralRange makeRange(icFloat16Number start, icFloat16Number end, icUInt16Number steps)
+{
+  icSpectralRange r;
+  r.start = start;
+  r.end = end;
+  r.steps = steps;
+  return r;
+}
+
+// A connection conditions object carrying both an illuminant and an observer, so that a
+// header-consistent spectral profile can be connected all the way through rather than
+// stopping on a missing tag. Without the observer, pushRad2Cie() refuses every case and
+// the accept-controls below could not tell "the guard let this through" from "the guard
+// rejected it".
+class StubPcc : public IIccProfileConnectionConditions
+{
+public:
+  StubPcc(const icSpectralRange &illumRange, const icSpectralRange &observerRange)
+  {
+    std::vector<icFloatNumber> spd(illumRange.steps ? illumRange.steps : 1, 1.0f);
+    m_svc.setIlluminant(icIlluminantD50, illumRange, &spd[0]);
+
+    // Three observer curves (x, y, z) laid end to end, as setObserver() expects.
+    std::vector<icFloatNumber> obs(observerRange.steps ? observerRange.steps * 3 : 3, 1.0f);
+    m_svc.setObserver(icStdObs1931TwoDegrees, observerRange, &obs[0]);
+  }
+
+  virtual const CIccTagSpectralViewingConditions *getPccViewingConditions() { return &m_svc; }
+  virtual CIccTagMultiProcessElement *getCustomToStandardPcc() { return NULL; }
+  virtual CIccTagMultiProcessElement *getStandardToCustomPcc() { return NULL; }
+
+  virtual void getNormIlluminantXYZ(icFloatNumber *pXYZ) { pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f; }
+  virtual void getLumIlluminantXYZ(icFloatNumber *pXYZ) { pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f; }
+  virtual bool getMediaWhiteXYZ(icFloatNumber *pXYZ)
+  {
+    pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f;
+    return true;
+  }
+
+private:
+  CIccTagSpectralViewingConditions m_svc;
+};
+
+// Connect() reads only a handful of things from the xforms on either side of it: which
+// spaces and sample counts they present, whether they are input/MCS/abstract, their
+// connection conditions, and their profile. A stub supplies exactly those. The two pure
+// virtuals (GetXformType, Apply) are never reached - Connect() does not apply anything.
+class StubXform : public CIccXform
+{
+public:
+  StubXform(CIccProfile *pProfile, bool bInput, icColorSpaceSignature space,
+            icUInt16Number nSamples, IIccProfileConnectionConditions *pPcc)
+  {
+    m_pProfile = pProfile;
+    ShareProfile();          // the test owns the profiles, not the xform
+    m_bInput = bInput;
+    m_pConnectionConditions = pPcc;
+    m_space = space;
+    m_nSamples = nSamples;
+  }
+
+  virtual icXformType GetXformType() const { return icXformTypeMatrixTRC; }
+  virtual void Apply(CIccApplyXform *, icFloatNumber *, const icFloatNumber *) const {}
+
+  // Curve extraction is only used by the optimiser once a chain is built; Connect() never
+  // asks. NULL is the same answer CIccPcsXform itself gives.
+  virtual LPIccCurve *ExtractInputCurves() { return NULL; }
+  virtual LPIccCurve *ExtractOutputCurves() { return NULL; }
+
+  virtual icColorSpaceSignature GetSrcSpace() const { return m_space; }
+  virtual icColorSpaceSignature GetDstSpace() const { return m_space; }
+  virtual icUInt16Number GetNumSrcSamples() const { return m_nSamples; }
+  virtual icUInt16Number GetNumDstSamples() const { return m_nSamples; }
+
+private:
+  icColorSpaceSignature m_space;
+  icUInt16Number m_nSamples;
+};
+
+// A header-only profile. Connect()'s new check reads m_Header and nothing else, and the
+// push* helpers it dispatches to read the same ranges from the same place.
+void setHeader(CIccProfile &prof, icUInt32Number spectralPCS,
+               const icSpectralRange &spectralRange, const icSpectralRange &biSpectralRange)
+{
+  std::memset(&prof.m_Header, 0, sizeof(prof.m_Header));
+  prof.m_Header.version = icVersionNumberV5;
+  prof.m_Header.deviceClass = icSigColorSpaceClass;
+  prof.m_Header.colorSpace = icSigRgbData;
+  prof.m_Header.spectralPCS = (icColorSpaceSignature)spectralPCS;
+  prof.m_Header.spectralRange = spectralRange;
+  prof.m_Header.biSpectralRange = biSpectralRange;
+}
+
+// Connects a spectral source profile to an XYZ destination, the shape the reproducer
+// takes, and returns Connect()'s status. nChannels is what the signature declares (and
+// therefore what the pixel buffer would be sized to); the ranges are what the pushed
+// steps would be sized from.
+icStatusCMM connectSpectralSource(icColorSpaceSignature pcsType, icUInt16Number nChannels,
+                                  const icSpectralRange &spectralRange,
+                                  const icSpectralRange &biSpectralRange)
+{
+  const icSpectralRange stdRange = makeRange(icRange380nm, icRange780nm, 81);
+  StubPcc pcc(stdRange, stdRange);
+
+  CIccProfile srcProf, dstProf;
+  setHeader(srcProf, icNColorSpaceSig(pcsType, nChannels), spectralRange, biSpectralRange);
+
+  // A plain XYZ destination: no spectral PCS of its own, so it cannot be the side that
+  // trips the check and the result is attributable to the source alone.
+  std::memset(&dstProf.m_Header, 0, sizeof(dstProf.m_Header));
+  dstProf.m_Header.version = icVersionNumberV5;
+  dstProf.m_Header.deviceClass = icSigOutputClass;
+  dstProf.m_Header.colorSpace = icSigCmykData;
+  dstProf.m_Header.pcs = icSigXYZData;
+
+  StubXform from(&srcProf, true, (icColorSpaceSignature)icNColorSpaceSig(pcsType, nChannels),
+                 nChannels, &pcc);
+  StubXform to(&dstProf, false, icSigXYZPcsData, 3, &pcc);
+
+  CIccPcsXform pcs;
+  return pcs.Connect(&from, &to);
+}
+
+// The defect. Each of the three plain spectral PCS types states its sample count twice;
+// when the two disagree the profile must be refused rather than reinterpreted.
+void testMismatchedSpectralRangeIsRejected()
+{
+  struct Case {
+    icColorSpaceSignature type;
+    const char *what;
+  } cases[] = {
+    { icSigReflectanceSpectralData,  "reflectance ('rs')" },
+    { icSigTransmisionSpectralData,  "transmission ('ts')" },
+    { icSigRadiantSpectralData,      "radiant ('es')" },
+  };
+
+  for (size_t c = 0; c < sizeof(cases)/sizeof(cases[0]); c++) {
+    char msg[240];
+
+    // The reproducer's exact numbers: 36 channels declared, 184 steps used.
+    icStatusCMM stat = connectSpectralSource(cases[c].type, 36,
+                                             makeRange(icRange380nm, icRange780nm, 184),
+                                             makeRange(0, 0, 0));
+
+    std::snprintf(msg, sizeof(msg),
+                  "%s: 36 declared channels against spectralRange.steps == 184 is refused, "
+                  "not built into a 3x184 matrix run over a 36-float pixel",
+                  cases[c].what);
+    check(stat == icCmmStatInvalidProfile, msg);
+
+    // The other direction is equally unusable: more channels than there are samples to
+    // fill them leaves the tail of every pixel undefined.
+    stat = connectSpectralSource(cases[c].type, 184,
+                                 makeRange(icRange380nm, icRange780nm, 36),
+                                 makeRange(0, 0, 0));
+
+    std::snprintf(msg, sizeof(msg),
+                  "%s: 184 declared channels against spectralRange.steps == 36 is refused",
+                  cases[c].what);
+    check(stat == icCmmStatInvalidProfile, msg);
+  }
+}
+
+// Bi-spectral carries one sample per (spectral, bi-spectral) wavelength pair, so the
+// channel count has to equal the product rather than either factor.
+void testMismatchedBiSpectralRangeIsRejected()
+{
+  const icSpectralRange spectral = makeRange(icRange380nm, icRange780nm, 31);
+  const icSpectralRange biSpectral = makeRange(icRange380nm, icRange780nm, 41);
+
+  // 31 * 41 == 1271, so 36 is a mismatch. Also the shape of a header that names one
+  // factor instead of the product.
+  icStatusCMM stat = connectSpectralSource(icSigBiSpectralReflectanceData, 36,
+                                           spectral, biSpectral);
+  check(stat == icCmmStatInvalidProfile,
+        "bi-spectral: 36 declared channels against a 31 x 41 range product is refused");
+
+  stat = connectSpectralSource(icSigBiSpectralReflectanceData, 31, spectral, biSpectral);
+  check(stat == icCmmStatInvalidProfile,
+        "bi-spectral: naming only the spectral factor (31) as the channel count is refused");
+}
+
+// The exclusion that mirrors the validator. For a sparse-matrix PCS the channel count is
+// the float length of the encoded matrix blob the pixel carries, not a sample count, so
+// it is unrelated to the ranges and a "mismatch" here is normal. Connect() must let it
+// past the new check and fall through to the switch, which has its own answer for this
+// source/destination pair. An over-eager guard would turn that answer into
+// icCmmStatInvalidProfile and this assertion catches it.
+void testSparseMatrixPcsIsOutOfScope()
+{
+  icStatusCMM stat = connectSpectralSource(icSigSparseMatrixReflectanceData, 36,
+                                           makeRange(icRange380nm, icRange780nm, 184),
+                                           makeRange(icRange380nm, icRange780nm, 41));
+
+  check(stat != icCmmStatInvalidProfile,
+        "sparse-matrix PCS is not subject to the channels-vs-range check");
+}
+
+// Controls. The check sits in front of every spectral branch of Connect(), so a guard
+// that rejected too much would break spectral colour management wholesale; these pin the
+// conformant shapes that must still connect.
+void testConformantHeadersStillConnect()
+{
+  // 1. The reproducer's own shape, corrected: 36 channels, 36 steps.
+  icStatusCMM stat = connectSpectralSource(icSigReflectanceSpectralData, 36,
+                                           makeRange(icRange380nm, icRange780nm, 36),
+                                           makeRange(0, 0, 0));
+  check(stat == icCmmStatOk,
+        "reflectance: 36 channels with spectralRange.steps == 36 still connects");
+
+  // 2. The 81-step shape the Testing corpus is full of, and where channel count and step
+  //    count coincide with the stub illuminant/observer range.
+  stat = connectSpectralSource(icSigReflectanceSpectralData, 81,
+                               makeRange(icRange380nm, icRange780nm, 81),
+                               makeRange(0, 0, 0));
+  check(stat == icCmmStatOk,
+        "reflectance: 81 channels with spectralRange.steps == 81 still connects");
+
+  // 3. A consistent bi-spectral header: 31 x 41 == 1271 channels.
+  stat = connectSpectralSource(icSigBiSpectralReflectanceData, 1271,
+                               makeRange(icRange380nm, icRange780nm, 31),
+                               makeRange(icRange380nm, icRange780nm, 41));
+  check(stat != icCmmStatInvalidProfile,
+        "bi-spectral: a channel count equal to the range product is not rejected by the check");
+}
+
+// A profile with no spectral PCS at all has nothing to be inconsistent with, and the
+// overwhelming majority of connections are of this kind. The check must be inert for
+// them however the (unused) spectral range fields happen to be filled in.
+void testNonSpectralConnectionIsUnaffected()
+{
+  const icSpectralRange stdRange = makeRange(icRange380nm, icRange780nm, 81);
+  StubPcc pcc(stdRange, stdRange);
+
+  CIccProfile srcProf, dstProf;
+  std::memset(&srcProf.m_Header, 0, sizeof(srcProf.m_Header));
+  srcProf.m_Header.version = icVersionNumberV4;
+  srcProf.m_Header.deviceClass = icSigInputClass;
+  srcProf.m_Header.colorSpace = icSigRgbData;
+  srcProf.m_Header.pcs = icSigXYZData;
+  // spectralPCS stays icSigNoSpectralData while the range fields carry residue; nothing
+  // may key off them.
+  srcProf.m_Header.spectralRange = makeRange(icRange380nm, icRange780nm, 184);
+
+  std::memset(&dstProf.m_Header, 0, sizeof(dstProf.m_Header));
+  dstProf.m_Header.version = icVersionNumberV4;
+  dstProf.m_Header.deviceClass = icSigOutputClass;
+  dstProf.m_Header.colorSpace = icSigCmykData;
+  dstProf.m_Header.pcs = icSigXYZData;
+
+  StubXform from(&srcProf, true, icSigXYZPcsData, 3, &pcc);
+  StubXform to(&dstProf, false, icSigXYZPcsData, 3, &pcc);
+
+  CIccPcsXform pcs;
+  icStatusCMM stat = pcs.Connect(&from, &to);
+
+  // icCmmStatIdentityXform, not icCmmStatOk: both sides present XYZ under the same
+  // connection conditions, so Optimize() collapses the chain and reports that it did.
+  // That is a success outcome -- what matters here is that the new check did not turn a
+  // connection carrying leftover spectral range bytes into icCmmStatInvalidProfile.
+  check(stat == icCmmStatIdentityXform || stat == icCmmStatOk,
+        "an XYZ-to-XYZ connection with no spectral PCS still succeeds");
+}
+
+} // namespace
+
+int main()
+{
+  testMismatchedSpectralRangeIsRejected();
+  testMismatchedBiSpectralRangeIsRejected();
+  testSparseMatrixPcsIsOutOfScope();
+  testConformantHeadersStillConnect();
+  testNonSpectralConnectionIsUnaffected();
+
+  if (g_fail)
+    std::fprintf(stderr, "[spectral-pcs-range] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[spectral-pcs-range] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1067,6 +1067,53 @@ function(iccdev_add_pcs_birefl_illuminant_range_test)
   endif()
 endfunction()
 
+# #1932: CIccPcsXform::Connect() sized the spectral PCS steps it pushes from the header's
+# spectralRange while the pixel buffers those steps run in are sized from the channel
+# count in the spectralPCS signature, and never checked that the two agreed. A header
+# declaring "rs" + 36 channels alongside spectralRange.steps == 184 produced a 3x184
+# observer matrix reading a 36-float pixel (CWE-125 heap over-read in
+# CIccSparseMatrix::MultiplyVector). CIccProfile::Validate() already calls that a critical
+# error, but nothing on the apply path calls Validate().
+#
+# Drives Connect() directly through stub xforms, so the assertions are on returned status
+# and need no sanitizer. Pins the deliberate sparse-matrix exclusion and the conformant
+# shapes too: the check fronts every spectral branch, so a guard that rejected too much
+# would break spectral colour management wholesale. Header + IccProfLib only, no fixture.
+function(iccdev_add_spectral_pcs_range_consistency_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccSpectralPcsRangeConsistencyTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/spectral-pcs-range-consistency.cpp"
+  )
+  target_link_libraries(iccSpectralPcsRangeConsistencyTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccSpectralPcsRangeConsistencyTest)
+
+  add_test(
+    NAME iccdev.spectral-pcs-range-consistency
+    COMMAND "$<TARGET_FILE:iccSpectralPcsRangeConsistencyTest>"
+  )
+  set_tests_properties(iccdev.spectral-pcs-range-consistency PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;security;spectral;issue-1932;regression"
+  )
+  if(WIN32)
+    set(_spectral_pcs_range_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccSpectralPcsRangeConsistencyTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _spectral_pcs_range_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.spectral-pcs-range-consistency PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_spectral_pcs_range_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1853: CIccProfile::calcMediaWhiteXYZ() read the spectral white point tag with
 # GetValues()'s default nVectorSize of 1, so all but the first sample of the white vector
 # were uninitialized heap by the time they reached the returned XYZ. Builds its profiles
@@ -3178,6 +3225,7 @@ if(WIN32)
   iccdev_add_getvalues_nstart_test()
   iccdev_add_rangemap_uninitialized_test()
   iccdev_add_pcs_birefl_illuminant_range_test()
+  iccdev_add_spectral_pcs_range_consistency_test()
   iccdev_add_spectral_media_white_test()
   iccdev_add_gbd_zero_pcs_test()
   iccdev_add_mpe_empty_identity_test()
@@ -3425,6 +3473,7 @@ iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
 iccdev_add_rangemap_uninitialized_test()
 iccdev_add_pcs_birefl_illuminant_range_test()
+iccdev_add_spectral_pcs_range_consistency_test()
 iccdev_add_spectral_media_white_test()
 iccdev_add_gbd_zero_pcs_test()
 iccdev_add_mpe_empty_identity_test()

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -2121,6 +2121,56 @@ CIccPcsXform::~CIccPcsXform()
 
 /**
  **************************************************************************
+ * Name: icSpectralPcsMatchesRange
+ *
+ * Purpose:
+ *  Reports whether a header's spectral PCS signature and its spectral range
+ *  definition describe the same number of samples.
+ *
+ *  A spectral PCS signature carries its channel count in its low 16 bits, and that
+ *  count is the pixel width the CMM moves across the connection: it is what
+ *  CIccXform::GetNumSrcSamples()/GetNumDstSamples() report, and in turn what
+ *  CIccApplyCmm::InitPixel() sizes m_Pixel/m_Pixel2 from. The PCS steps that
+ *  CIccPcsXform::Connect() pushes are sized from the header's spectralRange /
+ *  biSpectralRange instead. When the two disagree, a step operates on a wider
+ *  vector than the pixel buffer holding it.
+ *
+ *  CIccProfile::Validate() already reports both disagreements as critical errors
+ *  (IccProfile.cpp, the bi-spectral product and the plain spectral count in the
+ *  spectralPCS switch), but nothing on the apply path consults it - iccApplyProfiles
+ *  and the CMM never call Validate() - so the check has to exist here too.
+ *
+ *  The scoping deliberately mirrors the validator's. icSigNoSpectralData has no
+ *  spectral PCS to be inconsistent with, and the sparse-matrix PCS is excluded
+ *  because there the channel count is the size of the encoded matrix blob carried in
+ *  the pixel rather than a sample count, so it is independent of the ranges by design
+ *  (see CIccPcsStepSrcSparseMatrix, which takes the two separately).
+ **************************************************************************
+ */
+static bool icSpectralPcsMatchesRange(const icHeader &hdr)
+{
+  icColorSpaceSignature sig = (icColorSpaceSignature)hdr.spectralPCS;
+
+  switch (icGetColorSpaceType(sig)) {
+    case icSigReflectanceSpectralData:
+    case icSigTransmisionSpectralData:
+    case icSigRadiantSpectralData:
+      return icNumColorSpaceChannels(sig) == (icUInt32Number)hdr.spectralRange.steps;
+
+    case icSigBiSpectralReflectanceData:
+      // One sample per (spectral, bi-spectral) wavelength pair. Widened before the
+      // multiply so a large pair cannot wrap the 16-bit product into a value that
+      // happens to match the channel count.
+      return icNumColorSpaceChannels(sig) ==
+             (icUInt32Number)hdr.biSpectralRange.steps * (icUInt32Number)hdr.spectralRange.steps;
+
+    default:
+      return true;
+  }
+}
+
+/**
+ **************************************************************************
  * Name: CIccPcsXform::Connect
  * 
  * Purpose: 
@@ -2212,6 +2262,29 @@ icStatusCMM CIccPcsXform::Connect(CIccXform *pFromXform, CIccXform *pToXform)
       m_dstSpace = icGetColorSpaceType(m_dstSpace);
 
     m_nDstSamples = pToXform->GetNumSrcSamples();
+
+    // m_nSrcSamples and m_nDstSamples were just taken from the neighbouring xforms, which
+    // derive them from their profile's PCS signature. Every spectral branch of the switch
+    // below instead sizes the steps it pushes from that profile's spectralRange, so a
+    // header whose two statements of the same quantity disagree produces a chain that
+    // reads or writes past the pixel buffer the caller allocated from the signature.
+    //
+    // Issue #1932 is that read: a header pairing an "rs" spectral PCS of 36 channels with
+    // spectralRange.steps == 184 reached pushRef2Xyz(), whose 3x184 observer matrix -
+    // well formed in itself - indexed a 36-float pixel buffer. Rejecting the profile is
+    // the only correct outcome; there is no way to tell which of the two numbers the
+    // producer meant, and Validate() already treats the disagreement as a critical error.
+    //
+    // Named pSpectralSrc/pSpectralDst rather than the pFromProfile/pToProfile used
+    // elsewhere in this function: the icSigRadiantSpectralPcsData case below declares its
+    // own pFromProfile, and reusing the name here would shadow it under -Wshadow.
+    CIccProfile *pSpectralSrc = pFromXform->GetProfilePtr();
+    CIccProfile *pSpectralDst = pToXform->GetProfilePtr();
+
+    if ((pSpectralSrc && !icSpectralPcsMatchesRange(pSpectralSrc->m_Header)) ||
+        (pSpectralDst && !icSpectralPcsMatchesRange(pSpectralDst->m_Header))) {
+      return icCmmStatInvalidProfile;
+    }
 
     switch (m_srcSpace) {
       case icSigLabPcsData:


### PR DESCRIPTION
Fixes #1932.

@xsscx — reproduced your PoC exactly, then found the defect is not where the stack trace
points. Evidence first, because the sparse matrix is innocent.

## The sparse matrix is well formed

Instrumenting `CIccSparseMatrix::MultiplyVector` at the moment of the over-read:

```
rows=3 cols=184 maxEntries=176 rawSize=1080
RowStart: 0 58 116 174
ColIdx:   0 2 3 9 10 15 ... 179 180 183
```

Monotonic row starts, all within `m_nMaxEntries`, every column index ascending and
`< 184`. **`IsValid()` returns true on it.** Nothing about the matrix is wrong, and
hardening `MultiplyVector` would be hardening the wrong object — it is handed a bare
`const icFloatNumber *` and cannot know how long it is.

ASan names the buffer that actually overflowed:

```
0x...410 is located 0 bytes after 144-byte region [0x...380,0x...410)
allocated by thread T0 here:
    #1 CIccApplyCmm::InitPixel() IccProfLib/IccCmm.cpp:8331
```

144 bytes = **36 floats**. That is the CMM pixel buffer, and a 3x184 matrix is being run
over it.

## Root cause: the header states its sample count twice, and the two disagree

Your reproducer is a TIFF whose embedded ICC carries an `ICC5`/`ICCp` tag, and *that*
v5 sub-profile is the payload (`-embedded 10003` selects it, `+10000` = "use V5
sub-profile if present"). Its header says:

| field | value |
|---|---|
| `spectralPCS` | `0x72730024` — `"rs"` + **36** channels |
| `spectralRange` | start 398nm, end 538nm, **184** steps |

Both numbers describe the same quantity, and the two halves of the CMM read different ones:

- the channel count in the signature is what `GetNumSrcSamples()`/`GetNumDstSamples()`
  report, and what `CIccApplyCmm::InitPixel()` sizes `m_Pixel`/`m_Pixel2` from → **36**;
- `CIccPcsXform::Connect()` sizes every spectral step it pushes from `spectralRange`, so
  `pushRef2Xyz()` → `pushRad2Cie()` → `pushMatrix(3, 184, observer)` builds a **3x184**
  observer matrix, which `CIccPcsStepMatrix::reduce()` converts to the sparse matrix above.

Dumping the chain makes the contradiction explicit — note the xform declares 36 source
samples while its first step consumes 184:

```
[PCSXFORM] srcSamples=36 dstSamples=3 MaxChannels=184 steps: [type=14 src=184 dst=3] [type=4 src=3 dst=3]
[INITPIXEL] nSamples=36
```

`MultiplyVector` then reads `pVector[36]` on the 37th column. CWE-125.

## The check already exists — the apply path just never asks

`CIccProfile::Validate()` reports exactly this as a **critical error**, in the
`spectralPCS` switch of `CheckHeader()`:

```
Number of channels defined for spectral PCS do not match spectral range definition.
```

Neither `iccApplyProfiles` nor `CIccCmm` calls `Validate()`, so nothing enforced it. The
fix puts the same rule on the apply path.

## Fix

One guard in `CIccPcsXform::Connect()`, placed right after `m_nSrcSamples`/`m_nDstSamples`
are taken from the neighbouring xforms and **before the dispatch switch** — the single
choke point every spectral route passes through. Returns `icCmmStatInvalidProfile` before
any step is pushed.

Rejection is the only correct outcome: there is no way to tell which of the two numbers
the producer meant, and honouring either silently reinterprets the pixel data.

```
$ iccApplyProfiles hbo-...icc out.tif 1 1 0 1 1 -embedded 10003 \
    -pcc hybrid/ICC/Spec400_10_700-F11_2deg-Abs.icc sRGB_v4_ICC_preference.icc 1
Error - Begin() failed (status 3: Invalid profile); profile chain is incompatible
```

**The scoping deliberately mirrors the validator's.** The sparse-matrix PCS (`sm`) is
*excluded*, because there the channel count is the length of the encoded matrix blob the
pixel carries rather than a sample count, so it is independent of the ranges by design —
`CIccPcsStepSrcSparseMatrix` is handed the two separately. `iccdev.spectral-pcs-range-consistency`
pins that exclusion so a later tidy-up cannot quietly widen it.

`ConnectFirst()`/`ConnectLast()` need no equivalent: both only push colorimetric steps and
never read `spectralRange`.

## Considered and rejected

I drafted a second, more general guard — "a step chain's first step may not read more
channels than the xform declares as its source". It is wrong: `pushXYZNormalize()`
legitimately applies a scratch `CIccPcsXform` with `m_nSrcSamples == 0` and an 81-channel
step, so the invariant would have broken a working path. Recording it here so it does not
get re-proposed.

## Test

`iccdev.spectral-pcs-range-consistency` (`.github/ci/regression/`) drives `Connect()`
through stub xforms, so every assertion is on returned status and needs no sanitizer. No
fixture and no I/O, so a corpus change cannot silently disable it. It covers:

- the reproducer's shape for all three plain spectral types (`rs`/`ts`/`es`), both directions
  of the mismatch;
- bi-spectral, where the channel count must equal the `steps x steps` product;
- the sparse-matrix exclusion;
- conformant headers that must still connect (36/36, 81/81, a consistent 31x41 bi-spectral);
- an XYZ-to-XYZ connection carrying leftover spectral range bytes, which must be unaffected.

**Red-green:** with the guard removed, **8 assertions fail and every control still passes**
— so the failures are attributable to the guard, not to a broken harness.

## Verification

| check | result |
|---|---|
| Reproducer under ASan, before fix | heap-buffer-overflow at `IccSparseMatrix.cpp:312`, matching the issue |
| Reproducer under ASan, after fix | rejected, `status 3: Invalid profile`, no report |
| **Every `.icc` in the tree**: 255 in `Testing/`, 24 under `.github/ci/` | 77 carry a spectral PCS in the check's scope, **0 rejected** |
| **CI's own container** (`iccdev-ci-regression`), g++ **15.2.0**, Release + LTO, `-Wall -Wextra -Wpedantic -Werror` | **0 warnings**, including the new test target |
| Full ctest, clang ASan+UBSan Debug | green |
| New test under `ASAN_OPTIONS=detect_leaks=1` | clean (CTest env sets `detect_leaks=0`, so a leak would otherwise pass silently) |

**Not caused by this change:** `iccdev.hybrid-pipeline` fails under `ctest -j4` and passes
standalone (358 s), and its container failure ("Unable to save profile as
`ICC/MultSpectralRGB.icc`") **reproduces identically on pristine master `05b5d54f` in the
same image** — a mounted-volume write issue, not a regression. Same family as the known
`tool-coverage` parallel flake.

On the corpus files and CB tooling you posted in #1931 — I have not harvested those yet;
they look directly useful for the `IccMpeXml.cpp` `atoi` family and I will pick them up there.
