### PR TITLE
fix(#2011): label the BT.2100 PQ fixtures as PQ, and pin it with a CTest

### DIFF
--- a/.github/ci/test-data/ub-cicp-colorprimaries-1346.xml
+++ b/.github/ci/test-data/ub-cicp-colorprimaries-1346.xml
@@ -219,7 +219,11 @@
 	</XYZArrayType> </mediaWhitePointTag>
 
     <cicpTag> <cicpType>
-      <cicpFields ColorPrimaries="-1" TransferCharacteristics="18" MatrixCoefficients="0" VideoFullRangeFlag="1"/>
+      <!-- ColorPrimaries="-1" is this PoC's deliberate defect (#1346). Everything
+           else has to stay a faithful copy of the BT2100PQFullScene donor, so
+           TransferCharacteristics tracks the donor's correction to 16, ST 2084
+           (PQ), per ITU-T H.273 Table 3. Nothing in the regression reads it. -->
+      <cicpFields ColorPrimaries="-1" TransferCharacteristics="16" MatrixCoefficients="0" VideoFullRangeFlag="1"/>
     </cicpType> </cicpTag>
 
 	<copyrightTag> <multiLocalizedUnicodeType>

--- a/.github/scripts/iccdev-issue-2011-hdr-cicp-transfer-regression.sh
+++ b/.github/scripts/iccdev-issue-2011-hdr-cicp-transfer-regression.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+###############################################################################
+# iccDEV issue #2011
+#   BT.2100 fixtures must declare the cicp TransferCharacteristics that matches
+#   the transfer function they actually encode
+###############################################################################
+#
+# All four Testing/HDR/BT2100PQ*.xml declared TransferCharacteristics="18" while
+# carrying the SMPTE ST 2084 constants in their FormulaSegments.  Per ITU-T
+# H.273 Table 3, 18 is ARIB STD-B67 (HLG); ST 2084 (PQ) is 16.  The curve maths
+# was right and the label was wrong, so the fixtures were internally
+# inconsistent -- and these files exist to be read as worked examples of a PQ
+# profile's cicpTag, which is exactly the field that lied.
+#
+# The cicp code point was not the only claim that was wrong.  Three of the four
+# also carried "BT.2100 HLG ..." in their profileDescriptionTag.  Both fields
+# were copied from the HLG siblings the PQ fixtures were derived from, which is
+# what makes them one defect rather than two: the same wrong answer in the field
+# a CMM reads and in the field a person reads.  The two are asserted separately
+# below, because they did not break together -- BT2100PQFullScene.xml had a
+# correct description and a wrong code point, and it is the file the CI
+# regressions happen to use, which is part of why this survived.
+#
+# Nothing in iccDEV noticed, and the reason is narrower than "no cross-check":
+# CIccTagCicp::Validate (IccProfLib/IccTagBasic.cpp) reads m_nMatrixCoefficients
+# against the profile's colour space and nothing else.  It never inspects
+# m_nTransferCharacteristics at all, at any value.  So all ten Testing/HDR
+# fixtures reported "Profile is valid for version 5.10" before the correction
+# and report it after, with byte-identical validation output.  A range check
+# would not have helped either: 18 is a perfectly legal code point, just not
+# this profile's.  Only a consistency check catches this shape, and that check
+# does not exist in the library -- so this test supplies it for the corpus.
+#
+# WHAT IS ASSERTED.  For every tracked XML carrying a recognisable BT.2100
+# transfer function, both of its claims about that curve must agree with the
+# constants present in the document:
+#
+#   ST 2084 (PQ)      m1 = 0.1593017578125  (2610/16384)  -> 16, "BT.2100 PQ"
+#   ARIB STD-B67 HLG  a  = 0.17883277                     -> 18, "BT.2100 HLG"
+#
+# The classification keys on the curve constants rather than on the file name,
+# so a fixture renamed or copied under a misleading name is still judged by what
+# it encodes -- which is the whole point, since the file names here were the one
+# thing that was right.  Files carrying neither constant family are skipped
+# rather than failed: this test pins BT.2100 fixtures, not every profile with a
+# cicpTag.  Files carrying both are a failure -- that is an ambiguous document,
+# not a passing one.  A fixture with no cicpTag is still description-checked;
+# the two SceneToDisplayLink fixtures are that case.
+#
+# ROUND TRIP.  Where iccFromXml accepts the document, the corrected value is
+# also asserted after XML -> ICC -> XML.  A cicp code point that were dropped or
+# narrowed on the way through would satisfy a text-only check while the profile
+# a consumer actually opens still carried the wrong number.
+#
+# CONTROLS.  A text check that stopped matching -- a constant reformatted, an
+# attribute or a description reworded -- would pass silently on every fixture
+# forever, so each half of the defect is reintroduced into a copy and must be
+# caught: one copy with TransferCharacteristics put back to 18, one described
+# again as "BT.2100 HLG".  They are separate because the two claims broke
+# independently.  If either control is reported consistent, the assertions above
+# are not testing anything and this script exits non-zero on that basis alone.
+#
+# Environment variables (set by the CTest harness):
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools/
+#   ICCDEV_TEST_OUTDIR -- output directory for generated artifacts / logs
+#
+# Exit codes:
+#   0 - pass (or skipped cleanly)
+#   2 - regression detected
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-2011}"
+mkdir -p "$OUTDIR"
+
+# The tools are optional here.  The core assertion is about document content and
+# needs nothing built; only the round-trip half is skipped when they are absent,
+# which keeps this test useful in a checkout-only job.
+FROMXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccFromXml -type f 2>/dev/null | head -1)"
+TOXML="$(find "$TOOLS_DIR" -maxdepth 2 -name iccToXml -type f 2>/dev/null | head -1)"
+
+status=0
+
+# ITU-T H.273 Table 3 code points, and the constant that identifies each curve.
+# The PQ probe is m1 = 2610/16384 and the HLG probe is the ARIB STD-B67 'a'.
+# Both are long enough to be unambiguous and appear in every fixture of their
+# family, in the forward transfer function and again in its inverse.
+PQ_CONST='0\.1593017578125'
+HLG_CONST='0\.17883277'
+PQ_TC=16
+HLG_TC=18
+
+# classify <file>
+# Echoes the TransferCharacteristics the document's curve content requires, or
+# an empty string when the file is not a BT.2100 fixture.  Echoes "AMBIGUOUS"
+# when a document somehow carries both families.
+classify() {
+  local f="$1" pq hlg
+  pq=$(grep -c "$PQ_CONST" "$f" 2>/dev/null || true)
+  hlg=$(grep -c "$HLG_CONST" "$f" 2>/dev/null || true)
+  if [ "$pq" -gt 0 ] && [ "$hlg" -gt 0 ]; then echo "AMBIGUOUS"
+  elif [ "$pq" -gt 0 ]; then echo "$PQ_TC"
+  elif [ "$hlg" -gt 0 ]; then echo "$HLG_TC"
+  else echo ""
+  fi
+}
+
+# declared_tc <file>
+# Echoes the TransferCharacteristics attribute value, or "" when there is no
+# cicpFields element at all.  The two SceneToDisplayLink fixtures are BT.2100
+# curves with no cicpTag, and that is legitimate -- a link profile has no device
+# encoding to describe -- so they land here and are skipped, not failed.
+declared_tc() {
+  sed -n 's/.*<cicpFields[^>]*TransferCharacteristics="\([0-9]*\)".*/\1/p' "$1" 2>/dev/null | head -1
+}
+
+# declared_curve_name <file>
+# Echoes "PQ" or "HLG" as named in the profileDescriptionTag, or "" when the
+# description names neither.  The cicp code point was not the only place these
+# fixtures claimed to be HLG: three of the four PQ files also carried an HLG
+# profileDescriptionTag, copied wholesale from their HLG siblings, which is the
+# same defect in the field a human reads instead of the field a CMM reads.
+# The corpus spells the same thing several ways -- "BT.2100 PQ ...",
+# "Rec. 2100 RGB with Hlg", "Algorithmic Rec. 2100 RGB with HLG" -- so the
+# curve name is matched as a standalone word anywhere in the description rather
+# than against one phrasing.  A description naming both, or neither, yields ""
+# and is not judged: only an unambiguous claim can be wrong.
+declared_curve_name() {
+  local d hlg pq
+  d=$(sed -n 's/.*CDATA\[\([^]]*\)\].*/\1/p' "$1" 2>/dev/null | head -1)
+  hlg=$(printf '%s' "$d" | grep -ciE '(^|[^A-Za-z])hlg([^A-Za-z]|$)' || true)
+  pq=$(printf '%s' "$d" | grep -ciE '(^|[^A-Za-z])pq([^A-Za-z]|$)' || true)
+  if [ "$hlg" -gt 0 ] && [ "$pq" -eq 0 ]; then echo "HLG"
+  elif [ "$pq" -gt 0 ] && [ "$hlg" -eq 0 ]; then echo "PQ"
+  else echo ""
+  fi
+}
+
+# check_one <label> <file> -- returns 0 when consistent, 1 when it is not,
+# and 0 with a [SKIP] line when the file is out of scope.
+check_one() {
+  local label="$1" f="$2" want got name wantname rc=0
+  want=$(classify "$f")
+  got=$(declared_tc "$f")
+
+  if [ "$want" = "AMBIGUOUS" ]; then
+    echo "[FAIL] $label -- carries both ST 2084 and ARIB STD-B67 constants"
+    return 1
+  fi
+  if [ -z "$want" ]; then
+    echo "[SKIP] $label -- no BT.2100 transfer function"
+    return 0
+  fi
+
+  # The human-readable claim and the machine-readable one are checked against
+  # the same curve content, so a fixture cannot satisfy one by breaking the
+  # other. The description is checked even where there is no cicpTag: the two
+  # link fixtures name their curve too.
+  if [ "$want" = "$PQ_TC" ]; then wantname=PQ; else wantname=HLG; fi
+  name=$(declared_curve_name "$f")
+  if [ -n "$name" ] && [ "$name" != "$wantname" ]; then
+    echo "[FAIL] $label -- profileDescriptionTag says $name, curve content is $wantname"
+    rc=1
+  fi
+
+  if [ -z "$got" ]; then
+    # No cicpTag is legitimate here -- a link profile has no device encoding to
+    # describe. Say which half ran so the log does not read as no coverage.
+    if [ "$rc" -eq 0 ]; then
+      if [ -n "$name" ]; then
+        echo "[PASS] $label -- no cicpTag; description names $name, matching the encoded curve"
+      else
+        echo "[SKIP] $label -- no cicpTag, and the description names neither curve"
+      fi
+    fi
+    return "$rc"
+  fi
+  if [ "$got" != "$want" ]; then
+    echo "[FAIL] $label -- declares TransferCharacteristics=$got, curve content is $want"
+    return 1
+  fi
+  [ "$rc" -eq 0 ] && echo "[PASS] $label -- TransferCharacteristics=$got and the description both match the encoded curve"
+  return "$rc"
+}
+
+echo "=================================================================="
+echo " BT.2100 cicp TransferCharacteristics consistency (issue #2011)"
+echo "=================================================================="
+
+# Both roots that carry cicp-bearing XML today: the HDR fixtures themselves and
+# the CI test-data copy of one of them.  Enumerated by content rather than by a
+# hard-coded list so a fixture added later is covered without editing this file.
+# Read into an array rather than a whitespace-split string: nothing in the tree
+# has a space in its path today, but that is an assumption about the checkout
+# directory as much as about the repo, and it does not need to be made.
+CANDIDATES=()
+while IFS= read -r _f; do
+  CANDIDATES+=("$_f")
+done < <(find "$REPO_ROOT/Testing" "$REPO_ROOT/.github/ci/test-data" \
+           -name '*.xml' -type f 2>/dev/null | sort)
+if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+  echo "[SKIP] no XML fixtures found under Testing/ or .github/ci/test-data/"
+  exit 0
+fi
+
+checked=0
+for f in "${CANDIDATES[@]}"; do
+  # Scope is "carries a BT.2100 transfer function", not "carries a cicpTag":
+  # the two link fixtures have no cicpTag but do name their curve in the
+  # description, and that claim is checked as well.  Everything else would
+  # produce the same skip line and drown the log.
+  [ -n "$(classify "$f")" ] || continue
+  rel="${f#"$REPO_ROOT"/}"
+  check_one "$rel" "$f" || status=2
+  checked=$((checked + 1))
+done
+
+if [ "$checked" -eq 0 ]; then
+  echo "[FAIL] no BT.2100 fixture was found -- the corpus moved, or the curve"
+  echo "       constants were reformatted, and this test is looking at nothing"
+  status=2
+fi
+echo "------------------------------------------------------------------"
+echo "Checked $checked BT.2100 fixture(s)"
+
+# --- round trip -------------------------------------------------------------
+# The value has to survive conversion, not just sit in the document.  Anything
+# iccFromXml refuses is reported and skipped rather than failed: this test is
+# not the acceptance test for those documents, and .github/ci/test-data holds
+# deliberately-invalid PoCs that are meant to be refused.
+
+if [ -n "$FROMXML" ] && [ -x "$FROMXML" ] && [ -n "$TOXML" ] && [ -x "$TOXML" ]; then
+  echo ""
+  echo "--- XML -> ICC -> XML ---"
+  for f in "${CANDIDATES[@]}"; do
+    grep -q '<cicpFields' "$f" 2>/dev/null || continue
+    want=$(classify "$f")
+    if [ -z "$want" ] || [ "$want" = "AMBIGUOUS" ]; then continue; fi
+    rel="${f#"$REPO_ROOT"/}"
+    base="$(basename "$f" .xml)"
+    if ! "$FROMXML" "$f" "$OUTDIR/$base.icc" > "$OUTDIR/$base.fromxml.log" 2>&1 \
+       || [ ! -s "$OUTDIR/$base.icc" ]; then
+      echo "[SKIP] $rel -- iccFromXml did not produce a profile (see $base.fromxml.log)"
+      continue
+    fi
+    if ! "$TOXML" "$OUTDIR/$base.icc" "$OUTDIR/$base.rt.xml" > "$OUTDIR/$base.toxml.log" 2>&1 \
+       || [ ! -s "$OUTDIR/$base.rt.xml" ]; then
+      echo "[FAIL] $rel -- iccToXml did not re-serialize the profile"
+      status=2
+      continue
+    fi
+    rt=$(declared_tc "$OUTDIR/$base.rt.xml")
+    if [ "$rt" != "$want" ]; then
+      echo "[FAIL] $rel -- round-tripped as TransferCharacteristics=${rt:-<absent>}, expected $want"
+      status=2
+    else
+      echo "[PASS] $rel -- TransferCharacteristics=$rt survives XML -> ICC -> XML"
+    fi
+  done
+else
+  echo ""
+  echo "[SKIP] round trip -- iccFromXml / iccToXml not found under $TOOLS_DIR"
+fi
+
+# --- control ----------------------------------------------------------------
+# Put the defect back into a copy and require the classifier to catch it.  A
+# check whose grep stopped matching -- a constant reformatted, an attribute
+# renamed -- would otherwise report [PASS] on every fixture forever.
+
+echo ""
+echo "--- control: the defect, reintroduced ---"
+CONTROL_SRC="$REPO_ROOT/Testing/HDR/BT2100PQFullDisplay.xml"
+if [ ! -f "$CONTROL_SRC" ]; then
+  echo "[FAIL] control donor Testing/HDR/BT2100PQFullDisplay.xml is missing"
+  status=2
+else
+  # Control 1: the cicp code point put back to 18.
+  CONTROL="$OUTDIR/control-pq-cicp-2011.xml"
+  sed 's/\(<cicpFields[^>]*\)TransferCharacteristics="16"/\1TransferCharacteristics="18"/' \
+    "$CONTROL_SRC" > "$CONTROL"
+  if [ "$(declared_tc "$CONTROL")" != "18" ]; then
+    echo "[FAIL] control -- the cicp mutation did not apply, so it proves nothing"
+    status=2
+  elif check_one "control" "$CONTROL" > /dev/null 2>&1; then
+    echo "[FAIL] control -- a PQ fixture declaring 18 was reported consistent;"
+    echo "       the cicp assertions above are not testing anything"
+    status=2
+  else
+    echo "[PASS] control -- a PQ fixture declaring TransferCharacteristics=18 is caught"
+  fi
+
+  # Control 2: the description put back to HLG.  Checked separately because the
+  # two claims are read by different audiences and broke independently -- one
+  # PQ fixture had a correct description and a wrong cicp code point.
+  CONTROL2="$OUTDIR/control-pq-desc-2011.xml"
+  sed 's/BT\.2100 PQ /BT.2100 HLG /' "$CONTROL_SRC" > "$CONTROL2"
+  if [ "$(declared_curve_name "$CONTROL2")" != "HLG" ]; then
+    echo "[FAIL] control -- the description mutation did not apply, so it proves nothing"
+    status=2
+  elif check_one "control" "$CONTROL2" > /dev/null 2>&1; then
+    echo "[FAIL] control -- a PQ fixture described as HLG was reported consistent;"
+    echo "       the description assertions above are not testing anything"
+    status=2
+  else
+    echo "[PASS] control -- a PQ fixture described as 'BT.2100 HLG' is caught"
+  fi
+fi
+
+echo "------------------------------------------------------------------"
+if [ "$status" -eq 0 ]; then
+  echo "RESULT: PASS"
+else
+  echo "RESULT: FAIL"
+fi
+exit "$status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5295,6 +5295,28 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1781-applytolink-qa-matrix.sh"
 )
 
