### PR TITLE
fix(#1954,#1931): parse MPE XML attributes into the widths they are stored in

### DIFF
--- a/.github/scripts/iccdev-issue-1954-mpe-attr-narrowing-regression.sh
+++ b/.github/scripts/iccdev-issue-1954-mpe-attr-narrowing-regression.sh
@@ -1,0 +1,336 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issues #1954 and #1931
+#   atoi() narrowing in the IccMpeXml.cpp MPE element readers, and the
+#   "%d"-printed 32-bit fields in the matching writers
+###############################################################################
+#
+# The MPE half of the family #1908 and #1909 fixed at the tag-level readers.
+# Every affected site parsed an unsigned attribute with atoi(), which returns a
+# signed int, and then stored or cast the result into an icUInt16Number or
+# icUInt32Number member:
+#
+#   m_nFunctionType = atoi(icXmlAttrValue(funcType));
+#   m_flags         = atoi(icXmlAttrValue(pNode, "Flags", "0"));
+#   m_storageType   = (icUInt16Number)atoi(icXmlAttrValue(attr));
+#
+# A value that does not fit changed on the way in instead of being refused.
+# The reported breadcrumbs are the negative ones -- FunctionType="-143" landing
+# as 65393 (#1954) and FunctionType="-1" landing as 65535 (#1931) -- but those
+# are also the half a later constraint already caught, because the function-type
+# switch rejects anything it does not recognise. The half with teeth in an
+# ordinary CI job is the overflow, which lands on a value the switch DOES
+# recognise:
+#
+#   FunctionType="65536"  stored and re-serialized as 0    (a valid function)
+#   Reserved2="-1"        stored and re-serialized as 65535
+#   Flags="-1"            stored as 0xFFFFFFFF
+#
+# CASE W -- the writer, and why it had to be fixed in the same change.
+# CIccMpeXmlEmissionCLUT::ToXml cast its 32-bit m_flags to unsigned and then
+# printed it with "%d", so the cast was a no-op and any profile whose Flags had
+# bit 31 set was written out negative. Flags="2147483650" is a legal value that
+# Read32() accepts from disk, and master re-serializes it as "-2147483646".
+# Pre-fix that still round-tripped, because the reader's atoi() wrapped the
+# negative straight back -- two defects cancelling. Fixing only the reader would
+# therefore have stopped those profiles loading at all. This case asserts the
+# attribute is emitted unsigned AND that the value survives a full
+# XML -> ICC -> XML -> ICC trip, which is what pins the two halves together.
+#
+# Every fixture is a tracked Testing/ document with ONE attribute changed, so
+# everything else it exercises is a known-good path. The mutation is applied
+# here rather than checked in, and the script FAILS if a mutation did not apply:
+# a silently-unmutated fixture would convert cleanly and every assertion below
+# would pass while testing nothing.
+#
+# CONTROLS. Each laundering case is paired with the value it wrapped to, as a
+# legal document that must still convert: FunctionType="0", Reserved2="65535",
+# Flags="0". That pairing separates "refuses a value that does not fit the
+# field" from "lowered the ceiling" -- a fix that rejected both would satisfy
+# every rejection assertion here while having broken ordinary profiles.
+# Flags="2147483650" is a control in the same sense: it is representable in the
+# 32-bit field, so it must still be ACCEPTED, and its stored value checked.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1954}"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+TOXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccToXml -type f 2>/dev/null | head -1)"
+
+status=0
+
+# Donors. Each is a tracked fixture that already exercises the element under test.
+CALC=Testing/Calc/RGBWProjector.xml          # <FormulaSegment FunctionType="0">
+TONEMAP=Testing/HDR/BT2100HlgFullScene.xml   # <ToneMapFunction FunctionType="0">
+ECLUT=Testing/Display/LaserProjector.xml     # <EmissionCLutElement ... Flags="0">
+
+# mutate <donor-relative-path> <output-name> <find> <replace> [<find> <replace>]...
+#
+# Applies literal substitutions to a tracked fixture and writes the result to
+# OUTDIR. Refuses to write a fixture a substitution did not change, which is what
+# keeps a donor edited upstream from turning this test into a silent no-op.
+mutate() {
+  local donor="$REPO_ROOT/$1" out="$OUTDIR/$2"
+  local rel="$1"
+  shift 2
+  if [ ! -f "$donor" ]; then
+    echo "[SKIP] donor fixture missing: $rel"
+    return 1
+  fi
+  python3 - "$donor" "$out" "$@" <<'PYEOF'
+import sys
+donor, out = sys.argv[1], sys.argv[2]
+pairs = sys.argv[3:]
+src = open(donor, encoding="utf-8", errors="surrogateescape").read()
+for find, repl in zip(pairs[0::2], pairs[1::2]):
+    if find not in src:
+        sys.stderr.write(find[:70] + "\n")
+        sys.exit(3)
+    # Only the first occurrence: these donors repeat the same element, and one
+    # changed attribute is enough to reach the reader under test.
+    src = src.replace(find, repl, 1)
+open(out, "w", encoding="utf-8", errors="surrogateescape").write(src)
+PYEOF
+  local rc=$?
+  if [ $rc -eq 3 ]; then
+    echo "[FAIL] fixture drift: a literal no longer appears in $rel --"
+    echo "       the case below would have run against an unmutated document"
+    status=2
+    return 1
+  elif [ $rc -ne 0 ]; then
+    echo "[SKIP] could not build $2 from $rel"
+    return 1
+  fi
+  return 0
+}
+
+TOOL_RC=0
+TOOL_LOG=""
+TOOL_ICC=""
+run_tool() {
+  # Sets globals rather than echoing: a caller using $(run_tool ...) would run
+  # this in a subshell and TOOL_RC would never reach the caller.
+  local xml="$OUTDIR/$1" base="${1%.xml}"
+  TOOL_LOG="$OUTDIR/$base.log"
+  TOOL_ICC="$OUTDIR/$base.icc"
+  rm -f "$TOOL_ICC"
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0:allocator_may_return_null=1" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$FROMXML" "$xml" "$TOOL_ICC" -noid > "$TOOL_LOG" 2>&1
+  TOOL_RC=$?
+}
+
+# A laundering case: the document must be refused, and no profile written.
+# $1 = fixture  $2 = description  $3 = grep pattern showing the value that landed
+expect_reject() {
+  run_tool "$1"
+  if [ -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1954/#1931: $2 -- profile written (rc=$TOOL_RC)"
+    if [ -n "${TOXML:-}" ] && [ -x "${TOXML:-}" ] && \
+       "$TOXML" "$TOOL_ICC" "$OUTDIR/${1%.xml}.roundtrip.xml" >/dev/null 2>&1; then
+      echo "       written profile re-serializes as:"
+      grep -oE "$3" "$OUTDIR/${1%.xml}.roundtrip.xml" | head -2 | sed 's/^/         /'
+    fi
+    status=2
+  else
+    echo "[PASS] $2 -- refused"
+  fi
+  rm -f "$TOOL_ICC"
+}
+
+# A control: the value is representable and must still be accepted.
+expect_accept() {
+  run_tool "$1"
+  if [ -f "$TOOL_ICC" ]; then
+    echo "[PASS] control: $2 still converts"
+  else
+    echo "[FAIL] control: $2 was rejected -- the fix is refusing representable"
+    echo "       values, not just unrepresentable ones"
+    sed -n '1,6p' "$TOOL_LOG"
+    status=2
+  fi
+  rm -f "$TOOL_ICC"
+}
+
+echo "=================================================================="
+echo " MPE XML attribute narrowing regression (issues #1954, #1931)"
+echo "=================================================================="
+
+# --- Case A: overflow laundered into a value the later check accepts ---------
+
+# 65536 & 0xFFFF == 0, and function type 0 is "Y = a*X^g" -- a supported type,
+# so the switch downstream cannot tell this from a well-formed document.
+if mutate "$CALC" formula-ft-launder-1931.xml 'FunctionType="0"' 'FunctionType="65536"'; then
+  expect_reject formula-ft-launder-1931.xml \
+    'FormulaSegment FunctionType="65536"' 'FunctionType="[-0-9]+"'
+fi
+# Control: the wrapped value itself is a legal function type and must convert.
+if mutate "$CALC" formula-ft-control-1931.xml 'FunctionType="0"' 'FunctionType="0"'; then
+  expect_accept formula-ft-control-1931.xml 'FunctionType="0" (the wrapped value)'
+fi
+
+# Same element, the 16-bit Reserved2 field: -1 landed as 65535.
+if mutate "$CALC" formula-res2-launder-1931.xml \
+     '<FormulaSegment Start="-inf" End="0.0" FunctionType="0"' \
+     '<FormulaSegment Start="-inf" End="0.0" Reserved2="-1" FunctionType="0"'; then
+  expect_reject formula-res2-launder-1931.xml \
+    'FormulaSegment Reserved2="-1"' 'Reserved2="[-0-9]+"'
+fi
+# Control: 65535 is representable in the u16 and must still be accepted.
+if mutate "$CALC" formula-res2-control-1931.xml \
+     '<FormulaSegment Start="-inf" End="0.0" FunctionType="0"' \
+     '<FormulaSegment Start="-inf" End="0.0" Reserved2="65535" FunctionType="0"'; then
+  expect_accept formula-res2-control-1931.xml 'Reserved2="65535" (the wrapped value)'
+fi
+
+# The tone map function reader, which is the #1954 call site.
+#
+# The literal below is anchored on "<ToneMapFunction " rather than on
+# FunctionType alone, and that matters: this donor carries nine <FormulaSegment>
+# elements before its single <ToneMapFunction>, so a bare 'FunctionType="0"'
+# substitution lands on the segment at line 29 and re-tests
+# CIccFormulaCurveSegmentXml::ParseXml while appearing to cover the tone map.
+# The mislabelled version of this case did exactly that -- it was red on master
+# for the wrong reader, and IccMpeXml.cpp:1920 was never reached.
+if mutate "$TONEMAP" tonemap-ft-launder-1954.xml \
+     '<ToneMapFunction FunctionType="0">' '<ToneMapFunction FunctionType="65536">'; then
+  expect_reject tonemap-ft-launder-1954.xml \
+    'ToneMapFunction FunctionType="65536"' '<ToneMapFunction FunctionType="[-0-9]+"'
+fi
+if mutate "$TONEMAP" tonemap-ft-control-1954.xml \
+     '<ToneMapFunction FunctionType="0">' '<ToneMapFunction FunctionType="0">'; then
+  expect_accept tonemap-ft-control-1954.xml 'ToneMapFunction FunctionType="0"'
+fi
+
+# The 32-bit spectral CLUT flags. Unlike the cases above this one was accepted
+# outright pre-fix: 0xFFFFFFFF is a value the element is willing to hold, so
+# nothing downstream objected.
+if mutate "$ECLUT" eclut-flags-launder-1931.xml 'Flags="0"' 'Flags="-1"'; then
+  expect_reject eclut-flags-launder-1931.xml \
+    'EmissionCLutElement Flags="-1"' 'Flags="[-0-9]+"'
+fi
+if mutate "$ECLUT" eclut-flags-control-1931.xml 'Flags="0"' 'Flags="0"'; then
+  expect_accept eclut-flags-control-1931.xml 'EmissionCLutElement Flags="0"'
+fi
+
+# --- Case B: the reported breadcrumbs ---------------------------------------
+#
+# Both negatives wrap to a function type the switch does not recognise, so they
+# were already refused pre-fix and these assertions pass either way in an
+# ordinary build. They are kept because they are what the issues reported, and
+# because on an integer/implicit-conversion build the UBSan diagnostic they used
+# to raise is the thing that has to be gone. The log check below is what gives
+# them teeth there.
+if mutate "$CALC" formula-ft-breadcrumb-1931.xml 'FunctionType="0"' 'FunctionType="-1"'; then
+  expect_reject formula-ft-breadcrumb-1931.xml \
+    'FormulaSegment FunctionType="-1" (#1931 breadcrumb)' 'FunctionType="[-0-9]+"'
+  if grep -q "runtime error:.*implicit conversion" "$OUTDIR/formula-ft-breadcrumb-1931.log" 2>/dev/null; then
+    echo "[FAIL] #1931: UBSan implicit-conversion report still raised at the"
+    echo "       formula segment reader:"
+    grep -m1 "runtime error:" "$OUTDIR/formula-ft-breadcrumb-1931.log" | sed 's/^/         /'
+    status=2
+  fi
+fi
+if mutate "$TONEMAP" tonemap-ft-breadcrumb-1954.xml \
+     '<ToneMapFunction FunctionType="0">' '<ToneMapFunction FunctionType="-143">'; then
+  expect_reject tonemap-ft-breadcrumb-1954.xml \
+    'ToneMapFunction FunctionType="-143" (#1954 breadcrumb)' '<ToneMapFunction FunctionType="[-0-9]+"'
+  if grep -q "runtime error:.*implicit conversion" "$OUTDIR/tonemap-ft-breadcrumb-1954.log" 2>/dev/null; then
+    echo "[FAIL] #1954: UBSan implicit-conversion report still raised at the"
+    echo "       tone map reader:"
+    grep -m1 "runtime error:" "$OUTDIR/tonemap-ft-breadcrumb-1954.log" | sed 's/^/         /'
+    status=2
+  fi
+fi
+
+# --- Case W: the writer, and the reader/writer coupling ---------------------
+#
+# Flags="2147483650" (0x80000002) is legal: Read32() accepts the whole 32-bit
+# range from disk. Pre-fix the tool ACCEPTED it -- atoi() overflowed to a
+# negative that wrapped back to the right number by accident -- and then wrote
+# it back out as "-2147483646". So the assertion that has teeth here is not
+# acceptance but what the writer emits, and whether the value survives a second
+# trip through the parser now that negatives are refused.
+if [ -z "${TOXML:-}" ] || [ ! -x "${TOXML:-}" ]; then
+  echo "[SKIP] iccToXml not found; writer round-trip case not run"
+elif mutate "$ECLUT" eclut-flags-hibit-1931.xml 'Flags="0"' 'Flags="2147483650"'; then
+  expect_accept eclut-flags-hibit-1931.xml 'EmissionCLutElement Flags="2147483650" (representable)'
+  run_tool eclut-flags-hibit-1931.xml
+  if [ ! -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1931: a representable 32-bit Flags was refused; the writer"
+    echo "       case below cannot run"
+    status=2
+  else
+    RT_XML="$OUTDIR/eclut-flags-hibit-1931.rt.xml"
+    RT_ICC="$OUTDIR/eclut-flags-hibit-1931.rt.icc"
+    if ! "$TOXML" "$TOOL_ICC" "$RT_XML" >/dev/null 2>&1; then
+      echo "[FAIL] #1931: iccToXml could not re-serialize the profile"
+      status=2
+    else
+      EMITTED="$(grep -oE '<EmissionCLutElement[^>]*Flags="[-0-9]+"' "$RT_XML" \
+                 | head -1 | grep -oE 'Flags="[-0-9]+"')"
+      if [ "$EMITTED" = 'Flags="2147483650"' ]; then
+        echo "[PASS] writer emits $EMITTED unsigned"
+      else
+        echo "[FAIL] #1931: writer emitted $EMITTED for a 32-bit Flags of"
+        echo "       0x80000002 -- '%d' is reinterpreting the field as signed,"
+        echo "       and the parser now refuses the negative it produces, so"
+        echo "       such profiles no longer round-trip"
+        status=2
+      fi
+      # Second trip: the emitted attribute has to be readable again. Pre-fix
+      # this worked only because a negative attribute wrapped back; post-fix it
+      # has to work because the attribute is correct.
+      rm -f "$RT_ICC"
+      "$FROMXML" "$RT_XML" "$RT_ICC" -noid >/dev/null 2>&1
+      if [ ! -f "$RT_ICC" ]; then
+        echo "[FAIL] #1931: the writer's own output no longer parses -- the"
+        echo "       reader and writer halves of this fix disagree"
+        status=2
+      else
+        FLAGS_HEX="$(python3 - "$RT_ICC" <<'PYEOF'
+import sys
+d = open(sys.argv[1], 'rb').read()
+o = d.find(b'eclt')
+# Element header: sig(4) reserved(4) inChannels(2) outChannels(2) then flags(4).
+print(f"0x{int.from_bytes(d[o+12:o+16],'big'):08x}" if o >= 0 else "no-eclt")
+PYEOF
+)"
+        if [ "$FLAGS_HEX" = "0x80000002" ]; then
+          echo "[PASS] round-trip preserves eclt flags $FLAGS_HEX"
+        else
+          echo "[FAIL] #1931: eclt flags came back as $FLAGS_HEX, expected 0x80000002"
+          status=2
+        fi
+      fi
+      rm -f "$RT_ICC"
+    fi
+    rm -f "$TOOL_ICC"
+  fi
+fi
+
+echo "------------------------------------------------------------------"
+if [ $status -eq 0 ]; then
+  echo "[OK] MPE XML attribute narrowing regression: all cases pass"
+else
+  echo "[REGRESSION] MPE XML attribute narrowing: see failures above"
+fi
+exit $status

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4306,6 +4306,34 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1909-xml-narrowing-regression.sh"
 )
 
+# #1954/#1931: the same narrowing at the MPE element readers, which is the
+# surface #1908 and #1909 did not cover.  The reported breadcrumbs are negatives
+# (FunctionType="-143" -> 65393, "-1" -> 65535), but those wrap to a function
+# type the switch already refuses, so the cases with teeth in an ordinary job
+# are the overflows that land on a value it accepts: FunctionType="65536" is
+# stored and re-serialized as 0, a supported function, and Reserved2="-1" as
+# 65535.  Flags="-1" on the spectral CLUT was accepted outright, since
+# 0xFFFFFFFF is a value that 32-bit field is willing to hold.
+# One case covers the writer, which had to change in the same commit: it cast
+# m_flags to unsigned and then printed it with "%d", so a legal Flags of
+# 0x80000002 was written back out as "-2147483646".  That round-tripped only
+# because the reader's atoi() wrapped the negative straight back, so tightening
+# the reader alone would have stopped those profiles loading -- the case asserts
+# the attribute is emitted unsigned and survives XML -> ICC -> XML -> ICC.
+# Controls pair every rejection with the value it wrapped to (0, 65535, 0) plus
+# Flags="2147483650" itself, which must still be accepted: that is what shows
+# the fix refuses unrepresentable values rather than having lowered a ceiling.
+# Fixtures are mutated from tracked Testing/ XML at run time and the script
+# fails if a mutation did not apply, so a donor edited upstream cannot turn
+# this into a silent no-op.
+iccdev_add_script_test(
+  iccdev.issue-1954-mpe-attr-narrowing-regression
+  120
+  "iccdev;xml;mpe;issue-1954;issue-1931;regression;ubsan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1954-mpe-attr-narrowing-regression.sh"
+)
+
 # #1810: 'RICC' in the CMM and platform header fields of 15 Testing fixtures.
 # 'RICC' was never registered -- icSigRefIccMAX itself carried 0x52494343
 # ('RICC') against a comment and a registry that both said 'RIMX', until #1473

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -282,10 +282,21 @@ bool CIccFormulaCurveSegmentXml::ToXml(std::string &xml, std::string blanks)
   xml += line;
 
   if (m_nReserved) {
-    snprintf(line, bufSize, " Reserved=\"%d\"", (unsigned int) m_nReserved);
+    // m_nReserved is an icUInt32Number that Read32() fills from the element
+    // header, so every value up to 0xFFFFFFFF is representable on disk.  The
+    // (unsigned int) cast below was already there and says what was intended,
+    // but "%d" reinterprets the argument as signed, so anything with bit 31
+    // set was written out negative -- 0x80000002 became "-2147483646" (#1931).
+    // The reader then wrapped that back through atoi(), so the value survived
+    // only because the two defects cancelled; "%u" is what makes the attribute
+    // correct on its own.  CIccMpeXmlCLUT::ToXml below already prints its
+    // Reserved this way, so this brings the segment writer in line with it.
+    snprintf(line, bufSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
   if (m_nReserved2) {
+    // m_nReserved2 is an icUInt16Number, which promotes to a non-negative int,
+    // so "%d" cannot misprint it and is left alone.
     snprintf(line, bufSize, " Reserved2=\"%d\"", m_nReserved2);
     xml += line;
   }
@@ -308,11 +319,30 @@ bool CIccFormulaCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
     return false;
   }
 
-  m_nReserved  = atoi(icXmlAttrValue(pNode, "Reserved",  "0"));
-  m_nReserved2 = atoi(icXmlAttrValue(pNode, "Reserved2", "0"));
-  m_nFunctionType = atoi(icXmlAttrValue(funcType));
+  // atoi() returns a signed int, and these three members are unsigned, so a
+  // negative or oversized attribute used to change value on the way in rather
+  // than be refused: Reserved2="-1" became 65535 and FunctionType="65536"
+  // became 0, which the switch below then accepted as the perfectly valid
+  // "Y = a*X^g" type (#1931).  icXmlParseU16/U32 (IccUtilXml.h, added by
+  // #1925) refuse the sign, trailing garbage and the overflow instead, so a
+  // value that cannot be represented stops the parse rather than silently
+  // becoming a different one.  The defaults stay "0" so documents that omit
+  // the attribute keep loading exactly as before.
+  if (!icXmlParseU32(icXmlAttrValue(pNode, "Reserved", "0"), m_nReserved)) {
+    parseStr += "Invalid Reserved in Formula Segment\n";
+    return false;
+  }
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "Reserved2", "0"), m_nReserved2)) {
+    parseStr += "Invalid Reserved2 in Formula Segment\n";
+    return false;
+  }
+  if (!icXmlParseU16(icXmlAttrValue(funcType), m_nFunctionType)) {
+    parseStr += "Invalid FunctionType in Formula Segment\n";
+    return false;
+  }
 
