### PR TITLE
fix(#1977): retire the iccPawgReport --read option

### DIFF
--- a/.github/scripts/icc-pawg-qa-scan.sh
+++ b/.github/scripts/icc-pawg-qa-scan.sh
@@ -8,13 +8,14 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 export ICC_QA_TOOL_NAME="iccPawgReport"
 export ICC_QA_TOOL="${ICC_PAWG_REPORT:-$REPO_ROOT/Build/Tools/IccPawgReport/iccPawgReport}"
-export ICC_QA_TOOL_USAGE="iccPawgReport [--json] [--read] profile.icc"
+export ICC_QA_TOOL_USAGE="iccPawgReport [--json] profile.icc"
 export ICC_QA_OUT_PREFIX="pawg-qa"
 export ICC_QA_TIMEOUT_DEFAULT="${ICC_PAWG_QA_TIMEOUT:-60}"
+# The read/json-read variants drove the --read option, retired in #1977 because it
+# could never recover a profile the strict parse rejected. They are not replaced:
+# both ran the same code path as their non---read counterparts above.
 export ICC_QA_VARIANTS='text||
-json|--json|
-read|--read|
-json-read|--json --read|'
+json|--json|'
 
 # shellcheck source=.github/scripts/icc-tool-qa-scan-common.sh
 source "$SCRIPT_DIR/icc-tool-qa-scan-common.sh"

--- a/.github/scripts/icc-pawg-qa-scan.sh
+++ b/.github/scripts/icc-pawg-qa-scan.sh
@@ -17,5 +17,11 @@ export ICC_QA_TIMEOUT_DEFAULT="${ICC_PAWG_QA_TIMEOUT:-60}"
 export ICC_QA_VARIANTS='text||
 json|--json|'
 
+# The source= directive records the path for anyone running shellcheck -x; without
+# -x, which is how the pre-flight gate invokes it, shellcheck still reports SC1091
+# for the unfollowed file, so suppress it here as well. Pre-existing, and surfaced
+# only because the gate lints changed files and this is the first change to touch
+# this one -- the two sibling icc-*-qa-scan.sh scripts carry the same latent finding.
 # shellcheck source=.github/scripts/icc-tool-qa-scan-common.sh
+# shellcheck disable=SC1091
 source "$SCRIPT_DIR/icc-tool-qa-scan-common.sh"

--- a/.github/scripts/iccdev-pawg-report-regression-tests.sh
+++ b/.github/scripts/iccdev-pawg-report-regression-tests.sh
@@ -277,6 +277,57 @@ run_directory_input_crash_guard() {
   pass_case "$name" "directory input handled gracefully (no crash, non-zero exit, report rendered)"
 }
 
+# #1977: --read claimed to load a profile the strict validation parse rejected, via
+# ReadIccProfile(). It could never do so -- every condition that makes
+# ValidateIccProfile() return NULL also makes CIccProfile::Read() fail -- so the
+# option was retired. Pin the retirement: it must be rejected like any other unknown
+# switch rather than quietly accepted and ignored, which would leave callers
+# believing a fallback ran.
+run_retired_read_option_rejected() {
+  local name="pawg-read-option-retired"
+  local logfile="$OUTDIR/$name.log"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$logfile"
+
+  if [ ! -x "$PAWG" ]; then
+    fail_case "$name" "missing executable: $PAWG"
+    return
+  fi
+  if [ ! -f "$GOOD_PROFILE" ]; then
+    fail_case "$name" "missing test profile: $GOOD_PROFILE"
+    return
+  fi
+
+  timeout 60 "$PAWG" --read "$GOOD_PROFILE" > "$logfile" 2>&1 || exit_code=$?
+
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    sed -n '1,40p' "$logfile"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "--read was accepted (expected non-zero exit; the option is retired)"
+    return
+  fi
+  if ! grep -F -q 'Unknown option "--read"' "$logfile"; then
+    fail_case "$name" "--read rejected without naming it as an unknown option"
+    sed -n '1,20p' "$logfile"
+    return
+  fi
+  if grep -F -q "[ SECURITY ]" "$logfile"; then
+    fail_case "$name" "--read still produced a report body"
+    return
+  fi
+
+  pass_case "$name" "retired --read option is rejected as an unknown switch"
+}
+
 run_good_profile() {
   local name="$1"
   local flag="$2"
@@ -1448,7 +1499,7 @@ run_static_source_audit
 run_binary_size_guard
 run_directory_input_crash_guard
 run_good_profile "pawg-valid-profile-fidelity" ""
-run_good_profile "pawg-read-option-fidelity" "--read"
+run_retired_read_option_rejected
 run_json_report
 run_truncated_profile
 run_private_malware_profile

--- a/Tools/CmdLine/IccPawgReport/IccPawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/IccPawgReport.cpp
@@ -73,26 +73,27 @@
 
 static void printUsage()
 {
-  printf("Usage: iccPawgReport {--read} {--json} profile\n");
+  printf("Usage: iccPawgReport {--json} profile\n");
   printf("\nEmits an ICC PAWG profile assessment checklist report aligned with\n");
   printf("https://www.color.org/profiles/assessment/index.xalter\n");
-  printf("  --read   Use ReadIccProfile (eager load) fallback after validation parse failure\n");
   printf("  --json   Emit machine-readable JSON evidence instead of text\n");
   printf("iccPawgReport built with IccProfLib version " ICCPROFLIBVER "\n\n");
 }
 
 int main(int argc, char *argv[])
 {
-  bool bUseRead = false;
   bool bJson = false;
   std::string profilePath;
 
+  // --read used to select a ReadIccProfile() fallback here after the strict
+  // validation parse returned NULL. It could never recover a profile -- every
+  // condition that makes ValidateIccProfile() return NULL also makes
+  // CIccProfile::Read() fail -- so it was retired (#1977). It is deliberately
+  // not accepted-and-ignored: falling through to the unrecognised-switch branch
+  // below tells a caller still passing it, rather than silently doing nothing.
   for (int k = 1; k < argc; k++) {
-  
-    if (strcasecmp(argv[k], "--read") == 0) {
-      bUseRead = true;
-    }
-    else if (strcasecmp(argv[k], "--json") == 0) {
+
+    if (strcasecmp(argv[k], "--json") == 0) {
       bJson = true;
     }
     else if ( strcasecmp( argv[k], "-V" ) == 0
@@ -124,7 +125,7 @@ int main(int argc, char *argv[])
 
 
   try {
-    return DumpPawgReport(profilePath.c_str(), bUseRead, bJson);
+    return DumpPawgReport(profilePath.c_str(), bJson);
   }
   catch (const std::exception& e) {
     fprintf(stderr, "ERROR - exception while processing PAWG report for '%s': %s\n", profilePath.c_str(), e.what() );

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -2338,8 +2338,14 @@ bool HasFail(const std::vector<PawgItem> &items)
 
 } // namespace
 
-int DumpPawgReport(const char *szFilename, bool bUseRead, bool bJson)
+int DumpPawgReport(const char *szFilename, bool bJson)
 {
+  // The raw byte read is deliberately unconditional and comes first: it does not
+  // depend on IccProfLib parsing the file at all, so a profile the library refuses
+  // still receives the full raw-byte security assessment below, with the
+  // parsed-profile items reported as NOT RUN. That graceful degradation is what
+  // makes a strict-only load acceptable -- and is why the --read fallback that
+  // used to sit further down was never needed (#1977).
   RawProfile raw;
   LoadRawProfile(szFilename, raw);
 
@@ -2351,25 +2357,6 @@ int DumpPawgReport(const char *szFilename, bool bUseRead, bool bJson)
   std::string sReport;
   icValidateStatus nStatus = icValidateOK;
   CIccProfile *pIcc = ValidateIccProfile(szFilename, sReport, nStatus);
-
-  // --read is meant to still assess a profile the strict path rejected.  As things
-  // stand it can never recover one: ValidateIccProfile() returns NULL only when
-  // ReadValidate() reaches icValidateCriticalError, and the sole two ways it does
-  // that -- ReadBasic() failing, and any LoadTag() failing -- are exactly the two
-  // conditions CIccProfile::Read() bails on, so ReadIccProfile() returns NULL for
-  // the same inputs.  (CheckTagLayout(), the only other contributor, tops out at
-  // icValidateWarning.)  This branch therefore holds a profile pointer that is
-  // always NULL.
-  //
-  // It used to run a second full Validate() over that never-non-NULL profile and
-  // store the status into nStatus, which no later statement reads -- the discarded
-  // store scan-build reported (#1959).  Dropping it costs nothing even if the two
-  // read paths later diverge and this branch goes live: EvaluatePawg() validates
-  // whichever profile it is handed, and TagTypeAllowedVerdict() turns that status
-  // into the C-item the report prints.
-  if (bUseRead && !pIcc) {
-    pIcc = ReadIccProfile(szFilename);
-  }
 
   std::vector<PawgItem> items = EvaluatePawg(raw, pIcc);
 

--- a/Tools/CmdLine/IccPawgReport/PawgReport.h
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.h
@@ -65,7 +65,7 @@
 #include <cstddef>
 #include <string>
 
-int DumpPawgReport(const char *szFilename, bool bUseRead, bool bJson);
+int DumpPawgReport(const char *szFilename, bool bJson);
 
 // Assessment-only entry points (issue #1775): run the PAWG evaluation "up to the
 // point of Output, not for Output" over an in-memory profile image, so the

--- a/Tools/CmdLine/IccPawgReport/Readme.md
+++ b/Tools/CmdLine/IccPawgReport/Readme.md
@@ -7,13 +7,16 @@
 ```sh
 iccPawgReport profile.icc
 iccPawgReport --json profile.icc
-iccPawgReport --read profile.icc
 ```
 
 Options:
 
 - `--json` out instead of text report
-- `--read` eager `ReadIccProfile()` loading after validation parse failure
+
+A profile that IccProfLib refuses to parse is still assessed: the raw-byte checks run from the
+file contents directly, and the checks that need a parsed profile are reported as `NOT RUN`.
+(A `--read` option previously claimed to load such a profile via `ReadIccProfile()`. It could
+never do so and was retired in #1977.)
 
 The report prints 32 checklist items:
 


### PR DESCRIPTION
Part of #1977.

Retires `iccPawgReport --read`. @xsscx confirmed on #1972 that it was leftover prototyping scaffolding rather than an intended feature, and #1977 records the mechanism and scope.

## Why it can never have worked

`DumpPawgReport()` only consulted the flag after the strict path had already returned NULL:

```cpp
  CIccProfile *pIcc = ValidateIccProfile(szFilename, sReport, nStatus);

  if (bUseRead && !pIcc) {
    pIcc = ReadIccProfile(szFilename);
  }
```

`ValidateIccProfile()` returns NULL on a parsed profile only when `ReadValidate()` reaches `icValidateCriticalError`, and the two conditions that get it there are exactly the conditions `CIccProfile::Read()` — behind `ReadIccProfile()` — bails on:

| condition | `ReadValidate()` | `CIccProfile::Read()` |
|---|---|---|
| `ReadBasic()` fails | critical, `IccProfile.cpp:941` | `return false`, `:874` |
| any `LoadTag()` fails | critical, `:992` | `return false`, `:905` |
| `CheckTagLayout()` | tops out at `icValidateWarning` | not consulted |

Supporting facts, both checked rather than assumed: `icValidateStatus` is ordered `OK(0) < Warning(1) < NonCompliant(2) < CriticalError(3)` (`IccDefs.h:106-111`), so `>= icValidateCriticalError` matches only the maximum and the `NonCompliant`/`Warning` header checks cannot trigger the NULL return; and `LoadTag()` opens with an absolute `Seek(offset, icSeekSet)`, so the repositioning `ReadValidate()` does beforehand cannot change its outcome relative to `Read()`'s loop.

The root of the mistake is that `ReadIccProfile()` is the **eager** loader, not a permissive one. On tag structure it is *stricter* than a lazy `OpenIccProfile()`, so it fails on precisely the conditions that just made `ReadValidate()` report critical.

## Nothing is lost

The graceful degradation `--read` was reaching for already exists and never depended on it. `LoadRawProfile()` runs unconditionally at the top of `DumpPawgReport()`, before and independently of any IccProfLib parsing, so a file the library refuses still receives the full raw-byte security assessment with the parsed-profile items reported as `NOT RUN`. That reasoning is now recorded where the fallback used to sit, because it is what makes a strict-only load acceptable here.

## Retired, not accepted-and-ignored

`--read` now falls through to the existing unrecognised-switch branch:

```
$ iccPawgReport --read profile.icc
Unknown option "--read"

Usage: iccPawgReport {--json} profile
...
$ echo $?
1
```

A caller still passing it is told plainly, rather than believing a fallback ran.

## Scripts move with the source

`icc-pawg-qa-scan.sh` drove two of its four QA variants through `--read` and runs in CI from `ci-iccdev-tool-tests.yml`. Leaving it would turn those two into `exit 1`. They are dropped rather than replaced — both executed the same code path as their non-`--read` counterparts.

`pawg-read-option-fidelity`, which only ever asserted that a good profile reports identically with the flag set, is replaced by `pawg-read-option-retired`, which pins the rejection.

## Not touched

`iccDumpProfile` has a separate `--read` with different semantics — eager `ReadIccProfile()` *instead of* lazy `OpenIccProfile()`, not a post-failure fallback (`iccDumpProfile.cpp:210`). It is live and working, and along with `icc-dumpprofile-qa-scan.sh` and `docs/ctest.md:273` is deliberately left alone.

## Verification

**Acceptance test from #1977 — report output unchanged.** All 80 tracked `Testing/*.icc` profiles, text and JSON modes, version string normalised: **12639 lines, 0 diff** against pre-removal master.

**The new regression case is red-tested.** Silently re-accepting `--read` makes it fail with `--read was accepted (expected non-zero exit; the option is retired)`, so it catches the accepted-and-ignored mode specifically rather than just the presence of the flag.

**Build and suite.**
- `IccPawgReport.cpp` and `PawgReport.cpp` compile clean under `-Wall -Wextra -Wpedantic -Werror` on **gcc and clang**
- `shellcheck -S error` clean on both changed scripts
- 7 PAWG CTests pass
- full local suite 148/150; the two failures are environmental and reproduce independently of this branch — `spectral-tiff-preview` (missing python `imagecodecs`) and `qa-profile-manifest` (`0 mismatched`, one *unlisted* stray untracked file in my working tree)

Rebased onto `c0cd71db` so CI validates the landing tree.
