### PR TITLE
fix(#1950): guard the CAM adapting luminance against a negative value

### DIFF
--- a/.github/ci/regression/cam-degenerate.cpp
+++ b/.github/ci/regression/cam-degenerate.cpp
@@ -83,8 +83,14 @@ int main()
   // 400. A very large m_La matters specifically: it makes H_Function(m_Fl) round
   // to exactly 400.0f in float, which is how a crafted profile lands the argument
   // precisely on the division by zero rather than merely past it.
+  // The negative, infinite and NaN entries are #1950. This sweep originally ran
+  // over non-negative adapting luminances only, which is exactly the gap that
+  // defect lived in -- see case 7 below.
   static const icFloatNumber kLa[] = {0.0f, 1e-6f, 0.01f, 1.0f, 100.0f,
-                                      1e6f, 1e12f, 1e30f, 1e38f};
+                                      1e6f, 1e12f, 1e30f, 1e38f,
+                                      -1e-6f, -0.1f, -0.2f, -0.5f, -1.0f,
+                                      -100.0f, -1e6f, -1e30f,
+                                      INFINITY, -INFINITY, NAN};
   static const icFloatNumber kYb[] = {0.0f, 1e-6f, 20.0f, 100.0f, 1e6f, 1e30f};
   static const icFloatNumber kJ[]  = {-1e30f, -100.0f, 0.0f, 50.0f, 100.0f,
                                       1e6f, 1e30f, 1e38f};
@@ -147,6 +153,57 @@ int main()
                    " channel %d: %g -> %g\n",
                    i, (double)midXyz[i], (double)backXyz[i]);
       return 6;
+    }
+  }
+
+  // --- #1950: negative adapting luminance ------------------------------------
+  //
+  // CalcCoefficients computed k = 1.0f / (5.0f * m_La + 1.0f) with no domain
+  // check on m_La. The denominator is exactly zero at m_La == -0.2f, because
+  // 5.0f * -0.2f rounds to exactly -1.0f in float, so the pole is landed on
+  // rather than approached. iccApplyProfiles reached it from profile data: the
+  // colorEncodingParams white-point luminance defaults the ambient luminance to
+  // Lw/5, so an s15Fixed16 Lw of -1.0 produces m_La == -0.2 exactly.
+  //
+  // Read case 7 together with the dbz helper in
+  // .github/scripts/iccdev-cam-degenerate-regression-tests.sh. This case cannot
+  // detect the division on its own and is not written as though it can: every
+  // negative m_La, the one that divided by zero included, already returned
+  // finite zeros through the public API, because the NaN that the same line
+  // produced downstream was flushed to zero by the Hyperbolic()/HyperbolicInv()
+  // guards. What case 7 pins is that contract -- that the guard added for the
+  // division resolves to the degenerate zero state and does not start returning
+  // NaN, infinity or some new non-zero answer for these luminances. The division
+  // itself is caught by the helper, which compiles IccCAM.cpp with
+  // -fsanitize=float-divide-by-zero regardless of how the library was built.
+  static const icFloatNumber kNegLa[] = {-0.2f, -0.5f, -1.0f, -1e6f};
+
+  for (size_t i = 0; i < sizeof(kNegLa) / sizeof(kNegLa[0]); i++) {
+    CIccCamConverter negCam;
+    icFloatNumber negWhite[3] = {0.9642f, 1.0f, 0.8249f};
+
+    negCam.SetParameter_WhitePoint(negWhite);
+    negCam.SetParameter_La(kNegLa[i]);
+    negCam.SetParameter_Yb(20.0f);
+
+    icFloatNumber negXyz[3] = {0.25f, 0.50f, 0.75f};
+    icFloatNumber negJab[3] = {-1.0f, -1.0f, -1.0f};
+    negCam.XYZToJab(negXyz, negJab, 1);
+
+    icFloatNumber negInJab[3] = {50.0f, 1.0f, -1.0f};
+    icFloatNumber negOutXyz[3] = {-1.0f, -1.0f, -1.0f};
+    negCam.JabToXYZ(negInJab, negOutXyz, 1);
+
+    if (!is_finite_triplet(negJab) || !is_zero_triplet(negJab) ||
+        !is_finite_triplet(negOutXyz) || !is_zero_triplet(negOutXyz)) {
+      std::fprintf(stderr,
+                   "[cam-degenerate] FAIL (#1950): La=%g -> jab=%g %g %g"
+                   " xyz=%g %g %g\n",
+                   (double)kNegLa[i],
+                   (double)negJab[0], (double)negJab[1], (double)negJab[2],
+                   (double)negOutXyz[0], (double)negOutXyz[1],
+                   (double)negOutXyz[2]);
+      return 7;
     }
   }
 

