### PR TITLE
fix(#1954,#1931): parse the remaining XML attributes into the widths they are stored in

### DIFF
--- a/.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh
+++ b/.github/scripts/iccdev-issue-1342-1343-imageparse-signed-unsigned-regression.sh
@@ -14,9 +14,18 @@
 #   IccTagXml.cpp:5548:25: runtime error: implicit conversion from type 'int'
 #   of value -98 ... to type 'icUInt32Number' ... changed the value to ...
 #
-# The fix parses into a signed temporary and floors negatives to 0, so no
-# signed->unsigned wrap occurs.  This test replays the two fuzz PoCs through
-# iccFromXml and fails if the implicit-conversion runtime error reappears.
+# The original fix parsed into a signed temporary and floored negatives to 0, so
+# no signed->unsigned wrap occurred.  The #1954/#1931 follow-up replaced that
+# with icXmlParseU32, which refuses the value outright instead of laundering it
+# into 0 -- flooring had left everything above INT_MAX unreachable, so a legal
+# SeamlessIndicator of 2147483650 was silently stored as 0.  Either way no
+# implicit signed->unsigned conversion occurs, which is all this test asserts;
+# the two PoCs are now rejected earlier than they used to be, and the value
+# preservation that replaced the flooring is covered by
+# iccdev.issue-1954-xml-attr-narrowing-followup-regression.
+#
+# This test replays the two fuzz PoCs through iccFromXml and fails if the
+# implicit-conversion runtime error reappears.
 #
 # This check is only meaningful when iccFromXml was built with the UBSan
 # integer / implicit-conversion sanitizer (the ci-iccdev-tool-tests workflow

--- a/.github/scripts/iccdev-issue-1954-xml-attr-narrowing-followup-regression.sh
+++ b/.github/scripts/iccdev-issue-1954-xml-attr-narrowing-followup-regression.sh
@@ -1,0 +1,349 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issues #1954 and #1931 -- follow-up
+#   the atoi() sites OUTSIDE IccMpeXml.cpp: the profile-header spectral ranges,
+#   the sparse-matrix type, the spectral viewing-conditions ranges, and the two
+#   embedded-image tags together with the writers that fed them
+###############################################################################
+#
+# #1962 fixed the MPE element readers in IccMpeXml.cpp and left the remaining
+# raw `atoi(icXmlAttrValue(...))` sites for this change, since they sit in the
+# territory #1909 covered at the tag level. They are the same defect: an
+# unsigned attribute parsed with atoi(), which returns a signed int, then stored
+# or cast into a narrower or unsigned field, so a value that does not fit
+# changes on the way in instead of being refused.
+#
+# As in #1962, the cases with teeth in an ordinary CI job are NOT the negatives
+# the issues reported -- those tend to wrap into a range a later check already
+# rejects. The ones that matter land on a value the rest of the library accepts:
+#
+#   SpectralRange   steps="65567"      stored and re-serialized as 31
+#   BiSpectralRange steps="65577"      stored and re-serialized as 41
+#   SparseMatrixArray matrixType="65540"  stored as 4 (icSparseMatrixFloat32,
+#                                      a fully supported type)
+#
+# In each case master reports "Profile parsed and saved correctly" and writes a
+# profile carrying a number the source document never contained.
+#
+# CASE W -- the writers, and why they had to change in the same commit.
+#
+# CIccTagXmlEmbeddedHeightImage::ToXml and its NormalImage twin cast two
+# unsigned 32-bit fields to unsigned and then printed them with "%d", so the
+# cast was a no-op:
+#
+#   SeamlessIndicator -- an icUInt32Number; a value with bit 31 set was written
+#     out negative, and the reader (which floored negatives to 0 after #1342)
+#     then read it back as 0. Those two do NOT cancel: SeamlessIndicator=
+#     "2147483650" round-trips to "0" on master, i.e. the value is destroyed.
+#
+#   EncodingFormat -- an icImageEncodingType, whose underlying type is fixed at
+#     icUInt32Number and whose own header defines icImageTypeMaximum =
+#     0xffffffff. Here the two halves DO cancel: master accepts
+#     EncodingFormat="-12623518", stores 4282343778, and prints it back as
+#     "-12623518", so a malformed attribute survives a full round-trip
+#     unchanged. Fixing the reader alone would have stopped iccDEV's own output
+#     loading, which is exactly the coupling #1962 documented for MPE Flags.
+#
+# CASE T -- atoi() where atof() was meant.
+#
+# CIccTagXmlSpectralViewingConditions::ParseXml read the ObserverFuncs "end"
+# wavelength with atoi() while the sibling "start", and both endpoints of the
+# IlluminantSPD range beside it, use atof(). "end" is a nm wavelength held as a
+# float16, so the integer parse truncated the fraction: end="702.5" was stored
+# and re-serialized as 702.
+#
+# CASE X -- a writer typo, found while fixing the reader beside it.
+#
+# CIccProfileXml::ToXmlWithBlanks ended the BiSpectralRange format string with
+# "/>\n)", so a stray ')' was emitted after the newline, immediately before the
+# closing tag, in every profile carrying a bi-spectral range. It round-tripped
+# only because the reader finds <Wavelengths> with icXmlFindNode(), which walks
+# past text nodes. The tracked PoC fixture ub-heightimage-parsexml-1342.xml has
+# the junk baked into line 29, which is how long it has been emitted.
+#
+# Every fixture is a tracked document with ONE attribute changed, applied here
+# rather than checked in, and the script FAILS if a mutation did not apply: a
+# silently-unmutated fixture would convert cleanly and every assertion below
+# would pass while testing nothing.
+#
+# CONTROLS. Each laundering case is paired with the value it wrapped to, as a
+# legal document that must still convert (steps="31", steps="41",
+# matrixType="4"). That pairing separates "refuses a value that does not fit the
+# field" from "lowered the ceiling". SeamlessIndicator="2147483650" is a control
+# in the same sense: it is representable in its 32-bit field, so it must be
+# ACCEPTED and must survive the round trip intact.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1954-followup}"
+mkdir -p "$OUTDIR"
+
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+if [ -z "$FROMXML" ] || [ ! -x "$FROMXML" ]; then
+  echo "[SKIP] iccFromXml not found under $TOOLS_DIR"
+  exit 0
+fi
+TOXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccToXml -type f 2>/dev/null | head -1)"
+
+status=0
+
+# Donors. Each already exercises the reader under test on a known-good path.
+FLUOR=Testing/Named/FluorescentNamedColor.xml        # spectral + bi-spectral ranges,
+                                                     # and an <ObserverFuncs> range
+SPARSE=Testing/Named/SparseMatrixNamedColor.xml      # <SparseMatrixArray matrixType="1">
+HEIGHT=.github/ci/test-data/ub-heightimage-parsexml-1342.xml  # the only tracked
+                                                     # document carrying a <HeightImage>
+
+# mutate <donor-relative-path> <output-name> <find> <replace> [<find> <replace>]...
+#
+# Applies literal substitutions to a tracked fixture and writes the result to
+# OUTDIR. Refuses to write a fixture a substitution did not change, which keeps a
+# donor edited upstream from turning this test into a silent no-op.
+mutate() {
+  local donor="$REPO_ROOT/$1" out="$OUTDIR/$2"
+  local rel="$1"
+  shift 2
+  if [ ! -f "$donor" ]; then
+    echo "[SKIP] donor fixture missing: $rel"
+    return 1
+  fi
+  python3 - "$donor" "$out" "$@" <<'PYEOF'
+import sys
+donor, out = sys.argv[1], sys.argv[2]
+pairs = sys.argv[3:]
+src = open(donor, encoding="utf-8", errors="surrogateescape").read()
+for find, repl in zip(pairs[0::2], pairs[1::2]):
+    if find not in src:
+        sys.stderr.write(find[:70] + "\n")
+        sys.exit(3)
+    src = src.replace(find, repl, 1)
+open(out, "w", encoding="utf-8", errors="surrogateescape").write(src)
+PYEOF
+  local rc=$?
+  if [ $rc -eq 3 ]; then
+    echo "[FAIL] fixture drift: a literal no longer appears in $rel --"
+    echo "       the case below would have run against an unmutated document"
+    status=2
+    return 1
+  elif [ $rc -ne 0 ]; then
+    echo "[SKIP] could not build $2 from $rel"
+    return 1
+  fi
+  return 0
+}
+
+TOOL_RC=0
+TOOL_LOG=""
+TOOL_ICC=""
+run_tool() {
+  # Sets globals rather than echoing: a caller using $(run_tool ...) would run
+  # this in a subshell and TOOL_RC would never reach the caller.
+  local xml="$OUTDIR/$1" base="${1%.xml}"
+  TOOL_LOG="$OUTDIR/$base.log"
+  TOOL_ICC="$OUTDIR/$base.icc"
+  rm -f "$TOOL_ICC"
+  ASAN_OPTIONS="detect_leaks=0:halt_on_error=0:exitcode=0:allocator_may_return_null=1" \
+  UBSAN_OPTIONS="print_stacktrace=1:halt_on_error=0" \
+    "$FROMXML" "$xml" "$TOOL_ICC" -noid > "$TOOL_LOG" 2>&1
+  TOOL_RC=$?
+}
+
+# A laundering case: the document must be refused, and no profile written.
+# $1 = fixture  $2 = description  $3 = grep pattern showing the value that landed
+expect_reject() {
+  run_tool "$1"
+  if [ -f "$TOOL_ICC" ]; then
+    echo "[FAIL] #1954/#1931: $2 -- profile written (rc=$TOOL_RC)"
+    if [ -n "${TOXML:-}" ] && [ -x "${TOXML:-}" ] && \
+       "$TOXML" "$TOOL_ICC" "$OUTDIR/${1%.xml}.roundtrip.xml" >/dev/null 2>&1; then
+      echo "       written profile re-serializes as:"
+      grep -oE "$3" "$OUTDIR/${1%.xml}.roundtrip.xml" | head -2 | sed 's/^/         /'
+    fi
+    status=2
+  else
+    echo "[PASS] $2 -- refused"
+  fi
+  rm -f "$TOOL_ICC"
+}
+
+# A control: the value is representable and must still be accepted.
+expect_accept() {
+  run_tool "$1"
+  if [ -f "$TOOL_ICC" ]; then
+    echo "[PASS] control: $2 still converts"
+  else
+    echo "[FAIL] control: $2 was rejected -- the fix is refusing representable"
+    echo "       values, not just unrepresentable ones"
+    sed -n '1,6p' "$TOOL_LOG"
+    status=2
+  fi
+  rm -f "$TOOL_ICC"
+}
+
+# A value-preservation case: convert, re-serialize, and require the attribute to
+# come back carrying exactly what the source document said.
+# $1 = fixture  $2 = description  $3 = extended regex the round-tripped XML must match
+expect_roundtrip() {
+  run_tool "$1"
+  local rt="$OUTDIR/${1%.xml}.roundtrip.xml"
+  if [ ! -f "$TOOL_ICC" ]; then
+    echo "[FAIL] $2 -- profile not written (rc=$TOOL_RC)"
+    sed -n '1,6p' "$TOOL_LOG"
+    status=2
+    return
+  fi
+  if [ -z "${TOXML:-}" ] || [ ! -x "${TOXML:-}" ]; then
+    echo "[SKIP] $2 -- iccToXml not available to re-serialize"
+    return
+  fi
+  if ! "$TOXML" "$TOOL_ICC" "$rt" >/dev/null 2>&1; then
+    echo "[FAIL] $2 -- iccToXml could not re-serialize the profile"
+    status=2
+    return
+  fi
+  if grep -qE "$3" "$rt"; then
+    echo "[PASS] $2 -- survives XML -> ICC -> XML"
+  else
+    echo "[FAIL] $2 -- value did not survive the round trip; got:"
+    grep -oE 'SeamlessIndicator="[^"]*"|EncodingFormat="[^"]*"|<ObserverFuncs[^>]*|steps="[0-9]*"' \
+      "$rt" | head -4 | sed 's/^/         /'
+    status=2
+  fi
+}
+
+echo "=================================================================="
+echo " XML attribute narrowing follow-up (issues #1954, #1931)"
+echo " readers outside IccMpeXml.cpp, and the writers coupled to them"
+echo "=================================================================="
+
+# --- Case A: profile-header spectral ranges ---------------------------------
+#
+# steps is the sample count for the whole spectral PCS. 65567 & 0xFFFF == 31,
+# which is the donor's real count, so master stores a profile indistinguishable
+# from the unmutated one while the document asked for something else. This is
+# the header-level source of the very disagreement #1932 had to reject in
+# CIccPcsXform::Connect.
+if mutate "$FLUOR" hdr-spectral-steps-launder.xml \
+     '<Wavelengths start="400" end="700" steps="31"/>' \
+     '<Wavelengths start="400" end="700" steps="65567"/>'; then
+  expect_reject hdr-spectral-steps-launder.xml \
+    'SpectralRange steps="65567"' 'steps="[-0-9]+"'
+fi
+# Control: 31 is the wrapped value and the donor's own count -- must convert.
+if mutate "$FLUOR" hdr-spectral-steps-control.xml \
+     '<Wavelengths start="400" end="700" steps="31"/>' \
+     '<Wavelengths start="400" end="700" steps="31"/>'; then
+  expect_accept hdr-spectral-steps-control.xml 'SpectralRange steps="31" (the wrapped value)'
+fi
+
+# The bi-spectral (fluorescence) axis, same reader shape. 65577 & 0xFFFF == 41.
+if mutate "$FLUOR" hdr-bispectral-steps-launder.xml \
+     '<Wavelengths start="300" end="700" steps="41"/>' \
+     '<Wavelengths start="300" end="700" steps="65577"/>'; then
+  expect_reject hdr-bispectral-steps-launder.xml \
+    'BiSpectralRange steps="65577"' 'steps="[-0-9]+"'
+fi
+if mutate "$FLUOR" hdr-bispectral-steps-control.xml \
+     '<Wavelengths start="300" end="700" steps="41"/>' \
+     '<Wavelengths start="300" end="700" steps="41"/>'; then
+  expect_accept hdr-bispectral-steps-control.xml 'BiSpectralRange steps="41" (the wrapped value)'
+fi
+
+# --- Case B: sparse matrix type ---------------------------------------------
+#
+# icSparseMatrixType has a fixed underlying type of uint16_t. 65540 & 0xFFFF == 4
+# == icSparseMatrixFloat32, a fully supported type, so nothing downstream could
+# tell the malformed document from a valid one.
+if mutate "$SPARSE" sparse-matrixtype-launder.xml \
+     'matrixType="1"' 'matrixType="65540"'; then
+  expect_reject sparse-matrixtype-launder.xml \
+    'SparseMatrixArray matrixType="65540"' 'matrixType="[-0-9]+"'
+fi
+if mutate "$SPARSE" sparse-matrixtype-control.xml \
+     'matrixType="1"' 'matrixType="4"'; then
+  expect_accept sparse-matrixtype-control.xml 'matrixType="4" (the wrapped value)'
+fi
+
+# --- Case T: atoi() where atof() was meant ----------------------------------
+#
+# The ObserverFuncs "end" wavelength is a float16 in nm; the integer parse threw
+# the fraction away. Its sibling "start" always used atof(), so this asserts the
+# two endpoints of one range finally agree.
+if mutate "$FLUOR" observer-end-fraction.xml \
+     '<ObserverFuncs start="400" end="700" steps="31">' \
+     '<ObserverFuncs start="400" end="702.5" steps="31">'; then
+  expect_roundtrip observer-end-fraction.xml \
+    'ObserverFuncs end="702.5" keeps its fractional nm' \
+    '<ObserverFuncs[^>]*end="702\.5'
+fi
+
+# --- Case W: the embedded-image readers and their writers -------------------
+#
+# The donor is an intentionally-invalid fuzz PoC -- the only tracked document
+# with a <HeightImage> -- so these mutations also normalize EncodingFormat to a
+# real value (icTiffImageType == 1) where the case is about SeamlessIndicator.
+#
+# EncodingFormat="-12623518" as tracked: master accepts it, stores 4282343778,
+# and its "%d" writer prints it straight back, so the malformed attribute
+# survived a full round trip. Both halves are fixed, so it must now be refused.
+if mutate "$HEIGHT" heightimage-encformat-negative.xml \
+     'EncodingFormat="-12623518"' 'EncodingFormat="-12623518"'; then
+  expect_reject heightimage-encformat-negative.xml \
+    'HeightImage EncodingFormat="-12623518"' 'EncodingFormat="[-0-9]+"'
+fi
+
+# SeamlessIndicator with bit 31 set is representable in its icUInt32Number
+# field, so it is a control: it must be ACCEPTED and must come back as itself.
+# On master the "%d" writer emitted it negative and the reader's floor-to-0
+# swallowed it, so it round-tripped to "0" -- the value was destroyed rather
+# than merely misprinted.
+if mutate "$HEIGHT" heightimage-seamless-hibit.xml \
+     'SeamlessIndicator="-98" EncodingFormat="-12623518"' \
+     'SeamlessIndicator="2147483650" EncodingFormat="1"'; then
+  expect_roundtrip heightimage-seamless-hibit.xml \
+    'HeightImage SeamlessIndicator="2147483650" (bit 31 set)' \
+    'SeamlessIndicator="2147483650"'
+fi
+
+# --- Case X: the BiSpectralRange writer typo --------------------------------
+#
+# Assert the stray ')' is gone from freshly written output. Checked against a
+# profile iccDEV produces itself, so this fails if the format string regresses.
+if mutate "$FLUOR" bispectral-writer-junk.xml \
+     '<Wavelengths start="300" end="700" steps="41"/>' \
+     '<Wavelengths start="300" end="700" steps="41"/>'; then
+  run_tool bispectral-writer-junk.xml
+  RT="$OUTDIR/bispectral-writer-junk.roundtrip.xml"
+  if [ -f "$TOOL_ICC" ] && [ -n "${TOXML:-}" ] && [ -x "${TOXML:-}" ] && \
+     "$TOXML" "$TOOL_ICC" "$RT" >/dev/null 2>&1; then
+    if grep -qE '^\)' "$RT"; then
+      echo "[FAIL] BiSpectralRange writer emits a stray ')' text node:"
+      grep -nE '^\)' "$RT" | head -2 | sed 's/^/         /'
+      status=2
+    else
+      echo "[PASS] BiSpectralRange writer emits no stray ')'"
+    fi
+  else
+    echo "[SKIP] BiSpectralRange writer check -- could not produce round-trip XML"
+  fi
+fi
+
+echo "------------------------------------------------------------------"
+if [ "$status" -eq 0 ]; then
+  echo "RESULT: PASS"
+else
+  echo "RESULT: FAIL"
+fi
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4334,6 +4334,34 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1954-mpe-attr-narrowing-regression.sh"
 )
 
