### PR TITLE
fix(#1980): reject a non-physical encoding white-point luminance

### DIFF
--- a/.github/ci/regression/encoding-surround-ratio-divzero.cpp
+++ b/.github/ci/regression/encoding-surround-ratio-divzero.cpp
@@ -1,44 +1,45 @@
-// Regression for the second half of #1817: the surround ratio in
-// CIccDefaultEncProfileConverter::ConvertFromParams must not divide by a
-// profile-supplied zero.
+// Regression for the second half of #1817 and for #1980: the colour-space
+// white-point luminance in CIccDefaultEncProfileConverter::ConvertFromParams
+// must be a physically meaningful value before anything is derived from it.
 //
-// The converter reads the white-point luminance straight out of the encoding
-// parameters and then formed the surround ratio unguarded:
+// The converter reads the luminance straight out of the encoding parameters:
 //
 //     icFloatNumber Lw  = pParams->GetElemNumberValue(icSigCeptWhitePointLuminanceMbr, 100);
 //     ...
 //     icFloatNumber SWr = Lsw / Lw;
 //
-// Lw is attacker-controlled, so a profile carrying a zero white-point luminance
-// made this a division by zero. The same AFL corpus that produced the
-// IccCAM.cpp:150 report reaches this path through iccApplyProfiles.
+// Lw is profile-supplied, so a crafted profile controls it. #1817 reported the
+// division above: a zero Lw with a positive viewing surround yielded +infinity,
+// and "+inf > 0.2" selected *Average* surround -- the least conservative
+// setting, chosen off a white point carrying no luminance at all.
 //
-// SWr only picks one of three surround categories, so the guard resolves a
-// degenerate ratio to 0.0f, which selects Dark surround. Exactly one case
-// changes: Lsw > 0 with Lw == 0 used to yield +infinity, and "+inf > 0.2"
-// selected *Average* surround -- the least conservative setting, chosen off a
-// white point carrying no luminance at all. That is the case exercised below.
+// Guarding the division alone left the rest of the block reading from the same
+// value. Lw also scales the illuminant and surround XYZ written into the
+// viewing-conditions tag, defaults the ambient luminance La and the viewing
+// surround Lsw, and becomes the CAM Yb parameter. A negative Lw therefore
+// propagated a negative luminance into all of that state; the CAM adapting-
+// luminance guard added for #1950 contains only the last of those consequences.
+// #1980 rejects the parameters outright instead: ICC.2:2023 12.2.3.2.6 defines
+// 'wlum' as a luminance in cd/m2 and admits no zero or negative exception.
+//
+// NOTE: this changes the #1817 contract deliberately. A zero white-point
+// luminance used to convert with status icEncConvertOk (having resolved the
+// guarded ratio to Dark surround); it is now rejected as bad parameters. The
+// zero case is kept below precisely so that change stays visible and asserted
+// rather than being dropped along with the defect.
+//
+// Detection no longer depends on the build. The pre-#1817 defect was only
+// observable under -fsanitize=float-divide-by-zero, because an infinite ratio
+// merely mis-selected a surround category that is not reachable from the
+// returned profile. Rejection is observable from the return status in every
+// configuration, so these cases are deterministic contract checks and a plain
+// build now carries the same signal as an ASAN+UBSAN one.
 //
 // The test drives the public IIccEncProfileConverter handler with the smallest
 // parameter structure that reaches the surround block. Two things are required
 // to get there: the primaries must form an invertible matrix, and the white
 // point must not be D50, because the block is inside a "header illuminant is not
 // D50" branch. D65 primaries satisfy both.
-//
-// Detection depends on the build, and it is worth being precise about that. The
-// unfixed converter still returns icEncConvertOk here -- the infinite ratio only
-// mis-selects the surround, which is not observable from the returned profile
-// without reaching into the CAM converter it builds internally. So this test
-// catches the regression through the sanitizer, not through its return value:
-// under -fsanitize=float-divide-by-zero it aborts with
-//
-//     IccProfLib/IccEncoding.cpp:435:29: runtime error: division by zero
-//
-// That is the configuration ENABLE_SANITIZERS produces, and the one the CI
-// ASAN+UBSAN jobs build, so the coverage is real -- but on a plain build this
-// test only confirms the path still converts cleanly. Note that plain
-// -fsanitize=undefined is *not* enough on either gcc or clang;
-// float-divide-by-zero has to be requested explicitly.
 //
 // Returns 0 on success; non-zero on failure.
 
@@ -50,6 +51,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <limits>
 
 #ifdef USEICCDEVNAMESPACE
 using namespace iccDEV;
@@ -82,20 +84,18 @@ bool attachFloats(CIccTagStruct *pParams, icSignature sig,
   return true;
 }
 
-} // namespace
-
-int main()
+// Build the minimal colorEncodingParams struct that reaches the viewing-
+// conditions block. pWhiteLum == NULL omits the white-point luminance member
+// entirely, which is the common case: the converter then defaults it to 100.
+CIccTagStruct *buildParams(const icFloatNumber *pWhiteLum)
 {
   CIccTagStruct *pParams = (CIccTagStruct *)CIccTag::Create(icSigTagStructType);
-  if (!pParams) {
-    std::fprintf(stderr, "[encoding-surround] could not create params struct\n");
-    return 1;
-  }
+  if (!pParams)
+    return NULL;
 
   if (!pParams->SetTagStructType(icSigColorEncodingParamsSruct)) {
-    std::fprintf(stderr, "[encoding-surround] could not set struct type\n");
     delete pParams;
-    return 1;
+    return NULL;
   }
 
   // D65 white point: not D50, so the viewing-conditions block that carries the
@@ -105,10 +105,8 @@ int main()
   const icFloatNumber green[2] = {0.3000f, 0.6000f};
   const icFloatNumber blue[2]  = {0.1500f, 0.0600f};
 
-  // The #1817 input: a zero white-point luminance, with a positive viewing
-  // surround so the ratio is +inf rather than NaN. That is the combination that
-  // previously selected Average surround.
-  const icFloatNumber whiteLum[1] = {0.0f};
+  // A positive viewing surround, so a zero Lw makes the ratio +inf rather than
+  // NaN. That is the #1817 combination that selected Average surround.
   const icFloatNumber surround[1] = {1.0f};
 
   bool ok =
@@ -117,12 +115,28 @@ int main()
     attachFloats(pParams, icSigCeptRedPrimaryXYZMbr, red, 2) &&
     attachFloats(pParams, icSigCeptGreenPrimaryXYZMbr, green, 2) &&
     attachFloats(pParams, icSigCeptBluePrimaryXYZMbr, blue, 2) &&
-    attachFloats(pParams, icSigCeptWhitePointLuminanceMbr, whiteLum, 1) &&
     attachFloats(pParams, icSigCeptViewingSurroundMbr, surround, 1);
 
+  if (ok && pWhiteLum)
+    ok = attachFloats(pParams, icSigCeptWhitePointLuminanceMbr, pWhiteLum, 1);
+
   if (!ok) {
-    std::fprintf(stderr, "[encoding-surround] could not build params struct\n");
     delete pParams;
+    return NULL;
+  }
+
+  return pParams;
+}
+
+// Convert once with the given white-point luminance and check the outcome.
+// pWhiteLum == NULL omits the member. Returns 0 on success.
+int runCase(const char *szName, const icFloatNumber *pWhiteLum,
+            icStatusEncConvert expectStat)
+{
+  CIccTagStruct *pParams = buildParams(pWhiteLum);
+  if (!pParams) {
+    std::fprintf(stderr, "[encoding-surround] %s: could not build params struct\n",
+                 szName);
     return 1;
   }
 
@@ -136,35 +150,87 @@ int main()
 
   IIccEncProfileConverter *pConverter = IIccEncProfileConverter::GetHandler();
   if (!pConverter) {
-    std::fprintf(stderr, "[encoding-surround] no encoding converter handler\n");
+    std::fprintf(stderr, "[encoding-surround] %s: no encoding converter handler\n",
+                 szName);
     delete pParams;
     return 1;
   }
 
-  // Pre-fix, this call divided 1.0f by 0.0f while choosing the surround. Under a
-  // float-divide-by-zero build it aborts here rather than returning.
   CIccProfilePtr newIcc = NULL;
   icStatusEncConvert stat = pConverter->ConvertFromParams(newIcc, pParams, &hdr);
 
   delete pParams;
 
-  if (stat != icEncConvertOk) {
+  int rc = 0;
+
+  if (stat != expectStat) {
     std::fprintf(stderr,
-                 "[encoding-surround] FAIL: zero white-point luminance did not "
-                 "convert cleanly (status %d)\n", (int)stat);
-    if (newIcc)
-      delete newIcc;
-    return 2;
+                 "[encoding-surround] FAIL: %s: expected status %d, got %d\n",
+                 szName, (int)expectStat, (int)stat);
+    rc = 2;
   }
 
-  if (!newIcc) {
-    std::fprintf(stderr, "[encoding-surround] FAIL: converter reported success "
-                         "but produced no profile\n");
-    return 3;
+  // A rejected conversion must leave no profile behind, and an accepted one must
+  // produce one. The rejection path releases the profile it had already built,
+  // so a leak here is what a sanitizer build reports.
+  const bool bWantProfile = (expectStat == icEncConvertOk);
+  if (!rc && ((newIcc != NULL) != bWantProfile)) {
+    std::fprintf(stderr,
+                 "[encoding-surround] FAIL: %s: %s\n", szName,
+                 bWantProfile ? "converter reported success but produced no profile"
+                              : "rejected parameters produced a profile");
+    rc = 3;
   }
 
-  delete newIcc;
+  if (newIcc)
+    delete newIcc;
 
-  std::fprintf(stdout, "[encoding-surround] zero white-point luminance handled\n");
+  if (!rc)
+    std::fprintf(stdout, "[encoding-surround] ok: %s\n", szName);
+
+  return rc;
+}
+
+} // namespace
+
+int main()
+{
+  const icFloatNumber zero     = 0.0f;
+  const icFloatNumber negative = -1.0f;
+  const icFloatNumber nan      = std::numeric_limits<icFloatNumber>::quiet_NaN();
+  const icFloatNumber inf      = std::numeric_limits<icFloatNumber>::infinity();
+  const icFloatNumber valid    = 100.0f;
+
+  int rc = 0;
+
+  // The #1817 input. Previously converted with icEncConvertOk; rejected as of
+  // #1980. See the contract note at the top of this file.
+  rc |= runCase("zero white-point luminance rejected", &zero,
+                icEncConvertBadParams);
+
+  // The #1980 input: a negative luminance reached the illuminant, surround, CAM
+  // Yb and default La state before any guard downstream could contain it.
+  rc |= runCase("negative white-point luminance rejected", &negative,
+                icEncConvertBadParams);
+
+  rc |= runCase("NaN white-point luminance rejected", &nan,
+                icEncConvertBadParams);
+
+  rc |= runCase("infinite white-point luminance rejected", &inf,
+                icEncConvertBadParams);
+
+  // Controls: the guard must not narrow the accepted range. A plain positive
+  // luminance converts, and so does a struct that omits the member altogether --
+  // the overwhelmingly common case, which defaults to 100 cd/m2.
+  rc |= runCase("valid white-point luminance accepted", &valid,
+                icEncConvertOk);
+
+  rc |= runCase("absent white-point luminance accepted", NULL,
+                icEncConvertOk);
+
+  if (rc)
+    return rc;
+
+  std::fprintf(stdout, "[encoding-surround] all white-point luminance cases passed\n");
   return 0;
 }

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3015,7 +3015,7 @@ function(iccdev_add_encoding_surround_test)
   set_tests_properties(iccdev.encoding-surround-ratio-divzero PROPERTIES
     WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
     TIMEOUT 60
-    LABELS "iccdev;encoding;issue-1817;regression"
+    LABELS "iccdev;encoding;issue-1817;issue-1980;regression"
   )
   if(WIN32)
     set(_encsurround_windows_env_mods

--- a/IccProfLib/IccEncoding.cpp
+++ b/IccProfLib/IccEncoding.cpp
@@ -390,6 +390,23 @@ icStatusEncConvert CIccDefaultEncProfileConverter::ConvertFromParams(CIccProfile
       pIcc->m_Header.illuminant.Y!=icDtoF(icD50XYZ[1]) ||
       pIcc->m_Header.illuminant.Z!=icDtoF(icD50XYZ[2])) {
 
+    // ICC.2:2023 12.2.3.2.6 defines 'wlum' as the colour-space white-point
+    // luminance in cd/m2, and supplies no exception admitting zero. Everything
+    // this block derives treats it as a physical luminance: it scales the
+    // illuminant and surround XYZ written into the viewing-conditions tag below,
+    // it defaults the ambient luminance La and the viewing surround Lsw, and it
+    // becomes the CAM Yb parameter and the divisor of the surround ratio. A
+    // profile supplies it, so a crafted one can make it zero, negative or
+    // non-finite; reject the parameters here rather than propagate a value that
+    // cannot describe a white point. This is read before the viewing-conditions
+    // tag is allocated so that the rejection path has nothing to release but the
+    // profile itself.
+    icFloatNumber Lw = pParams->GetElemNumberValue(icSigCeptWhitePointLuminanceMbr, 100);
+    if (!(std::isfinite((double)Lw) && Lw > 0.0f)) {
+      delete pIcc;
+      return icEncConvertBadParams;
+    }
+
      //Set Spectral Viewing Conditions
     CIccTagSpectralViewingConditions *pCond = (CIccTagSpectralViewingConditions*)CIccTag::Create(icSigSpectralViewingConditionsType);
     if (!pCond) {
@@ -398,7 +415,6 @@ icStatusEncConvert CIccDefaultEncProfileConverter::ConvertFromParams(CIccProfile
     }
 
     icFloatNumber illXYZ[3];
-    icFloatNumber Lw = pParams->GetElemNumberValue(icSigCeptWhitePointLuminanceMbr, 100);
     pCond->setIlluminant(XYZWhite);
     //pCond->m_stdIlluminant = icIlluminantCustom;
     illXYZ[0] = pCond->m_illuminantXYZ.X = Lw * XYZWhite[0];
@@ -432,19 +448,19 @@ icStatusEncConvert CIccDefaultEncProfileConverter::ConvertFromParams(CIccProfile
     pCstmConvert->SetParameter_La(La);
     pCstmConvert->SetParameter_Yb(Lw);
 
-    // Lw is the white-point luminance read from the profile a few lines above
-    // (icSigCeptWhitePointLuminanceMbr, defaulting to 100), so a malformed profile
-    // can set it to zero and turn this ratio into a division by zero. This is the
-    // companion site to the H_FunctionInv guard in IccCAM.cpp: the AFL patch stack
-    // pairs the two as one defect, and a constructed colorEncodingParams struct
-    // with a zero white-point luminance reproduces it directly (#1817).
+    // This ratio was the division by zero reported in #1817, reached when a
+    // malformed profile set the white-point luminance to zero. It is the
+    // companion site to the H_FunctionInv guard in IccCAM.cpp, which the AFL
+    // patch stack pairs with it as one defect.
     //
-    // SWr only selects one of the three surround categories below, so a degenerate
-    // ratio resolves to 0.0f, which falls through to Dark surround -- the
-    // conservative choice when the white luminance is zero or non-finite. Only one
-    // case changes: Lsw > 0 with Lw == 0 previously produced +infinity and so
-    // selected Average surround, the least conservative option, off a white point
-    // that carries no luminance at all. Every finite non-zero Lw is unaffected.
+    // The Lw terms below are now redundant: the #1980 check above rejects the
+    // parameters unless Lw is finite and strictly positive, so no zero or
+    // non-finite Lw reaches this point. They are kept because they are cheap and
+    // because they state the precondition this expression depends on at the site
+    // that depends on it. Lsw is a separate profile-supplied value with its own
+    // default and no such precondition, so its isfinite test remains load-bearing:
+    // a non-finite Lsw still resolves SWr to 0.0f and falls through to Dark
+    // surround, the conservative category.
     icFloatNumber SWr = 0.0f;
     if (std::isfinite((double)Lsw) && std::isfinite((double)Lw) && Lw != 0.0f)
       SWr = Lsw / Lw;


### PR DESCRIPTION
Fixes #1980.

Developed from the QA branch `ci-qa-issue-1980` (@xsscx, `7c8dcb71`), which is where the
spec anchor and the shape of the check come from. The code here is written fresh, and
reviewing that branch turned up two things worth correcting before this lands — those are
below rather than folded in silently.

## The defect

`CIccDefaultEncProfileConverter::ConvertFromParams` reads the colour-space white-point
luminance out of the encoding parameters and then derives the entire viewing-conditions
block from it:

```cpp
icFloatNumber Lw = pParams->GetElemNumberValue(icSigCeptWhitePointLuminanceMbr, 100);
```

| consumer | site |
|---|---|
| scales the illuminant XYZ written into `spectralViewingConditionsTag` | `IccEncoding.cpp:418-420` |
| defaults the ambient luminance `La` | `:423` |
| scales the surround XYZ (via `La`) | `:427-437` |
| defaults the viewing surround `Lsw` | `:441` |
| becomes the CAM `Yb` parameter | `:449` |
| divisor of the surround ratio | `:466` |

ICC.2:2023 12.2.3.2.6 defines `wlum` as a luminance in cd/m², and supplies no exception
admitting zero. The value is profile-supplied, so a crafted profile controls it.

#1817 guarded only the last row of that table. Every other consumer still read the same
value, and the CAM adapting-luminance guard added for #1950 contains only the `La`
consequence — after the bad value has already been written into the tag. So a negative
luminance still propagated a negative illuminant and surround XYZ into a profile that the
converter then reported as successfully built.

This validates the luminance once, where it is read, and rejects the parameters when it is
not finite and strictly positive.

## Two corrections to the QA branch

### 1. The check's placement leaks the viewing-conditions tag

On the branch the check sits *after* `pCond = CIccTag::Create(icSigSpectralViewingConditionsType)`
but before `pIcc->AttachTag(icSigSpectralViewingConditionsTag, pCond)`, so `delete pIcc` on
the reject path never reaches it. Built at that exact placement and run under ASAN with
`ASAN_OPTIONS=detect_leaks=1`:

```
Direct leak of 96 byte(s) in 1 object(s) allocated from:
    #4 CIccTag::Create(icTagTypeSignature) IccProfLib/IccTagBasic.cpp:339
    #5 CIccDefaultEncProfileConverter::ConvertFromParams IccProfLib/IccEncoding.cpp:394
SUMMARY: AddressSanitizer: 384 byte(s) leaked in 4 allocation(s).
```

96 bytes per reject input, once for each of the four. Worth noting that CI's own ctest runs
with `detect_leaks=0`, so this would not have surfaced there.

Here the read and the check are hoisted *above* that allocation instead, so the reject path
has nothing to release but the profile itself. Same build, same test, this placement: clean.

### 2. The test change dropped #1817's coverage

The branch swaps the test input from `0.0f` to `-1.0f` and flips the expectation. That
removes zero — the value #1817 was actually about — from the suite at the same moment its
contract changes, so nothing would have recorded the change.

The regression is extended into a table of cases instead of having its input replaced:

| case | expected |
|---|---|
| zero (the #1817 input) | `icEncConvertBadParams` |
| negative (the #1980 input) | `icEncConvertBadParams` |
| NaN | `icEncConvertBadParams` |
| infinite | `icEncConvertBadParams` |
| `100.0f` | `icEncConvertOk`, profile produced |
| member absent entirely | `icEncConvertOk`, profile produced |

The last two are controls: the guard must not narrow the accepted range, and the absent
member — overwhelmingly the common case, defaulting to 100 cd/m² — has to keep working.

## Behaviour change

This changes the #1817 contract deliberately, and reviewers should be looking at it:

**a zero white-point luminance previously converted with `icEncConvertOk`**, having resolved
the guarded ratio to Dark surround. **It is now `icEncConvertBadParams`.**

The surround-ratio guard from #1817 is kept rather than removed. Its `Lw` terms are now
redundant, but its `Lsw` term is still load-bearing — `Lsw` is a separate profile-supplied
value with its own default and no equivalent precondition, so a non-finite `Lsw` still
resolves the ratio to `0.0f` and falls through to Dark surround. The comment there now
records which of its terms this check makes redundant, so the next reader is not misled by
a rationale that no longer holds.

## Verification

| check | result |
|---|---|
| red — library reverted to master, new test | 4/4 reject cases **fail**, both controls pass |
| green | 6/6 pass |
| full ctest, gcc Debug | 150/151; the one failure is `spectral-tiff-preview`, a local missing `imagecodecs` python module, unrelated |
| ASAN + LSan (`detect_leaks=1`) | clean at this placement; leak above reproduced at the branch's |
| `-Wall -Wextra -Wpedantic -Werror`, both changed TUs | 0 warnings across gcc/clang × Debug/Release |
| `preflight-safety-checks.sh` | 0 failures (1 skip: `codeql` not installed locally) |
| clang Release | passes — confirms the `isfinite` guard survives optimisation |

## Scope

The check is deliberately confined to `wlum`. While reviewing the surrounding function I
found a separate, pre-existing memory-safety defect that this PR does **not** touch:

`IccEncoding.cpp:237` takes `pLumMtx` from `pParams->FindElemOfType(icSigCeptLumaChromaMatrixMbr, ...)`
— a borrowed pointer, exactly as `pWhitePt`, `pSurround` and `pSegCurve` are treated in the
same function — and then `delete`s it at `:259` while it is still in the struct's element
list. `icConvertEncodingProfile` deletes `pParams` at `:666`, whose destructor frees the
elements again. A profile carrying a `ceptLumaChromaMatrixMbr` of 9 or more values reaches
it. That is a double free on profile-controlled input and wants its own issue and its own
regression rather than being folded in here; happy to file it separately if you would like,
@xsscx.