--- a/.github/ci/regression/cam-la-divzero.cpp
+++ b/.github/ci/regression/cam-la-divzero.cpp
@@ -1,0 +1,72 @@
+// #1950: division by zero in CIccCamConverter::CalcCoefficients for a negative
+// adapting luminance.
+//
+// CalcCoefficients computed
+//
+//     k = 1.0f / (5.0f * m_La + 1.0f);
+//
+// with no domain check on m_La. The denominator is exactly zero when m_La is
+// -0.2f: 5.0f * -0.2f rounds to exactly -1.0f in float, so the pole is landed on
+// precisely rather than approached. Every negative m_La also made the following
+// line take a fractional power of a negative number, leaving NaN in m_Fl.
+//
+// The value is profile-controlled. icConvertEncodingProfile passes the
+// colorEncodingParams ambient white-point luminance straight to
+// SetParameter_La, defaulting it to the white-point luminance divided by five
+// (IccEncoding.cpp), so an s15Fixed16 ceptWhitePointLuminanceMbr of -1.0 gives
+// m_La == -0.2 exactly. UBSan reported it through iccApplyProfiles as
+//
+//     IccProfLib/IccCAM.cpp:306:11: runtime error: division by zero
+//
+// This helper is compiled together with IccProfLib/IccCAM.cpp under
+// -fsanitize=float-divide-by-zero by
+// .github/scripts/iccdev-cam-degenerate-regression-tests.sh. Building the
+// converter into the helper is the point of the file: the division is inside
+// IccProfLib, so instrumenting only the helper would not see it, and no CI lane
+// both builds the library with float-divide-by-zero and runs ctest. Compiling
+// the translation unit here makes the check independent of how the library was
+// configured.
+//
+// There is deliberately nothing to assert on. A negative adapting luminance
+// already produced finite zeros through the public API before the guard existed,
+// because the NaN was flushed to zero downstream by the Hyperbolic() and
+// HyperbolicInv() guards, so no return value distinguishes the defective
+// converter from the fixed one. The sanitizer report is the signal, and the
+// script fails the case on "runtime error:" in the output. The value contract
+// for these same luminances is asserted separately, as case 7 of
+// cam-degenerate.cpp.
+
+#include "IccCAM.h"
+
+#include <cstdio>
+
+int main()
+{
+  // -0.2f is the pole itself. The neighbours are carried along so that a future
+  // guard written only for the exact value, rather than for the domain, still
+  // has the rest of the negative range exercised against the sanitizer.
+  static const icFloatNumber kLa[] = {-0.2f, -0.1f, -0.5f, -1.0f, -100.0f,
+                                      -1e6f, -1e-6f};
+
+  icFloatNumber whitePoint[3] = {0.9642f, 1.0f, 0.8249f};
+
+  for (size_t i = 0; i < sizeof(kLa) / sizeof(kLa[0]); i++) {
+    CIccCamConverter cam;
+
+    cam.SetParameter_WhitePoint(whitePoint);
+    cam.SetParameter_La(kLa[i]);
+    cam.SetParameter_Yb(20.0f);
+
+    icFloatNumber xyz[3] = {0.25f, 0.50f, 0.75f};
+    icFloatNumber jab[3] = {-1.0f, -1.0f, -1.0f};
+    cam.XYZToJab(xyz, jab, 1);
+
+    icFloatNumber inJab[3] = {50.0f, 1.0f, -1.0f};
+    icFloatNumber outXyz[3] = {-1.0f, -1.0f, -1.0f};
+    cam.JabToXYZ(inJab, outXyz, 1);
+  }
+
+  std::printf("[cam-la-divzero] swept %zu negative adapting luminances\n",
+              sizeof(kLa) / sizeof(kLa[0]));
+  return 0;
+}

