### PR TITLE
harvest(#1853): take the ci-qa-flags test-harness fixes that stand alone on master

### DIFF
--- a/.github/scripts/iccdev-calculator-regression-tests.sh
+++ b/.github/scripts/iccdev-calculator-regression-tests.sh
@@ -30,7 +30,13 @@ fi
 FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
 DUMP="$TOOLS_DIR/IccDumpProfile/iccDumpProfile"
 APPLYNCM="$TOOLS_DIR/IccApplyNamedCmm/iccApplyNamedCmm"
-ISSUE_1103_CALC_UNDERFLOW_PROFILE="$TESTING_DIR/CalcTest/uio-CIccCalculatorFunc-CheckUnderflowOverflow-IccMpeCalc_cpp-Line4238.icc"
+# Read the issue-1103 fixture from the regression corpus rather than from
+# Testing/CalcTest. The two paths hold the same blob, and the sha256 below is
+# checked before use either way, but Testing/ is the generated-profile corpus
+# that CreateAllProfiles.sh rewrites, whereas .github/ci/regression/ holds
+# fixtures that exist only to pin a defect. Pointing at the latter keeps this
+# test from depending on corpus contents it does not own.
+ISSUE_1103_CALC_UNDERFLOW_PROFILE="$REPO_ROOT/.github/ci/regression/issue-1103-calculator-window-underflow.icc"
 ISSUE_1103_CALC_UNDERFLOW_SHA256="e482d1defb841192735881d80b4b7ca0540f5b859164153f0be2080ce6167800"
 
 export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0:detect_leaks=0}"

--- a/.github/scripts/iccdev-profile-visualize-tests.sh
+++ b/.github/scripts/iccdev-profile-visualize-tests.sh
@@ -90,28 +90,6 @@ require_tiff() {
   return 0
 }
 
-# shellcheck disable=SC2329
-require_svg() {
-  # shellcheck disable=SC2317
-  local name="$1"
-  # shellcheck disable=SC2317
-  local path="$2"
-
-  # shellcheck disable=SC2317
-  require_file "$name" "$path" || return 1
-
-  # shellcheck disable=SC2317
-  if ! grep -Fq "<svg" "$path" 2>/dev/null; then
-    # shellcheck disable=SC2317
-    fail_case "$name" "missing svg root: $path"
-    # shellcheck disable=SC2317
-    return 1
-  fi
-
-  # shellcheck disable=SC2317
-  return 0
-}
-
 require_pdf() {
   local name="$1"
   local path="$2"

--- a/Build/Cmake/Testing/RunWindowsSharedExportTest.cmake
+++ b/Build/Cmake/Testing/RunWindowsSharedExportTest.cmake
@@ -37,7 +37,21 @@ set(_log_file "${ICCDEV_TEST_OUTDIR}/output.log")
 set(_exports_log "${ICCDEV_TEST_OUTDIR}/iccproflib-exports.txt")
 set(_consumer_root "${ICCDEV_TEST_OUTDIR}/consumer-work")
 if(DEFINED ENV{TEMP} AND NOT "$ENV{TEMP}" STREQUAL "")
-  set(_consumer_root "$ENV{TEMP}/iccdev-issue-987-shared-mpe-export-${ICCDEV_CONFIG}")
+  # The consumer tree is built under %TEMP% rather than the test output directory
+  # to keep the nested CMake configure clear of the long build-tree path, since
+  # the generated project pushes several directory levels deeper again and the
+  # classic 260-character limit still applies to the compiler tool chain.
+  #
+  # Derive the leaf name from the build directory, test name and configuration
+  # instead of naming the test literally. The literal name distinguished only the
+  # configuration, so two build trees on one machine at the same configuration
+  # resolved to a single path - and the REMOVE_RECURSE below clears this directory
+  # whole, so concurrent runs did not merely share it, they deleted each other's
+  # sources mid-configure. All three inputs are validated non-empty above. The
+  # digest is also shorter than the name it replaces, which buys back path budget.
+  string(SHA256 _consumer_hash "${ICCDEV_BUILD_DIR}|${ICCDEV_TEST_NAME}|${ICCDEV_CONFIG}")
+  string(SUBSTRING "${_consumer_hash}" 0 12 _consumer_hash)
+  set(_consumer_root "$ENV{TEMP}/iccdev-issue-987-${_consumer_hash}")
 endif()
 set(_consumer_src_dir "${_consumer_root}/consumer")
 set(_consumer_build_dir "${_consumer_root}/consumer-build")

--- a/Build/Cmake/vcpkg.json
+++ b/Build/Cmake/vcpkg.json
@@ -12,7 +12,8 @@
     "libxml2",
     "libiconv",
     "nlohmann-json",
-    "libjpeg-turbo"
+    "libjpeg-turbo",
+    "zlib"
   ],
   "overrides": []
 }


