### PR TITLE
ci(#2016): pin the CodeQL bundle at 2.25.6 in both installer sites

### DIFF
--- a/.github/workflows/ci-codeql-security.yml
+++ b/.github/workflows/ci-codeql-security.yml
@@ -108,9 +108,13 @@ jobs:
           unset GITHUB_TOKEN || true
           source "$TRUSTED_SCRIPTS/sanitize-sed.sh"
           if ! command -v codeql >/dev/null 2>&1; then
-            CODEQL_VER="2.24.1"
+            # CODEQL_SHA256 is the release asset digest for this exact bundle, so the
+            # two values below must always be refreshed together:
+            #   gh api repos/github/codeql-action/releases/tags/codeql-bundle-v"$CODEQL_VER" \
+            #     --jq '.assets[]|select(.name=="codeql-bundle-linux64.tar.gz").digest'
+            CODEQL_VER="2.25.6"
             CODEQL_ARCHIVE="/tmp/codeql-bundle-linux64.tar.gz"
-            CODEQL_SHA256="9767468e00a505ed022eedcf5813dd47760567a400ead7bf2519ce22f953dde1"
+            CODEQL_SHA256="55c5a760f8a98d882ce452f69c427116a034d91450c627bef717d4acd896632c"
             CODEQL_URL="https://github.com/github/codeql-action/releases/download"
             curl -fsSL --retry 3 \
               -o "${CODEQL_ARCHIVE}" \

--- a/.github/workflows/ci-preflight-safety.yml
+++ b/.github/workflows/ci-preflight-safety.yml
@@ -103,9 +103,13 @@ jobs:
           if command -v codeql >/dev/null 2>&1; then
             dirname "$(command -v codeql)" >> "$GITHUB_PATH"
           else
-            CODEQL_VER="2.24.1"
+            # Keep in lockstep with the same pin in ci-codeql-security.yml; the digest
+            # is the release asset's, so bump CODEQL_VER and CODEQL_SHA256 together:
+            #   gh api repos/github/codeql-action/releases/tags/codeql-bundle-v"$CODEQL_VER" \
+            #     --jq '.assets[]|select(.name=="codeql-bundle-linux64.tar.gz").digest'
+            CODEQL_VER="2.25.6"
             CODEQL_ARCHIVE="/tmp/codeql-bundle-linux64.tar.gz"
-            CODEQL_SHA256="9767468e00a505ed022eedcf5813dd47760567a400ead7bf2519ce22f953dde1"
+            CODEQL_SHA256="55c5a760f8a98d882ce452f69c427116a034d91450c627bef717d4acd896632c"
             CODEQL_URL="https://github.com/github/codeql-action/releases/download"
             curl -fsSL --retry 3 \
               -o "${CODEQL_ARCHIVE}" \


### PR DESCRIPTION
Part of #2016.

`ci-codeql-security.yml` pinned the 2.24.1 bundle while the CLI in use is 2.25.6.

## Two sites, not one

The issue names `ci-codeql-security.yml`, but the installer block is duplicated verbatim in `ci-preflight-safety.yml:110`. Bumping only the named file would leave the pre-flight gate resolving a different CodeQL than the gate it pre-flights for, so both move together.

| Site | Was | Now |
|---|---|---|
| `ci-codeql-security.yml:115` | 2.24.1 | 2.25.6 |
| `ci-preflight-safety.yml:110` | 2.24.1 | 2.25.6 |

## The version is half of a coupled pair

The block verifies the download with `sha256sum -c`, so `CODEQL_VER` and `CODEQL_SHA256` must move together or the step fails closed at the checksum. The new digest is the release asset own value:

```
gh api repos/github/codeql-action/releases/tags/codeql-bundle-v2.25.6 \
  --jq '.assets[]|select(.name=="codeql-bundle-linux64.tar.gz").digest'
sha256:55c5a760f8a98d882ce452f69c427116a034d91450c627bef717d4acd896632c
```

The method was validated by reproducing the outgoing pin: the same query against `codeql-bundle-v2.24.1` returns `9767468e...dde1`, matching what is in the repo today. That one-liner is now recorded in a comment at both sites, because the absence of a recorded method is what let the pin drift.

## The custom queries are not affected by the bundle change

This was the risk worth checking before bumping, given `unbounded-profile-loop.ql` changed in #2015. It does not apply, for a structural reason:

- `codeql-pack.lock.yml` pins `codeql/cpp-all` at **8.0.3**, resolved by `codeql pack install` from the registry rather than from the bundle. The 2.24.1 bundle ships **7.1.0**, so the custom queries were already running against libraries the bundle does not supply. The bump changes the evaluator, not their semantics.
- Both custom suites compile clean under 2.25.6, no errors and no warnings:
  - `iccdev-security-suite.qls`
  - `iccdev-jsonlib-suite.qls`
- Suite plumbing survives: `cpp-security-and-quality.qls` is still present at tag `codeql-cli/v2.25.6`, and the `cpp/path-injection` id that `iccdev-cpp-security-and-quality.qls` excludes is unchanged there, so the exclusion does not silently become a no-op.

## Pre-flight

Ran the CI gate itself, `preflight-safety-checks.sh --require-tools`, against `origin/master`: **failures: 0, skips: 0**. YAML parse, actionlint 1.7.12 (the pinned version), yamllint and zizmor all pass over both edited files.

## Expected, and what is not verified here

Alert movement in the **standard** suite is expected rather than a regression: `codeql/cpp-queries` advances a full generation with the bundle (bundled `cpp-all` 7.1.0 to 10.2.0). I did not measure that delta against a database locally, as it would require both 810 MB bundles plus a full build; this PR run surfaces it directly.

Incidental, not touched here: the nested `iccdev-mcp/` pack declares `codeql/python-all`, whose deps the `codeql pack install "$TRUSTED_CODEQL_QUERIES"` step does not install. Harmless today because all six of its queries are explicitly excluded from `iccdev-security-suite.qls`. Outside the scope of #2016.