### PR TITLE
fix(#1958,#1959): drop the two SAST dead stores, and record why the third report is not one

### DIFF
--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -352,13 +352,13 @@ int main(int argc, const char* argv[])
     // fromArgs() reports how many arguments it consumed and stops at the first it
     // does not recognise, so anything left over was silently discarded -- a
     // mistyped trailing profile path or intent ran the transform as though it had
-    // not been given, and the tool exited 0. Consume the count and refuse the
-    // remainder rather than reporting success for a command line that was not
-    // fully honoured (#1674).
-    argv += nArg;
-    argc -= nArg;
-
-    if (argc) {
+    // not been given, and the tool exited 0. Refuse the remainder rather than
+    // reporting success for a command line that was not fully honoured (#1674).
+    // This is the last use of the argument vector, so compare the consumed count
+    // against what was offered instead of advancing argv/argc once more: the
+    // pointer bump that paired with the count above would be a store no later
+    // read could observe (#1958).
+    if (nArg != argc) {
       printf("Unexpected extra arguments\n");
       return EXIT_FAILURE;
     }

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -2343,15 +2343,32 @@ int DumpPawgReport(const char *szFilename, bool bUseRead, bool bJson)
   RawProfile raw;
   LoadRawProfile(szFilename, raw);
 
+  // sReport/nStatus exist only to satisfy ValidateIccProfile's out-parameters:
+  // this entry point reports the PAWG checklist, not the validation log, and the
+  // checklist derives its own verdict from the profile.  TagTypeAllowedVerdict()
+  // re-runs Validate() on the parsed profile and turns that status into the C-item
+  // the report actually prints, so nothing downstream of here reads either local.
   std::string sReport;
   icValidateStatus nStatus = icValidateOK;
   CIccProfile *pIcc = ValidateIccProfile(szFilename, sReport, nStatus);
 
+  // --read is meant to still assess a profile the strict path rejected.  As things
+  // stand it can never recover one: ValidateIccProfile() returns NULL only when
+  // ReadValidate() reaches icValidateCriticalError, and the sole two ways it does
+  // that -- ReadBasic() failing, and any LoadTag() failing -- are exactly the two
+  // conditions CIccProfile::Read() bails on, so ReadIccProfile() returns NULL for
+  // the same inputs.  (CheckTagLayout(), the only other contributor, tops out at
+  // icValidateWarning.)  This branch therefore holds a profile pointer that is
+  // always NULL.
+  //
+  // It used to run a second full Validate() over that never-non-NULL profile and
+  // store the status into nStatus, which no later statement reads -- the discarded
+  // store scan-build reported (#1959).  Dropping it costs nothing even if the two
+  // read paths later diverge and this branch goes live: EvaluatePawg() validates
+  // whichever profile it is handed, and TagTypeAllowedVerdict() turns that status
+  // into the C-item the report prints.
   if (bUseRead && !pIcc) {
     pIcc = ReadIccProfile(szFilename);
-    if (pIcc) {
-      nStatus = pIcc->Validate(sReport);
-    }
   }
 
   std::vector<PawgItem> items = EvaluatePawg(raw, pIcc);


### PR DESCRIPTION
Part of #1958 and part of #1959.

`scan-build` reported three findings across these two tools. Two are real dead stores and are removed here; the third is a false positive and is left alone, with the reasoning recorded so it does not get re-reported as new.

## 1. `iccApplyNamedCmm.cpp:358` — `argv += nArg` (#1958)

Real dead store. The #1674 leftover-argument check pairs a pointer advance with a count decrement, but this is the **last** use of the argument vector — nothing reads `argv` or `argc` after the guard:

```
$ awk 'NR>360 && /\bargc\b|\bargv\b/' Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
(no output)
```

Comparing the consumed count against what was offered expresses the same test without either mutation:

```cpp
-    argv += nArg;
-    argc -= nArg;
-
-    if (argc) {
+    if (nArg != argc) {
       printf("Unexpected extra arguments\n");
```

Equivalent for every input, including a `fromArgs()` that over-reports: `nArg > argc` makes `nArg != argc` true, exactly as the old `argc -= nArg; if (argc)` did.

## 2. `PawgReport.cpp:2353` — `nStatus = pIcc->Validate(sReport)` (#1959)

Real, and more than a store: `CIccProfile::Validate` is `const` (`IccProfile.h:186`), with no `mutable` members and no `const_cast` in its body, so this was a **whole validation pass whose only effect was the discarded assignment**. Nothing downstream of it reads `nStatus` or `sReport`.

The verdict is not lost. `EvaluatePawg()` → `TagTypeAllowedVerdict()` (`PawgReport.cpp:1358`) validates the profile it is handed and turns that status into the C-item the report actually prints.

### Side finding: the `--read` branch this sits in is unreachable

Recorded in a comment, **not acted on** — retiring a documented option is a maintainer call.

`ValidateIccProfile()` returns NULL only when `ReadValidate()` reaches `icValidateCriticalError`, and it reaches that only via:

| path | `ReadValidate` | `CIccProfile::Read` |
|---|---|---|
| `ReadBasic()` fails | critical (`IccProfile.cpp:936`) | returns false (`:872`) |
| any `LoadTag()` fails | critical (`:992`) | returns false (`:901`) |
| `CheckTagLayout()` | tops out at `icValidateWarning` | not consulted |

Both critical paths are exactly the conditions `Read()` bails on, so `ReadIccProfile()` returns NULL for the same inputs. `--read` can never recover a profile the strict path rejected; the inner `if (pIcc)` was never true. That is why no fixture could reach the dead store — I tried all 80 tracked profiles and seven header-corruption variants before working it out from the source.

## 3. `iccApplyNamedCmm.cpp:401` `[unix.Stream]` — false positive, unchanged

The issue title classes this as `deadcode.DeadStores`, but it is a different check and it is wrong. `icFlushAndClose()` (`IccCmdLineUtil.h:247`) always `fclose`s unless the handle is `stdout`:

```cpp
  if (f == stdout)
    return !failed;
  if (fclose(f) != 0)
    failed = true;
```

and `icOpenRegularWriteFile()` (`:206`) returns `stdout` only for a null or empty filename — which the enclosing `if (!exportFile.empty())` excludes. The analyzer simply does not follow the inline header. No leak, no change. The same pattern is in `iccApplySearch.cpp:376` and `iccApplyProfiles.cpp:335`, so expect the same FP there.

## Verification

**Red/green on the analyzer that produced the reports** — same checker, same flags, `clang++ --analyze`:

| TU | on `9b430d2a` | on this branch |
|---|---|---|
| `iccApplyNamedCmm.cpp` | `:358 Value stored to 'argv' is never read` | gone |
| `PawgReport.cpp` | `:2353 Value stored to 'nStatus' is never read` | gone |
| `iccApplyNamedCmm.cpp` | `:401 [unix.Stream]` | still present (the FP above) |

Both reproduce at exactly the reported lines before the change, so this is a genuine red→green, not a false pass.

**Red-test on the existing CTest.** `iccdev.applynamedcmm-cli-args` (added for #1674) already covers this path. Neutering the rewritten guard to `if (false)` makes its `normal-extra` case fail; restoring it passes. The rewrite is pinned, not assumed.

**Behavioural equivalence for #1959.** `iccPawgReport` output is byte-identical across all 80 tracked profiles × 4 flag combinations (`""`, `--read`, `--json`, `--read --json`) — 320 invocations, zero diff.

**Build and suite.**
- Both files compile clean under `-Wall -Wextra -Wpedantic -Werror` on **gcc and clang** (the `ci-pr-gcc15.yml` gate).
- The 35 CTests touching either tool pass.
- Full local suite 148/150; the two failures are environmental and reproduce independently of this branch — `spectral-tiff-preview` (missing python `imagecodecs`) and `qa-profile-manifest` (`0 mismatched`, one *unlisted* stray untracked file in my working tree).

No CTest added: both changes are provably observation-free, so a new test could only pin analyzer output rather than behaviour. The `#1674` guard already has the regression test that matters.

## Adjacent, not in scope

The `#1674` leftover-argument rejection exists **only** in `iccApplyNamedCmm`. `iccApplySearch.cpp:335` and `iccApplyProfiles.cpp:303` still parse past unrecognised trailing arguments and exit 0 — the original defect, unfixed in two of three tools. Extending it changes command lines those tools currently accept, so it wants a maintainer decision rather than a drive-by here.
