### PR TITLE
fix(#1953): advance the destination pointer in the CMTranslateRGBsExt output-stride branch

### DIFF
--- a/Tools/Winnt/IccDEVCmm/IccDEVCmm.cpp
+++ b/Tools/Winnt/IccDEVCmm/IccDEVCmm.cpp
@@ -2086,9 +2086,15 @@ BOOL WINAPI CMTranslateRGBsExt(
             }
             icUInt16Number *bits = (icUInt16Number*)lpDestBits;
 
-            *bits++ = (icUInt8Number)(UnitClip(destPixel[0]) * 255.0 + 0.5);
-            *bits++ = (icUInt8Number)(UnitClip(destPixel[1]) * 255.0 + 0.5);
-            *bits   = (icUInt8Number)(UnitClip(destPixel[2]) * 255.0 + 0.5);
+            // 16-bit samples are full-range: the matching reader above divides
+            // by 65535, BM_16b_GRAY below multiplies by 65535, and so does the
+            // 16-bit output path in CMTranslateColors.  Scaling by 255 through
+            // an icUInt8Number cast wrote an 8-bit value into a 16-bit sample,
+            // so a full-scale channel came back as 255/65535 -- under 0.4% of
+            // the intended level -- and the format did not round-trip (#1953).
+            *bits++ = (icUInt16Number)(UnitClip(destPixel[0]) * 65535.0 + 0.5);
+            *bits++ = (icUInt16Number)(UnitClip(destPixel[1]) * 65535.0 + 0.5);
+            *bits   = (icUInt16Number)(UnitClip(destPixel[2]) * 65535.0 + 0.5);
 
             lpDestBits += 6;
           }
@@ -2101,9 +2107,11 @@ BOOL WINAPI CMTranslateRGBsExt(
           {
             icUInt16Number *bits = (icUInt16Number*)lpDestBits;
 
-            *bits++ = (icUInt8Number)(UnitClip(destPixel[0]) * 255.0 + 0.5);
-            *bits++ = (icUInt8Number)(UnitClip(destPixel[1]) * 255.0 + 0.5);
-            *bits   = (icUInt8Number)(UnitClip(destPixel[2]) * 255.0 + 0.5);
+            // Same full-range 16-bit contract as BM_16b_Lab above; these four
+            // formats shared the 255-through-icUInt8Number quantization (#1953).
+            *bits++ = (icUInt16Number)(UnitClip(destPixel[0]) * 65535.0 + 0.5);
+            *bits++ = (icUInt16Number)(UnitClip(destPixel[1]) * 65535.0 + 0.5);
+            *bits   = (icUInt16Number)(UnitClip(destPixel[2]) * 65535.0 + 0.5);
 
             lpDestBits += 6;
           }
@@ -2156,12 +2164,29 @@ BOOL WINAPI CMTranslateRGBsExt(
       lpSrcBits = lpSrcLine + dwInputStride;
     }
 
+    // Both blocks re-base a walking pointer onto the next row: the inner loop
+    // leaves lpSrcBits/lpDestBits just past the last pixel it touched, and the
+    // row start was saved in lpSrcLine/lpDestLine above.  A zero stride means
+    // "no explicit stride", so the row is DWORD-padded the way Windows packs
+    // bitmap scanlines; a non-zero stride is the caller's own row pitch.
+    //
+    // The output block re-based lpSrcBits rather than lpDestBits, so a caller
+    // supplying dwOutputStride got two wrong results at once.  lpDestBits was
+    // left wherever the inner loop stopped, so rows landed at the pixel pitch
+    // instead of the caller's stride and the padding between rows was never
+    // written.  And lpSrcBits was overwritten with an address inside the
+    // *destination* bitmap, so from row 1 on the input pixels were read back
+    // out of the destination rather than from the source.  Both are silent:
+    // the clobbered pointer stays within the destination allocation for the
+    // usual geometries, so the transform returns TRUE with wrong pixels rather
+    // than faulting.  It has to be lpDestBits here, exactly as the input block
+    // above re-bases lpSrcBits (#1953).
     if (!dwOutputStride) {
       size_t dwAlignedSize = (((lpDestBits - lpDestLine) + 3)>>2)<<2;
       lpDestBits = lpDestLine + dwAlignedSize;
     }
     else {
-      lpSrcBits = lpDestLine + dwOutputStride;
+      lpDestBits = lpDestLine + dwOutputStride;
     }
   }
   return TRUE;

