### PR TITLE
fix(#1964): restore the acs element channel counts dropped by the JSON reader

### DIFF
--- a/.github/scripts/iccdev-issue-1843-zero-signature-roundtrip-regression.sh
+++ b/.github/scripts/iccdev-issue-1843-zero-signature-roundtrip-regression.sh
@@ -26,8 +26,16 @@
 #
 # Commit 751a0c6b (PR #1365) fixed this same defect class for the profile header
 # fields by writing an empty element for zero.  This test covers the writers that
-# were missed.  Readers on both sides already map empty text back to zero, so the
-# fix is writer-only and the assertions below are all "what comes back out".
+# were missed.  For the zero-signature defect the readers on both sides already
+# map empty text back to zero, so that fix is writer-only and the assertions are
+# all "what comes back out".
+#
+# Section 3 additionally covers a *reader* defect found in the same two acs
+# element handlers: CIccMpeJsonBAcs/EAcs::ParseJson dropped the input/output
+# channel counts that the JSON writer had stamped on them, so an acs bookend
+# reloaded from JSON reported zero channels and failed element-chain validation.
+# Its assertions are the byte comparison and the validation report, not the
+# serialized text, because the text was never wrong.
 #
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
@@ -215,19 +223,41 @@ fi
 #
 # Zero is a named, legal acs signature -- IccProfLib calls it icSigAcsZero -- so
 # an element carrying it must not acquire one on the way through either format.
-# The element is grafted onto a tracked MPE fixture because the corpus has no
-# profile with an acs bookend of its own.
+# The elements are grafted onto a tracked MPE fixture because the corpus has no
+# profile with an acs bookend of its own; the begin bookend goes first in the
+# element chain and the end bookend last, which is where they belong.
+#
+# This section also covers a second, independent defect in the same two readers.
+# CIccTagJsonMultiProcessElement::ToJson stamps inputChannels/outputChannels onto
+# every element generically, and each element's ParseJson reads them back --
+# except CIccMpeJsonBAcs/EAcs::ParseJson, which did not.  Since
+# CIccMpeCreator::CreateElement builds these through CIccMpeBAcs(nChannels = 0),
+# an acs bookend came back from JSON reporting 0 in and 0 out however many the
+# document declared, and the profile that had just been written out valid
+# reloaded as
+#
+#   Error! - AToB1Tag:Mis-matching number of input channels in first process element!
+#
+# The XML reader was always correct here (CIccMpeXmlBAcs::ParseXml calls
+# icXmlParseChannels), which is why only the JSON round trip was affected.  An
+# earlier revision of this test excluded the JSON round trip from the byte
+# comparison below for exactly that reason; both formats are now checked.
 # ===========================================================================
 MPE_XML="$REPO_ROOT/Testing/Display/sRGB_D65_MAT-300lx.xml"
 if [ -f "$MPE_XML" ]; then
   awk '{
+    if (!de && $0 ~ /<\/MultiProcessElements>/) {
+      print "        <EAcsElement InputChannels=\"3\" OutputChannels=\"3\" Signature=\"\"/>"
+      de = 1
+    }
     print
-    if (!done && $0 ~ /<MultiProcessElements InputChannels="3" OutputChannels="3">/) {
+    if (!db && $0 ~ /<MultiProcessElements InputChannels="3" OutputChannels="3">/) {
       print "        <BAcsElement InputChannels=\"3\" OutputChannels=\"3\" Signature=\"\"/>"
-      done = 1
+      db = 1
     }
   }' "$MPE_XML" > "$OUTDIR/acs-in.xml"
   assert_present "$OUTDIR/acs-in.xml" "<BAcsElement" "the grafted BAcsElement"
+  assert_present "$OUTDIR/acs-in.xml" "<EAcsElement" "the grafted EAcsElement"
 
   run acs-build "$FROMXML" "$OUTDIR/acs-in.xml" "$OUTDIR/acs.icc"
 
@@ -238,18 +268,54 @@ if [ -f "$MPE_XML" ]; then
   run acs-tojson "$TOJSON" "$OUTDIR/acs.icc" "$OUTDIR/acs.json"
   assert_absent "$OUTDIR/acs.json" '"signature": "NULL"' "BAcsElement signature"
 
-  # As above, assert on the bytes that come back rather than only on the text
-  # that went out.  Only the XML round trip is checked this way: the JSON parser
-  # for acs elements does not restore the element's input/output channel counts,
-  # so an ICC -> JSON -> ICC profile is not byte-identical for reasons that have
-  # nothing to do with the signature.  That is a separate defect; asserting
-  # byte-equality here would tie this test to it.
-  run acs-fromxml "$FROMXML" "$OUTDIR/acs.xml" "$OUTDIR/acs-rt.icc"
-  if ! cmp -s "$OUTDIR/acs.icc" "$OUTDIR/acs-rt.icc"; then
-    cmp -l "$OUTDIR/acs.icc" "$OUTDIR/acs-rt.icc" 2>/dev/null | sed -n '1,6p' | sed 's/^/    /'
-    fail "an ICC -> XML -> ICC round trip changed the bytes of an icSigAcsZero element (#1843)"
+  # The writer half was never at fault -- assert that, so a future failure here
+  # is attributed to the reader rather than to the counts going missing upstream.
+  #
+  # This has to be scoped to the acs element objects rather than grepped for
+  # across the file: the fixture is 3-channel throughout, so a bare search for
+  # '"inputChannels": 3' matches a dozen other elements and would still pass with
+  # the acs counts gone.  Isolate each element object by brace and test inside
+  # it, which also keeps the check independent of key order -- ICC_JSON_ORDERED
+  # changes that, and a fixed-offset context window would silently stop matching.
+  assert_acs_counts() {
+    local file="$1" elem="$2" block
+    block="$(awk -v e="$elem" '
+      /\{/  { buf = "" }
+              { buf = buf $0 "\n" }
+      /\}/  { if (buf ~ "\"type\": \"" e "\"") printf "%s", buf; buf = "" }
+    ' "$file")"
+    [ -n "$block" ] || fail "$elem is missing from the JSON entirely (#1843)"
+    printf '%s' "$block" | grep -qF '"inputChannels": 3' \
+      || fail "$elem lost its inputChannels in the JSON writer (#1843)"
+    printf '%s' "$block" | grep -qF '"outputChannels": 3' \
+      || fail "$elem lost its outputChannels in the JSON writer (#1843)"
+  }
+  assert_acs_counts "$OUTDIR/acs.json" BAcsElement
+  assert_acs_counts "$OUTDIR/acs.json" EAcsElement
+
+  # Assert on the bytes that come back rather than only on the text that went
+  # out.  Checking the serialized text alone is too weak: it passes as soon as
+  # the writer stops emitting "NULL", even if the reader then restores some other
+  # wrong value -- which is precisely what the dropped channel counts did.
+  run acs-fromxml  "$FROMXML"  "$OUTDIR/acs.xml"  "$OUTDIR/acs-rt-xml.icc"
+  run acs-fromjson "$FROMJSON" "$OUTDIR/acs.json" "$OUTDIR/acs-rt-json.icc"
+  for fmt in xml json; do
+    if ! cmp -s "$OUTDIR/acs.icc" "$OUTDIR/acs-rt-$fmt.icc"; then
+      cmp -l "$OUTDIR/acs.icc" "$OUTDIR/acs-rt-$fmt.icc" 2>/dev/null | sed -n '1,6p' | sed 's/^/    /'
+      fail "an ICC -> ${fmt} -> ICC round trip changed the bytes of an icSigAcsZero element (#1843)"
+    fi
+  done
+
+  # The byte comparison above is the strict assertion, but it reports a diff
+  # rather than the symptom a user would see, so check the symptom too: before
+  # the reader fix the reloaded profile failed element-chain validation.
+  "$DUMP" -v "$OUTDIR/acs-rt-json.icc" > "$OUTDIR/acs-validate-json.log" 2>&1
+  if grep -q "Mis-matching number of input channels" "$OUTDIR/acs-validate-json.log"; then
+    grep -n "Mis-matching number of input channels" "$OUTDIR/acs-validate-json.log" \
+      | sed -n '1,3p' | sed 's/^/    /'
+    fail "the JSON round trip dropped the acs element channel counts (#1843)"
   fi
-  echo "    BAcsElement: icSigAcsZero survives both writers, XML byte-exact"
+  echo "    BAcs/EAcsElement: icSigAcsZero and the channel counts survive both round trips, byte-exact"
 else
   echo "    [note] $MPE_XML absent -- BAcs section skipped"
 fi

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1188,8 +1188,39 @@ bool CIccMpeJsonBAcs::ToJson(IccJson &j)
   return true;
 }
 