+# #2011: the BT.2100 fixtures have to agree with themselves.  All four
+# Testing/HDR/BT2100PQ*.xml declared cicp TransferCharacteristics="18" -- ARIB
+# STD-B67 (HLG) per ITU-T H.273 Table 3 -- while carrying the SMPTE ST 2084
+# constants, which is 16; three of them also described themselves as
+# "BT.2100 HLG".  Both claims came from the HLG siblings they were copied from.
+# Nothing caught it: CIccTagCicp::Validate reads MatrixCoefficients against the
+# colour space and never inspects TransferCharacteristics at all, so every one
+# of these validated clean before the correction and validates clean after.
+# This test supplies the consistency check the library does not have, for the
+# corpus, keyed on the curve constants rather than the file name so a renamed or
+# copied fixture is still judged by what it encodes.  Two controls reintroduce
+# each half of the defect and must be caught, so a grep that stopped matching
+# cannot leave this passing on nothing.
+# Runs without the tools built; the XML -> ICC -> XML half is skipped instead.
+iccdev_add_script_test(
+  iccdev.issue-2011-hdr-cicp-transfer-regression
+  120
+  "iccdev;xml;fixtures;hdr;cicp;issue-2011;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2011-hdr-cicp-transfer-regression.sh"
+)
+
 # Describe sink + options API smoke test. Verifies byte-equivalence
 # between the legacy std::string Describe() and the new
 # Describe(IDescribeSink&, const DescribeOptions&) virtual, plus

