### PR TITLE
fix(#1976): report the gamut transform's destination as gamt, and classify on zero

### DIFF
--- a/.github/ci/regression/gamut-xform-semantics.cpp
+++ b/.github/ci/regression/gamut-xform-semantics.cpp
@@ -1,0 +1,254 @@
+// Regression for #1976: the gamt transform reported the wrong destination, and
+// CIccCmm::IsInGamut() classified 16-bit gamut codes as though the tag were 8-bit.
+//
+// Two independent defects, both pinned here.
+//
+// 1. Connection metadata.  ICC.1:2022 9.2.29 lets gamutTag be lut8Type, lut16Type
+//    or lutBToAType -- all B-to-A shaped -- so CIccXform::Create()'s icXformLutGamut
+//    case forces bInput false to walk the tag in its stored direction.  m_bInput,
+//    though, also drives GetDstSpace()/GetNumDstSamples(), whose !m_bInput branches
+//    return the profile's *device* space.  CIccCmm::AddXform() had correctly recorded
+//    PCS -> icSigGamutData, so the two disagreed and Begin()'s trailing output-count
+//    guard rejected the chain with icCmmStatBadSpaceLink.  Every gamt-bearing profile
+//    in Testing/ failed this way; the path had no working caller.  The fix marks the
+//    xform via SetGamutXform() so the reported destination no longer follows m_bInput.
+//
+// 2. Classification.  The tag defines zero as in gamut and every non-zero value as
+//    out of gamut.  IsInGamut() instead returned true for anything below 1/255 -- a
+//    faithful float rewrite of the original (unsigned)(v*255.0) truncation, so the
+//    8-bit assumption predates the rewrite.  For a lut16Type gamt that swallows every
+//    code below 258, since 1/255 is exactly 257/65535.  All 7 corpus gamt tables store
+//    8-bit values replicated x257, so their nodes sit on or above that cutoff and it
+//    is interpolation between a zero node and a non-zero one that lands underneath:
+//    3444 Lab coordinates swept through CMYK-3DLUTs.icc give 92 such results, the
+//    smallest ~7.1e-15.  The fix compares against zero.
+//
+// The profile is built in memory rather than loaded, because every gamt-bearing
+// profile under Testing/ is generated from XML by the suite rather than tracked, so a
+// fixture-loading test would depend on generation order.  Its CLUT is flat at 1/65535
+// so the applied value is independent of interpolation and of which grid cell the
+// input lands in.
+//
+// Each assertion is red-green against one half of the fix: the Begin()/space
+// assertions fail with icCmmStatBadSpaceLink without (1), and the sub-1/255
+// assertions fail without (2).  Header + IccProfLib only.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccCmm.h"
+#include "IccProfile.h"
+#include "IccTagLut.h"
+#include "IccTagBasic.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <limits>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[gamut-xform] FAIL: %s\n", what);
+  }
+}
+
+// Smallest non-zero code a lut16Type gamt tag can carry.  This is the value the
+// 1/255 threshold used to swallow, and it is what a real gamt profile produces at
+// its least-out-of-gamut nodes.
+const icFloatNumber kSmallest16BitCode = 1.0f / 65535.0f;
+
+// Build a curve of nEntries evenly-spaced points spanning 0..1, i.e. an identity
+// ramp, so the CLUT value passes through the transform unchanged.
+CIccTagCurve *identityCurve(icUInt32Number nEntries)
+{
+  // Guards the division below; a single-entry curve is a gamma curve, not a ramp.
+  if (nEntries < 2)
+    return NULL;
+
+  CIccTagCurve *pCurve = new CIccTagCurve();
+  if (!pCurve || !pCurve->SetSize(nEntries))
+    return NULL;
+
+  for (icUInt32Number i = 0; i < nEntries; i++)
+    (*pCurve)[i] = (icFloatNumber)i / (icFloatNumber)(nEntries - 1);
+
+  return pCurve;
+}
+
+// An output-class CMYK profile with a Lab PCS carrying a lut16Type gamt tag that is
+// flat at kSmallest16BitCode.  Only the header fields and the tag the gamut xform
+// path consults are populated -- the profile is never written or validated.
+CIccProfile *buildGamutProfile()
+{
+  CIccProfile *pProfile = new CIccProfile();
+  if (!pProfile)
+    return NULL;
+
+  pProfile->InitHeader();
+  pProfile->m_Header.deviceClass = icSigOutputClass;
+  pProfile->m_Header.colorSpace = icSigCmykData;
+  pProfile->m_Header.pcs = icSigLabData;
+  pProfile->m_Header.renderingIntent = icPerceptual;
+
+  // 3 PCS channels in, 1 gamut channel out -- the shape 9.2.29 requires.
+  CIccTagLut16 *pLut = new CIccTagLut16();
+  if (!pLut) {
+    delete pProfile;
+    return NULL;
+  }
+  pLut->Init(3, 1);
+  pLut->SetColorSpaces(icSigLabData, icSigGamutData);
+
+  // CIccMBB sizes the A and B curve arrays from IsInputB(), so ask it which side
+  // carries how many rather than assuming the lut16 convention.
+  LPIccCurve *pCurvesA = pLut->NewCurvesA();
+  LPIccCurve *pCurvesB = pLut->NewCurvesB();
+  if (!pCurvesA || !pCurvesB) {
+    delete pLut;
+    delete pProfile;
+    return NULL;
+  }
+
+  const int nA = pLut->IsInputB() ? 1 : 3;
+  const int nB = pLut->IsInputB() ? 3 : 1;
+  for (int i = 0; i < nA; i++)
+    pCurvesA[i] = identityCurve(2);
+  for (int i = 0; i < nB; i++)
+    pCurvesB[i] = identityCurve(2);
+
+  icUInt8Number grid[3] = { 2, 2, 2 };
+  CIccCLUT *pCLUT = pLut->NewCLUT(grid, 2);
+  if (!pCLUT) {
+    delete pLut;
+    delete pProfile;
+    return NULL;
+  }
+
+  // Flat table: 2*2*2 nodes, one output channel each.  A constant table makes the
+  // applied result independent of interpolation, so the assertion below pins the
+  // classification rather than the interpolator.
+  for (icUInt32Number i = 0; i < pCLUT->NumPoints(); i++)
+    (*pCLUT)[i] = kSmallest16BitCode;
+
+  if (!pProfile->AttachTag(icSigGamutTag, pLut)) {
+    delete pLut;
+    delete pProfile;
+    return NULL;
+  }
+
+  return pProfile;
+}
+
+// Defect 2: the tag defines in-gamut as exactly zero.
+void testIsInGamutThreshold()
+{
+  icFloatNumber v;
+
+  v = 0.0f;
+  check(CIccCmm::IsInGamut(&v), "zero must be in gamut");
+
+  // Was reported in gamut by the 1/255 threshold; this is the assertion the
+  // defect report measured at ~1.5e-05.
+  v = kSmallest16BitCode;
+  check(!CIccCmm::IsInGamut(&v), "smallest 16-bit code (1/65535) must be out of gamut");
+
+  v = 1.0f / 512.0f;
+  check(!CIccCmm::IsInGamut(&v), "1/512 must be out of gamut");
+
+  // The largest 16-bit code the old cutoff still swallowed.  1/255 is exactly
+  // 257/65535, so code 256 is the last one below it -- an exact binary value on
+  // every platform, unlike a nextafter() step, and it names the real boundary.
+  v = 256.0f / 65535.0f;
+  check(!CIccCmm::IsInGamut(&v), "largest code below 1/255 (256/65535) must be out of gamut");
+
+  // At and above the old cutoff both behaviours agree; pinned so a future rewrite
+  // cannot regress the side that was already correct.
+  v = 1.0f / 255.0f;
+  check(!CIccCmm::IsInGamut(&v), "1/255 must be out of gamut");
+
+  v = 1.0f;
+  check(!CIccCmm::IsInGamut(&v), "one must be out of gamut");
+
+  // Neither compares equal to zero, so both classify as out of gamut -- the safe
+  // verdict for a value the transform could not produce meaningfully.
+  v = std::numeric_limits<icFloatNumber>::quiet_NaN();
+  check(!CIccCmm::IsInGamut(&v), "NaN must not be reported in gamut");
+
+  v = std::numeric_limits<icFloatNumber>::infinity();
+  check(!CIccCmm::IsInGamut(&v), "infinity must not be reported in gamut");
+}
+
+// Defect 1: the chain must link, and must advertise one gamut channel out.
+void testGamutXformConnection()
+{
+  CIccProfile *pProfile = buildGamutProfile();
+  check(pProfile != NULL, "gamut test profile could be built");
+  if (!pProfile)
+    return;
+
+  CIccCmm cmm;
+
+  // AddXform takes ownership of pProfile, including on its failure paths.
+  icStatusCMM rv = cmm.AddXform(pProfile, icPerceptual, icInterpLinear, NULL,
+                                icXformLutGamut, false);
+  check(rv == icCmmStatOk, "AddXform accepts a gamt profile as a gamut transform");
+  if (rv != icCmmStatOk)
+    return;
+
+  // Without the fix this is icCmmStatBadSpaceLink (2): Begin()'s output-count guard
+  // compares GetDestSamples() (1, from icSigGamutData) against the xform's
+  // GetNumDstSamples(), which followed m_bInput and answered 4 for CMYK.
+  rv = cmm.Begin();
+  check(rv == icCmmStatOk, "Begin() links a PCS -> gamut chain");
+  if (rv != icCmmStatOk)
+    return;
+
+  check(cmm.GetSourceSpace() == icSigLabData, "source space is the profile PCS");
+  check(cmm.GetDestSpace() == icSigGamutData, "destination space is icSigGamutData");
+  check(cmm.GetDestSamples() == 1, "destination carries a single gamut channel");
+
+  CIccXform *pXform = cmm.GetLastXform();
+  check(pXform != NULL, "gamut xform is present in the chain");
+  if (pXform) {
+    check(pXform->GetDstSpace() == icSigGamutData,
+          "xform reports icSigGamutData, not the device space");
+    check(pXform->GetNumDstSamples() == 1,
+          "xform reports one destination sample, not the device channel count");
+  }
+
+  // End to end: a PCS pixel must produce one gamut sample, and that sample -- being
+  // non-zero but well under 1/255 -- must classify as out of gamut.  This is the
+  // pair of defects meeting: before the fix the Apply could not be reached at all,
+  // and had it been, the value would have been called in gamut.
+  const icFloatNumber src[3] = { 0.5f, 0.5f, 0.5f };
+  icFloatNumber dst[1] = { -1.0f };
+
+  rv = cmm.Apply(dst, src);
+  check(rv == icCmmStatOk, "Apply produces a gamut value");
+  if (rv == icCmmStatOk) {
+    check(dst[0] > 0.0f && dst[0] < 1.0f / 255.0f,
+          "applied gamut value is non-zero and below the old 1/255 cutoff");
+    check(!CIccCmm::IsInGamut(dst), "applied sub-1/255 gamut value is out of gamut");
+  }
+}
+
+}  // namespace
+
+int main()
+{
+  testIsInGamutThreshold();
+  testGamutXformConnection();
+
+  if (g_fail)
+    std::fprintf(stderr, "[gamut-xform] %d assertion(s) failed\n", g_fail);
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -993,6 +993,50 @@ function(iccdev_add_getvalues_nstart_test)
   endif()
 endfunction()
 
+# #1976: two defects on the gamt path. CIccXform::Create() forces bInput false to walk
+# the B-to-A shaped gamut tag, but m_bInput also drove GetDstSpace()/GetNumDstSamples(),
+# so the xform advertised the profile's device space while CIccCmm::AddXform() had
+# recorded PCS -> icSigGamutData; Begin() rejected every gamt-bearing profile in Testing/
+# with icCmmStatBadSpaceLink. Separately CIccCmm::IsInGamut() applied an 8-bit 1/255
+# threshold to a tag that may be lut16Type, so 16-bit out-of-gamut codes below 258 read
+# as in gamut. Pins the corrected connection metadata and the exact-zero classification;
+# builds its gamt profile in memory because the corpus gamt profiles are generated from
+# XML rather than tracked. Header + IccProfLib only.
+function(iccdev_add_gamut_xform_semantics_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccGamutXformSemanticsTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/gamut-xform-semantics.cpp"
+  )
+  target_link_libraries(iccGamutXformSemanticsTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccGamutXformSemanticsTest)
+
+  add_test(
+    NAME iccdev.gamut-xform-semantics
+    COMMAND "$<TARGET_FILE:iccGamutXformSemanticsTest>"
+  )
+  set_tests_properties(iccdev.gamut-xform-semantics PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;cmm;gamut;issue-1976;regression"
+  )
+  if(WIN32)
+    set(_gamut_xform_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccGamutXformSemanticsTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _gamut_xform_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.gamut-xform-semantics PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_gamut_xform_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1853: CIccMatrixMath::rangeMap() discarded SetRange()'s verdict and returned a matrix
 # whose coefficients were never written, so a rejected spectral range pair fed
 # uninitialized heap into the colour math (CWE-908). Pins the corrected NULL return, the
@@ -3347,6 +3391,7 @@ if(WIN32)
   iccdev_add_reflectance_observer_illum_range_test()
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
+  iccdev_add_gamut_xform_semantics_test()
   iccdev_add_rangemap_uninitialized_test()
   iccdev_add_pcs_birefl_illuminant_range_test()
   iccdev_add_pcs_applyillum_chain_sizing_test()
@@ -3597,6 +3642,7 @@ iccdev_add_xform_abstorel_adjust_test()
 iccdev_add_reflectance_observer_illum_range_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
+iccdev_add_gamut_xform_semantics_test()
 iccdev_add_rangemap_uninitialized_test()
 iccdev_add_pcs_birefl_illuminant_range_test()
 iccdev_add_pcs_applyillum_chain_sizing_test()

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -1241,6 +1241,12 @@ CIccXform *CIccXform::Create(CIccProfile *pProfile,
       rv->m_pConnectionConditions = pProfile;
 
     rv->SetParams(pProfile, bInput, nIntent, nTagIntent, bUseSpectralPCS, nInterp, pHintManager, bAbsToRel, nMCS);
+
+    // The icXformLutGamut case above forced bInput false to walk the gamt tag
+    // in its stored B-to-A direction.  Record that this is a gamut xform so the
+    // reported destination stays icSigGamutData rather than the device space.
+    if (nLutType == icXformLutGamut)
+      rv->SetGamutXform();
   }
   else if (bOwnsProfile) {
     // No xform was produced. pProfile never reached SetParams(), so free it here
@@ -1894,6 +1900,14 @@ icUInt16Number CIccXform::GetNumSrcSamples() const
 */
 icColorSpaceSignature CIccXform::GetDstSpace() const
 {
+  // A gamut xform consumes the PCS and produces the single gamut channel, so
+  // its destination is icSigGamutData whatever the profile's device space is.
+  // m_bInput is false here purely to traverse the B-to-A shaped gamt tag; the
+  // !m_bInput branch below would otherwise report m_Header.colorSpace and
+  // contradict the PCS -> gamt link CIccCmm::AddXform() already recorded.
+  if (m_bGamutXform)
+    return icSigGamutData;
+
   icColorSpaceSignature rv;
   icProfileClassSignature deviceClass = m_pProfile->m_Header.deviceClass;
 
@@ -1936,6 +1950,12 @@ icColorSpaceSignature CIccXform::GetDstSpace() const
 */
 icUInt16Number CIccXform::GetNumDstSamples() const
 {
+  // Must track GetDstSpace() above: CIccCmm::Begin() rejects the chain with
+  // icCmmStatBadSpaceLink when this disagrees with the CMM destination sample
+  // count, and CIccApplyCmm sizes its pixel buffers from it.
+  if (m_bGamutXform)
+    return (icUInt16Number)icGetSpaceSamples(icSigGamutData);
+
   icUInt16Number rv;
 
   if (m_nMCS==icToMCS) {
@@ -8056,6 +8076,12 @@ CIccXform *CIccXformMpe::Create(CIccProfile *pProfile, bool bInput/* =true */, i
 
   if (rv) {
     rv->SetParams(pProfile, bInput, nIntent, nTagIntent, bUseSpectralPCS, nInterp, pHintManager, bAbsToRel);
+
+    // Same reasoning as the icXformLutGamut case in CIccXform::Create(): this
+    // overload has no in-tree caller, but it is public API and its gamut case
+    // forces bInput false the same way, so it needs the same marking.
+    if (nLutType == icXformLutGamut)
+      rv->SetGamutXform();
   }
   else if (bOwnsProfile) {
     // No xform was produced; pProfile never reached SetParams(), so free it here
@@ -9735,9 +9761,9 @@ icStatusCMM CIccCmm::RemoveAllIO()
  ** Name: CIccCmm::IsInGamut
  **
  ** Purpose:
- **  Function to check if internal representation of gamut is in gamut.  Note
- **  that the gamut table is 8 bit and a color is considered to be out of gamut
- **  if the value is not zero.
+ **  Function to check if internal representation of gamut is in gamut.  A
+ **  colour is in gamut only when the gamut value is zero; every non-zero
+ **  value means out of gamut.
  **
  **  Args:
  **   pInternal = internal pixel representation of gamut value
@@ -9747,10 +9773,22 @@ icStatusCMM CIccCmm::RemoveAllIO()
  **************************************************************************/
 bool CIccCmm::IsInGamut(icFloatNumber *pInternal)
 {
-  // replace float->int conversion with simple float comparison
-  if (*pInternal < (1.0f/255.0f))
-    return true;
-  return false;
+  // The gamt tag may be lut8Type, lut16Type or lutBToAType, so what reaches us
+  // is a normalized float, not an 8-bit code.  Treating anything below 1/255 as
+  // in gamut (and the equivalent (unsigned)(v*255.0) truncation it replaced)
+  // accepted every 16-bit code below 258; 1/255 is exactly 257/65535.
+  //
+  // Stored nodes rarely land there - all 7 gamt tables in Testing/ hold 8-bit
+  // values replicated x257, so wherever a non-zero node exists the smallest is
+  // exactly 257, i.e. 1/255, which the old test judged correctly.  Interpolation
+  // is what exposes the threshold: between a zero node and a 257 node every
+  // intermediate value falls under the cutoff.  Sweeping 3444 Lab coordinates
+  // through CMYK-3DLUTs.icc yields 92 out-of-gamut results the old test called
+  // in gamut, the smallest ~7.1e-15.
+  //
+  // Compare against zero, which is what the tag definition specifies.  NaN and
+  // infinity both fail this test and so report out of gamut, the safe verdict.
+  return *pInternal == 0.0f;
 }
 
 

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -435,6 +435,11 @@ public:
   //ShareProfile should only be called when the profile is shared between transforms 
   void ShareProfile() { m_bOwnsProfile = false; } 
   void SetPcsAdjustXform() { m_bPcsAdjustXform = true; }
+  /// Marks this xform as the gamut check for its profile.  The gamt tag is
+  /// B-to-A shaped, so Create() traverses it with bInput false; without this
+  /// flag the !m_bInput branches of GetDstSpace()/GetNumDstSamples() would
+  /// report the profile's device space instead of the single gamut channel.
+  void SetGamutXform() { m_bGamutXform = true; }
 
   virtual icStatusCMM Begin();
 
@@ -522,6 +527,9 @@ protected:
   CIccProfile *m_pProfile;
   bool m_bOwnsProfile = true;
   bool m_bPcsAdjustXform = false;
+  /// Set by SetGamutXform().  Decouples the reported destination of a gamut
+  /// xform from m_bInput, which selects LUT traversal direction only.
+  bool m_bGamutXform = false;
   bool m_bInput;
   icRenderingIntent m_nIntent;
   icRenderingIntent m_nTagIntent;


### PR DESCRIPTION
Part of #1976.

Fixes both defects reported there. Deliberately **not** `Fixes #1976` — see "What this
does not include" at the end; the close is @xsscx's call.

Reported by @xsscx, whose `ci-qa-maintainer-test-branch` established the bisect to
`1f0a9dd` (2015) and confirmed `321dbb1` (#1177) as a faithful rewrite rather than the
origin of the threshold. Both findings reproduce; the analysis below is my own
verification, with one correction to the framing.

## 1. The gamut transform could never be used

ICC.1:2022 9.2.29 allows `gamutTag` to be `lut8Type`, `lut16Type` or `lutBToAType` — all
B-to-A shaped — so `CIccXform::Create()`'s `icXformLutGamut` case forces `bInput` false to
traverse the tag in its stored direction. But `m_bInput` also drives `GetDstSpace()` and
`GetNumDstSamples()`, whose `!m_bInput` branches answer with the profile's **device** space:

| | reported by the xform | recorded by `AddXform` |
|---|---|---|
| destination space | `m_Header.colorSpace` (e.g. `CMYK`) | `icSigGamutData` |
| destination samples | 4 | 1 |

`Begin()`'s trailing output-count guard compares `GetDestSamples()` against the last
xform's `GetNumDstSamples()` and rejected the chain with `icCmmStatBadSpaceLink`.

**Every gamt-bearing profile in the corpus failed.** A full tag-table scan of all 255
`.icc` under `Testing/` finds exactly 7 carrying `gamutTag`. Measured on master `c0cd71db`
with `iccApplyNamedCmm <lab> 3 0 <profile> 30`:

| profile | gamt type | master | this PR |
|---|---|---|---|
| `Testing/V2/v2CmykLut16.icc` | `lut16Type` | rc=1 `Invalid space link` | rc=0 |
| `Testing/CMYK-3DLUTs/CMYK-3DLUTs.icc` | `lutBtoAType` | rc=1 | rc=0 |
| `Testing/CMYK-3DLUTs/CMYK-3DLUTs2.icc` | `lutBtoAType` | rc=1 | rc=0 |
| `Testing/hybrid/ICC/CMYK_Hybrid_Profile.icc` | `lutBtoAType` | rc=1 | rc=0 |
| `Testing/hybrid/ICC/CMYK-W_Overprint_Profile.icc` | `lutBtoAType` | rc=1 | rc=0 |
| `Testing/hybrid/ICC/CMYK-S_Overprint_Profile.icc` | `lutBtoAType` | rc=1 | rc=0 |
| `Testing/hybrid/ICC/CMYK-STop_Overprint_Profile.icc` | `lutBtoAType` | rc=1 | rc=0 |

7 of 7 red, 7 of 7 green. The path had no working caller in the tree.

`SetGamutXform()` now marks the transform so its reported destination stops following the
traversal direction, leaving `m_bInput` doing only the one job it is meant to do.

### Two scope decisions

**A setter, not a `SetParams()` parameter.** `SetParams()` is documented as the API for
overridden `Create` functions, so an added parameter is a public surface change every
out-of-tree subclass inherits. `CIccXform` already has this exact idiom one line above —
`ShareProfile()`, `SetPcsAdjustXform()` — so `SetGamutXform()` matches it and changes no
existing signature.

**The source side is deliberately untouched.** Extracting both `case icXformLutGamut:`
blocks confirms neither assigns `bUseSpectralPCS`, so it stays false and `GetSrcSpace()`
already returns `m_Header.pcs` — exactly what `AddXform` records. Overriding the source
accessors too would be redundant.

## 2. `IsInGamut()` applied an 8-bit threshold to a tag that need not be 8-bit

```cpp
if (*pInternal < (1.0f/255.0f))   // in gamut
```

`1/255` is exactly `257/65535`, so every 16-bit code below 258 read as in gamut. The tag
defines zero as in gamut and every non-zero value as out.

### Correction to the report's framing

The report cites a measured `1.5259e-05` (= `1/65535`) as the misclassified value. That is
right about the *encoding* but not about how the defect is reached on real profiles.

Every `gamt` value in all 7 corpus tables is `≡ 0 (mod 257)` — 8-bit values replicated ×257
— so wherever a non-zero node exists at all, the smallest is exactly `257/65535 == 1/255`,
which the **old** test classified *correctly*. What exposes the threshold is
**interpolation** between a zero node and a non-zero one, where intermediate values fall
underneath.

Sweeping 3444 Lab coordinates through `CMYK-3DLUTs.icc`:

```
92 of 3444 results land in (0, 1/255)      <- all reported in gamut by the old test
smallest: 7.13166e-15
```

So the defect is real and reachable on tracked corpus data, but through the interpolator
rather than through a stored node. Without that measurement the change looks unreachable
on the corpus, so it is recorded in the code comment and the test.

The comparison is now against zero. NaN and infinity both fail it and so report out of
gamut — the safe verdict for a value the transform could not produce meaningfully.

## Coverage of the other gamut paths

`CIccXformMpe::Create()` gets the same marking: no in-tree caller, but it is public API and
its gamut case forces `bInput` false identically. `CIccCmm::AddXform()` and
`CIccNamedColorCmm::AddXform()` both route through `CIccXform::Create()` with the lut type
intact, so they are covered without further change. The tag-based `AddXform` overload has
no gamut concept — it never mentions `icSigGamutData` — and is untouched.

## Test

`iccdev.gamut-xform-semantics` (`.github/ci/regression/gamut-xform-semantics.cpp`), pinning
both the connection metadata and the exact-zero classification, registered in both call
lists in `Build/Cmake/Testing/CMakeLists.txt`.

It builds its gamt profile **in memory**: all seven gamt-bearing profiles under `Testing/`
are generated from XML by the suite rather than tracked, so a fixture-loading test would
depend on generation order.

Each assertion is red-green against one half of the fix — verified by ablation, and
re-verified after every restructuring of the test:

| tree state | failing assertions |
|---|---|
| master (both defects) | 4 — three classification, one connection |
| only `IsInGamut` reverted | 4 classification (incl. the end-to-end one, which now reaches `Apply`) |
| only destination accessors reverted | 1 connection |
| this PR | 0 |

The sub-cutoff assertion uses `256.0f/65535.0f` — the largest 16-bit code the old threshold
swallowed — rather than a `nextafter()` step, so it is an exact binary value on every
platform and names the real boundary.

## Pre-flight

| lane | result |
|---|---|
| **GCC 15.2.0, CI regression container**, Release+LTO, `-Wall -Wextra -Wpedantic -Werror`, strict warnings ENABLED | `grep -cE 'warning:'` = **0**, errors = 0 |
| clang 18 Debug, full build | 0 warnings; ctest 150/151 |
| clang ASan+UBSan Debug, `ASAN_OPTIONS=detect_leaks=1` | ctest 150/151; **0 sanitizer findings** |
| `git diff --check` | clean |

The single failure in every lane is `iccdev.spectral-tiff-preview` — a missing local python
`imagecodecs` module, failing identically on unmodified master here, not a regression.

All 7 corpus profiles above were also re-run under ASan+UBSan with leak detection: rc=0,
zero findings.

## What this does not include

`ci-qa-maintainer-test-branch` also carries synthetic `.icc`/`.xml`/`.json`/`.tif` fixtures,
a shell regression driver, and an `iccApplyProfiles` intent-30 TIFF path. None of that is
here: the two library defects reproduce on profiles already in the corpus, so the added
fixtures are not needed to pin them, and the tool-level coverage is a separate scope call.
That is why this is `Part of` rather than `Fixes` — if you consider the tool-level
regressions in scope for #1976, they still need doing.