-
+  // The switch still decides which function types are supported; the parse
+  // above only guarantees the value reaching it is the one the document said.
   switch(m_nFunctionType) {
     case 0x0000:
       m_nParameters = 4;
@@ -494,7 +524,20 @@ bool CIccSampledCurveSegmentXml::ParseXml(xmlNode *pNode, std::string &parseStr)
       icUInt16Number storageType = icValueTypeFloat32;
       xmlAttr *attr = icXmlFindAttr(pNode, "StorageType");
       if (attr) {
-       storageType = (icUInt16Number)atoi(icXmlAttrValue(attr));
+        // The explicit (icUInt16Number) cast here hid the same narrowing the
+        // Formula Segment above suffered from: it silenced UBSan without
+        // making the value correct, so StorageType="65536" arrived as 0 and
+        // selected icValueTypeUInt8 in the chain below rather than being
+        // refused (#1931).  Parse strictly and reject instead -- the storage
+        // type picks which reader interprets the binary file that follows, so
+        // a substituted value reads the samples at the wrong width.
+        // `file` is owned here -- every other failure exit in this branch
+        // releases it before returning, so this one must too.
+        if (!icXmlParseU16(icXmlAttrValue(attr), storageType)) {
+          parseStr += "Invalid StorageType in Sampled Curve Segment\n";
+          delete file;
+          return false;
+        }
       }
 
       if (storageType == icValueTypeUInt8){
@@ -737,10 +780,23 @@ bool CIccSampledCalculatorCurveXml::ParseXml(xmlNode *pNode, std::string &parseS
     return false;
   }
 
-  m_nDesiredSize = (icUInt32Number)atoi(icXmlAttrValue(attr));
-
-  m_nReserved  = (icUInt32Number)atoi(icXmlAttrValue(pNode, "Reserved",  "0"));
-  m_nReserved2 = (icUInt16Number)atoi(icXmlAttrValue(pNode, "Reserved2", "0"));
+  // Same signed-to-unsigned narrowing as the Formula Segment above, but behind
+  // explicit casts, which suppress the UBSan check without changing the
+  // outcome: DesiredSize="-1" became 4294967295 and was then used as the
+  // interpolation sample count (#1931).  Parse strictly so the count that
+  // reaches the curve is the one the document actually asked for.
+  if (!icXmlParseU32(icXmlAttrValue(attr), m_nDesiredSize)) {
+    parseStr += "Invalid DesiredSize in Sampled Calculator Curve\n";
+    return false;
+  }
+  if (!icXmlParseU32(icXmlAttrValue(pNode, "Reserved", "0"), m_nReserved)) {
+    parseStr += "Invalid Reserved in Sampled Calculator Curve\n";
+    return false;
+  }
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "Reserved2", "0"), m_nReserved2)) {
+    parseStr += "Invalid Reserved2 in Sampled Calculator Curve\n";
+    return false;
+  }
 
   xmlNode *pCalcNode = icXmlFindNode(pNode->children, "CalculatorElement");
   if (pCalcNode) {
@@ -824,19 +880,34 @@ bool CIccSingleSampledCurveXml::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   m_lastEntry = (icFloatNumber)atof(icXmlAttrValue(attr));
 
+  // As above: the explicit casts made these three narrowings invisible to
+  // UBSan without making them safe.  StorageType and ExtensionType each select
+  // behaviour rather than carrying data -- the storage type picks the sample
+  // width and the extension type picks the clip/extend rule -- so a wrapped
+  // value silently changes how the curve is read (#1931).  Both keep their
+  // pre-existing defaults when the attribute is absent.
   m_storageType = icValueTypeFloat32;
   attr = icXmlFindAttr(pNode, "StorageType");
   if (attr) {
-    m_storageType = (icUInt16Number)atoi(icXmlAttrValue(attr));
+    if (!icXmlParseU16(icXmlAttrValue(attr), m_storageType)) {
+      parseStr += "Invalid StorageType in Single Sampled Curve\n";
+      return false;
+    }
   }
 
   m_extensionType = icClipSingleSampledCurve;
   attr = icXmlFindAttr(pNode, "ExtensionType");
   if (attr) {
-    m_extensionType = (icUInt16Number)atoi(icXmlAttrValue(attr));
+    if (!icXmlParseU16(icXmlAttrValue(attr), m_extensionType)) {
+      parseStr += "Invalid ExtensionType in Single Sampled Curve\n";
+      return false;
+    }
   }
 
-  m_nReserved = (icUInt32Number)atoi(icXmlAttrValue(pNode, "Reserved", "0"));
+  if (!icXmlParseU32(icXmlAttrValue(pNode, "Reserved", "0"), m_nReserved)) {
+    parseStr += "Invalid Reserved in Single Sampled Curve\n";
+    return false;
+  }
 
   const char *filename = icXmlAttrValue(pNode, "Filename");
 
@@ -1300,7 +1371,14 @@ bool CIccMpeXmlCurveSet::ToXml(std::string &xml, std::string blanks/* = ""*/)
   return true;
 }
 