--- a/Testing/HDR/BT2100PQFullDisplay.xml
+++ b/Testing/HDR/BT2100PQFullDisplay.xml
@@ -18,7 +18,9 @@
   </Header>
   <Tags>
     <profileDescriptionTag> <multiLocalizedUnicodeType>
-      <LocalizedText LanguageCountry="enUS"><![CDATA[BT.2100 HLG Full Range RGB to/from Display Light]]></LocalizedText>
+      <!-- Corrected from "HLG": this fixture encodes the ST 2084 (PQ) transfer
+           function, not ARIB STD-B67. See the cicpTag note below. -->
+      <LocalizedText LanguageCountry="enUS"><![CDATA[BT.2100 PQ Full Range RGB to/from Display Light]]></LocalizedText>
     </multiLocalizedUnicodeType> </profileDescriptionTag>
 	
 	<AToB1Tag> <multiProcessElementType>
@@ -187,7 +189,10 @@
 	</XYZArrayType> </mediaWhitePointTag>
 
     <cicpTag> <cicpType>
-      <cicpFields ColorPrimaries="9" TransferCharacteristics="18" MatrixCoefficients="0" VideoFullRangeFlag="1"/>
+      <!-- ITU-T H.273 Table 3: 16 is SMPTE ST 2084 (PQ), which is the transfer
+           function the FormulaSegments above actually encode. 18 is ARIB STD-B67
+           (HLG) and belongs to the BT2100Hlg* fixtures, not to this one. -->
+      <cicpFields ColorPrimaries="9" TransferCharacteristics="16" MatrixCoefficients="0" VideoFullRangeFlag="1"/>
     </cicpType> </cicpTag>
 
 	<copyrightTag> <multiLocalizedUnicodeType>

