### PR TITLE
fix(#1856): bound profile and config JSON at one configurable limit

### DIFF
--- a/.github/scripts/iccdev-json-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-json-parser-regression-tests.sh
@@ -22,6 +22,18 @@ TESTING_DIR="${ICCDEV_TESTING_DIR:-Testing}"
 OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-json-parser-regressions}"
 mkdir -p "$OUTDIR"
 
+# Resolve both to absolute paths before deriving any tool path from them. CTest
+# passes these already absolute, but the defaults above are relative to the repo
+# root, and a test that has to run a tool from another working directory (the
+# issue #1856 fixture below builds its profile from Testing/hybrid, whose XML
+# references sibling data files) would otherwise fail to find the binary.
+if [ -d "$TOOLS_DIR" ]; then
+  TOOLS_DIR="$(cd "$TOOLS_DIR" && pwd)"
+fi
+if [ -d "$TESTING_DIR" ]; then
+  TESTING_DIR="$(cd "$TESTING_DIR" && pwd)"
+fi
+
 TOJSON="$TOOLS_DIR/IccToJson/iccToJson"
 FROMJSON="$TOOLS_DIR/IccFromJson/iccFromJson"
 FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
@@ -32,9 +44,14 @@ export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
 
 PASS=0
 FAIL=0
+SKIPPED=0
 ASAN_FINDINGS=0
 UBSAN_FINDINGS=0
 TOTAL=0