-static icCurveSetCurvePtr ParseXmlCurve(xmlNode* pNode, std::string parseStr)
+// parseStr is taken by reference rather than by value: each branch below hands
+// it to a curve's ParseXml(), which appends the reason a curve failed, but the
+// by-value parameter meant every one of those messages was written into a copy
+// and discarded at the return.  Callers were left with only their own generic
+// "Unable to parse element ..." line, which is why a malformed segment reported
+// nothing about the attribute that actually caused it (#1931).  Both call sites
+// already hold a std::string& of their own, so the reason now reaches the user.
+static icCurveSetCurvePtr ParseXmlCurve(xmlNode* pNode, std::string &parseStr)
 {
   icCurveSetCurvePtr rv = NULL;
   
@@ -1890,10 +1968,14 @@ bool CIccXmlToneMapFunc::ToXml(std::string& xml, std::string blanks /* = "" */)
   xml += blanks + line;
 
   if (m_nReserved) {
-    snprintf(line, lineSize, " Reserved=\"%d\"", (unsigned int) m_nReserved);
+    // Same u32-printed-as-signed defect the Formula Segment writer had: the
+    // (unsigned int) cast states the intent but "%d" ignores it, so bit 31
+    // came back out negative.  See CIccFormulaCurveSegmentXml::ToXml above.
+    snprintf(line, lineSize, " Reserved=\"%u\"", (unsigned int) m_nReserved);
     xml += line;
   }
   if (m_nReserved2) {
+    // icUInt16Number: promotes to a non-negative int, so "%d" is safe here.
     snprintf(line, lineSize, " Reserved2=\"%d\"", m_nReserved2);
     xml += line;
   }
@@ -1916,8 +1998,24 @@ bool CIccXmlToneMapFunc::ParseXml(xmlNode* pNode, std::string& parseStr)
     return false;
   }
 