+# #1954/#1931 follow-up: the same narrowing at the atoi() sites OUTSIDE
+# IccMpeXml.cpp, which the test above deliberately left for a separate change.
+# As there, the cases with teeth are the overflows rather than the reported
+# negatives, because they land on values the rest of the library accepts:
+# SpectralRange steps="65567" is stored and re-serialized as 31, BiSpectralRange
+# steps="65577" as 41, and SparseMatrixArray matrixType="65540" as 4 --
+# icSparseMatrixFloat32, a fully supported type -- with iccFromXml reporting
+# "Profile parsed and saved correctly" in every case.
+# Two cases cover the writers, which had to change in the same commit. The
+# embedded-image tags print two unsigned 32-bit fields with "%d": for
+# EncodingFormat that cancels against the reader, so master accepts
+# EncodingFormat="-12623518" and re-emits it verbatim, while for
+# SeamlessIndicator it does not, so the legal value 2147483650 round-trips to 0
+# and is destroyed. A third asserts the ObserverFuncs "end" wavelength keeps its
+# fraction, since that reader used atoi() where its own sibling uses atof().
+# A fourth pins a writer typo found beside them: the BiSpectralRange format
+# string ended "/>\n)" and emitted a stray ')' text node into every profile
+# carrying a bi-spectral range.
+# Controls pair every rejection with the value it wrapped to (31, 41, 4), so a
+# fix that simply lowered a ceiling would fail here.
+iccdev_add_script_test(
+  iccdev.issue-1954-xml-attr-narrowing-followup-regression
+  120
+  "iccdev;xml;header;sparsematrix;issue-1954;issue-1931;regression;ubsan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1954-xml-attr-narrowing-followup-regression.sh"
+)
+
 # #1810: 'RICC' in the CMM and platform header fields of 15 Testing fixtures.
 # 'RICC' was never registered -- icSigRefIccMAX itself carried 0x52494343
 # ('RICC') against a comment and a registry that both said 'RIMX', until #1473

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -205,7 +205,19 @@ bool CIccProfileXml::ToXmlWithBlanks(std::string &xml, std::string blanks)
     }
     if (m_Header.biSpectralRange.steps) {
       xml += blanks + "    <BiSpectralRange>\n";
-      snprintf(line, bufSize, "     <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n)",
+      // The format string used to end "/>\n)", so a stray ')' was appended after
+      // the newline and landed immediately before the closing tag, i.e. every
+      // profile carrying a biSpectralRange was written out with a junk text node
+      // inside the element:
+      //
+      //      <Wavelengths start="300.00000000" end="700.00000000" steps="41"/>
+      //  )    </BiSpectralRange>
+      //
+      // It round-tripped only because the reader locates <Wavelengths> with
+      // icXmlFindNode(), which walks past text nodes, so nothing ever looked at
+      // it.  The SpectralRange writer directly above is the same statement
+      // without the typo and is what this now matches.
+      snprintf(line, bufSize, "     <Wavelengths start=\"" icXmlHalfFmt "\" end=\"" icXmlHalfFmt "\" steps=\"%d\"/>\n",
               icF16toF(m_Header.biSpectralRange.start), icF16toF(m_Header.biSpectralRange.end), m_Header.biSpectralRange.steps);
       xml += blanks + line;
       xml += blanks + "    </BiSpectralRange>\n";
@@ -627,7 +639,20 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
       if (start && end && steps) {
         m_Header.spectralRange.start = icFtoF16((icFloatNumber)atof(icXmlAttrValue(start)));
         m_Header.spectralRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(end)));
-        m_Header.spectralRange.steps = (icUInt16Number)atoi(icXmlAttrValue(steps));
+
+        // steps is the sample count for the whole spectral PCS, so narrowing it
+        // modulo 65536 substitutes a different spectrum rather than failing:
+        // steps="65567" was stored -- and written back out on save -- as 31,
+        // while iccFromXml still reported "Profile parsed and saved correctly".
+        // The explicit (icUInt16Number) cast made that silent to UBSan as well.
+        // This is the header-level twin of what #1925 fixed in the tag readers
+        // and #1908 in the MPE elements, and it feeds the very disagreement
+        // #1932 had to reject downstream in CIccPcsXform::Connect -- a
+        // spectralPCS channel count that does not match spectralRange.steps.
+        if (!icXmlParseU16(icXmlAttrValue(steps), m_Header.spectralRange.steps)) {
+          parseStr += "Invalid SpectralRange Wavelengths steps\n";
+          return false;
+        }
       }
     }
     else if (!icXmlStrCmp(pNode->name, "BiSpectralRange")) {
@@ -640,7 +665,15 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
       if (start && end && steps) {
         m_Header.biSpectralRange.start = icFtoF16((icFloatNumber)atof(icXmlAttrValue(start)));
         m_Header.biSpectralRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(end)));
