### PR TITLE
fix(#1856): parse XML from a bounded buffer so a large CLUT round-trips

### DIFF
--- a/.github/scripts/iccdev-xml-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-xml-parser-regression-tests.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+###############################################################################
+# iccDEV XML parser regression tests
+###############################################################################
+#
+# Issue #1856. Two things are pinned here, and they pull in opposite
+# directions, which is why they share a script:
+#
+#   1. iccDEV must be able to read back the XML it just wrote. A profile whose
+#      CLUT serialises to a single text node larger than libxml2's
+#      XML_MAX_TEXT_LENGTH (10 MB) used to be refused on read, so iccToXml
+#      could emit a document iccFromXml then rejected.
+#
+#   2. Relaxing that must not have been done with XML_PARSE_HUGE, which would
+#      also have disabled the nesting-depth and name-length caps for every
+#      input. The hardening cases below fail if someone later reaches for that
+#      flag to solve a size problem.
+#
+# The fix reads the document into one contiguous buffer and parses that, which
+# avoids the streaming reader's per-node accumulation limit, and bounds the
+# whole document instead (icXmlMaxTextFileBytes).
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-xml-parser-regressions}"
+mkdir -p "$OUTDIR"
+
+# Absolute paths before any tool path is derived from them: the round-trip case
+# runs tools from Testing/ so that a profile's sibling data files resolve.
+if [ -d "$TOOLS_DIR" ]; then
+  TOOLS_DIR="$(cd "$TOOLS_DIR" && pwd)"
+fi
+if [ -d "$TESTING_DIR" ]; then
+  TESTING_DIR="$(cd "$TESTING_DIR" && pwd)"
+fi
+
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+TOXML="$TOOLS_DIR/IccToXml/iccToXml"
+APPLYTOLINK="$TOOLS_DIR/IccApplyToLink/iccApplyToLink"
+
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+PASS=0
+FAIL=0
+SKIPPED=0
+TOTAL=0
+
+# The document bound the XML reader was built with, in MiB. Kept in step with
+# icXmlMaxTextFileBytes in IccXML/IccLibXML/IccUtilXml.h so that a build which
+# retunes the constant reports a skip rather than a spurious failure.
+XML_MAX_FILE_MB="${ICC_XML_MAX_FILE_MB:-256}"
+
+# libxml2's per-text-node limit on the streaming path. The round-trip fixture
+# below is only meaningful if it produces a node larger than this.
+XML_MAX_TEXT_LENGTH=10000000
+
+pass() { echo "  [PASS] $1"; PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); }
+fail() { echo "  [FAIL] $1 -- $2"; FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); }
+skip() { echo "  [SKIP] $1 -- $2"; SKIPPED=$((SKIPPED + 1)); TOTAL=$((TOTAL + 1)); }
+
+check_sanitizers() {
+  local name="$1" logfile="$2"
+  if grep -q "ERROR: AddressSanitizer" "$logfile" 2>/dev/null; then
+    fail "$name" "AddressSanitizer finding"
+    return 1
+  fi
+  if grep -q "runtime error:" "$logfile" 2>/dev/null; then
+    fail "$name" "undefined behavior"
+    return 1
+  fi
+  return 0
+}
+
+###############################################################################
+# 1. Round-trip a profile whose XML carries a text node over the streaming cap
+###############################################################################
+
+echo "=== Large text node round-trip (issue #1856) ==="
+
+roundtrip_large_text_node() {
+  local name="xml-large-text-node-roundtrip"
+  local src="$TESTING_DIR/CMYK-3DLUTs/CMYK-3DLUTs.icc"
+  local dst="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+  local link="$OUTDIR/link33.icc"
+  local xml="$OUTDIR/link33.xml"
+  local back="$OUTDIR/link33-roundtrip.icc"
+  local logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$APPLYTOLINK" ] || [ ! -x "$TOXML" ] || [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccApplyToLink, iccToXml or iccFromXml not built"
+    return
+  fi
+  if [ ! -f "$src" ] || [ ! -f "$dst" ]; then
+    skip "$name" "source profiles missing (run CreateAllProfiles.sh)"
+    return
+  fi
+
+  # A grid-33 CMYK->RGB device link is the cheapest way to get a CLUT that
+  # serialises past the 10 MB text-node limit: 33^4 grid points x 3 channels
+  # is ~21 MB of whitespace-separated values in one element.
+  if ! "$APPLYTOLINK" "$link" 0 33 0 "issue 1856 regression" 0 1 1 1 \
+       "$src" 1 "$dst" 1 >"$logfile" 2>&1; then
+    fail "$name" "iccApplyToLink failed to build the fixture link"
+    return
+  fi
+
+  if ! "$TOXML" "$link" "$xml" >>"$logfile" 2>&1; then
+    fail "$name" "iccToXml failed on the fixture link"
+    return
+  fi
+
+  # Confirm the fixture actually exercises the limit. If a future change to the
+  # writer shortens the node below the cap this test would silently stop
+  # testing anything, so treat that as a skip with the measured size.
+  local longest
+  longest="$(python3 - "$xml" <<'PY'
+import re, sys
+data = open(sys.argv[1], "rb").read()
+print(max((len(m.group(1)) for m in re.finditer(rb">([^<]*)<", data)), default=0))
+PY
+)"
+  if [ -z "$longest" ] || [ "$longest" -le "$XML_MAX_TEXT_LENGTH" ]; then
+    skip "$name" "longest text node ${longest:-unknown} bytes does not exceed $XML_MAX_TEXT_LENGTH"
+    return
+  fi
+
+  if ! "$FROMXML" "$xml" "$back" >>"$logfile" 2>&1; then
+    fail "$name" "iccFromXml refused a ${longest}-byte text node it had just written"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || return
+
+  # Byte-compare, ignoring the two header fields that are expected to differ
+  # between two writes: the creation dateTime (offsets 24-35) and the profile
+  # ID / MD5 (offsets 84-99). Without masking these, a correct round trip
+  # still compares unequal.
+  if python3 - "$link" "$back" <<'PY'
+import sys
+def norm(path):
+    b = bytearray(open(path, "rb").read())
+    b[24:36] = b"\0" * 12
+    b[84:100] = b"\0" * 16
+    return bytes(b)
+sys.exit(0 if norm(sys.argv[1]) == norm(sys.argv[2]) else 1)
+PY
+  then
+    pass "$name (${longest} byte text node, round-trip byte-identical)"
+  else
+    fail "$name" "round-trip profile differs from the original"
+  fi
+}
+
+roundtrip_large_text_node
+
+###############################################################################
+# 2. Parser hardening must survive the fix
+###############################################################################
+#
+# Each of these is refused by libxml2 only because XML_PARSE_HUGE is NOT set.
+# If a later change sets it to solve a size problem, these turn red.
+
+echo "=== Parser hardening still armed ==="
+
+reject_case() {
+  local name="$1" file="$2" why="$3"
+  local logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  if "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1; then
+    fail "$name" "$why was accepted"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || return
+  pass "$name ($why refused)"
+}
+
+# Nesting past libxml2's 256-level default depth cap.
+python3 - "$OUTDIR/deep.xml" <<'PY'
+import sys
+open(sys.argv[1], "w").write("<IccProfile>" + "<n>" * 3000 + "</n>" * 3000 + "</IccProfile>")
+PY
+reject_case "xml-reject-deep-nesting" "$OUTDIR/deep.xml" "3000 levels of nesting"
+
+# Element name past XML_MAX_NAME_LENGTH (50000).
+python3 - "$OUTDIR/longname.xml" <<'PY'
+import sys
+open(sys.argv[1], "w").write("<IccProfile><" + "z" * 60000 + "/></IccProfile>")
+PY
+reject_case "xml-reject-long-name" "$OUTDIR/longname.xml" "a 60000-byte element name"
+
+# Entity amplification. Bounded at 10^6 characters so a regression cannot
+# exhaust memory on the machine running the suite.
+python3 - "$OUTDIR/laughs.xml" <<'PY'
+import sys
+open(sys.argv[1], "w").write(
+    '<?xml version="1.0"?>\n<!DOCTYPE IccProfile [\n'
+    '<!ENTITY a "AAAAAAAAAA">\n'
+    '<!ENTITY b "&a;&a;&a;&a;&a;&a;&a;&a;&a;&a;">\n'
+    '<!ENTITY c "&b;&b;&b;&b;&b;&b;&b;&b;&b;&b;">\n'
+    '<!ENTITY d "&c;&c;&c;&c;&c;&c;&c;&c;&c;&c;">\n'
+    '<!ENTITY e "&d;&d;&d;&d;&d;&d;&d;&d;&d;&d;">\n'
+    '<!ENTITY f "&e;&e;&e;&e;&e;&e;&e;&e;&e;&e;">\n'
+    ']>\n<IccProfile>&f;</IccProfile>\n')
+PY
+reject_case "xml-reject-entity-amplification" "$OUTDIR/laughs.xml" "a billion-laughs document"
+
+###############################################################################
+# 3. The whole-document bound replaces the per-node one
+###############################################################################
+
+echo "=== Document size bound ==="
+
+oversize_document() {
+  local name="xml-reject-oversize-document"
+  local file="$OUTDIR/oversize.xml"
+  local logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  # Needs a little over the configured bound on disk; skip rather than fail on
+  # a constrained runner.
+  local need_mb=$((XML_MAX_FILE_MB + 8))
+  local avail_mb
+  avail_mb="$(df -Pm "$OUTDIR" 2>/dev/null | awk 'NR==2 {print $4}')"
+  if [ -z "$avail_mb" ] || [ "$avail_mb" -lt $((need_mb + 256)) ]; then
+    skip "$name" "needs ${need_mb} MiB free in $OUTDIR, has ${avail_mb:-unknown}"
+    return
+  fi
+
+  python3 - "$file" "$need_mb" <<'PY'
+import sys
+path, mb = sys.argv[1], int(sys.argv[2])
+with open(path, "wb") as f:
+    f.write(b"<IccProfile><Data>")
+    chunk = b"7" * (1 << 20)
+    for _ in range(mb):
+        f.write(chunk)
+    f.write(b"</Data></IccProfile>")
+PY
+
+  if "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1; then
+    fail "$name" "a ${need_mb} MiB document was accepted above the ${XML_MAX_FILE_MB} MiB bound"
+    rm -f "$file"
+    return
+  fi
+
+  # The rejection must say why. A bare parse failure here is what made the
+  # original report hard to diagnose.
+  if grep -q "exceeds ${XML_MAX_FILE_MB} MiB limit" "$logfile"; then
+    pass "$name (refused with the compiled-in bound reported)"
+  else
+    fail "$name" "refused without naming the size limit"
+  fi
+  rm -f "$file"
+}
+
+oversize_document
+
+###############################################################################
+
+echo
+echo "=== Summary ==="
+echo "  Total:   $TOTAL"
+echo "  Passed:  $PASS"
+echo "  Failed:  $FAIL"
+echo "  Skipped: $SKIPPED"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4146,6 +4146,26 @@ set_tests_properties(iccdev.pcc-zero-illuminant-regressions PROPERTIES
   FIXTURES_REQUIRED iccdev_profiles
 )
 