-  m_nReserved2 = atoi(icXmlAttrValue(pNode, "Reserved2"));
-  m_nFunctionType = atoi(icXmlAttrValue(funcType));
+  // FunctionType="-143" reached this icUInt16Number as 65393 (#1954), and the
+  // same wrap let FunctionType="65536" arrive as 0 -- a supported type -- so
+  // the switch below could not tell a malformed document from a valid one.
+  //
+  // Note the "0" default added to Reserved2: this call site, unlike its
+  // Formula Segment counterpart, relied on icXmlAttrValue() returning "" for
+  // an absent attribute and atoi("") yielding 0.  icXmlParseU16 rejects the
+  // empty string, so the default has to be spelled out here or every tone map
+  // function that omits Reserved2 -- which is all of them in the corpus --
+  // would stop parsing.
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "Reserved2", "0"), m_nReserved2)) {
+    parseStr += "Invalid Reserved2 in Tone Map Function\n";
+    return false;
+  }
+  if (!icXmlParseU16(icXmlAttrValue(funcType), m_nFunctionType)) {
+    parseStr += "Invalid FunctionType in Tone Map Function\n";
+    return false;
+  }
 
   switch (m_nFunctionType) {
   case 0x0000:
@@ -2159,8 +2257,17 @@ bool CIccMpeXmlExtCLUT::ToXml(std::string &xml, std::string blanks/* = ""*/)
 
 bool CIccMpeXmlExtCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  m_storageType = (icUInt16Number)atoi(icXmlAttrValue(pNode, "StorageType", "0"));
-  m_nReserved2 = atoi(icXmlAttrValue(pNode, "Reserved2", "0"));
+  // Both members are icUInt16Number; StorageType went through an explicit cast
+  // and Reserved2 through an implicit one, but each wrapped a negative or
+  // oversized attribute into a different value rather than refusing it (#1931).
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "StorageType", "0"), m_storageType)) {
+    parseStr += "Invalid StorageType in ExtCLutElement\n";
+    return false;
+  }
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "Reserved2", "0"), m_nReserved2)) {
+    parseStr += "Invalid Reserved2 in ExtCLutElement\n";
+    return false;
+  }
 
   if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
                           "ExtCLutElement", parseStr)) {
@@ -2695,8 +2802,17 @@ bool CIccMpeXmlCalculator::ParseImport(xmlNode *pNode, std::string importPath, s
                 return false;
               }
             }
