### PR TITLE
fix(#1997): assert the XML read bound fits int instead of testing it at runtime

### DIFF
--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -583,12 +583,14 @@ xmlDoc *icXmlReadFileBounded(const char *szFilename, int nOptions, std::string *
     return NULL;
   }
 
-  // xmlReadMemory takes the length as int; the bound above keeps every
-  // accepted size well inside that, and this states the dependency.
-  if ((unsigned long long)pos > (unsigned long long)std::numeric_limits<int>::max()) {
-    fclose(f);
-    return NULL;
-  }
+  // xmlReadMemory takes the length as int, so icXmlMaxTextFileBytes has to stay
+  // inside int range for the (int)len cast below to be lossless. Stated as a
+  // compile-time assertion rather than a runtime test: the bound checked just
+  // above already refuses anything larger, so a runtime test is unreachable
+  // while the constant is 256 MiB, and it would only convert a constant retuned
+  // past INT_MAX into a silent NULL return - where this refuses to build.
+  static_assert(icXmlMaxTextFileBytes <= (size_t)std::numeric_limits<int>::max(),
+                "icXmlMaxTextFileBytes must fit the int length xmlReadMemory takes");
 
   size_t len = (size_t)pos;
 


### PR DESCRIPTION
Fixes #1997.

Code-scanning alert **2350** (`cpp/constant-comparison`, warning) fired on
`IccXML/IccLibXML/IccUtilXml.cpp:588` at `a7abbee84a27`, which is the merge commit of
#1995 — so this is a follow-up on my own change rather than a pre-existing defect.

## The finding is accurate

`icXmlReadFileBounded` applied the whole-document bound and then re-checked the same value
against `INT_MAX`:

```cpp
// :572 - refuses anything over icXmlMaxTextFileBytes
if ((unsigned long long)pos > (unsigned long long)icXmlMaxTextFileBytes) { ... return NULL; }

// :588 - flagged: unreachable
if ((unsigned long long)pos > (unsigned long long)std::numeric_limits<int>::max()) { ... }
```

`icXmlMaxTextFileBytes` is 256 MiB (268435456, `IccUtilXml.h:102`); `INT_MAX` is 2147483647.
Everything reaching :588 has already been bounded to an eighth of `INT_MAX`, so the
comparison is always false. This is not a false positive and is not dismissed as one.

## What the change does

The dead branch was documenting a real constraint — `xmlReadMemory` takes the buffer length
as `int`, so the `(int)len` cast at :634 is only lossless while the bound stays inside `int`
range. The fix preserves that statement and makes it compile-time:

```cpp
static_assert(icXmlMaxTextFileBytes <= (size_t)std::numeric_limits<int>::max(),
              "icXmlMaxTextFileBytes must fit the int length xmlReadMemory takes");
```

This is stronger than the branch it replaces, which is the argument for fixing rather than
dismissing. The runtime test could only have mattered if `icXmlMaxTextFileBytes` were
retuned past `INT_MAX`, and in that case it would not have protected anything — it would
have silently returned `NULL` for every file over 2 GiB, turning a mis-configuration into an
unexplained read failure. The assertion refuses to build instead.

Precedent for the pattern is `IccProfLib/IccMpeCalc.cpp:2328`, an in-function `static_assert`
that a constant fits a narrower type.

Because the flagged line is removed rather than suppressed, alert 2350 should auto-close on
the next scan; no dismissal is required.

## Verification

| check | result |
|---|---|
| red — `icXmlMaxTextFileBytes` set to 4 GiB | build **fails** with the assertion message, confirming it bites rather than being decorative |
| green — constant restored | clang builds `IccXML2` clean |
| second toolchain | gcc builds `IccXML2` clean |
| CI pre-flight gate | `preflight-safety-checks.sh --require-tools`, run bare against `origin/master`: failures 0, skips 0 |
| MSVC `min`/`max` macro risk | not applicable — `IccUtilXml.cpp:75-76` defines `NOMINMAX` before `windows.h` and additionally `#undef max`; the identical `std::numeric_limits<int>::max()` expression already shipped in #1995 |
| descriptor paths | the deleted branch contained an `fclose(f)`; every remaining `return` after the `fopen` at :551 is still preceded by `fclose` (:562, :567, :582, :610) or covered by the unconditional `fclose` at :615. No descriptor leak. |

## No CTest

The removed branch was unreachable, so the change has no observable runtime behaviour to
assert. The only testable property in the area is the 256 MiB bound itself, which is #1995's
behaviour and is not what this touches. Raising it here rather than leaving the omission to
look like an oversight — happy to add one if you would rather have the bound pinned by a
test.

## Build

```
cmake -S Build/Cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_TOOLS=OFF
cmake --build build --target IccXML2 -j4
```