--- a/Testing/HDR/BT2100PQFullScene.xml
+++ b/Testing/HDR/BT2100PQFullScene.xml
@@ -219,7 +219,10 @@
 	</XYZArrayType> </mediaWhitePointTag>
 
     <cicpTag> <cicpType>
-      <cicpFields ColorPrimaries="9" TransferCharacteristics="18" MatrixCoefficients="0" VideoFullRangeFlag="1"/>
+      <!-- ITU-T H.273 Table 3: 16 is SMPTE ST 2084 (PQ), which is the transfer
+           function the FormulaSegments above actually encode. 18 is ARIB STD-B67
+           (HLG) and belongs to the BT2100Hlg* fixtures, not to this one. -->
+      <cicpFields ColorPrimaries="9" TransferCharacteristics="16" MatrixCoefficients="0" VideoFullRangeFlag="1"/>
     </cicpType> </cicpTag>
 
 	<copyrightTag> <multiLocalizedUnicodeType>

--- a/Testing/HDR/BT2100PQNarrowDisplay.xml
+++ b/Testing/HDR/BT2100PQNarrowDisplay.xml
@@ -18,7 +18,9 @@
   </Header>
   <Tags>
     <profileDescriptionTag> <multiLocalizedUnicodeType>
-      <LocalizedText LanguageCountry="enUS"><![CDATA[BT.2100 HLG Narrow Range RGB to/from Display Light]]></LocalizedText>
+      <!-- Corrected from "HLG": this fixture encodes the ST 2084 (PQ) transfer
+           function, not ARIB STD-B67. See the cicpTag note below. -->
+      <LocalizedText LanguageCountry="enUS"><![CDATA[BT.2100 PQ Narrow Range RGB to/from Display Light]]></LocalizedText>
     </multiLocalizedUnicodeType> </profileDescriptionTag>
 	
 	<AToB1Tag> <multiProcessElementType>