-bool CIccMpeJsonBAcs::ParseJson(const IccJson &j, std::string & /*parseStr*/)
+bool CIccMpeJsonBAcs::ParseJson(const IccJson &j, std::string &parseStr)
 {
+  // CIccTagJsonMultiProcessElement::ToJson stamps inputChannels/outputChannels
+  // onto every element generically in its element-array loop, and each element's
+  // own ParseJson is responsible for reading them back.  Of the eighteen
+  // CIccMpeJson*::ParseJson implementations these two -- BAcs and EAcs -- were
+  // the only ones that did not, so the counts were written and then dropped.
+  //
+  // Nothing left them at a wrong value: CIccMpeCreator::CreateElement builds the
+  // element through CIccMpeBAcs(nChannels = 0), so an acs bookend read back from
+  // JSON always reported 0 in and 0 out however many the document declared.  The
+  // element chain then no longer matched the tag, and a profile that was valid
+  // going in came back with
+  //
+  //   Error! - AToB1Tag:Mis-matching number of input channels in first process element!
+  //
+  // The XML reader has always done this -- CIccMpeXmlBAcs::ParseXml calls
+  // icXmlParseChannels() and refuses the element without it -- which is why the
+  // XML round trip of the same profile is byte-exact and only the JSON one is
+  // not.  icJsonValidChannels is the JSON-side equivalent of that helper's
+  // "both present, both non-zero, both within the channel ceiling" test, and is
+  // what every other element reader in this file already uses (#1843).
+  int nIn = 0, nOut = 0;
+  jGetValue(j, "inputChannels",  nIn);
+  jGetValue(j, "outputChannels", nOut);
+
+  if (!icJsonValidChannels(nIn, nOut)) {
+    parseStr += "Invalid inputChannels or outputChannels in BAcsElement\n";
+    return false;
+  }
+  m_nInputChannels  = (icUInt16Number)nIn;
+  m_nOutputChannels = (icUInt16Number)nOut;
+
   std::string sig, hex;
   jGetString(j, "signature", sig);
   jGetString(j, "data", hex);
@@ -1215,8 +1246,23 @@ bool CIccMpeJsonEAcs::ToJson(IccJson &j)
   return true;
 }
 