### PR DESCRIPTION
## PR Summary

Part of #1853. Four changes from `ci-qa-flags` that depend on nothing else from that branch,
so they can land without waiting on any of the held work.

`ci-qa-flags` has been rebased and now carries #1967, so everything below is measured against
`master` `1334d769` with the branch at `ac36a83a`. Each change is verified against master
rather than taken on the branch's word; the two that assert behaviour are red/green tested.

### 1. Windows shared-export consumer path — `RunWindowsSharedExportTest.cmake`

The consumer tree under `%TEMP%` was named for the test and the configuration only:

```cmake
set(_consumer_root "$ENV{TEMP}/iccdev-issue-987-shared-mpe-export-${ICCDEV_CONFIG}")
```

Two build trees on one machine at the same configuration therefore resolve to one path. That
is not a benign share — the script `file(REMOVE_RECURSE)`s this directory before writing into
it, so a second run deletes the first run's consumer sources mid-configure.

Naming it from a digest of build directory, test name and configuration separates them. All
three inputs are already validated non-empty by the `_required_vars` loop above. The digest is
also shorter than the name it replaces, which buys back budget against the 260-character path
limit that the nested configure is already working close to.

Measured by driving the `-P` script directly with `TEMP` set:

| | `build-A/Release` + `build-B/Release` |
|---|---|
| master | **1** directory — they collide |
| this PR | **2** directories |

Configurations remain distinct exactly as before, and re-running the same inputs reuses the
same directory rather than leaking a new one each time.

### 2. issue-1103 calculator fixture — `iccdev-calculator-regression-tests.sh`

The test read its fixture from `Testing/CalcTest/`. `Testing/` is the generated corpus that
`CreateAllProfiles.sh` rewrites, whereas `.github/ci/regression/` holds fixtures that exist
only to pin a defect — and #1907 already placed this one there.

Both paths resolve to the **same git blob** (`48c3b369`), and to the sha256 the script already
checks before use, so the repoint is byte-identical today. It stops the test depending on
corpus contents it does not own.

Verified it actually reads the new path: with the fixture moved aside the case fails naming
that exact path, and the other 10 of 11 cases still pass.

### 3. Dead `require_svg` helper — `iccdev-profile-visualize-tests.sh`

Defined once, called nowhere, and carrying nine shellcheck suppressions (`SC2329` "never
invoked", `SC2317` "unreachable") that were needed only because it was dead. shellcheck is
clean on the file after removing it, which confirms the suppressions had no other purpose.

### 4. `zlib` in the vcpkg manifest — `vcpkg.json`

`ICC_USE_ZLIB` defaults `ON` and the build does `find_package(ZLIB REQUIRED)`, so zlib is a
direct requirement — but the manifest never declared it and relied on `libpng`, `tiff` and
`libxml2` to keep pulling it in. That holds today, which is why nothing is broken; it stops
holding the moment any of those gains a zlib-ng option or drops the dependency.

The CI Windows leg installs from a pre-exported dependency zip rather than from this manifest,
so this changes no CI behaviour. It follows the `ICC_USE_ZLIB` `PUBLIC` link fix from #1907.

### Deliberately not taken

`ci-json-roundtrip.yml` — the branch adds a `build-test-binaries` build there, but all three
tests that workflow selects (`json-parser-regressions`, `stdobserver-regressions`,
`mluc-iso-code-regressions`) are `iccdev_add_script_test`. That target only gathers the
`EXCLUDE_FROM_ALL` compiled regression helpers, so the build would produce dozens of
executables the workflow never runs. Left on the branch.

### Pre-flight

- `shellcheck` rc=0 on both scripts
- `vcpkg.json` parses
- full `ctest` on a gcc build: **148/150**. The two failures are known local noise, not
  regressions — `qa-profile-manifest` reports **213 matched / 0 mismatched** and fails only on
  an untracked leftover profile in my working tree, and `spectral-tiff-preview` needs the
  python `imagecodecs` module.

@xsscx this touches CTest/Build infrastructure, which the checklist reserves for maintainer
request — noting that #1853 is assigned to me with all four buckets, so it is in scope, but say
the word if you would rather take any of these yourself.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes — no user-visible behaviour changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes — no parser or memory-safety code touched
- [x] Added or updated regression coverage for behavior changes
- [x] For Python package changes, followed `docs/python-packaging-release.md` — n/a, no Python package changes
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer — this is the #1853 harvest, assigned to me
- [x] New source files include the ICC copyright and BSD 3-Clause license header — no new source files
- [x] Code style matches nearby code