+            // `offset` above is deliberately left as a signed int: CIccTempDeclVar
+            // stores it in an `int m_pos` whose -1 means "no position given", so
+            // atoi() there is reading a genuinely signed field and is correct.
+            // `size` is the icUInt16Number, and it is the one that wrapped --
+            // Size="-1" became 65535 and was accepted as a 65535-element
+            // declaration rather than rejected (#1931).
             if ((attr = icXmlFindAttr(pNext, "Size"))) {
-              size = (icUInt16Number)atoi(icXmlAttrValue(attr));
+              if (!icXmlParseU16(icXmlAttrValue(attr), size)) {
+                parseStr += "Invalid Size in calculator variable declaration\n";
+                return false;
+              }
             }
             if (size < 1) size = 1;
 
@@ -3549,7 +3665,15 @@ bool CIccMpeXmlEmissionCLUT::ToXml(std::string &xml, std::string blanks/* = ""*/
     xml +=  buf;
   }
 
-  snprintf(buf, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Flags=\"%d\" StorageType=\"%d\">\n", NumInputChannels(), NumOutputChannels(), (unsigned int) m_flags, (unsigned int) m_nStorageType);
+  // m_flags is 32-bit and already cast to unsigned, so the "%d" was the only
+  // thing left reinterpreting it as signed: a profile whose Flags had bit 31
+  // set was written out as a negative number (0x80000002 -> "-2147483646"),
+  // and only the reader's matching atoi() wrap carried it back intact (#1931).
+  // With the parser above now refusing a negative Flags, emitting "%u" here is
+  // what keeps such profiles round-tripping.  StorageType keeps "%d": it is an
+  // icUInt16Number, which promotes to a non-negative int, so that conversion
+  // was never able to misprint it.
+  snprintf(buf, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Flags=\"%u\" StorageType=\"%d\">\n", NumInputChannels(), NumOutputChannels(), (unsigned int) m_flags, (unsigned int) m_nStorageType);
   xml += buf;
 
   snprintf(buf, bufSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_Range.start), icF16toF(m_Range.end), m_Range.steps);