-bool CIccMpeJsonEAcs::ParseJson(const IccJson &j, std::string & /*parseStr*/)
+bool CIccMpeJsonEAcs::ParseJson(const IccJson &j, std::string &parseStr)
 {
+  // The end-of-chain bookend carries the same two attributes as the begin
+  // bookend above and had the same defect; CIccMpeEAcs(nChannels = 0) leaves the
+  // counts at zero in exactly the same way.  See CIccMpeJsonBAcs::ParseJson for
+  // the reasoning and for why the XML side was already correct (#1843).
+  int nIn = 0, nOut = 0;
+  jGetValue(j, "inputChannels",  nIn);
+  jGetValue(j, "outputChannels", nOut);
+
+  if (!icJsonValidChannels(nIn, nOut)) {
+    parseStr += "Invalid inputChannels or outputChannels in EAcsElement\n";
+    return false;
+  }
+  m_nInputChannels  = (icUInt16Number)nIn;
+  m_nOutputChannels = (icUInt16Number)nOut;
+
   std::string sig, hex;
   jGetString(j, "signature", sig);
   jGetString(j, "data", hex);


### PR DESCRIPTION
## PR Summary

Fixes #1964. Follow-up to #1843, where this defect was found and left as a documented carve-out
in that issue's regression test.

`CIccTagJsonMultiProcessElement::ToJson` stamps `inputChannels`/`outputChannels` onto every MPE
element generically in its element-array loop, and each element's `ParseJson` reads them back.
`CIccMpeJsonBAcs::ParseJson` and `CIccMpeJsonEAcs::ParseJson` were the two of eighteen that did
not.

Nothing left them at a wrong value. `CIccMpeCreator::CreateElement` builds these through
`CIccMpeBAcs(nChannels = 0)`, so an acs bookend read back from JSON reported 0 in and 0 out
however many the document declared, the element chain no longer matched the tag, and a profile
that had just been written out valid reloaded as:

```
Profile parsed. Profile is invalid, but saved correctly
Error! - AToB1Tag:Mis-matching number of input channels in first process element!
```

The XML reader was always correct here — `CIccMpeXmlBAcs::ParseXml` calls `icXmlParseChannels()`
and refuses the element without usable counts — which is why the XML round trip of the same
profile is byte-exact and only the JSON one is not. Both readers now use `icJsonValidChannels`,
the JSON-side equivalent of that helper's "both present, both non-zero, both within the channel
ceiling" test, exactly as the other sixteen element readers in the file already do.

### Scope was measured, not assumed

Four further readers do not mention the counts. None is a defect, so none is touched:

| reader | why it is already correct |
|---|---|
| `CIccMpeJsonEmissionCLUT` | delegates to `icSpectralCLUTParseJson`, which reads and validates them (`IccMpeJson.cpp:2384-2392`) |
| `CIccMpeJsonReflectanceCLUT` | same delegation |
| `CIccMpeJsonJabToXYZ` | definitionally 3 -> 3; sets both counts directly |
| `CIccMpeJsonXYZToJab` | same |

One related divergence is **left alone deliberately**: `CIccMpeXmlJabToXYZ::ParseXml`
(`IccMpeXml.cpp:2539`) rejects a document declaring anything other than 3/3, while the JSON side
silently forces 3. That is benign — the JSON reader cannot produce a wrong element, only accept a
wrong document — and tightening it would reject documents that are currently accepted. Flagged in
#1964 as a separate maintainer call rather than folded in here.

### Backward compatibility

Not a concern. The writer has stamped these counts since the original JSON support commit
`60bbb8c9` (#803), so every JSON document this library has ever produced carries them. The change
makes the JSON reader refuse an acs element that lacks them, which is what the XML reader has
always done.

### Regression coverage

No new test script. The existing `iccdev-issue-1843-zero-signature-roundtrip-regression.sh`
already carried this defect as a carve-out — its BAcs section excluded the JSON round trip from
the byte comparison "because the JSON parser for acs elements does not restore the element's
input/output channel counts". That carve-out is removed and the section now:

- grafts **both** bookends, in their correct chain positions (begin first, end last) rather than
  only a `BAcsElement`;
- compares **both** round trips byte-for-byte, where before only XML was compared;
- asserts the writer still emits the counts, so a future failure is attributed to the reader
  rather than to the counts going missing upstream;
- asserts the reloaded profile does not report the element-chain error, which is the symptom a
  user actually sees — the byte comparison is the stricter assertion but reports a diff rather
  than a cause.

The writer assertion is scoped to the acs element objects by brace rather than grepped for
across the file. The fixture is 3-channel throughout, so a bare search for `"inputChannels": 3`
matches a dozen other elements and would still pass with the acs counts gone — it was written
that way first and did not discriminate. Isolating the object also keeps the check independent
of key order, which `ICC_JSON_ORDERED` changes and which would silently break a fixed-offset
context window.

### Verification

- **Red/green.** Red established on an independent pre-fix build, confirmed pre-fix by the
  absence of the new diagnostic string in its `libIccJSON2.so` and run under `env -i` so no
  library path leaked in. This matters here: reference binaries copied out of a build tree still
  resolve their `.so` from that tree, which produced a false pass earlier in this issue family.
  Green after the change, with the JSON round trip byte-identical and the counts back at 3/3.
- **The new assertion was itself red/green tested** against a JSON mutated to drop only the
  `BAcsElement` counts: it fires on that block while the untouched `EAcsElement` block still
  passes, which is what proves it is per-element and not file-wide.
- **Full local `ctest`:** 147/149. The two failures are pre-existing and unrelated —
  `spectral-tiff-preview` (missing python `imagecodecs` on this host) and `qa-profile-manifest`,
  which reports `213 profiles matched, 0 mismatched` and fails only on `1 unlisted`: a stray
  untracked `Testing/hbo-iccviz-...Line757.icc` dated 2026-06-23. **0 mismatched** is the
  relevant number — this change alters no corpus validation verdict.
- **Build:** clean under clang 18 Release, and under `-Wall -Wextra -Wpedantic -Werror -std=c++17`
  with Homebrew clang 21.1.3. 0 warnings, 0 errors in both.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in Contributing document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed docs/python-packaging-release.md
- [x] Did not change maintainer-owned workflow, CTest, CPack or sanitizer infrastructure — the
      only script touched is the existing `#1843` regression script, which this change makes
      strictly stronger; no workflow, harness, macro, CPack or sanitizer infrastructure is
      modified, and no CTest registration changes (the test is already registered).
- [x] New source files include the ICC copyright and BSD 3-Clause license header — no new source
      files.
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
