### PR TITLE
fix(#1948): read float buffers as bytes in the CIccIO writers, and record the corpus verdicts (#1946)

### DIFF
--- a/.github/ci/regression/iccio-write-float-aliasing.cpp
+++ b/.github/ci/regression/iccio-write-float-aliasing.cpp
@@ -1,0 +1,154 @@
+// Guards the strict-aliasing fix in CIccIO::Write16/Write32/Write64
+// (IccProfLib/IccIO.cpp) reported as #1948.
+//
+// CIccIO::WriteFloat32Float() forwards straight to Write32() whenever
+// icFloatNumber and icFloat32Number are the same width, which is the normal
+// build.  Write32() used to load the caller's buffer through an
+// icUInt32Number lvalue:
+//
+//     icUInt32Number *ptr = (icUInt32Number*)pBuf32;
+//     tmp = *ptr;
+//
+// The object being read is a float, so that load is undefined behaviour: a
+// float and an icUInt32Number are not similar types, and the compiler is
+// entitled to assume a store through one cannot be observed by a load through
+// the other.  With -flto (ENABLE_LTO defaults to ON) the store in
+// CIccSegmentedCurve::Write() and this load land in one optimization scope,
+// and clang at -O3 drops the store as dead.  Every breakpoint then reached the
+// file as the stack slot's initial 0.0.
+//
+// The read path was always safe because icSwab32Array() walks the buffer as
+// icUInt8Number, which may alias any object - which is why readers agreed
+// across toolchains while writers did not.  The writers now load the same way.
+//
+// The damage is not cosmetic.  A segmented curve whose trailing breakpoint is
+// flattened to 0.0 gives its sampled segment an end point equal to its start
+// point, and CIccSampledCurveSegment::Begin() (IccMpeBasic.cpp) refuses a
+// segment whose range is zero, so the curve set cannot be applied at all.
+//
+// This test drives the library path rather than calling Write32() directly:
+// both the store and the load live inside IccProfLib, so the test reproduces
+// wherever the library itself is miscompiled, independently of how this
+// translation unit is built.
+
+#include "IccMpeBasic.h"
+#include "IccIO.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <cstring>
+
+// CIccSegmentedCurve::Write() emits, in order: the curve signature (4 bytes),
+// a reserved word (4), the segment count (2), a second reserved word (2), then
+// one big-endian float breakpoint for every segment after the first.  With
+// three segments the two breakpoints therefore sit at offsets 12 and 16.
+static const size_t kBreakpoint0Offset = 12;
+static const size_t kBreakpoint1Offset = 16;
+
+static icUInt32Number beU32(const icUInt8Number *p)
+{
+  return ((icUInt32Number)p[0] << 24) | ((icUInt32Number)p[1] << 16) |
+         ((icUInt32Number)p[2] << 8) | (icUInt32Number)p[3];
+}
+
+int main()
+{
+  // The shape taken from Testing/Calc/RGBWProjector.xml, the fixture that
+  // exposed this: a formula segment covering everything below 0.0, a sampled
+  // segment across the unit interval, and a formula segment above 1.0.  The
+  // breakpoint that was being lost is the third segment's start point, 1.0.
+  CIccSegmentedCurve curve;
+
+  icFloatNumber params[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+
+  CIccFormulaCurveSegment *pLow = new CIccFormulaCurveSegment(icMinFloat32Number, 0.0f);
+  pLow->SetFunction(0, 4, params);
+  if (!curve.Insert(pLow)) {
+    std::printf("FAIL: could not insert the low formula segment\n");
+    return 1;
+  }
+
+  CIccSampledCurveSegment *pMid = new CIccSampledCurveSegment(0.0f, 1.0f);
+  if (!pMid->SetSize(4)) {
+    std::printf("FAIL: could not size the sampled segment\n");
+    return 1;
+  }
+  icFloatNumber *pSamples = pMid->GetSamples();
+  for (icUInt32Number i = 0; i < pMid->GetSize(); i++)
+    pSamples[i] = (icFloatNumber)i / (icFloatNumber)(pMid->GetSize() - 1);
+  if (!curve.Insert(pMid)) {
+    std::printf("FAIL: could not insert the sampled segment\n");
+    return 1;
+  }
+
+  icFloatNumber highParams[4] = { 1.0f, 0.0f, 0.0f, 1.0f };
+  CIccFormulaCurveSegment *pHigh = new CIccFormulaCurveSegment(1.0f, icMaxFloat32Number);
+  pHigh->SetFunction(0, 4, highParams);
+  if (!curve.Insert(pHigh)) {
+    std::printf("FAIL: could not insert the high formula segment\n");
+    return 1;
+  }
+
+  CIccMemIO io;
+  if (!io.Alloc(4096, true)) {
+    std::printf("FAIL: could not allocate the write buffer\n");
+    return 1;
+  }
+
+  if (!curve.Write(&io)) {
+    std::printf("FAIL: CIccSegmentedCurve::Write reported failure\n");
+    return 1;
+  }
+
+  const size_t written = io.GetLength();
+  if (written < kBreakpoint1Offset + 4) {
+    std::printf("FAIL: wrote only %zu bytes, too short to hold two breakpoints\n", written);
+    return 1;
+  }
+
+  // 0x3F800000 is the big-endian IEEE-754 encoding of 1.0f, and 0x00000000 of
+  // 0.0f.  Reading the emitted bytes rather than the in-memory segment is the
+  // point: the defect was in what reached the buffer, not in what the object
+  // held.
+  const icUInt8Number *pData = io.GetData();
+  const icUInt32Number bp0 = beU32(pData + kBreakpoint0Offset);
+  const icUInt32Number bp1 = beU32(pData + kBreakpoint1Offset);
+
+  if (bp0 != 0x00000000u) {
+    std::printf("FAIL: first breakpoint wrote 0x%08X, expected 0x00000000 (0.0)\n", bp0);
+    return 1;
+  }
+
+  if (bp1 != 0x3F800000u) {
+    std::printf("FAIL: second breakpoint wrote 0x%08X, expected 0x3F800000 (1.0)\n"
+                "      The segmented curve declared a start point of 1.0 for its "
+                "trailing segment;\n"
+                "      a value of 0x00000000 is the #1948 strict-aliasing defect in "
+                "CIccIO::Write32.\n",
+                bp1);
+    return 1;
+  }
+
+  // Read the bytes back and confirm the curve is usable.  This is the part a
+  // byte comparison alone would miss: with the breakpoint flattened, the
+  // sampled segment comes back with a zero range and Begin() rejects it, so
+  // the whole curve set fails to initialize.
+  io.Seek(0, icSeekSet);
+
+  CIccSegmentedCurve readBack;
+  if (!readBack.Read((icUInt32Number)written, &io)) {
+    std::printf("FAIL: CIccSegmentedCurve::Read rejected the bytes just written\n");
+    return 1;
+  }
+
+  if (!readBack.Begin(icElemInterpLinear, NULL)) {
+    std::printf("FAIL: the round-tripped curve would not Begin(); a sampled segment "
+                "with a zero range is the #1948 symptom\n");
+    return 1;
+  }
+
+  std::printf("CIccIO float writers OK: breakpoints 0x%08X 0x%08X, curve begins after "
+              "round-trip\n",
+              bp0, bp1);
+  return 0;
+}

--- a/.github/scripts/iccdev-qa-profile-manifest.sh
+++ b/.github/scripts/iccdev-qa-profile-manifest.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+#
+# iccdev-qa-profile-manifest.sh - generate or enforce the QA profile manifest (#1809).
+#
+# The Testing corpus mixes three kinds of profile that a bare "did iccDumpProfile
+# exit non-zero" sweep cannot tell apart: conformant examples, profiles that carry
+# a known baselined warning, and fixtures that are malformed on purpose. Without a
+# manifest, a deliberate rejection reads as an unexplained failure, and - worse - a
+# real regression that turns a conformant profile critical is indistinguishable
+# from the negatives that are supposed to be critical.
+#
+# Testing/qa-profile-manifest.tsv records, per profile, the validation verdict the
+# corpus is expected to produce. This script has two modes:
+#
+#   check     re-validate every profile and diff the result against the manifest
+#             (this is what the CTest runs)
+#   generate  rewrite the manifest from the current corpus (maintainer action -
+#             review the diff, it is a deliberate re-baseline)
+#
+# Both modes require the corpus to have been generated already (Testing/CreateAllProfiles.sh);
+# under CTest that is the iccdev_profiles fixture.
+set -uo pipefail
+
+MODE="${1:-check}"
+case "$MODE" in
+  check|generate) ;;
+  *) echo "usage: $0 {check|generate}" >&2; exit 2 ;;
+esac
+
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$(cd "$(dirname "$0")/../../Testing" && pwd)}"
+MANIFEST="${ICCDEV_QA_MANIFEST:-$TESTING_DIR/qa-profile-manifest.tsv}"
+
+if [ ! -d "$TESTING_DIR" ]; then
+  echo "[FAIL] Testing directory not found: $TESTING_DIR" >&2
+  exit 1
+fi
+
+if ! command -v iccDumpProfile >/dev/null 2>&1; then
+  echo "[FAIL] iccDumpProfile not on PATH" >&2
+  exit 1
+fi
+
+# Validation is what the manifest describes, so -v is required. Verbosity 26 matches
+# the sweep in #1809. The issue's own repro additionally passes "ALL" to dump every
+# tag; that was measured to produce an identical status line and exit code for all
+# 213 profiles, so the cheaper form is used here and tag-dump coverage is left to
+# the tests that exist for it.
+dump_verbosity=26
+
+# Map the printed report line to the manifest's expected_status vocabulary. These
+# are the exact strings iccDumpProfile.cpp prints for each icValidateStatus.
+classify_status() {
+  local log="$1"
+  if   grep -Fq 'Profile has Critical Error(s)'      "$log"; then echo critical
+  elif grep -Fq 'Profile violates ICC specification' "$log"; then echo noncompliant
+  elif grep -Fq 'Profile has warning(s)'             "$log"; then echo warning
+  elif grep -Fq 'Profile is valid'                   "$log"; then echo valid
+  elif grep -Fq 'Profile has unknown status!'        "$log"; then echo unknown
+  else echo none
+  fi
+}
+
+# A sanitizer finding or a fatal signal is never baselined: those fail every suite,
+# including the negative one, where the profile is meant to be *rejected* rather
+# than to crash the validator.
+classify_sanitizer() {
+  local log="$1"
+  if   grep -Fq 'ERROR: AddressSanitizer' "$log"; then echo asan
+  elif grep -Fq 'UndefinedBehaviorSanitizer' "$log"; then echo ubsan
+  elif grep -Fq 'runtime error:' "$log"; then echo ubsan
+  elif grep -Eq 'DEADLYSIGNAL|Segmentation fault|Bus error|core dumped' "$log"; then echo signal
+  else echo none
+  fi
+}
+
+# Suite follows mechanically from the verdict, so the manifest stays regenerable
+# and nobody has to hand-adjudicate 213 rows:
+#   valid        -> positive       must stay clean; any diagnostic is a regression
+#   warning      -> compatibility  a known diagnostic is baselined, escalation fails
+#   critical     -> negative       rejection is the expected result; acceptance fails
+classify_suite() {
+  case "$1" in
+    valid)                   echo positive ;;
+    warning)                 echo compatibility ;;
+    noncompliant|critical)   echo negative ;;
+    *)                       echo unknown ;;
+  esac
+}
+
+# One short, stable reason per diagnostic family, so a reviewer reading the manifest
+# can see why a row is baselined without re-running the tool.
+classify_rationale() {
+  local status="$1" log="$2"
+  case "$status" in
+    valid)
+      echo "conformant example profile; validates clean"
+      ;;
+    warning)
+      if grep -Fq 'appears to be normalized' "$log"; then
+        echo "baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)"
+      elif grep -Fq 'sampled curve has a range of zero' "$log"; then
+        echo "baselined: sampled curve has a range of zero"
+      else
+        echo "baselined: profile validates with warnings"
+      fi
+      ;;
+    critical)
+      # Header damage is checked first because it is the broader defect: the one
+      # fuzz-derived fixture in this corpus reports a truncated header *and* a
+      # calculator underflow, and describing it by the underflow alone would put it
+      # in the same family as the 77 hand-authored calculator negatives, which are
+      # structurally well-formed profiles that fail only on calculator semantics.
+      if grep -Eq 'Bad Header File Size|Bad Profile ID' "$log"; then
+        echo "negative fixture: fuzz-derived malformed profile must be rejected"
+      elif grep -Fq 'causes an evaluation stack underflow' "$log"; then
+        echo "negative fixture: calculator evaluation stack underflow must be rejected"
+      elif grep -Fq 'accesses illegal temporary channels' "$log"; then
+        echo "negative fixture: illegal temporary channel access must be rejected"
+      elif grep -Fq 'function has invalid operations' "$log"; then
+        # calcUnderStack_fLab is the one member of the calcUnderStack_* family that
+        # reports this instead of an underflow: the operation is rejected as invalid
+        # before the stack depth is ever assessed. Recorded as its own reason so the
+        # manifest does not imply it exercises the same validator path as its 73 siblings.
+        echo "negative fixture: invalid calculator operation must be rejected"
+      else
+        echo "negative fixture: malformed profile must be rejected"
+      fi
+      ;;
+    *)
+      echo "unclassified"
+      ;;
+  esac
+}
+
+# sha256 is populated only for profiles git actually tracks (#1809 resolution path 1).
+# The generated corpus cannot carry a stable digest: almost every source XML sets
+# <CreationDateTime>now</CreationDateTime>, which icGetDateTimeValue resolves through
+# localtime_r at conversion time, and the header date feeds the recomputed profile ID.
+# Two conversions a second apart differ, and two machines in different time zones
+# differ as well. For those rows expected_status/expected_exit carry the contract.
+# The digest is read from the git object rather than from disk so that regenerating
+# the corpus in place can never silently re-baseline it.
+git_blob_sha256() {
+  local rel="$1"
+  if git -C "$REPO_ROOT" ls-files --error-unmatch "$rel" >/dev/null 2>&1; then
+    git -C "$REPO_ROOT" show "HEAD:$rel" 2>/dev/null | sha256sum | cut -d' ' -f1
+  else
+    echo "-"
+  fi
+}
+
+REPO_ROOT="$(git -C "$TESTING_DIR" rev-parse --show-toplevel 2>/dev/null || echo "")"
+
+# The corpus this manifest describes is what CreateAllProfiles.sh produces plus the
+# profiles git tracks. Testing/hybrid/ICC and Testing/hybrid/Results are excluded
+# because they are not corpus at all: iccdev.hybrid-pipeline writes its own output
+# there while the suite runs, and Testing/hybrid/.gitignore - a committed file - says
+# so, listing "ICC/*.icc" and "Results/*.icc" as generated artifacts. It is the only
+# .gitignore under Testing/ that declares .icc output. Without this the manifest test
+# is ordering-dependent: it sees 213 profiles alone and 232 after the hybrid pipeline
+# has run, and the difference is not something a verdict baseline should adjudicate.
+list_corpus() {
+  find "$TESTING_DIR" -name '*.icc' \
+    ! -path "$TESTING_DIR/hybrid/ICC/*" \
+    ! -path "$TESTING_DIR/hybrid/Results/*" \
+    | sort
+}
+
+write_header() {
+  cat <<'EOF'
+# Testing/qa-profile-manifest.tsv - expected validation verdict per corpus profile (#1809)
+#
+# Regenerate with:  .github/scripts/iccdev-qa-profile-manifest.sh generate
+# Enforced by CTest: iccdev.qa-profile-manifest
+#
+# Columns (tab separated):
+#   path                repository path, relative to Testing/
+#   suite               positive | compatibility | negative
+#   expected_status     valid | warning | noncompliant | critical
+#   expected_exit       decimal exit code from iccDumpProfile -v
+#   expected_sanitizer  none  (a sanitizer finding fails every suite, negatives included)
+#   source              tracked | generated
+#   sha256              digest of the tracked git blob, or - when generated
+#   rationale           why this row reads the way it does
+#
+# Suite policy:
+#   positive       must validate clean; any new diagnostic is a regression
+#   compatibility  a known diagnostic is baselined; escalation beyond it fails
+#   negative       rejection is the expected result; acceptance is a failure
+#
+# iccDumpProfile status-to-exit mapping (Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp).
+# Note that the text verdict and the exit code deliberately disagree for one status,
+# so a harness reading $? and a harness reading the report do not see the same thing:
+#   valid         "Profile is valid"                            exit 0
+#   warning       "Profile has warning(s)"                      exit 0
+#   noncompliant  "Profile violates ICC specification"          exit 0    <-- asymmetry
+#   critical      "Profile has Critical Error(s) ..."           exit 255
+#   unknown       "Profile has unknown status!"                 exit 254
+# The manifest therefore records expected_status and expected_exit as independent
+# fields rather than deriving one from the other. No profile in the corpus currently
+# validates as overall noncompliant, so no row exercises that pairing today; the
+# mapping is recorded here so the contract is explicit if one appears.
+#
+# sha256 is populated only for git-tracked profiles. The generated corpus resolves
+# <CreationDateTime>now</CreationDateTime> through localtime_r at conversion time and
+# recomputes the profile ID from it, so its bytes are neither clock- nor timezone-stable.
+#
+# Scope: this manifest covers Testing/ only. The repository also tracks 24 profiles
+# under .github/ci/regression/ and .github/ci/test-data/ - deliberately malformed PoC
+# and fuzz fixtures - which are deliberately NOT listed here. Each is already the
+# input to a dedicated regression test that asserts a specific behaviour, and those
+# assertions are narrower than a whole-profile validation verdict. Extending the
+# manifest to cover them would be a separate change.
+EOF
+  printf '#\n'
+  printf '# path\tsuite\texpected_status\texpected_exit\texpected_sanitizer\tsource\tsha256\trationale\n'
+}
+
+tmp_log="$(mktemp)"
+trap 'rm -f "$tmp_log"' EXIT
+
+emit_rows() {
+  while IFS= read -r f; do
+    local_rel="${f#"$TESTING_DIR"/}"
+
+    timeout -k 5s 120s iccDumpProfile -v "$dump_verbosity" "$f" > "$tmp_log" 2>&1
+    rc=$?
+
+    status="$(classify_status "$tmp_log")"
+    san="$(classify_sanitizer "$tmp_log")"
+    suite="$(classify_suite "$status")"
+    rationale="$(classify_rationale "$status" "$tmp_log")"
+
+    repo_rel="Testing/$local_rel"
+    if [ -n "$REPO_ROOT" ] && git -C "$REPO_ROOT" ls-files --error-unmatch "$repo_rel" >/dev/null 2>&1; then
+      source_kind="tracked"
+      sha="$(git_blob_sha256 "$repo_rel")"
+    else
+      source_kind="generated"
+      sha="-"
+    fi
+
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$local_rel" "$suite" "$status" "$rc" "$san" "$source_kind" "$sha" "$rationale"
+  done < <(list_corpus)
+}
+
+if [ "$MODE" = "generate" ]; then
+  {
+    write_header
+    emit_rows
+  } > "$MANIFEST.new"
+  mv "$MANIFEST.new" "$MANIFEST"
+  rows=$(grep -cv '^#' "$MANIFEST")
+  echo "[OK] wrote $MANIFEST ($rows profiles)"
+  exit 0
+fi
+
+# ---- check mode ----
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "[FAIL] manifest not found: $MANIFEST" >&2
+  exit 1
+fi
+
+# Measure the corpus into a temp table first, then let awk join it against the
+# manifest. The lookup deliberately lives in awk rather than in a bash associative
+# array: macOS still ships bash 3.2, where "declare -A" is a syntax error, and
+# nothing else under .github/scripts requires bash 4.
+measured="$(mktemp)"
+trap 'rm -f "$tmp_log" "$measured"' EXIT
+
+list_corpus | while IFS= read -r f; do
+  rel="${f#"$TESTING_DIR"/}"
+
+  timeout -k 5s 120s iccDumpProfile -v "$dump_verbosity" "$f" > "$tmp_log" 2>&1
+  rc=$?
+
+  # Recomputed here rather than trusted from the manifest, so a tracked fixture
+  # edited under a stale baseline is caught rather than confirmed.
+  if [ -n "$REPO_ROOT" ] && git -C "$REPO_ROOT" ls-files --error-unmatch "Testing/$rel" >/dev/null 2>&1; then
+    sha="$(git_blob_sha256 "Testing/$rel")"
+  else
+    sha="-"
+  fi
+
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    "$rel" "$(classify_status "$tmp_log")" "$rc" "$(classify_sanitizer "$tmp_log")" "$sha"
+done > "$measured"
+
+awk -F'\t' '
+  # Pass 1: the manifest.
+  FNR == NR {
+    if ($0 ~ /^#/ || $1 == "") next
+    m_suite[$1]  = $2
+    m_status[$1] = $3
+    m_exit[$1]   = $4
+    m_san[$1]    = $5
+    m_source[$1] = $6
+    m_sha[$1]    = $7
+    rows++
+    next
+  }
+
+  # Pass 2: what the corpus actually did.
+  {
+    path = $1; status = $2; rc = $3; san = $4; sha = $5
+    total++
+
+    if (!(path in m_status)) {
+      unlisted++
+      printf "  [UNLISTED] %s -- present in the corpus but absent from the manifest\n", path
+      next
+    }
+    seen[path] = 1
+
+    row_fail = 0
+    if (status != m_status[path]) {
+      printf "  [STATUS] %s -- expected %s, got %s (suite %s)\n", path, m_status[path], status, m_suite[path]
+      row_fail = 1
+    }
+    if (rc != m_exit[path]) {
+      printf "  [EXIT] %s -- expected exit %s, got %s\n", path, m_exit[path], rc
+      row_fail = 1
+    }
+    # A sanitizer finding fails regardless of suite. A negative fixture is expected
+    # to be rejected cleanly, not to trip the sanitizer on the way.
+    if (san != m_san[path]) {
+      printf "  [SANITIZER] %s -- expected %s, got %s\n", path, m_san[path], san
+      row_fail = 1
+    }
+    # Only tracked rows carry a digest; a mismatch means the fixture changed under a
+    # baseline that still claims to describe it.
+    if (m_source[path] == "tracked" && m_sha[path] != "-" && sha != "-" && sha != m_sha[path]) {
+      printf "  [SHA256] %s -- tracked fixture changed; manifest baseline is stale\n", path
+      row_fail = 1
+    }
+
+    if (row_fail) fail++; else ok++
+  }
+
+  END {
+    # A manifest row whose profile is gone is as much a drift signal as a new
+    # profile that nothing describes.
+    for (path in m_status) {
+      if (!(path in seen)) {
+        missing++
+        printf "  [MISSING] %s -- listed in the manifest but not present in the corpus\n", path
+      }
+    }
+
+    printf "\n"
+    printf "qa-profile-manifest: %d profiles, %d matched, %d mismatched, %d unlisted, %d missing (%d manifest rows)\n",
+           total, ok, fail, unlisted, missing, rows
+
+    if (total == 0) {
+      print "[FAIL] no profiles found - was CreateAllProfiles.sh run?" > "/dev/stderr"
+      exit 1
+    }
+    if (fail > 0 || unlisted > 0 || missing > 0) {
+      print "[FAIL] corpus validation verdicts do not match the manifest" > "/dev/stderr"
+      print "       If this is an intended change, re-baseline with:" > "/dev/stderr"
+      print "       .github/scripts/iccdev-qa-profile-manifest.sh generate" > "/dev/stderr"
+      exit 1
+    }
+    print "[OK] every corpus profile matches its manifest verdict"
+  }
+' "$MANIFEST" "$measured"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3537,6 +3537,30 @@ set_tests_properties(iccdev.legacy-run-tests PROPERTIES
   FIXTURES_REQUIRED iccdev_profiles
 )
 
