### PR TITLE
fix(#1853): see container-size clamps and constructor guards in unbounded-profile-loop

### DIFF
--- a/.github/codeql-queries/unbounded-profile-loop.ql
+++ b/.github/codeql-queries/unbounded-profile-loop.ql
@@ -25,17 +25,64 @@ predicate isNarrowCountType(Type t) {
   t.getName().regexpMatch("(?i).*(char|short|byte|u?int(8|16)|icUInt(8|16)Number|icInt(8|16)Number).*")
 }
 
+predicate accessesField(Expr e, Field field) {
+  e.getAChild*().(FieldAccess).getTarget() = field
+}
+
+/**
+ * Holds if `condition` compares `field` directly against the size of a
+ * container - `field > v.size()`, `s.length() < field`, and so on.
+ *
+ * Clamping a loop bound to the size of the container the loop indexes is the
+ * strongest form of the check available, and strictly stronger than comparing
+ * against a hard-coded ceiling: it cannot drift when the container changes.
+ * It carries none of the tokens the text regex below looks for, though, so
+ * without this predicate such a clamp is invisible and the loop is reported as
+ * unbounded. That produced alerts #2344-#2348 on IccProfLib/IccCmmSearch.cpp,
+ * where `m_nCostApply` is clamped against three `std::vector::size()` values
+ * before use and every one of the five reports was a false positive.
+ *
+ * Matched structurally - the field on one side of a comparison, the size call
+ * on the other - rather than by widening the text regex again. A regex that
+ * merely looked for "size" anywhere in the guard would also accept a guard
+ * about some unrelated container, and text-matching is already what has made
+ * the predicate below brittle (see its macro-expansion note).
+ */
+predicate comparesFieldAgainstContainerSize(Expr condition, Field field) {
+  // RelationalOperation, deliberately not ComparisonOperation: the latter is
+  // also the superclass of EqualityOperation, so `if (m_nCount == v.size())`
+  // - a test, not a clamp, and no bound in either direction - would satisfy
+  // this and silence every loop over the field in the whole declaring type.
+  exists(RelationalOperation cmp, FunctionCall sizeCall |
+    cmp = condition.getAChild*() and
+    sizeCall.getTarget() instanceof MemberFunction and
+    sizeCall.getTarget().getName().regexpMatch("(?i)^(size|length)$")
+  |
+    accessesField(cmp.getLeftOperand(), field) and
+    sizeCall = cmp.getRightOperand().getAChild*()
+    or
+    accessesField(cmp.getRightOperand(), field) and
+    sizeCall = cmp.getLeftOperand().getAChild*()
+  )
+}
+
 predicate conditionMentionsFieldAndBound(Expr condition, Field field) {
-  condition.getAChild*().(FieldAccess).getTarget() = field and
-  // Match a guard that names a recognised upper bound. NOTE: object-like macros
-  // (e.g. #define MAX_CALC_ELEMENTS 65536) are expanded before CodeQL builds the
-  // AST, so a guard written `field >= MAX_CALC_ELEMENTS` presents here as the
-  // literal `65536`, never the macro spelling. The bare value must therefore be
-  // listed alongside the macro name. Includes the concrete caps used across the
-  // library: 65536 (MAX_CALC_ELEMENTS) and 16777215/0xffffff (the 24-bit array
-  // serialization cap) in addition to the previously-listed 4096/65535.
-  condition.getAChild*().toString().regexpMatch(
-    "(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|65536|16777215|0xffffff|MAX_CALC_ELEMENTS|kMax).*"
+  accessesField(condition, field) and
+  (
+    // Match a guard that names a recognised upper bound. NOTE: object-like macros
+    // (e.g. #define MAX_CALC_ELEMENTS 65536) are expanded before CodeQL builds the
+    // AST, so a guard written `field >= MAX_CALC_ELEMENTS` presents here as the
+    // literal `65536`, never the macro spelling. The bare value must therefore be
+    // listed alongside the macro name. Includes the concrete caps used across the
+    // library: 65536 (MAX_CALC_ELEMENTS) and 16777215/0xffffff (the 24-bit array
+    // serialization cap) in addition to the previously-listed 4096/65535.
+    condition.getAChild*().toString().regexpMatch(
+      "(?i).*(max|limit|bound|INT_MAX|icMaxEnum|4096|65535|65536|16777215|0xffffff|MAX_CALC_ELEMENTS|kMax).*"
+    )
+    or
+    // ...or a clamp against the size of the container being walked, which names
+    // no bound at all yet bounds the loop more tightly than any constant can.
+    comparesFieldAgainstContainerSize(condition, field)
   )
 }
 
@@ -51,7 +98,17 @@ predicate hasSetupBoundGuardInSameType(Field field) {
   exists(IfStmt guard, Function setup |
     setup = guard.getEnclosingFunction() and
     setup.getDeclaringType() = field.getDeclaringType() and
-    setup.getName().regexpMatch("(?i).*(open|create|init|read|validate|load|parse|set).*") and
+    (
+      // A constructor is the commonest place in this codebase to establish a
+      // field invariant, and it is the one function whose name can never match
+      // the list below - getName() returns the class name. Excluding it defeats
+      // this predicate's own purpose, and did: the clamp behind alerts
+      // #2345-#2348 sits in CIccApplyCmmSearch's constructor, so every loop
+      // reading the field from another method was reported as unguarded.
+      setup instanceof Constructor
+      or
+      setup.getName().regexpMatch("(?i).*(open|create|init|read|validate|load|parse|set).*")
+    ) and
     conditionMentionsFieldAndBound(guard.getCondition(), field)
   )
 }


### PR DESCRIPTION
Part of #1853. Does not close it — this is one item out of the harvest.

`iccdev/unbounded-profile-loop` reported five loops in `IccProfLib/IccCmmSearch.cpp`
(lines 103, 130, 194, 199, 217) as driven by an unbounded profile field. All five were
false positives, dismissed as such on 2026-08-06 as alerts #2344–#2348. The cause was in
the query, not the C++: `m_nCostApply` is clamped at construction against three
`std::vector::size()` values, is written only at `:95/:97/:99/:101`, and the containers it
was clamped against carry `push_back` only — no `clear`, `erase`, `resize` or `pop_back`
anywhere in the file. The constructor's clamp is therefore a lifetime invariant, and a
malformed profile cannot influence the iteration count at all.

This is a direct continuation of #1751 (`56c02ef4`), which scoped the guard-suppression
clauses in this same query to the enclosing function, and of `2de8b172`, which widened the
constant list for the same class of false positive.

## The two defects

**A — `conditionMentionsFieldAndBound` could only see constants.** A guard qualified only
if its *text* carried a `max`/`limit`/`bound` token or one of the known magic caps. The
clamp here reads `m_nCostApply > pCmm->m_dst_to_mid.size()` — no token, no literal — so it
was invisible, even though clamping a loop bound to the size of the container the loop
indexes is the strongest form of the check available and cannot drift when the container
changes.

Now matched structurally by a new `comparesFieldAgainstContainerSize`: the field on one
side of a `RelationalOperation`, a `size()`/`length()` **member** call on the other.
Deliberately *not* another widening of the regex — text-matching is what made this
predicate brittle in the first place (see the macro-expansion note it already carries), and
a regex looking for "size" anywhere in the guard would also accept a guard about an
unrelated container.

**B — `hasSetupBoundGuardInSameType` excluded constructors.** It required the guarding
function's name to match `open|create|init|read|validate|load|parse|set`. A constructor can
never match that — `getName()` returns the class name — yet it is the commonest place in
this codebase to establish a field invariant, and the predicate's own comment says it
exists for functions that "establish same-object field invariants before loop use".

## Validation

A synthetic probe **first**, because a query that stops flagging `IccCmmSearch.cpp` could
equally be a query that stops flagging everything; only a control that must keep firing
distinguishes those. Eight cases: the two false-positive shapes; four controls that must
keep firing (a genuinely unclamped loop; a guard mentioning `.size()` but not the loop
field; a class whose constructor establishes no invariant; a bare equality *test* against a
size, which is not a clamp); one regression control for the existing
named-setup/constant-guard path; and one precision probe, C4.

| variant | n | fires |
|---|---|---|
| current | 7 | FP1 FP2 C1 C2 C3 C4 C5 |
| B only (constructors) | **7** | unchanged — **inert on its own** |
| A only (`.size()` clamp) | 5 | FP1 C1 C2 C3 C5 |
| A + B via `ComparisonOperation` | 3 | C1 C2 C3 — **C5 wrongly suppressed** |
| **A + B via `RelationalOperation`** | **4** | C1 C2 C3 **C5** |

Two things worth flagging from that table.

It corrects my own scoping note on #1853: "both must be fixed" understated it. **B changes
nothing on its own** — the constructor's guard still fails the text regex. A is the
load-bearing half; B only becomes reachable once A can see the clamp.

And a review of an earlier revision of this branch caught a real defect in my first cut:
`ComparisonOperation` is also the superclass of `EqualityOperation`, so
`if (m_nCount == v.size())` — a test, not a clamp — satisfied the predicate and silenced
every loop over that field class-wide. `RelationalOperation` matches what the doc comment
actually claims. C5 covers it, and the five `IccCmmSearch` suppressions are identical
either way, so the correction costs the fix nothing.

**Real differential.** One CodeQL database, old query vs new. The C++ does not change, so
same-database old-vs-new is the correct comparison rather than red/green worktrees.
Database built from the tree at `800562ed` (`-DENABLE_TOOLS=OFF --target IccXML2`, clang,
593,244 LoC baseline).

```
current: 6 results   →   fixed: 1 result
suppressed:      IccCmmSearch.cpp 103, 130, 194, 199, 217   (exactly alerts #2344-#2348)
newly flagged:   none
```

The one surviving result, `IccMpeBasic.cpp:2434`, is alert #881 — already dismissed as a
false positive on separate grounds — and it is **retained**, which is what shows the query
still fires on real code.

Pre-flight was CI's own gate for this change: `codeql database analyze` with
`iccdev-security-suite.qls`, mirroring `ci-codeql-security.yml`. Clean, 11 results across
the suite, no pack or suite resolution errors. `codeql query compile` clean in-place.
`qlpack.yml` deliberately not bumped — the last five query-touching commits do not touch
it.

## What I am not fixing here, stated rather than left to be found

**A third blind spot, found while validating.** `IccMpeBasic.cpp:2434` survives because a
bound applied to a *setter argument* is invisible to a field-based guard: `:2417` clamps
the local `nSize` to `ICC_MAXCALCCURVESIZE`, and the bound reaches `m_nCount` only through
`SetSize(nSize)`. Folding a fix for that into this diff would have made the differential
above unattributable. Happy to raise it separately if you want it pursued.

**Nothing ties the sized container to the one the loop indexes.** Probe C4 clamps the field
against an unrelated member's `size()`, then indexes a different member, and is
**suppressed**. This is live in the tree, not just in the probe: the loop at `:199` is now
suppressed on the strength of the constructor clamps, yet its body indexes
`pCmm->m_src_to_mid[i]` at `:203`, and `m_src_to_mid` is **not** among the three containers
clamped at `:96-101`. That loop *is* safe — in the `m_nAttached == 2` branch the guard at
`:193` diverts before it, and in the `> 2` branch `Begin()` pushes to both containers under
`checkCmmStatus` before any apply object exists — but it is safe for control-flow reasons
the predicate cannot see, so the suppression is right by luck rather than by evidence.
Requiring the `size()` call's qualifier to be a container subscripted in the loop body would
fix this and would still clear #2344–#2348. Larger design change than the two defects scoped
here; wants its own validation pass, so I have not folded it in.

**The exemption is type-global.** `hasSetupBoundGuardInSameType` has no ordering or flow
requirement, so any qualifying guard anywhere in the type exempts the field everywhere;
accepting constructors widens that surface. Inherent to the predicate as it already stood
for named setup methods, not introduced here, but now reachable from one more place.

**There is no query-test fixture in the repo.** Nothing under `.github/codeql-queries/`
carries a `.qlref`/`.expected` pair, so nothing in CI would catch a future widening that
silenced this query outright — exactly the failure mode the probe above exists to rule out
by hand. Happy to promote the probe into a real fixture if you want that infrastructure;
it is new CI surface, so I have not added it unasked.

## Note on the result count

Zero true positives on the current tree is expected, not a sign the query is inert: all 417
historical alerts from this rule are `state=fixed` and 26 are dismissed, so there is
nothing genuinely unclamped left for it to find. That is precisely why the synthetic
controls were mandatory — a real-code count alone cannot tell "correct" from "inert".

Local CodeQL is 2.25.6; `ci-codeql-security.yml` pins the 2.24.1 bundle. Stating the skew
rather than hiding it; the query uses only long-standing classes (`RelationalOperation`,
`MemberFunction`, `Constructor`).
