### PR TITLE
fix(#2012,#2013,#2014): publish the spec tag names, keep the legacy ones readable

### DIFF
--- a/.github/ci/regression/tag-name-spelling.cpp
+++ b/.github/ci/regression/tag-name-spelling.cpp
@@ -1,0 +1,162 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression: g_icTagNameTable published ten tag names that matched neither the
+// signature nor their own siblings (#2012, #2013, #2014).
+//
+// IccTagFactory.cpp carried, among correctly-named neighbours:
+//
+//   {icSigBRDFAToB0Tag, "BRDFAToB0Tag"},   // ICC.2-2023 9.2.14-17 -> brdfAToB0Tag
+//   {icSigBRDFDToB0Tag, "BRDFDToB0Tag"},   // ICC.2-2023 9.2.26-29 -> brdfDToB0Tag
+//   {icSigHToS2Tag,     "HTSB2Tag"},       // siblings are HToS0/1/3Tag
+//   {icSigCxFTag,       "CxfTag"},         // ICC.2-2023 9.2.58    -> cxfTag
+//
+// This is not confined to human-readable dumps. g_icTagNameTable is the single
+// source for BOTH directions of the mapping and drives the XML element name and
+// the JSON key: IccProfileXml.cpp:259 and IccProfileJson.cpp:220 write through
+// GetTagSigName, IccProfileXml.cpp:743 and IccProfileJson.cpp:450 read through
+// GetTagNameSig. Because both directions consulted the same wrong entry, the old
+// behaviour was self-consistent -- a profile round-tripped fine. What was wrong
+// is the name iccDEV published to everyone else.
+//
+// The uppercase BRDF entries were internally inconsistent quite apart from the
+// specification: the brdfMToB/brdfMToS entries immediately above them in the same
+// table already map an uppercase icSigBRDFM* enum to a lowercase name, so the
+// enum spelling was never the thing being echoed.
+//
+// HToS2 is the opposite case and is deliberately NOT lowercased: that family is
+// uppercase by design, like AToB/BToA/MToB, so the correction is HToS2Tag.
+//
+// Why the fix needs a second half: renaming alone would make iccDEV unable to
+// read any XML or JSON it had previously written for these ten tags. Each old
+// name is therefore retained in g_icAltTagNameTable, which only GetTagNameSig
+// consults -- read-only, so the legacy name keeps parsing and nothing emits it
+// again. That asymmetry is the whole contract, and it is what this test pins:
+// for every corrected tag, the NEW name must be what is emitted, and BOTH names
+// must still resolve back to the signature.
+//
+// The controls matter as much as the assertions. The sibling and pre-existing
+// alias cases below fail if a careless edit lowercased a whole family or turned
+// the alias table into a catch-all, and the negative case fails if an unknown
+// name started resolving to something.
+//
+// Exit code 0 = pass, 1 = a case regressed.
+#include "IccTagFactory.h"
+
+#include <cstdio>
+#include <cstring>
+
+static int g_failures = 0;
+
+// szOld is the name this library emitted before the fix; it must remain readable
+// but must never be produced again. szNew is the corrected, published name.
+struct TagNameFix {
+  icTagSignature sig;
+  const char *szNew;
+  const char *szOld;
+  const char *szIssue;
+};
+
+static const TagNameFix kCorrected[] = {
+  {icSigBRDFAToB0Tag, "brdfAToB0Tag", "BRDFAToB0Tag", "#2013"},
+  {icSigBRDFAToB1Tag, "brdfAToB1Tag", "BRDFAToB1Tag", "#2013"},
+  {icSigBRDFAToB2Tag, "brdfAToB2Tag", "BRDFAToB2Tag", "#2013"},
+  {icSigBRDFAToB3Tag, "brdfAToB3Tag", "BRDFAToB3Tag", "#2013"},
+  {icSigBRDFDToB0Tag, "brdfDToB0Tag", "BRDFDToB0Tag", "#2013"},
+  {icSigBRDFDToB1Tag, "brdfDToB1Tag", "BRDFDToB1Tag", "#2013"},
+  {icSigBRDFDToB2Tag, "brdfDToB2Tag", "BRDFDToB2Tag", "#2013"},
+  {icSigBRDFDToB3Tag, "brdfDToB3Tag", "BRDFDToB3Tag", "#2013"},
+  {icSigHToS2Tag,     "HToS2Tag",     "HTSB2Tag",     "#2012"},
+  {icSigCxFTag,       "cxfTag",       "CxfTag",       "#2014"},
+};
+
+// Names that must NOT have moved. The brdfM* pair guards against lowercasing
+// having been applied to the whole BRDF block; the HToS siblings guard against
+// HToS2 having been "corrected" downwards into lowercase along with it.
+static const TagNameFix kUnchanged[] = {
+  {icSigBRDFMToB0Tag, "brdfMToB0Tag", NULL, "sibling"},
+  {icSigBRDFMToS0Tag, "brdfMToS0Tag", NULL, "sibling"},
+  {icSigHToS0Tag,     "HToS0Tag",     NULL, "sibling"},
+  {icSigHToS1Tag,     "HToS1Tag",     NULL, "sibling"},
+  {icSigHToS3Tag,     "HToS3Tag",     NULL, "sibling"},
+  {icSigCicpTag,      "cicpTag",      NULL, "sibling"},
+};
+
+static void expectEmitted(const TagNameFix &fix)
+{
+  const icChar *szGot = CIccTagCreator::GetTagSigName(fix.sig);
+
+  if (!szGot) {
+    printf("FAIL [%s emit %s]: GetTagSigName returned NULL\n",
+           fix.szIssue, fix.szNew);
+    g_failures++;
+    return;
+  }
+  if (strcmp(szGot, fix.szNew) != 0) {
+    printf("FAIL [%s emit]: GetTagSigName gave \"%s\", expected \"%s\"\n",
+           fix.szIssue, szGot, fix.szNew);
+    g_failures++;
+    return;
+  }
+  printf("ok   [%s emit]: %s\n", fix.szIssue, szGot);
+}
+
+static void expectResolves(const char *szCase, const char *szName,
+                           icTagSignature sigExpected)
+{
+  icTagSignature sigGot = CIccTagCreator::GetTagNameSig(szName);
+
+  if (sigGot != sigExpected) {
+    printf("FAIL [%s]: \"%s\" resolved to 0x%08X, expected 0x%08X\n",
+           szCase, szName, (unsigned)sigGot, (unsigned)sigExpected);
+    g_failures++;
+    return;
+  }
+  printf("ok   [%s]: \"%s\" -> 0x%08X\n", szCase, szName, (unsigned)sigGot);
+}
+
+int main()
+{
+  const size_t nCorrected = sizeof(kCorrected) / sizeof(kCorrected[0]);
+  const size_t nUnchanged = sizeof(kUnchanged) / sizeof(kUnchanged[0]);
+
+  // 1 -- the corrected name is what gets published, in XML, JSON and dumps.
+  for (size_t i = 0; i < nCorrected; i++)
+    expectEmitted(kCorrected[i]);
+
+  // 2 -- the corrected name reads back, so newly written documents load.
+  for (size_t i = 0; i < nCorrected; i++)
+    expectResolves("new-name reads", kCorrected[i].szNew, kCorrected[i].sig);
+
+  // 3 -- the legacy name still reads, so documents this library wrote before the
+  // fix -- including .github/ci/test-data/zxml-plaintext-1853.xml, which carries
+  // a literal <CxfTag> element -- keep loading.
+  for (size_t i = 0; i < nCorrected; i++)
+    expectResolves("legacy alias reads", kCorrected[i].szOld, kCorrected[i].sig);
+
+  // 4 -- controls: neighbouring names must be exactly where they were.
+  for (size_t i = 0; i < nUnchanged; i++) {
+    expectEmitted(kUnchanged[i]);
+    expectResolves("sibling reads", kUnchanged[i].szNew, kUnchanged[i].sig);
+  }
+
+  // 5 -- the alias table predates this fix and must still work; if adding ten
+  // entries had disturbed it, this is what notices.
+  expectResolves("pre-existing alias", "materialTypeArrayTag",
+                 icSigMultiplexTypeArrayTag);
+  expectResolves("pre-existing alias", "materialDefaultValuesTag",
+                 icSigMultiplexDefaultValuesTag);
+
+  // 6 -- a name in neither table must still be unknown. Guards against the alias
+  // lookup degrading into something that answers for anything.
+  expectResolves("unknown stays unknown", "notATagNameTag", icSigUnknownTag);
+
+  if (g_failures) {
+    printf("\n%d tag-name case(s) regressed\n", g_failures);
+    return 1;
+  }
+
+  printf("\nall tag-name cases passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2827,6 +2827,60 @@ function(iccdev_add_curve_setsize_contract_test)
   endif()
 endfunction()
 
+# #2012/#2013/#2014: g_icTagNameTable published ten tag names matching neither
+# the signature nor their siblings. The table drives the XML element name and the
+# JSON key in both directions, so the corrected name must be the one emitted while
+# the legacy name keeps resolving through the read-only g_icAltTagNameTable.
+# Links IccProfLib only -- the contract is the factory mapping, not a round-trip.
+function(iccdev_add_tag_name_spelling_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccTagNameSpellingTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/tag-name-spelling.cpp"
+  )
+  target_compile_features(iccTagNameSpellingTest PRIVATE cxx_std_17)
+  target_include_directories(iccTagNameSpellingTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccTagNameSpellingTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccTagNameSpellingTest)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.tag-name-spelling
+      COMMAND "$<TARGET_FILE:iccTagNameSpellingTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.tag-name-spelling
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccTagNameSpellingTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.tag-name-spelling PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;tagfactory;naming;regression"
+  )
+  if(WIN32)
+    set(_tag_name_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccTagNameSpellingTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _tag_name_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.tag-name-spelling PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_tag_name_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1886: CIccMpeXmlUnknown::ToXml formatted the Reserved attribute into `line`
 # and then appended `buf`, which still held the element's type signature from the
 # icGetSigStr call above it. The value was dropped and the signature was injected
@@ -3770,6 +3824,7 @@ if(WIN32)
   iccdev_add_xml_relaxng_validation_leak_test()
   iccdev_add_xml_curve_oversize_file_test()
   iccdev_add_curve_setsize_contract_test()
+  iccdev_add_tag_name_spelling_test()
   iccdev_add_mpexml_unknown_reserved_test()
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_proflib_exported_global_definitions_test()
@@ -4033,6 +4088,7 @@ iccdev_add_xml_writer_graceful_degrade_test()
 iccdev_add_xml_relaxng_validation_leak_test()
 iccdev_add_xml_curve_oversize_file_test()
 iccdev_add_curve_setsize_contract_test()
+iccdev_add_tag_name_spelling_test()
 iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_proflib_exported_global_definitions_test()

--- a/IccProfLib/IccTagFactory.cpp
+++ b/IccProfLib/IccTagFactory.cpp
@@ -115,14 +115,19 @@ icSigNamePair g_icTagNameTable[] = {
   {icSigBRDFMToS1Tag, "brdfMToS1Tag"},
   {icSigBRDFMToS2Tag, "brdfMToS2Tag"},
   {icSigBRDFMToS3Tag, "brdfMToS3Tag"},
-  {icSigBRDFAToB0Tag, "BRDFAToB0Tag"},
-  {icSigBRDFAToB1Tag, "BRDFAToB1Tag"},
-  {icSigBRDFAToB2Tag, "BRDFAToB2Tag"},
-  {icSigBRDFAToB3Tag, "BRDFAToB3Tag"},
-  {icSigBRDFDToB0Tag, "BRDFDToB0Tag"},
-  {icSigBRDFDToB1Tag, "BRDFDToB1Tag"},
-  {icSigBRDFDToB2Tag, "BRDFDToB2Tag"},
-  {icSigBRDFDToB3Tag, "BRDFDToB3Tag"},
+  // ICC.2-2023 9.2.14-17 and 9.2.26-29 spell these brdfAToB0Tag..brdfDToB3Tag.  The
+  // uppercase BRDF here was inconsistent with the brdfMToB/brdfMToS entries directly
+  // above, which already map an uppercase icSigBRDFM* enum to a lowercase name; the
+  // enum spelling is unrelated to the emitted name.  Legacy names read via
+  // g_icAltTagNameTable.
+  {icSigBRDFAToB0Tag, "brdfAToB0Tag"},
+  {icSigBRDFAToB1Tag, "brdfAToB1Tag"},
+  {icSigBRDFAToB2Tag, "brdfAToB2Tag"},
+  {icSigBRDFAToB3Tag, "brdfAToB3Tag"},
+  {icSigBRDFDToB0Tag, "brdfDToB0Tag"},
+  {icSigBRDFDToB1Tag, "brdfDToB1Tag"},
+  {icSigBRDFDToB2Tag, "brdfDToB2Tag"},
+  {icSigBRDFDToB3Tag, "brdfDToB3Tag"},
   {icSigSurfaceMapTag, "surfaceMapTag"},
   {icSigBToA0Tag, "BToA0Tag"},
   {icSigBToA1Tag, "BToA1Tag"},
@@ -159,7 +164,11 @@ icSigNamePair g_icTagNameTable[] = {
   {icSigGreenTRCTag, "greenTRCTag"},
   {icSigHToS0Tag, "HToS0Tag"},
   {icSigHToS1Tag, "HToS1Tag"},
-  {icSigHToS2Tag, "HTSB2Tag"},
+  // "HTSB2Tag" matched neither the signature ('H2S2') nor the three siblings around
+  // it.  This family is uppercase by design, like AToB/BToA/MToB, so the correction is
+  // to HToS2Tag rather than to a lowercase spelling.  Legacy name reads via
+  // g_icAltTagNameTable.
+  {icSigHToS2Tag, "HToS2Tag"},
   {icSigHToS3Tag, "HToS3Tag"},
   {icSigLuminanceTag, "luminanceTag"},
   {icSigMeasurementTag, "measurementTag"},
@@ -207,7 +216,10 @@ icSigNamePair g_icTagNameTable[] = {
   {icSigOutputResponseTag, "outputResponseTag"},
   {icSigPerceptualRenderingIntentGamutTag, "perceptualRenderingIntentGamutTag"},
   {icSigSaturationRenderingIntentGamutTag, "saturationRenderingIntentGamutTag"},
-  {icSigCxFTag, "CxfTag"},
+  // ICC.2-2023 9.2.58 spells this cxfTag; CxF is the format name, not the tag name, and
+  // the neighbouring v5 entries are all lowercase-initial.  Legacy name reads via
+  // g_icAltTagNameTable.
+  {icSigCxFTag, "cxfTag"},
   {icSigSpectralDataInfoTag, "spectralDataInfoTag"},
   {icSigSpectralWhitePointTag, "spectralWhitePointTag"},
   {icSigCustomToStandardPccTag, "customToStandardPccTag"},
@@ -227,9 +239,23 @@ icSigNamePair g_icTagNameTable[] = {
 };
 
 icSigNamePair g_icAltTagNameTable[] = {
-  // Legacy names for backward compatibility with older XML/JSON files
+  // Legacy names for backward compatibility with older XML/JSON files.  Only
+  // GetTagNameSig consults this table, so entries here are read-only: a document that
+  // still carries the old name keeps loading, while nothing writes it again.
   {icSigMultiplexTypeArrayTag, "materialTypeArrayTag"},
   {icSigMultiplexDefaultValuesTag, "materialDefaultValuesTag"},
+  // Names corrected in the main table above; every one of these was previously emitted
+  // by this library, so dropping them would make iccDEV unable to read its own output.
+  {icSigBRDFAToB0Tag, "BRDFAToB0Tag"},
+  {icSigBRDFAToB1Tag, "BRDFAToB1Tag"},
+  {icSigBRDFAToB2Tag, "BRDFAToB2Tag"},
+  {icSigBRDFAToB3Tag, "BRDFAToB3Tag"},
+  {icSigBRDFDToB0Tag, "BRDFDToB0Tag"},
+  {icSigBRDFDToB1Tag, "BRDFDToB1Tag"},
+  {icSigBRDFDToB2Tag, "BRDFDToB2Tag"},
+  {icSigBRDFDToB3Tag, "BRDFDToB3Tag"},
+  {icSigHToS2Tag, "HTSB2Tag"},
+  {icSigCxFTag, "CxfTag"},
   {(icTagSignature)0,""},
 };
 


### PR DESCRIPTION
Part of #2012, part of #2013, part of #2014.

`g_icTagNameTable` published ten tag names that matched neither the signature nor their own siblings.

| Was | Now | Authority | Issue |
|---|---|---|---|
| `BRDFAToB0Tag`..`BRDFAToB3Tag` | `brdfAToB0Tag`..`brdfAToB3Tag` | ICC.2-2023 9.2.14-17 | #2013 |
| `BRDFDToB0Tag`..`BRDFDToB3Tag` | `brdfDToB0Tag`..`brdfDToB3Tag` | ICC.2-2023 9.2.26-29 | #2013 |
| `HTSB2Tag` | `HToS2Tag` | siblings `HToS0/1/3Tag`, sig `H2S2` | #2012 |
| `CxfTag` | `cxfTag` | ICC.2-2023 9.2.58 | #2014 |

One defect, one table, adjacent lines. Three separate PRs would serialise three edits to the same lines for no benefit, so they are fixed together; the closing keyword is deliberately omitted so each issue can be closed on its own assessment.

## Not just dumps

`g_icTagNameTable` is the single source for **both** directions and drives the XML element name and the JSON key. Writers: `IccProfileXml.cpp:259`, `IccProfileJson.cpp:220`. Readers: `IccProfileXml.cpp:743`, `IccProfileJson.cpp:450`. Because both directions consulted the same wrong entry the old behaviour was self-consistent and profiles round-tripped, so nothing ever failed -- what was wrong is the name iccDEV published to everyone else.

## Why these spellings

The uppercase BRDF entries were inconsistent quite apart from the specification: the `brdfMToB`/`brdfMToS` entries immediately above them in the same table already map an uppercase `icSigBRDFM*` enum to a lowercase name, so the enum spelling was never the thing being echoed.

`HToS2` is the opposite case and is deliberately **not** lowercased. That family is uppercase by design, like `AToB`/`BToA`/`MToB`, so the correction is `HToS2Tag`, not `hToS2Tag`.

The `icSig*` enum constants are untouched. The other hits across `IccCmm.cpp`, `IccProfile.cpp` and `IccTagMPE.cpp` are enum identifiers, not strings, so tag dispatch and validation are unaffected.

## The compatibility half

Renaming alone would make iccDEV unable to read any XML or JSON it had already written for these ten tags. Each old name is therefore retained in `g_icAltTagNameTable`, which only `GetTagNameSig` consults -- read-only, so the legacy name keeps parsing and nothing emits it again. The table already worked this way for `materialTypeArrayTag` and `materialDefaultValuesTag`; this uses the existing mechanism rather than inventing one.

## Evidence

**End to end, both surfaces.** `.github/ci/test-data/zxml-plaintext-1853.xml` carries a literal `<CxfTag>` element:

- `iccFromXml` still parses it, through the alias
- `iccToXml` now writes the profile back as `<cxfTag>`
- `iccToJson` emits `"cxfTag"`, and `iccFromJson` reads it back

**New CTest `iccdev.tag-name-spelling`**, registered at both call sites in `Build/Cmake/Testing/CMakeLists.txt`. It pins the asymmetry that is the actual contract: for all ten tags the corrected name must be emitted, and *both* names must resolve to the signature. Controls cover the untouched siblings, the two pre-existing aliases, and an unknown name that must stay unknown.

Red against the unfixed library: **20 assertions fail** (10 emit + 10 new-name reads). Green after.

**Full suite:** 160/161. The single failure is `iccdev.spectral-tiff-preview`, `ModuleNotFoundError: No module named 'imagecodecs'` -- a missing local Python package, unrelated to this change.

**Pre-flight:** `preflight-safety-checks.sh --require-tools` against `origin/master` -- failures: 0, skips: 0.

## Noted, not fixed here

`GetTagNameSig` (`IccTagFactory.cpp:534`) folds both tables into one map with `operator[]`, primary first and alias second, so an alias would silently override a primary entry of the same name. There are **no collisions today** -- verified across both tables, zero duplicate names and zero alias-vs-primary clashes -- so this is latent, and it is pre-existing rather than introduced here. It is worth raising because this PR grows the alias table from 2 to 12 entries and establishes it as the home for future renames: a later rename that parks an old name which is also the current published name of a different tag would misresolve with no build or test failure. A one-line `insert` instead of `operator[]`, or a startup assert, would close it. Left out to keep this PR to the three issues -- happy to file or fix separately.

Also out of scope: the "Related Scope Gap" raised in #2014, that iccDEV has no `brdfBToA*`/`brdfBToD*` signatures at all. That is a missing-feature issue, not a naming one.