@@ -224,7 +226,10 @@
 	</XYZArrayType> </mediaWhitePointTag>
 	
     <cicpTag> <cicpType>
-      <cicpFields ColorPrimaries="9" TransferCharacteristics="18" MatrixCoefficients="0" VideoFullRangeFlag="0"/>
+      <!-- ITU-T H.273 Table 3: 16 is SMPTE ST 2084 (PQ), which is the transfer
+           function the FormulaSegments above actually encode. 18 is ARIB STD-B67
+           (HLG) and belongs to the BT2100Hlg* fixtures, not to this one. -->
+      <cicpFields ColorPrimaries="9" TransferCharacteristics="16" MatrixCoefficients="0" VideoFullRangeFlag="0"/>
     </cicpType> </cicpTag>
 
 	<copyrightTag> <multiLocalizedUnicodeType>

--- a/Testing/HDR/BT2100PQNarrowScene.xml
+++ b/Testing/HDR/BT2100PQNarrowScene.xml
@@ -18,7 +18,9 @@
   </Header>
   <Tags>
     <profileDescriptionTag> <multiLocalizedUnicodeType>
-      <LocalizedText LanguageCountry="enUS"><![CDATA[BT.2100 HLG Narrow Range RGB to/from Scene Light]]></LocalizedText>
+      <!-- Corrected from "HLG": this fixture encodes the ST 2084 (PQ) transfer
+           function, not ARIB STD-B67. See the cicpTag note below. -->
+      <LocalizedText LanguageCountry="enUS"><![CDATA[BT.2100 PQ Narrow Range RGB to/from Scene Light]]></LocalizedText>
     </multiLocalizedUnicodeType> </profileDescriptionTag>
 	
 	<AToB1Tag> <multiProcessElementType>