@@ -3580,13 +3704,26 @@ bool CIccMpeXmlEmissionCLUT::ToXml(std::string &xml, std::string blanks/* = ""*/
 
 bool CIccMpeXmlEmissionCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  m_nStorageType = (icUInt16Number)atoi(icXmlAttrValue(pNode, "StorageType", "0"));
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "StorageType", "0"), m_nStorageType)) {
+    parseStr += "Invalid StorageType in EmissionCLutElement\n";
+    return false;
+  }
 
   if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
                           "CLutElement", parseStr)) {
     return false;
   }
-  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
+  // m_flags is an icUInt32Number carrying the icRelativeSpectralData /
+  // icLabSpectralData bits, and Read32() accepts the whole 32-bit range from
+  // disk, so the parser has to as well.  Flags="-1" reached it as 0xFFFFFFFF
+  // (#1931), and atoi() cannot even express the upper half of the range: it
+  // returns a negative for "2147483650", which then wrapped back to the right
+  // number only by accident of two's complement.  icXmlParseU32 accepts the
+  // full range directly and refuses anything outside it.
+  if (!icXmlParseU32(icXmlAttrValue(pNode, "Flags", "0"), m_flags)) {
+    parseStr += "Invalid Flags in EmissionCLutElement\n";
+    return false;
+  }
 
   xmlNode *pData;
 
