### PR TITLE
fix(#1811): report normalized luminance as a possibility, and pin it with a CTest

### DIFF
--- a/.github/ci/regression/luminance-normalization-diagnostic.cpp
+++ b/.github/ci/regression/luminance-normalization-diagnostic.cpp
@@ -1,0 +1,113 @@
+/*
+    File:       luminance-normalization-diagnostic.cpp
+
+    Contains:   CTest helper for CIccInfo::CheckLuminance()'s normalized-luminance
+                diagnostic (#1811).
+
+    spectralViewingConditionsTag's illuminantXYZ and surroundXYZ carry absolute
+    luminance in cd/m^2.  A producer that writes chromaticity-normalized values
+    instead leaves Y at exactly 1, and CheckLuminance() reports that as a warning.
+
+    #1811 asked for the diagnostic to be exercised at normalized and at physical
+    values, naming 1, 300 and 500 as representative.  Those three are not an
+    arbitrary spread -- Testing/Display carries the same profile at each of them:
+
+        sRGB_D65_MAT.xml        X=0.9504    Y=1.0    Z=1.0889
+        sRGB_D65_MAT-300lx.xml  X=285.12    Y=300    Z=326.67   ( = 300 x the above )
+        sRGB_D65_MAT-500lx.xml  X=475.20    Y=500    Z=544.45   ( = 500 x the above )
+
+    which is also why value 1 is the interesting one.  Scaling the 300 cd/m^2
+    fixture down to 1 cd/m^2 reproduces the normalized fixture exactly, so the two
+    readings of Y = 1 -- "normalized" and "a legal 1 cd/m^2 dark surround" -- are
+    the same three numbers.  No test on the tag's own values can separate them, and
+    a 1 cd/m^2 surround is not hypothetical: the BT.2100 fixtures in this corpus
+    use 5 cd/m^2.  The diagnostic is therefore phrased as a possibility and left at
+    Warning, and this test pins that -- both that it still fires on the normalized
+    case and that it stays a Warning rather than escalating.
+
+    Testing CheckLuminance() directly rather than through
+    CIccTagSpectralViewingConditions::Validate() keeps the subject isolated: that
+    Validate() also reports a critical error for a missing observer CMF, which would
+    mask the status under test.
+
+    Exit codes:
+      0 - expected results observed
+      1 - unexpected result
+*/
+
+#include "IccUtil.h"
+
+#include <cstdio>
+#include <string>
+
+static int g_failures = 0;
+
+static void check(bool condition, const char* label)
+{
+  if (condition) {
+    std::fprintf(stdout, "luminance-normalization-diagnostic: PASS  %s\n", label);
+    return;
+  }
+  std::fprintf(stdout, "luminance-normalization-diagnostic: FAIL  %s\n", label);
+  ++g_failures;
+}
+
+// D65 chromaticity, which is what every fixture in the affected corpus population
+// uses.  Scaling it is what turns a normalized triple into a physical one, so the
+// helper takes the luminance and derives X and Z from it.
+static icFloatXYZNumber d65AtLuminance(icFloatNumber Y)
+{
+  icFloatXYZNumber XYZ;
+  XYZ.X = static_cast<icFloatNumber>(0.9504 * Y);
+  XYZ.Y = Y;
+  XYZ.Z = static_cast<icFloatNumber>(1.0889 * Y);
+  return XYZ;
+}
+
+// Returns the status and hands back the report so the caller can assert on the
+// message text as well.  sReport starts empty each time: CheckLuminance appends,
+// and a shared buffer would let one case's message satisfy the next case's check.
+static icValidateStatus runCheck(icFloatNumber Y, std::string& sReport)
+{
+  CIccInfo Info;
+  sReport.clear();
+  return Info.CheckLuminance(sReport, d65AtLuminance(Y), "spectralViewingConditionsTag::>illuminantXYZ");
+}
+
+int main()
+{
+  std::string sReport;
+
+  // Y = 1: the normalized case, and simultaneously a legal 1 cd/m^2 reading.  It
+  // must warn, and it must not do more than warn.
+  check(runCheck(1.0f, sReport) == icValidateWarning, "Y=1 reports a warning");
+  check(sReport.find("possibly normalized") != std::string::npos,
+        "Y=1 message is phrased as a possibility, not an assertion");
+  check(sReport.find("cd/m^2") != std::string::npos,
+        "Y=1 message states the expected unit");
+
+  // The two physical values #1811 names.  Both are far outside the window, so a
+  // clean report here is what tells a reviewer the diagnostic is not simply always on.
+  check(runCheck(300.0f, sReport) == icValidateOK, "Y=300 is accepted");
+  check(sReport.empty(), "Y=300 adds nothing to the report");
+
+  check(runCheck(500.0f, sReport) == icValidateOK, "Y=500 is accepted");
+  check(sReport.empty(), "Y=500 adds nothing to the report");
+
+  // The window is an absolute +/-0.01 around 1.0, not a relative tolerance.  Pinning
+  // both sides keeps a later change from widening it into the physical range, where
+  // it would start flagging genuinely dark surrounds: 5 cd/m^2 is in use in this
+  // corpus today and must stay clean.
+  check(runCheck(0.995f, sReport) == icValidateWarning, "Y=0.995 is inside the window");
+  check(runCheck(1.005f, sReport) == icValidateWarning, "Y=1.005 is inside the window");
+  check(runCheck(0.98f, sReport) == icValidateOK, "Y=0.98 is outside the window");
+  check(runCheck(1.02f, sReport) == icValidateOK, "Y=1.02 is outside the window");
+  check(runCheck(5.0f, sReport) == icValidateOK, "Y=5 (BT.2100 surround) is accepted");
+
+  if (g_failures) {
+    std::fprintf(stdout, "luminance-normalization-diagnostic: %d failure(s)\n", g_failures);
+    return 1;
+  }
+  std::fprintf(stdout, "luminance-normalization-diagnostic: all checks passed\n");
+  return 0;
+}

--- a/.github/scripts/iccdev-qa-profile-manifest.sh
+++ b/.github/scripts/iccdev-qa-profile-manifest.sh
@@ -96,7 +96,13 @@ classify_rationale() {
       echo "conformant example profile; validates clean"
       ;;
     warning)
-      if grep -Fq 'appears to be normalized' "$log"; then
+      # Matches CIccInfo::CheckLuminance's message text. #1811 reworded it from
+      # "appears to be normalized!" to "possibly normalized" because a normalized Y
+      # and a physical 1 cd/m^2 Y are indistinguishable, so the tool no longer
+      # asserts what it cannot prove. The rationale string below is deliberately
+      # unchanged: the 27 rows it labels are the same 27 profiles, so the manifest
+      # itself does not need regenerating for a wording change.
+      if grep -Fq 'possibly normalized' "$log"; then
         echo "baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)"
       elif grep -Fq 'sampled curve has a range of zero' "$log"; then
         echo "baselined: sampled curve has a range of zero"

--- a/.github/workflows/ci-pr-action.yml
+++ b/.github/workflows/ci-pr-action.yml
@@ -96,7 +96,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGRESSION_IMAGE_TAG: sha-547c4bed27b0432942b2b34c57d5bd5495191798
+  REGRESSION_IMAGE_TAG: sha-b28cafe490a14bf1decbcef0e6caa56e1308f707
 
 jobs:
   detect-src:

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2827,6 +2827,67 @@ function(iccdev_add_curve_setsize_contract_test)
   endif()
 endfunction()
 
+# #1811: spectralViewingConditions illuminantXYZ/surroundXYZ carry absolute
+# luminance in cd/m^2, and CIccInfo::CheckLuminance warns when Y is 1 because that
+# is what chromaticity normalization leaves behind. The check cannot be exact --
+# Testing/Display holds the same profile at Y = 1, 300 and 500, and the 300 cd/m^2
+# fixture scaled to 1 cd/m^2 *is* the normalized fixture -- so this pins that the
+# diagnostic still fires on Y = 1, stays a Warning rather than escalating to an
+# assertion, and leaves the physical values #1811 names untouched.
+#
+# Pure library test -- no fixtures on disk and no tool invocation -- so it needs
+# only IccProfLib and no scratch directory. Exercising CheckLuminance directly
+# rather than CIccTagSpectralViewingConditions::Validate keeps the missing-observer
+# critical error from masking the status under test.
+function(iccdev_add_luminance_normalization_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccLuminanceNormalizationTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/luminance-normalization-diagnostic.cpp"
+  )
+  target_compile_features(iccLuminanceNormalizationTest PRIVATE cxx_std_17)
+  target_include_directories(iccLuminanceNormalizationTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccLuminanceNormalizationTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccLuminanceNormalizationTest)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.luminance-normalization
+      COMMAND "$<TARGET_FILE:iccLuminanceNormalizationTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.luminance-normalization
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccLuminanceNormalizationTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.luminance-normalization PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;luminance;validation;issue-1811;regression"
+  )
+  if(WIN32)
+    set(_luminance_norm_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccLuminanceNormalizationTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _luminance_norm_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.luminance-normalization PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_luminance_norm_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #2012/#2013/#2014: g_icTagNameTable published ten tag names matching neither
 # the signature nor their siblings. The table drives the XML element name and the
 # JSON key in both directions, so the corrected name must be the one emitted while
@@ -3824,6 +3885,7 @@ if(WIN32)
   iccdev_add_xml_relaxng_validation_leak_test()
   iccdev_add_xml_curve_oversize_file_test()
   iccdev_add_curve_setsize_contract_test()
+  iccdev_add_luminance_normalization_test()
   iccdev_add_tag_name_spelling_test()
   iccdev_add_mpexml_unknown_reserved_test()
   iccdev_add_proflib_exported_data_linkage_test()
@@ -4088,6 +4150,7 @@ iccdev_add_xml_writer_graceful_degrade_test()
 iccdev_add_xml_relaxng_validation_leak_test()
 iccdev_add_xml_curve_oversize_file_test()
 iccdev_add_curve_setsize_contract_test()
+iccdev_add_luminance_normalization_test()
 iccdev_add_tag_name_spelling_test()
 iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_proflib_exported_data_linkage_test()

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -2733,14 +2733,33 @@ icValidateStatus CIccInfo::CheckData(std::string &sReport, const icDateTimeNumbe
   return rv;
 }
 
+// The only caller is CIccTagSpectralViewingConditions::Validate, which applies this
+// to illuminantXYZ and to surroundXYZ.  Both fields carry absolute luminance in
+// cd/m^2, so a Y of 1 is the signature of a producer that wrote chromaticity-
+// normalized values instead -- normalizing divides every component by Y, which is
+// what leaves Y at exactly 1.
+//
+// The test cannot be made exact, and that is a property of the data rather than of
+// this implementation: a normalized XYZ and a genuine 1 cd/m^2 XYZ are the same
+// three numbers.  Testing/Display carries the proof as a fixture pair --
+// sRGB_D65_MAT-300lx.xml is 300 x (0.9504, 1.0, 1.0889) and sRGB_D65_MAT.xml is that
+// same triple at Y = 1, which is simultaneously the normalized form and a legal
+// 1 cd/m^2 dark surround.  Surrounds do live down there; the BT.2100 fixtures in
+// this corpus use 5 cd/m^2.  So the finding is reported as a possibility rather
+// than an assertion, and stays at Warning: no value of Y on its own proves the tag
+// wrong.  Proving it wrong needs context this function is not given -- see #1811 for
+// the corpus population where illuminantXYZ and surroundXYZ disagree on units.
 icValidateStatus CIccInfo::CheckLuminance(std::string &sReport, const icFloatXYZNumber &XYZ, std::string sDesc/*=""*/)
 {
   icValidateStatus rv = icValidateOK;
 
+  // An absolute +/-0.01 window, not a relative one: it brackets exactly [0.99, 1.01].
+  // Kept as it was -- widening it would start reaching into the physical range, where
+  // the 5 cd/m^2 surrounds this corpus already uses would begin to trip it.
   if (fabs(XYZ.Y - 1.0) < 0.01) {
     sReport += icMsgValidateWarning;
     sReport += sDesc;
-    sReport += " - XYZNumber appears to be normalized! Y value should reflect absolute luminance.\n";
+    sReport += " - XYZNumber Y is possibly normalized; Y should carry absolute luminance in cd/m^2.\n";
     rv = icValidateWarning;
   }
 


### PR DESCRIPTION
## Summary

`CIccInfo::CheckLuminance` (`IccProfLib/IccUtil.cpp`) warns when a
`spectralViewingConditions` `illuminantXYZ`/`surroundXYZ` Y lands within 0.01 of 1.0,
on the theory that a producer wrote chromaticity-normalized values into a field that
carries absolute luminance in cd/m². It stated that as a conclusion —
`XYZNumber appears to be normalized!` — which is more than the data supports.

**The check cannot be made exact, and that is a property of the data, not of the
implementation.** Normalizing divides every component by Y, so a normalized XYZ and a
genuine 1 cd/m² XYZ are the same three numbers. `Testing/Display` already carries the
proof, as the same profile authored at three luminance levels:

| fixture | X | Y | Z |
|---|---|---|---|
| `sRGB_D65_MAT.xml` | 0.9504 | 1.0 | 1.0889 |
| `sRGB_D65_MAT-300lx.xml` | 285.12 | 300 | 326.67 |
| `sRGB_D65_MAT-500lx.xml` | 475.20 | 500 | 544.45 |

The 300 cd/m² fixture divided by 300 **is** the normalized fixture. A 1 cd/m² surround is
not hypothetical either — the BT.2100 fixtures in this corpus use 5 cd/m². So the
diagnostic is reworded to say `possibly normalized`, to name the unit, and to stay at
`Warning`, which is #1811's fourth bullet.

Behaviour is otherwise unchanged: same 0.01 window, same status, same 27 corpus profiles.

## Changes

- **`IccProfLib/IccUtil.cpp`** — reworded message; why-comment recording why the check is
  inherently inexact, so a later reader does not try to "tighten" it.
- **`.github/ci/regression/luminance-normalization-diagnostic.cpp`** (new) — exercises the
  three values #1811 names (1, 300, 500), which are the three levels the `sRGB_D65_MAT`
  family is authored at, plus both window edges and the 5 cd/m² BT.2100 surround. It calls
  `CheckLuminance` directly rather than going through
  `CIccTagSpectralViewingConditions::Validate`, whose missing-observer **critical** would
  mask the status under test.
- **`Build/Cmake/Testing/CMakeLists.txt`** — registration, in both call lists.
- **`.github/scripts/iccdev-qa-profile-manifest.sh`** — the manifest matched the old message
  text to attribute 27 baselined rows to #1811, so it moves in step. The rationale string is
  unchanged and the manifest **regenerates byte-identical**. Left alone, those 27 rows would
  have silently degraded to the generic warning rationale on the next `generate` — check mode
  does not compare that column, so nothing would have gone red.

## Verification

Red/green proven: built against master's library, the two wording assertions fail and the ten
behavioural ones pass — the behavioural half deliberately pins *unchanged* behaviour.

| lane | result |
|---|---|
| strict clang 21.1.3, `-Wall -Wextra -Wpedantic -Werror` (`all` + `check`) | 0 warnings |
| GCC 15.2.0 in CI's own regression container, same flags + LTO | 0 warnings |
| GCC strict ASAN+UBSAN Debug, run with `detect_leaks=1` | 0 warnings, clean |
| `ci-pr-unix` default flags, gcc + clang | 0 warnings |
| full `ctest` | 162/163 |
| `shellcheck` / `bash -n` / `git diff --check` | rc=0 |

The one ctest failure is `iccdev.spectral-tiff-preview`, which fails on a missing local
`imagecodecs` Python module and is unrelated to this change.

Manifest coupling verified both directions: regenerating with the updated script is
byte-identical to the committed TSV, and regenerating with the old matcher takes the `#1811`
rows from 27 to 0.

## Scope

**Part of #1811.** The issue's first bullet — writing the intended physical luminance into
the generated profiles — is a corpus decision rather than a code one and is deliberately not
here. Sweeping all 318 `IlluminantXYZ`/`SurroundXYZ` rows in `git ls-files '*.xml'` shows 48
rows across 28 fixtures at Y≈1.0, splitting into two populations that want different answers:

- **20 fixtures where both fields are ≈1.0** — coherently normalized, and including all seven
  `SpecRef/` reference profiles.
- **8 `ICS/` fixtures where illuminant is 1.0 but surround is 160 or 500** — mixed units inside
  a single tag, incoherent under either reading, and the stronger case for a fixture fix.

Both are noted on the issue for @maxderhak / @ChrisCoxArt.