@@ -232,7 +234,10 @@
 	</XYZArrayType> </mediaWhitePointTag>
 
     <cicpTag> <cicpType>
-      <cicpFields ColorPrimaries="9" TransferCharacteristics="18" MatrixCoefficients="0" VideoFullRangeFlag="0"/>
+      <!-- ITU-T H.273 Table 3: 16 is SMPTE ST 2084 (PQ), which is the transfer
+           function the FormulaSegments above actually encode. 18 is ARIB STD-B67
+           (HLG) and belongs to the BT2100Hlg* fixtures, not to this one. -->
+      <cicpFields ColorPrimaries="9" TransferCharacteristics="16" MatrixCoefficients="0" VideoFullRangeFlag="0"/>
     </cicpType> </cicpTag>
 
 	<copyrightTag> <multiLocalizedUnicodeType>


### PR DESCRIPTION
Part of #2011.

All four `Testing/HDR/BT2100PQ*.xml` declared cicp `TransferCharacteristics="18"`. Per
ITU-T H.273 Table 3 that is ARIB STD-B67 (HLG); SMPTE ST 2084 (PQ) is **16**. The curve
content is genuinely PQ — m1 = `0.1593017578125` (2610/16384), c1 = `0.8359375`,
c2 = `18.8515625`, c3 = `18.6875`, each present twice per file in the forward transfer
function and again in its inverse — so the label was wrong, not the maths.

