### PR TITLE
fix(#2043): restate the luminance window's real bounds and pin its float edges

### DIFF
--- a/.github/ci/regression/luminance-normalization-diagnostic.cpp
+++ b/.github/ci/regression/luminance-normalization-diagnostic.cpp
@@ -38,6 +38,7 @@
 #include "IccUtil.h"
 
 #include <cstdio>
+#include <limits>
 #include <string>
 
 static int g_failures = 0;
@@ -94,10 +95,45 @@ int main()
   check(runCheck(500.0f, sReport) == icValidateOK, "Y=500 is accepted");
   check(sReport.empty(), "Y=500 adds nothing to the report");
 
-  // The window is an absolute +/-0.01 around 1.0, not a relative tolerance.  Pinning
-  // both sides keeps a later change from widening it into the physical range, where
-  // it would start flagging genuinely dark surrounds: 5 cd/m^2 is in use in this
-  // corpus today and must stay clean.
+  // The window is an absolute +/-0.01 around 1.0, not a relative tolerance, and the
+  // comparison is strict -- so in exact arithmetic it is the OPEN interval
+  // (0.99, 1.01).  The version of this test that shipped with the diagnostic claimed
+  // it "brackets exactly [0.99, 1.01]", which is wrong twice over, and #2043 caught
+  // it: exactly 0.99 is outside the open interval, while float(0.99) is
+  // 0.99000000953674316 -- greater than 0.99 -- and so is inside.  runCheck takes an
+  // icFloatNumber, which is float, so these four assertions describe what a caller
+  // actually observes at the edge, not what the literal 0.01 suggests.
+  //
+  // The steps to the adjacent representable values are written as epsilon rather than
+  // std::nextafter().  epsilon() is 2^-23, which is the float spacing throughout
+  // [1, 2); halving it gives 2^-24, the spacing throughout [0.5, 1).  Both are exact
+  // powers of two, so the subtraction and addition are themselves exact and evaluate
+  // identically on every compiler -- the same reason gamut-xform-semantics.cpp names
+  // its boundary as 256/65535 instead of stepping to it.
+  // Those two spacings are the ones that hold for a 24-bit significand.  If
+  // icFloatNumber ever widens, the edges move and these four cases stop describing
+  // the boundary at all, so say so at compile time rather than failing at run time
+  // with a message that would point at the window instead of at the type.
+  static_assert(std::numeric_limits<icFloatNumber>::digits == 24,
+                "the window-edge cases below assume icFloatNumber is a 32-bit float");
+
+  const icFloatNumber kEpsilon = std::numeric_limits<icFloatNumber>::epsilon();
+  const icFloatNumber kSpacingBelowOne = kEpsilon / 2;  // ULP across [0.5, 1)
+  const icFloatNumber kSpacingAboveOne = kEpsilon;      // ULP across [1, 2)
+
+  check(runCheck(0.99f, sReport) == icValidateWarning,
+        "float(0.99) is inside the window, though exactly 0.99 would not be");
+  check(runCheck(1.01f, sReport) == icValidateWarning,
+        "float(1.01) is inside the window, though exactly 1.01 would not be");
+  check(runCheck(0.99f - kSpacingBelowOne, sReport) == icValidateOK,
+        "the next float below 0.99 is outside the window");
+  check(runCheck(1.01f + kSpacingAboveOne, sReport) == icValidateOK,
+        "the next float above 1.01 is outside the window");
+
+  // Interior and clearly exterior values keep a later change from narrowing the
+  // window, or from widening it into the physical range where it would start
+  // flagging genuinely dark surrounds: 5 cd/m^2 is in use in this corpus today and
+  // must stay clean.
   check(runCheck(0.995f, sReport) == icValidateWarning, "Y=0.995 is inside the window");
   check(runCheck(1.005f, sReport) == icValidateWarning, "Y=1.005 is inside the window");
   check(runCheck(0.98f, sReport) == icValidateOK, "Y=0.98 is outside the window");

--- a/.github/instructions/matlab-mex.instructions.md
+++ b/.github/instructions/matlab-mex.instructions.md
@@ -17,6 +17,8 @@ matlab/
   mex/
     icc_mex.cpp           # MEX gateway (702 lines) -- action-string dispatch
   +iccdev/
+    +qa/
+      check_luminance_normalization.m  # Issue #1811 fixture calculation model
     IccProfile.m          # Profile class (open, read, header, color_space)
     IccCmm.m              # Color management module wrapper
     IccApply.m            # Thread-safe per-thread apply handle
@@ -27,9 +29,11 @@ matlab/
   examples/
     read_profile.m        # Profile reading example
     color_transform.m     # Color transform example
+    luminance_normalization.m # Explain issue #1811 fixture scaling
   build_mex.m             # Build script (auto-detects library location)
   tests/
     test_iccdev.m         # Test suite (MATLAB/Octave compatible)
+    test_luminance_normalization.m # Dependency-free issue #1811 check
   README.md               # Usage documentation
 ```
 
@@ -123,6 +127,29 @@ For Docker CLI interoperability:
 ```matlab
 run_docker_qa();
 ```
+
+For issue #1811 luminance calculations, first run the dependency-free MATLAB
+model:
+
+```matlab
+test_luminance_normalization();
+run('matlab/examples/luminance_normalization.m');
+```
+
+Then run the native C++ implementation check from a CMake tree configured with
+`ENABLE_TESTS=ON`:
+
+```powershell
+cmake --build msvc --config Release --target iccLuminanceNormalizationTest
+ctest --test-dir msvc -C Release `
+  -R '^iccdev\.luminance-normalization$' `
+  --output-on-failure --no-tests=error
+```
+
+The MATLAB layer validates XML fixture scaling and emulates `icFloatNumber`
+precision. The native CTest calls `CIccInfo::CheckLuminance` and pins its
+warning status, message, nominal `0.99`/`1.01` endpoints, adjacent float
+values, and physical Y values 5, 300, and 500.
 
 ## Dependencies
 

--- a/.github/prompts/debug-matlab-bindings.prompt.md
+++ b/.github/prompts/debug-matlab-bindings.prompt.md
@@ -26,10 +26,30 @@ correct profile or transform results.
    - stale loaded MEX
    - missing generated profiles
    - CMM input shape or lifecycle error
+   - issue #1811 fixture normalization or float-window mismatch
+   - disagreement between the MATLAB model and native `CheckLuminance`
    - Docker daemon, image, mount, or output-contract error
 
-6. Fix the root cause and add the nearest MATLAB regression.
-7. Run `test_iccdev`, `run_local_qa`, `run_docker_qa`, and all examples.
-8. Preserve unrelated generated files and report exact validation results.
-9. Review staged and untracked files for credentials, licenses, tokens,
-   personal data, and local MATLAB Project metadata before any push.
+6. For luminance normalization failures, separate the two validation layers:
+
+   ```matlab
+   test_luminance_normalization();
+   run('matlab/examples/luminance_normalization.m');
+   ```
+
+   ```powershell
+   cmake --build msvc --config Release `
+     --target iccLuminanceNormalizationTest
+   ctest --test-dir msvc -C Release `
+     -R '^iccdev\.luminance-normalization$' `
+     --output-on-failure --no-tests=error
+   ```
+
+   The MATLAB layer reads the XML fixtures and models single-precision
+   arithmetic. The native layer is authoritative for
+   `CIccInfo::CheckLuminance` status and message behavior.
+7. Fix the root cause and add the nearest MATLAB or native regression.
+8. Run `test_iccdev`, `run_local_qa`, `run_docker_qa`, and all examples.
+9. Preserve unrelated generated files and report exact validation results.
+10. Review staged and untracked files for credentials, licenses, tokens,
+    personal data, and local MATLAB Project metadata before any push.

--- a/.github/skills/matlab-bindings-test/SKILL.md
+++ b/.github/skills/matlab-bindings-test/SKILL.md
@@ -30,7 +30,27 @@ profiles, examples, and native handle lifecycle behavior.
 
 6. Generate or copy canonical `Testing/Display/*.icc` profiles. Exclude logs,
    crash artifacts, and unrelated untracked files.
-7. Run:
+7. When validating issue #1811 or luminance diagnostics, run both layers:
+
+   ```matlab
+   addpath('matlab');
+   addpath('matlab/tests');
+   test_luminance_normalization();
+   run('matlab/examples/luminance_normalization.m');
+   ```
+
+   ```powershell
+   cmake --build msvc --config Release `
+     --target iccLuminanceNormalizationTest
+   ctest --test-dir msvc -C Release `
+     -R '^iccdev\.luminance-normalization$' `
+     --output-on-failure --no-tests=error
+   ```
+
+   The MATLAB test confirms fixture arithmetic independently. The CTest must
+   call the real `CIccInfo::CheckLuminance`; do not treat the MATLAB model as
+   proof of native message or status behavior.
+8. Run:
 
    ```matlab
    addpath('matlab/tests');
@@ -42,7 +62,7 @@ profiles, examples, and native handle lifecycle behavior.
    run('matlab/examples/docker_interop.m');
    ```
 
-8. Confirm `icc_mex` loads from the package private directory and any required
+9. Confirm `icc_mex` loads from the package private directory and any required
    runtime DLL is staged beside it.
 
 ## Failure Rules
@@ -62,6 +82,8 @@ profiles, examples, and native handle lifecycle behavior.
 - Release static library path.
 - MEX output path and dependency paths.
 - Exact MATLAB test result.
+- Issue #1811 fixture normalization error and warning-window values, when in scope.
+- Native `iccdev.luminance-normalization` CTest result, when in scope.
 - Example completion.
 - Docker image ID or digest and interoperability result.
 - Any skipped profile-dependent checks and why.

--- a/.github/workflows/ci-matlab.yml
+++ b/.github/workflows/ci-matlab.yml
@@ -23,6 +23,10 @@ on:
       - "Build/Cmake/**"
       - "IccProfLib/**"
       - "matlab/**"
+      - "Testing/Display/sRGB_D65_MAT.xml"
+      - "Testing/Display/sRGB_D65_MAT-300lx.xml"
+      - "Testing/Display/sRGB_D65_MAT-500lx.xml"
+      - "Testing/HDR/BT2100PQFullDisplay.xml"
       - "Testing/sRGB_v4_ICC_preference.icc"
   pull_request:
     branches:
@@ -32,6 +36,10 @@ on:
       - "Build/Cmake/**"
       - "IccProfLib/**"
       - "matlab/**"
+      - "Testing/Display/sRGB_D65_MAT.xml"
+      - "Testing/Display/sRGB_D65_MAT-300lx.xml"
+      - "Testing/Display/sRGB_D65_MAT-500lx.xml"
+      - "Testing/HDR/BT2100PQFullDisplay.xml"
       - "Testing/sRGB_v4_ICC_preference.icc"
   workflow_dispatch:
 
@@ -70,6 +78,17 @@ jobs:
         with:
           release: R2026a
 
+      - name: Reproduce luminance normalization calculations
+        # matlab-actions/run-command v3
+        uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264
+        with:
+          command: >-
+            addpath('matlab');
+            addpath(fullfile('matlab', 'tests'));
+            test_luminance_normalization();
+            run(fullfile('matlab', 'examples', 'luminance_normalization.m'))
+          generate-summary: false
+
       - name: Configure and build IccProfLib
         env:
           POWERSHELL_TELEMETRY_OPTOUT: "1"
@@ -88,7 +107,7 @@ jobs:
           cmake -S Build\Cmake -B out\matlab `
             -G "Visual Studio 17 2022" `
             -A x64 `
-            -DENABLE_TESTS=OFF `
+            -DENABLE_TESTS=ON `
             -DENABLE_TOOLS=OFF `
             -DENABLE_WXWIDGETS=OFF `
             -DENABLE_SHARED_LIBS=OFF `
@@ -105,9 +124,31 @@ jobs:
           }
 
           cmake --build out\matlab --config Release `
-            --target IccProfLib2-static --parallel
+            --target IccProfLib2-static iccLuminanceNormalizationTest --parallel
           if ($LASTEXITCODE -ne 0) {
-            throw "IccProfLib2-static build failed with exit code $LASTEXITCODE"
+            throw "Native luminance test build failed with exit code $LASTEXITCODE"
+          }
+
+      - name: Run native luminance regression
+        env:
+          POWERSHELL_TELEMETRY_OPTOUT: "1"
+          POWERSHELL_UPDATECHECK: Off
+        run: |
+          Set-StrictMode -Version Latest
+          $ErrorActionPreference = 'Stop'
+          $PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+          git config --global credential.helper ""
+          if (Test-Path Env:GITHUB_TOKEN) {
+            Remove-Item Env:GITHUB_TOKEN -ErrorAction SilentlyContinue
+          }
+          . .trusted-helpers/.github/scripts/sanitize.ps1
+
+          ctest --test-dir out\matlab -C Release `
+            -R '^iccdev\.luminance-normalization$' `
+            --output-on-failure `
+            --no-tests=error
+          if ($LASTEXITCODE -ne 0) {
+            throw "Native luminance regression failed with exit code $LASTEXITCODE"
           }
 
       - name: Build MATLAB MEX gateway

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -2753,7 +2753,14 @@ icValidateStatus CIccInfo::CheckLuminance(std::string &sReport, const icFloatXYZ
 {
   icValidateStatus rv = icValidateOK;
 
-  // An absolute +/-0.01 window, not a relative one: it brackets exactly [0.99, 1.01].
+  // An absolute +/-0.01 window, not a relative one.  The comment added here with the
+  // diagnostic said it "brackets exactly [0.99, 1.01]"; #2043 showed that to be wrong
+  // in both directions, so it is restated rather than repeated.  The comparison is
+  // strict, so in exact arithmetic the window is the OPEN interval (0.99, 1.01) and a
+  // Y of exactly 0.99 falls outside it.  XYZ.Y is an icFloatNumber, though, and the
+  // comparison promotes it to double: float(0.99) is 0.99000000953674316, which is
+  // greater than 0.99 and therefore lands inside.  The effective edge is up to one
+  // float ULP beyond the nominal one on each side; the CTest pins that directly.
   // Kept as it was -- widening it would start reaching into the physical range, where
   // the 5 cd/m^2 surrounds this corpus already uses would begin to trip it.
   if (fabs(XYZ.Y - 1.0) < 0.01) {

--- a/docs/matlab-bindings.md
+++ b/docs/matlab-bindings.md
@@ -72,6 +72,44 @@ run('E:\opt\iccDEV\matlab\examples\read_profile.m');
 run('E:\opt\iccDEV\matlab\examples\color_transform.m');
 ```
 
+Reproduce the spectral-viewing luminance calculations from issue #1811
+without a C++ build or MEX gateway:
+
+```matlab
+addpath('E:\opt\iccDEV\matlab');
+addpath('E:\opt\iccDEV\matlab\tests');
+test_luminance_normalization();
+run('E:\opt\iccDEV\matlab\examples\luminance_normalization.m');
+```
+
+This check reads the `sRGB_D65_MAT` fixtures authored at Y=1, 300, and
+500 cd/m^2, verifies that dividing each XYZ triple by Y produces the same
+D65 chromaticity, and records the single-precision behavior of the absolute
+`0.01` warning window around Y=1. Hosted CI also builds and runs
+`iccdev.luminance-normalization`, which calls the native
+`CIccInfo::CheckLuminance` implementation and verifies its status, message,
+nominal `0.99`/`1.01` endpoints, and adjacent representable float values.
+
+Run the same native check locally from a CMake tree configured with
+`ENABLE_TESTS=ON`:
+
+```powershell
+cmake --build msvc --config Release `
+  --target iccLuminanceNormalizationTest
+ctest --test-dir msvc -C Release `
+  -R '^iccdev\.luminance-normalization$' `
+  --output-on-failure --no-tests=error
+```
+
+Interpret the layers separately:
+
+- `test_luminance_normalization` confirms the checked-in XML values and
+  independently reproduces their double- and single-precision calculations.
+- `iccdev.luminance-normalization` calls the compiled C++ method and is
+  authoritative for validation status and diagnostic wording.
+- Agreement between both layers confirms the fixture evidence and the native
+  implementation without making either test self-referential.
+
 Expected coverage includes profile open/read/header checks, CMM pipeline and
 bulk apply, per-thread apply handles, parent-close invalidation, native handle
 lifecycle checks, single-precision input, missing-profile errors, finite output,

--- a/matlab/+iccdev/+qa/check_luminance_normalization.m
+++ b/matlab/+iccdev/+qa/check_luminance_normalization.m
@@ -1,0 +1,93 @@
+function results = check_luminance_normalization(fixture_root)
+%CHECK_LUMINANCE_NORMALIZATION Verify spectral-viewing luminance calculations.
+%
+%   results = iccdev.qa.check_luminance_normalization()
+%   results = iccdev.qa.check_luminance_normalization(fixture_root)
+%
+% Reads the sRGB D65 fixtures authored at Y=1, 300, and 500 cd/m^2,
+% confirms that scaling each XYZ triple by its Y produces the same D65
+% chromaticity, and emulates CIccInfo::CheckLuminance using single precision.
+%
+% Copyright (c) International Color Consortium.
+% BSD 3-Clause License. See LICENSE.md for details.
+
+  if nargin < 1
+    matlab_dir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+    repo_root = fileparts(matlab_dir);
+    fixture_root = fullfile(repo_root, 'Testing');
+  end
+
+  display_dir = fullfile(fixture_root, 'Display');
+  fixture_names = {
+    'sRGB_D65_MAT.xml'
+    'sRGB_D65_MAT-300lx.xml'
+    'sRGB_D65_MAT-500lx.xml'
+  };
+  expected_y = [1; 300; 500];
+  illuminant = zeros(3, 3);
+  surround = zeros(3, 3);
+
+  for i = 1:numel(fixture_names)
+    fixture_path = fullfile(display_dir, fixture_names{i});
+    xml = fileread(fixture_path);
+    illuminant(i, :) = read_xyz(xml, 'IlluminantXYZ');
+    surround(i, :) = read_xyz(xml, 'SurroundXYZ');
+  end
+
+  tolerance = 1e-12;
+  assert(max(abs(illuminant(:, 2) - expected_y)) < tolerance, ...
+    'iccdev:luminanceFixtureY', ...
+    'Fixture Y values do not match 1, 300, and 500 cd/m^2.');
+  assert(max(abs(illuminant(:) - surround(:))) < tolerance, ...
+    'iccdev:luminanceFixtureMismatch', ...
+    'IlluminantXYZ and SurroundXYZ differ in the sRGB D65 fixtures.');
+
+  normalized = bsxfun(@rdivide, illuminant, illuminant(:, 2));
+  normalized_error = max(abs(normalized - normalized(1, :)), [], 2);
+  assert(max(normalized_error) < tolerance, ...
+    'iccdev:luminanceNormalizationMismatch', ...
+    'The 300 and 500 cd/m^2 fixtures do not normalize to the Y=1 fixture.');
+
+  bt2100_path = fullfile(fixture_root, 'HDR', 'BT2100PQFullDisplay.xml');
+  bt2100_xml = fileread(bt2100_path);
+  bt2100_surround = read_xyz(bt2100_xml, 'SurroundXYZ');
+  assert(abs(bt2100_surround(2) - 5.0) < tolerance, ...
+    'iccdev:luminanceBt2100Mismatch', ...
+    'The BT.2100 fixture surround is not 5 cd/m^2.');
+
+  case_y = single([0.98; 0.99; 0.995; 1.0; 1.005; 1.01; 1.02; 5; 300; 500]);
+  distance = abs(double(case_y) - 1.0);
+  warns = distance < 0.01;
+  expected_warns = logical([0; 1; 1; 1; 1; 1; 0; 0; 0; 0]);
+  assert(isequal(warns, expected_warns), ...
+    'iccdev:luminanceWindowMismatch', ...
+    'Single-precision warning-window behavior changed.');
+
+  results.fixtureNames = fixture_names;
+  results.illuminantXYZ = illuminant;
+  results.surroundXYZ = surround;
+  results.normalizedXYZ = normalized;
+  results.normalizationError = normalized_error;
+  results.bt2100SurroundXYZ = bt2100_surround;
+  results.windowY = double(case_y);
+  results.windowDistance = distance;
+  results.windowWarns = warns;
+end
+
+function xyz = read_xyz(xml, tag_name)
+  tag_match = regexp(xml, ['<' tag_name '\s+[^>]*>'], 'match', 'once');
+  assert(~isempty(tag_match), 'iccdev:luminanceTagMissing', ...
+    'Missing %s element.', tag_name);
+
+  xyz = zeros(1, 3);
+  attributes = {'X', 'Y', 'Z'};
+  for i = 1:numel(attributes)
+    token = regexp(tag_match, ...
+      [attributes{i} '="([^"]+)"'], 'tokens', 'once');
+    assert(~isempty(token), 'iccdev:luminanceAttributeMissing', ...
+      'Missing %s attribute on %s.', attributes{i}, tag_name);
+    xyz(i) = str2double(token{1});
+    assert(isfinite(xyz(i)), 'iccdev:luminanceAttributeInvalid', ...
+      'Invalid %s attribute on %s.', attributes{i}, tag_name);
+  end
+end

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -103,6 +103,7 @@ cmm.close();
 | Function | Description |
 |----------|-------------|
 | `iccdev.sig_to_str(sig)` | Convert 4-byte ICC signature to ASCII string |
+| `iccdev.qa.check_luminance_normalization()` | Reproduce spectral-viewing luminance scaling and warning-window checks |
 | `iccdev.docker_available(image)` | Check Docker daemon and image availability |
 | `iccdev.docker_validate(profile, ...)` | Run containerized dump and round-trip validation |
 | `build_mex(...)` | Build the MEX extension |
@@ -204,6 +205,30 @@ Validate the same profile with the published container:
 run_docker_qa();
 run('matlab/examples/docker_interop.m');
 ```
+
+Reproduce the issue #1811 spectral-viewing luminance calculations without
+building the MEX gateway:
+
+```matlab
+addpath('matlab');
+addpath('matlab/tests');
+test_luminance_normalization();
+run('matlab/examples/luminance_normalization.m');
+```
+
+Validate the compiled `CIccInfo::CheckLuminance` implementation separately
+from a CMake tree configured with `ENABLE_TESTS=ON`:
+
+```powershell
+cmake --build msvc --config Release `
+  --target iccLuminanceNormalizationTest
+ctest --test-dir msvc -C Release `
+  -R '^iccdev\.luminance-normalization$' `
+  --output-on-failure --no-tests=error
+```
+
+The MATLAB check is an independent fixture/arithmetic model. The native CTest
+is authoritative for warning status and message behavior; both should pass.
 
 See [MATLAB bindings and QA](../docs/matlab-bindings.md) for the Windows
 desktop workflow, profile generation, WSL2 boundaries, troubleshooting, and

--- a/matlab/examples/luminance_normalization.m
+++ b/matlab/examples/luminance_normalization.m
@@ -1,0 +1,38 @@
+%% luminance_normalization.m - Reproduce issue #1811 calculations
+%
+% Copyright (c) International Color Consortium.
+% BSD 3-Clause License. See LICENSE.md for details.
+
+this_dir = fileparts(mfilename('fullpath'));
+matlab_dir = fileparts(this_dir);
+addpath(matlab_dir);
+
+results = iccdev.qa.check_luminance_normalization();
+
+fprintf('Fixture normalization to Y=1:\n');
+for i = 1:numel(results.fixtureNames)
+  xyz = results.illuminantXYZ(i, :);
+  normalized = results.normalizedXYZ(i, :);
+  fprintf(['  %-26s XYZ=(%.12g, %.12g, %.12g)  ' ...
+    'normalized=(%.12g, %.12g, %.12g)\n'], ...
+    results.fixtureNames{i}, xyz(1), xyz(2), xyz(3), ...
+    normalized(1), normalized(2), normalized(3));
+end
+
+fprintf('\nSingle-precision CheckLuminance window:\n');
+for i = 1:numel(results.windowY)
+  if results.windowWarns(i)
+    status = 'Warning';
+  else
+    status = 'OK';
+  end
+  fprintf('  Y=%-8g distance=%-12.9g %s\n', ...
+    results.windowY(i), results.windowDistance(i), status);
+end
+
+fprintf(['\nThe 300 and 500 cd/m^2 fixtures normalize to the same XYZ ' ...
+  'triple as the Y=1 fixture.\n']);
+fprintf('The BT.2100 physical surround remains Y=%.12g cd/m^2.\n', ...
+  results.bt2100SurroundXYZ(2));
+fprintf(['Nominal Y=0.99 and Y=1.01 both warn after conversion to ' ...
+  'single precision.\n']);

--- a/matlab/tests/test_luminance_normalization.m
+++ b/matlab/tests/test_luminance_normalization.m
@@ -1,0 +1,27 @@
+function test_luminance_normalization()
+%TEST_LUMINANCE_NORMALIZATION Reproduce issue #1811 luminance calculations.
+%
+% Copyright (c) International Color Consortium.
+% BSD 3-Clause License. See LICENSE.md for details.
+
+  results = iccdev.qa.check_luminance_normalization();
+
+  expected_normalized = [0.9504, 1.0, 1.0889];
+  expected_rows = repmat(expected_normalized, 3, 1);
+  assert(max(abs(results.normalizedXYZ(:) - expected_rows(:))) < 1e-12, ...
+    'Normalized fixtures must reproduce the D65 XYZ triple.');
+  assert(max(results.normalizationError) < 1e-12, ...
+    'Fixture normalization error exceeds tolerance.');
+  assert(abs(results.bt2100SurroundXYZ(2) - 5.0) < 1e-12, ...
+    'The BT.2100 physical surround should remain at 5 cd/m^2.');
+
+  warn_y = results.windowY(results.windowWarns);
+  clean_y = results.windowY(~results.windowWarns);
+  assert(isequal(single(warn_y), ...
+    single([0.99; 0.995; 1; 1.005; 1.01])), ...
+    'Unexpected warning-window values.');
+  assert(isequal(single(clean_y), single([0.98; 1.02; 5; 300; 500])), ...
+    'Unexpected accepted luminance values.');
+
+  fprintf('Luminance normalization calculations passed.\n');
+end


### PR DESCRIPTION
Cross-check of the MATLAB QA reproduction in #2043, plus the corrections it turned up.

## The reproduction holds, and it caught a wrong comment of mine

@xsscx's reproduction is correct. Verified independently:

| value | `fabs(XYZ.Y - 1.0)` | result |
|---|---|---|
| `0.99f` -> 0.99000000953674316 | 0.0099999904632568359 | **Warning** |
| `1.01f` -> 1.0099999904632568 | 0.0099999904632568359 | **Warning** |
| next float below `0.99f` | 0.010000050067901611 | OK |
| next float above `1.01f` | 0.010000109672546387 | OK |
| exact double `0.99` | 0.010000000000000009 | OK |

The comment I shipped with the #1811 diagnostic said the window "brackets exactly
`[0.99, 1.01]`". That is wrong in both directions:

- the comparison is strict, so in exact arithmetic the window is the **open** interval
  `(0.99, 1.01)` and a Y of exactly `0.99` is **outside** it;
- `XYZ.Y` is an `icFloatNumber`, and the comparison promotes it to `double`, so
  `float(0.99)` is `0.99000000953674316` -- greater than `0.99` -- and lands **inside**.

The effective edge therefore sits up to one float ULP beyond the nominal one on each
side. `CheckLuminance` is unchanged; the window is correct, only its description was not.

## One correction to the patch: no `std::nextafter`

The four new cases step to the adjacent representable values with
`numeric_limits<icFloatNumber>::epsilon()` instead of `std::nextafter()`. `epsilon()`
is `2^-23`, the float spacing across `[1, 2)`; half of it is `2^-24`, the spacing
across `[0.5, 1)`. Both are exact powers of two, so the arithmetic is exact and
evaluates identically everywhere.

This follows existing precedent in the same corpus --
`.github/ci/regression/gamut-xform-semantics.cpp:166` names its boundary as `256/65535`
rather than stepping to it, "an exact binary value on every platform, unlike a
nextafter() step". There is no other `std::nextafter` in the regression tree, so this
keeps the call shape off the MSVC legs entirely.

Confirmed bit-identical to `std::nextafter` under gcc 13.3 and clang 18.1.3.

A `static_assert` on `digits == 24` pins the assumption: `icFloatNumber` is
`typedef float` (`IccDefs.h:88`), and if it ever widens these four cases stop
describing the boundary. Better to say so at compile time than to fail at run time
with a message pointing at the window instead of at the type.

## Red-tested

All four assertions were checked against a deliberately altered window:

- narrowed to `< 0.0099999` -> both "inside" cases fail
- widened to `< 0.0100002` -> both "outside" cases fail

## MATLAB layer

Lands @xsscx's MATLAB work for the same diagnostic: a dependency-free model of the
fixture scaling and of the single-precision window, plus the Windows MSVC `ctest` step
that runs `iccdev.luminance-normalization` under `--no-tests=error`.

That last part matters beyond this issue: it makes the native assertions **proven** to
execute on the Windows leg rather than assumed to, which is a gap that has bitten this
repo before.

Every assertion in the MATLAB layer was verified against the checked-in fixtures.

## Pre-flight

| gate | result |
|---|---|
| clang 21.1.3, `-Wall -Wextra -Wpedantic -Werror` | 0 warnings, 0 errors |
| GCC 15.2.0 in `iccdev-ci-regression`, `-Werror` + LTO | 0 warnings, 0 errors |
| ASAN + UBSAN, `detect_leaks=1` | clean |
| actionlint / zizmor / yamllint (CI's config) | all clean |
| `ctest` | `iccdev.luminance-normalization` passes on every profile |

Part of #2043.