--- a/Tools/Winnt/IccDEVCmm/tests/IccDEVCmmSmoke.cpp
+++ b/Tools/Winnt/IccDEVCmm/tests/IccDEVCmmSmoke.cpp
@@ -20,6 +20,8 @@ typedef DWORD(WINAPI *CMGetInfoFn)(DWORD);
 typedef BOOL(WINAPI *CMIsProfileValidFn)(HPROFILE, LPBOOL);
 typedef HCMTRANSFORM(WINAPI *CMCreateMultiProfileTransformFn)(HPROFILE *, DWORD, PDWORD, DWORD, DWORD);
 typedef BOOL(WINAPI *CMTranslateColorsFn)(HCMTRANSFORM, LPCOLOR, DWORD, COLORTYPE, LPCOLOR, COLORTYPE);
+typedef BOOL(WINAPI *CMTranslateRGBsExtFn)(HCMTRANSFORM, LPVOID, BMFORMAT, DWORD, DWORD, DWORD,
+                                           LPVOID, BMFORMAT, DWORD, LPBMCALLBACKFN, LPARAM);
 typedef BOOL(WINAPI *CMDeleteTransformFn)(HCMTRANSFORM);
 
 struct CmmApi
@@ -29,6 +31,7 @@ struct CmmApi
     CMIsProfileValidFn is_profile_valid;
     CMCreateMultiProfileTransformFn create_multi_profile_transform;
     CMTranslateColorsFn translate_colors;
+    CMTranslateRGBsExtFn translate_rgbs_ext;
     CMDeleteTransformFn delete_transform;
 };
 
@@ -81,12 +84,15 @@ static bool load_cmm(const wchar_t *dll_path, CmmApi &api)
     api.create_multi_profile_transform = reinterpret_cast<CMCreateMultiProfileTransformFn>(
         require_proc(api.module, "CMCreateMultiProfileTransform"));
     api.translate_colors = reinterpret_cast<CMTranslateColorsFn>(require_proc(api.module, "CMTranslateColors"));
+    api.translate_rgbs_ext = reinterpret_cast<CMTranslateRGBsExtFn>(
+        require_proc(api.module, "CMTranslateRGBsExt"));
     api.delete_transform = reinterpret_cast<CMDeleteTransformFn>(require_proc(api.module, "CMDeleteTransform"));
 
     return api.get_info &&
            api.is_profile_valid &&
            api.create_multi_profile_transform &&
            api.translate_colors &&
+           api.translate_rgbs_ext &&
            api.delete_transform;
 }
 
@@ -180,6 +186,113 @@ static bool check_rgb_roundtrip_transform(const CmmApi &api, HPROFILE profile)
     return true;
 }
 