-        m_Header.biSpectralRange.steps = (icUInt16Number)atoi(icXmlAttrValue(steps));
+
+        // Same defect and same reasoning as the spectralRange steps above; this
+        // count sizes the bi-spectral (fluorescence) axis, which #1677 showed
+        // must agree with the PCS steps or the mapping is built from a range the
+        // profile does not actually carry.
+        if (!icXmlParseU16(icXmlAttrValue(steps), m_Header.biSpectralRange.steps)) {
+          parseStr += "Invalid BiSpectralRange Wavelengths steps\n";
+          return false;
+        }
       }
     }
     else if (!icXmlStrCmp(pNode->name, "MCS")) {

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -1493,7 +1493,20 @@ bool CIccTagXmlSparseMatrixArray::ParseXml(xmlNode *pNode, std::string &parseStr
         parseStr += "Invalid SparseMatrixArray outputChannels\n";
         return false;
       }
-      icSparseMatrixType nMatrixType = (icSparseMatrixType)atoi(icXmlAttrValue(matrixType));
+      // icSparseMatrixType has a fixed underlying type of uint16_t, so the cast
+      // narrowed the same way the outputChannels above used to: matrixType="65540"
+      // became 4 -- icSparseMatrixFloat32, a fully supported type -- and the
+      // profile then "parsed and saved correctly", leaving no way to tell a
+      // malformed document from a valid one.  That is the #1931 shape exactly.
+      // Parse into the width the enum is stored in and reject what does not fit;
+      // the switch-like dispatch on m_nMatrixType below still decides which of
+      // the types are actually supported.
+      icUInt16Number nMatrixTypeVal = 0;
+      if (!icXmlParseU16(icXmlAttrValue(matrixType), nMatrixTypeVal)) {
+        parseStr += "Invalid SparseMatrixArray matrixType\n";
+        return false;
+      }
+      icSparseMatrixType nMatrixType = (icSparseMatrixType)nMatrixTypeVal;
 
       xmlNode *pChild;
 
@@ -2602,14 +2615,28 @@ bool CIccTagXmlSpectralViewingConditions::ParseXml(xmlNode *pNode, std::string &
     }
     attr = icXmlFindAttr(pChild, "end");
     if (attr) {
-      m_observerRange.end = icFtoF16((icFloatNumber)atoi(icXmlAttrValue(attr)));
+      // This alone among the four range endpoints in this function parsed with
+      // atoi() rather than atof().  "end" is a wavelength in nm held as a
+      // float16, so the integer parse silently truncated the fraction: an
+      // ObserverFuncs range ending at end="702.5" was stored as 702, and the
+      // writer at the top of this file then emitted the truncated value.  The
+      // matching "start" three lines above, and both endpoints of the
+      // IlluminantSPD range below, already use atof() -- this brings the odd one
+      // out in line with them.
+      m_observerRange.end = icFtoF16((icFloatNumber)atof(icXmlAttrValue(attr)));
     }
     attr = icXmlFindAttr(pChild, "steps");
     if (attr) {
-      int tempSteps = atoi(icXmlAttrValue(attr));
-      if (tempSteps <= 0 || tempSteps > 0xffff)
+      // The <=0 / >0xffff guard below already refused every value that could not
+      // reach the icUInt16Number field, so unlike the sites above this one was
+      // not narrowing.  What remained was atoi() itself: its behaviour is
+      // undefined -- not merely wrong -- when the text does not fit an int, so
+      // steps="99999999999999999999" was UB before the guard could look at it.
+      // icXmlParseU16 uses strtoul and reports the overflow instead.  A value of
+      // 0 now reaches the shared "if these are not set correctly" check below
+      // rather than returning here, which is the same refusal one step later.
+      if (!icXmlParseU16(icXmlAttrValue(attr), m_observerRange.steps))
         return false;
-      m_observerRange.steps = (icUInt16Number)tempSteps;
     }
     attr = icXmlFindAttr(pChild, "reserved");
     if (attr) {
@@ -2660,10 +2687,12 @@ bool CIccTagXmlSpectralViewingConditions::ParseXml(xmlNode *pNode, std::string &
     }
     attr = icXmlFindAttr(pChild, "steps");
     if (attr) {
-      int tempSteps = atoi(icXmlAttrValue(attr));
-      if (tempSteps <= 0 || tempSteps > 0xffff)
+      // Same reasoning as the ObserverFuncs steps above: already range-guarded,
+      // so this replaces atoi()'s undefined behaviour on an out-of-int input,
+      // not a narrowing.  Zero is caught by the m_illuminantRange.steps == 0
+      // check a few lines below.
+      if (!icXmlParseU16(icXmlAttrValue(attr), m_illuminantRange.steps))
         return false;
-      m_illuminantRange.steps = (icUInt16Number)tempSteps;
     }
     attr = icXmlFindAttr(pChild, "reserved");
     if (attr) {
@@ -4530,15 +4559,23 @@ bool icMBBFromXml(CIccMBB *pMBB, xmlNode *pNode, icConvertType nType, std::strin
   if (!in || !out)
     return false;
 
-  int nIn = atoi(icXmlAttrValue(in));
-  int nOut = atoi(icXmlAttrValue(out));
+  // The 1..15 range checks below already refused everything that could not be
+  // used, so these two were never narrowing.  atoi() is still undefined when the
+  // attribute does not fit an int, though, so the parse happens through
+  // icXmlParseU16 first and the range checks then apply to a value that is
+  // defined.  The 15-channel ceiling is passed as the parser's max_value so an
+  // over-large count is rejected at the parse rather than after it; the explicit
+  // "< 1" test below still rejects 0, which the unsigned parse accepts.
+  icUInt16Number nInVal = 0, nOutVal = 0;
+  if (!icXmlParseU16(icXmlAttrValue(in), nInVal, 15) ||
+      !icXmlParseU16(icXmlAttrValue(out), nOutVal, 15))
+    return false;
+
+  int nIn = (int)nInVal;
+  int nOut = (int)nOutVal;
 
   // must have at least 1 input and 1 output
   if (nIn < 1 || nOut < 1)
-    return false;
-
-  // and the current limit is for 15 channels
-  if (nIn > 15 || nOut > 15)
     return false;
 
   pMBB->Init(nIn, nOut);
@@ -5976,14 +6013,34 @@ bool CIccTagXmlEmbeddedHeightImage::ParseXml(xmlNode *pNode, std::string &parseS
     return false;
 
   // SeamlessIndicator is stored as an unsigned 32-bit indicator (the binary
-  // Read() path uses Read32).  atoi() returns a signed int, so a negative XML
-  // attribute used to wrap to a huge unsigned value through the implicit
-  // int -> icUInt32Number conversion (#1342).  The value is now parsed into a
-  // signed temporary and any negative (invalid) input is floored to 0, so the
-  // stored indicator is always a well-defined non-negative number.
-  int nSeamlessIndicator = atoi(icXmlAttrValue(tagNode, "SeamlessIndicator", "0"));
-  m_nSeamlesIndicator = nSeamlessIndicator < 0 ? 0 : (icUInt32Number)nSeamlessIndicator;
-  m_nEncodingFormat = (icImageEncodingType)atoi(icXmlAttrValue(tagNode, "EncodingFormat", "0"));
+  // Read() path uses Read32).  #1342 stopped the negative wrap by flooring a
+  // negative atoi() result to 0, which removed the UBSan finding but left the
+  // upper half of the range unreachable: atoi() is undefined above INT_MAX, so
+  // SeamlessIndicator="2147483650" -- a perfectly ordinary 32-bit value -- came
+  // out of the parse negative and was then floored, i.e. written as 0.  Parsing
+  // with icXmlParseU32 makes the whole 32-bit range read back as itself and
+  // refuses what genuinely does not fit instead of laundering it into 0.
+  if (!icXmlParseU32(icXmlAttrValue(tagNode, "SeamlessIndicator", "0"), m_nSeamlesIndicator)) {
+    parseStr += "Invalid SeamlessIndicator in HeightImage\n";
+    return false;
+  }
+
+  // icImageEncodingType has a fixed underlying type of icUInt32Number and its
+  // own header defines icImageTypeMaximum = 0xffffffff, so the full unsigned
+  // range is representable.  The cast from atoi()'s signed int therefore did not
+  // narrow so much as re-label: EncodingFormat="-12623518" was accepted as
+  // 4282343778, and the writer below -- which printed the value with "%d" --
+  // turned it straight back into "-12623518", so the malformed attribute
+  // survived a full round-trip unchanged.  The two defects cancelled, which is
+  // why neither showed up on its own; both are fixed here, exactly as #1962 had
+  // to fix the MPE Flags reader and writer together.
+  icUInt32Number nEncodingFormat = 0;
+  if (!icXmlParseU32(icXmlAttrValue(tagNode, "EncodingFormat", "0"), nEncodingFormat)) {
+    parseStr += "Invalid EncodingFormat in HeightImage\n";
+    return false;
+  }
+  m_nEncodingFormat = (icImageEncodingType)nEncodingFormat;
+
   m_fMetersMinPixelValue = (icFloatNumber)atof(icXmlAttrValue(tagNode, "MetersMinPixelValue", "0.0"));
   m_fMetersMaxPixelValue = (icFloatNumber)atof(icXmlAttrValue(tagNode, "MetersMaxPixelValue", "0.0"));
 
@@ -6050,10 +6107,19 @@ bool CIccTagXmlEmbeddedHeightImage::ToXml(std::string &xml, std::string blanks/*
   char buf[bufSize];
 
   xml += blanks + "<HeightImage";
-  snprintf(buf, bufSize, " SeamlessIndicator=\"%d\"", (unsigned int) m_nSeamlesIndicator);
+  // Both fields are unsigned 32-bit -- m_nSeamlesIndicator is an icUInt32Number
+  // and icImageEncodingType has a fixed underlying type of icUInt32Number, with
+  // icImageTypeMaximum = 0xffffffff defined in icProfileHeader.h.  The
+  // (unsigned int) casts already said as much, but "%d" reinterprets the
+  // argument as signed, so anything with bit 31 set was written out negative:
+  // an encoding format of icImageTypeMaximum was emitted as
+  // EncodingFormat="-1".  "%u" is what makes these attributes correct on their
+  // own rather than only in combination with a reader that wraps them back
+  // (#1931); the ParseXml above no longer does that.
+  snprintf(buf, bufSize, " SeamlessIndicator=\"%u\"", (unsigned int) m_nSeamlesIndicator);
   xml += buf;
 
-  snprintf(buf, bufSize, " EncodingFormat=\"%d\"", (unsigned int) m_nEncodingFormat);
+  snprintf(buf, bufSize, " EncodingFormat=\"%u\"", (unsigned int) m_nEncodingFormat);
   xml += buf;
 
   snprintf(buf, bufSize, " MetersMinPixelValue=\"%.12f\"", m_fMetersMinPixelValue);
@@ -6085,15 +6151,22 @@ bool CIccTagXmlEmbeddedNormalImage::ParseXml(xmlNode *pNode, std::string &parseS
   if (!tagNode)
     return false;
 
-  // SeamlessIndicator is stored as an unsigned 32-bit indicator (the binary
-  // Read() path uses Read32).  atoi() returns a signed int, so a negative XML
-  // attribute used to wrap to a huge unsigned value through the implicit
-  // int -> icUInt32Number conversion (#1343).  The value is now parsed into a
-  // signed temporary and any negative (invalid) input is floored to 0, so the
-  // stored indicator is always a well-defined non-negative number.
-  int nSeamlessIndicator = atoi(icXmlAttrValue(tagNode, "SeamlessIndicator", "0"));
-  m_nSeamlesIndicator = nSeamlessIndicator < 0 ? 0 : (icUInt32Number)nSeamlessIndicator;
-  m_nEncodingFormat = (icImageEncodingType)atoi(icXmlAttrValue(tagNode, "EncodingFormat", "0"));
+  // The normal-image tag carries the same two attributes as the height-image
+  // tag above and had the same pair of defects; #1343 is the twin of #1342.  See
+  // CIccTagXmlEmbeddedHeightImage::ParseXml for the reasoning -- the flooring
+  // that closed the negative wrap also made every value above INT_MAX read back
+  // as 0, and the EncodingFormat reader cancelled against its own writer.
+  if (!icXmlParseU32(icXmlAttrValue(tagNode, "SeamlessIndicator", "0"), m_nSeamlesIndicator)) {
+    parseStr += "Invalid SeamlessIndicator in NormalImage\n";
+    return false;
+  }
+
+  icUInt32Number nEncodingFormat = 0;
+  if (!icXmlParseU32(icXmlAttrValue(tagNode, "EncodingFormat", "0"), nEncodingFormat)) {
+    parseStr += "Invalid EncodingFormat in NormalImage\n";
+    return false;
+  }
+  m_nEncodingFormat = (icImageEncodingType)nEncodingFormat;
 
   xmlNode *pImageNode;
   pImageNode = icXmlFindNode(tagNode->children, "Image");
@@ -6157,10 +6230,12 @@ bool CIccTagXmlEmbeddedNormalImage::ToXml(std::string &xml, std::string blanks/*
   char buf[bufSize];
 
   xml += blanks + "<NormalImage";
-  snprintf(buf, bufSize, " SeamlessIndicator=\"%d\"", (unsigned int) m_nSeamlesIndicator);
+  // Same two unsigned 32-bit fields, same "%d"-on-an-unsigned-value defect as
+  // CIccTagXmlEmbeddedHeightImage::ToXml above.
+  snprintf(buf, bufSize, " SeamlessIndicator=\"%u\"", (unsigned int) m_nSeamlesIndicator);
   xml += buf;
 
-  snprintf(buf, bufSize, " EncodingFormat=\"%d\"", (unsigned int) m_nEncodingFormat);
+  snprintf(buf, bufSize, " EncodingFormat=\"%u\"", (unsigned int) m_nEncodingFormat);
   xml += buf;
 
   if (!m_nSize) {


### PR DESCRIPTION
## PR Summary

Corrects the remaining `atoi(icXmlAttrValue(...))` sites — the 12 outside `IccMpeXml.cpp` that
#1962 enumerated and deliberately left for a follow-up — together with the writers that turned
out to be coupled to two of them.

Part of #1954, Part of #1931.

(Again "Part of" rather than a closing keyword: these two issues have now been worked in two
passes, and whether anything further remains is the maintainers' call, not an automatic close.)

This completes the commitment in #1962's body. Same family as #1908 (MPE channel counts) and
#1909 (tag-level readers): an unsigned attribute parsed with `atoi()`, which returns a signed
`int`, then stored or cast into a narrower or unsigned field.

### The 12 sites are not one thing

Measuring them before converting them changed what this PR claims. They fall into four groups,
and only some are defects:

**1. Genuine laundering, unguarded — the ones with teeth**

As in #1962, the reported negatives are the weak half. What changes behaviour is the overflow
that lands on a value the rest of the library accepts:

| site | document says | stored and re-serialized as | tool reports |
|---|---|---|---|
| `IccProfileXml.cpp:630` | `steps="65567"` | **31** | `Profile parsed and saved correctly` |
| `IccProfileXml.cpp:643` | `steps="65577"` | **41** | `Profile parsed and saved correctly` |
| `IccTagXml.cpp:1496` | `matrixType="65540"` | **4** | `Profile parsed and saved correctly` |

The two header `steps` are the sample count for the whole spectral PCS. This is the
header-level *source* of the disagreement #1932 had to reject downstream in
`CIccPcsXform::Connect` — a `spectralPCS` channel count that does not match
`spectralRange.steps`. `icSparseMatrixType` has a fixed underlying type of `uint16_t`, so
`matrixType` wrapped into the enum's own range and landed on `icSparseMatrixFloat32`, a fully
supported type — nothing downstream could tell the malformed document from a valid one.

**2. Already range-guarded — not narrowing, and this PR does not claim they were**

`IccTagXml.cpp:2609,2663` (`<=0 || >0xffff`) and `:4533,4534` (channels 1..15) already refused
every value that could not reach their field. The only thing left was `atoi()` itself, whose
behaviour is *undefined* — not merely wrong — when the text does not fit an `int`. They move to
`icXmlParseU16` for that reason alone; their existing guards are preserved, and the `< 1` test
still rejects 0, which an unsigned parse accepts.

**3. A different defect class — `atoi` where `atof` was meant**

`IccTagXml.cpp:2605` read the `ObserverFuncs` `end` wavelength with `atoi()`, while its own
sibling `start` three lines above, and both endpoints of the `IlluminantSPD` range below it, use
`atof()`. `end` is a wavelength in nm held as a float16, so the integer parse truncated the
fraction:

```
<ObserverFuncs start="400" end="702.5" steps="31">   ->  end="702.00000000"
```

**4. Reader and writer cancelling — the embedded-image tags**

`CIccTagXmlEmbeddedHeightImage::ToXml` and its `NormalImage` twin cast two unsigned 32-bit
fields to `unsigned` and then print them with `"%d"`, so the cast is a no-op. The two fields
behave differently, and that difference is the point:

- **`EncodingFormat`** — `icImageEncodingType` has a fixed underlying type of `icUInt32Number`,
  and `icProfileHeader.h` defines `icImageTypeMaximum = 0xffffffff`. Reader and writer cancel
  *exactly*: master accepts `EncodingFormat="-12623518"`, stores `4282343778`, and prints it
  straight back, so a malformed attribute survives a full round trip unchanged. Fixing the
  reader alone would have stopped iccDEV's own output loading — the same coupling #1962
  documented for the MPE `Flags`.

- **`SeamlessIndicator`** — an `icUInt32Number`. Here they do **not** cancel. #1342/#1343 closed
  the negative wrap by flooring a negative `atoi()` result to 0. That removed the UBSan finding,
  but it left everything above `INT_MAX` unreachable, so a legal value is destroyed rather than
  misprinted:

```
SeamlessIndicator="2147483650"   ->  written as "-2147483646"  ->  read back as 0
```

  Flooring launders; refusing is what makes the field honest. The whole 32-bit range now reads
  back as itself.

### One writer typo found beside them

`CIccProfileXml::ToXmlWithBlanks` ended the `BiSpectralRange` format string with `"/>\n)"`, so a
stray `)` was emitted after the newline, immediately before the closing tag, in **every** profile
carrying a bi-spectral range:

```
    <BiSpectralRange>
     <Wavelengths start="300.00000000" end="700.00000000" steps="41"/>
)    </BiSpectralRange>
```

It round-tripped only because the reader locates `<Wavelengths>` with `icXmlFindNode()`, which
walks past text nodes. The junk is baked into line 29 of the tracked fixture
`.github/ci/test-data/ub-heightimage-parsexml-1342.xml`, which is how long it has been emitted.
The `SpectralRange` writer directly above is the same statement without the typo.

### Corpus

All **211** tracked `*.xml` converted with a clean `origin/master` build and with this branch:

| result | count |
|---|---|
| byte-identical payload | **209** |
| payload differences | **0** |
| accept/reject changes | **2** |

Both status changes are the intentionally-invalid `#1342`/`#1343` fuzz PoCs, which are now
refused instead of laundered. Comparison masks the two fields that legitimately differ run to
run — creation dateTime (bytes 24..35) and the profile ID (84..99).

### Regression coverage

`iccdev.issue-1954-xml-attr-narrowing-followup-regression`, in the idiom of the #1909, #1898 and
#1962 tests: every fixture is a tracked document with one attribute changed, mutated at run time,
and the script fails if a mutation did not apply, so a donor edited upstream cannot silently turn
a case into a no-op.

**Ten assertions, seven red on master:** the three laundering cases above, the two image-tag
cases, the `end="702.5"` truncation, and the stray `)`.

**Three are controls, and they pass on master by design.** Each laundering case is paired with
the value it wrapped to as a legal document that must still convert — `steps="31"`, `steps="41"`,
`matrixType="4"`. That is what separates *refusing a value that does not fit the field* from
*lowering a ceiling*. `SeamlessIndicator="2147483650"` is a control in the same sense: it is
representable, so it must be accepted **and** come back as itself, which is what pins the reader
and writer together — a change to either half alone fails that case.

The `#1342`/`#1343` regression script keys on the UBSan diagnostic and still passes. Its
description is updated, since the flooring it documented no longer exists.

### A verification note worth recording

An early red/green comparison here was a **false pass**. Reference binaries copied out of the
build tree still resolve `libIccXML2.so` from that tree, so after rebuilding they silently ran
the new code and "master" agreed with the fix. The red evidence above was re-established from a
clean `origin/master` build in a detached worktree with its own build directory.

**Build** — clang 18 strict `Release` with LTO, `-Wall -Wextra -Wpedantic -Werror -std=c++17`:
0 warnings, 0 errors. Full local `ctest` run: 149 tests, all pass except
`iccdev.spectral-tiff-preview`, which fails on this host for a missing python `imagecodecs`
module and is unrelated to this change.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in Contributing document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed docs/python-packaging-release.md
- [x] Did not change maintainer-owned workflow, CTest, CPack or sanitizer infrastructure — the
      new test registers through the existing `iccdev_add_script_test()` helper; no workflow,
      harness, macro, CPack or sanitizer infrastructure is modified. The one edit to an existing
      script (`iccdev-issue-1342-1343-...sh`) is to its comment block only, correcting a
      description of behaviour this PR changes; its logic and assertions are untouched.
