### PR TITLE
fix(#2024): search published tag names before legacy aliases in GetTagNameSig

### DIFF
--- a/.github/ci/regression/tag-name-spelling.cpp
+++ b/.github/ci/regression/tag-name-spelling.cpp
@@ -102,6 +102,24 @@ static void expectEmitted(const TagNameFix &fix)
   printf("ok   [%s emit]: %s\n", fix.szIssue, szGot);
 }
 
+// A legacy name must stay readable without ever becoming the published name of the
+// tag it resolves to. Resolving the alias and asking what that signature emits is
+// the whole check: if the two ever agree, the entry has stopped being an alias.
+static void expectNotEmitted(const char *szAlias)
+{
+  icTagSignature sig = CIccTagCreator::GetTagNameSig(szAlias);
+  const icChar *szEmitted = CIccTagCreator::GetTagSigName(sig);
+
+  if (szEmitted && strcmp(szEmitted, szAlias) == 0) {
+    printf("FAIL [alias not emitted]: \"%s\" is the published name of 0x%08X\n",
+           szAlias, (unsigned)sig);
+    g_failures++;
+    return;
+  }
+  printf("ok   [alias not emitted]: \"%s\" emits as \"%s\"\n",
+         szAlias, szEmitted ? szEmitted : "(none)");
+}
+
 static void expectResolves(const char *szCase, const char *szName,
                            icTagSignature sigExpected)
 {
@@ -151,6 +169,21 @@ int main()
   // 6 -- a name in neither table must still be unknown. Guards against the alias
   // lookup degrading into something that answers for anything.
   expectResolves("unknown stays unknown", "notATagNameTag", icSigUnknownTag);
+
+  // 7 -- no alias may also be the published name of a tag. GetTagNameSig searches
+  // the published names first and the legacy names only on a miss, so a legacy
+  // entry that collides with a live name is unreachable: the lookup answers with
+  // the published tag and the alias silently does nothing. That is the failure
+  // this asserts against, and it is the reason the two tables are searched in
+  // sequence rather than merged into one map. Checking it through the public API
+  // -- rather than by walking the tables -- is deliberate: g_icTagNameTable and
+  // g_icAltTagNameTable do have external linkage, but they appear in no public
+  // header and carry no ICCPROFLIB_API marking, so they are not exported from the
+  // shared library and an extern declaration here would fail to link on MSVC.
+  for (size_t i = 0; i < nCorrected; i++)
+    expectNotEmitted(kCorrected[i].szOld);
+  expectNotEmitted("materialTypeArrayTag");
+  expectNotEmitted("materialDefaultValuesTag");
 
   if (g_failures) {
     printf("\n%d tag-name case(s) regressed\n", g_failures);

--- a/IccProfLib/IccTagFactory.cpp
+++ b/IccProfLib/IccTagFactory.cpp
@@ -85,6 +85,10 @@ static icTagSigToNameMap g_TagSigToNameMap;
 
 typedef std::map<std::string, icTagSignature> icTagNameToSigMap;
 static icTagNameToSigMap g_TagNameToSigMap;
+//Legacy names are kept in their own map, consulted only after the published names miss,
+//so an alias can never shadow the current name of a different tag.  This mirrors
+//g_AltTagTypeNameToSigMap and GetTagTypeNameSig below, which already work this way.
+static icTagNameToSigMap g_AltTagNameToSigMap;
 
 typedef struct {
   icTagSignature sig;
@@ -531,11 +535,21 @@ icTagSignature CIccSpecTagFactory::GetTagNameSig(const icChar *szName)
   if (g_TagNameToSigMap.empty()) {
     for (int i = 0; g_icTagNameTable[i].sig; i++)
       g_TagNameToSigMap[g_icTagNameTable[i].szName] = g_icTagNameTable[i].sig;
-    for (int i = 0; g_icAltTagNameTable[i].sig; i++)
-      g_TagNameToSigMap[g_icAltTagNameTable[i].szName] = g_icAltTagNameTable[i].sig;
   }
   icTagNameToSigMap::iterator sig = g_TagNameToSigMap.find(szName);
   if (sig != g_TagNameToSigMap.end())
+    return sig->second;
+
+  //Allow conversion from alternate names (backwards compatibility with earlier versions).
+  //Folding both tables into one map let a legacy entry overwrite a published one of the
+  //same name, because the alias loop ran second and operator[] assigns unconditionally.
+  //Searching the published names first makes that impossible rather than merely unlikely.
+  if (g_AltTagNameToSigMap.empty()) {
+    for (int i = 0; g_icAltTagNameTable[i].sig; i++)
+      g_AltTagNameToSigMap[g_icAltTagNameTable[i].szName] = g_icAltTagNameTable[i].sig;
+  }
+  sig = g_AltTagNameToSigMap.find(szName);
+  if (sig != g_AltTagNameToSigMap.end())
     return sig->second;
 
   return icSigUnknownTag;


### PR DESCRIPTION
Fixes #2024.

`GetTagNameSig` folded `g_icTagNameTable` and `g_icAltTagNameTable` into a single
map -- primaries first, aliases second, both with `operator[]`. Because
`operator[]` assigns unconditionally, a legacy entry whose name matched a
published name overwrote it, and the lookup then answered with the legacy tag.
`IccProfileXml.cpp:743` and `IccProfileJson.cpp:450` both read through this
function, so a shadowed name means an XML element or JSON key parses into the
wrong tag. Nothing reports it: the build succeeds, every existing test passes,
and the alias simply wins.

## Latent today, not active

Measured across both tables on `84c9c1b7`: 130 published names, 12 aliases, all
distinct -- **zero** alias-vs-published collisions and zero duplicate published
names. So this is latent, and pre-existing rather than introduced by #2023.

It is worth closing now because #2012/#2013/#2014 grew the alias table from 2
entries to 12 and made it the home for future renames. That is exactly the
change that makes a collision plausible: a later rename parking an old name that
is also the current published name of a *different* tag would misresolve, with
no build or test failure.

## The fix is an existing pattern, not a new one

`GetTagTypeNameSig` (`IccTagFactory.cpp:557-580`), twenty lines below, has always
kept its legacy names in a separate `g_AltTagTypeNameToSigMap` and consults it
only after the published names miss. This change gives `GetTagNameSig` the same
shape, so shadowing becomes structurally impossible rather than merely unlikely,
and the alias map is not built at all in the common case.

This is a better fix than the one-line `insert()` I floated in #2023's body:
`insert()` would still depend on the two loops running in the right order.

## Red/green

Behaviour is identical for every name in the tables today, so the test cannot
show a difference without a collision. I introduced one temporarily -- a legacy
entry named `cicpTag`, the published name of a different tag:

| lookup form | `GetTagNameSig("cicpTag")` | test |
|---|---|---|
| merged map (before) | `0x43784620` (`CxF `) -- alias shadowed the live tag | **exit 1** |
| published-first (after) | `0x63696370` (`cicp`) | exit 0 |

The case that caught it is the existing `sibling reads` control. The collision
was reverted before commit; it is not in this diff.

## What ships in the test

One invariant added to `iccdev.tag-name-spelling`: no legacy name may also be the
published name of the tag it resolves to -- i.e. an alias must never be
simultaneously live. It is checked through the public API rather than by walking
the tables: `g_icTagNameTable` and `g_icAltTagNameTable` do have external
linkage, but they appear in no public header and carry no `ICCPROFLIB_API`
marking, so they are not exported from the shared library and an `extern`
declaration in the test would fail to link on MSVC.

To be precise about coverage, since the two guard different things: this new
assertion catches an alias that is also live for the *same* tag; a cross-tag
collision like the one used above is caught by the sibling controls.

## Pre-flight

| lane | result |
|---|---|
| clang 21.1.3 Release, `-Wall -Wextra -Wpedantic -Werror` (`strict warnings ENABLED`) | 0 warnings, 0 errors |
| GCC 15.2.0 + LTO, in CI's own regression container (`strict warnings ENABLED`) | 0 warnings, 0 errors |
| ASAN+UBSAN Debug, `detect_leaks=1` | clean, exit 0 |
| full ctest | 160/161 |

CI's gate is `grep -cE 'warning:' build.log` = 0, run on both strict lanes above.
The single ctest failure is `iccdev.spectral-tiff-preview`,
`ModuleNotFoundError: No module named 'imagecodecs'` -- a missing local Python
package, unrelated to this change.

`detect_leaks=1` was used deliberately because CI's ctest environment sets
`detect_leaks=0`; this change adds a lazily-populated global map, which is where
a leak would hide.

No CMake change: `iccdev.tag-name-spelling` is already registered at both call
sites from #2023, and only the test body changed.