+// Bitmap translation with an explicit destination stride (#1953).
+//
+// CMTranslateRGBs always passes dwOutputStride 0, so only a direct
+// CMTranslateRGBsExt caller reaches the strided row-advance path, and nothing
+// here exercised it.  Every source row carries identical pixels, which makes
+// the two regressions checkable without depending on what the transform does
+// to a colour:
+//
+//   * rows must land on the caller's stride, so the pad bytes between rows
+//     stay at the fill value -- the shipped code advanced the destination by
+//     the pixel pitch instead and wrote over them;
+//   * identical input rows must give identical output rows -- the shipped code
+//     re-based the *source* pointer into the destination bitmap, so rows after
+//     the first were converted from whatever was in the destination;
+//   * a full-scale 16-bit channel must come back full-scale -- the shipped
+//     BM_16b_RGB writer quantized to 255 through an icUInt8Number cast.
+static bool check_rgbs_ext_output_stride(const CmmApi &api, HPROFILE profile)
+{
+    HPROFILE profiles[2] = { profile, profile };
+    DWORD intents[2] = { INTENT_PERCEPTUAL, INTENT_PERCEPTUAL };
+
+    HCMTRANSFORM transform = api.create_multi_profile_transform(profiles, 2, intents, 2, 0);
+    if (!transform) {
+        print_last_error("CMCreateMultiProfileTransform (RGBsExt)");
+        return false;
+    }
+
+    const DWORD width = 2;
+    const DWORD height = 3;
+    // Explicit cast: sizeof makes the expression size_t, and narrowing it to
+    // DWORD implicitly draws C4267 from MSVC.
+    const DWORD row_bytes = static_cast<DWORD>(width * 3 * sizeof(unsigned short));  // BM_16b_RGB
+    const DWORD input_stride = row_bytes;                        // packed source
+    const DWORD pad_bytes = 4;
+    const DWORD output_stride = row_bytes + pad_bytes;           // padded destination
+    const unsigned char fill = 0xAA;
+
+    std::vector<unsigned short> src(width * height * 3, 0xFFFF);
+    std::vector<unsigned char> dest(output_stride * height, fill);
+
+    BOOL ok = api.translate_rgbs_ext(transform,
+                                     src.data(), BM_16b_RGB,
+                                     width, height, input_stride,
+                                     dest.data(), BM_16b_RGB, output_stride,
+                                     NULL, 0);
+    DWORD translate_error = ok ? ERROR_SUCCESS : GetLastError();
+
+    if (!api.delete_transform(transform)) {
+        print_last_error("CMDeleteTransform (RGBsExt)");
+        return false;
+    }
+
+    if (!ok) {
+        SetLastError(translate_error);
+        print_last_error("CMTranslateRGBsExt");
+        return false;
+    }
+
+    bool passed = true;
+
+    for (DWORD row = 0; row < height; row++) {
+        const unsigned char *row_base = dest.data() + static_cast<size_t>(row) * output_stride;
+
+        for (DWORD pad = 0; pad < pad_bytes; pad++) {
+            if (row_base[row_bytes + pad] != fill) {
+                std::printf("[FAIL] Row %lu padding byte %lu was overwritten (0x%02X); "
+                            "destination rows are not honouring dwOutputStride\n",
+                            row, pad, row_base[row_bytes + pad]);
+                passed = false;
+                break;
+            }
+        }
+
+        // Deliberately a loose bound.  The defect quantized to 255 -- 0.4% of
+        // range -- so any threshold well clear of 8-bit separates the two
+        // encodings, and keeping it loose stops this from becoming an
+        // assertion about round-trip colour accuracy.
+        const unsigned short *samples = reinterpret_cast<const unsigned short *>(row_base);
+        for (DWORD sample = 0; sample < width * 3; sample++) {
+            if (samples[sample] < 30000) {
+                std::printf("[FAIL] Row %lu sample %lu is %u; a full-scale 16-bit channel "
+                            "must stay in the 16-bit range (a value near 255 indicates the "
+                            "8-bit quantization)\n",
+                            row, sample, samples[sample]);
+                passed = false;
+                break;
+            }
+        }
+
+        if (row > 0 && std::memcmp(row_base, dest.data(), row_bytes) != 0) {
+            std::printf("[FAIL] Row %lu differs from row 0 although every source row is "
+                        "identical; source pixels were not read from the source bitmap\n",
+                        row);
+            passed = false;
+        }
+    }
+
+    if (!passed)
+        return false;
+
+    const unsigned short *first = reinterpret_cast<const unsigned short *>(dest.data());
+    std::printf("[INFO] BM_16b_RGB %lux%lu stride=%lu first pixel=(%u,%u,%u)\n",
+                width, height, output_stride, first[0], first[1], first[2]);
+    std::printf("[OK] CMTranslateRGBsExt honoured dwOutputStride and 16-bit sample range\n");
+    return true;
+}
+
 int main(int argc, char **argv)
 {
     if (argc != 3) {
@@ -202,7 +315,8 @@ int main(int argc, char **argv)
         return 1;
 
     bool ok = check_profile_valid(api, profile) &&
-              check_rgb_roundtrip_transform(api, profile);
+              check_rgb_roundtrip_transform(api, profile) &&
+              check_rgbs_ext_output_stride(api, profile);
 
     CloseColorProfile(profile);
 


### PR DESCRIPTION
Part of #1953.

Both items in the issue's Rev.A code review are real and still on master. Note
that the issue's Conclusions comment records *"Fix in `c7883bd`"* — `c7883bd1` is
`test(#1946): record and enforce the expected validation verdict for every corpus
profile` (#1947), which touches the QA manifest and nothing under `Tools/Winnt/`.
Neither defect had been fixed.

## 1. The output-stride branch re-based the source pointer

`Tools/Winnt/IccDEVCmm/IccDEVCmm.cpp`, end of the `CMTranslateRGBsExt` row loop:

```cpp
if (!dwOutputStride) {
  size_t dwAlignedSize = (((lpDestBits - lpDestLine) + 3)>>2)<<2;
  lpDestBits = lpDestLine + dwAlignedSize;
}
else {
  lpSrcBits = lpDestLine + dwOutputStride;   // should be lpDestBits
}
```

One assignment, two wrong results whenever a caller supplies a non-zero
`dwOutputStride`:

- `lpDestBits` is left wherever the inner pixel loop stopped, so rows land at the
  pixel pitch instead of the caller's stride and the padding between rows is
  never written;
- `lpSrcBits` is overwritten with an address inside the **destination** bitmap,
  so from row 1 on the input pixels are read back out of the destination.

### This is silent corruption, not a memory-safety defect

Worth stating precisely, because it sets the severity. I reduced the row-advance
arithmetic and ran the as-shipped form against five plausible geometries with
exact-sized heap allocations under ASan — padded stride with the buffer sized
`stride*height`, the same with an unpadded last row, a taller image, a large
stride, and `stride == rowBytes`. **None faulted.** The clobbered pointer lands
inside the destination allocation and stays there, so the call returns `TRUE`
with wrong pixels rather than crashing.

The arithmetic, as shipped vs. fixed, for a 2x3 `BM_16b_RGB` image with
`rowBytes=12` and `outputStride=16`:

```
--- AS SHIPPED ---
  dest row starts : 0 12 24    (expected 0 16 32)
  src  row starts : 0 80 92    (expected 0 12 24)
  src ptr left source buffer: YES
  first output sample: 255     (expected 65535)

--- FIXED ---
  dest row starts : 0 16 32
  src  row starts : 0 12 24
  src ptr left source buffer: no
  first output sample: 65535
```

### Blast radius

`CMTranslateRGBs` always passes `dwOutputStride` 0 and so takes the DWORD-padded
branch; only a direct `CMTranslateRGBsExt` caller reaches this. I swept the file
for siblings — `CMCheckRGBs` has the only other strided row loop, but it has no
destination bitmap and re-bases `lpSrcBits` correctly. This is the sole site.

## 2. The 16-bit three-channel writers quantized to 8 bits

`BM_16b_Lab` and `BM_16b_RGB`/`XYZ`/`Yxy`/`G3CH` wrote

```cpp
*bits++ = (icUInt8Number)(UnitClip(destPixel[0]) * 255.0 + 0.5);
```

into `icUInt16Number` samples. The oracle is in the same file: the matching
readers divide by `65535` (`IccDEVCmm.cpp:1841-1843`), `BM_16b_GRAY` twelve lines
below multiplies by `65535`, and so does the 16-bit path in `CMTranslateColors`.
So these formats could not round-trip — a full-scale channel came back at
`255/65535`, under 0.4% of the intended level.

## Provenance

Both sites blame to the 2015 repository root `1f0a9dd` and are unchanged since,
matching the bisect on the issue.

## Test

`IccDEVCmmSmoke` now exercises `CMTranslateRGBsExt` — the coverage gap called out
in the issue's Note comment ("it does not exercise `CMTranslateRGBsExt`, where
CTest coverage is needed"). The harness previously reached only
`CMTranslateColors`.

Every source row carries identical pixels, which keeps the assertions independent
of what the transform does to a colour:

- inter-row padding must keep its fill byte — catches rows landing at the pixel
  pitch;
- output rows must be identical to one another — catches source pixels being read
  from the destination;
- a full-scale 16-bit channel must stay in the 16-bit range — catches the 8-bit
  quantization. The bound is deliberately loose (30000) so this does not become an
  assertion about round-trip colour accuracy.

## Verification, and its limit

Stating this plainly rather than implying more than I ran:

- **Mechanism — verified locally.** The reduction above, plus the ASan geometry
  sweep.
- **The CTest — compiled, not executed.** `IccDEVCmm` is `WIN32`-gated in CMake
  and I have no Windows toolchain on this host, so I syntax- and format-checked
  the harness against faithful Win64 type stubs under
  `-Wall -Wextra -Wformat=2 -Wconversion` (clean, apart from the five pre-existing
  `-Wcast-function-type` warnings on the existing `FARPROC` casts) and pre-empted
  an MSVC C4267 narrowing on `sizeof`. **This PR's CI is its first real
  execution.**

I did confirm it will not be a no-op: `CMTranslateRGBsExt` is exported
(`IccDEVCmm.def` `@18`), `ENABLE_CMM_TOOLS` defaults `ON` and is forced on in the
ClangCL and MinGW jobs, `run-recent-ctests.py` runs with no `--limit`, and
`include_windows` is true for a full-scope PR.

Left to the maintainers: whether `#1953` stays open for the rest of the Windows
tracking scope.