+# Issue #1856. Pins both halves of the XML reader's size behaviour at once: a
+# profile whose CLUT exceeds libxml2's per-text-node limit must still round
+# trip, and the depth, name-length and entity-amplification caps must stay
+# armed. The second half exists so that a future attempt to solve a size
+# problem with XML_PARSE_HUGE turns this test red instead of quietly widening
+# what the parser accepts. Builds the fixture link with iccApplyToLink, so it
+# needs the generated profiles.
+if(TARGET iccFromXml AND TARGET iccToXml AND TARGET iccApplyToLink)
+  iccdev_add_script_test(
+    iccdev.xml-parser-regressions
+    600
+    "iccdev;xml;parser;regression;issue-1856;asan;slow"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-xml-parser-regression-tests.sh"
+  )
+  set_tests_properties(iccdev.xml-parser-regressions PROPERTIES
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+endif()
+
 if(ICCDEV_HAS_ICCCONNECT)
   iccdev_add_script_test(
     iccdev.iccconnect-search-cost-regressions

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2738,11 +2738,13 @@ bool CIccMpeXmlCalculator::ParseImport(xmlNode *pNode, std::string importPath, s
               continue;
             }
 
-            /* Parse the file and get the DOM. See IccProfileXml.cpp for
-             * the rationale for dropping XML_PARSE_HUGE and avoiding
-             * XML_PARSE_NOENT - matches the main LoadXml entry point.
+            /* Parse the file and get the DOM. See IccProfileXml.cpp for the
+             * rationale for still avoiding XML_PARSE_HUGE and XML_PARSE_NOENT,
+             * and icXmlReadFileBounded for why an imported document is read
+             * into a buffer and bounded rather than streamed - this matches
+             * the main LoadXml entry point.
              */
-            doc = xmlReadFile(file.c_str(), NULL, XML_PARSE_NONET);
+            doc = icXmlReadFileBounded(file.c_str(), XML_PARSE_NONET, &parseStr);
 
             if (doc == NULL) {
               parseStr += "Unable to import '";

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -1033,18 +1033,30 @@ bool CIccProfileXml::LoadXml(const char *szFilename, const char *szRelaxNGDir, s
   xmlDoc *doc = NULL;
   xmlNode *root_element = NULL;
 
+  std::string my_parseStr;
+
+  if (!parseStr)
+    parseStr = &my_parseStr;
+
+  *parseStr = "";
+
   /* Parse the file and get the DOM.
    *
-   * Drop XML_PARSE_HUGE: it disables libxml2's depth cap, name-length
-   * cap, text-length cap, and the billion-laughs entity-expansion guard
-   * - all of which protect against crafted inputs. Keep XML_PARSE_NONET
-   * (no network), do not set XML_PARSE_NOENT (it substitutes entity
-   * references and may load local external entities), and do not set
+   * Still no XML_PARSE_HUGE: it disables the nesting-depth cap and the
+   * name-length cap for every input, and it is not needed to read back a
+   * large CLUT - icXmlReadFileBounded parses from one contiguous buffer,
+   * which avoids the streaming text-node cap that refused iccToXml's own
+   * output in issue #1856, and bounds the document instead. Keep
+   * XML_PARSE_NONET (no network), do not set XML_PARSE_NOENT (it substitutes
+   * entity references and may load local external entities), and do not set
    * XML_PARSE_DTDLOAD. ICC profiles never use DTD entities legitimately.
+   *
+   * parseStr is set up above rather than after the parse so that a rejection
+   * on size reaches the caller as a reason instead of a bare parse failure.
    */
-  doc = xmlReadFile(szFilename, NULL, XML_PARSE_NONET);
+  doc = icXmlReadFileBounded(szFilename, XML_PARSE_NONET, parseStr);
 
-  if (doc == NULL) 
+  if (doc == NULL)
     return false;
 
   if (szRelaxNGDir && szRelaxNGDir[0]) {
@@ -1074,12 +1086,9 @@ bool CIccProfileXml::LoadXml(const char *szFilename, const char *szRelaxNGDir, s
 	    return false;  
   }
    
-  std::string my_parseStr;
-
-  if (!parseStr)
-    parseStr = &my_parseStr;
-
-  *parseStr = "";
+  /* parseStr was bound and cleared before the parse above, so that a size
+   * rejection could be reported; nothing has written to it on the path that
+   * reaches here. */
 
   /*Get the root element node */
   root_element = xmlDocGetRootElement(doc);

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -63,6 +63,9 @@
 
 #include <cstdlib>  /* std::strtoul, std::strtoull */
 #include <cerrno>   /* errno, ERANGE */
+#include <cstdio>   /* fopen, fseek, ftell, fread - icXmlReadFileBounded */
+#include <new>      /* std::nothrow - icXmlReadFileBounded */
+#include <string>   /* std::string, std::to_string */
 #include <time.h>
 #include "IccUtilXml.h"
 #include "IccConvertUTF.h"
@@ -526,6 +529,110 @@ bool icXmlValidateFileCount(size_t value, icUInt32Number &count, std::string &pa
 
   count = (icUInt32Number)value;
   return true;
+}
+
+xmlDoc *icXmlReadFileBounded(const char *szFilename, int nOptions, std::string *parseStr)
+{
+  // libxml2's streaming reader hands character data to the tree builder in
+  // successive chunks, and the append path that joins those chunks is where
+  // XML_MAX_TEXT_LENGTH (10 MB) is enforced. A profile whose CLUT serialises
+  // to a larger single text node is therefore refused on read even though
+  // iccToXml had just written it - issue #1856. Parsing one contiguous buffer
+  // never takes that append path, so the round trip holds without
+  // XML_PARSE_HUGE, which would additionally have disabled the nesting-depth
+  // and name-length caps for every input.
+  //
+  // What the per-node cap gave up is replaced by a whole-document bound, which
+  // is the stricter promise: it limits total parsed size instead of the size of
+  // any one node, and today the streamed path applies no document bound at all.
+  if (!szFilename || !*szFilename)
+    return NULL;
+
+  FILE *f = fopen(szFilename, "rb");
+  if (!f) {
+    if (parseStr) {
+      *parseStr += "Unable to open '";
+      *parseStr += szFilename;
+      *parseStr += "'\n";
+    }
+    return NULL;
+  }
+
+  if (fseek(f, 0, SEEK_END) != 0) {
+    fclose(f);
+    return NULL;
+  }
+  long pos = ftell(f);
+  if (pos < 0 || fseek(f, 0, SEEK_SET) != 0) {
+    fclose(f);
+    return NULL;
+  }
+
+  // Compared in a width that cannot narrow the bound where long is 32-bit.
+  if ((unsigned long long)pos > (unsigned long long)icXmlMaxTextFileBytes) {
+    if (parseStr) {
+      // Report the bound that was actually compiled in rather than a fixed
+      // number, so the message stays true if the constant is retuned.
+      *parseStr += "XML file '";
+      *parseStr += szFilename;
+      *parseStr += "' exceeds " +
+                   std::to_string((unsigned long long)icXmlMaxTextFileBytes / (1024 * 1024)) +
+                   " MiB limit\n";
+    }
+    fclose(f);
+    return NULL;
+  }
+
+  // xmlReadMemory takes the length as int; the bound above keeps every
+  // accepted size well inside that, and this states the dependency.
+  if ((unsigned long long)pos > (unsigned long long)std::numeric_limits<int>::max()) {
+    fclose(f);
+    return NULL;
+  }
+
+  size_t len = (size_t)pos;
+
+  // Allocated nothrow and reported, matching the other bounded text-buffer
+  // sites in this file. At this bound a refused allocation is a plausible
+  // outcome rather than a fatal one, and the streaming reader being replaced
+  // returned NULL on failure instead of throwing.
+  char *buf = new(std::nothrow) char[len ? len : 1];
+  if (!buf) {
+    if (parseStr) {
+      *parseStr += "Out of memory allocating ";
+      *parseStr += std::to_string((unsigned long long)len);
+      *parseStr += " bytes to parse '";
+      *parseStr += szFilename;
+      *parseStr += "'\n";
+    }
+    fclose(f);
+    return NULL;
+  }
+
+  size_t got = len ? fread(buf, 1, len, f) : 0;
+  fclose(f);
+
+  if (got != len) {
+    delete[] buf;
+    if (parseStr) {
+      *parseStr += "Unable to read '";
+      *parseStr += szFilename;
+      *parseStr += "'\n";
+    }
+    return NULL;
+  }
+
+  // The filename is passed as the document URL so libxml2 keeps reporting
+  // errors against it and still resolves relative references the same way
+  // xmlReadFile did.
+  //
+  // libxml2 copies the buffer into the document, so releasing it here does
+  // not leave the returned tree pointing at freed memory. Verified under
+  // ASAN by clobbering and freeing the buffer before walking the tree.
+  xmlDoc *doc = xmlReadMemory(buf, (int)len, szFilename, NULL, nOptions);
+  delete[] buf;
+
+  return doc;
 }
 
 xmlAttr *icXmlFindAttr(xmlNode *pNode, const char *szAttrName)

--- a/IccXML/IccLibXML/IccUtilXml.h
+++ b/IccXML/IccLibXML/IccUtilXml.h
@@ -97,8 +97,19 @@ bool icXmlValidateFileCount(size_t value, icUInt32Number &count, std::string &pa
 
 // Maximum byte count for text file buffers: caps num+1 from wrapping size_t
 // and prevents downstream ParseTextArrayNum from consuming gigabytes.
-// Used at every new(std::nothrow) char[num+1] text-buffer site.
+// Used at every new(std::nothrow) char[num+1] text-buffer site, and as the
+// whole-document bound applied by icXmlReadFileBounded below.
 static const size_t icXmlMaxTextFileBytes = 256ULL * 1024 * 1024;
+
+// Reads an XML document into one contiguous buffer and parses that, instead of
+// letting libxml2 stream the file. Returns NULL if the file cannot be read, if
+// it is larger than icXmlMaxTextFileBytes, or if it does not parse; on success
+// the caller owns the document and releases it with xmlFreeDoc. nOptions is
+// passed to libxml2 unchanged, so the caller keeps control of the parser flags.
+// The implementation comment explains why the buffer rather than the file is
+// what gets parsed - it is what lets a large CLUT round-trip without
+// XML_PARSE_HUGE. Diagnostics are appended to parseStr when one is supplied.
+xmlDoc *icXmlReadFileBounded(const char *szFilename, int nOptions, std::string *parseStr = NULL);
 
 #define icXmlStrCmp(x, y) strcmp((const char *)(x), (const char*)(y))
 


### PR DESCRIPTION
Part of #1856. This is the XML half only — the JSON cap landed in #1981 and its
follow-ups moved to #1994. Item 1 of the issue ("confirm whether to enable
`XML_PARSE_HUGE`, CMake default or toggle?") is left open deliberately: the finding
below is that there may be nothing to enable, but that call is @ChrisCoxArt's to make.

Detail and full measurements in
https://github.com/InternationalColorConsortium/iccDEV/issues/1856#issuecomment-5200070914.

## Problem

`iccToXml` can write a document `iccFromXml` then refuses. A profile whose CLUT
serialises to a single text node above libxml2's `XML_MAX_TEXT_LENGTH` (10 MB) is
rejected on read, so the two tools disagree about what a valid profile is.

Reproducible in 2.5 s from tracked profiles:

```
iccApplyToLink link33.icc 0 33 0 "repro" 0 1 1 1 \
    Testing/CMYK-3DLUTs/CMYK-3DLUTs.icc 1 Testing/sRGB_v4_ICC_preference.icc 1
iccToXml   link33.icc  link33.xml     # 21.7 MB, longest text node 21,705,957 bytes
iccFromXml link33.xml  back.icc       # refused
```

The tracked corpus is already close to the limit — `Testing/Display/LaserProjector.xml`
carries a 7,473,697-byte node, 74.7% of the cap.

## Why not `XML_PARSE_HUGE`

The limit is enforced on the path that *appends* successive character-data chunks to a
text node as they arrive from the streaming reader. One contiguous buffer never takes
that path. Same bytes, same options, libxml2 2.9.14:

| single text node | `xmlReadFile` | `xmlReadMemory` |
|---|---|---|
| 9 MB | parsed | parsed |
| 11 MB | **refused** | parsed |
| 40 MB | **refused** | parsed |
| 120 MB | **refused** | parsed |

So the round trip is recoverable without the flag, which would additionally have
disabled the nesting-depth and name-length caps for every input. (The existing rationale
comment also credited it with holding off billion-laughs; that is actually done by not
setting `XML_PARSE_NOENT`, and the comment is corrected here.)

## Change

`icXmlReadFileBounded` reads the document, bounds it at the existing
`icXmlMaxTextFileBytes`, and parses the buffer. Both `xmlReadFile` sites use it — the
profile entry point and the calculator `<Import>` path — with parser options unchanged.

`CIccProfileXml::LoadXml` applied **no document bound at all** before this:
`icXmlMaxTextFileBytes` guarded only embedded file references, and libxml2's caps bound a
node rather than a file, so a large document made of small nodes was never limited. The
change trades a per-node cap for a whole-document cap, which is the stricter promise, and
a rejection now reports the bound instead of failing as a bare parse error.

The buffer is allocated `nothrow` and a refusal reported, matching the other bounded
text-buffer sites in the file and preserving the reader's contract of returning NULL
rather than throwing. libxml2 copies the buffer into the document, so it is released
before returning — confirmed under ASAN by clobbering and freeing the buffer before
walking the tree.

## Evidence

| | before | after |
|---|---|---|
| 21.7 MB profile XML | refused | round-trips, byte-identical ignoring dateTime + MD5 |
| peak RSS, that file | 50 MB | 69 MB |
| peak RSS, 8 MiB of ~1M tiny nodes | 59.0x input | 34.9x input |
| 212 tracked `.xml`, parse outcome | 196 ok / 16 fail | identical |
| deep nesting / long name / billion laughs | refused | refused |

The RSS cost on the text-dense case is real and expected: the raw buffer and the tree are
held at once. That is the same asymmetry raised for `loadJsonFrom` in #1994, and it
applies here too. On the node-dense shape the buffered path is cheaper.

## Test

`iccdev.xml-parser-regressions` (5 cases) covers the round trip **and**, deliberately, the
three hardening cases — so a later attempt to solve a size problem by reaching for
`XML_PARSE_HUGE` turns this red rather than quietly widening what the parser accepts.

- Red on the unfixed tree: 2 fail / 3 pass. Green after: 5/5.
- Clean under `-fsanitize=address,undefined` with `detect_leaks=1`, verified against a
  deliberate-leak control so the clean result is meaningful.
- Full local suite green apart from `spectral-tiff-preview`, which fails on this machine
  for a missing `imagecodecs` module unrelated to this change.

## Two judgement calls, stated rather than buried

1. **No new CMake knob.** Reused the existing `icXmlMaxTextFileBytes` rather than adding an
   `ICC_XML_MAX_FILE_MB` mirroring `ICC_JSON_MAX_FILE_MB`. That introduces no new number
   and no new configuration surface. If you would rather XML had the same configurability
   JSON has, it is a small follow-up — a preference question, not a technical one.
2. **256 MiB is a refusal that did not exist before.** At the ~3x profile-to-XML expansion
   measured here that is roughly an 85 MB profile; nothing tracked approaches it, and the
   28 MB link in the original report would emit ~87 MB, well inside. Worth an explicit nod
   rather than a silent tightening.

Not addressed here, noted while working: `LoadXml`'s RelaxNG validation paths return
`false` without `xmlFreeDoc(doc)` — pre-existing, out of scope for this issue, and better
raised separately than folded into this diff.
