### PR TITLE
fix(#2000): copy the cicp fields in CIccTagCicp's copy constructor

### DIFF
--- a/.github/ci/regression/cicp-copy-ctor-uninitialized.cpp
+++ b/.github/ci/regression/cicp-copy-ctor-uninitialized.cpp
@@ -1,0 +1,164 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression: CIccTagCicp's copy constructor had an empty body (#2000).
+//
+// IccTagBasic.cpp carried:
+//
+//   CIccTagCicp::CIccTagCicp(const CIccTagCicp& /* ITXYZ */)
+//   {
+//   }
+//
+// The parameter name is copy-paste residue from CIccTagXYZ's copy constructor
+// higher in the same file, and the body was never written. A copy constructor
+// does not delegate to CIccTagCicp(), so the four icUInt8Number members -- which
+// have no in-class initialiser (IccTagBasic.h) -- were left uninitialized rather
+// than zeroed. That is CWE-457, and Write(), Describe() and Validate() all read
+// the members straight out, so the indeterminate value can reach output.
+//
+// The tell that it was an oversight rather than a decision: operator= twenty
+// lines below copies all four correctly, and the doc comment above the copy
+// constructor already documents the parameter as ITCICP.
+//
+// Reachability is mainline, not fuzzed. CIccTagCicp::NewCopy() *is* this
+// constructor (IccTagBasic.h: `return new CIccTagCicp(*this)`), CIccProfile's
+// copy constructor clones every tag through NewCopy(), and CIccApplyBPC copies
+// the whole profile (IccApplyBPC.cpp) -- which the shipped CLI tools reach via
+// intent + 40 (40/41/42 = Perceptual/RelativeColorimetric/Saturation with BPC).
+//
+// The three levels below are that chain, from the constructor outwards:
+//   1. direct copy construction
+//   2. NewCopy(), the virtual dispatch BPC actually goes through
+//   3. the CIccProfile copy constructor with a cicpTag attached
+//
+// On making this bite reliably: a naive version of this test can PASS BY LUCK,
+// because an uninitialized read returns whatever the storage happened to hold.
+// Measured against the unfixed library under ASan/UBSan Debug, the three levels
+// do not even agree with each other:
+//
+//   copy-construct (stack)   0/0/0/0
+//   newcopy        (heap)    190/190/190/190   (0xBE, ASan's malloc fill byte)
+//   profile-copy   (heap)    190/190/190/190
+//
+// So the heap levels are deterministic under ASan, but the stack level read
+// zeros in that build -- which is exactly why the fixture values below must be
+// non-zero. Had this test used 0/0/0/0 as its fixture, the copy-construct case
+// would have PASSED against the broken library. The values are also all
+// different so a uniformly-filled allocation cannot masquerade as a good copy.
+// These numbers are measured, not predicted; the red/green was run both ways.
+//
+// Exit code 0 = pass, 1 = a case regressed.
+#include "IccTagBasic.h"
+#include "IccProfile.h"
+
+#include <cstdio>
+#include <string>
+
+// BT.2020 primaries / PQ transfer / BT.2020 non-constant luminance / full range.
+// Deliberately non-zero and all different -- see the note above: the stack-level
+// case read 0/0/0/0 against the unfixed library, so a zero fixture would have
+// made that assertion toothless.
+static const icUInt8Number kPrimaries  = 9;
+static const icUInt8Number kTransfer   = 16;
+static const icUInt8Number kMatrix     = 9;
+static const icUInt8Number kFullRange  = 1;
+
+static int g_failures = 0;
+
+static void expectFields(const char *szCase, CIccTagCicp &tag)
+{
+  icUInt8Number p = 0, t = 0, m = 0, f = 0;
+  tag.GetFields(p, t, m, f);
+
+  if (p != kPrimaries || t != kTransfer || m != kMatrix || f != kFullRange) {
+    printf("FAIL [%s]: got %u/%u/%u/%u, expected %u/%u/%u/%u\n", szCase,
+           (unsigned)p, (unsigned)t, (unsigned)m, (unsigned)f,
+           (unsigned)kPrimaries, (unsigned)kTransfer,
+           (unsigned)kMatrix, (unsigned)kFullRange);
+    g_failures++;
+    return;
+  }
+
+  printf("ok   [%s]: %u/%u/%u/%u survived the copy\n", szCase,
+         (unsigned)p, (unsigned)t, (unsigned)m, (unsigned)f);
+}
+
+int main()
+{
+  // Level 1 -- direct copy construction, the defect at its source.
+  {
+    CIccTagCicp src;
+    src.SetFields(kPrimaries, kTransfer, kMatrix, kFullRange);
+
+    CIccTagCicp copy(src);
+    expectFields("copy-construct", copy);
+  }
+
+  // Level 2 -- NewCopy(), which is the copy constructor reached through the
+  // virtual CIccTag interface. This is the call CIccProfile makes per tag.
+  {
+    CIccTagCicp src;
+    src.SetFields(kPrimaries, kTransfer, kMatrix, kFullRange);
+
+    CIccTag *pCopy = src.NewCopy();
+    if (!pCopy) {
+      printf("FAIL [newcopy]: NewCopy returned NULL\n");
+      g_failures++;
+    }
+    else {
+      CIccTagCicp *pCicp = dynamic_cast<CIccTagCicp *>(pCopy);
+      if (!pCicp) {
+        printf("FAIL [newcopy]: NewCopy did not return a CIccTagCicp\n");
+        g_failures++;
+      }
+      else {
+        expectFields("newcopy", *pCicp);
+      }
+      delete pCopy;
+    }
+  }
+
+  // Level 3 -- the mainline path: CIccProfile's copy constructor clones every
+  // tag via NewCopy(), which is what CIccApplyBPC does to the profile it is
+  // handed. The profile needs no more than the one tag for this; it is never
+  // written or applied, only copied.
+  {
+    CIccProfile src;
+    CIccTagCicp *pTag = new CIccTagCicp();
+    pTag->SetFields(kPrimaries, kTransfer, kMatrix, kFullRange);
+
+    if (!src.AttachTag(icSigCicpTag, pTag)) {
+      printf("FAIL [profile-copy]: AttachTag(icSigCicpTag) failed\n");
+      g_failures++;
+      delete pTag;
+    }
+    else {
+      CIccProfile copy(src);
+
+      CIccTag *pFound = copy.FindTag(icSigCicpTag);
+      if (!pFound) {
+        printf("FAIL [profile-copy]: copied profile has no cicpTag\n");
+        g_failures++;
+      }
+      else {
+        CIccTagCicp *pCicp = dynamic_cast<CIccTagCicp *>(pFound);
+        if (!pCicp) {
+          printf("FAIL [profile-copy]: cicpTag is not a CIccTagCicp\n");
+          g_failures++;
+        }
+        else {
+          expectFields("profile-copy", *pCicp);
+        }
+      }
+    }
+  }
+
+  if (g_failures) {
+    printf("%d case(s) regressed\n", g_failures);
+    return 1;
+  }
+
+  printf("all cases passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -993,6 +993,51 @@ function(iccdev_add_getvalues_nstart_test)
   endif()
 endfunction()
 
+# #2000: CIccTagCicp's copy constructor had an empty body and a commented-out
+# parameter (/* ITXYZ */, copy-paste residue from CIccTagXYZ), so the four
+# icUInt8Number members -- which have no in-class initialiser -- were left
+# uninitialized on every copy (CWE-457). NewCopy() *is* that constructor, and
+# CIccProfile's copy constructor clones each tag through NewCopy(), which is the
+# path CIccApplyBPC takes for intents 40/41/42. Pins all three levels. The
+# fixture values are non-zero and distinct because the pre-fix reads differ per
+# level -- measured 0/0/0/0 for the stack copy and 0xBE (ASan's malloc fill) for
+# both heap copies -- so a zero fixture would leave the stack assertion toothless.
+# Header + IccProfLib only.
+function(iccdev_add_cicp_copy_ctor_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCicpCopyCtorTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/cicp-copy-ctor-uninitialized.cpp"
+  )
+  target_link_libraries(iccCicpCopyCtorTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccCicpCopyCtorTest)
+
+  add_test(
+    NAME iccdev.cicp-copy-ctor-uninitialized
+    COMMAND "$<TARGET_FILE:iccCicpCopyCtorTest>"
+  )
+  set_tests_properties(iccdev.cicp-copy-ctor-uninitialized PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;tag;cicp;security;issue-2000;regression"
+  )
+  if(WIN32)
+    set(_cicp_copy_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCicpCopyCtorTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _cicp_copy_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.cicp-copy-ctor-uninitialized PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_cicp_copy_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1976: two defects on the gamt path. CIccXform::Create() forces bInput false to walk
 # the B-to-A shaped gamut tag, but m_bInput also drove GetDstSpace()/GetNumDstSamples(),
 # so the xform advertised the profile's device space while CIccCmm::AddXform() had
@@ -3572,6 +3617,7 @@ if(WIN32)
   iccdev_add_reflectance_observer_illum_range_test()
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
+  iccdev_add_cicp_copy_ctor_test()
   iccdev_add_gamut_xform_semantics_test()
   iccdev_add_rangemap_uninitialized_test()
   iccdev_add_pcs_birefl_illuminant_range_test()
@@ -3830,6 +3876,7 @@ iccdev_add_xform_abstorel_adjust_test()
 iccdev_add_reflectance_observer_illum_range_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
+iccdev_add_cicp_copy_ctor_test()
 iccdev_add_gamut_xform_semantics_test()
 iccdev_add_rangemap_uninitialized_test()
 iccdev_add_pcs_birefl_illuminant_range_test()

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -4622,8 +4622,20 @@ CIccTagCicp::CIccTagCicp()
  *  ITCICP = The CIccTagCicp object to be copied
  *****************************************************************************
  */
-CIccTagCicp::CIccTagCicp(const CIccTagCicp& /* ITXYZ */)
+CIccTagCicp::CIccTagCicp(const CIccTagCicp& ITCICP)
 {
+  // #2000: this body was empty and the parameter was commented out as
+  // /* ITXYZ */ -- copy-paste residue from CIccTagXYZ's copy constructor above.
+  // A copy constructor does not delegate to CIccTagCicp(), so the four members
+  // were left uninitialized rather than zeroed, and NewCopy() below is exactly
+  // this constructor: every profile copied through CIccProfile's copy
+  // constructor (which clones each tag via NewCopy) produced a cicpTag whose
+  // fields were read indeterminate by Write, Describe and Validate. Copy them,
+  // matching operator= just below, which had it right all along.
+  m_nColorPrimaries = ITCICP.m_nColorPrimaries;
+  m_nTransferCharacteristics = ITCICP.m_nTransferCharacteristics;
+  m_nMatrixCoefficients = ITCICP.m_nMatrixCoefficients;
+  m_nVideoFullRangeFlag = ITCICP.m_nVideoFullRangeFlag;
 }
 
 

--- a/IccProfLib/IccTagBasic.h
+++ b/IccProfLib/IccTagBasic.h
@@ -861,7 +861,10 @@ class ICCPROFLIB_API CIccTagCicp : public CIccTag
 public:
   CIccTagCicp();
   CIccTagCicp(const CIccTagCicp& ITCICP);
-  CIccTagCicp& operator=(const CIccTagCicp& XYZTag);
+  // #2000: parameter was named XYZTag here, the same CIccTagXYZ copy-paste that
+  // left the copy constructor's body empty. The definition already calls it
+  // cicpTag; renamed so the declaration stops pointing at the wrong class.
+  CIccTagCicp& operator=(const CIccTagCicp& cicpTag);
   virtual CIccTag* NewCopy() const { return new CIccTagCicp(*this); }
   virtual ~CIccTagCicp();
 


### PR DESCRIPTION
Fixes #2000.

## What was wrong

`IccProfLib/IccTagBasic.cpp` carried:

```cpp
CIccTagCicp::CIccTagCicp(const CIccTagCicp& /* ITXYZ */)
{
}
```

`ITXYZ` is copy-paste residue from `CIccTagXYZ`'s copy constructor higher in the same file. A
copy constructor does not delegate to `CIccTagCicp()`, and the four `icUInt8Number` members
have no in-class initialiser, so **every copied `cicpTag` was left uninitialized rather than
zeroed** — CWE-457. `Write()`, `Describe()` and `Validate()` read the members directly, so the
indeterminate value can reach output.

Two tells that it is an oversight rather than a decision:

1. `operator=` twenty lines below copies all four correctly.
2. The doc comment above the constructor **already documents the parameter as `ITCICP`** — only
   the body and the parameter name were wrong.

## Reachability — mainline, not fuzzed

`NewCopy()` *is* this constructor (`IccTagBasic.h`) → `CIccProfile`'s copy constructor clones
every tag through `NewCopy()` (`IccProfile.cpp`) → `CIccApplyBPC` copies the whole profile
(`IccApplyBPC.cpp`) → reachable from the shipped CLI tools via **intent + 40** (40/41/42 =
Perceptual / RelativeColorimetric / Saturation with BPC).

## Also in this change

- Renames the header's `operator=` parameter `XYZTag` → `cicpTag`. Same copy-paste, and it is
  the thing that makes the defect hard to see; the definition already called it `cicpTag`.

## Deliberately not done

**No in-class `= 0` initialisers.** They would be defence in depth *in addition to* this fix,
never instead of it: for CICP a zero means "Reserved/Unspecified", so an initialiser alone
converts an indeterminate answer into a confidently wrong one. Happy to add them on top if
that is wanted.

## Sweep

Checked the rest of IccProfLib for the same shape. The only other copy constructor with an
empty body is `CIccTagLutBtoA`, which delegates to `CIccTagLutAtoB` in its initialiser list and
adds no members of its own — correct as written, left alone.

## Test

Adds `.github/ci/regression/cicp-copy-ctor-uninitialized.cpp` and the
`iccdev.cicp-copy-ctor-uninitialized` CTest, pinning all three levels of the chain above:
direct copy construction, `NewCopy()`, and the `CIccProfile` copy constructor.

Measured against the **unfixed** library under ASan/UBSan Debug, the three levels do not agree
with each other:

| level | pre-fix read |
|---|---|
| copy-construct (stack) | `0/0/0/0` |
| newcopy (heap) | `190/190/190/190` (0xBE, ASan's malloc fill) |
| profile-copy (heap) | `190/190/190/190` |

which is why the fixture uses distinctive non-zero values (9/16/9/1 = BT.2020 / PQ /
BT.2020-NCL / full range). **A `0/0/0/0` fixture would have left the stack assertion
toothless** — the pass-by-luck failure mode this kind of test invites. Red/green run both ways,
and re-verified after the test's comments were revised.

## Pre-flight

| lane | result |
|---|---|
| clang 21.1.3 Release, `-Wall -Wextra -Wpedantic -Werror` ("strict warnings ENABLED") | `grep -cE 'warning:'` = **0**, errors 0 |
| GCC 15.2.0 in CI's own regression container, strict + `-DENABLE_LTO=ON` ("strict warnings ENABLED") | `grep -cE 'warning:'` = **0**, errors 0; new CTest passes there too |
| ASan+UBSan Debug, full `ctest` | 155/157; the 2 failures are pre-existing local noise (`tool-coverage` CMM profile-chain errors, `spectral-tiff-preview` missing `imagecodecs`) |
| new test under `ASAN_OPTIONS=detect_leaks=1` | clean — it `new`s library objects, so this was checked rather than assumed |

No shell or workflow files changed, so the shellcheck/actionlint pre-flight gates are not
engaged by this diff.