Checked before touching anything: every PQ-named fixture carries only ST 2084 constants
and every HLG-named fixture carries only ARIB B67 constants. The file names were the one
thing that was already right.

## A second wrong claim, same root cause

Three of the four also described themselves as **`BT.2100 HLG ...`** in
`profileDescriptionTag` — `FullDisplay`, `NarrowDisplay`, `NarrowScene`. Both wrong claims
came from the HLG siblings these files were copied from, which is what makes them one
defect rather than two: the same wrong answer in the field a CMM reads and in the field a
person reads.

They did not break together, and the exception explains the survival. `BT2100PQFullScene.xml`
had a **correct** description and a **wrong** code point — and it is the fixture the #1909
and #1346 regressions happen to use.

| fixture | cicp TC | description |
|---|---|---|
| `BT2100PQFullDisplay.xml` | 18 → **16** | `HLG` → **`PQ`** |
| `BT2100PQFullScene.xml` | 18 → **16** | already `PQ` ✓ |
| `BT2100PQNarrowDisplay.xml` | 18 → **16** | `HLG` → **`PQ`** |
| `BT2100PQNarrowScene.xml` | 18 → **16** | `HLG` → **`PQ`** |
| the four `BT2100Hlg*` | 18 ✓ | `HLG` ✓ |

**The description half is beyond the literal scope of the issue, which is about
`TransferCharacteristics` only.** It is included because it is the same defect from the
same copy, and correcting one while leaving the other would leave the fixtures still
contradicting themselves. Happy to split it out if you would rather keep this to the one
attribute.

`.github/ci/test-data/ub-cicp-colorprimaries-1346.xml` is corrected too. It is a copy of
the `BT2100PQFullScene` donor whose deliberate defect is `ColorPrimaries="-1"`; nothing in
that regression reads `TransferCharacteristics`, and leaving it would park the same
misleading example in a second place.

## Blast radius, measured rather than assumed