+# #1809: the corpus mixes conformant examples, profiles carrying a baselined
+# warning, and fixtures that are malformed on purpose. A sweep that only asks
+# whether iccDumpProfile exited non-zero cannot tell a deliberate rejection from a
+# regression, so the 78 negative fixtures either read as unexplained failures or,
+# if the sweep tolerates them, mask a conformant profile that has newly turned
+# critical. Testing/qa-profile-manifest.tsv records the expected verdict per
+# profile and this test enforces it. It runs after iccdev.create-profiles because
+# 133 of the 213 profiles do not exist until that fixture generates them.
+# The manifest is expressed in terms of what iccDumpProfile -v reports, so the test
+# is only meaningful where that tool was built.
+if(TARGET iccDumpProfile)
+  iccdev_add_script_test(
+    iccdev.qa-profile-manifest
+    300
+    "iccdev;qa;manifest;profiles;validation;issue-1809;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-qa-profile-manifest.sh"
+    check
+  )
+  set_tests_properties(iccdev.qa-profile-manifest PROPERTIES
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+endif()
+
 if(ICCDEV_HAS_JSON_RUNTIME_CONFIG_TOOLS AND ICCDEV_HAS_JSON_TOOLS)
   iccdev_add_script_test(
     iccdev.tool-coverage

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1976,6 +1976,50 @@ function(iccdev_add_fileio_seek_tell_test)
   endif()
 endfunction()
 
+# Guards the strict-aliasing fix in CIccIO::Write16/Write32/Write64 (#1948).
+# Those writers used to load the caller's buffer through the wide integer type,
+# which is undefined behaviour when the buffer holds floats -- as it does on
+# every WriteFloat32Float() call. Under -flto (ENABLE_LTO defaults to ON) clang
+# at -O3 dropped the caller's store, so segmented-curve breakpoints reached the
+# file as 0.0 and the resulting curve sets could not be applied. The test drives
+# CIccSegmentedCurve::Write and inspects the emitted bytes. Core IccProfLib
+# only, so no extra include dirs are needed.
+function(iccdev_add_iccio_write_float_aliasing_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccIoWriteFloatAliasingTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/iccio-write-float-aliasing.cpp"
+  )
+  target_link_libraries(iccIoWriteFloatAliasingTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccIoWriteFloatAliasingTest)
+
+  add_test(
+    NAME iccdev.iccio-write-float-aliasing
+    COMMAND
+      "$<TARGET_FILE:iccIoWriteFloatAliasingTest>"
+  )
+  set_tests_properties(iccdev.iccio-write-float-aliasing PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;fileio;curves;issue-1948;regression"
+  )
+  if(WIN32)
+    set(_iccio_aliasing_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccIoWriteFloatAliasingTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _iccio_aliasing_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.iccio-write-float-aliasing PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_iccio_aliasing_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_profile_write_failure_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -3191,6 +3235,7 @@ if(WIN32)
   iccdev_add_fileio_getlength_position_test()
   iccdev_add_profile_write_failure_test()
   iccdev_add_fileio_seek_tell_test()
+  iccdev_add_iccio_write_float_aliasing_test()
   iccdev_add_tagdata_zlib_roundtrip_test()
   iccdev_add_ziputf8_settext_contract_test()
   iccdev_add_compression_describe_labels_test()
@@ -3440,6 +3485,7 @@ iccdev_add_embedio_read8_bounds_test()
 iccdev_add_fileio_getlength_position_test()
 iccdev_add_profile_write_failure_test()
 iccdev_add_fileio_seek_tell_test()
+iccdev_add_iccio_write_float_aliasing_test()
 iccdev_add_tagdata_zlib_roundtrip_test()
 iccdev_add_ziputf8_settext_contract_test()
 iccdev_add_compression_describe_labels_test()

--- a/IccProfLib/IccIO.cpp
+++ b/IccProfLib/IccIO.cpp
@@ -222,16 +222,28 @@ size_t CIccIO::Write16(void *pBuf16, size_t nNum)
 #ifndef ICC_BYTE_ORDER_LITTLE_ENDIAN
   return Write8(pBuf16, nNum<<1)>>1;
 #else
-  icUInt16Number *ptr = (icUInt16Number*)pBuf16;
-  icUInt16Number tmp;
+  // Walk the caller's buffer as icUInt8Number and reorder the bytes into a
+  // scratch buffer, rather than loading it as an icUInt16Number and swapping
+  // the value. Callers hand these writers float buffers as well as integer
+  // ones -- WriteFloat32Float forwards straight into Write32 when icFloatNumber
+  // and icFloat32Number are the same width -- and reading a float through a
+  // wide integer lvalue is undefined (#1948). unsigned char may alias any
+  // object, so this form is well defined for every caller. It also mirrors
+  // icSwab16Array/icSwab32Array in IccUtil.h, which the read path has always
+  // used and which is why readers were never affected.
+  //
+  // The bytes are shuffled directly instead of via memcpy because memcpy is
+  // intercepted under ASAN: a call per element measurably slowed the sanitizer
+  // lanes, where these writers carry every CLUT a profile contains.
+  const icUInt8Number *ptr = (const icUInt8Number*)pBuf16;
+  icUInt8Number tmp[2];
   size_t i;
 
   for (i=0; i<nNum; i++) {
-    tmp = *ptr;
-    icSwab16(tmp);
-    if (Write8(&tmp, 2)!=2)
+    tmp[0] = ptr[1]; tmp[1] = ptr[0];
+    if (Write8(tmp, 2)!=2)
       break;
-    ptr++;
+    ptr += 2;
   }
 
   return i;
@@ -260,16 +272,19 @@ size_t CIccIO::Write32(void *pBuf32, size_t nNum)
 #ifndef ICC_BYTE_ORDER_LITTLE_ENDIAN
   return Write8(pBuf32, nNum<<2)>>2;
 #else
-  icUInt32Number *ptr = (icUInt32Number*)pBuf32;
-  icUInt32Number tmp;
+  // See the note in Write16: the buffer is walked as unsigned char because
+  // WriteFloat32Float routes float data through here, and a wide-integer load
+  // of a float object is undefined (#1948). This is the writer that flattened
+  // segmented-curve breakpoints to 0.0 under clang -O3 with LTO.
+  const icUInt8Number *ptr = (const icUInt8Number*)pBuf32;
+  icUInt8Number tmp[4];
   size_t i;
 
   for (i=0; i<nNum; i++) {
-    tmp = *ptr;
-    icSwab32(tmp);
-    if (Write8(&tmp, 4)!=4)
+    tmp[0] = ptr[3]; tmp[1] = ptr[2]; tmp[2] = ptr[1]; tmp[3] = ptr[0];
+    if (Write8(tmp, 4)!=4)
       break;
-    ptr++;
+    ptr += 4;
   }
 
   return i;
@@ -298,16 +313,19 @@ size_t CIccIO::Write64(void *pBuf64, size_t nNum)
 #ifndef ICC_BYTE_ORDER_LITTLE_ENDIAN
   return Write8(pBuf64, nNum<<3)>>3;
 #else
-  icUInt64Number *ptr = (icUInt64Number*)pBuf64;
-  icUInt64Number tmp;
+  // See the note in Write16. Kept in the same form as its 16- and 32-bit
+  // siblings: icFloatNumber is configurable, so a build where it is 64 bits
+  // wide reaches this writer with float data by the same route.
+  const icUInt8Number *ptr = (const icUInt8Number*)pBuf64;
+  icUInt8Number tmp[8];
   size_t i;
 
   for (i=0; i<nNum; i++) {
-    tmp = *ptr;
-    icSwab64(tmp);
-    if (Write8(&tmp, 8)!=8)
+    tmp[0] = ptr[7]; tmp[1] = ptr[6]; tmp[2] = ptr[5]; tmp[3] = ptr[4];
+    tmp[4] = ptr[3]; tmp[5] = ptr[2]; tmp[6] = ptr[1]; tmp[7] = ptr[0];
+    if (Write8(tmp, 8)!=8)
       break;
-    ptr++;
+    ptr += 8;
   }
 
   return i;

--- a/Testing/Readme.md
+++ b/Testing/Readme.md
@@ -66,3 +66,43 @@ fixtures during `iccFromXml` XML-to-ICC round-trip testing.
 Use this split when interpreting CI output: the generated corpus includes both
 spec-valid examples and negative regression profiles that intentionally exercise
 ICC/iccMAX validation failures.
+
+## QA Profile Manifest
+
+`expected-invalid-fromxml.tsv` above covers the XML-to-ICC direction.
+`qa-profile-manifest.tsv` covers the other half: the validation verdict each
+profile in the corpus is expected to produce when `iccDumpProfile -v` reads it.
+
+Every profile is assigned to one of three suites, and the suite follows from the
+verdict rather than from a hand-adjudicated list:
+
+| suite | expected status | rule |
+|---|---|---|
+| `positive` | `valid` | must validate clean; any new diagnostic is a regression |
+| `compatibility` | `warning` | a known diagnostic is baselined; escalation beyond it fails |
+| `negative` | `critical` | rejection is the expected result; acceptance is a failure |
+
+A sanitizer finding or fatal signal fails every suite, negatives included: a
+malformed fixture is meant to be *rejected*, not to crash the validator.
+
+`sha256` is populated only for the profiles git tracks. The generated corpus
+cannot carry a stable digest because nearly every source XML sets
+`<CreationDateTime>now</CreationDateTime>`, which resolves through `localtime_r`
+at conversion time and feeds the recomputed profile ID — two conversions a second
+apart differ, and two machines in different time zones differ as well. For those
+rows `expected_status` and `expected_exit` carry the contract instead.
+
+The manifest also records `expected_status` and `expected_exit` as independent
+fields rather than deriving one from the other, because `iccDumpProfile` maps
+`noncompliant` to exit 0: a harness reading `$?` and a harness parsing the report
+do not see the same verdict.
+
+The CTest `iccdev.qa-profile-manifest` enforces the manifest. To re-baseline it
+deliberately, after a change that is meant to move verdicts:
+
+```sh
+.github/scripts/iccdev-qa-profile-manifest.sh generate
+```
+
+Review the resulting diff — it is the list of profiles whose validation outcome
+changed.

--- a/Testing/qa-profile-manifest.tsv
+++ b/Testing/qa-profile-manifest.tsv
@@ -1,0 +1,258 @@
+# Testing/qa-profile-manifest.tsv - expected validation verdict per corpus profile (#1809)
+#
+# Regenerate with:  .github/scripts/iccdev-qa-profile-manifest.sh generate
+# Enforced by CTest: iccdev.qa-profile-manifest
+#
+# Columns (tab separated):
+#   path                repository path, relative to Testing/
+#   suite               positive | compatibility | negative
+#   expected_status     valid | warning | noncompliant | critical
+#   expected_exit       decimal exit code from iccDumpProfile -v
+#   expected_sanitizer  none  (a sanitizer finding fails every suite, negatives included)
+#   source              tracked | generated
+#   sha256              digest of the tracked git blob, or - when generated
+#   rationale           why this row reads the way it does
+#
+# Suite policy:
+#   positive       must validate clean; any new diagnostic is a regression
+#   compatibility  a known diagnostic is baselined; escalation beyond it fails
+#   negative       rejection is the expected result; acceptance is a failure
+#
+# iccDumpProfile status-to-exit mapping (Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp).
+# Note that the text verdict and the exit code deliberately disagree for one status,
+# so a harness reading $? and a harness reading the report do not see the same thing:
+#   valid         "Profile is valid"                            exit 0
+#   warning       "Profile has warning(s)"                      exit 0
+#   noncompliant  "Profile violates ICC specification"          exit 0    <-- asymmetry
+#   critical      "Profile has Critical Error(s) ..."           exit 255
+#   unknown       "Profile has unknown status!"                 exit 254
+# The manifest therefore records expected_status and expected_exit as independent
+# fields rather than deriving one from the other. No profile in the corpus currently
+# validates as overall noncompliant, so no row exercises that pairing today; the
+# mapping is recorded here so the contract is explicit if one appears.
+#
+# sha256 is populated only for git-tracked profiles. The generated corpus resolves
+# <CreationDateTime>now</CreationDateTime> through localtime_r at conversion time and
+# recomputes the profile ID from it, so its bytes are neither clock- nor timezone-stable.
+#
+# Scope: this manifest covers Testing/ only. The repository also tracks 24 profiles
+# under .github/ci/regression/ and .github/ci/test-data/ - deliberately malformed PoC
+# and fuzz fixtures - which are deliberately NOT listed here. Each is already the
+# input to a dedicated regression test that asserts a specific behaviour, and those
+# assertions are narrower than a whole-profile validation verdict. Extending the
+# manifest to cover them would be a separate change.
+#
+# path	suite	expected_status	expected_exit	expected_sanitizer	source	sha256	rationale
+ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc	compatibility	warning	0	none	tracked	317a85b01c29550c5289e505079a549c12aaf92cfebc80d04b6626f717675fce	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+CMYK-3DLUTs/CMYK-3DLUTs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+CMYK-3DLUTs/CMYK-3DLUTs2.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Calc/CameraModel.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Calc/ElevenChanKubelkaMunk.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Calc/RGBWProjector.icc	compatibility	warning	0	none	generated	-	baselined: sampled curve has a range of zero
+Calc/argbCalc.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Calc/srgbCalc++Test.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Calc/srgbCalcTest.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+CalcTest/calcCheckInit.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+CalcTest/calcExercizeOps.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+CalcTest/calcOverMem_tget.icc	negative	critical	255	none	tracked	c173bcf5237b7233a62ff860d4eef07a62cc71766a65f45ce618a28abccd8274	negative fixture: illegal temporary channel access must be rejected
+CalcTest/calcOverMem_tput.icc	negative	critical	255	none	tracked	910a30b6e0f3141356855816b6ad01c384f058ba5f3cbeaccf48612e3e8ed51f	negative fixture: illegal temporary channel access must be rejected
+CalcTest/calcOverMem_tsav.icc	negative	critical	255	none	tracked	1faaf2d2d6883587987d090f087bfb3d150b714586d4b8f5af6a380336734a54	negative fixture: illegal temporary channel access must be rejected
+CalcTest/calcUnderStack_abs.icc	negative	critical	255	none	tracked	55491c621d748b06a170a7cf957c6abca6f2f3f4daf64d3eb5f882e3a9cf53c5	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_acos.icc	negative	critical	255	none	tracked	c2a4088f5c8bb2c9917e8aa6b2f2b02dc10a7018f0ca28fe05fbb298cc832ecb	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_add.icc	negative	critical	255	none	tracked	b834ca6a6c3eacc71c7ad719e820679725e14e6385dbba88845dabe15bbdf0e7	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_and.icc	negative	critical	255	none	tracked	001550770824b27ccae6c62128275b821943699225ae4bdf76ea8fc7ffb2b22d	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_asin.icc	negative	critical	255	none	tracked	75fc42038663df61ff0c4af64063b5e2235a70d8b3707bab51e24a34983f76be	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_atan.icc	negative	critical	255	none	tracked	dc16f0cf6f5970813e4a16583e9f1bc83208595f1b045d005be40906fda412c2	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_atn2.icc	negative	critical	255	none	tracked	6d112c17ce211eb0ae7f86ef79031f5ec44cefc209326422258f6b6d5c165280	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_calc.icc	negative	critical	255	none	tracked	63a834309fc26e9866a3c66d1eed3b8fe5252ee755d8cfb7adb76524d288051e	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_cb.icc	negative	critical	255	none	tracked	74916825af46fedee5e83f112cfb8f70150bff4cac2d8c5a1a0d162e0a41e49f	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_cbrt.icc	negative	critical	255	none	tracked	4c9728673c2376a763bfcfff5065c7e9b535742ebe4e44b73a30fc896b7f1745	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_ceil.icc	negative	critical	255	none	tracked	23d07ab318dbc5dc9c2f88c21ce4cd1313581c3d92c43cb477f85d3bca25b8e2	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_clut.icc	negative	critical	255	none	tracked	ef04de439f4d2ea473455d2c6599671e354e43090c127403cc581433efe6ab77	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_copy.icc	negative	critical	255	none	tracked	af14c27221bb58482c3a215b4762f5a9b780a5e9f30c749d12a7a767f47ea394	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_cos.icc	negative	critical	255	none	tracked	c0688a061c6cdd9ea54c0b63168b441ca7eb79567c5188c564a8f3c928b17e02	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_ctop.icc	negative	critical	255	none	tracked	75956f56252e1c51b8ad9f42e25f01bbfc108bbac96f4e7239dcb6c6e4e59d75	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_curv.icc	negative	critical	255	none	tracked	f78e4ba63f66975e9a3007fcf702720ff3e58bfaad96b0a3f5f1d73d2d9f441b	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_div.icc	negative	critical	255	none	tracked	48c4c2a0ad067a98f74d19f0a926a58b34eb39eac9743e759a6203cd4f26362e	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_elem.icc	negative	critical	255	none	tracked	97e4a9037b4051a08c6f82c7b3c51c673cda7084be4ef43d4acafce2a8d74027	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_eq.icc	negative	critical	255	none	tracked	9d8db6ddf955488a8f0ed1229ebccc9fddef98819f9c823ea01a5ea10b060d09	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_exp.icc	negative	critical	255	none	tracked	9f8513df40bf79f521ab91261d058722de6779db761362b995c4bc015849a69d	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_fJab.icc	negative	critical	255	none	tracked	e85ff92894cd45fc4c1c7cc92c786a1d1ce12e83348af5b2f76b7729ba8c305b	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_fLab.icc	negative	critical	255	none	tracked	f9d701306787e57d6d97e54f0950526632247403a30c88ea0c345780abc2a2ca	negative fixture: invalid calculator operation must be rejected
+CalcTest/calcUnderStack_flip.icc	negative	critical	255	none	tracked	be5ae0b734bbc862f0c928186d5e6e5d566efaa32ca8bdd88858ab06c933ae4c	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_flor.icc	negative	critical	255	none	tracked	914d2e7c9a42fc8a4add67b2d9635f99166e8de060e334eae0fa8ddae6f74c88	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_gama.icc	negative	critical	255	none	tracked	4157041c786e98bb4d9f960ec37c705bbc65d4f42754780151cb8243a2ab4010	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_ge.icc	negative	critical	255	none	tracked	220cfc7f4ffe589ba0e11fac673ec7b34ad23948b679401482444e505b0ca861	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_gt.icc	negative	critical	255	none	tracked	19a9ea2cfa4e79ea1c1a1b9d41ea38e873f4bd160ad1b5443ee400de5eacffbe	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_if.icc	negative	critical	255	none	tracked	d494109fa9df23ad820d177711321c6bed2dc9f72e338924ffd0b66fef9a5811	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_le.icc	negative	critical	255	none	tracked	917f8d74598b20cb98c41fe90d87e6703b4133f3708a058749c8e38bcd812fe5	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_ln.icc	negative	critical	255	none	tracked	546fe11cd54fa3fea3b5cf1edf9202e1bc6bd4ee8c9cb31f94ed266bbd6aecc7	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_log.icc	negative	critical	255	none	tracked	72c1239f98ac2c2f6a63e9abbbae322dc3ba90a53014395ee05e8008f44b10bd	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_lt.icc	negative	critical	255	none	tracked	4b3d61e7dd57ae56a6ce0ed3e01efac3c80d7c50c2a261e80e838bcb0ed6f828	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_max.icc	negative	critical	255	none	tracked	1a231b367f33878cb1b972b72ba50b7c8f020371136682a7c620f0dec2d1f338	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_min.icc	negative	critical	255	none	tracked	61e5bc90b18322db1611d6650d8f4b2dc68ee80269f879dab695779394c9ab67	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_mod.icc	negative	critical	255	none	tracked	02b1290612894a7dbf75b4d1ea29f3b597784f263ffaba9042c5494c38d156b2	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_mtx.icc	negative	critical	255	none	tracked	1d13a8a7e0518e2a7eabc54a6211e3cae96666641781a4234d1ef28f38b733b9	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_mul.icc	negative	critical	255	none	tracked	faab71dfb3fb303124baafde99a77afe87ad6581ff0f692e9a50ea50120f800f	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_near.icc	negative	critical	255	none	tracked	78dc625fccbeab44cbffd99c74e459b839e9449df3ca08584bc777e42758c2bd	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_neg.icc	negative	critical	255	none	tracked	0c362fa351473f147ffc79dfd1b4066ab39b60f7d7ef0aae8572c9e42cb5fb5b	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_not.icc	negative	critical	255	none	tracked	2ff1814404fb970dcef91477c650af561cfd5c5fd827c8b6e84d4b64b088cf45	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_or.icc	negative	critical	255	none	tracked	d0284f3855f2a3bcd4b30269a8ed490adb1a4b79e9921ead04100d9f1875afde	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_out.icc	negative	critical	255	none	tracked	b21524c7ad300f5b4de29df1f2fc4850f5609b15b23fce452447f8bf52afa0d8	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_pop.icc	negative	critical	255	none	tracked	68dc10f1cc27cec14a9cd6850a23a383f9e807b422b2870a607af3f4ce8603ef	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_posd.icc	negative	critical	255	none	tracked	562789d54d942bd4462d0dedf516615c2bbe9f514cfb1fc7449e89a8b004a8fa	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_pow.icc	negative	critical	255	none	tracked	0bbeb8094a52b0501cd668642652baf0a5afa5bc185ca8b7e90db83280909906	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_prod.icc	negative	critical	255	none	tracked	1efe436d22abcfe5991294c424dbf2e6e6a5bae00af27708788ed95ba69c2a69	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_ptoc.icc	negative	critical	255	none	tracked	c597d1d624f8542fa48106e172862211cca1e1df93eb755abcc9ac1989ecef63	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_rnum.icc	negative	critical	255	none	tracked	fb7c4771203de70c151e0c64a00e92b20ca901fedc670f8bcb1a20a61567cf59	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_rond.icc	negative	critical	255	none	tracked	9bb57fe98d445bdf4f1be1b6d7681ae75ae2fa03955f00e31205bd6a0e701a3b	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_rotl.icc	negative	critical	255	none	tracked	23bef4fa6674b2bda6c0890054961cd7ec28d7492adef25e33d97c3e4e7c0b36	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_rotr.icc	negative	critical	255	none	tracked	37b94e0dad136f57f42aee409aa167a28f8e5593f6dc4b27f716c84367577e43	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sadd.icc	negative	critical	255	none	tracked	ba93db85e082d774279db19b6bd89ecdf5f02d22de75a3c62fbb076bb131d91f	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sdiv.icc	negative	critical	255	none	tracked	c9ded33e1d96de30d2971302d0d058de723a8f78e175bb39b9d294b4517d60ed	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sel.icc	negative	critical	255	none	tracked	01d48b3d346734ed887079dfe244f6eab164ccfb533417e3a9536cf5d54b807a	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sign.icc	negative	critical	255	none	tracked	72dc8c6140280c00c8451deb09e7539055aa67bf6bc44dcddea7013d3545e276	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sin.icc	negative	critical	255	none	tracked	1e764439291ea2330d7a13350c639ce8aa568267bc640345bec22fbba11f92f7	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_smul.icc	negative	critical	255	none	tracked	c65e8a9c8104af9334de6d4f8ef3ff46157ec8482737b311906a8ab995f5eb4c	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_solv.icc	negative	critical	255	none	tracked	3fcd34a23d034b46d290411a2720c356587040d87615fffb8fe8e18a96e283ab	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sq.icc	negative	critical	255	none	tracked	c2cccd7583bd8fce546c8b85271dd83a299e58afa3786dd52ee124b81084e04e	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sqrt.icc	negative	critical	255	none	tracked	b135b8db39df174ce3ca3fe14b8f05e1510adcbe4e4d24f7dbc3131c91a6830d	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_ssub.icc	negative	critical	255	none	tracked	747b6a93f678140b2599c1f855bcea7ef4381361345339bcff92c77b1e751f0c	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sub.icc	negative	critical	255	none	tracked	d2948d5113c445f0c964852721238ef926b5fc607c4e0d55884d68e3832fde0b	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_sum.icc	negative	critical	255	none	tracked	377aa0136787b69899c939c50c98849f419d1d948ae8f694ba923c44abc98e99	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_tJab.icc	negative	critical	255	none	tracked	83ccfc547011aa6a46e88a5f01161b276f9a59d042cf15fa06a653642e825f46	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_tLab.icc	negative	critical	255	none	tracked	ff4c36c885fe62ee146f4989b620e222d0a8d46e40b06b3b2b378d57ef138a27	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_tint.icc	negative	critical	255	none	tracked	e8dcc33ccea64916c50b3959dfd6eeefd17b57ba5334a6bd5e456f77097beca8	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_tput.icc	negative	critical	255	none	tracked	a830629daf1ca891e53fce7d1652fd852bdc50fbf40fde0125ba4059bd02379f	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_tran.icc	negative	critical	255	none	tracked	f183be035cc400bd3a3cbb8b6def27e57d314384935813f512dd08c0e4362186	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_trnc.icc	negative	critical	255	none	tracked	486a484f65e09eb3784385d77b5c580200fbff73799a5415843a28392ee3b184	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_tsav.icc	negative	critical	255	none	tracked	d6d0171e887a7f514b302d54948cbbc75cfaf1e2c844846456e7ac1082f4cf91	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_vand.icc	negative	critical	255	none	tracked	c80514c393719ad855db9d19e3260eb392cbd3221ccd6a4c70fe13b78eed43f1	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_vmax.icc	negative	critical	255	none	tracked	b6470cf53f981bb6830150c05ed49bfa1838eda66edc00f3ef1d5d3fd410b0e5	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_vmin.icc	negative	critical	255	none	tracked	cd1f4f7e1af19ab0025a2afccd460626ce7616236177fc7bc60baf0110c2faae	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/calcUnderStack_vor.icc	negative	critical	255	none	tracked	154a8645e48e3cef1c72801488013b3d50dd252a3fb392f8c6f4685780d21628	negative fixture: calculator evaluation stack underflow must be rejected
+CalcTest/uio-CIccCalculatorFunc-CheckUnderflowOverflow-IccMpeCalc_cpp-Line4238.icc	negative	critical	255	none	tracked	e482d1defb841192735881d80b4b7ca0540f5b859164153f0be2080ce6167800	negative fixture: fuzz-derived malformed profile must be rejected
+Display/GrayGSDF.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Display/LCDDisplay.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Display/LaserProjector.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Display/Rec2020rgbColorimetric.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Display/Rec2020rgbSpectral.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Display/Rec2100HlgFull.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Display/Rec2100HlgNarrow.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Display/RgbGSDF.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Display/sRGB_D65_MAT-300lx.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Display/sRGB_D65_MAT-500lx.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Display/sRGB_D65_MAT.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Display/sRGB_D65_colorimetric.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Encoding/ISO22028-Encoded-bg-sRGB.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Encoding/ISO22028-Encoded-sRGB.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Encoding/sRgbEncoding.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Encoding/sRgbEncodingOverrides.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+ICS/Lab_float-D65_2deg-Part1.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+ICS/Lab_float-IllumA_2deg-Part2.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+ICS/Lab_int-D65_2deg-Part1.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+ICS/Lab_int-IllumA_2deg-Part2.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+ICS/Rec2100HlgFull-Part1.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+ICS/Rec2100HlgFull-Part2.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+ICS/Rec2100HlgFull-Part3.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+ICS/Spec400_10_700-D50_2deg-Part1.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+ICS/Spec400_10_700-D93_2deg-Part2.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+ICS/XYZ_float-D65_2deg-Part1.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+ICS/XYZ_float-IllumA_2deg-Part2.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+ICS/XYZ_int-D65_2deg-Part1.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+ICS/XYZ_int-IllumA_2deg-Part2.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Named/FluorescentNamedColor.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Named/NamedColor.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Named/NamedColorV4.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+Named/SparseMatrixNamedColor.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+Overprint/17ChanPart1.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Lab_float-D50_2deg.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Lab_float-D93_2deg-MAT.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+PCC/Lab_int-D50_2deg.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Lab_int-D65_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Lab_int-IllumA_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec380_10_730-D50_2deg.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec380_10_730-D65_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec380_1_780-D50_2deg.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec380_5_780-D50_2deg.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-B_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-B_2deg-CAM.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-B_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-B_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D50_10deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D50_10deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D50_20yo2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D50_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D50_2deg.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D50_40yo2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D50_60yo2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D50_80yo2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D65_10deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D65_10deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D65_20yo2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D65_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D65_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D65_40yo2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D65_60yo2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D65_80yo2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D93_10deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D93_10deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D93_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-D93_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DB_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DB_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DB_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DG_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DG_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DG_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DR_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DR_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-DR_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-F11_2deg-CAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-F11_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-G_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-G_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-G_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-IllumA_10deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-IllumA_10deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-IllumA_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-IllumA_2deg-CAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-IllumA_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-N_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-N_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-N_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-R1_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-R1_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-R1_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-R2_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-R2_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-R2_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-Y_2deg-Abs.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-Y_2deg-CAT02.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/Spec400_10_700-Y_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/XYZ_float-D50_2deg.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/XYZ_float-D65_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/XYZ_int-D50_2deg.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/XYZ_int-D65_2deg-MAT-Lvl2.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+PCC/XYZ_int-D65_2deg-MAT.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+SpecRef/RefDecC.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+SpecRef/RefDecH.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+SpecRef/RefIncW.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+SpecRef/SixChanCameraRef.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+SpecRef/SixChanInputRef.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+SpecRef/argbRef.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+SpecRef/srgbRef.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
+V2/v2CmykLut16.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+V2/v2RgbLut8.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+V2/v2RgbMatrixTRC.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/17ChanWithSpots-MVIS.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/18ChanWithSpots-MVIS.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/6ChanSelect-MID.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/Flexo-CMYKOGP/4ChanSelect-MID.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/Flexo-CMYKOGP/7ChanSelect-MID.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/Flexo-CMYKOGP/CGYK-SelectMID.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/Flexo-CMYKOGP/CMPK-SelectMID.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/Flexo-CMYKOGP/CMYK-SelectMID.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/Flexo-CMYKOGP/CMYKOGP-MVIS-Smooth.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+mcs/Flexo-CMYKOGP/OMYK-SelectMID.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+sRGB_v4_ICC_preference.icc	positive	valid	0	none	tracked	83174717332326ddc198d9df188a4daec27b8979ba152cebbfc470c793d0bb11	conformant example profile; validates clean

--- a/Testing/qa-profile-manifest.tsv
+++ b/Testing/qa-profile-manifest.tsv
@@ -48,7 +48,7 @@ CMYK-3DLUTs/CMYK-3DLUTs.icc	positive	valid	0	none	generated	-	conformant example
 CMYK-3DLUTs/CMYK-3DLUTs2.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
 Calc/CameraModel.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
 Calc/ElevenChanKubelkaMunk.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
-Calc/RGBWProjector.icc	compatibility	warning	0	none	generated	-	baselined: sampled curve has a range of zero
+Calc/RGBWProjector.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
 Calc/argbCalc.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
 Calc/srgbCalc++Test.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
 Calc/srgbCalcTest.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean


### PR DESCRIPTION
Fixes #1946.
Fixes #1948.

#1809 carried two halves: the empty-processing-element policy, which landed as #1887, and
the QA manifest, which @xsscx authorized on 2026-07-28 in
https://github.com/InternationalColorConsortium/iccDEV/issues/1809#issuecomment-5107754290
("Go with PoLR paths based on your preference & resolution"), taking both resolutions I
proposed: `sha256` scoped to what git tracks, and `noncompliant` recorded together with
`expected_exit: 0` rather than assuming the two correlate. #1809 closed when #1887 merged,
so the manifest half is filed separately as #1946 and this PR delivers it.

## The problem

The corpus mixes three kinds of profile that a "did `iccDumpProfile` exit non-zero" sweep
cannot tell apart: conformant examples, profiles carrying a known baselined warning, and
fixtures that are malformed on purpose. 78 of the 213 profiles are deliberate negatives.
Without a manifest they either read as unexplained failures, or — if a sweep tolerates
them — they mask a conformant profile that has newly turned critical.

## What the corpus actually does

Measured in a clean worktree, rebased onto `c95a8343`. That matters: a working tree that
has run the suite carries 232 `.icc` under `Testing/` where a clean checkout has 213, so measuring in
place produces the wrong baseline.

| suite | expected status | exit | count |
|---|---|---|---|
| positive | valid | 0 | 108 |
| compatibility | warning | 0 | 27 |
| negative | critical | 255 | 78 |

Suite is derived from the verdict rather than hand-assigned, so the manifest stays
regenerable and nobody adjudicates 213 rows by hand.

## Four things that came out of the measurement

**1. All 27 warnings are #1811.** Every one is the
`spectralViewingConditions` `illuminantXYZ`/`surroundXYZ` "appears to be normalized"
diagnostic. That gives #1811 a measured scope it did not have: fixing it moves all 27
profiles from `warning` to `valid`, leaving zero `compatibility` rows, and is a deliberate
re-baseline of this manifest. Corrected on the issue in
https://github.com/InternationalColorConsortium/iccDEV/issues/1811#issuecomment-5154495751 —
my first census said 27 of 28, with `Calc/RGBWProjector.icc` as an unrelated zero-range
sampled curve. That profile was never a warning; it was the #1948 miscompilation described
below.

**2. No profile validates as overall `noncompliant`.** The asymmetry #1809 asked me to
encode has no live instance. `NonCompliant! -` appears as a per-tag diagnostic line in
quantity, but never as the profile verdict. The status-to-exit mapping is recorded in the
manifest header as the explicit contract, and the header says plainly that no row exercises
that pairing today, rather than implying coverage that does not exist.

**3. `calcUnderStack_fLab.icc` does not report a stack underflow.** It reports
"function has invalid operations" — the operation is rejected before stack depth is ever
assessed — unlike its 73 siblings. Recorded as its own reason so the manifest does not
imply it exercises the same validator path. Flagging as an observation, not a defect claim.

**4. The issue's repro passes `ALL`; it makes no difference here.** I measured both
`iccDumpProfile -v 26 <f>` and `iccDumpProfile --diag -v 26 <f> ALL` across all 213
profiles: identical status line and identical exit code in every case. The test uses the
cheaper form and runs in ~5s.

## sha256 scoping

80 tracked profiles carry a digest; the 133 generated ones carry `-`. 178 of the 191
tracked `Testing` XML fixtures set `<CreationDateTime>now</CreationDateTime>`, which
`icGetDateTimeValue` resolves through `localtime_r` at conversion time and which then feeds
the recomputed profile ID — so those bytes are neither clock- nor timezone-stable.
Re-verified for this PR: two conversions of `Calc/CameraModel.xml` two seconds apart differ.
The digest is read from the git object rather than from disk, so regenerating the corpus in
place cannot silently re-baseline it.

## Scope

Covers `Testing/` only. The 24 profiles tracked under `.github/ci/regression/` and
`.github/ci/test-data/` are deliberately excluded and the manifest header says so: each is
already the input to a dedicated regression test whose assertion is narrower than a
whole-profile verdict. `Testing/hybrid/ICC` and `Testing/hybrid/Results` are excluded
because they are `iccdev.hybrid-pipeline` output rather than corpus —
`Testing/hybrid/.gitignore` declares exactly those two paths as generated, and it is the
only `.gitignore` under `Testing/` that declares `.icc` output. Without that exclusion the
test is ordering-dependent, seeing 213 profiles alone and 232 after the hybrid pipeline has
run.

## Verification

- Clean worktree at `c95a8343`, both toolchains: 0 build warnings and 146/147 `ctest`
  under gcc strict ASAN+UBSan Release (CI's own configuration) and under clang Release with
  LTO. The single failure in both is `spectral-tiff-preview`, which fails because this local
  environment lacks the python `imagecodecs` module - unrelated, and failing before this
  change.
- Re-run under an ASan+UBSan build: 213/213 match, so `expected_sanitizer: none` is
  verified rather than asserted.
- Red-tested five failure modes plus a control: wrong status/exit, a corpus profile
  missing from the manifest, a manifest row whose profile is gone, tracked-fixture digest
  drift, and sanitizer detection. All five fail as intended; the unmodified control passes.
- `generate` is idempotent: regenerating produces a byte-identical manifest.
- The manifest survives a full corpus regeneration, which is the property that makes
  scoping `sha256` workable.
- `shellcheck` clean under CI's own invocation. Avoids `declare -A`: macOS ships bash 3.2
  and nothing else under `.github/scripts` requires bash 4.

---

# The second half: #1948, and why this PR grew

The manifest above was red in CI on exactly one row, and the row was right about my machine
rather than about the corpus. Chasing that produced a real `IccProfLib` defect.

## What it is

`CIccIO::Write16`/`Write32`/`Write64` loaded the caller's buffer through the wide integer
type before byte-swapping it:

```cpp
// IccProfLib/IccIO.cpp, CIccIO::Write32
icUInt32Number *ptr = (icUInt32Number*)pBuf32;
tmp = *ptr;
```

`WriteFloat32Float` forwards straight into `Write32` whenever `icFloatNumber` and
`icFloat32Number` are the same width, which is the normal build. So the object being read is
a `float`, read through an `icUInt32Number` lvalue. Those are not similar types, so the
compiler may assume a store through one is not observable by a load through the other.

`ENABLE_LTO` defaults to `ON`, which puts the store in `CIccSegmentedCurve::Write` and this
load into one optimization scope. clang at `-O3` then drops the store as dead. That function
reuses a single stack slot for every breakpoint, so the slot kept its initial zero and every
breakpoint reached the file as `0.0`.

The read path was never affected: `icSwab32Array` walks the buffer as `icUInt8Number`, which
may alias any object. That asymmetry is why readers agreed across toolchains while writers
did not.

## Why it matters

Not cosmetic. A flattened trailing breakpoint gives the sampled segment an end point equal to
its start point, and `CIccSampledCurveSegment::Begin` (`IccMpeBasic.cpp:1187`) refuses a zero
range — so the curve set cannot be applied at all. Any profile written by an optimized clang
build carries this, including the default macOS toolchain.

gcc is unaffected today, but by the optimizer's choice rather than by the standard.

## Evidence

Same source, same commit, unpatched tree, only the build changed:

| build | trailing breakpoint |
|---|---|
| clang `-O3`, LTO on (project default) | `0x00000000` |
| clang `-O3 -fno-strict-aliasing` | `0x3F800000` |
| clang `-O3` + ASAN/UBSan | `0x3F800000` |
| clang Debug | `0x3F800000` |
| gcc `-O3` | `0x3F800000` |

`-fno-strict-aliasing` alone flipping it at the same `-O3` is the discriminator. Note that
neither ASAN nor UBSan catches this, so a green sanitizer lane is not evidence of absence.

## The fix

The writers now walk the buffer as `unsigned char` and reorder bytes into a small scratch
buffer, matching what `icSwab32Array` has always done on the read side.

The bytes are shuffled directly rather than copied out with `memcpy`. Both forms are well
defined, but `memcpy` is intercepted under ASAN, and a call per element cost about 20% on
`iccdev.issue-1781-applytolink-qa-matrix` — enough to push it past its timeout under parallel
load, since these writers carry every CLUT a profile contains:

| `Write32` form | that test, under ASAN |
|---|---|
| original (undefined) | 26.3s |
| `memcpy` | 31.5s |
| byte shuffle (this PR) | 24.7s |

## Verification

- `.github/ci/regression/iccio-write-float-aliasing.cpp` drives `CIccSegmentedCurve::Write`
  and asserts the emitted breakpoint bytes, then reads them back and confirms the curve still
  begins. Both the store and the load live inside `IccProfLib`, so it reproduces wherever the
  library is miscompiled, independently of how the test translation unit is built.
- Red-tested: on the unfixed tree it fails with exactly
  `second breakpoint wrote 0x00000000, expected 0x3F800000`.
- All 191 tracked `Testing/*.xml` now convert to byte-identical profiles under clang `-O3`
  and gcc `-O3`, modulo the creation date (24-35) and profile ID (84-99) recorded per
  conversion. `hybrid/CMYK-STop_Overprint_Profile` also differs at 2685017-2685083, which is
  the same date/ID pair of an *embedded* profile at offset 2684984, not a divergence.
  `Calc/calcImport.xml`, `Calc/calcVars.xml` and `SpecRef/RefEstimationImport.xml` are not
  standalone-convertible under either toolchain.

## The one manifest row

`Calc/RGBWProjector.icc` moves from `compatibility`/`warning` to `positive`/`valid`. It is
generated from XML at test time, so the baseline had captured this miscompilation as expected
behaviour. Regenerating the manifest instead of fixing the writers would have written my
host's miscompilation into the repository — the row count that had to change was derived from
CI's own `212 matched, 1 mismatched`, not from a wholesale re-baseline.