+
+# Bound the JSON readers were built with, so a size-threshold test can tell a
+# real regression from a build that simply configured a different limit.
+JSON_MAX_FILE_MB="${ICC_JSON_MAX_FILE_MB:-128}"
 
 check_sanitizers() {
   local name="$1"
@@ -312,6 +329,105 @@ run_tojson_valid_json_test() {
 
   echo "  [PASS] $name (iccToJson emitted valid JSON)"
   PASS=$((PASS + 1))
+}
+
+# Issue #1856. iccToJson emits, at its own documented -indent=4, a document that
+# the reader's former fixed 64 MiB cap refused, so the tool could write a file it
+# could not read back. This pins that round trip.
+#
+# The two thresholds are deliberately distinct. Below 64 MiB the fixture has
+# stopped exercising anything and the test has lost its teeth, which is a
+# failure. Above the bound this build was actually configured with, refusal is
+# correct behaviour rather than a regression, so the case is skipped instead.
+run_large_indented_roundtrip_test() {
+  local xml_name="$1"
+  local name="issue-1856-indent4"
+  local profile="$OUTDIR/$name-source.icc"
+  local json_file="$OUTDIR/$name.json"
+  local output_file="$OUTDIR/$name.icc"
+  local fromxml_log="$OUTDIR/$name-fromxml.log"
+  local tojson_log="$OUTDIR/$name-tojson.log"
+  local fromjson_log="$OUTDIR/$name-fromjson.log"
+  local exit_code=0
+  local json_size=0
+  local former_cap=$((64 * 1024 * 1024))
+  local configured_cap=$((JSON_MAX_FILE_MB * 1024 * 1024))
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$profile" "$json_file" "$output_file" "$fromxml_log" "$tojson_log" "$fromjson_log"
+
+  if [ ! -f "$TESTING_DIR/hybrid/$xml_name" ]; then
+    echo "  [FAIL] $name -- missing fixture $TESTING_DIR/hybrid/$xml_name"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  # Only the source XML is tracked; the profile it builds is ~3.7 MB and the
+  # JSON it then emits is ~93 MiB, so both are generated here. iccFromXml runs
+  # with Testing/hybrid as its working directory because the XML pulls in
+  # sibling data files by relative path.
+  ( cd "$TESTING_DIR/hybrid" && timeout 300 "$FROMXML" "$xml_name" "$profile" ) \
+    > "$fromxml_log" 2>&1 || exit_code=$?
+  if ! check_sanitizers "$name-fromxml" "$fromxml_log"; then
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [ "$exit_code" -ne 0 ] || [ ! -s "$profile" ]; then
+    echo "  [FAIL] $name -- iccFromXml failed to build the fixture with exit=$exit_code"
+    sed -n '1,5p' "$fromxml_log"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  exit_code=0
+  timeout 300 "$TOJSON" "$profile" "$json_file" -indent=4 > "$tojson_log" 2>&1 || exit_code=$?
+  if ! check_sanitizers "$name-tojson" "$tojson_log"; then
+    FAIL=$((FAIL + 1))
+    rm -f "$profile" "$json_file"
+    return
+  fi
+  if [ "$exit_code" -ne 0 ] || [ ! -s "$json_file" ]; then
+    echo "  [FAIL] $name -- iccToJson failed with exit=$exit_code"
+    sed -n '1,5p' "$tojson_log"
+    FAIL=$((FAIL + 1))
+    rm -f "$profile" "$json_file"
+    return
+  fi
+
+  json_size="$(wc -c < "$json_file")"
+  if [ "$json_size" -le "$former_cap" ]; then
+    echo "  [FAIL] $name -- fixture emits $json_size bytes, no longer above the former 64 MiB cap"
+    FAIL=$((FAIL + 1))
+    rm -f "$profile" "$json_file"
+    return
+  fi
+  if [ "$json_size" -gt "$configured_cap" ]; then
+    echo "  [SKIP] $name -- $json_size bytes exceeds this build's ${JSON_MAX_FILE_MB} MiB limit; refusal is correct"
+    SKIPPED=$((SKIPPED + 1))
+    TOTAL=$((TOTAL - 1))
+    rm -f "$profile" "$json_file"
+    return
+  fi
+
+  exit_code=0
+  timeout 300 "$FROMJSON" "$json_file" "$output_file" > "$fromjson_log" 2>&1 || exit_code=$?
+  # Drop the multi-MiB intermediates as soon as they have been read, so this
+  # test's peak disk footprint is not carried through the rest of the suite.
+  rm -f "$profile" "$json_file"
+  if ! check_sanitizers "$name-fromjson" "$fromjson_log"; then
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [ "$exit_code" -ne 0 ] || [ ! -s "$output_file" ]; then
+    echo "  [FAIL] $name -- iccFromJson rejected $json_size bytes under a ${JSON_MAX_FILE_MB} MiB limit (exit=$exit_code)"
+    sed -n '1,5p' "$fromjson_log"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+
+  echo "  [PASS] $name (${json_size} byte -indent=4 document round-tripped)"
+  PASS=$((PASS + 1))
+  rm -f "$output_file"
 }
 
 if [ ! -x "$TOJSON" ] || [ ! -x "$FROMJSON" ] || [ ! -x "$FROMXML" ]; then
@@ -667,6 +783,7 @@ run_xml_reject_test "xml-matrix-huge-channels" "$XML_MATRIX_HUGE" "Invalid Input
 run_xml_reject_test "xml-empty-private-type" "$XML_EMPTY_PRIVATE_TYPE" "Invalid private tag type attribute"
 run_tojson_valid_json_test "text-invalid-ascii-tojson" "$TEXT_INVALID_ASCII"
 run_tojson_success_test "namedcolor-invalid-ascii-tojson" "$NAMED_INVALID_ASCII"
+run_large_indented_roundtrip_test "CMYK-W_Overprint_Profile.xml"
 
 HELPER_SRC="$OUTDIR/json-config-helper-test.cpp"
 HELPER_BIN="$OUTDIR/json-config-helper-test"
@@ -819,6 +936,7 @@ echo "JSON/XML parser/config regression summary:"
 echo "  Total:      $TOTAL"
 echo "  Passed:     $PASS"
 echo "  Failed:     $FAIL"
+echo "  Skipped:    $SKIPPED"
 echo "  ASAN:       $ASAN_FINDINGS"
 echo "  UBSAN:      $UBSAN_FINDINGS"
 

--- a/.github/skills/json-config-regression/SKILL.md
+++ b/.github/skills/json-config-regression/SKILL.md
@@ -23,6 +23,9 @@ for `iccApplyNamedCmm`, `iccApplyProfiles`, or `iccApplySearch`.
 - Propagate failed nested `ParseJson()` or `fromJson()` calls.
 - Reject bad struct members instead of skipping them.
 - Reset stale state before parse and honor reset/fromJson flags.
+- Keep raw-input size bounds finite, and keep the profile reader and the `-cfg`
+  reader on the same bound. When changing one, check it against what `iccToJson`
+  itself emits at its documented `-indent` settings, not against an estimate.
 
 ## Validation
 

--- a/.github/workflows/ci-pr-action.yml
+++ b/.github/workflows/ci-pr-action.yml
@@ -98,7 +98,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGRESSION_IMAGE_TAG: ci-qa-pr-docker-testing
+  REGRESSION_IMAGE_TAG: sha-547c4bed27b0432942b2b34c57d5bd5495191798
 
 jobs:
   detect-src:

--- a/Build/Cmake/CMakeLists.txt
+++ b/Build/Cmake/CMakeLists.txt
@@ -465,6 +465,36 @@ option(ENABLE_SHARED_LIBS         "Build dynamic link libraries"                
 option(ENABLE_STATIC_LIBS         "Build static libraries"                              ON)
 option(ENABLE_ICCXML              "Build IccXML library support"                        ON)
 option(ENABLE_ICCJSON             "Build IccJSON library support"                       ON)
+
+# Maximum raw JSON input accepted by the IccJSON profile reader and by the
+# IccConnect JSON config reader. Both bound the file before nlohmann expands
+# it in memory, so this is a denial-of-service boundary rather than a format
+# limit. It is a configure-time knob instead of a literal because the former
+# fixed caps (64 MiB and 100 MiB) were set against an estimate the corpus does
+# not support, and the smaller one sat below what iccToJson itself emits at its
+# own documented -indent=4 - see issue #1856.
+#
+# 128 MiB clears every tracked fixture at -indent=4 (92.9 MiB) with headroom to
+# -indent=5, which is the range the defect was about. It is deliberately not
+# raised to icXmlMaxTextFileBytes' 256 MiB: a byte count is a weak proxy for the
+# memory this is meant to bound, because whitespace inflates the file without
+# inflating the parsed document. Measured peak RSS per input byte ranges from
+# 1.4x on an indented profile to 16.3x on a dense array of small values, so the
+# cap admits roughly 2 GiB on hostile input and doubling it would double that.
+set(ICC_JSON_MAX_FILE_MB "128" CACHE STRING
+    "Maximum JSON input size in MiB accepted by IccJSON and the JSON config readers")
+if(NOT ICC_JSON_MAX_FILE_MB MATCHES "^[1-9][0-9]*$")
+  message(FATAL_ERROR
+    "ICC_JSON_MAX_FILE_MB must be a positive integer (got '${ICC_JSON_MAX_FILE_MB}')")
+endif()
+# The point of the cap is that it is finite, so refuse a value large enough to
+# be equivalent to removing it.
+if(ICC_JSON_MAX_FILE_MB GREATER 1024)
+  message(FATAL_ERROR
+    "ICC_JSON_MAX_FILE_MB must not exceed 1024 MiB (got '${ICC_JSON_MAX_FILE_MB}')")
+endif()
+math(EXPR ICC_JSON_MAX_FILE_BYTES "${ICC_JSON_MAX_FILE_MB} * 1024 * 1024")
+
 option(ENABLE_IMAGE_TOOLS         "Build TIFF/PNG/JPEG image-dependent tools"           ON)
 option(ENABLE_CMM_TOOLS           "Build Windows CMM DLL tool"                          ON)
 option(ENABLE_IIS_TOOLS           "Build Windows IIS ISAPI tool"                        ON)
@@ -716,6 +746,7 @@ message(STATUS "ENABLE_SHARED_LIBS         = ${ENABLE_SHARED_LIBS}")
 message(STATUS "ENABLE_STATIC_LIBS         = ${ENABLE_STATIC_LIBS}")
 message(STATUS "ENABLE_ICCXML              = ${ENABLE_ICCXML}")
 message(STATUS "ENABLE_ICCJSON             = ${ENABLE_ICCJSON}")
+message(STATUS "ICC_JSON_MAX_FILE_MB       = ${ICC_JSON_MAX_FILE_MB}")
 message(STATUS "ENABLE_IMAGE_TOOLS         = ${ENABLE_IMAGE_TOOLS}")
 message(STATUS "ENABLE_CMM_TOOLS           = ${ENABLE_CMM_TOOLS}")
 message(STATUS "ENABLE_IIS_TOOLS           = ${ENABLE_IIS_TOOLS}")

--- a/Build/Cmake/IccConnect/CMakeLists.txt
+++ b/Build/Cmake/IccConnect/CMakeLists.txt
@@ -77,6 +77,12 @@ IF(ENABLE_SHARED_LIBS)
 
   target_compile_features(${TARGET_NAME} PUBLIC cxx_std_17)
 
+  # Issue #1856. The JSON config reader in IccJsonUtil.cpp shares the bound
+  # applied to profile JSON, so a -cfg document and a profile document are
+  # accepted or refused at the same size rather than at 100 MiB and 64 MiB.
+  target_compile_definitions(${TARGET_NAME} PRIVATE
+    ICC_JSON_MAX_FILE_BYTES=${ICC_JSON_MAX_FILE_BYTES})
+
   target_include_directories(${TARGET_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../IccConnect/IccLibConnect>
@@ -105,6 +111,10 @@ IF(ENABLE_STATIC_LIBS)
   set_target_properties(${TARGET_NAME}-static PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
 
   target_compile_features(${TARGET_NAME}-static PUBLIC cxx_std_17)
+
+  # Keep the static archive on the same bound as the shared library above.
+  target_compile_definitions(${TARGET_NAME}-static PRIVATE
+    ICC_JSON_MAX_FILE_BYTES=${ICC_JSON_MAX_FILE_BYTES})
 
   target_include_directories(${TARGET_NAME}-static PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/Build/Cmake/IccJSON/CMakeLists.txt
+++ b/Build/Cmake/IccJSON/CMakeLists.txt
@@ -90,6 +90,12 @@ IF(ENABLE_SHARED_LIBS)
 
   target_compile_features(${TARGET_NAME} PUBLIC cxx_std_17)
 
+  # Issue #1856. PRIVATE because the bound is an implementation detail of this
+  # library's reader, not part of its interface; IccProfileJson.cpp carries a
+  # matching fallback so non-CMake builds still compile with a finite cap.
+  target_compile_definitions(${TARGET_NAME} PRIVATE
+    ICC_JSON_MAX_FILE_BYTES=${ICC_JSON_MAX_FILE_BYTES})
+
   target_include_directories(${TARGET_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../../../IccJSON/IccLibJSON>
@@ -119,6 +125,10 @@ IF(ENABLE_STATIC_LIBS)
   # Disable LTO per-target as defense-in-depth.  (See GitHub issue #814.)
   set_target_properties(${TARGET_NAME}-static PROPERTIES INTERPROCEDURAL_OPTIMIZATION OFF)
   target_compile_features(${TARGET_NAME}-static PUBLIC cxx_std_17)
+
+  # Keep the static archive on the same bound as the shared library above.
+  target_compile_definitions(${TARGET_NAME}-static PRIVATE
+    ICC_JSON_MAX_FILE_BYTES=${ICC_JSON_MAX_FILE_BYTES})
 
   target_include_directories(${TARGET_NAME}-static PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3601,6 +3601,10 @@ set(ICCDEV_TEST_ENV
   "ICCDEV_TESTING_DIR=${ICCDEV_TESTING_DIR}"
   "ICCDEV_BUILD_DIR=${CMAKE_BINARY_DIR}"
   "ICCDEV_REQUIRE_JSON_ROUNDTRIP=${ICCDEV_REQUIRE_JSON_ROUNDTRIP}"
+  # Issue #1856. The JSON size bound is configurable, so a test that asserts on
+  # a document size has to know which limit the readers were actually built
+  # with rather than assuming the default.
+  "ICC_JSON_MAX_FILE_MB=${ICC_JSON_MAX_FILE_MB}"
 )
 
 iccdev_add_iccconnect_thread_test()

--- a/IccConnect/IccLibConnect/IccJsonUtil.cpp
+++ b/IccConnect/IccLibConnect/IccJsonUtil.cpp
@@ -84,6 +84,14 @@
 #include <unistd.h>
 #endif
 
+// Issue #1856. Kept in step with the IccJSON profile reader so a JSON config
+// document and a profile document are bounded at the same size. The build
+// system is the source of truth (CMake cache variable ICC_JSON_MAX_FILE_MB);
+// this fallback only keeps non-CMake builds compiling with a finite cap.
+#ifndef ICC_JSON_MAX_FILE_BYTES
+#define ICC_JSON_MAX_FILE_BYTES (128ULL * 1024 * 1024)
+#endif
+
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
 #endif
@@ -561,7 +569,9 @@ bool loadJsonFrom(json& j, const char* szFname)
     long pos = ftell(f);
     if (pos <= 0) { fclose(f); return false; }
     unsigned long flen = (unsigned long)pos;
-    if (flen > 100 * 1024 * 1024) { fclose(f); return false; }
+    // Compared in a width that cannot narrow the configured bound on a
+    // platform where unsigned long is 32-bit.
+    if ((unsigned long long)flen > (unsigned long long)ICC_JSON_MAX_FILE_BYTES) { fclose(f); return false; }
     if (fseek(f, 0, SEEK_SET) != 0) { fclose(f); return false; }
     std::string buf(flen, '\0');
 

--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -68,6 +68,15 @@
 #include <sstream>
 #include <set>
 #include <map>
+#include <string>
+
+// Issue #1856. The build system is the source of truth for this bound (CMake
+// cache variable ICC_JSON_MAX_FILE_MB); this fallback only keeps builds that do
+// not go through Build/Cmake compiling, and must stay finite for the same
+// reason the cap exists at all.
+#ifndef ICC_JSON_MAX_FILE_BYTES
+#define ICC_JSON_MAX_FILE_BYTES (128ULL * 1024 * 1024)
+#endif
 
 typedef std::map<icUInt32Number, icTagSignature> IccOffsetTagSigMap;
 
@@ -611,14 +620,32 @@ bool CIccProfileJson::LoadJson(const char *szFilename, std::string *parseStr)
 
   // Cap raw JSON size. nlohmann's default nesting + size limits are
   // effectively "everything fits in memory", which is a DoS primitive
-  // when the JSON comes from an untrusted source. 64 MB is generous
-  // for any legitimate ICC profile round-trip - real JSON dumps of
-  // even big iccMAX spectral profiles top out around 5 MB.
+  // when the JSON comes from an untrusted source, so the bound stays.
+  //
+  // Issue #1856: the previous fixed 64 MiB was chosen against an estimate
+  // that "even big iccMAX spectral profiles top out around 5 MB", which the
+  // tracked corpus does not support - the profile built from
+  // Testing/hybrid/CMYK-W_Overprint_Profile.xml emits 55.5 MiB at the default
+  // -indent=2 and 92.9 MiB at the documented -indent=4, so iccToJson could
+  // write a document iccFromJson then refused.
+  // The bound is now a build-time knob (ICC_JSON_MAX_FILE_MB) defaulting to
+  // 128 MiB, which clears every tracked fixture through -indent=5. It does not
+  // remove the asymmetry entirely, since -indent accepts up to 20 (392.7 MiB on
+  // the same profile), and a byte count is only a proxy for the memory this
+  // guards: indentation inflates the file without inflating the parsed
+  // document, so the cost per admitted byte varies by an order of magnitude
+  // with document shape.
   static const std::streamsize kMaxJsonFileBytes =
-      static_cast<std::streamsize>(64) * 1024 * 1024;
+      static_cast<std::streamsize>(ICC_JSON_MAX_FILE_BYTES);
   auto sz = f.tellg();
   if (sz < 0 || sz > kMaxJsonFileBytes) {
-    if (parseStr) *parseStr += std::string("JSON file exceeds 64 MB limit\n");
+    if (parseStr) {
+      // Report the bound that was actually compiled in, so a build that
+      // configured a different limit does not print a misleading number.
+      *parseStr += "JSON file exceeds " +
+                   std::to_string(kMaxJsonFileBytes / (1024 * 1024)) +
+                   " MiB limit\n";
+    }
     return false;
   }
   f.seekg(0, std::ios::beg);

--- a/docs/iccjson.md
+++ b/docs/iccjson.md
@@ -11,8 +11,52 @@ iccToJson src_profile.icc dest_profile.json [-indent=N]
 iccFromJson src_profile.json dest_profile.icc [-noid]
 ```
 
-- `-indent=N`: pretty-print with N spaces of indentation (default: 2)
+- `-indent=N`: pretty-print with N spaces of indentation (default: 2, clamped to 0-20)
 - `-noid`: suppress writing the profile ID into the saved file
+
+## Input Size Limit
+
+`iccFromJson` and the JSON configuration readers bound the raw file before
+parsing it, because the underlying parser has no effective size or nesting
+limit of its own. The default bound is **128 MiB**, and a file above it is
+refused with a diagnostic and a non-zero exit status, leaving no output file.
+
+Builds that need a different bounded limit can configure
+`-DICC_JSON_MAX_FILE_MB=<positive MiB value>`; values above 1024 are rejected
+at CMake configuration time, and the compiled-in value is what the diagnostic
+reports.
+
+Note that `iccToJson` can still emit documents larger than the bound, because
+its output grows roughly linearly with `-indent`. Measured on the profile built
+from `Testing/hybrid/CMYK-W_Overprint_Profile.xml` (3,721,864 bytes as `.icc`),
+one of the largest the tracked corpus produces:
+
+| `-indent` | emitted JSON | within the 128 MiB default |
+|---|---|---|
+| 2 (default) | 58,159,328 bytes (55.5 MiB) | yes |
+| 4 | 97,444,884 bytes (92.9 MiB) | yes |
+| 5 | 117,087,662 bytes (111.7 MiB) | yes |
+| 6 | 136,730,440 bytes (130.4 MiB) | no |
+| 20 (maximum) | 411,729,332 bytes (392.7 MiB) | no |
+
+So a round trip holds for every tracked profile up to `-indent=5`; beyond that
+a large profile can still produce a file this reader will not accept back.
+
+Raise `ICC_JSON_MAX_FILE_MB` if that matters for a given build, but note what
+the bound does and does not buy. It limits input bytes, which is only a proxy
+for the memory the parser then commits, and the two are loosely coupled:
+indentation inflates the file without inflating the parsed document, so peak
+memory is governed by document shape rather than by file size.
+
+| input | peak RSS | per input byte |
+|---|---|---|
+| profile at `-indent=2` (58.2 MB) | 79 MB | 1.4x |
+| same profile at `-indent=0` (18.9 MB) | 79 MB | 4.3x |
+| dense object of small pairs (10.9 MB) | 109 MiB | 10.5x |
+| dense array of small values (20.0 MB) | 312 MiB | 16.3x |
+
+At the 128 MiB default the worst of those shapes implies roughly 2 GiB of peak
+resident memory, and raising the bound scales that proportionally.
 
 After creating a profile, validate it with:
 


### PR DESCRIPTION
Part of #1856 — the JSON half. The `XML_PARSE_HUGE` half is deliberately not
addressed here; see **Scope** at the end.

Developed from the QA branch `ci-qa-issue-1856` (@xsscx, `f81ff047`), which is
where the CMake-knob approach comes from. The code here is written fresh, and
the review of that branch turned up four things worth correcting before this
lands — those are listed below rather than folded in silently.

## The defect

The two JSON readers carried different fixed caps, and the smaller one sat
inside the range iccDEV's own tools produce.

`CIccProfileJson::LoadJson` refused any document over 64 MiB, on the stated
assumption that *"real JSON dumps of even big iccMAX spectral profiles top out
around 5 MB"*. The tracked corpus does not support that estimate:

| source | `.icc` | `iccToJson` output | |
|---|---|---|---|
| `Testing/hybrid/CMYK-W_Overprint_Profile.xml` | 3,721,864 | 58,159,328 (`-indent=2`, the default) | under the old cap |
| same | 3,721,864 | **97,444,884** (`-indent=4`, documented) | **refused by the old cap** |

So `iccToJson` could write, at a documented setting, a file `iccFromJson` then
refused. The refusal itself was clean — specific diagnostic, exit 1, no output
file — so this is a threshold defect, not a silent-failure one.

Separately, `loadJsonFrom` in `IccJsonUtil.cpp`, which reads the `-cfg`
documents, applied an unrelated **100 MiB** to the same kind of input.

## The fix

Both readers now share one bound, `ICC_JSON_MAX_FILE_BYTES`, derived at
configure time from a new `ICC_JSON_MAX_FILE_MB` cache variable.

**The default is 128 MiB**, which clears every tracked fixture at the documented
`-indent=4` with headroom through `-indent=5` — the range the defect was about.

| `-indent` | emitted JSON | within 128 MiB |
|---|---|---|
| 2 (default) | 58,159,328 (55.5 MiB) | yes |
| 4 | 97,444,884 (92.9 MiB) | yes |
| 5 | 117,087,662 (111.7 MiB) | yes |
| 6 | 136,730,440 (130.4 MiB) | no |
| 20 (max) | 411,729,332 (392.7 MiB) | no |

### Why not 256 MiB, to match the XML side

This issue asks to align the XML and JSON limits, and `icXmlMaxTextFileBytes`
(`IccXML/IccLibXML/IccUtilXml.h`) is 256 MiB — so matching it is the obvious
move. I measured before taking it, and the measurement argues against.

A byte count is a weak proxy for the memory this cap exists to bound.
Indentation inflates the file without inflating the parsed document: peak RSS
was **flat at 79 MB** for the same profile emitted at `-indent=0`, `1` and `2`,
spanning 18.9 MB to 58.2 MB of input. What actually drives memory is document
shape:

| input | peak RSS | per input byte |
|---|---|---|
| profile at `-indent=2` (58.2 MB) | 79 MB | 1.4x |
| same profile at `-indent=0` (18.9 MB) | 79 MB | 4.3x |
| dense object of small pairs (10.9 MB) | 109 MiB | 10.5x |
| dense array of small values (20.0 MB) | 312 MiB | **16.3x** |

So 128 MiB already admits roughly 2 GiB of peak resident memory on hostile
input, and 256 MiB would admit about 4 GiB — more than a CI runner has. The
alignment argument is about consistency, not about memory, and I did not want it
to read as though the larger cap were the safer one.

Two follow-ups this suggests, not done here:

- A node or depth budget (nlohmann supports one via `parser_callback_t`) would
  bound memory directly instead of by proxy. That is the control this issue
  probably wants in the long run.
- The two paths are not symmetric at equal byte counts: `loadJsonFrom` holds
  `std::string buf(flen)` **and** the DOM simultaneously, where `LoadJson`
  streams via `f >> root` and never holds the raw text.

### A third 64 MiB cap, left alone deliberately

`IccJSON/IccLibJSON/IccTagJson.cpp:2248` (`kMaxClutFileBytes`) also refuses at
64 MiB. It is **not** included in this change, and that is a judgement call
worth stating rather than leaving to look like an oversight: it bounds an
external CLUT *data* file referenced from a JSON document, not the JSON document
itself, so it is a different resource with a different threat model and no
reason to move in lockstep. Its sibling `kMaxSparseMatrixArrayBytes`
(`IccTagBasic.cpp:5599`) is 64 MiB for the same class of reason. Happy to bring
either in scope if you would rather all four moved together.

This also does not remove the emit/read asymmetry entirely, and
`docs/iccjson.md` says so rather than implying it is solved.

Also: the value is rejected at configure time if it is not a positive integer or
exceeds 1024 MiB; each translation unit keeps a finite fallback so non-CMake
builds still compile with a cap; and the diagnostic now reports the limit that
was actually compiled in (`JSON file exceeds 256 MiB limit`) instead of a
hard-coded number.

## Findings from the QA branch, corrected here

1. **The new test hard-failed on a bare developer run.** It runs `iccFromXml`
   inside `cd Testing/hybrid`, but the script's own documented default
   `ICCDEV_TOOLS_DIR=Build/Tools` is *relative*, so the binary is not found from
   there. CI never saw it because CTest injects an absolute path. Red-tested:
   relative → exit **127**, absolute → exit **0**. The script now resolves
   `ICCDEV_TOOLS_DIR`/`ICCDEV_TESTING_DIR` to absolute paths up front.
2. **The test asserted a hard-coded 64 MiB while the cap is configurable**, so a
   build configuring a lower bound would fail on correct behaviour. It now fails
   only if the fixture drops back *under* the former 64 MiB cap (at which point
   it has stopped exercising the threshold) and *skips* when the configured
   bound is below the fixture, where refusal is right.
3. **A missing hybrid fixture aborted the whole suite** (`exit 1` at top level).
   Fixture construction moved inside the test: one `[FAIL]`, not a suite abort.
4. **The diagnostic lost its number** ("exceeds configured size limit"). It now
   reports the compiled-in value.

## Testing

- New case in `iccdev.json-parser-regressions`, red/green proven:
  - red (unpatched): `[FAIL] iccFromJson rejected 97444884 bytes ... (exit=1)`
  - green: `[PASS] issue-1856-indent4 (97444884 byte -indent=4 document round-tripped)`
  - skip path exercised by configuring a bound below the fixture
- Knob proven end-to-end: rebuilt at `-DICC_JSON_MAX_FILE_MB=64` the reader
  refuses and prints `exceeds 64 MiB limit`; at the default it accepts.
  Configure-time validation rejects `0`, `abc`, `07`, `2048`; accepts `1024`.
- `ctest`: 149/150. The one failure, `iccdev.spectral-tiff-preview`, is a local
  environment gap (`ModuleNotFoundError: No module named 'imagecodecs'`) and is
  unrelated to this change.
- Cost: the new case adds ~19s and ~97 MiB of transient disk under ASan, both
  released immediately; the whole script runs 28.8s against its 300s budget.
- Builds, CI's own zero-warning gate (`grep -cE 'warning:'` = 0): strict clang
  ASan+UBSan Debug; GCC **15.2.0** in the pinned CI regression container with
  *strict warnings ENABLED*. `shellcheck` 0.9.0 (CI's pin) clean.

## Scope

This is the JSON half only. `IccProfileXml.cpp:1038` records a deliberate
decision to drop `XML_PARSE_HUGE`, because it disables libxml2's depth,
name-length, text-length and entity-expansion guards. Restoring it is a security
trade-off, and the issue still lists that item as pending confirmation from
@ChrisCoxArt — so it is left untouched here and the issue should stay open for
it.