@@ -3655,7 +3792,8 @@ bool CIccMpeXmlReflectanceCLUT::ToXml(std::string &xml, std::string blanks/* = "
     xml +=  buf;
   }
 
-  snprintf(buf, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Flags=\"%d\">\n", NumInputChannels(), NumOutputChannels(), (unsigned int) m_flags);
+  // 32-bit m_flags printed as signed, exactly as in CIccMpeXmlEmissionCLUT::ToXml.
+  snprintf(buf, bufSize, " InputChannels=\"%d\" OutputChannels=\"%d\" Flags=\"%u\">\n", NumInputChannels(), NumOutputChannels(), (unsigned int) m_flags);
   xml += buf;
 
   snprintf(buf, bufSize, "  <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n", icF16toF(m_Range.start), icF16toF(m_Range.end), m_Range.steps);
@@ -3686,13 +3824,21 @@ bool CIccMpeXmlReflectanceCLUT::ToXml(std::string &xml, std::string blanks/* = "
 
 bool CIccMpeXmlReflectanceCLUT::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  m_nStorageType = (icUInt16Number)atoi(icXmlAttrValue(pNode, "StorageType", "0"));
+  // Same pair of fields, same widths, same defect as CIccMpeXmlEmissionCLUT
+  // above -- both derive from CIccMpeSpectralCLUT, so m_flags is 32-bit here too.
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "StorageType", "0"), m_nStorageType)) {
+    parseStr += "Invalid StorageType in ReflectanceCLutElem\n";
+    return false;
+  }
 
   if (!icXmlParseChannels(pNode, m_nInputChannels, m_nOutputChannels,
                           "CLutElement", parseStr)) {
     return false;
   }
-  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
+  if (!icXmlParseU32(icXmlAttrValue(pNode, "Flags", "0"), m_flags)) {
+    parseStr += "Invalid Flags in ReflectanceCLutElem\n";
+    return false;
+  }
 
   xmlNode *pData;
 
@@ -3755,7 +3901,13 @@ bool CIccMpeXmlEmissionObserver::ParseXml(xmlNode *pNode, std::string &parseStr)
                           "EmissionObserverElement", parseStr)) {
     return false;
   }
-  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
+  // The observer elements derive from CIccMpeSpectralObserver, whose m_flags is
+  // an icUInt16Number rather than the CLUT elements' 32-bit one, so this is the
+  // narrower parse -- and correspondingly the writer's "%d" is already safe here.
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "Flags", "0"), m_flags)) {
+    parseStr += "Invalid Flags in EmissionObserverElement\n";
+    return false;
+  }
 
   xmlNode *pData;
 
@@ -3837,7 +3989,11 @@ bool CIccMpeXmlReflectanceObserver::ParseXml(xmlNode *pNode, std::string &parseS
                           "ReflectanceObserverElement", parseStr)) {
     return false;
   }
-  m_flags = atoi(icXmlAttrValue(pNode, "Flags", "0"));
+  // 16-bit m_flags, as in CIccMpeXmlEmissionObserver above.
+  if (!icXmlParseU16(icXmlAttrValue(pNode, "Flags", "0"), m_flags)) {
+    parseStr += "Invalid Flags in ReflectanceObserverElement\n";
+    return false;
+  }
 
   xmlNode *pData;
 


### PR DESCRIPTION
## PR Summary

Corrects the `atoi()` narrowing family in the `IccMpeXml.cpp` MPE element readers, and the
`"%d"`-printed 32-bit fields in the matching writers, which turned out to be the other half of
the same defect.

Part of #1954, Part of #1931.

(Deliberately "Part of" rather than a closing keyword: 12 sibling `atoi` sites remain outside
this file, listed at the end, so neither issue should auto-close on merge.)

This is the MPE surface that #1908 (MPE channel counts) and #1909 (tag-level readers) did not
cover. Same shape as both: an unsigned attribute parsed with `atoi()`, which returns a signed
`int`, then stored or cast into an `icUInt16Number` / `icUInt32Number`.

### The reported breadcrumbs are the half with the least teeth

Both issues report a negative:

```
IccMpeXml.cpp:1920:21: implicit conversion from 'int' -143 to 'icUInt16Number' -> 65393   (#1954)
IccMpeXml.cpp:313:21:  implicit conversion from 'int' -1   to 'icUInt16Number' -> 65535   (#1931)
```

Both are real UB and both are gone. But 65393 and 65535 are function types the `switch` below
already refuses, so in an ordinary build the document was rejected anyway. **The half that
actually changes behaviour is the overflow, because it lands on a value the switch accepts:**

| document says | master stores and re-serializes as |
|---|---|
| `FormulaSegment FunctionType="65536"` | `0` — a supported function (`Y = a*X^g`) |
| `ToneMapFunction FunctionType="65536"` | `0` |
| `FormulaSegment Reserved2="-1"` | `65535` |
| `EmissionCLutElement Flags="-1"` | accepted as `0xFFFFFFFF` |

Those convert with exit 0 on master. `icXmlParseU16`/`icXmlParseU32` (`IccUtilXml.h`, added by
#1925) already refuse the sign, the trailing garbage and the overflow, so the 21 affected sites
now use them. Where the cast was explicit it was also suppressing UBSan's truncation check, so
those sites were silently wrong rather than reported.

### The writers had to change in the same commit

This is the part that was not in either issue, and it is why the fix could not be reader-only.

Four writer sites cast a 32-bit field to unsigned and then printed it with `"%d"`, so the cast
was a no-op. `CIccMpeXmlCLUT::ToXml` in the same file already uses `"%u"`, which is what the
other four were meant to do.

Consequence, measured on `Testing/Display/LaserProjector` with its `eclt` flags patched to
`0x80000002` — a value `Read32()` accepts from disk, so it is legal on the wire:

```
master:  writer emits  Flags="-2147483646"      <- 32-bit field printed as signed
         reader atoi() wraps it back to 0x80000002
         => round-trips ONLY because two defects cancel
```

So tightening the reader alone would have stopped every such profile from loading. With both
halves fixed the element writes `Flags="2147483650"` and reads back to the same four bytes,
with no wrap anywhere in the path.

### Two call sites that needed care rather than mechanical replacement

- **Tone map `Reserved2`** relied on `icXmlAttrValue()` returning `""` for an absent attribute
  and `atoi("")` yielding 0 — unlike its formula-segment counterpart it passed no `"0"` default.
  `icXmlParseU16` rejects the empty string, so the default is spelled out explicitly; without it
  every tone map function in the corpus would have stopped parsing.
- **Calculator variable `Position` is genuinely signed.** `CIccTempDeclVar` stores it in an
  `int m_pos` whose `-1` means "no position given", so its `atoi()` is correct and is left
  alone. Only the adjacent `icUInt16Number Size` is converted. This is the one site in xsscx's
  list that is not a defect.

### `ParseXmlCurve` dropped every reason a curve failed (#1931 item 4)

It took `parseStr` **by value**, so each curve's `ParseXml()` appended its diagnostic to a copy
that was discarded at the return, leaving callers with only a generic `Unable to parse element`.
Now a reference — which is what makes the new messages above actually reach the user:

```
Invalid FunctionType in Formula Segment
Unable to parse FormulaSegment
Unable to parse element of type CIccMpeXmlCurveSet starting on line 30
```

### Evidence

**Corpus — no behaviour change for legitimate documents.** All **211 tracked `*.xml`** (not just
`Testing/`; includes `.github/ci/test-data/`) converted against master and against the fix:
**211/211 identical accept/reject status, 211/211 byte-identical payloads.** Method per the
in-repo hazard notes: one build directory with the source toggled between passes (a detached
worktree is not a valid binary baseline), and every profile header masked for creation
`dateTime` + `profileID` — note `Testing/hybrid/CMYK_Hybrid_Profile` **embeds a second profile**
carrying its own copies of both at offset 2684976, so masking only the outer header reports a
false difference.

**CTest** — `iccdev.issue-1954-mpe-attr-narrowing-regression`, in the idiom of the #1909/#1898
tests: fixtures are tracked `Testing/` documents with one attribute changed, mutated at run time,
and the script fails if a mutation did not apply so a donor edited upstream cannot silently turn
it into a no-op.

| build | master | with fix |
|---|---|---|
| ordinary Release | **FAIL** — 5 cases | PASS |
| UBSan + integer sanitizer | **FAIL** — both breadcrumbs | PASS |

Each breadcrumb case raises exactly one report at exactly the line its issue cites
(`IccMpeXml.cpp:1920` for #1954, `:313` for #1931).

Controls pair every rejection with the value it wrapped to (`0`, `65535`, `0`) and add
`Flags="2147483650"`, which must still be **accepted** — that is what separates "refuses a value
that does not fit the field" from "lowered a ceiling".

One note on the test itself: the tone map fixture is anchored on the `<ToneMapFunction ` literal
rather than on `FunctionType` alone. The donor carries nine `<FormulaSegment>` elements before
its single tone map, so a bare substitution lands on the first segment — the earlier version of
that case was red on master for the wrong reader while `IccMpeXml.cpp:1920` went untouched.

**Build** — GCC strict `Release` LTO with `-Wall -Wextra -Wpedantic -Werror -std=c++17`:
0 warnings, 0 errors. Full local `ctest` suite run.

### Not covered here

12 raw `atoi(icXmlAttrValue(...))` sites remain outside this file and are deliberately left for
a follow-up rather than mixed in, since they sit in #1909's territory:

- `IccProfileXml.cpp:630,643` — profile-header `spectralRange` / `biSpectralRange` **steps**,
  unguarded. Adjacent to #1932, which was exactly a spectral-range header disagreeing with the
  channel count.
- `IccTagXml.cpp:1496, 2605, 2609, 2663, 4533, 4534, 5984, 5986, 6094, 6096`.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in Contributing document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed docs/python-packaging-release.md
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer infrastructure — the new
      test registers through the existing `iccdev_add_script_test()` helper; no workflow, harness,
      macro, CPack or sanitizer infrastructure is modified