--- a/.github/scripts/iccdev-cam-degenerate-regression-tests.sh
+++ b/.github/scripts/iccdev-cam-degenerate-regression-tests.sh
@@ -137,7 +137,11 @@ run_cam_degenerate_helper() {
     return
   fi
 
-  san_flags=("${SAN_FLAGS[@]}")
+  # Expanded through the ${x[@]+"${x[@]}"} form because the script runs under
+  # "set -u" and an empty array expansion is an unbound-variable error in the
+  # bash 3.2 that ships as /bin/bash on macOS. SAN_FLAGS is empty whenever the
+  # build enabled no sanitizers at all.
+  san_flags=(${SAN_FLAGS[@]+"${SAN_FLAGS[@]}"})
 
   if ! "$CXX" -std=c++17 "${san_flags[@]}" \
       -I"$REPO_ROOT/IccProfLib" \
@@ -235,7 +239,7 @@ run_cam_divzero_helper() {
   # The library's own sanitizers first, so the link resolves, then
   # float-divide-by-zero unconditionally: it is the check this case exists for,
   # and it must apply whether or not the build enabled ENABLE_FLOAT_SANITIZER.
-  if ! "$CXX" -std=c++17 "${SAN_FLAGS[@]}" -fsanitize=float-divide-by-zero -g \
+  if ! "$CXX" -std=c++17 ${SAN_FLAGS[@]+"${SAN_FLAGS[@]}"} -fsanitize=float-divide-by-zero -g \
       -DICCPROFLIB_EXPORTS \
       -I"$REPO_ROOT/IccProfLib" \
       -I"$BUILD_DIR/IccProfLib" \

--- a/.github/scripts/iccdev-cam-degenerate-regression-tests.sh
+++ b/.github/scripts/iccdev-cam-degenerate-regression-tests.sh
@@ -150,9 +150,106 @@ run_cam_degenerate_helper() {
   pass_case "$name" "degenerate CAM state produces finite zero output"
 }
 
+# #1950: CalcCoefficients divided by 5*m_La + 1 with no domain check on m_La,
+# and that denominator is exactly zero at m_La == -0.2f.
+#
+# This needs its own helper rather than another case in cam-degenerate.cpp. The
+# division happens inside IccProfLib, so it is only instrumented when the library
+# itself was compiled with -fsanitize=float-divide-by-zero -- and no CI lane both
+# enables that and runs ctest (the float-sanitized build in ci-docker-pr.yml
+# builds iccDumpProfile only). Sanitizer flags on the helper alone would not see
+# it, so the helper compiles IccCAM.cpp into its own binary instead. Its copy of
+# the converter then wins for the calls the helper makes, and the check works
+# against an ordinary non-sanitized library build.
+#
+# The value contract for these luminances is asserted separately, as case 7 of
+# cam-degenerate.cpp; it cannot catch the division, because a negative m_La
+# already produced finite zeros through the public API. See the comment there.
+run_cam_divzero_helper() {
+  local name="cam-la-divide-by-zero"
+  local helper_cpp="$REPO_ROOT/.github/ci/regression/cam-la-divzero.cpp"
+  local cam_cpp="$REPO_ROOT/IccProfLib/IccCAM.cpp"
+  local helper_bin="${TMPDIR:-/tmp}/iccdev-${name}-helper-$$"
+  local compile_log="$OUTDIR/$name.compile.log"
+  local run_log="$OUTDIR/$name.run.log"
+  local lib_dir="$BUILD_DIR/IccProfLib"
+  local lib_arg=""
+  local run_ec=0
+
+  TOTAL=$((TOTAL + 1))
+
+  if [ -z "$BUILD_DIR" ] || [ ! -d "$lib_dir" ]; then
+    fail_case "$name" "missing build directory with IccProfLib"
+    return
+  fi
+
+  for lib_name in IccProfLib2d IccProfLib2; do
+    if [ -f "$lib_dir/lib${lib_name}.so" ] || [ -f "$lib_dir/lib${lib_name}.dylib" ]; then
+      lib_arg="-l${lib_name}"
+      break
+    fi
+  done
+
+  if [ -z "$lib_arg" ]; then
+    fail_case "$name" "missing shared IccProfLib library in $lib_dir"
+    return
+  fi
+
+  if [ ! -f "$helper_cpp" ] || [ ! -f "$cam_cpp" ]; then
+    fail_case "$name" "missing helper source $helper_cpp or $cam_cpp"
+    return
+  fi
+
+  # Not every supported compiler carries this check; skip rather than fail so a
+  # toolchain without it does not turn into a false regression.
+  if ! echo 'int main(){return 0;}' |
+       "$CXX" -x c++ -std=c++17 -fsanitize=float-divide-by-zero - \
+         -o "$helper_bin" >/dev/null 2>&1; then
+    rm -f "$helper_bin"
+    pass_case "$name" "skipped -- $CXX does not support -fsanitize=float-divide-by-zero"
+    return
+  fi
+  rm -f "$helper_bin"
+
+  if ! "$CXX" -std=c++17 -fsanitize=float-divide-by-zero -g \
+      -DICCPROFLIB_EXPORTS \
+      -I"$REPO_ROOT/IccProfLib" \
+      -I"$BUILD_DIR/IccProfLib" \
+      "$helper_cpp" "$cam_cpp" \
+      -L"$lib_dir" "$lib_arg" -Wl,-rpath,"$lib_dir" \
+      -o "$helper_bin" > "$compile_log" 2>&1; then
+    fail_case "$name" "failed to compile helper"
+    sed -n '1,80p' "$compile_log"
+    rm -f "$helper_bin"
+    return
+  fi
+
+  UBSAN_OPTIONS="print_stacktrace=0" \
+    LD_LIBRARY_PATH="$lib_dir:${LD_LIBRARY_PATH:-}" "$helper_bin" \
+    > "$run_log" 2>&1 || run_ec=$?
+
+  if grep -q "runtime error:" "$run_log" 2>/dev/null; then
+    fail_case "$name" "division by zero in CalcCoefficients for a negative adapting luminance"
+    sed -n '1,80p' "$run_log"
+    rm -f "$helper_bin"
+    return
+  fi
+
+  if [ "$run_ec" -ne 0 ]; then
+    fail_case "$name" "helper exited $run_ec"
+    sed -n '1,80p' "$run_log"
+    rm -f "$helper_bin"
+    return
+  fi
+
+  rm -f "$helper_bin"
+  pass_case "$name" "negative adapting luminance does not divide by zero"
+}
+
 echo "=== CAM degenerate-state regression ==="
 
 run_cam_degenerate_helper
+run_cam_divzero_helper
 
 echo "CAM degenerate-state regression: $PASS passed, $FAIL failed, $TOTAL total"
 

--- a/.github/scripts/iccdev-cam-degenerate-regression-tests.sh
+++ b/.github/scripts/iccdev-cam-degenerate-regression-tests.sh
@@ -46,6 +46,7 @@ export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=1,print_stacktrace=1}"
 
 PASS=0
 FAIL=0
+SKIP=0
 TOTAL=0
 
 # A helper is compiled here and linked against the library the build produced, so
@@ -100,6 +101,19 @@ pass_case() {
   local reason="$2"
   echo "  [PASS] $name -- $reason"
   PASS=$((PASS + 1))
+}
+
+# A case that could not run at all is neither a pass nor a regression, and it
+# must not be reported as either. Counting it as a pass is what makes a check
+# quietly stop checking: ctest prints a script test's output only when it fails,
+# so a case that degraded into a no-op would look exactly like one that ran. The
+# script exits 77 when this fires and the test is registered SKIP_RETURN_CODE 77,
+# so ctest reports the run as Skipped rather than Passed.
+skip_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [SKIP] $name -- $reason"
+  SKIP=$((SKIP + 1))
 }
 
 run_cam_degenerate_helper() {
@@ -231,7 +245,7 @@ run_cam_divzero_helper() {
        "$CXX" -x c++ -std=c++17 -fsanitize=float-divide-by-zero - \
          -o "$helper_bin" >/dev/null 2>&1; then
     rm -f "$helper_bin"
-    pass_case "$name" "skipped -- $CXX does not support -fsanitize=float-divide-by-zero"
+    skip_case "$name" "$CXX does not support -fsanitize=float-divide-by-zero"
     return
   fi
   rm -f "$helper_bin"
@@ -279,10 +293,20 @@ echo "=== CAM degenerate-state regression ==="
 run_cam_degenerate_helper
 run_cam_divzero_helper
 
-echo "CAM degenerate-state regression: $PASS passed, $FAIL failed, $TOTAL total"
+echo "CAM degenerate-state regression: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total"
 
+# A real regression outranks an incomplete run, so failures are reported first.
 if [ "$FAIL" -ne 0 ]; then
   exit 1
+fi
+
+# Otherwise any skipped case downgrades the whole test to Skipped. That is
+# deliberately conservative: the only case that can skip is the divide-by-zero
+# detector, and without it this script has not verified the thing it is named
+# for, so reporting Passed would overstate what ran. The cases that did run
+# still print their own [PASS] lines above.
+if [ "$SKIP" -ne 0 ]; then
+  exit 77
 fi
 
 exit 0

--- a/.github/scripts/iccdev-cam-degenerate-regression-tests.sh
+++ b/.github/scripts/iccdev-cam-degenerate-regression-tests.sh
@@ -48,6 +48,46 @@ PASS=0
 FAIL=0
 TOTAL=0
 
+# A helper is compiled here and linked against the library the build produced, so
+# it has to be built with the same sanitizers the library was, or the link fails
+# on the runtime symbols the library references. Both helpers below need this, so
+# work it out once.
+#
+# ENABLE_FLOAT_SANITIZER is deliberately handled alongside the others: it is a
+# standalone option rather than something ENABLE_ASAN or ENABLE_UBSAN implies, so
+# a build that enables only it produces a library needing
+# __ubsan_handle_float_cast_overflow_abort, which used to fail to link here.
+SAN_FLAGS=()
+
+compute_san_flags() {
+  [ -f "$BUILD_DIR/CMakeCache.txt" ] || return 0
+
+  if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+    if "$CXX" --version 2>/dev/null | grep -qi clang; then
+      SAN_FLAGS+=("-fsanitize=address,undefined,integer,float-divide-by-zero,float-cast-overflow")
+    else
+      SAN_FLAGS+=("-fsanitize=address,undefined")
+    fi
+    return 0
+  fi
+
+  if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+    SAN_FLAGS+=("-fsanitize=address")
+  fi
+  if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+    SAN_FLAGS+=("-fsanitize=undefined")
+  fi
+  if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
+     "$CXX" --version 2>/dev/null | grep -qi clang; then
+    SAN_FLAGS+=("-fsanitize=integer")
+  fi
+  if grep -q '^ENABLE_FLOAT_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+    SAN_FLAGS+=("-fsanitize=float-divide-by-zero,float-cast-overflow")
+  fi
+}
+
+compute_san_flags
+
 fail_case() {
   local name="$1"
   local reason="$2"
@@ -97,26 +137,7 @@ run_cam_degenerate_helper() {
     return
   fi
 
-  if [ -f "$BUILD_DIR/CMakeCache.txt" ]; then
-    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
-      if "$CXX" --version 2>/dev/null | grep -qi clang; then
-        san_flags+=("-fsanitize=address,undefined,integer,float-divide-by-zero,float-cast-overflow")
-      else
-        san_flags+=("-fsanitize=address,undefined")
-      fi
-    else
-      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
-        san_flags+=("-fsanitize=address")
-      fi
-      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
-        san_flags+=("-fsanitize=undefined")
-      fi
-      if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
-         "$CXX" --version 2>/dev/null | grep -qi clang; then
-        san_flags+=("-fsanitize=integer")
-      fi
-    fi
-  fi
+  san_flags=("${SAN_FLAGS[@]}")
 
   if ! "$CXX" -std=c++17 "${san_flags[@]}" \
       -I"$REPO_ROOT/IccProfLib" \
@@ -211,7 +232,10 @@ run_cam_divzero_helper() {
   fi
   rm -f "$helper_bin"
 
-  if ! "$CXX" -std=c++17 -fsanitize=float-divide-by-zero -g \
+  # The library's own sanitizers first, so the link resolves, then
+  # float-divide-by-zero unconditionally: it is the check this case exists for,
+  # and it must apply whether or not the build enabled ENABLE_FLOAT_SANITIZER.
+  if ! "$CXX" -std=c++17 "${SAN_FLAGS[@]}" -fsanitize=float-divide-by-zero -g \
       -DICCPROFLIB_EXPORTS \
       -I"$REPO_ROOT/IccProfLib" \
       -I"$BUILD_DIR/IccProfLib" \

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3970,6 +3970,13 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}"
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-cam-degenerate-regression-tests.sh"
 )
+# The #1950 divide-by-zero case needs -fsanitize=float-divide-by-zero from the
+# compiler driving the test. A toolchain without it cannot run that case, and the
+# script exits 77 so this reports as Skipped instead of a Passed run that checked
+# less than its name claims.
+set_tests_properties(iccdev.cam-degenerate-regressions PROPERTIES
+  SKIP_RETURN_CODE 77
+)
 
 if(TARGET iccApplyProfiles)
   iccdev_add_script_test(

--- a/IccProfLib/IccCAM.cpp
+++ b/IccProfLib/IccCAM.cpp
@@ -300,6 +300,54 @@ CIccCamConverter::CalcCoefficients ()
 {
 	icFloatNumber	k, La5, rgbC[3], rgbP[3];
 
+	// m_La is the absolute luminance of the adapting field in cd/m^2, so it is
+	// meaningful only when it is finite and non-negative. It is not validated
+	// upstream: IccEncoding.cpp:432 passes it straight from the profile's
+	// colorEncodingParams structure, defaulting to the white-point luminance
+	// divided by five, and any of those numbers can be negative in a malformed
+	// profile.
+	//
+	// Two things go wrong once m_La is negative, and they share this root cause:
+	//
+	//   - k below divides by 5*m_La + 1, which is exactly zero when m_La is
+	//     -0.2f. The pole is hit precisely rather than approached, because
+	//     5.0f * -0.2f rounds to exactly -1.0f in float. #1950 reached it with
+	//     an s15Fixed16 ceptWhitePointLuminanceMbr of -1.0, which makes the
+	//     ambient luminance default to -1.0/5 == -0.2 and made UBSan report
+	//     "division by zero" at this line through iccApplyProfiles.
+	//
+	//   - La5 is then negative, so pow(La5, 0.333333) on the m_Fl line is a
+	//     fractional power of a negative number, which is NaN. That happens for
+	//     every negative m_La, not just the one that divides by zero, and left
+	//     NaN sitting in m_Fl for the rest of the object's life.
+	//
+	// Resolving to the degenerate all-zero state matches how this converter
+	// already answers a state it cannot compute with -- see the m_WhitePoint[1]
+	// and n_pow guards immediately below, and the domain guard in
+	// H_FunctionInv() (#1817). It is also what every one of these inputs already
+	// produced through the public API: the NaN above propagated into
+	// Hyperbolic()/HyperbolicInv(), whose own guards flushed the result to zero,
+	// so XYZToJab() and JabToXYZ() returned finite zeros for every negative,
+	// infinite and NaN adapting luminance before this guard existed. The guard
+	// therefore removes the undefined behaviour and the NaN state without moving
+	// any colour value.
+	//
+	// m_La == 0 is deliberately left on the path below. It is degenerate in its
+	// own way, but it divides by 1, keeps m_Fl finite, and currently returns a
+	// non-zero J -- changing that is a separate question from this defect.
+	if (!std::isfinite((double)m_La) || m_La < 0.0f) {
+		m_D = 0.0f;
+		m_Fl = 0.0f;
+		m_n = 0.0f;
+		m_factor = 0.0f;
+		m_Nbb = 0.0f;
+		m_z = 0.0f;
+		m_x0 = 0.0f;
+		m_cc = 0.0f;
+		m_AWhite = 0.0f;
+		return;
+	}
+
 	double epow = pow (2.7182818, (-((double)m_La + 42.0)/92.0) );
 	m_D = (icFloatNumber) (m_F *(1.0 - (epow/ 3.6)) );
 


### PR DESCRIPTION
## PR Summary

Fixes #1950.

`CIccCamConverter::CalcCoefficients` computed

```cpp
// IccProfLib/IccCAM.cpp:306
k = 1.0f / (5.0f * m_La + 1.0f);
```

with no domain check on `m_La`. That denominator is **exactly** zero when `m_La` is `-0.2f`,
because `5.0f * -0.2f` rounds to exactly `-1.0f` in float, so the pole is landed on rather
than approached.

`m_La` is profile-controlled. `icConvertEncodingProfile` passes the `colorEncodingParams`
ambient white-point luminance straight to `SetParameter_La` and defaults it to the
white-point luminance divided by five (`IccEncoding.cpp:408`, `:432`), so an s15Fixed16
`ceptWhitePointLuminanceMbr` of `-1.0` gives `m_La == -0.2` exactly.

The attached AFL case does exactly that. Its `sf32` signature sits at offset 532 and the
reserved word at 536, putting the value at **540** -- matching the reported
`op:int16 pos:540 val:-1` breadcrumb, which overwrites the integer part of the fixed-point
number with `0xFFFF`.

## The reported division is one point in a broken regime

Fixing only the denominator would have silenced the sanitizer and left the rest in place.
For **every** negative `m_La`, `La5` on the next line is negative, so

```cpp
m_Fl = (icFloatNumber)(0.2 * k * La5 + 0.1 * (1 - k) * (1 - k) * pow ((double)La5, 0.333333));
```

takes a fractional power of a negative number, which is NaN -- and that NaN then sat in
`m_Fl` for the life of the object. The guard is therefore on the domain of `m_La` rather
than on the one denominator.

Measured, not assumed:

| `Lw` | `La = Lw/5` | `5*La + 1` | `pow(5*La, 1/3)` |
|---|---|---|---|
| -3.0 | -0.6 | -2 | NaN |
| -2.0 | -0.4 | -1 | NaN |
| **-1.0** | **-0.2** | **0** -- divides by zero | NaN |
| -0.5 | -0.1 | 0.5 | NaN |
| 0.0 | 0.0 | 1 | 0 |

Resolving to the degenerate all-zero state matches how this converter already answers a
state it cannot compute with -- the `m_WhitePoint[1]` and `n_pow` guards immediately below,
and the `H_FunctionInv` domain guard from #1817.

`m_La == 0` is deliberately left on the existing path: it divides by one, keeps `m_Fl`
finite, and currently returns a non-zero J. Changing that is a separate question from this
defect.

## No colour value moves

A sweep of sixteen adapting luminances through both public entry points is **byte-identical**
before and after the change. Every negative, infinite and NaN luminance already returned
finite zeros, because the NaN above propagated into `Hyperbolic()`/`HyperbolicInv()`, whose
own guards flushed the result to zero. The guard reaches that same state without the
undefined behaviour and without the NaN in `m_Fl`.

```
          La | XYZToJab(0.25,0.50,0.75)     | JabToXYZ(50,1,-1)
      -1e+06 |    0.000    0.000    0.000   |    0.000    0.000    0.000
        -1.0 |    0.000    0.000    0.000   |    0.000    0.000    0.000
        -0.2 |    0.000    0.000    0.000   |    0.000    0.000    0.000
         0.0 |  100.000    0.000    0.000   |    0.000    0.000    0.000
       1e-06 |    3.847   -0.639   -0.365   |    0.923    0.827    0.982
       100.0 |    3.852  -21.123  -12.754   |    0.819    0.844    0.711
         inf |    0.000    0.000    0.000   |    0.000    0.000    0.000
         nan |    0.000    0.000    0.000   |    0.000    0.000    0.000
```

## Regression coverage is split in two, deliberately

**No return value distinguishes the defective converter from the fixed one** -- that is what
the table above shows. A value assertion therefore cannot catch this defect, and none is
written as though it can.

- **`.github/ci/regression/cam-la-divzero.cpp` is the detector.** It is compiled *together
  with* `IccProfLib/IccCAM.cpp` under `-fsanitize=float-divide-by-zero`. That is the point of
  the file rather than an implementation detail: the division is inside IccProfLib, so it is
  only instrumented when the library itself carries the flag, and **no CI lane both enables
  it and runs ctest** -- the float-sanitized build in `ci-docker-pr.yml` builds
  `iccDumpProfile` only. Compiling the translation unit into the helper makes the check work
  against an ordinary library build.

- **`cam-degenerate.cpp` gains case 7 and a widened sweep**, pinning the value contract for
  negative, infinite and NaN luminances. That sweep's `kLa` was entirely non-negative, which
  is exactly the gap this defect lived in.

## Verification

- **Red/green, plain Debug build.** Against the pre-fix tree the new case fails with the
  reported breadcrumb at the exact line and column, while case 7 still passes:

  | | pre-fix `origin/master` | with fix |
  |---|---|---|
  | `cam-la-divide-by-zero` | **FAIL** -- `IccCAM.cpp:306:11: runtime error: division by zero` | PASS |
  | `cam-degenerate` (incl. case 7) | **PASS** | PASS |

  Case 7 passing against the defective code is the evidence that the value assertions cannot
  catch this and that the helper is carrying the check.

- **The PoC.** Reproduced through `iccApplyProfiles` on a float-sanitized build at
  `IccCAM.cpp:306:11`, and clean after the change. Note the PoC's
  `Invalid space link` error is pre-existing and unrelated -- every `Lw` variant including
  `+100.0` produces it; the division was aborting the process before it got that far.

- **Both build configurations**, since this PR touches the harness: a plain Debug build, and
  a Debug build with `ENABLE_ASAN`, `ENABLE_UBSAN` and `ENABLE_FLOAT_SANITIZER` all on.

- **Full local ctest: 147/149.** The two failures are pre-existing and unrelated --
  `spectral-tiff-preview` (missing python `imagecodecs` on this host) and
  `qa-profile-manifest`, which reports `213 matched, 0 mismatched` and fails only on one
  stray untracked profile.

- **Build:** `IccCAM.cpp` compiles with 0 warnings, 0 errors under both clang 18 and g++ at
  `-Wall -Wextra -Wpedantic -Werror -std=c++17`.

## Two harness fixes came out of the above

Both are in the script this PR already had to touch, and both are pre-existing:

1. `ENABLE_FLOAT_SANITIZER` is a standalone CMake option, not something `ENABLE_ASAN` or
   `ENABLE_UBSAN` implies. A build enabling only it produced a library referencing
   `__ubsan_handle_float_cast_overflow_abort` while the helper was compiled with no
   sanitizer, and the existing case failed to link. The detection now runs once and is
   shared by both helpers.

2. The expansions use the `${x[@]+"${x[@]}"}` form, because the script runs under `set -u`
   where an empty array expansion is an unbound-variable error in the bash 3.2 that ships as
   `/bin/bash` on macOS.

## Noted, not fixed

`IccEncoding.cpp` never checks that the profile's white-point luminance is physically
meaningful, so a negative `Lw` also flows into `m_illuminantXYZ` and `m_surroundXYZ` a few
lines above the CAM setup. That is a separate defect from the one reported here and is left
for a maintainer call rather than folded in.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in Contributing document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes -- no user-visible change
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [ ] Did not change maintainer-owned workflow, CTest, CPack or sanitizer infrastructure --
      **this one is not clean and is called out deliberately.** No workflow, CMake
      registration, CPack or macro is touched, and no new CTest is registered. But the
      existing `iccdev-cam-degenerate-regression-tests.sh` does gain a second case and two
      fixes to its sanitizer-flag detection, described above. Flagging it for a maintainer
      rather than ticking the box.
- [x] New source files include the ICC copyright and BSD 3-Clause license header -- the one
      new file, `cam-la-divzero.cpp`, follows the header convention of its sibling
      `cam-degenerate.cpp` in the same directory
- [x] Code style matches nearby code: tabs and brace placement of `IccCAM.cpp`, two-space
      indent in the regression sources
