### PR TITLE
fix(#1975): quiet the CFL fuzzer log and stop the UBSAN silence list drifting

### DIFF
--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -751,18 +751,12 @@ jobs:
             for d in "$ICCDEV_BUILD_DIR"/Tools/*; do
               [ -d "$d" ] && export PATH="$(realpath "$d"):$PATH"
             done
-            printf "%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n" \
-              "unsigned-integer-overflow:*/IccMD5.cpp" \
-              "shift-base:*/IccMD5.cpp" \
-              "shift-exponent:*/IccMD5.cpp" \
-              "# Recoverable runtime UBSAN noise from libstdc++ implementation internals." \
-              "# Fatal IntegerSanitizer builds require the compile-time ignorelist instead." \
-              "unsigned-integer-overflow:*/include/c++/*/bits/basic_string.h" \
-              "unsigned-integer-overflow:*/include/c++/*/bits/basic_string.tcc" \
-              "unsigned-integer-overflow:*/include/c++/*/bits/stl_bvector.h" \
-              "unsigned-integer-overflow:*/include/c++/*/bits/stl_uninitialized.h" \
-              "unsigned-integer-overflow:*/include/c++/*/bits/vector.tcc" \
-              "unsigned-integer-overflow:*/include/c++/*/ext/string_conversions.h" > silence.txt
+            # Testing/silence.txt is tracked and already holds this exact list,
+            # so assert it is present rather than rewriting it. The same list
+            # used to be maintained by hand in three places and the copy in
+            # docker/iccdev-generate-profiles.sh had already drifted two entries
+            # short of the tracked one.
+            test -r ./silence.txt
             test -x ./CreateAllProfiles.sh
             test -x ./RunTests.sh
             test -x ./HDR/mkprofiles.sh

--- a/cfl/icc_cli_fuzzer.cpp
+++ b/cfl/icc_cli_fuzzer.cpp
@@ -29,6 +29,7 @@
 
 static constexpr size_t kMaxInputSize = 1024 * 1024;
 static constexpr int kChildTimeoutSeconds = 10;
+static constexpr size_t kMaxCapturedStderr = 256 * 1024;
 
 static std::string GetEnvOrDefault(const char *name, const char *fallback) {
   const char *value = getenv(name);
@@ -140,10 +141,96 @@ static std::vector<std::string> BuildArgs(const std::string &target,
   return {};
 }
 
+// Open the temp file that the child's stderr is redirected into. On success the
+// caller owns both the descriptor and the path.
+static bool MakeStderrCapture(std::string &path, int &fd) {
+  std::string tmpdir = GetEnvOrDefault("TMPDIR", "/tmp");
+  std::string pattern = JoinPath(tmpdir, "iccdev-cfl-stderr-XXXXXX");
+  std::vector<char> writable(pattern.begin(), pattern.end());
+  writable.push_back('\0');
+
+  fd = mkstemp(writable.data());
+  if (fd < 0)
+    return false;
+
+  path = writable.data();
+  return true;
+}
+
+// True when the capture has to be shown even though the child exited normally.
+// A sanitizer report can reach stderr without aborting if UBSAN_OPTIONS is
+// overridden to recover, and an oversized capture is by definition not the
+// short per-input parser message this filter exists to drop.
+static bool StderrCaptureHasReport(const std::string &path) {
+  FILE *f = fopen(path.c_str(), "rb");
+  if (!f)
+    return false;
+
+  std::string text;
+  char buf[4096];
+  size_t n;
+  bool oversized = false;
+  while ((n = fread(buf, 1, sizeof(buf), f)) > 0) {
+    text.append(buf, n);
+    if (text.size() > kMaxCapturedStderr) {
+      oversized = true;
+      break;
+    }
+  }
+  fclose(f);
+
+  if (oversized)
+    return true;
+
+  static const char *const kReportMarkers[] = {
+      "runtime error:",
+      "ERROR: AddressSanitizer",
+      "ERROR: LeakSanitizer",
+      "SUMMARY: AddressSanitizer",
+      "SUMMARY: UndefinedBehaviorSanitizer",
+  };
+  for (const char *marker : kReportMarkers) {
+    if (text.find(marker) != std::string::npos)
+      return true;
+  }
+  return false;
+}
+
+static void StreamStderrCapture(const std::string &path) {
+  FILE *f = fopen(path.c_str(), "rb");
+  if (!f)
+    return;
+
+  char buf[4096];
+  size_t n;
+  while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+    fwrite(buf, 1, n, stderr);
+
+  fclose(f);
+  fflush(stderr);
+}
+
 static int RunChild(const std::vector<std::string> &args) {
-  pid_t pid = fork();
-  if (pid < 0)
+  // The child's stderr is captured instead of inherited. The fromxml target
+  // hands every input straight to libxml2, whose default error handler prints a
+  // "Start tag expected, '<' not found" block per file, so for a fuzzer -- where
+  // almost no input is well-formed XML -- that is one block per iteration
+  // burying the real output. Only stdout was redirected before, which is why the
+  // tool's own "Unable to Parse" line was already hidden while libxml2's was
+  // not. The capture is replayed whenever it could carry signal, so no sanitizer
+  // report is lost; installing a quiet libxml2 error handler in IccXML instead
+  // would suppress those diagnostics for every real caller of iccFromXml.
+  std::string err_path;
+  int err_fd = -1;
+  if (!MakeStderrCapture(err_path, err_fd))
     __builtin_trap();
+
+  pid_t pid = fork();
+  if (pid < 0) {
+    close(err_fd);
+    unlink(err_path.c_str());
+    __builtin_trap();
+  }
 
   if (pid == 0) {
     std::vector<char *> argv;
@@ -155,26 +242,49 @@ static int RunChild(const std::vector<std::string> &args) {
     setenv("ASAN_OPTIONS", "detect_leaks=0:halt_on_error=1:abort_on_error=1:allocator_may_return_null=1", 0);
     setenv("UBSAN_OPTIONS", "halt_on_error=1:abort_on_error=1:print_stacktrace=1", 0);
     freopen("/dev/null", "w", stdout);
+    if (err_fd != STDERR_FILENO) {
+      dup2(err_fd, STDERR_FILENO);
+      close(err_fd);
+    }
     execv(argv[0], argv.data());
     _exit(126);
   }
 
+  close(err_fd);
+
+  bool reaped = false;
+  bool crashed = false;
+  int exit_code = 0;
   for (int i = 0; i < kChildTimeoutSeconds * 100; i++) {
     int status = 0;
     pid_t done = waitpid(pid, &status, WNOHANG);
     if (done == pid) {
-      if (WIFSIGNALED(status))
-        __builtin_trap();
-      if (WIFEXITED(status) && WEXITSTATUS(status) == 126)
-        __builtin_trap();
-      return WIFEXITED(status) ? WEXITSTATUS(status) : 0;
+      reaped = true;
+      crashed = WIFSIGNALED(status) ||
+                (WIFEXITED(status) && WEXITSTATUS(status) == 126);
+      exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 0;
+      break;
     }
     usleep(10000);
   }
 
-  kill(pid, SIGKILL);
-  waitpid(pid, nullptr, 0);
-  __builtin_trap();
+  if (!reaped) {
+    kill(pid, SIGKILL);
+    waitpid(pid, nullptr, 0);
+    crashed = true;
+  }
+
+  // Replay before trapping so the crashing run's diagnostics still reach the
+  // log, and on a clean exit only when the capture holds something worth
+  // reading. The routine parse-error chatter is dropped on both paths.
+  if (crashed || StderrCaptureHasReport(err_path))
+    StreamStderrCapture(err_path);
+  unlink(err_path.c_str());
+
+  if (crashed)
+    __builtin_trap();
+
+  return exit_code;
 }
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {

--- a/docker/iccdev-generate-profiles.sh
+++ b/docker/iccdev-generate-profiles.sh
@@ -9,17 +9,34 @@ for d in "$tools_root"/*; do
   fi
 done
 
-printf '%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n' \
-  'unsigned-integer-overflow:*/IccMD5.cpp' \
-  'shift-base:*/IccMD5.cpp' \
-  'shift-exponent:*/IccMD5.cpp' \
-  '# Recoverable runtime UBSAN noise from libstdc++ implementation internals.' \
-  '# Fatal IntegerSanitizer builds require the compile-time ignorelist instead.' \
-  'unsigned-integer-overflow:*/include/c++/*/bits/basic_string.h' \
-  'unsigned-integer-overflow:*/include/c++/*/bits/basic_string.tcc' \
-  'unsigned-integer-overflow:*/include/c++/*/bits/stl_bvector.h' \
-  'unsigned-integer-overflow:*/include/c++/*/bits/stl_uninitialized.h' > silence.txt
+# Use the suppression list that is tracked in Testing/ instead of regenerating a
+# copy of it here. Every caller runs with Testing/ as the working directory --
+# the default tools_root above is written relative to it -- so the tracked file
+# is always alongside. The copy this replaced had drifted two entries short of
+# the tracked list: bits/vector.tcc and ext/string_conversions.h were absent.
+#
+# Those entries only matter where the integer sanitizer is on, because
+# unsigned-integer-overflow belongs to -fsanitize=integer and not to
+# -fsanitize=undefined. Of the three callers, two qualify: Dockerfile.ci-regression
+# builds clang with ENABLE_SANITIZERS=ON, which CMake expands to include integer,
+# and Dockerfile.nixos sets ENABLE_INTEGER_SANITIZER=ON outright. Only the plain
+# Dockerfile is exempt, because it is gcc and CMake skips IntSan there.
+#
+# The runtime list this points at is the right venue only where the build also
+# allows recovery -- ci-regression passes SANITIZER_RECOVER=ON, so suppressions
+# apply. Dockerfile.nixos leaves it OFF and so compiles in
+# -fno-sanitize-recover=integer, which no runtime suppression can override; that
+# configuration needs the compile-time -DUBSAN_IGNORELIST= instead, as the header
+# of .github/ci/ubsan-ignorelist.txt already says.
+#
+# Reading the file also stops this script overwriting a tracked source file as a
+# side effect, which Dockerfile.ci-regression previously had to undo.
+silence_file="$PWD/silence.txt"
+if [ ! -r "$silence_file" ]; then
+  echo "ERROR: UBSAN suppression list not found: $silence_file" >&2
+  exit 1
+fi
 
 ASAN_OPTIONS='print_scariness=1:halt_on_error=1:detect_leaks=0' \
-  UBSAN_OPTIONS="halt_on_error=0:suppressions=$PWD/silence.txt" \
+  UBSAN_OPTIONS="halt_on_error=0:suppressions=$silence_file" \
   ./CreateAllProfiles.sh


### PR DESCRIPTION
## PR Summary

Part of #1975 — this answers the **Added Scope Request** posted on the issue, not the
issue's original scope. `processLuts` external linkage and its fuzz-harnessable entry are
untouched and #1975 stays open for them.

@xsscx — the two asks were "add `vector.tcc` / `string_conversions.h` / `stl_uninitialized.h`
to UB silence" and "silence the LibXML2 noise emitting from the Fuzzer". Both are addressed,
but each turned out to be somewhere other than where it looks, so the reasoning is below.

## 1. UB-silence list — the headers were already there; the copies had drifted

All three headers landed on the canonical lists in `bdce04b3` (#1881, 07-28). The real defect
is that the same list is maintained by hand in several places and one had gone stale:

| copy | libstdc++ entries |
|---|---|
| `.github/ci/ubsan-ignorelist.txt` (canonical, compile-time) | 6 |
| `Testing/silence.txt` (canonical, runtime) | 6 |
| `.github/workflows/ci-docker.yml` inline `printf` | 6 — byte-identical to the tracked file |
| **`docker/iccdev-generate-profiles.sh`** | **4 — missing `bits/vector.tcc` and `ext/string_conversions.h`** |
| 3× `.github/scripts/iccdev-*-regression-tests.sh` | 6, as a `grep -Ev` regex |

The two missing entries are two of the three headers named in the request.

**Where that actually bites.** `unsigned-integer-overflow` belongs to `-fsanitize=integer`,
not to `-fsanitize=undefined` — verified locally on clang 21.1.3 (`unsigned x=0; x--` is
silent under `undefined`, reported under `integer`). So the drift only matters where IntSan
is on. Configuring both shapes locally gives:

| caller of the script | build | `integer`? | recovery | runtime suppressions in force? |
|---|---|---|---|---|
| `Dockerfile` | gcc, `ENABLE_SANITIZERS=ON` | no — *"IntegerSanitizer requires Clang; skipping for GNU"* | — | n/a |
| `Dockerfile.ci-regression` | clang, `ENABLE_SANITIZERS=ON` + `SANITIZER_RECOVER=ON` | **yes** | recoverable | **yes — this is where the two missing entries were live** |
| `Dockerfile.nixos` | clang, `ENABLE_INTEGER_SANITIZER=ON` | **yes** | `-fno-sanitize-recover=integer` | **no** |

Worth flagging separately: on `Dockerfile.nixos` the runtime list cannot help at all, because
IntSan findings are compiled fatal there and no `UBSAN_OPTIONS=suppressions=` overrides that.
That configuration needs the compile-time `-DUBSAN_IGNORELIST=`, exactly as the header of
`.github/ci/ubsan-ignorelist.txt` already says. Adding the entries is still right, it is just
not the mechanism that would rescue nixos. Happy to follow up separately if you want that
plumbed through — it is a Dockerfile change, so I have left it out of this PR.

**The fix.** Both regenerators now read the tracked `Testing/silence.txt` instead of rewriting
it, with a fail-loud guard when it is absent. All three Dockerfiles already invoke the script
with `Testing/` as the working directory — the script's own default `tools_root=../Build/Tools`
is written relative to it — so the tracked file is always alongside. The `ci-docker.yml` copy
was byte-identical to the tracked file and carried the same latent hazard, so it goes the same
way.

This also removes a side effect: the script wrote `silence.txt` into `$PWD`, i.e. it
**overwrote the tracked `Testing/silence.txt`**, which `Dockerfile.ci-regression` had to undo
with an explicit `git checkout -- silence.txt`. That guard still passes, it just has nothing
left to undo.

## 2. libxml2 noise — it is the CLI harness, not the new visualization one

The noise is **not** coming from `icc_profilevisualize_fuzzer`. That harness is in-process and
feeds ICC bytes to `OpenIccProfile`, and never reaches libxml2. The `/tmp/iccdev-cfl-input-XXXXXX`
in the pasted output is the `mkstemp` template in **`cfl/icc_cli_fuzzer.cpp`** — the fork/exec
harness — and specifically its `fromxml` target, which hands each input to `iccFromXml` and so
to libxml2's default error handler.

Reproduced directly against a prebuilt `iccFromXml` before changing anything:

```
$ iccFromXml /tmp/iccdev-cfl-input-AbC123 out.icc 2>&1 1>/dev/null
/tmp/iccdev-cfl-input-AbC123:1: parser error : Start tag expected, '<' not found
W%%%%%%%%%%%%%%%%%%%%%%%
^
```

Root cause is one line: `RunChild` did `freopen("/dev/null", "w", stdout)` and left **stderr
inherited**. That is exactly why the tool's own `Unable to Parse '...'` line was already hidden
while libxml2's survived — they go to different streams.

**The fix, and what it deliberately does not do.** The child's stderr is captured to a temp file
and replayed only when it could carry signal: the child terminated abnormally, or the capture
holds a sanitizer marker, or it exceeds 256 KiB. Two tempting shortcuts are wrong here:

- **`2>/dev/null` on the child** would discard ASAN/UBSAN reports, which arrive on the same
  stream. The parent would still trap on the signal, so a found bug becomes a crash with no
  stack.
- **A quiet libxml2 error handler in `IccXML`** would suppress those diagnostics for every real
  caller of `iccFromXml`, not just the fuzzer. iccDEV installs no libxml2 error handler anywhere
  today, and this is not the place to start.

The marker scan exists because `RunChild` sets `UBSAN_OPTIONS` with `setenv(..., 0)`, which does
not overwrite — an outer `halt_on_error=0` wins, and a recovering report would otherwise be
dropped on a cleanly-exiting child.

## Verification

- **Red/green**, `fromxml` over a junk corpus, old harness vs new: **6 parse-error blocks → 0**.
  libFuzzer's own `INFO:` output is no longer buried.
- **Diagnostics still survive**, via fake tools injected through `ICCDEV_CFL_TOOL_DIR`:
  a recovering UBSAN report on a child that exits 0 is **shown**; an AddressSanitizer report on
  an aborting child is **replayed before the trap**; routine parser chatter on exit 1 is
  **dropped**.
- All six CFL targets build clean under the exact production flags from `cfl/build.sh`,
  `-fsanitize=fuzzer,address,undefined` plus `-Wall -Wextra -Werror`.
- 300 iterations under `ASAN_OPTIONS=detect_leaks=1` — no leak, and an isolated `TMPDIR` is left
  with **0** files, so the added capture file does not accumulate.
- Script simulation: new script → 11-line suppression list and the tracked file untouched;
  old script → 9-line list and the tracked file clobbered; missing-file guard exits 1.
- `shellcheck` bare rc=0; full `.github/scripts/preflight-safety-checks.sh` → **0 failures**;
  actionlint / yamllint / zizmor OK.

No C++ in the CMake build changed — `cfl/` is built only by `cfl/build.sh` and is not referenced
by `Build/Cmake/CMakeLists.txt`, so there is no new CTest to pair here. Say the word if you would
rather I add a drift guard for the three remaining `grep -Ev` copies of the list.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Updated documentation for user-visible behavior changes
- [x] Ran sanitizer coverage for memory-safety or parser changes
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes, followed `docs/python-packaging-release.md` — n/a
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer — the `ci-docker.yml` and `docker/` edits are the substance of the scope request on #1975
- [x] New source files include the ICC copyright and BSD 3-Clause license header — no new files
- [x] Code style matches nearby code
