### PR TITLE
fix(#1941): convert IccMatrixMath.cpp to LF so a touched line stops tripping diff --check

### DIFF
--- a/IccProfLib/IccMatrixMath.cpp
+++ b/IccProfLib/IccMatrixMath.cpp
@@ -12,7 +12,7 @@
  * The ICC Software License, Version 0.2
  *
  *
- * Copyright (c) 2003-2015 The International Color Consortium. All rights 
+ * Copyright (c) 2003-2015 The International Color Consortium. All rights
  * reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -20,7 +20,7 @@
  * are met:
  *
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  *
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in
@@ -48,20 +48,20 @@
  * ====================================================================
  *
  * This software consists of voluntary contributions made by many
- * individuals on behalf of the The International Color Consortium. 
+ * individuals on behalf of the The International Color Consortium.
  *
  *
  * Membership in the ICC is encouraged when this software is used for
- * commercial purposes. 
+ * commercial purposes.
  *
- *  
+ *
  * For more information on The International Color Consortium, please
  * see <http://www.color.org/>.
- *  
- * 
+ *
+ *
  */
 
-////////////////////////////////////////////////////////////////////// 
+//////////////////////////////////////////////////////////////////////
 // HISTORY:
 //
 // -Initial implementation by Max Derhak 5-15-2003
@@ -88,8 +88,8 @@ namespace iccDEV {
 /**
 **************************************************************************
 * Name: CIccMatrixMath::CIccMatrixMath
-* 
-* Purpose: 
+*
+* Purpose:
 *  Constructor
 **************************************************************************
 */
@@ -115,8 +115,8 @@ CIccMatrixMath::CIccMatrixMath(icUInt16Number nRows, icUInt16Number nCols, bool 
 /**
 **************************************************************************
 * Name: CIccMatrixMath::CIccMatrixMath
-* 
-* Purpose: 
+*
+* Purpose:
 *  Copy Constructor
 **************************************************************************
 */
@@ -164,8 +164,8 @@ CIccMatrixMath &CIccMatrixMath::operator=(const CIccMatrixMath &matrix)
 /**
 **************************************************************************
 * Name: CIccMatrixMath::~CIccMatrixMath
-* 
-* Purpose: 
+*
+* Purpose:
 *  Destructor
 **************************************************************************
 */
@@ -178,8 +178,8 @@ CIccMatrixMath::~CIccMatrixMath()
 /**
 **************************************************************************
 * Name: CIccMatrixMath::VectorMult
-* 
-* Purpose: 
+*
+* Purpose:
 *  Multiplies pSrc vector passed by a matrix resulting in a pDst vector
 **************************************************************************
 */
@@ -201,8 +201,8 @@ void CIccMatrixMath::VectorMult(icFloatNumber *pDst, const icFloatNumber *pSrc) 
 /**
 **************************************************************************
 * Name: CIccMatrixMath::dump
-* 
-* Purpose: 
+*
+* Purpose:
 *  dumps the context of the step
 **************************************************************************
 */
@@ -226,8 +226,8 @@ void CIccMatrixMath::dumpMtx(std::string &str) const
 /**
 **************************************************************************
 * Name: CIccMatrixMath::Mult
-* 
-* Purpose: 
+*
+* Purpose:
 *  Creates a new CIccMatrixMath that is the result of concatentating
 *  another matrix with this matrix. (IE result = matrix * this).
 **************************************************************************
@@ -263,8 +263,8 @@ CIccMatrixMath *CIccMatrixMath::Mult(const CIccMatrixMath *matrix) const
 /**
 **************************************************************************
 * Name: CIccMatrixMath::VectorScale
-* 
-* Purpose: 
+*
+* Purpose:
 *  Multiplies each row by values of vector passed in
 **************************************************************************
 */
@@ -282,8 +282,8 @@ void CIccMatrixMath::VectorScale(const icFloatNumber *vec)
 /**
 **************************************************************************
 * Name: CIccMatrixMath::Scale
-* 
-* Purpose: 
+*
+* Purpose:
 *  Multiplies all values in matrix by a single scale factor
 **************************************************************************
 */
@@ -301,8 +301,8 @@ void CIccMatrixMath::Scale(icFloatNumber v)
 /**
 **************************************************************************
 * Name: CIccMatrixMath::Invert
-* 
-* Purpose: 
+*
+* Purpose:
 *  Inverts the matrix
 **************************************************************************
 */
@@ -320,8 +320,8 @@ bool CIccMatrixMath::Invert()
 /**
 **************************************************************************
 * Name: CIccMatrixMath::RowSum
-* 
-* Purpose: 
+*
+* Purpose:
 *  Creates a new CIccMatrixMath step that is the result of multiplying the
 *  matrix of this object to the scale of another object.
 **************************************************************************
@@ -344,8 +344,8 @@ icFloatNumber CIccMatrixMath::RowSum(icUInt16Number nRow) const
 /**
 **************************************************************************
 * Name: CIccMatrixMath::isIdentityMtx
-* 
-* Purpose: 
+*
+* Purpose:
 *  Determines if applying this step will result in negligible change in data
 **************************************************************************
 */
@@ -376,8 +376,8 @@ bool CIccMatrixMath::isIdentityMtx() const
 /**
 **************************************************************************
 * Name: CIccMatrixMath::SetRange
-* 
-* Purpose: 
+*
+* Purpose:
 *  Fills a matrix math object that can be used to convert
 *  spectral vectors from one spectral range to another using linear interpolation.
 **************************************************************************


### PR DESCRIPTION
Fixes #1941

## What the issue reported, and what is actually wrong

The issue reports that `IccMatrixMath.cpp` has CRLF characters that `git diff --check`
treats as trailing whitespace, and proposes:

```
perl -0pi -e 's/[ \t]+\r\n/\r\n/g; s/[ \t]+\n/\n/g' IccMatrixMath.cpp
```

That is necessary but not sufficient. It strips the trailing space/tab runs but leaves the
CRLF in place, and **the CR is itself what `diff --check` is reporting**: `.gitattributes`
carries rules for `*.sh` and `.githooks/*` only, and git's `cr-at-eol` whitespace rule is
off by default, so git counts the carriage return as trailing whitespace. Every line a
change touches in this file is flagged regardless of what that line contains.

Red-tested on `8b66b43a`, adding a single line with no trailing whitespace at all:

```
$ git diff --check -- IccProfLib/IccMatrixMath.cpp
IccProfLib/IccMatrixMath.cpp:78: trailing whitespace.
+// probe
(exit 2)
```

After this change the same probe edit exits 0.

## This is not a style change

`IccMatrixMath.cpp` is the **only CRLF file among the 259 tracked C/C++ sources** in the
tree:

```
$ for f in $(git ls-files '*.cpp' '*.h' '*.c' '*.hpp'); do
    grep -q $'\r$' "$f" && echo "$f"; done
IccProfLib/IccMatrixMath.cpp
```

It has been CRLF since `1f0a9dd` (Sep 2015). Converting it brings it into line with its
258 siblings rather than imposing a new convention on any of them.

## What changed

Both halves, in one pass:

- the 32 trailing space/tab runs are stripped — all of them in the licence header and the
  function banner comments, **none in code**;
- the line terminators are converted CRLF → LF.

Every CR in the file was a line terminator; none appeared inside a string literal or
anywhere else that would make the conversion meaningful (`grep -cP '\r(?!$)'` → 0).

## Verification: byte-identical object, not an assertion

The change is provably semantics-free. Compiling the file before and after with the
project's own `IccProfLib2` command line (clang-18, ASAN+UBSAN, `-Wall -Wextra
-Wshadow -Wnull-dereference -Werror=uninitialized`, `-std=gnu++17 -g`) produces an
identical object both times:

```
e51a30c0532344b71539b8bc1102d9952791afc5bcd4bbeb0ac136a0066dde68  before.o
e51a30c0532344b71539b8bc1102d9952791afc5bcd4bbeb0ac136a0066dde68  after.o
```

The line count is unchanged at 516, so no debug line numbers move either.

**For review:** `git show -w --ignore-cr-at-eol` renders this commit as an empty diff.

## Pre-flight

- Build: **0 warnings** (`grep -cE 'warning:' build.log` → 0).
- Full local CTest: **145 tests**. Three failures, none related and all reproducible on an
  unmodified tree:
  - `iccdev.spectral-tiff-preview` — `ModuleNotFoundError: No module named 'imagecodecs'`,
    a missing local Python dependency that CI installs.
  - `iccdev.tool-coverage` — the known parallel-load flake; passes standalone (51.4s).
  - `iccdev.issue-1781-applytolink-qa-matrix` — same family, newly observed: **123.9s under
    `-j4`, 42.9s standalone** on the identical tree. It regenerates CMYK fixtures in the
    shared `Testing/` dir, so it races with `tool-coverage` / `create-profiles` the same way.

No CTest is added: there is no behaviour to assert, and the byte-identical object is the
stronger evidence.

## Deliberately not included

Preventing recurrence repo-wide would mean adding a `*.cpp` / `*.h` rule to
`.gitattributes`. That has a far wider blast radius than this one file and is a
maintainer call, so it is left out. Happy to follow up with it if wanted.
