### PR TITLE
fix(#1853): stop a refused illuminant resample shortening the PCS chain

### DIFF
--- a/.github/ci/regression/pcs-applyillum-chain-sizing.cpp
+++ b/.github/ci/regression/pcs-applyillum-chain-sizing.cpp
@@ -1,0 +1,320 @@
+// Regression for #1853 (the ci-qa-flags bucket-4 remainder): the PCS step chain that
+// CIccPcsXform::Connect() builds could be left disagreeing with itself, and the
+// temporaries the chain runs through were sized on the assumption that it never is.
+//
+// Two independent halves, both in IccCmm.cpp.
+//
+// 1. pushApplyIllum() dropped a refused resampling step instead of rejecting.
+//
+//    CIccPcsXform::rangeMap() answers NULL for two different situations: the ranges are
+//    identical so no matrix is needed, or a matrix was needed and SetRange() refused to
+//    build one (it rejects any pair carrying <= 1 step, a non-finite endpoint or a
+//    zero-width source span). pushApplyIllum() reaches its rangeMap() calls only inside
+//    the else of an icSameSpectralRange() test, so NULL there can only be the failure
+//    answer -- yet both calls were written as
+//
+//        ptr.ptr = rangeMap(...);
+//        if (ptr.ptr)
+//          m_list->push_back(ptr);
+//
+//    A refused map therefore shortened the chain and returned icCmmStatOk. What is left
+//    is a scale running at illuminantRange.steps over a vector that is
+//    spectralRange.steps wide. The second call is the damaging one, because it is the
+//    last step pushed and so its output is what the caller reads back: dropping it makes
+//    the chain hand illuminantRange.steps values to a consumer expecting
+//    spectralRange.steps, past the end of the destination pixel when the illuminant is
+//    the wider of the two. These were the last two of the six CIccPcsXform::rangeMap()
+//    call sites in that file still treating the ambiguous NULL as benign; the other four
+//    -- pushSpecToRange() and the three in pushBiRef2Rad()/pushBiRef2Ref() -- already
+//    reject (see #1677 and pcs-birefl-illuminant-range.cpp, which pins those).
+//
+//    These assertions need no sanitizer: on unfixed sources the call returns
+//    icCmmStatOk with a short chain, and here it must return a failure status.
+//
+// 2. CIccPcsXform::MaxChannels() did not count what the temporaries are written with.
+//
+//    CIccApplyPcsXform::Init() sizes m_temp1/m_temp2 from MaxChannels(), and
+//    CIccApplyPcsXform::Apply() hands those two buffers to every step except the last as
+//    its *destination*. MaxChannels() took GetDstChannels() from the first step only and
+//    GetSrcChannels() from all of them, so no step after the first had its output width
+//    counted. On a chain that agrees with itself the answer comes out the same -- each
+//    intermediate output is also the next step's input and is counted in that role --
+//    which is why it has held. Once a chain does not agree, the miss is an undersized
+//    buffer that a step is about to write through.
+//
+//    Asserted twice over, so the case does not depend on how the build was configured:
+//    on the return value of MaxChannels() itself, which fails anywhere, and by running a
+//    pixel through the chain, which is what a sanitizer build sees as the overflow.
+//
+// The controls matter as much as the rejections. Only a handful of spectral profiles
+// exist in Testing/ and none of them exercise a refused illuminant map, so an over-eager
+// guard in pushApplyIllum() would go unnoticed by the rest of the suite; and the
+// MaxChannels() rewrite must not shrink the answer for any chain that sizes correctly
+// today. Both are pinned below.
+//
+// Header + IccProfLib only, no fixture and no I/O.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccCmm.h"
+#include "IccPcc.h"
+#include "IccProfile.h"
+#include "IccTagBasic.h"
+#include "IccUtil.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[pcs-applyillum-chain] FAIL: %s\n", what);
+  }
+}
+
+icSpectralRange makeRange(icFloat16Number start, icFloat16Number end, icUInt16Number steps)
+{
+  icSpectralRange r;
+  r.start = start;
+  r.end = end;
+  r.steps = steps;
+  return r;
+}
+
+// pushApplyIllum() asks the connection conditions for the viewing conditions tag and
+// nothing else, so the remaining interface methods are stubs.
+class StubPcc : public IIccProfileConnectionConditions
+{
+public:
+  explicit StubPcc(const icSpectralRange &illumRange)
+  {
+    std::vector<icFloatNumber> spd(illumRange.steps ? illumRange.steps : 1, 1.0f);
+    m_svc.setIlluminant(icIlluminantD50, illumRange, &spd[0]);
+  }
+
+  virtual const CIccTagSpectralViewingConditions *getPccViewingConditions() { return &m_svc; }
+  virtual CIccTagMultiProcessElement *getCustomToStandardPcc() { return NULL; }
+  virtual CIccTagMultiProcessElement *getStandardToCustomPcc() { return NULL; }
+
+  virtual void getNormIlluminantXYZ(icFloatNumber *pXYZ) { pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f; }
+  virtual void getLumIlluminantXYZ(icFloatNumber *pXYZ) { pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f; }
+  virtual bool getMediaWhiteXYZ(icFloatNumber *pXYZ)
+  {
+    pXYZ[0] = pXYZ[1] = pXYZ[2] = 1.0f;
+    return true;
+  }
+
+  // Reports what getIlluminant() will actually hand the code under test, which is not
+  // always what was asked for: the tag falls back to a known standard SPD when the
+  // custom illuminant did not take.
+  icUInt16Number effectiveIlluminantSteps()
+  {
+    icSpectralRange got;
+    return m_svc.getIlluminant(got) ? got.steps : 0;
+  }
+
+private:
+  CIccTagSpectralViewingConditions m_svc;
+};
+
+// pushApplyIllum(), pushMatrix() and pushScale() are protected; subclassing is the
+// supported way in. MaxChannels(), GetNewApply() and Apply() are already public.
+class PcsXformProbe : public CIccPcsXform
+{
+public:
+  using CIccPcsXform::pushApplyIllum;
+  using CIccPcsXform::pushMatrix;
+  using CIccPcsXform::pushScale;
+
+  size_t stepCount() const { return m_list ? m_list->size() : 0; }
+};
+
+// A header-only profile: pushApplyIllum() reads m_Header.spectralRange and nothing else.
+void setHeader(CIccProfile &prof, const icSpectralRange &spectralRange)
+{
+  std::memset(&prof.m_Header, 0, sizeof(prof.m_Header));
+  prof.m_Header.version = icVersionNumberV5;
+  prof.m_Header.deviceClass = icSigColorSpaceClass;
+  prof.m_Header.spectralPCS = icNColorSpaceSig(icSigRadiantSpectralData, spectralRange.steps);
+  prof.m_Header.spectralRange = spectralRange;
+}
+
+// ---------------------------------------------------------------------------
+// 1. pushApplyIllum() must reject an illuminant range it cannot resample.
+// ---------------------------------------------------------------------------
+
+void testApplyIllumRejectsUnmappableIlluminantRange()
+{
+  // The profile's own range is the same in both cases; only the illuminant varies, so
+  // each case isolates one of the two rangeMap() legs.
+  const icSpectralRange spectralRange = makeRange(icRange380nm, icRange780nm, 36);
+
+  struct Case {
+    icSpectralRange illumRange;
+    const char *what;
+    const char *leg;
+  } cases[] = {
+    // A single-step illuminant is storable but is neither a usable resampling source
+    // nor a usable destination, so SetRange() refuses both legs. Unfixed, the whole
+    // chain collapses to the bare scale.
+    { makeRange(icRange380nm, icRange780nm, 1),
+      "single-step illuminant",
+      "both legs" },
+
+    // A zero-width span is refused as a source (srcScale == 0) while remaining a legal
+    // destination, so here the outbound matrix is built and only the return leg is
+    // refused. This is the shape that leaves the wrong width at the end of the chain.
+    { makeRange(icRange380nm, icRange380nm, 81),
+      "zero-width illuminant span",
+      "return leg only" },
+  };
+
+  for (size_t c = 0; c < sizeof(cases)/sizeof(cases[0]); c++) {
+    char msg[260];
+    StubPcc pcc(cases[c].illumRange);
+
+    CIccProfile prof;
+    setHeader(prof, spectralRange);
+
+    PcsXformProbe probe;
+    icStatusCMM stat = probe.pushApplyIllum(&prof, &pcc);
+
+    std::snprintf(msg, sizeof(msg),
+                  "%s (%s refused): pushApplyIllum rejects a %u-step illuminant it cannot "
+                  "map onto a 36-step spectral range, instead of dropping the step and "
+                  "reporting success",
+                  cases[c].what, cases[c].leg, (unsigned)pcc.effectiveIlluminantSteps());
+    check(stat != icCmmStatOk, msg);
+
+    std::snprintf(msg, sizeof(msg),
+                  "%s: no PCS step is left behind on the reject path", cases[c].what);
+    check(probe.stepCount() == 0, msg);
+  }
+}
+
+// Controls for the guard above: the two shapes that must keep working.
+void testMappableIlluminantRangesStillAccepted()
+{
+  // 1. Illuminant range identical to the profile's. No matrices are needed and the
+  //    scale alone is the whole chain -- the case the NULL return originally meant.
+  {
+    const icSpectralRange range = makeRange(icRange380nm, icRange780nm, 36);
+    StubPcc pcc(range);
+
+    CIccProfile prof;
+    setHeader(prof, range);
+
+    PcsXformProbe probe;
+    icStatusCMM stat = probe.pushApplyIllum(&prof, &pcc);
+
+    check(stat == icCmmStatOk, "identical illuminant and spectral range still accepted");
+    check(probe.stepCount() == 1, "identical ranges still push exactly the scale step");
+  }
+
+  // 2. Different but mappable, which is the ordinary case: an 81-step illuminant over a
+  //    36-step spectral PCS. Both matrices are built and the scale runs between them.
+  {
+    const icSpectralRange spectralRange = makeRange(icRange380nm, icRange780nm, 36);
+    const icSpectralRange illumRange = makeRange(icRange380nm, icRange780nm, 81);
+    StubPcc pcc(illumRange);
+
+    CIccProfile prof;
+    setHeader(prof, spectralRange);
+
+    PcsXformProbe probe;
+    icStatusCMM stat = probe.pushApplyIllum(&prof, &pcc);
+
+    check(stat == icCmmStatOk, "mappable illuminant range still accepted");
+    check(probe.stepCount() == 3, "mappable ranges still push resample, scale, resample");
+
+    // The chain widens to the illuminant in the middle and comes back, so the
+    // temporaries have to hold the illuminant's width. This is also the control on the
+    // MaxChannels() rewrite: a chain that agrees with itself must size exactly as before.
+    check(probe.MaxChannels() == illumRange.steps,
+          "a self-consistent chain still sizes its temporaries to the widest step");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. MaxChannels() must count every step's output, not just the first step's.
+// ---------------------------------------------------------------------------
+
+void testMaxChannelsCoversEveryStepOutput()
+{
+  // Widths chosen so that master's walk cannot reach the middle step's output:
+  //
+  //   step 0  matrix  4 <- 4    src 4, dst 4    (first step: dst IS counted)
+  //   step 1  matrix 64 <- 4    src 4, dst 64   (writes 64 into a temporary)
+  //   step 2  matrix  4 <- 8    src 8, dst 4    (last step: writes the caller's pixel)
+  //
+  // Taking dst from step 0 and src from all three gives max(4, 4, 4, 8) == 8, so the
+  // temporaries hold 8 floats and step 1 writes 64 of them. Step 2 reading only 8 back is
+  // what keeps the shortfall out of the src-side tally -- that disagreement between step
+  // 1's output and step 2's input is exactly the condition the old walk assumed away.
+  const icUInt16Number kWide = 64;
+  const icUInt16Number kNarrow = 4;
+  const icUInt16Number kMid = 8;
+
+  // Only the declared widths matter here, not the arithmetic, so one buffer large enough
+  // for the widest step (kWide x kWide) backs all three pushMatrix() calls; each copies
+  // the nRows * nCols prefix it needs.
+  std::vector<icFloatNumber> coeffs((size_t)kWide * kWide, 0.0f);
+  for (icUInt16Number i = 0; i < kWide; i++)
+    coeffs[(size_t)i * kWide + i] = 1.0f;
+
+  PcsXformProbe probe;
+  probe.pushMatrix(kNarrow, kNarrow, &coeffs[0]);
+  probe.pushMatrix(kWide, kNarrow, &coeffs[0]);
+  probe.pushMatrix(kNarrow, kMid, &coeffs[0]);
+
+  char msg[240];
+  std::snprintf(msg, sizeof(msg),
+                "MaxChannels counts the %u-channel output of a middle step (reported %u)",
+                (unsigned)kWide, (unsigned)probe.MaxChannels());
+  check(probe.MaxChannels() >= kWide, msg);
+
+  // Run a pixel through it. Under ASAN this is the assertion: unfixed, step 1's Apply()
+  // writes kWide floats into the kMid-float temporary that Init() allocated. Without a
+  // sanitizer the write is silent, which is why the MaxChannels() value is checked above
+  // as well rather than relying on this alone.
+  icStatusCMM status = icCmmStatOk;
+  CIccApplyXform *pApply = probe.GetNewApply(status);
+
+  check(pApply != NULL, "the three-step chain builds an apply object");
+
+  if (pApply) {
+    icFloatNumber src[kWide];
+    icFloatNumber dst[kWide];
+
+    for (icUInt16Number i = 0; i < kWide; i++) {
+      src[i] = 0.5f;
+      dst[i] = 0.0f;
+    }
+
+    probe.Apply(pApply, dst, src);
+    delete pApply;
+  }
+}
+
+} // namespace
+
+int main()
+{
+  testApplyIllumRejectsUnmappableIlluminantRange();
+  testMappableIlluminantRangesStillAccepted();
+  testMaxChannelsCoversEveryStepOutput();
+
+  if (g_fail)
+    std::fprintf(stderr, "[pcs-applyillum-chain] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[pcs-applyillum-chain] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1079,6 +1079,57 @@ function(iccdev_add_pcs_birefl_illuminant_range_test)
   endif()
 endfunction()
 
+# #1853 (ci-qa-flags bucket 4): the PCS step chain could be left disagreeing with itself,
+# and the temporaries it runs through were sized assuming it never is.
+#
+# pushApplyIllum() held the last two of the six CIccPcsXform::rangeMap() call sites still
+# reading the ambiguous NULL as "no conversion needed" when, inside the else of an
+# icSameSpectralRange() test, it can only mean SetRange() refused the pair. It dropped the
+# step and returned icCmmStatOk, leaving a scale running at illuminantRange.steps over a
+# spectralRange.steps-wide vector -- and when the dropped step is the return leg, that
+# width is what the caller reads back.
+#
+# CIccPcsXform::MaxChannels() then failed to contain it: it took GetDstChannels() from the
+# first step only, so no later step had the width it writes into m_temp1/m_temp2 counted.
+#
+# Header + IccProfLib only, no fixture. Also pins the controls -- no spectral profile in
+# Testing/ exercises a refused illuminant map, and none would notice a MaxChannels() that
+# started answering smaller.
+function(iccdev_add_pcs_applyillum_chain_sizing_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccPcsApplyIllumChainSizingTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/pcs-applyillum-chain-sizing.cpp"
+  )
+  target_link_libraries(iccPcsApplyIllumChainSizingTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccPcsApplyIllumChainSizingTest)
+
+  add_test(
+    NAME iccdev.pcs-applyillum-chain-sizing
+    COMMAND "$<TARGET_FILE:iccPcsApplyIllumChainSizingTest>"
+  )
+  set_tests_properties(iccdev.pcs-applyillum-chain-sizing PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;security;spectral;issue-1853;regression"
+  )
+  if(WIN32)
+    set(_pcs_applyillum_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccPcsApplyIllumChainSizingTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _pcs_applyillum_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.pcs-applyillum-chain-sizing PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_pcs_applyillum_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1932: CIccPcsXform::Connect() sized the spectral PCS steps it pushes from the header's
 # spectralRange while the pixel buffers those steps run in are sized from the channel
 # count in the spectralPCS signature, and never checked that the two agreed. A header
@@ -3298,6 +3349,7 @@ if(WIN32)
   iccdev_add_getvalues_nstart_test()
   iccdev_add_rangemap_uninitialized_test()
   iccdev_add_pcs_birefl_illuminant_range_test()
+  iccdev_add_pcs_applyillum_chain_sizing_test()
   iccdev_add_spectral_pcs_range_consistency_test()
   iccdev_add_spectral_media_white_test()
   iccdev_add_gbd_zero_pcs_test()
@@ -3547,6 +3599,7 @@ iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
 iccdev_add_rangemap_uninitialized_test()
 iccdev_add_pcs_birefl_illuminant_range_test()
+iccdev_add_pcs_applyillum_chain_sizing_test()
 iccdev_add_spectral_pcs_range_consistency_test()
 iccdev_add_spectral_media_white_test()
 iccdev_add_gbd_zero_pcs_test()

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -2964,22 +2964,35 @@ CIccApplyXform *CIccPcsXform::GetNewApply(icStatusCMM &status)
  * 
  * Purpose: 
  *  Returns the maximum number of channels used by PCS xform steps
+ *
+ *  This is what CIccApplyPcsXform::Init() sizes m_temp1/m_temp2 from, and
+ *  CIccApplyPcsXform::Apply() hands those two buffers to every step in the list
+ *  except the last, so the count has to cover each step's output width as well as
+ *  each step's input width.
+ *
+ *  The walk used to take GetDstChannels() from the first step only and
+ *  GetSrcChannels() from all of them. On a chain whose steps agree -- step i's
+ *  output width equalling step i+1's input width -- that reaches the same answer,
+ *  which is why it has held up: every intermediate output is also the next step's
+ *  input and gets counted in that role. It stops holding as soon as a chain does not
+ *  agree with itself, and then the miss is an undersized destination for a step that
+ *  is about to write through it. Counting both widths at every step removes the
+ *  dependence on that assumption; the result is never smaller than before, so a chain
+ *  that sized correctly still sizes the same.
  **************************************************************************
  */
 icUInt16Number CIccPcsXform::MaxChannels()
 {
   icUInt16Number nMax = 0;
-  CIccPcsStepList::const_iterator s = m_list->begin();
-  if (s==m_list->end())
-    return nMax;
-  nMax = s->ptr->GetDstChannels();
-  if (s->ptr->GetSrcChannels()>nMax)
-    nMax = s->ptr->GetSrcChannels();
-  s++;
-  for (; s!= m_list->end(); s++) {
+  CIccPcsStepList::const_iterator s;
+
+  for (s = m_list->begin(); s != m_list->end(); s++) {
     if (s->ptr->GetSrcChannels()>nMax)
       nMax = s->ptr->GetSrcChannels();
+    if (s->ptr->GetDstChannels()>nMax)
+      nMax = s->ptr->GetDstChannels();
   }
+
   return nMax;
 }
 
@@ -3638,17 +3651,47 @@ icStatusCMM CIccPcsXform::pushApplyIllum(CIccProfile *pProfile, IIccProfileConne
       m_list->push_back(ptr);
     }
     else {
-      ptr.ptr  = rangeMap(pProfile->m_Header.spectralRange, illuminantRange);
-      if (ptr.ptr) {
-        m_list->push_back(ptr);
+      // Control reaches here only because the ranges differ, so rangeMap() returning
+      // NULL can carry just one of its two meanings: not "no conversion is needed" but
+      // "a conversion was needed and SetRange() refused to build one" -- it rejects any
+      // pair carrying <= 1 step, a non-finite endpoint or a zero-width source span.
+      // Skipping the step on that answer is what the outer if() already handles for the
+      // identical case; here it silently shortens the chain instead, leaving the scale
+      // running at illuminantRange.steps over a vector that is spectralRange.steps wide.
+      // Nothing downstream contains that: CIccApplyPcsXform::Init() sizes its
+      // temporaries from the steps that survived, and Begin() still reports success.
+      // Of the six rangeMap() call sites in this file the other four -- pushSpecToRange()
+      // and the three in pushBiRef2Rad()/pushBiRef2Ref() -- already reject a refused map;
+      // these two were the last that did not.
+      //
+      // The return leg is the more damaging of the two to drop, because it is the last
+      // step pushed here and so its output is what the caller reads back: without it the
+      // chain hands illuminantRange.steps values to a consumer expecting
+      // spectralRange.steps, writing past the end of the destination pixel whenever the
+      // illuminant is the wider of the two. The two legs also fail independently -- an
+      // illuminant declaring a zero-width span is refused as a resampling source while
+      // still being usable as a destination -- so both are built before either is pushed,
+      // which leaves the step list untouched on a reject the way the sibling sites do.
+      CIccPcsStepMatrix *pToIllum = rangeMap(pProfile->m_Header.spectralRange, illuminantRange);
+      CIccPcsStepMatrix *pFromIllum = pToIllum ? rangeMap(illuminantRange, pProfile->m_Header.spectralRange) : NULL;
+
+      if (!pToIllum || !pFromIllum) {
+        // Nothing has been pushed, so these are still owned here; a step handed to
+        // m_list is deleted by the destructor instead.
+        delete pToIllum;
+        delete pFromIllum;
+        delete pScale;
+        return icCmmStatInvalidProfile;
       }
+
+      ptr.ptr = pToIllum;
+      m_list->push_back(ptr);
 
       ptr.ptr = pScale;
       m_list->push_back(ptr);
 
-      ptr.ptr = rangeMap(illuminantRange, pProfile->m_Header.spectralRange);
-      if (ptr.ptr)
-        m_list->push_back(ptr);
+      ptr.ptr = pFromIllum;
+      m_list->push_back(ptr);
     }
   }
   return icCmmStatOk;

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -981,6 +981,26 @@ public:
   virtual ~CIccPcsStepSrcMatrix();
 
   virtual void Apply(CIccApplyPcsStep *pApply, icFloatNumber *pDst, const icFloatNumber *pSrc) const;
+  // m_nCols is the width of m_vals -- the single illuminant row this step multiplies by
+  // -- and not the number of values Apply() consumes from pSrc, which walks pSrc as a
+  // flattened m_nRows x m_nCols matrix. The two differ because the matrix arrives in the
+  // pixel rather than in the step. What keeps that read in bounds is the header check in
+  // icSpectralPcsMatchesRange(): a bi-spectral PCS signature has to declare
+  // spectralRange.steps * biSpectralRange.steps channels, and that channel count is the
+  // pixel width the CMM moves across the connection. The distinction matters if this
+  // step is ever placed anywhere but first in a chain, where pSrc would be a
+  // CIccApplyPcsXform temporary sized from these accessors instead of the pixel.
+  //
+  // Reporting m_nCols is deliberate rather than an oversight. Returning the
+  // product would inflate CIccApplyPcsXform's temporaries for no gain on the only
+  // shape that occurs: the corpus's one bi-spectral profile is 31 x 41, so
+  // MaxChannels() would answer 1271 instead of 41 and size both temporaries from
+  // that, while a first step never reads from a temporary at all.
+  //
+  // Revisit if this accessor gains a second consumer -- specifically any
+  // sample-count validation added to CIccPcsXform::Optimize(). That would read it
+  // to decide whether a profile is rejected, and such a decision needs the count
+  // Apply() actually consumes, not the width of m_vals.
   virtual icUInt16Number GetSrcChannels() const { return m_nCols; }
   virtual icUInt16Number GetDstChannels() const { return m_nRows; }
 


### PR DESCRIPTION
Part of #1853 — the bucket 4 remainder. Bucket 1 (the `.github` harvest) is untouched and
still open, so this is deliberately **not** a closing reference.

Two defects in the PCS step chain, plus the sizing that should have contained the first.

## 1. `pushApplyIllum()` dropped a refused resample and reported success

`CIccPcsXform::rangeMap()` answers NULL for two different situations: the ranges are
identical so no matrix is needed, or a matrix was needed and `SetRange()` refused to build
one (it rejects any pair carrying `<= 1` step, a non-finite endpoint or a zero-width source
span). `pushApplyIllum()` reaches its two `rangeMap()` calls only inside the `else` of an
`icSameSpectralRange()` test, so NULL there can only be the second — yet both were written

```cpp
ptr.ptr = rangeMap(...);
if (ptr.ptr)
  m_list->push_back(ptr);
```

so a refused map silently shortened the chain and the function still returned
`icCmmStatOk`. What survives is a scale running at `illuminantRange.steps` over a vector
that is `spectralRange.steps` wide.

**Dropping the return leg is the damaging case.** It is the last step pushed here, so its
output is what the caller reads back: the chain hands `illuminantRange.steps` values to a
consumer expecting `spectralRange.steps`, writing past the end of the destination pixel
whenever the illuminant is the wider of the two.

The two legs fail independently — an illuminant declaring a zero-width span is refused as a
resampling *source* while remaining a legal *destination* — so the fix builds both matrices
before pushing either, which leaves the step list untouched on a reject the way the sibling
sites do.

These were the last two of the six `CIccPcsXform::rangeMap()` call sites in `IccCmm.cpp`
still treating the ambiguous NULL as benign; `pushSpecToRange()` and the three in
`pushBiRef2Rad()`/`pushBiRef2Ref()` already reject (#1677, PR #1912).

## 2. `MaxChannels()` did not count what the temporaries are written with

`CIccApplyPcsXform::Init()` sizes `m_temp1`/`m_temp2` from `MaxChannels()`, and
`CIccApplyPcsXform::Apply()` hands those two buffers to every step except the last as its
**destination**. The walk took `GetDstChannels()` from the first step only and
`GetSrcChannels()` from all of them, so no step after the first had its output width
counted.

On a chain whose steps agree this reaches the same answer — every intermediate output is
also the next step's input and gets counted in that role — which is why it has held up. It
stops holding as soon as a chain does not agree with itself, and then the miss is an
undersized buffer that a step is about to write through. Counting both widths at every step
**never answers smaller than before**, so a chain that sized correctly still sizes the same.

## 3. `CIccPcsStepSrcMatrix::GetSrcChannels()` — documented, not changed

It reports the width of `m_vals`, not the flattened `m_nRows x m_nCols` matrix `Apply()`
consumes from `pSrc`. To be precise about the interaction with (2): `MaxChannels()` *does*
read this accessor, for every step including the first. What makes the understatement
harmless is that a `SrcMatrix` is only ever pushed first, and a first step reads the
external pixel rather than a temporary — and what keeps *that* read in bounds is the
`icSpectralPcsMatchesRange()` header check added for #1932 (PR #1942), which forces a
bi-spectral header to declare `spectralRange.steps * biSpectralRange.steps` channels.

Correcting it to the product was considered and deliberately not done, because it would
inflate the temporaries for no gain on the only shape that occurs: the corpus's one
bi-spectral profile is 31 x 41, so `MaxChannels()` would answer 1271 instead of 41 and size
both `m_temp1`/`m_temp2` from that, on a path where the step never reads a temporary at all.

**This should be revisited if the accessor gains a second consumer — specifically any
sample-count validation added to `CIccPcsXform::Optimize()`.** That would read
`GetSrcChannels()` to decide whether a profile is *rejected*, and such a decision needs the
count `Apply()` actually consumes rather than the width of `m_vals`. Flagging it here
because that work is in flight on `ci-qa-flags`, and the two changes have to agree. The
same note is on the accessor itself so it is not lost with this PR.

## Test

Adds `iccdev.pcs-applyillum-chain-sizing` (header + IccProfLib only, no fixture, no I/O).

| | result |
|---|---|
| against unfixed sources | **all 5 assertions fail**, and ASan reports a `heap-buffer-overflow WRITE` past the 32-byte temporary allocated at `CIccApplyPcsXform::Init()` (`IccCmm.cpp:2065`), through `CIccMatrixMath::VectorMult` |
| with the fix | all pass, clean under ASAN+UBSAN with `detect_leaks=1` |

`MaxChannels()` is asserted twice over — on its return value, which fails in any build, and
by running a pixel through the chain, which is what a sanitizer build sees as the overflow.
The value check exists so the case is not silently vacuous in a non-sanitized build.

**Controls are pinned too**, because nothing else in the suite would catch an over-eager
guard here: identical ranges still push exactly the scale step, different-but-mappable
ranges still push resample/scale/resample, and a self-consistent chain still sizes its
temporaries to the widest step.

### Why this was never seen

`pushApplyIllum()` is only reached when the destination PCS is radiant spectral data.
Sweeping every `.icc` under `Testing/` — **255 profiles, 78 with a real spectral PCS**
(66 `rs001F`, 7 `rs0024`, and one each of `bs04F7` / `sm0300` / `rs0191` / `rs0051` /
`rs0021`) — **none declares a radiant spectral PCS**. The corpus cannot reach this code,
which is why it survived and why the new reject changes no corpus result.

## Pre-flight

Rebased on `cd81a37c`. Zero compiler warnings on all four strict profiles:

| profile | warnings | ctest |
|---|---|---|
| clang ASAN+UBSAN Debug, `-Wall -Wextra -Wpedantic -Werror` | 0 | see note |
| gcc strict Release | 0 | 148/150 |
| **GCC 15.2.0 in CI's own `ci-qa-pr-docker-testing` container** | 0 | — |
| clang strict Release | 0 | — |

Note on the ASAN run: it shows extra failures versus the gcc run
(`pcc-zero-illuminant`, `cam-degenerate`, `lut16-zero-curve`) which are **not** regressions —
those CTests compile a helper without sanitizer flags, so it cannot link a sanitized
`libIccProfLib2d.so` (`undefined reference to __asan_report_store4`). That is an artifact of
passing `-fsanitize=` through `CMAKE_CXX_FLAGS` locally rather than `-DENABLE_SANITIZERS=ON`;
the gcc Release run is the control and shows only the two known-noise failures
(`spectral-tiff-preview`, missing python `imagecodecs`; and `qa-profile-manifest`, which
flags one untracked local file and reports **213 matched, 0 mismatched**).
