### PR TITLE
fix(#1991): apply encoding local overrides to the base params, not the source struct

### DIFF
--- a/.github/ci/regression/encoding-override-uaf.cpp
+++ b/.github/ci/regression/encoding-override-uaf.cpp
@@ -1,0 +1,258 @@
+// Regression for #1991: icConvertEncodingProfile's local-override loop must copy
+// the encoding profile's overrides into the base parameter struct, not delete and
+// re-attach them inside the struct it is iterating.
+//
+// When a colour-encoding profile's referenceName is not "ISO 22028-1", the
+// converter loads a base encoding profile named by its colorSpaceName, copies that
+// profile's colorEncodingParams struct into pParams, and is then supposed to layer
+// the profile's own colorEncodingParams over it as local overrides. The loop that
+// did the layering read:
+//
+//     for (entry=pTags->begin(); entry!=pTags->end(); entry++) {
+//       if (entry->pTag) {
+//         pStruct->DeleteElem(entry->TagInfo.sig);
+//         pStruct->AttachElem(entry->TagInfo.sig, entry->pTag->NewCopy());
+//       }
+//     }
+//
+// Both mutations targeted pStruct -- pEncodeIcc's own struct, the list being
+// walked -- rather than pParams. CIccTagStruct::DeleteElem erases the list node
+// and deletes the tag (IccTagComposite.cpp:865), so that produced three defects at
+// once:
+//
+//   1. Use-after-free. `entry` names the node just erased, and the next expression
+//      reads entry->TagInfo.sig and entry->pTag back out of it. Under ASAN this is
+//      a heap-use-after-free read of the IccTagEntry node, which CIccTagStruct::Read
+//      allocated from profile-controlled input.
+//   2. Erased-iterator walk. entry++ advances an iterator that is no longer in the
+//      list, so when the read does not fault the loop does not terminate. Driving
+//      the same defect through iccApplyToLink with a file-read profile hangs for
+//      minutes rather than faulting, which is why the ctest entry carries a
+//      timeout even though this binary itself faults promptly in both build kinds.
+//   3. The override never applied. pParams was never written, so the loop only
+//      deleted each element and re-attached a copy of itself. The local-override
+//      path was a no-op even when it did not crash.
+//
+// Defect 3 is the one with a build-independent contract, and it is what this test
+// asserts positively: the value the converter receives in pParams must be the
+// profile's override, not the base profile's. Asserting that also pins defects 1
+// and 2, because the fix that makes the override arrive is precisely the one that
+// stops the loop mutating the list it iterates.
+//
+// Measured against the unfixed library, the assertions are not what reports first
+// -- the call faults before returning, in both build kinds:
+//   - ASAN (the lanes CI runs ctest in): heap-use-after-free, a 4-byte read of the
+//     freed IccTagEntry node at IccEncoding.cpp:666, freed at :665.
+//   - unsanitized clang Debug: segmentation fault, exit 139.
+// The value and identity checks below therefore carry the contract for any build
+// where the read happens to land on still-mapped memory, and the fault carries it
+// everywhere else.
+//
+// The test drives the real icConvertEncodingProfile but replaces both of its
+// collaborators, so it needs no files and no particular working directory:
+//   - the cache handler returns an in-memory base profile instead of resolving
+//     "ISO22028-Encoded-<name>.icc" relative to the caller's cwd;
+//   - the converter captures pParams rather than building a profile from it.
+//
+// Returns 0 on success; non-zero on failure.
+
+#include "IccEncoding.h"
+#include "IccProfile.h"
+#include "IccTagComposite.h"
+#include "IccTagBasic.h"
+
+#include <cstdio>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+// Deliberately different so a discarded override is visible as a value, not just
+// as a sanitizer report: the base supplies 100, the profile overrides it with 250.
+const icFloatNumber kBaseLuminance     = 100.0f;
+const icFloatNumber kOverrideLuminance = 250.0f;
+
+// Attach a single-valued Float32 member. GetElemNumberValue reads element 0 of any
+// num-array member, which is how the converter reads 'wlum' at IccEncoding.cpp:420.
+// Ownership passes to the struct on success.
+bool attachNumber(CIccTagStruct *pStruct, icSignature sig, icFloatNumber val)
+{
+  CIccTagFloat32 *pTag = (CIccTagFloat32 *)CIccTag::Create(icSigFloat32ArrayType);
+  if (!pTag)
+    return false;
+
+  if (!pTag->SetSize(1)) {
+    delete pTag;
+    return false;
+  }
+  (*pTag)[0] = val;
+
+  if (!pStruct->AttachElem(sig, pTag)) {
+    delete pTag;
+    return false;
+  }
+
+  return true;
+}
+
+bool attachText(CIccProfile *pIcc, icSignature sig, const char *szText)
+{
+  CIccTagUtf8Text *pTag = (CIccTagUtf8Text *)CIccTag::Create(icSigUtf8TextType);
+  if (!pTag)
+    return false;
+
+  pTag->SetText(szText);
+
+  if (!pIcc->AttachTag(sig, pTag)) {
+    delete pTag;
+    return false;
+  }
+
+  return true;
+}
+
+CIccTagStruct *buildParams(icFloatNumber luminance)
+{
+  CIccTagStruct *pParams = (CIccTagStruct *)CIccTag::Create(icSigTagStructType);
+  if (!pParams)
+    return NULL;
+
+  if (!pParams->SetTagStructType(icSigColorEncodingParamsSruct) ||
+      !attachNumber(pParams, icSigCeptWhitePointLuminanceMbr, luminance)) {
+    delete pParams;
+    return NULL;
+  }
+
+  return pParams;
+}
+
+// Stands in for the file-backed default handler. icConvertEncodingProfile takes
+// ownership of nothing here -- it copies the params struct out and deletes the
+// profile it was handed -- so a fresh profile is returned on every call.
+class CaptureCacheHandler : public IIccEncProfileCacheHandler
+{
+public:
+  virtual CIccProfile *GetEncodingProfile(const icUChar * /*szColorSpaceName*/)
+  {
+    CIccProfile *pIcc = new CIccProfile();
+    if (!pIcc)
+      return NULL;
+
+    pIcc->m_Header.deviceClass = icSigColorEncodingClass;
+
+    CIccTagStruct *pParams = buildParams(kBaseLuminance);
+    if (!pParams || !pIcc->AttachTag(icSigColorEncodingParamsTag, pParams)) {
+      delete pParams;
+      delete pIcc;
+      return NULL;
+    }
+
+    return pIcc;
+  }
+};
+
+// Records what the override loop actually produced. Returning a status without
+// building a profile is enough: the caller passes it straight back, which also
+// confirms the call reached the converter rather than short-circuiting earlier.
+class CaptureConverter : public IIccEncProfileConverter
+{
+public:
+  CaptureConverter() : m_bCalled(false), m_luminance(0.0f) {}
+
+  virtual icStatusEncConvert ConvertFromParams(CIccProfilePtr &newIcc,
+                                               CIccTagStruct *pParams,
+                                               icHeader * /*pHeader*/)
+  {
+    newIcc = NULL;
+    m_bCalled = true;
+    if (pParams)
+      m_luminance = pParams->GetElemNumberValue(icSigCeptWhitePointLuminanceMbr, 0.0f);
+
+    return icEncConvertBadParams;
+  }
+
+  bool m_bCalled;
+  icFloatNumber m_luminance;
+};
+
+int runOverrideTest()
+{
+  // Both setters take ownership -- each deletes the handler it replaces, and each
+  // ignores a null argument -- so these must be heap objects and cannot be
+  // uninstalled afterwards. The converter is kept to read its capture back out.
+  CaptureConverter *pConverter = new CaptureConverter();
+
+  IIccEncProfileCacheHandler::SetEncCacheHandler(new CaptureCacheHandler());
+  IIccEncProfileConverter::SetEncProfileConverter(pConverter);
+
+  CIccProfile icc;
+  icc.m_Header.deviceClass = icSigColorEncodingClass;
+
+  // Anything other than "ISO 22028-1" selects the base-profile-plus-overrides
+  // branch; the colorSpaceName is what the cache handler would resolve to a file.
+  if (!attachText(&icc, icSigReferenceNameTag, "local override test") ||
+      !attachText(&icc, icSigColorSpaceNameTag, "TestSpace")) {
+    printf("[FAIL] could not build the encoding profile's text tags\n");
+    return 1;
+  }
+
+  CIccTagStruct *pOverrides = buildParams(kOverrideLuminance);
+  if (!pOverrides || !icc.AttachTag(icSigColorEncodingParamsTag, pOverrides)) {
+    printf("[FAIL] could not build the override params struct\n");
+    delete pOverrides;
+    return 1;
+  }
+
+  // Captured before the call so the check below never dereferences the tag --
+  // against the unfixed library that object is freed, and comparing addresses
+  // stays defined where reading through one would not.
+  const CIccTag *pBefore = pOverrides->FindElem(icSigCeptWhitePointLuminanceMbr);
+  if (!pBefore) {
+    printf("[FAIL] the override member is missing before the call\n");
+    return 1;
+  }
+
+  CIccProfilePtr newIcc = NULL;
+  icStatusEncConvert stat = icConvertEncodingProfile(newIcc, &icc);
+  delete newIcc;
+
+  int rc = 0;
+
+  if (!pConverter->m_bCalled) {
+    printf("[FAIL] the converter was never reached (status %d)\n", (int)stat);
+    return 1;
+  }
+
+  // The defect: the override was dropped and the base value survived.
+  if (pConverter->m_luminance != kOverrideLuminance) {
+    printf("[FAIL] the override did not reach pParams: expected %g, got %g\n",
+           (double)kOverrideLuminance, (double)pConverter->m_luminance);
+    rc = 1;
+  }
+
+  // The source struct is the caller's, and the converter has no business
+  // rewriting it. The unfixed loop deleted this element and attached a copy, so
+  // the entry survives with a different tag pointer -- after the original has
+  // already been freed and read back through.
+  const CIccTag *pAfter = pOverrides->FindElem(icSigCeptWhitePointLuminanceMbr);
+  if (pAfter != pBefore) {
+    printf("[FAIL] the encoding profile's own override element was replaced\n");
+    rc = 1;
+  }
+
+  if (!rc)
+    printf("[PASS] the local override reached pParams and the source struct was left intact\n");
+
+  return rc;
+}
+
+}  // namespace
+
+int main()
+{
+  // The installed handlers stay owned by the library globals for the life of the
+  // process; SetEnc*Handler ignores a null argument, so there is nothing to undo.
+  return runOverrideTest();
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3075,6 +3075,52 @@ function(iccdev_add_encoding_lumamtx_test)
   endif()
 endfunction()
 
+# icConvertEncodingProfile layered a colour-encoding profile's local overrides by
+# calling DeleteElem then AttachElem on pStruct -- the struct it was iterating --
+# instead of on pParams, the copy of the base encoding profile's params. DeleteElem
+# erases the list node and deletes the tag, so the loop read back an entry it had
+# just freed (heap use-after-free), advanced an erased iterator (a non-terminating
+# walk), and never wrote pParams at all, leaving the override silently discarded.
+# The regression asserts the override reaches the converter and that the profile's
+# own struct is left untouched (#1991). Against the unfixed library the call faults
+# before those assertions are reached -- heap-use-after-free under ASAN, exit 139
+# unsanitized -- and the timeout guards the erased-iterator walk, which does not
+# terminate when the read lands on still-mapped memory.
+function(iccdev_add_encoding_override_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccEncodingOverrideTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/encoding-override-uaf.cpp"
+  )
+  target_link_libraries(iccEncodingOverrideTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccEncodingOverrideTest)
+
+  add_test(
+    NAME iccdev.encoding-override-uaf
+    COMMAND "$<TARGET_FILE:iccEncodingOverrideTest>"
+  )
+  set_tests_properties(iccdev.encoding-override-uaf PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;encoding;issue-1991;regression"
+  )
+  if(WIN32)
+    set(_encoverride_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccEncodingOverrideTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _encoverride_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.encoding-override-uaf PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_encoverride_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # CIccPRMG::GetChroma normalized an arbitrary hue angle into [0, 360) with
 # "while (h < 0.0) h += 360.0;" / "while (h >= 360.0) h -= 360.0;". Those loops do
 # not terminate once |h| is large enough that 360 falls below the float's ULP
@@ -3419,6 +3465,7 @@ if(WIN32)
   iccdev_add_datetime_parse_test()
   iccdev_add_encoding_surround_test()
   iccdev_add_encoding_lumamtx_test()
+  iccdev_add_encoding_override_test()
   iccdev_add_parser_restore_calls_test()
   iccdev_add_tag_layout_shared_data_test()
   iccdev_add_pawg_q2_tonecurves_test()
@@ -3676,6 +3723,7 @@ iccdev_add_v2_xml_fixtures_test()
 iccdev_add_datetime_parse_test()
 iccdev_add_encoding_surround_test()
 iccdev_add_encoding_lumamtx_test()
+iccdev_add_encoding_override_test()
 iccdev_add_parser_restore_calls_test()
 iccdev_add_tag_layout_shared_data_test()
 iccdev_add_pawg_q2_tonecurves_test()

--- a/IccProfLib/IccEncoding.cpp
+++ b/IccProfLib/IccEncoding.cpp
@@ -655,15 +655,37 @@ icStatusEncConvert icConvertEncodingProfile(CIccProfilePtr &newIcc, CIccProfile 
 
         //Now Copy Overrides into pParams (if they exist in pEncodeIcc
         CIccTag *pOverridesTag = pEncodeIcc->FindTagOfType(icSigColorEncodingParamsTag, icSigTagStructType);
-        if (pOverridesTag) {
+        // pParams is the NewCopy of the base profile's params taken just above,
+        // and is the struct the overrides belong in. Both mutations below used to
+        // target pStruct -- pEncodeIcc's own struct, the one being iterated -- which
+        // made this loop delete each entry and re-attach a copy of itself while
+        // leaving pParams untouched, so no override ever reached the conversion.
+        // Writing to pParams instead is what the comment above describes, and it
+        // also removes the memory errors: DeleteElem erases the list node and frees
+        // the tag, so aiming it at pStruct invalidated `entry` (the subsequent
+        // entry++ walked a freed node) and freed the very tag the next line read
+        // back through it. pParams is a different struct, so iterating pStruct stays
+        // valid and the borrowed source tag is never freed (#1991).
+        if (pOverridesTag && pParams) {
           CIccTagStruct *pStruct = (CIccTagStruct*)pOverridesTag;
           TagEntryList *pTags = pStruct->GetElemList();
           if (pTags) {
             TagEntryList::iterator entry;
             for (entry=pTags->begin(); entry!=pTags->end(); entry++) {
               if (entry->pTag) {
-                pStruct->DeleteElem(entry->TagInfo.sig);
-                pStruct->AttachElem(entry->TagInfo.sig, entry->pTag->NewCopy());
+                // Copy first: on an allocation failure the base value is left in
+                // place rather than deleted and replaced with nothing. AttachElem
+                // dereferences its tag argument unguarded to set the parent object,
+                // so a null copy must never reach it.
+                CIccTag *pCopy = entry->pTag->NewCopy();
+                if (pCopy) {
+                  pParams->DeleteElem(entry->TagInfo.sig);
+                  // AttachElem refuses a signature that is still present and does
+                  // not take ownership when it does, so the copy is ours to free on
+                  // that path. The DeleteElem above should already have cleared it.
+                  if (!pParams->AttachElem(entry->TagInfo.sig, pCopy))
+                    delete pCopy;
+                }
               }
             }
           }


### PR DESCRIPTION
Fixes #1991.

`icConvertEncodingProfile`'s local-override loop called `DeleteElem` and `AttachElem` on
`pStruct` — the encoding profile's own `colorEncodingParams` struct, the list it was
iterating — rather than on `pParams`, the copy of the base encoding profile's params that
the comment directly above it names as the target.

`CIccTagStruct::DeleteElem` erases the list node **and** deletes the tag
(`IccTagComposite.cpp:865`), so aiming it at the struct under iteration produced three
defects in four lines:

1. **Heap use-after-free** — the next expression reads `entry->TagInfo.sig` and
   `entry->pTag` back out of the node just erased. The node is allocated by
   `CIccTagStruct::Read`, so the input is profile-controlled, and the path is reachable
   from `CIccXform::Create` (`IccCmm.cpp:559`) with any colour-encoding-class profile.
2. **Erased-iterator walk** — `entry++` advances an iterator already removed from the
   list, so when the read does not fault the loop does not terminate.
3. **The override never applied** — `pParams` was never written. The loop only deleted
   each element and re-attached a copy of itself, so the local-override path was a no-op
   even when it did not crash.

Retargeting both mutations at `pParams` removes all three: `pStruct` is no longer mutated,
so `entry` stays valid and the borrowed source tag is never freed.

## Behaviour change — worth a maintainer's eye

Local overrides now reach the converter, where previously they were silently discarded.
That is what the code documents as its intent, but it is a functional change riding on a
memory-safety fix, so it is called out rather than buried. @maxderhak @ChrisCoxArt for
insight on whether the override semantics should land together with the memory fix or
separately.

This does **not** widen the attack surface. `ConvertFromParams` already accepts a fully
attacker-controlled params struct, with no base profile at all, through the sibling
`"ISO 22028-1"` branch at `IccEncoding.cpp:632-636` — reached from the same
`CIccXform::Create` call. The override path is strictly less powerful: it can add or
replace members over a base, but cannot remove base members or set the struct type, so
every value the merge can produce was already producible directly. The existing validators
all evaluate `pParams` *after* the merge and therefore still fire on overridden values —
the #1980 `wlum` non-physical check, the #1410 `icYxy2XYZVector` divide-by-zero guard, and
`icMatrixInvert3x3`'s singularity test. Type confusion is blocked by `FindElemOfType`'s
type check, and every array read is length-gated ahead of its dereference
(`GetNumValues()<2` at `:170`/`:177`, `GetSize()<9` at `:242`, `<2` at `:311`/`:326`/`:338`).

## Two ownership contracts the fix has to respect

- `AttachElem` dereferences its tag argument unguarded to set the parent object
  (`IccTagComposite.cpp:843`), so a null `NewCopy()` must never reach it.
- `AttachElem` returns false *without* taking ownership when the signature is already
  present, so the copy is ours to free on that path.

The copy is also taken *before* the `DeleteElem`, so an allocation failure leaves the base
value in place rather than deleting it and replacing it with nothing.

## Verification

Red/green, measured both ways rather than reasoned about. Against the unfixed library the
regression faults before its assertions are reached:

| | Unfixed | Fixed |
|---|---|---|
| ASAN Debug (the lanes CI runs ctest in) | heap-use-after-free, 4-byte read at `IccEncoding.cpp:666`, freed at `:665` | `[PASS]`, clean under `detect_leaks=1` |
| Unsanitized clang Debug | SIGSEGV, exit 139 | `[PASS]` |
| Reported PoC via `iccApplyToLink` | hang >2 min | completes, fails benignly at CMM level |

The regression was re-red-tested against the exact committed state after its last
restructuring, so the assertions are known to still bite.

Pre-flight, with CI's own gate (`grep -cE 'warning:'` on the build log) rather than a green
ctest:

| Profile | Compiler | Configure line | Warnings |
|---|---|---|---|
| strict clang Release | Clang 18.1.3 | `strict warnings ENABLED` | 0 |
| gcc15 container (`sha-547c4bed`) | GNU 15.2.0 | `strict warnings ENABLED` | 0 |

Both logs confirm `IccEncoding.cpp` and the new regression actually compiled in that lane.
Full suite 153/154; the one failure is `spectral-tiff-preview`, a local
`ModuleNotFoundError: No module named 'imagecodecs'`, unrelated to this change.

## Test coverage — stated plainly

The new `iccdev.encoding-override-uaf` drives the real `icConvertEncodingProfile` with both
collaborators replaced — an in-memory base profile instead of the file-backed cache
handler, and a capturing converter — so it needs no fixture files and no particular working
directory. It asserts the override value arrives in `pParams` and that the profile's own
struct is left untouched.

That unit test is the **only** coverage of the new behaviour, and the green full-suite run
should not be read as corpus confirmation. Sweeping all 212 tracked `.xml`, no fixture
reaches this code path: only `Testing/Encoding/ISO22028-Encoded-{,bg-}sRGB.xml` carry a
`csnm` tag and both declare `rfnm = "ISO 22028-1"`, so they take the first branch.

Related, found while checking that and left out of scope here:
`Testing/Encoding/sRgbEncodingOverrides.xml` is evidently intended to exercise this
override path, but it carries no `csnm` tag — which is what the base lookup keys on — so it
returns `icEncConvertBadProfile` before reaching the loop and has never exercised anything.
Happy to file that separately.