Rebuilt all ten HDR fixtures before and after, with the creation dateTime (bytes 24–35)
and profile MD5 (84–99) masked so the comparison is not defeated by the two fields that
always differ:

- **exactly one byte differs in each of the four PQ profiles** — `022` → `020`
- the four HLG profiles and the two link profiles are **byte-identical**
- all ten still report `Profile is valid for version 5.10`, with byte-identical validation
  reports before and after
- the value survives XML → ICC → XML
- `iccdev.issue-1909-xml-narrowing-regression` passes on the corrected tree; the #1346 PoC
  is refused identically before and after

## Why nothing caught it, and what this PR does about it

The reason is narrower than "no cross-check". `CIccTagCicp::Validate`
(`IccProfLib/IccTagBasic.cpp`) reads `m_nMatrixCoefficients` against the profile's colour
space and nothing else — it **never inspects `m_nTransferCharacteristics` at all, at any
value**. A range check would not have helped either: 18 is a perfectly legal code point,
just not this profile's. Only a consistency check catches this shape.

That library gap is a larger question and is **not** addressed here. Instead the new CTest
supplies the consistency check for the corpus:

`iccdev.issue-2011-hdr-cicp-transfer-regression`

- classifies each fixture by the curve constants it actually contains, then requires both
  the cicp code point and the description to agree with that classification
- keys on **content, not file name** — deliberate, since the name was not what lied
- covers **16 BT.2100 fixtures**: all ten under `Testing/HDR/`, plus four
  `Testing/Display/Rec2100Hlg*`, `Testing/ICS/Rec2100HlgFull-Part3.xml`, and the CI
  test-data copy. The six outside `Testing/HDR/` were all already consistent.
- **two controls** reintroduce each half of the defect and must be caught, so a grep that
  stops matching cannot leave this passing on nothing
- red-tested against the unfixed fixtures: **eight FAIL lines across five files** — four
  wrong code points, three wrong descriptions, and the PoC — with no false positives on
  the HLG side

## Pre-flight

- `shellcheck` 0.9.0, bare, on the new script — clean
- local `ctest` 161/162; the single failure is `iccdev.spectral-tiff-preview`
  (`ModuleNotFoundError: No module named 'imagecodecs'`), a pre-existing gap in my
  environment and unrelated to this change
- new test verified registered and green through `ctest` itself, not just by running the
  script directly
- **no C or C++ changed by this PR**, so the compiler-warning gate is not perturbed — I am
  not claiming a strict multi-profile warnings sweep, because there is nothing here for it
  to measure
- the script is CRLF-safe and runs with the tools absent — verified by re-emitting the
  fixture set with CRLF terminators and running against it with no tools on PATH. It
  passes, and both controls still bite while the unfixed fixtures still come out red.

**Correction to an earlier version of this body.** I wrote that the Windows leg runs the
whole `ctest` unfiltered so this script executes there. The first half is true; the
conclusion is not. `Build/Cmake/Testing/CMakeLists.txt:3629` opens an `if(WIN32)` block
that registers a curated C++ list and `return()`s at `:3885`, before the script-test
section — so **no** `iccdev_add_script_test` test registers on Windows at all. That leg
runs 80 tests where Linux runs 152, and this one is not among them. Confirmed in this PR's
own job log rather than inferred from the workflow YAML. The CRLF hardening stays because
it costs nothing and stops the test being quietly wrong if that carve-out is ever lifted,
not because it is covering a live lane.

Where it **does** run, confirmed in the job log: `Tool Smoke Tests (ASAN+UBSAN, Debug) /
iccDEV Tools - GCC Strict ASAN+UBSAN` — `151/152 Test #161:
iccdev.issue-2011-hdr-cicp-transfer-regression ... Passed 2.44 sec`.

## Notes, not fixed here

The #1346 regression's premise is now stale: since #1909 landed, `iccFromXml` **refuses**
that PoC outright, so the UBSan sign-change site it targets is unreachable and the test
passes trivially. Identical before and after this change — raising it separately rather
than folding it in.
