### PR TITLE
fix(#1999): free the RelaxNG objects LoadXml creates for schema validation

### DIFF
--- a/.github/ci/regression/xml-relaxng-validation-leak.cpp
+++ b/.github/ci/regression/xml-relaxng-validation-leak.cpp
@@ -1,0 +1,130 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression: schema validation leaked every libxml2 object it created (#1999).
+//
+// CIccProfileXml::LoadXml takes an optional RelaxNG schema (iccFromXml -v). The
+// validation block built three libxml2 objects -- an xmlRelaxNGParserCtxt, the
+// xmlRelaxNG compiled from it, and an xmlRelaxNGValidCtxt -- and called none of
+// xmlRelaxNGFreeParserCtxt / xmlRelaxNGFree / xmlRelaxNGFreeValidCtxt on any
+// path out of the block. There were four bare "return false" exits and a
+// fall-through, and none of them released anything, so the leak was not confined
+// to an error case: validating successfully leaked all three as well. Measured
+// with iccFromXml -v on Testing/Display/sRGB_D65_MAT.xml under ASan/LSan before
+// the fix: 89,714 bytes in 1,094 allocations when validation passed, 8,821 bytes
+// in 40 allocations when it failed. Passing no schema leaked nothing, which is
+// what localizes it to this block.
+//
+// The same exits also walked away from the parsed document. icXmlReadFileBounded
+// hands ownership of it to LoadXml (IccUtilXml.h) and the function's only
+// xmlFreeDoc sits past the tail, after ParseXml. That one is NOT observable as a
+// leak -- LSan reports it neither directly nor indirectly, and it stays quiet
+// even with use_stacks=0:use_registers=0, so the block remains reachable from
+// libxml2 -- but returning without releasing a document this function owns is
+// still wrong, and the fix frees it. Do not expect this file to go red on that
+// half; the RelaxNG objects above are what it pins.
+//
+// A sibling of the document half in CIccMpeXmlCalculator::ParseImport does leak
+// and is pinned here too: an <Import> whose target parses but whose root element
+// is not IccCalcImport was rejected with a bare return, dropping the DOM that had
+// just been read. Measured at 6,306 bytes in 14 allocations on the fixture below.
+//
+// The pass/fail signal for the leaks is the LeakSanitizer at-exit scan, so this
+// only goes red under an ASan build with detect_leaks=1 -- the CTest registration
+// forces that on, because the CI tool-test job exports detect_leaks=0. The return
+// value assertions below run everywhere and pin the behaviour the fix had to keep
+// identical: the same accept/reject outcome at each of the four exits.
+//
+// Exit code 0 = pass, 1 = a case regressed.
+#include "IccProfileXml.h"
+#include "IccTagXmlFactory.h"
+#include "IccMpeXmlFactory.h"
+#include "IccXmlConfig.h"
+
+#include <cstdio>
+#include <string>
+
+static int g_failures = 0;
+
+// Each case gets its own CIccProfileXml so that a profile populated by a
+// successful load is destroyed before the next case runs; a shared instance
+// would blur which case any surviving allocation belonged to.
+static void check(const char *szCase,
+                  const char *szProfileXml,
+                  const char *szSchema,
+                  bool bExpectLoaded)
+{
+  CIccProfileXml profile;
+  std::string reason;
+
+  bool bLoaded = profile.LoadXml(szProfileXml, szSchema, &reason);
+
+  if (bLoaded != bExpectLoaded) {
+    printf("FAIL [%s]: LoadXml returned %s, expected %s (reason: %s)\n",
+           szCase, bLoaded ? "true" : "false", bExpectLoaded ? "true" : "false",
+           reason.c_str());
+    g_failures++;
+    return;
+  }
+
+  printf("ok   [%s]: LoadXml returned %s\n", szCase, bLoaded ? "true" : "false");
+}
+
+int main(int argc, char *argv[])
+{
+  if (argc < 6) {
+    printf("usage: %s <profile.xml> <accept.rng> <reject.rng> <malformed.rng> "
+           "<calc-import-main.xml>\n", argv[0]);
+    return 1;
+  }
+
+  const char *szProfileXml   = argv[1];
+  const char *szAcceptRng    = argv[2];
+  const char *szRejectRng    = argv[3];
+  const char *szMalformedRng = argv[4];
+  const char *szCalcImport   = argv[5];
+
+  // Same factory registration iccFromXml performs; without it the XML tag and
+  // element handlers this test drives are not reachable.
+  CIccTagCreator::PushFactory(new CIccTagXmlFactory());
+  CIccMpeCreator::PushFactory(new CIccMpeXmlFactory());
+
+  // The <Import> case below is gated on this the same way iccFromXml gates it.
+  IccXmlSetAllowFileIncludes(true);
+
+  // Validation succeeds. This is the path that leaked all three RelaxNG objects
+  // while reporting nothing wrong, so it is the important one.
+  check("relaxng-accept", szProfileXml, szAcceptRng, true);
+
+  // Validation runs and rejects the document (xmlRelaxNGValidateDoc != 0).
+  check("relaxng-reject", szProfileXml, szRejectRng, false);
+
+  // The schema is well-formed XML but does not compile, so xmlRelaxNGParse
+  // returns NULL and the parser context is the only object to release.
+  check("relaxng-malformed", szProfileXml, szMalformedRng, false);
+
+  // The schema file does not exist. xmlRelaxNGNewParserCtxt still returns a
+  // context for a URL it cannot read, so this exercises the same exit as the
+  // malformed case rather than the "no context at all" one; both are covered by
+  // a single cleanup block after the fix.
+  check("relaxng-missing", szProfileXml,
+        "relaxng-this-file-does-not-exist.rng", false);
+
+  // No schema at all -- the validation block is skipped entirely. Present as the
+  // control that isolates the leaks above to that block.
+  check("relaxng-none", szProfileXml, "", true);
+
+  // CIccMpeXmlCalculator::ParseImport: <Import> target parses but its root
+  // element is not IccCalcImport. Resolved relative to the working directory,
+  // which the CTest registration points at the fixture directory.
+  check("calc-import-badroot", szCalcImport, "", false);
+
+  if (g_failures) {
+    printf("%d case(s) regressed\n", g_failures);
+    return 1;
+  }
+
+  printf("all cases passed\n");
+  return 0;
+}

--- a/.github/ci/test-data/relaxng-accept-any.rng
+++ b/.github/ci/test-data/relaxng-accept-any.rng
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Deliberately permissive RelaxNG grammar: matches any element, attribute and
+     text content, so CIccProfileXml::LoadXml takes its validation-SUCCEEDS path
+     for any well-formed profile. That path is the one that used to leak the
+     RelaxNG parser context, the compiled schema and the validation context
+     without any diagnostic at all, so a schema that always passes is what pins
+     it. The repository ships no RelaxNG schema of its own, which is why this
+     fixture exists rather than reusing one. -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start><ref name="anything"/></start>
+  <define name="anything">
+    <element>
+      <anyName/>
+      <zeroOrMore>
+        <choice>
+          <attribute><anyName/></attribute>
+          <text/>
+          <ref name="anything"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+</grammar>

--- a/.github/ci/test-data/relaxng-calc-import-badroot-main.xml
+++ b/.github/ci/test-data/relaxng-calc-import-badroot-main.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Drives CIccMpeXmlCalculator::ParseImport down its invalid-root rejection.
+     The <Import> below names a file that parses as XML but whose root element
+     is not IccCalcImport, which is the branch that used to return without
+     releasing the document it had just read. Kept minimal: the import is
+     resolved before the rest of the calculator is examined, so nothing beyond
+     a well-formed CalculatorElement is needed to reach it. -->
+<IccProfile>
+	<Header>
+		<ProfileVersion>5.0</ProfileVersion>
+		<ProfileDeviceClass>spac</ProfileDeviceClass>
+		<DataColourSpace>RGB </DataColourSpace>
+		<PCS>XYZ </PCS>
+		<CreationDateTime>now</CreationDateTime>
+		<ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+		<DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+		<RenderingIntent>Relative</RenderingIntent>
+		<PCSIlluminant>
+			<XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+		</PCSIlluminant>
+		<ProfileCreator>ICC </ProfileCreator>
+	</Header>
+	<Tags>
+		<multiLocalizedUnicodeType>
+			<TagSignature>desc</TagSignature>
+			<LocalizedText LanguageCountry="enUS"><![CDATA[calc import badroot fixture]]></LocalizedText>
+		</multiLocalizedUnicodeType>
+		<multiProcessElementType>
+			<TagSignature>A2B1</TagSignature>
+			<MultiProcessElements InputChannels="3" OutputChannels="3">
+				<CalculatorElement InputChannels="3" OutputChannels="3">
+					<Imports>
+						<Import Filename="relaxng-calc-import-badroot-target.xml"/>
+					</Imports>
+					<MainFunction>{ in(0,3) out(0,3) }</MainFunction>
+				</CalculatorElement>
+			</MultiProcessElements>
+		</multiProcessElementType>
+	</Tags>
+</IccProfile>

--- a/.github/ci/test-data/relaxng-calc-import-badroot-target.xml
+++ b/.github/ci/test-data/relaxng-calc-import-badroot-target.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Import target for relaxng-calc-import-badroot-main.xml. Well-formed XML so
+     it parses into a document, but the root element is deliberately not
+     IccCalcImport so ParseImport rejects it after taking ownership of that
+     document. -->
+<NotAnIccCalcImport>
+	<Imports/>
+</NotAnIccCalcImport>

--- a/.github/ci/test-data/relaxng-malformed.rng
+++ b/.github/ci/test-data/relaxng-malformed.rng
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Well-formed XML that is not a usable RelaxNG grammar: <define> is
+     referenced nowhere and no <start> is given, so xmlRelaxNGParse fails to
+     compile it and returns NULL. Drives the LoadXml exit where the parser
+     context exists but the schema does not. -->
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <define name="orphan"><empty/></define>
+</grammar>

--- a/.github/ci/test-data/relaxng-reject-all.rng
+++ b/.github/ci/test-data/relaxng-reject-all.rng
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Valid RelaxNG that compiles cleanly but cannot match an ICC profile: the
+     document root would have to be <NeverMatchesAnIccProfile>. Drives
+     CIccProfileXml::LoadXml down the "result != 0" rejection, which is the exit
+     that reports the file as invalid and returns. -->
+<element name="NeverMatchesAnIccProfile" xmlns="http://relaxng.org/ns/structure/1.0">
+  <empty/>
+</element>

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2514,6 +2514,95 @@ function(iccdev_add_xml_writer_graceful_degrade_test)
   endif()
 endfunction()
 
+# #1999: CIccProfileXml::LoadXml's RelaxNG validation block (iccFromXml -v) created an
+# xmlRelaxNGParserCtxt, an xmlRelaxNG and an xmlRelaxNGValidCtxt and freed none
+# of them on any path -- four bare `return false` exits and a fall-through, so
+# the leak happened whether validation passed or failed. The same exits also
+# returned without the xmlFreeDoc that LoadXml owes the document, and a sibling
+# in CIccMpeXmlCalculator::ParseImport dropped the DOM of an <Import> whose root
+# element is not IccCalcImport.
+#
+# The leak signal is the LeakSanitizer at-exit scan, so this must run with
+# detect_leaks=1 -- see the `cmake -E env` note below. The test also asserts the
+# accept/reject outcome at each exit, which is meaningful in non-ASan builds too.
+# Needs IccXML (CIccProfileXml) + IccProfLib; skipped where IccXML is not built.
+function(iccdev_add_xml_relaxng_validation_leak_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccXmlRelaxNGValidationLeakTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/xml-relaxng-validation-leak.cpp"
+  )
+  target_include_directories(iccXmlRelaxNGValidationLeakTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccXML/IccLibXML"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+    ${LIBXML2_INCLUDE_DIR}
+  )
+  target_link_libraries(iccXmlRelaxNGValidationLeakTest PRIVATE
+    ${TARGET_LIB_ICCXML} ${TARGET_LIB_ICCPROFLIB} ${LIBXML2_LIBRARIES})
+  add_dependencies(check iccXmlRelaxNGValidationLeakTest)
+
+  # The CI tool-test job and ICCDEV_TEST_ENV both export
+  # ASAN_OPTIONS=...detect_leaks=0 to silence unrelated leaks in the smoke-tested
+  # tools. Inheriting that here would disable LSan and make this a false pass on
+  # a real leak. Force it back on for this test's own process via `cmake -E env`
+  # (a CTest ENVIRONMENT property is not reliable for ASAN_OPTIONS). Set ONLY
+  # detect_leaks=1: appending halt_on_error=0 makes the runtime print the leak
+  # and still exit 0, which ctest would read as a pass.
+  #
+  # The three existing leak regressions (cmmsearch-namedcolor-ownership,
+  # xform-create-tag-ownership, iccprofileplot-pdf-leak) skip themselves entirely
+  # on MSVC, whose AddressSanitizer has no LeakSanitizer and would be handed an
+  # option it does not implement. This test is not skipped there, because its
+  # LoadXml return-value assertions pin the accept/reject behaviour at each of the
+  # four RelaxNG exits and are worth running on Windows even with no leak check;
+  # only the detect_leaks=1 wrapper is dropped.
+  set(_relaxng_leak_args
+    "${ICCDEV_TESTING_DIR}/Display/sRGB_D65_MAT.xml"
+    "${ICCDEV_REPO_ROOT}/.github/ci/test-data/relaxng-accept-any.rng"
+    "${ICCDEV_REPO_ROOT}/.github/ci/test-data/relaxng-reject-all.rng"
+    "${ICCDEV_REPO_ROOT}/.github/ci/test-data/relaxng-malformed.rng"
+    "relaxng-calc-import-badroot-main.xml"
+  )
+  if(MSVC)
+    add_test(
+      NAME iccdev.xml-relaxng-validation-leak
+      COMMAND "$<TARGET_FILE:iccXmlRelaxNGValidationLeakTest>" ${_relaxng_leak_args}
+    )
+  else()
+    add_test(
+      NAME iccdev.xml-relaxng-validation-leak
+      COMMAND "${CMAKE_COMMAND}" -E env
+        "ASAN_OPTIONS=detect_leaks=1"
+        "$<TARGET_FILE:iccXmlRelaxNGValidationLeakTest>" ${_relaxng_leak_args}
+    )
+  endif()
+  # WORKING_DIRECTORY is the fixture directory rather than the usual output dir
+  # because <Import Filename="..."> is resolved relative to the process working
+  # directory, and IccXmlIsPathSafe rejects the absolute or "../" path that any
+  # other choice would need.
+  set_tests_properties(iccdev.xml-relaxng-validation-leak PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}/.github/ci/test-data"
+    TIMEOUT 60
+    LABELS "iccdev;xml;relaxng;leak;issue-1999;regression"
+  )
+  if(WIN32)
+    set(_relaxng_leak_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccXmlRelaxNGValidationLeakTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCXML}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _relaxng_leak_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.xml-relaxng-validation-leak PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_relaxng_leak_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1886: CIccMpeXmlUnknown::ToXml formatted the Reserved attribute into `line`
 # and then appended `buf`, which still held the element's type signature from the
 # icGetSigStr call above it. The value was dropped and the signature was injected
@@ -3454,6 +3543,7 @@ if(WIN32)
   iccdev_add_pawg_compression_paths_test()
   iccdev_add_json_sparsematrix_huaf_test()
   iccdev_add_xml_writer_graceful_degrade_test()
+  iccdev_add_xml_relaxng_validation_leak_test()
   iccdev_add_mpexml_unknown_reserved_test()
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_proflib_exported_global_definitions_test()
@@ -3712,6 +3802,7 @@ iccdev_add_compression_describe_labels_test()
 iccdev_add_pawg_compression_paths_test()
 iccdev_add_json_sparsematrix_huaf_test()
 iccdev_add_xml_writer_graceful_degrade_test()
+iccdev_add_xml_relaxng_validation_leak_test()
 iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_proflib_exported_global_definitions_test()

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2756,6 +2756,11 @@ bool CIccMpeXmlCalculator::ParseImport(xmlNode *pNode, std::string importPath, s
             /*Get the root element node */
             root_element = xmlDocGetRootElement(doc);
             if (strcmp((icChar*)root_element->name, "IccCalcImport")) {
+              /* #1999: the import loop owns doc from the read above until the
+               * xmlFreeDoc below, so rejecting the file here has to release
+               * it first - this return used to drop the document, leaking a
+               * whole parsed DOM per malformed import. */
+              xmlFreeDoc(doc);
               parseStr += "Invalid calc element import file '" + file + "'\n";
               return false;
             }

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -1060,30 +1060,57 @@ bool CIccProfileXml::LoadXml(const char *szFilename, const char *szRelaxNGDir, s
     return false;
 
   if (szRelaxNGDir && szRelaxNGDir[0]) {
-    xmlRelaxNGParserCtxt* rlxParser;
-    
-    rlxParser = xmlRelaxNGNewParserCtxt (szRelaxNGDir);
+    /* #1999: each libxml2 object created below has its own free function, and
+     * none of them used to be called on any path: this block was four bare
+     * "return false" statements and a fall-through that freed nothing, so a
+     * schema-validating run leaked the parser context, the compiled schema
+     * and the validation context whether validation passed or failed.
+     * bValid records the outcome so the cleanup runs once on the way out
+     * instead of being repeated at each exit.
+     *
+     * Ordering matters: the schema returned by xmlRelaxNGParse outlives its
+     * parser context, and the validation context refers to the schema, so
+     * they are released innermost-first.
+     */
+    bool bValid = false;
+    xmlRelaxNGParserCtxt* rlxParser = xmlRelaxNGNewParserCtxt(szRelaxNGDir);
 
     //validate the xml file
-    if (rlxParser){
-	    xmlRelaxNG* relaxNG = xmlRelaxNGParse(rlxParser);
-	    if (relaxNG){
-		    xmlRelaxNGValidCtxt* validCtxt = xmlRelaxNGNewValidCtxt(relaxNG);
-		    if (validCtxt){
-			    int result = xmlRelaxNGValidateDoc(validCtxt, doc);
-			    if (result != 0){
-				    printf("\nError: %d: '%s' is an invalid XML file.\n", result, szFilename);
-				    return false;
-			    }
-		    }
-		    else
-		      return false;
-	    }
-	    else
-		  return false;		  
+    if (rlxParser) {
+      xmlRelaxNG* relaxNG = xmlRelaxNGParse(rlxParser);
+
+      if (relaxNG) {
+        xmlRelaxNGValidCtxt* validCtxt = xmlRelaxNGNewValidCtxt(relaxNG);
+
+        if (validCtxt) {
+          int result = xmlRelaxNGValidateDoc(validCtxt, doc);
+
+          if (result != 0)
+            printf("\nError: %d: '%s' is an invalid XML file.\n", result, szFilename);
+          else
+            bValid = true;
+
+          xmlRelaxNGFreeValidCtxt(validCtxt);
+        }
+
+        xmlRelaxNGFree(relaxNG);
+      }
+
+      xmlRelaxNGFreeParserCtxt(rlxParser);
     }
-    else
-	    return false;  
+
+    /* Same rejection as before for a schema that will not load, will not
+     * compile, or that the document fails - only now the document goes back
+     * with it. icXmlReadFileBounded hands ownership of doc to this function
+     * (see IccUtilXml.h) and the sole xmlFreeDoc was past the tail of the
+     * function, so these exits used to walk away from it. LSan does not
+     * flag that one as leaked - the block stays reachable from libxml2 - so
+     * this is an ownership fix rather than a measured leak, unlike the
+     * RelaxNG objects above. */
+    if (!bValid) {
+      xmlFreeDoc(doc);
+      return false;
+    }
   }
    
   /* parseStr was bound and cleared before the parse above, so that a size


### PR DESCRIPTION
Fixes #1999. Follow-up to the note on #1995, opened at @xsscx's request.

## What was wrong

`CIccProfileXml::LoadXml`'s RelaxNG validation block (`iccFromXml -v`) created three libxml2
objects — an `xmlRelaxNGParserCtxt`, the `xmlRelaxNG` compiled from it, and an
`xmlRelaxNGValidCtxt` — and called none of `xmlRelaxNGFreeParserCtxt`, `xmlRelaxNGFree` or
`xmlRelaxNGFreeValidCtxt` on any path. There were four bare `return false` exits plus a
fall-through that freed nothing, so **the leak was not confined to an error case: a run that
validated successfully leaked all three.** None of the three free functions was called anywhere
in the tree.

`CIccMpeXmlCalculator::ParseImport` carried the same shape: an `<Import>` whose target parses
but whose root element is not `IccCalcImport` was rejected with a bare `return`, dropping the
DOM read three lines earlier.

## Measurements

`iccFromXml -v` on `Testing/Display/sRGB_D65_MAT.xml`, ASan/LSan `detect_leaks=1`,
clang 21.1.3, libxml2 2.9.14:

| case | before | after |
|---|---|---|
| schema accepts the document | 89,714 bytes / 1,094 allocs | clean |
| schema rejects the document | 8,821 bytes / 40 allocs | clean |
| schema does not compile | 8,821 bytes / 40 allocs | clean |
| no `-v` at all (control) | clean | clean |
| `ParseImport` bad-root import | 6,306 bytes / 14 allocs | clean |

The clean control is what localizes it — every leaked allocation's stack passes through
`IccProfileXml.cpp:1065/:1069/:1071/:1073`.

## What this fix does *not* claim

My original note on #1995 said these paths leak `doc`. The exits **do** return without the
`xmlFreeDoc` that `LoadXml` owes the document (`icXmlReadFileBounded` transfers ownership —
`IccUtilXml.h:107`), and that is fixed here. But it is **not observable as a leak**: LSan
reports it neither directly nor indirectly, and stays quiet even under
`use_stacks=0:use_registers=0`; deliberately omitting the free while freeing the RelaxNG
objects produces no report at all. It is fixed as an ownership defect, not counted as a
measured leak. The `ParseImport` document, by contrast, does leak and is measured above.

## Behaviour

Unchanged. Same accept/reject outcome at each of the four exits and the same message on a
rejected document; `bValid` records the outcome so cleanup runs once on the way out. Objects
are released innermost-first (the schema outlives its parser context; the validation context
refers to the schema). Verified separately: with a schema that accepts, the emitted profile is
byte-identical to the no-schema run apart from the creation `dateTime` and the profile ID that
derives from it.

**Note on the diff:** the validation block is re-indented to the file's prevailing 2-space
style. That is a consequence of restructuring its control flow (every line in the block
changed), not separate style churn.

## Test

Adds `.github/ci/regression/xml-relaxng-validation-leak.cpp` and the
`iccdev.xml-relaxng-validation-leak` CTest, covering all four RelaxNG exits, a no-schema
control, and the `ParseImport` case. The repository ships no `.rng`, so three schema fixtures
are added (permissive / rejecting / non-compiling) plus a two-file calc-import fixture.

- **Red on master:** 1,411,339 bytes in 13,401 allocations, test fails.
- **Green with this change**, and re-verified red/green *after* the CMake registration was
  restructured.

The registration forces `ASAN_OPTIONS=detect_leaks=1`, because the CI tool-test job and
`ICCDEV_TEST_ENV` export `detect_leaks=0` and would otherwise make it a false pass. Unlike the
three existing leak regressions, it is **not** skipped on MSVC — only the `detect_leaks=1`
wrapper is dropped there, so the `LoadXml` return-value assertions still run on Windows.

## Pre-flight

| lane | result |
|---|---|
| clang 21.1.3 Release, `-Wall -Wextra -Wpedantic -Werror` ("strict warnings ENABLED") | `grep -cE 'warning:'` = **0**, errors 0 |
| GCC 15.2.0 in CI's own regression container, strict + `-DENABLE_LTO=ON` ("strict warnings ENABLED") | `grep -cE 'warning:'` = **0**, errors 0 |
| ASan+UBSan Debug, full `ctest` | 154/156; the 2 failures are pre-existing local noise (`tool-coverage` CMM profile-chain errors, `spectral-tiff-preview` missing `imagecodecs`), unrelated to XML |
| libxml2 2.15.2 (container) | new CTest passes — behaviour holds across libxml2 2.9 → 2.15 |

No shell or workflow files changed, so the shellcheck/actionlint pre-flight gates are not
engaged by this diff.
