### PR TITLE
fix(#2006): report an over-cap curve SetSize as a failure

### DIFF
--- a/.github/ci/regression/curve-setsize-contract.cpp
+++ b/.github/ci/regression/curve-setsize-contract.cpp
@@ -1,0 +1,181 @@
+/*
+    File:       curve-setsize-contract.cpp
+
+    Contains:   CTest helper for CIccTagCurve::SetSize()'s return-value contract
+                and for CIccTagCurve::Read()'s handling of an over-cap on-disk
+                curveType (#2006, part 4a).
+
+    SetSize() used to answer a request above MAX_CURVE_ENTRIES the same way it
+    answered SetSize(0): free the table, set m_nSize to 0 and return true.  Those
+    two conditions mean opposite things.  Emptying a curve is a success -- a
+    zero-entry curveType is ICC.1 10.6's encoding of the identity -- while an
+    over-cap request is a refusal, and sharing one branch made the return value
+    unable to tell them apart.  Eleven places in IccXML and IccJSON ended up
+    defending against that independently -- eight compare m_nSize with the size
+    they asked for, three null-check the data pointer instead -- and three of
+    those eight only gained the guard in part 4b (#2008), having until then
+    written the parsed samples through the NULL m_Curve the branch left behind.
+
+    Two consequences are pinned here:
+
+      * SetSize() reports an over-cap request as false, and leaves any existing
+        table intact rather than destroying it on the way out.  Before 4a a
+        refused resize silently discarded a perfectly good curve and reported
+        success twice over.
+
+      * CIccTagCurve::Read() rejects a curveType whose declared count exceeds the
+        cap.  Read() has always checked SetSize()'s return, so the fix to the
+        setter is what makes that check load-bearing; previously the tag loaded
+        as a silent identity curve with its samples dropped and no error raised
+        anywhere.  curveType is the only file-driven path that can reach the cap:
+        lut8Type's tables are fixed at 256 entries, and lut16Type's counts are
+        uInt16 and already rejected above 4096 by CIccTagLut16::Read.
+
+    A declared count of 0 must keep working in both directions -- it is the
+    identity encoding, not a malformed tag -- so the zero and boundary cases are
+    checked alongside the refusal.
+
+    Exit codes:
+      0 - expected results observed
+      1 - unexpected result
+*/
+
+#include "IccIO.h"
+#include "IccTagLut.h"
+
+#include <cstdio>
+
+static int g_failures = 0;
+
+// MAX_CURVE_ENTRIES is a plain integer literal; give it the type SetSize() and
+// GetSize() actually use so none of the comparisons below is a signed/unsigned
+// mismatch under the strict warning sets CI builds with.
+static const icUInt32Number kCap = MAX_CURVE_ENTRIES;
+
+static void check(bool condition, const char* label)
+{
+  if (condition) {
+    std::fprintf(stdout, "curve-setsize-contract: PASS  %s\n", label);
+    return;
+  }
+
+  std::fprintf(stderr, "curve-setsize-contract: FAIL  %s\n", label);
+  g_failures++;
+}
+
+// Serialises a curveType tag: signature, reserved, count, then count uInt16
+// samples.  Writing through CIccIO keeps the byte order right without the test
+// having to hand-encode big-endian values.
+static bool buildCurveTag(CIccMemIO& io, icUInt32Number nCount)
+{
+  const size_t nBytes = 3 * sizeof(icUInt32Number) +
+                        (size_t)nCount * sizeof(icUInt16Number);
+
+  if (!io.Alloc(nBytes, true))
+    return false;
+
+  icTagTypeSignature sig = icSigCurveType;
+  icUInt32Number nReserved = 0;
+  icUInt32Number nSize = nCount;
+
+  if (!io.Write32(&sig) || !io.Write32(&nReserved) || !io.Write32(&nSize))
+    return false;
+
+  for (icUInt32Number i = 0; i < nCount; i++) {
+    // Ramp the samples so a dropped table is distinguishable from a read one.
+    icUInt16Number v = (icUInt16Number)(i & 0xffff);
+    if (!io.Write16(&v))
+      return false;
+  }
+
+  io.Seek(0, icSeekSet);
+  return true;
+}
+
+// Drives CIccTagCurve::Read over a synthesised tag of nCount entries and reports
+// whether the tag was accepted, along with the size the curve ended up with.
+static void readCase(icUInt32Number nCount, bool bExpectAccept,
+                     icUInt32Number nExpectSize, const char* label)
+{
+  CIccMemIO io;
+  if (!buildCurveTag(io, nCount)) {
+    std::fprintf(stderr, "curve-setsize-contract: SETUP FAIL  %s\n", label);
+    g_failures++;
+    return;
+  }
+
+  CIccTagCurve curve;
+  const bool bRead = curve.Read((icUInt32Number)io.GetLength(), &io);
+
+  check(bRead == bExpectAccept, label);
+  if (bRead == bExpectAccept)
+    check(curve.GetSize() == nExpectSize, label);
+}
+
+int main()
+{
+  // ---- SetSize(): an over-cap request is refused, and is not destructive ----
+  {
+    CIccTagCurve curve;
+    const icUInt32Number nKept = 4096;
+
+    check(curve.SetSize(nKept, icInitIdentity), "SetSize(4096) accepted");
+    check(curve.GetSize() == nKept, "SetSize(4096) sized the table");
+
+    icFloatNumber* pData = curve.GetData(0);
+    check(pData != NULL, "SetSize(4096) allocated the table");
+    const icFloatNumber vFirst = pData ? pData[0] : -1.0f;
+    const icFloatNumber vLast = pData ? pData[nKept - 1] : -1.0f;
+
+    // The refusal itself.  Before 4a this returned true.
+    check(!curve.SetSize(kCap + 1),
+          "SetSize(MAX_CURVE_ENTRIES+1) reports failure");
+
+    // ...and it must not have taken the existing table down with it.  Before 4a
+    // the curve was left empty with m_Curve NULL.
+    check(curve.GetSize() == nKept,
+          "refused SetSize left the existing size intact");
+    check(curve.GetData(0) != NULL,
+          "refused SetSize left the existing table allocated");
+    if (curve.GetData(0) != NULL) {
+      check(curve.GetData(0)[0] == vFirst && curve.GetData(0)[nKept - 1] == vLast,
+            "refused SetSize left the existing samples intact");
+    }
+  }
+
+  // ---- SetSize(): the boundary is accepted, and zero still empties ----
+  {
+    CIccTagCurve curve;
+    check(curve.SetSize(kCap),
+          "SetSize(MAX_CURVE_ENTRIES) accepted");
+    check(curve.GetSize() == kCap,
+          "SetSize(MAX_CURVE_ENTRIES) sized the table");
+
+    check(curve.SetSize(0), "SetSize(0) reports success");
+    check(curve.GetSize() == 0, "SetSize(0) emptied the table");
+    check(curve.GetData(0) == NULL, "SetSize(0) released the table");
+  }
+
+  // ---- Read(): an over-cap declared count is rejected ----
+  // Before 4a this returned true with an empty curve: SetSize() freed the table
+  // and reported success, and Read()'s `if (m_nSize)` then skipped the samples.
+  readCase(kCap + 1, false, 0,
+           "Read rejects a curveType declaring MAX_CURVE_ENTRIES+1 entries");
+
+  // ---- Read(): the boundary and the identity encoding still load ----
+  readCase(kCap, true, kCap,
+           "Read accepts a curveType declaring MAX_CURVE_ENTRIES entries");
+  readCase(0, true, 0,
+           "Read accepts a zero-entry curveType as the identity");
+  readCase(256, true, 256,
+           "Read accepts an ordinary 256-entry curveType");
+
+  if (g_failures) {
+    std::fprintf(stderr, "curve-setsize-contract: %d check(s) failed\n",
+                 g_failures);
+    return 1;
+  }
+
+  std::fprintf(stdout, "curve-setsize-contract: all checks passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2768,6 +2768,65 @@ function(iccdev_add_xml_curve_oversize_file_test)
   endif()
 endfunction()
 
+# #2006 part 4a: CIccTagCurve::SetSize() answered an over-cap request the same
+# way it answered SetSize(0) -- free the table, m_nSize = 0, return true -- so
+# the return value could not distinguish "emptied" (a success, and ICC.1 10.6's
+# identity encoding) from "refused". This pins the split contract: an over-cap
+# request now reports failure and leaves any existing table intact, and
+# CIccTagCurve::Read() consequently rejects a curveType whose declared count
+# exceeds the cap instead of loading it as a silent identity curve.
+#
+# Pure library test -- no fixtures on disk and no tool invocation -- so it needs
+# only IccProfLib and no scratch directory.
+function(iccdev_add_curve_setsize_contract_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCurveSetSizeContractTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/curve-setsize-contract.cpp"
+  )
+  target_compile_features(iccCurveSetSizeContractTest PRIVATE cxx_std_17)
+  target_include_directories(iccCurveSetSizeContractTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccCurveSetSizeContractTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccCurveSetSizeContractTest)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.curve-setsize-contract
+      COMMAND "$<TARGET_FILE:iccCurveSetSizeContractTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.curve-setsize-contract
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccCurveSetSizeContractTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.curve-setsize-contract PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;curve;setsize;regression"
+  )
+  if(WIN32)
+    set(_curve_contract_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCurveSetSizeContractTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _curve_contract_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.curve-setsize-contract PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_curve_contract_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1886: CIccMpeXmlUnknown::ToXml formatted the Reserved attribute into `line`
 # and then appended `buf`, which still held the element's type signature from the
 # icGetSigStr call above it. The value was dropped and the signature was injected
@@ -3710,6 +3769,7 @@ if(WIN32)
   iccdev_add_xml_writer_graceful_degrade_test()
   iccdev_add_xml_relaxng_validation_leak_test()
   iccdev_add_xml_curve_oversize_file_test()
+  iccdev_add_curve_setsize_contract_test()
   iccdev_add_mpexml_unknown_reserved_test()
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_proflib_exported_global_definitions_test()
@@ -3972,6 +4032,7 @@ iccdev_add_json_sparsematrix_huaf_test()
 iccdev_add_xml_writer_graceful_degrade_test()
 iccdev_add_xml_relaxng_validation_leak_test()
 iccdev_add_xml_curve_oversize_file_test()
+iccdev_add_curve_setsize_contract_test()
 iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_proflib_exported_global_definitions_test()

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -275,6 +275,16 @@ bool CIccTagCurve::Read(icUInt32Number size, CIccIO *pIO)
   if (headerSize + (icUInt64Number)nSize * sizeof(icUInt16Number) > size)
     return false;
 
+  // #2006: this is the sole file-driven path that can hand SetSize() a count
+  // above MAX_CURVE_ENTRIES -- lut8Type's tables are fixed at 256 entries, and
+  // lut16Type's counts are uInt16 and already rejected above 4096 by
+  // CIccTagLut16::Read, so only curveType's uInt32 count reaches the cap.  Now
+  // that SetSize() reports a refusal as false, this pre-existing check is what
+  // rejects such a tag.  It previously returned true with the table freed, and
+  // the `if (m_nSize)` below then skipped the sample read, so an over-cap
+  // curveType loaded as a silent identity curve and its samples were dropped
+  // with no error anywhere.  A declared count of 0 still succeeds: that is
+  // ICC.1 10.6's identity encoding, not a malformed tag.
   if (!SetSize(nSize, icInitNone))
     return false;
 
@@ -360,11 +370,10 @@ void CIccTagCurve::Describe(std::string &sDescription, int nVerboseness)
     if (nVerboseness > 75) {
       sDescription += "IN OUT\n";
 
-      // CWE-400/834: SetSize() caps m_nSize at nMaxCurveEntries and allocates
-      // m_Curve to match; assert that bound locally so the table walk has an
-      // explicit limit.
-      const icUInt32Number nMaxCurveEntries = 65536;
-      if (m_nSize > nMaxCurveEntries)
+      // CWE-400/834: SetSize() refuses a request above MAX_CURVE_ENTRIES and
+      // allocates m_Curve to match whatever it did accept; assert that bound
+      // locally so the table walk has an explicit limit.
+      if (m_nSize > MAX_CURVE_ENTRIES)
         return;
 
       for (icUInt32Number i=0; i<m_nSize; i++) {
@@ -432,11 +441,10 @@ void CIccTagCurve::DumpLut(std::string &sDescription, const icChar *szName,
 
       sDescription.reserve(sDescription.size() + m_nSize * 20);
 
-      // CWE-400/834: SetSize() caps m_nSize at nMaxCurveEntries and allocates
-      // m_Curve to match; assert that bound locally so the table walk has an
-      // explicit limit.
-      const icUInt32Number nMaxCurveEntries = 65536;
-      if (m_nSize > nMaxCurveEntries)
+      // CWE-400/834: SetSize() refuses a request above MAX_CURVE_ENTRIES and
+      // allocates m_Curve to match whatever it did accept; assert that bound
+      // locally so the table walk has an explicit limit.
+      if (m_nSize > MAX_CURVE_ENTRIES)
         return;
 
       for (i=0; i<(int)m_nSize; i++) {
@@ -480,12 +488,35 @@ bool CIccTagCurve::SetSize(icUInt32Number nSize, icTagCurveSizeInit nSizeOpt/*=i
   if (nSize==m_nSize)
     return true;
 
-  // set upper limit of 65536 table entries, to help catch errors
-  if (!nSize || nSize > 65536) {
+  // Emptying the curve is a success, not a refusal: a zero-entry curveType is
+  // ICC.1 10.6's own encoding of the identity, and nine call sites use SetSize(0)
+  // to mean "discard this table".  m_nMaxIndex is cleared with it -- Begin()
+  // recomputes it, but Apply() and Find() read it directly, so leaving the
+  // previous table's maximum index behind alongside a NULL m_Curve is a
+  // combination no caller should be able to observe.
+  if (!nSize) {
     free(m_Curve);
     m_Curve = NULL;
     m_nSize = 0;
+    m_nMaxIndex = 0;
     return true;
+  }
+  // #2006: a request above the cap is a refusal, and is now reported as one.
+  // It previously shared the branch above and inherited the `return true` that
+  // branch had earned for emptying the curve, so the return value could not
+  // distinguish "emptied" from "refused".  Eleven places in IccXML and IccJSON
+  // ended up defending against that on their own -- eight compare m_nSize with
+  // the size they asked for, three null-check the data pointer instead -- and
+  // three of those eight only gained the guard in #2008, having written the
+  // parsed samples through the NULL m_Curve this branch left behind.
+  //
+  // The existing table is deliberately left intact: a refused resize is a no-op
+  // rather than destructive, so SetSize(1024) followed by a refused
+  // SetSize(70000) no longer silently discards the 1024 entries.  Every caller
+  // that passes a non-literal size checks the return value (audited for #2006),
+  // so no caller is left writing into a table shorter than it expects.
+  else if (nSize > MAX_CURVE_ENTRIES) {
+    return false;
   }
   else {
     if (!m_Curve)
@@ -585,11 +616,10 @@ bool CIccTagCurve::IsIdentity()
     return  IsUnity(icFloatNumber(m_Curve[0]*65535.0/256.0));
   }
 
-  // CWE-400/834: SetSize() caps m_nSize at nMaxCurveEntries and allocates m_Curve
-  // to match; assert that bound locally so the table walk has an explicit upper
-  // limit.
-  const icUInt32Number nMaxCurveEntries = 65536;
-  if (m_nSize > nMaxCurveEntries)
+  // CWE-400/834: SetSize() refuses a request above MAX_CURVE_ENTRIES and allocates
+  // m_Curve to match whatever it did accept; assert that bound locally so the
+  // table walk has an explicit upper limit.
+  if (m_nSize > MAX_CURVE_ENTRIES)
     return false;
 
   icUInt32Number i;

--- a/IccProfLib/IccTagLut.h
+++ b/IccProfLib/IccTagLut.h
@@ -113,6 +113,20 @@ typedef enum {
   icInitIdentity,
 } icTagCurveSizeInit;
 
+// Upper limit on the number of entries in a curveType sampled table.  This is
+// iccDEV's own bound, not ICC.1's -- 10.6 encodes the count as a uInt32Number --
+// and it was introduced "to help catch errors" by 52720110, "Issue 1063, part 2"
+// (PR #1095).  It is not arbitrary:
+// CIccTagCurve::SetSize stores nSize-1 in m_nMaxIndex, which is an
+// icUInt16Number, so 65536 entries is exactly the largest table whose maximum
+// index still fits.  Raising it means widening m_nMaxIndex first.
+//
+// Centralised here per #2006 because the value is now load-bearing for a return
+// value rather than a local sanity check: SetSize() reports a request above it
+// as a failure, and Describe()/DumpLut()/IsIdentity() each assert the same bound
+// before walking m_Curve.  Same shape as MAX_CALC_ELEMENTS in IccMpeCalc.h.
+#define MAX_CURVE_ENTRIES 65536
+
 /**
 ****************************************************************************
 * Class: CIccTagCurve


### PR DESCRIPTION
## Summary

Part of #2006 — this is **4a**, the root-cause half. #2008 landed 4b (the crash) on
2026-08-07; this fixes the setter that all of 4b's guards were working around.

`CIccTagCurve::SetSize()` refused a request above its 65536-entry cap the same way it
honoured `SetSize(0)`: free the table, set `m_nSize` to 0 and `return true`. The two
conditions shared one branch and one return value, but they mean opposite things.
Emptying a curve is a **success** — a zero-entry `curveType` is ICC.1 10.6's encoding of
the identity, and nine call sites use `SetSize(0)` to say so. An over-cap request is a
**refusal**.

## Decisions this implements

Per @xsscx on #2006:

| Question | Ruling |
|---|---|
| Fix the setter rather than add a twelfth guard | [+1](https://github.com/InternationalColorConsortium/iccDEV/issues/2006#issuecomment-5218333471) |
| Should `Read` start rejecting an over-cap on-disk curve? | **+1 Yes** |
| Preserve the leniency locally in `Read` instead? | **+1 No** |
| *"4a is a change at one line: `:279` … rejecting when `m_nSize != nSize` is the entire fix"* | [+1](https://github.com/InternationalColorConsortium/iccDEV/issues/2006#issuecomment-5219781925) |

Those last two resolve into one change rather than two: **fixing the setter makes `Read`
correct with no edit at `:279` at all**, because `Read:278` already tests the return
value. No behaviour-code in `Read()` changes in this PR — only a comment recording that
the pre-existing check is now load-bearing.

@maxderhak and @ChrisCoxArt were added to #2006 for Insight & Discussion and have not
commented; this is deliberately marked *Part of* rather than closing the issue.

## The change

`IccProfLib/IccTagLut.cpp` — split the fused condition:

* `!nSize` keeps `return true`, and now also clears `m_nMaxIndex`. `Begin()` recomputes
  it, but `Apply()` and `Find()` read it directly, so a stale maximum index alongside a
  NULL `m_Curve` is a state no caller should be able to observe. **Not reachable today**
  — `Apply()` returns early on `!m_nSize` — so this is hygiene, not a fix for an observed
  defect.
* `nSize > MAX_CURVE_ENTRIES` returns **false**, and leaves any existing table intact.
  A refused resize becomes a no-op rather than destructive: `SetSize(1024)` followed by a
  refused `SetSize(70000)` no longer discards the 1024 entries while reporting success
  twice.

`IccProfLib/IccTagLut.h` — centralise the literal as `MAX_CURVE_ENTRIES`, replacing one
bare `65536` and three copies of a local `nMaxCurveEntries` const, on the pattern of
`MAX_CALC_ELEMENTS` (#1488). The value is **not arbitrary**: `SetSize` stores `nSize-1` in
`m_nMaxIndex`, an `icUInt16Number`, so 65536 is exactly the largest table whose maximum
index still fits. Raising the cap means widening `m_nMaxIndex` first. The header records
that so the next person does not have to re-derive it.

### Safety audit behind the non-destructive refusal

Leaving the old table on a refusal is only safe if **every** caller checks the return —
otherwise an unguarded caller writes through a valid-but-*short* buffer, which would
upgrade a NULL-deref into a heap overflow. Audited type-directed, across all three
libraries:

* no subclass overrides `CIccTagCurve::SetSize` (`CIccTagXmlCurve` and `CIccTagJsonCurve`
  both inherit it);
* every caller passing a **non-literal** size checks the return value;
* every unguarded caller passes a literal of 0, 1, 2, 3 or 256, which cannot trip the cap.

So no caller is left writing into a table shorter than it expects.

## Behaviour change, and the evidence for it

An on-disk `curveType` declaring more than 65536 entries goes from *"reads back empty,
returns true"* to *"rejected"*. Measured against two corpora rather than argued:

| Corpus | Curves | Largest | Over cap | Already emptied |
|---|---|---|---|---|
| Every `.icc` under `Testing/` (254 files) | 273 (byte scan) | 4096 | **0** | — |
| 29 shipping profiles on `registry.color.org` (108 MB) | 1356 (read back via the library) | 4096 | **0** | **0 of 1356** |

That last column is the one that matters: a byte scan alone cannot distinguish *"nothing
was over the cap"* from *"something was, and the library already ate it"*, because an
over-cap curve loads as size 0 with no error. Only reading `GetSize()` back after `Read`
separates them.

`curveType` is also the **only** file-driven path that can reach the cap — `lut8Type`'s
tables are fixed at 256 entries, and `lut16Type`'s counts are `uInt16` and already
rejected above 4096 at `IccTagLut.cpp:5671`.

## Regression coverage

Adds `iccdev.curve-setsize-contract` (`.github/ci/regression/curve-setsize-contract.cpp`),
a library-only test — no fixtures on disk, no tool invocation — registered in both CMake
call lists. It covers the refusal, its non-destructiveness, the 65536 boundary,
`SetSize(0)`, and `Read()` over synthesised `curveType` tags declaring 0, 256, 65536 and
65537 entries.

**Red/green proven** by reverting only `IccTagLut.cpp` to `d1218507` and rebuilding:
exactly four checks fail — the refusal, the retained size, the retained allocation, and
`Read`'s rejection — and all 20 pass with the fix in place.

## Pre-flight

| Lane | Result |
|---|---|
| clang 21.1.3 Release, `-Wall -Wextra -Wpedantic -Werror`, tools+tests | **0 warnings, 0 errors** |
| **GCC 15.2.0 in CI's own regression container** (`sha-547c4bed`), `-Werror` + `-DENABLE_LTO=ON` | **0 warnings, 0 errors** |
| clang ASAN+UBSAN Debug, `-Werror -g -O0` | **0 warnings, 0 errors** |
| Full CTest (Release, tools on) | **159/160** |
| New test under ASAN+UBSAN with `detect_leaks=1` | clean |
| `preflight-safety-checks.sh` | 0 failures |

Both strict lanes were confirmed genuinely strict by their configure output
(`strict warnings ENABLED (Clang 21.1.3)` / `(GNU 15.2.0)`) rather than assumed — local
`g++` is 13.3, below the floor where those flags switch on, so the GCC lane was run in
CI's container specifically to avoid reporting a silently-skipped profile as strict.

The single CTest failure is `iccdev.spectral-tiff-preview`, which fails identically on
master here: the host lacks the `imagecodecs` Python module. Unrelated to this change.
