### PR TITLE
fix(#2044): restore the u8Fixed8 gamma regression #968 dropped, with a derived bound

### DIFF
--- a/.github/ci/regression/curve-gamma-u8fixed8.cpp
+++ b/.github/ci/regression/curve-gamma-u8fixed8.cpp
@@ -1,0 +1,285 @@
+/*
+    File:       curve-gamma-u8fixed8.cpp
+
+    Contains:   CTest for the u8Fixed8Number gamma reconstruction that #808 fixed
+                (#815/#2044).
+
+    A one-entry curveType holds a gamma exponent as a u8Fixed8Number: an unsigned
+    16-bit integer with eight fractional bits, so the encoded value is raw/256 and
+    y = x^gamma.  ReadUInt16Float() normalizes on read by dividing by 65535, which
+    means every consumer has to undo that with
+
+        m_Curve[0] * 65535.0 / 256.0
+
+    and NOT m_Curve[0] * 256.0.  The ratio 65536/65535 between the two is why
+    Describe() and DumpLut() printed 2.2071 instead of 2.20703125 from 2005 until
+    #808, and why CIccTagJsonCurve::ToJson wrote the raw normalized 0.00862 instead
+    of a gamma at all.
+
+    WHY THIS FILE EXISTS: #808 shipped that fix with a regression -- steps R12/R13
+    in ci-iccdev-tool-tests.yml and R8 in ci-tool-tests.yml, covering all four
+    fixtures below.  Commit 35f5c5e6 ("Modify: CMake CTest CPack", #968) removed
+    both workflows' inline test bodies during the migration to CTest and the gamma
+    steps were not carried over, so master has had no coverage of this arithmetic
+    since.  Three of the four fixtures had no reference anywhere in the tree.  This
+    restores the coverage in the form the migration was moving toward.
+
+    The tolerance is derived, not observed.  #2044 measured the JSON error on
+    gamma-2.20703125.icc as 6.01e-08 and proposed pinning something near it; that
+    would be wrong for the corpus, because the error is proportional to the gamma
+    and gamma-2.3984375.icc is nearly twice as far out at 1.19e-07.  m_Curve[0] is
+    an icFloatNumber, so it carries the rounding of raw/65535 into a 24-bit
+    significand -- a relative error of at most 2^-24 -- and multiplying by the exact
+    ratio 65535/256 scales that straight through.  The bound is therefore
+    gamma * 2^-24, which is 1.43e-07 at gamma 2.4 and holds for every fixture.  The
+    old R13 check used a flat 0.01, roughly five orders looser than the effect it
+    was guarding, so it could not have failed for this reason.
+
+    What each fixture is asserted to do:
+
+      - Describe() must print the exact encoded value.  This is lossless: the
+        expression is evaluated in double and printed at %.10lf, so 2.20703125 comes
+        out exactly and a regression to *256.0 would read 2.2071068... instead.
+      - ToJson() must emit a gamma within the bound above, and that emitted decimal
+        must still round back to the stored integer.  The round trip is the property
+        that actually matters -- iccFromJson recovers raw 565 from 2.2070311898824 --
+        and it is what a presentation-precision change must not break.
+
+    The profile is read through CIccProfileJson with the JSON tag and MPE factories
+    pushed, which is exactly what iccToJson does, so the writer under test is the
+    shipping one rather than a re-implementation of it.
+
+    Usage:  curve-gamma-u8fixed8 <dir containing gamma-*.icc>
+
+    Exit codes:
+      0 - expected results observed
+      1 - unexpected result
+*/
+
+#include "IccProfileJson.h"
+#include "IccTagJsonFactory.h"
+#include "IccMpeJsonFactory.h"
+#include "IccUtilJson.h"
+#include "IccTagLut.h"
+#include "IccIO.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool condition, const std::string& label)
+{
+  if (condition) {
+    std::fprintf(stdout, "curve-gamma-u8fixed8: PASS  %s\n", label.c_str());
+    return;
+  }
+  std::fprintf(stdout, "curve-gamma-u8fixed8: FAIL  %s\n", label.c_str());
+  ++g_failures;
+}
+
+// The four fixtures #808 committed.  raw is the u8Fixed8Number actually stored in
+// each of rTRC/gTRC/bTRC; raw/256 is the exact value it encodes, and every one of
+// them is exactly representable in binary, which is what lets Describe() be
+// compared for equality rather than within a tolerance.
+struct Fixture {
+  const char*    file;
+  unsigned       raw;
+  double         gamma;
+};
+
+const Fixture kFixtures[] = {
+  { "gamma-1.0000000000.icc", 256u, 1.0        },
+  { "gamma-1.796875.icc",     460u, 1.796875   },
+  { "gamma-2.20703125.icc",   565u, 2.20703125 },
+  { "gamma-2.3984375.icc",    614u, 2.3984375  },
+};
+
+const icTagSignature kTrcTags[] = {
+  icSigRedTRCTag, icSigGreenTRCTag, icSigBlueTRCTag
+};
+
+const char* kTrcNames[] = { "redTRCTag", "greenTRCTag", "blueTRCTag" };
+
+// m_Curve[0] is float, so raw/65535 is rounded into a 24-bit significand before the
+// exact ratio 65535/256 scales it back up.  A relative error of at most 2^-24
+// survives that multiplication, so the absolute bound scales with the gamma itself.
+double reconstructionBound(double gamma)
+{
+  return gamma * std::numeric_limits<icFloatNumber>::epsilon() / 2;
+}
+
+// Describe() formats the exponent with "%.10lf", so the expected line is spelled the
+// same way rather than parsed back out -- a formatting change is itself a regression
+// in what a user reads, and #808 was reported from exactly this output.
+std::string expectedDescribeLine(double gamma)
+{
+  char buf[64];
+  std::snprintf(buf, sizeof(buf), "Y = X ^ %.10lf", gamma);
+  return std::string(buf);
+}
+
+// Tags serialize as a "Tags" array of single-key objects, so the tag is located by
+// name rather than by index: the ordering is the profile's, not ours.
+const IccJson* findTagObject(const IccJson& profile, const std::string& tagName)
+{
+  if (!profile.contains("Tags") || !profile["Tags"].is_array())
+    return NULL;
+
+  for (IccJson::const_iterator it = profile["Tags"].begin();
+       it != profile["Tags"].end(); ++it) {
+    if (it->is_object() && it->contains(tagName))
+      return &(*it)[tagName];
+  }
+  return NULL;
+}
+
+// All four fixtures point rTRC, gTRC and bTRC at a single shared tag offset, which
+// is legal and common -- the tag table may name the same data more than once.  The
+// writer serializes the first occurrence and emits {"sameAs": "<tag>"} for the rest,
+// so a lookup that only understood "data" would report the green and blue curves as
+// missing rather than as shared.  Following the link keeps all three channels
+// asserted, and pins the de-duplication itself: if it regressed to writing the value
+// out three times, or to naming a tag that is not in the document, this stops
+// resolving.  The hop count is bounded so a self- or mutual reference cannot spin.
+const IccJson* findTagData(const IccJson& profile, const char* tagName)
+{
+  std::string name(tagName);
+
+  for (int hops = 0; hops < 4; hops++) {
+    const IccJson* pTag = findTagObject(profile, name);
+    if (!pTag || !pTag->is_object())
+      return NULL;
+
+    if (pTag->contains("data"))
+      return &(*pTag)["data"];
+
+    if (!pTag->contains("sameAs") || !(*pTag)["sameAs"].is_string())
+      return NULL;
+
+    const std::string next = (*pTag)["sameAs"].get<std::string>();
+    if (next == name)
+      return NULL;
+    name = next;
+  }
+  return NULL;
+}
+
+void testFixture(const std::string& dir, const Fixture& fx)
+{
+  const std::string path = dir + "/" + fx.file;
+  const std::string tag = std::string(fx.file) + ": ";
+
+  CIccProfileJson profile;
+  CIccFileIO io;
+
+  if (!io.Open(path.c_str(), "r")) {
+    check(false, tag + "fixture opens");
+    return;
+  }
+  if (!profile.Read(&io)) {
+    check(false, tag + "fixture reads");
+    return;
+  }
+
+  // ---- library side: the value the curve holds, and what Describe() prints ----
+  for (int i = 0; i < 3; i++) {
+    CIccTag* pTag = profile.FindTag(kTrcTags[i]);
+    const std::string what = tag + kTrcNames[i] + " ";
+
+    if (!pTag || pTag->GetType() != icSigCurveType) {
+      check(false, what + "is a curveType");
+      continue;
+    }
+
+    CIccTagCurve* pCurve = static_cast<CIccTagCurve*>(pTag);
+    if (pCurve->GetSize() != 1) {
+      check(false, what + "holds exactly one entry (a gamma, not a table)");
+      continue;
+    }
+
+    // The stored float must still identify the encoded integer.  This is the
+    // reader's half of the contract and is exact: raw/65535 rounds to a float that
+    // maps back to raw and to no other value.
+    const double stored = static_cast<double>((*pCurve)[0]);
+    check(std::lround(stored * 65535.0) == static_cast<long>(fx.raw),
+          what + "normalized value recovers the stored u8Fixed8 integer");
+
+    std::string desc;
+    pCurve->Describe(desc, 100);
+    const std::string expected = expectedDescribeLine(fx.gamma);
+    check(desc.find(expected) != std::string::npos,
+          what + "Describe() prints \"" + expected + "\"");
+  }
+
+  // ---- writer side: what iccToJson emits for the same curves ----
+  IccJson j;
+  if (!profile.ToJson(j)) {
+    check(false, tag + "serializes to JSON");
+    return;
+  }
+
+  for (int i = 0; i < 3; i++) {
+    const std::string what = tag + kTrcNames[i] + " ";
+    const IccJson* pData = findTagData(j, kTrcNames[i]);
+
+    if (!pData || !pData->contains("gamma")) {
+      check(false, what + "JSON carries a gamma");
+      continue;
+    }
+    check((*pData)["curveType"] == "gamma",
+          what + "JSON curveType is \"gamma\"");
+
+    const double emitted = (*pData)["gamma"].get<double>();
+    const double bound = reconstructionBound(fx.gamma);
+    char label[256];
+
+    std::snprintf(label, sizeof(label),
+                  "JSON gamma %.12g is within %.3g of %.10f (error %.3g)",
+                  emitted, bound, fx.gamma, std::fabs(emitted - fx.gamma));
+    check(std::fabs(emitted - fx.gamma) <= bound, what + label);
+
+    // The round trip is the contract iccFromJson relies on: whatever decimal is
+    // emitted must still land on the same u8Fixed8 integer when it is read back.
+    check(std::lround(emitted * 256.0) == static_cast<long>(fx.raw),
+          what + "JSON gamma rounds back to the stored u8Fixed8 integer");
+  }
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+  if (argc != 2) {
+    std::fprintf(stderr, "usage: %s <dir containing gamma-*.icc>\n",
+                 argv[0] ? argv[0] : "curve-gamma-u8fixed8");
+    return 1;
+  }
+
+  // iccToJson's own wiring: without these the tags come back as plain IccProfLib
+  // objects with no ToJson, and the writer half of this test would silently cover
+  // nothing.
+  CIccTagCreator::PushFactory(new CIccTagJsonFactory());
+  CIccMpeCreator::PushFactory(new CIccMpeJsonFactory());
+
+  const std::string dir(argv[1]);
+  const size_t nFixtures = sizeof(kFixtures) / sizeof(kFixtures[0]);
+  for (size_t i = 0; i < nFixtures; i++)
+    testFixture(dir, kFixtures[i]);
+
+  if (g_failures) {
+    std::fprintf(stdout, "curve-gamma-u8fixed8: %d failure(s)\n", g_failures);
+    return 1;
+  }
+  std::fprintf(stdout, "curve-gamma-u8fixed8: all checks passed\n");
+  return 0;
+}

--- a/.github/instructions/matlab-mex.instructions.md
+++ b/.github/instructions/matlab-mex.instructions.md
@@ -30,7 +30,9 @@ matlab/
     read_profile.m        # Profile reading example
     color_transform.m     # Color transform example
     luminance_normalization.m # Explain issue #1811 fixture scaling
+    gamma_curve.m         # curveType u8Fixed8 gamma calculation example
   build_mex.m             # Build script (auto-detects library location)
+  run_gamma_qa.m          # Issue #815 gamma fixture and math verification
   tests/
     test_iccdev.m         # Test suite (MATLAB/Octave compatible)
     test_luminance_normalization.m # Dependency-free issue #1811 check
@@ -120,6 +122,7 @@ For the extended local smoke and stress checks:
 ```matlab
 addpath('matlab');
 run_local_qa();
+run_gamma_qa();
 ```
 
 For Docker CLI interoperability:

--- a/.github/prompts/debug-matlab-bindings.prompt.md
+++ b/.github/prompts/debug-matlab-bindings.prompt.md
@@ -48,8 +48,28 @@ correct profile or transform results.
    The MATLAB layer reads the XML fixtures and models single-precision
    arithmetic. The native layer is authoritative for
    `CIccInfo::CheckLuminance` status and message behavior.
-7. Fix the root cause and add the nearest MATLAB or native regression.
-8. Run `test_iccdev`, `run_local_qa`, `run_docker_qa`, and all examples.
-9. Preserve unrelated generated files and report exact validation results.
-10. Review staged and untracked files for credentials, licenses, tokens,
+7. For curveType gamma failures, the same split applies:
+
+   ```matlab
+   run_gamma_qa();
+   run('matlab/examples/gamma_curve.m');
+   ```
+
+   ```powershell
+   cmake --build msvc --config Release `
+     --target iccCurveGammaU8Fixed8Test
+   ctest --test-dir msvc -C Release `
+     -R '^iccdev\.curve-gamma-u8fixed8$' `
+     --output-on-failure --no-tests=error
+   ```
+
+   Confirm the issue #815 fixture decodes raw u8Fixed8 value 565 as gamma
+   2.20703125. The MATLAB layer decodes the bytes independently; the native
+   CTest is authoritative for what `Describe()` prints and what `ToJson()`
+   emits.
+8. Fix the root cause and add the nearest MATLAB or native regression.
+9. Run `test_iccdev`, `run_local_qa`, `run_gamma_qa`, `run_docker_qa`, and all
+   examples.
+10. Preserve unrelated generated files and report exact validation results.
+11. Review staged and untracked files for credentials, licenses, tokens,
     personal data, and local MATLAB Project metadata before any push.

--- a/.github/skills/matlab-bindings-test/SKILL.md
+++ b/.github/skills/matlab-bindings-test/SKILL.md
@@ -56,9 +56,11 @@ profiles, examples, and native handle lifecycle behavior.
    addpath('matlab/tests');
    test_iccdev();
    run_local_qa();
+   run_gamma_qa();
    run_docker_qa();
    run('matlab/examples/read_profile.m');
    run('matlab/examples/color_transform.m');
+   run('matlab/examples/gamma_curve.m');
    run('matlab/examples/docker_interop.m');
    ```
 
@@ -84,6 +86,8 @@ profiles, examples, and native handle lifecycle behavior.
 - Exact MATLAB test result.
 - Issue #1811 fixture normalization error and warning-window values, when in scope.
 - Native `iccdev.luminance-normalization` CTest result, when in scope.
+- Gamma QA result for the `rTRC`, `gTRC`, and `bTRC` issue #815 fixture.
+- Native `iccdev.curve-gamma-u8fixed8` CTest result, when in scope.
 - Example completion.
 - Docker image ID or digest and interoperability result.
 - Any skipped profile-dependent checks and why.

--- a/.github/workflows/ci-matlab.yml
+++ b/.github/workflows/ci-matlab.yml
@@ -18,6 +18,7 @@ on:
     branches:
       - master
       - ci-qa-matlab-examples
+      - ci-qa-matlab-examples-gamma
     paths:
       - ".github/workflows/ci-matlab.yml"
       - "Build/Cmake/**"
@@ -169,7 +170,8 @@ jobs:
             addpath(fullfile('matlab', 'tests'));
             run_local_qa();
             run(fullfile('matlab', 'examples', 'read_profile.m'));
-            run(fullfile('matlab', 'examples', 'color_transform.m'))
+            run(fullfile('matlab', 'examples', 'color_transform.m'));
+            run(fullfile('matlab', 'examples', 'gamma_curve.m'))
           generate-summary: false
 
   docker-interop:

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2839,6 +2839,70 @@ endfunction()
 # only IccProfLib and no scratch directory. Exercising CheckLuminance directly
 # rather than CIccTagSpectralViewingConditions::Validate keeps the missing-observer
 # critical error from masking the status under test.
+# Restores the u8Fixed8Number gamma coverage that shipped with #808 and was dropped
+# in 35f5c5e6 (#968) when ci-iccdev-tool-tests.yml / ci-tool-tests.yml lost their
+# inline bodies: steps R12/R13/R8 checked all four gamma-*.icc fixtures and none of
+# it was carried over to CTest, leaving three of the four fixtures unreferenced
+# anywhere in the tree. A one-entry curveType is a u8Fixed8 exponent, so consumers
+# must undo ReadUInt16Float's /65535 with `* 65535.0 / 256.0` rather than `* 256.0`.
+# The test reads each fixture through CIccProfileJson with the JSON factories pushed
+# -- iccToJson's own path -- and pins both Describe()'s exact text and the emitted
+# JSON gamma, the latter against a derived gamma*2^-24 bound rather than the flat
+# 0.01 the old R13 used (#2044). Needs IccJSON + IccProfLib; skipped where IccJSON
+# is not built.
+function(iccdev_add_curve_gamma_u8fixed8_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCJSON}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCurveGammaU8Fixed8Test
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/curve-gamma-u8fixed8.cpp"
+  )
+  target_compile_features(iccCurveGammaU8Fixed8Test PRIVATE cxx_std_17)
+  target_include_directories(iccCurveGammaU8Fixed8Test PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccJSON/IccLibJSON"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccCurveGammaU8Fixed8Test PRIVATE
+    ${TARGET_LIB_ICCJSON} ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccCurveGammaU8Fixed8Test)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.curve-gamma-u8fixed8
+      COMMAND "$<TARGET_FILE:iccCurveGammaU8Fixed8Test>"
+        "${ICCDEV_REPO_ROOT}/.github/ci/regression"
+    )
+  else()
+    add_test(
+      NAME iccdev.curve-gamma-u8fixed8
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccCurveGammaU8Fixed8Test>"
+        "${ICCDEV_REPO_ROOT}/.github/ci/regression"
+    )
+  endif()
+  set_tests_properties(iccdev.curve-gamma-u8fixed8 PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;json;curve;gamma;issue-815;issue-2044;regression"
+  )
+  if(WIN32)
+    set(_curve_gamma_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCurveGammaU8Fixed8Test>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCJSON}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _curve_gamma_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.curve-gamma-u8fixed8 PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_curve_gamma_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_luminance_normalization_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -3945,6 +4009,7 @@ if(WIN32)
   iccdev_add_xml_relaxng_validation_leak_test()
   iccdev_add_xml_curve_oversize_file_test()
   iccdev_add_curve_setsize_contract_test()
+  iccdev_add_curve_gamma_u8fixed8_test()
   iccdev_add_luminance_normalization_test()
   iccdev_add_tag_name_spelling_test()
   iccdev_add_struct_name_spelling_test()
@@ -4211,6 +4276,7 @@ iccdev_add_xml_writer_graceful_degrade_test()
 iccdev_add_xml_relaxng_validation_leak_test()
 iccdev_add_xml_curve_oversize_file_test()
 iccdev_add_curve_setsize_contract_test()
+iccdev_add_curve_gamma_u8fixed8_test()
 iccdev_add_luminance_normalization_test()
 iccdev_add_tag_name_spelling_test()
 iccdev_add_struct_name_spelling_test()

--- a/docs/matlab-bindings.md
+++ b/docs/matlab-bindings.md
@@ -70,6 +70,7 @@ Run the demonstrations:
 ```matlab
 run('E:\opt\iccDEV\matlab\examples\read_profile.m');
 run('E:\opt\iccDEV\matlab\examples\color_transform.m');
+run('E:\opt\iccDEV\matlab\examples\gamma_curve.m');
 ```
 
 Reproduce the spectral-viewing luminance calculations from issue #1811
@@ -113,7 +114,50 @@ Interpret the layers separately:
 Expected coverage includes profile open/read/header checks, CMM pipeline and
 bulk apply, per-thread apply handles, parent-close invalidation, native handle
 lifecycle checks, single-precision input, missing-profile errors, finite output,
-and self-transform accuracy.
+and self-transform accuracy. The gamma example also parses the checked-in
+`curveType` fixture independently of IccProfLib and verifies the encoding math
+from issue
+[#815](https://github.com/InternationalColorConsortium/iccDEV/issues/815).
+
+## curveType Gamma Cross-Check
+
+ICC.1:2022 section 4.9 defines `u8Fixed8Number` as an unsigned 16-bit value
+with eight fractional bits. Section 10.6 defines a one-entry `curveType` value
+as a gamma exponent in `y = x^gamma`, not an inverse exponent.
+
+The regression profile `.github/ci/regression/gamma-2.20703125.icc` stores the
+integer value 565 in each of `rTRC`, `gTRC`, and `bTRC`. MATLAB checks both
+equivalent calculations:
+
+```text
+encoded gamma:          565 / 256 = 2.20703125          (exact)
+normalized storage:     single(565 / 65535)             = 0.00862134713679552
+library reconstruction: stored * 65535 / 256            = 2.2070311898824
+```
+
+The reconstruction is close to the encoded value but not equal to it, and that
+is the point of the check. `IccProfLib` keeps the normalized value in an
+`icFloatNumber`, so rounding `565 / 65535` into a 24-bit significand costs a
+relative error of up to `2^-24`, which the exact ratio `65535 / 256` carries
+straight through. The bound is therefore `gamma * 2^-24` -- `1.32e-07` here --
+and the observed error is `6.01e-08`. Modelling this step in double precision
+instead would make the comparison succeed with an error of exactly zero no
+matter what the library did.
+
+The error is proportional to the gamma, so it is not the same across the
+corpus: `gamma-2.3984375.icc` sits at `1.19e-07`, nearly twice as far out. What
+must hold for every fixture is that the reconstructed value still rounds back
+to the stored integer, which is what `iccFromJson` relies on.
+
+This independently exercises the reconstruction corrected by PR
+[#808](https://github.com/InternationalColorConsortium/iccDEV/pull/808). The
+native `iccdev.curve-gamma-u8fixed8` CTest asserts the same bound against the
+compiled library across all four `gamma-*.icc` fixtures. Run the MATLAB layer
+directly with:
+
+```matlab
+results = run_gamma_qa();
+```
 
 ## Rebuild Loop
 
@@ -187,7 +231,8 @@ image; interactive local use defaults to `latest`.
 - [ ] `build_mex` completes without unresolved dependencies.
 - [ ] `test_iccdev` passes without skipped CMM tests.
 - [ ] `run_local_qa` passes.
-- [ ] Both examples complete.
+- [ ] All three examples complete.
+- [ ] `run_gamma_qa` decodes all three TRC tags as gamma 2.20703125.
 - [ ] `run_docker_qa` passes when Docker is available.
 - [ ] Rebuild works after `clear classes` and `clear mex`.
 - [ ] Modified `.m` and Markdown files remain ASCII.
@@ -195,8 +240,7 @@ image; interactive local use defaults to `latest`.
 ## Hosted Workflow
 
 `.github/workflows/ci-matlab.yml` runs for MATLAB-related pull requests to
-`master`, pushes to `master` and `ci-qa-matlab-examples`, and manual dispatch.
-It uses read-only permissions, trusted-base sanitizer helpers, SHA-pinned
-actions, a focused dependency-free Release build, the checked-in sRGB profile,
-a digest-pinned container interoperability job, and no cache or artifact
-publication.
+`master`, selected MATLAB QA branches, and manual dispatch. It uses read-only
+permissions, trusted-base sanitizer helpers, SHA-pinned actions, a focused
+dependency-free Release build, checked-in profiles, a digest-pinned container
+interoperability job, and no cache or artifact publication.

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -108,6 +108,7 @@ cmm.close();
 | `iccdev.docker_validate(profile, ...)` | Run containerized dump and round-trip validation |
 | `build_mex(...)` | Build the MEX extension |
 | `run_local_qa()` | Run local MEX regression and stress checks |
+| `run_gamma_qa()` | Verify issue #815 curveType u8Fixed8 gamma decoding |
 | `run_docker_qa(image)` | Validate the published container and output contract |
 
 ### iccdev.IccProfile
@@ -197,6 +198,32 @@ missing-profile smoke checks with:
 
 ```matlab
 run_local_qa();
+```
+
+Verify the ICC.1 `curveType` gamma calculation used by issue
+[#815](https://github.com/InternationalColorConsortium/iccDEV/issues/815)
+and PR
+[#808](https://github.com/InternationalColorConsortium/iccDEV/pull/808):
+
+```matlab
+run_gamma_qa();
+run('matlab/examples/gamma_curve.m');
+```
+
+The checked-in fixture stores 565 as a `u8Fixed8Number`, so the decoded gamma is
+`565 / 256 = 2.20703125` exactly. The library's normalized internal storage is
+`565 / 65535` held in an `icFloatNumber`, so reconstructing it as
+`stored * 65535 / 256` gives `2.2070311898824` -- within `gamma * 2^-24` of the
+encoded value, not equal to it, and still rounding back to 565.
+
+Validate the compiled library against the same arithmetic across all four
+`gamma-*.icc` fixtures:
+
+```powershell
+cmake --build msvc --config Release --target iccCurveGammaU8Fixed8Test
+ctest --test-dir msvc -C Release `
+  -R '^iccdev\.curve-gamma-u8fixed8$' `
+  --output-on-failure --no-tests=error
 ```
 
 Validate the same profile with the published container:

--- a/matlab/examples/gamma_curve.m
+++ b/matlab/examples/gamma_curve.m
@@ -1,0 +1,23 @@
+%% gamma_curve.m - Decode and apply an ICC curveType gamma value
+%
+% ICC.1:2022 sections 4.9 and 10.6 define a one-entry curveType as a
+% u8Fixed8Number exponent in y = x^gamma, not as an inverse exponent.
+%
+% Copyright (c) International Color Consortium.
+% BSD 3-Clause License. See LICENSE.md for details.
+
+thisDir = fileparts(mfilename('fullpath'));
+matlabDir = fileparts(thisDir);
+addpath(matlabDir);
+
+results = run_gamma_qa();
+gamma = results(1).gamma;
+inputValues = [0.0 0.18 0.25 0.5 0.75 1.0];
+outputValues = inputValues .^ gamma;
+
+fprintf('\n=== iccdev MATLAB Example: curveType Gamma ===\n\n');
+fprintf('ICC equation: y = x^gamma, gamma = %.8f\n\n', gamma);
+for i = 1:numel(inputValues)
+  fprintf('  %.2f -> %.8f\n', inputValues(i), outputValues(i));
+end
+fprintf('\nDone.\n');

--- a/matlab/run_gamma_qa.m
+++ b/matlab/run_gamma_qa.m
@@ -1,0 +1,156 @@
+function results = run_gamma_qa()
+%RUN_GAMMA_QA Verify curveType u8Fixed8 gamma decoding for issue #815.
+%
+% Decodes the raw u8Fixed8Number out of the checked-in fixture without going
+% through IccProfLib, so the arithmetic is an independent second opinion rather
+% than a restatement of the library. The reconstruction is modelled in single
+% precision because that is what IccProfLib stores; see the note at the bound
+% below and issue #2044. The native iccdev.curve-gamma-u8fixed8 CTest is
+% authoritative for what the compiled library actually prints and emits.
+%
+% Copyright (c) International Color Consortium.
+% BSD 3-Clause License. See LICENSE.md for details.
+
+  matlab_dir = fileparts(mfilename('fullpath'));
+  repo_root = fileparts(matlab_dir);
+  profile_path = fullfile(repo_root, '.github', 'ci', 'regression', ...
+    'gamma-2.20703125.icc');
+  expected_raw = 565;
+  expected_gamma = 2.20703125;
+  tag_signatures = {'rTRC', 'gTRC', 'bTRC'};
+
+  bytes = read_profile_bytes(profile_path);
+  results = struct('signature', {}, 'raw', {}, 'normalized', {}, ...
+    'stored', {}, 'gamma', {}, 'reconstructed', {}, 'reconstructionError', {});
+
+  % IccProfLib keeps the normalized value in an icFloatNumber, which is a 32-bit
+  % float, so the reconstruction it performs is bounded by that type's rounding
+  % and not by double precision. Modelling it in double would make the check
+  % below pass with an error of exactly zero no matter what the library did, so
+  % the storage step has to be spelled out. The bound is gamma * 2^-24: the
+  % relative error of rounding raw/65535 into a 24-bit significand is at most
+  % 2^-24, and multiplying by the exact ratio 65535/256 carries it straight
+  % through. eps('single') is 2^-23, hence the halving.
+  reconstruction_bound = expected_gamma * eps('single') / 2;
+
+  fprintf('=== iccdev MATLAB QA: curveType Gamma ===\n\n');
+  fprintf('Profile: %s\n', profile_path);
+
+  for i = 1:numel(tag_signatures)
+    raw = read_curve_gamma(bytes, tag_signatures{i});
+    normalized = double(raw) / 65535.0;
+    gamma = double(raw) / 256.0;
+    stored = single(normalized);
+    reconstructed = double(stored) * 65535.0 / 256.0;
+    reconstruction_error = abs(reconstructed - expected_gamma);
+
+    assert(raw == expected_raw, ...
+      '%s raw u8Fixed8 value should be %d, got %d.', ...
+      tag_signatures{i}, expected_raw, raw);
+
+    % The encoded value is exact: raw/256 is a dyadic rational and 565/256 is
+    % representable with no error at all, so this one is an equality.
+    assert(gamma == expected_gamma, ...
+      '%s gamma should be %.8f, got %.17g.', ...
+      tag_signatures{i}, expected_gamma, gamma);
+
+    assert(reconstruction_error <= reconstruction_bound, ...
+      ['%s single-precision reconstruction should be within %.3g of %.8f, ' ...
+       'got %.17g (error %.3g).'], ...
+      tag_signatures{i}, reconstruction_bound, expected_gamma, ...
+      reconstructed, reconstruction_error);
+
+    % What iccFromJson relies on: however the reconstructed decimal is printed,
+    % it must still land back on the same u8Fixed8 integer.
+    assert(round(reconstructed * 256.0) == raw, ...
+      '%s reconstruction should round-trip to raw u8Fixed8 value %d.', ...
+      tag_signatures{i}, raw);
+    assert(round(gamma * 256.0) == raw, ...
+      '%s gamma should round-trip to raw u8Fixed8 value %d.', ...
+      tag_signatures{i}, raw);
+
+    results(i).signature = tag_signatures{i};
+    results(i).raw = raw;
+    results(i).normalized = normalized;
+    results(i).stored = stored;
+    results(i).gamma = gamma;
+    results(i).reconstructed = reconstructed;
+    results(i).reconstructionError = reconstruction_error;
+
+    fprintf('  %s: raw=%d normalized=%.15f gamma=%.8f\n', ...
+      tag_signatures{i}, raw, normalized, gamma);
+    fprintf('        single-precision reconstruction=%.12f error=%.3g ', ...
+      reconstructed, reconstruction_error);
+    fprintf('(bound %.3g)\n', reconstruction_bound);
+  end
+
+  fprintf('\nPASS: 565 / 256 = 2.20703125 exactly, and the single-precision\n');
+  fprintf('      reconstruction stays within %.3g and rounds back to 565.\n', ...
+    reconstruction_bound);
+end
+
+function bytes = read_profile_bytes(profile_path)
+  file_id = fopen(profile_path, 'rb');
+  if file_id < 0
+    error('iccdev:gammaProfileMissing', ...
+      'Unable to open gamma regression profile: %s', profile_path);
+  end
+  cleanup = onCleanup(@() fclose(file_id));
+  bytes = fread(file_id, Inf, '*uint8');
+  clear cleanup;
+
+  if numel(bytes) < 132
+    error('iccdev:gammaProfileTruncated', ...
+      'Gamma regression profile is too short: %d bytes.', numel(bytes));
+  end
+end
+
+function raw = read_curve_gamma(bytes, tag_signature)
+  tag_count = read_u32_be(bytes, 129);
+  table_end = 132 + double(tag_count) * 12;
+  if table_end > numel(bytes)
+    error('iccdev:gammaTagTableTruncated', ...
+      'ICC tag table exceeds the profile size.');
+  end
+
+  for i = 0:double(tag_count) - 1
+    entry = 133 + i * 12;
+    signature = char(bytes(entry:entry + 3).');
+    if strcmp(signature, tag_signature)
+      tag_offset = read_u32_be(bytes, entry + 4);
+      tag_size = read_u32_be(bytes, entry + 8);
+      data_start = double(tag_offset) + 1;
+      data_end = double(tag_offset) + double(tag_size);
+
+      if tag_size < 14 || data_start < 1 || data_end > numel(bytes)
+        error('iccdev:gammaTagTruncated', ...
+          '%s curveType data exceeds the profile size.', tag_signature);
+      end
+      if ~strcmp(char(bytes(data_start:data_start + 3).'), 'curv')
+        error('iccdev:gammaTagType', ...
+          '%s is not encoded as curveType.', tag_signature);
+      end
+      if read_u32_be(bytes, data_start + 8) ~= 1
+        error('iccdev:gammaTagCount', ...
+          '%s curveType must contain one gamma value.', tag_signature);
+      end
+
+      raw = read_u16_be(bytes, data_start + 12);
+      return;
+    end
+  end
+
+  error('iccdev:gammaTagMissing', ...
+    'Gamma regression profile does not contain %s.', tag_signature);
+end
+
+function value = read_u16_be(bytes, index)
+  value = double(bytes(index)) * 256.0 + double(bytes(index + 1));
+end
+
+function value = read_u32_be(bytes, index)
+  value = double(bytes(index)) * 16777216.0 + ...
+    double(bytes(index + 1)) * 65536.0 + ...
+    double(bytes(index + 2)) * 256.0 + ...
+    double(bytes(index + 3));
+end

--- a/matlab/tests/test_iccdev.m
+++ b/matlab/tests/test_iccdev.m
@@ -3,7 +3,9 @@ function test_iccdev()
 %
 %   test_iccdev()
 %
-% Runs all tests and reports pass/fail. Requires icc_mex on the path.
+% Runs all tests and reports pass/fail/skip. Requires icc_mex on the path.
+% Groups that cannot run (missing fixture, no second profile, no Docker image)
+% are counted and listed rather than passing silently.
 %
 % Copyright (c) International Color Consortium.
 % BSD 3-Clause License. See LICENSE.md for details.
@@ -12,12 +14,21 @@ function test_iccdev()
 
   nPass = 0;
   nFail = 0;
+  % Skips are counted, not just printed. Several groups below stand down when a
+  % fixture, a second profile or the Docker image is unavailable, and until this
+  % counter existed the summary line reported only passes and failures -- so a run
+  % that silently skipped a third of the suite still ended in "N passed, 0 failed"
+  % and a green CI leg. #2043 and #2044 are both examples: each reported a clean
+  % result while "Docker interoperability" had not run at all.
+  nSkip = 0;
+  skipped = {};
 
   % --- Enum tests (always work) ---
   [nPass, nFail] = run_test(@test_color_space_values, 'ColorSpace values', nPass, nFail);
   [nPass, nFail] = run_test(@test_rendering_intent_values, 'RenderingIntent values', nPass, nFail);
   [nPass, nFail] = run_test(@test_interpolation_values, 'Interpolation values', nPass, nFail);
   [nPass, nFail] = run_test(@test_sig_to_str, 'sig_to_str', nPass, nFail);
+  [nPass, nFail] = run_test(@test_curve_gamma_fixture, 'curveType gamma math', nPass, nFail);
 
   % --- Profile tests (need test profiles) ---
   profilePath = find_test_profile();
@@ -28,7 +39,8 @@ function test_iccdev()
     [nPass, nFail] = run_test(@() test_profile_header_fields(profilePath), 'Header fields', nPass, nFail);
     [nPass, nFail] = run_test(@() test_profile_double_close(profilePath), 'Double close safety', nPass, nFail);
   else
-    fprintf('  SKIP: No test profiles found\n');
+    [nSkip, skipped] = note_skip('Profile open/header/read/fields/double-close', ...
+      'no test profile found', nSkip, skipped);
   end
 
   % --- CMM tests (basic, no profiles needed) ---
@@ -39,7 +51,8 @@ function test_iccdev()
     [nPass, nFail] = run_test(@() test_docker_input_validation(profilePath), ...
       'Docker input validation', nPass, nFail);
   else
-    fprintf('  SKIP: Docker input validation - no test profile found\n');
+    [nSkip, skipped] = note_skip('Docker input validation', ...
+      'no test profile found', nSkip, skipped);
   end
 
   [dockerAvailable, dockerDetails] = iccdev.docker_available();
@@ -47,7 +60,8 @@ function test_iccdev()
     [nPass, nFail] = run_test(@test_docker_interop, ...
       'Docker interoperability', nPass, nFail);
   else
-    fprintf('  SKIP: Docker interoperability - %s\n', dockerDetails);
+    [nSkip, skipped] = note_skip('Docker interoperability', dockerDetails, ...
+      nSkip, skipped);
   end
 
   % --- CMM pipeline tests (need two compatible profiles for transform) ---
@@ -60,14 +74,35 @@ function test_iccdev()
     [nPass, nFail] = run_test(@() test_mex_apply_parent_close(srcProf, dstProf), 'MEX apply parent close', nPass, nFail);
     [nPass, nFail] = run_test(@() test_cmm_single_precision(srcProf, dstProf), 'Single precision input', nPass, nFail);
   else
-    fprintf('  SKIP: No compatible profiles for CMM pipeline tests\n');
-    fprintf('        Run CreateAllProfiles.sh to generate Display profiles\n');
+    [nSkip, skipped] = note_skip('CMM pipeline/bulk/apply-handle/single-precision', ...
+      'no compatible profile pair; run CreateAllProfiles.sh', nSkip, skipped);
   end
 
-  fprintf('\n=== Results: %d passed, %d failed ===\n', nPass, nFail);
+  fprintf('\n=== Results: %d passed, %d failed, %d skipped ===\n', ...
+    nPass, nFail, nSkip);
+  if nSkip > 0
+    % Name them again at the end. A skip scrolls past in the middle of a long
+    % run, and the count alone does not say what stopped running.
+    fprintf('Skipped groups (coverage was reduced):\n');
+    for i = 1:numel(skipped)
+      fprintf('  - %s\n', skipped{i});
+    end
+  end
   if nFail > 0
     error('iccdev:testFailed', '%d test(s) failed.', nFail);
   end
+end
+
+% Records a skipped group so it reaches the summary as well as the log. Returns
+% the updated counter and list rather than using a global, matching the
+% pass/fail threading already used by run_test.
+function [nSkip, skipped] = note_skip(what, why, nSkip, skipped)
+  if isempty(why)
+    why = 'unavailable';
+  end
+  fprintf('  SKIP: %s - %s\n', what, why);
+  nSkip = nSkip + 1;
+  skipped{end+1} = sprintf('%s (%s)', what, why);
 end
 
 function [nPass, nFail] = run_test(fn, name, nPass, nFail)
@@ -197,6 +232,14 @@ end
 function test_sig_to_str()
   s = iccdev.sig_to_str(uint32(hex2dec('52474220')));
   assert(strcmp(s, 'RGB'), 'Expected RGB, got %s', s);
+end
+
+function test_curve_gamma_fixture()
+  results = run_gamma_qa();
+  assert(numel(results) == 3, 'Expected red, green, and blue TRC results');
+  assert(all([results.raw] == 565), 'Expected raw u8Fixed8 value 565');
+  assert(all([results.gamma] == 2.20703125), ...
+    'Expected decoded gamma 2.20703125');
 end
 
 function test_profile_open(path)


### PR DESCRIPTION
Cross-check of the MATLAB gamma QA in #2044.

@xsscx's arithmetic is right, and reproduced independently: raw **565**,
`565 / 256 = 2.20703125` exactly, normalized `0.008621347371633`, and an
`iccToJson` error of **6.01e-08**. `Describe()` is exact on all four fixtures, so
the conclusion that the native paths are specification-correct holds. Three
corrections.

## 1. The regression this proposes tightening no longer exists

"its existing PR #808 regression only requires tolerance < 0.01" refers to steps
**R12/R13** in `ci-iccdev-tool-tests.yml` and **R8** in `ci-tool-tests.yml`.
Commit `35f5c5e6` ("Modify: CMake CTest CPack", #968) removed both workflows'
inline bodies during the migration to CTest, and the gamma steps were not carried
over.

Master has had no gamma coverage since:

```
$ git grep -c gamma -- .github/workflows/     # no output
$ git grep -l "gamma-1.796875|gamma-2.3984375|gamma-1.0000000000"   # no output
```

Three of the four fixtures were referenced by **nothing**. The fourth is used
only by the #1355 round-trip script, which measures dE and never looks at the
gamma value. So the tolerance cannot be tightened -- the coverage has to come
back. This restores it as `iccdev.curve-gamma-u8fixed8`, over all four fixtures
and all three TRC channels.

## 2. The tolerance is derived, not measured

Pinning near the observed `6.01e-08` would be wrong for the corpus. The error is
proportional to the gamma:

| fixture | raw | JSON gamma | error | bound |
|---|---|---|---|---|
| `gamma-1.0000000000.icc` | 256 | 0.999999999767 | 2.33e-10 | 5.96e-08 |
| `gamma-1.796875.icc` | 460 | 1.79687499958 | 4.18e-10 | 1.07e-07 |
| `gamma-2.20703125.icc` | 565 | 2.20703118988 | **6.01e-08** | 1.32e-07 |
| `gamma-2.3984375.icc` | 614 | 2.39843761865 | **1.19e-07** | 1.43e-07 |

`m_Curve[0]` is an `icFloatNumber`, so rounding `raw/65535` into a 24-bit
significand costs at most a relative `2^-24`, and the exact ratio `65535/256`
carries it straight through. The bound is therefore **`gamma * 2^-24`**.

**The old flat `0.01` was not merely loose, it was inert.** Reintroducing the
pre-#808 `m_Curve[0] * 256.0` reconstruction moves the emitted value by
`1.53e-05` to `3.66e-05` across the corpus -- comfortably *inside* `0.01`. That
check could not have failed for the CWE-682 defect it was written to guard. The
derived bound catches it on all twelve fixture/channel combinations.

## 3. The MATLAB reconstruction check could not fail

`run_gamma_qa.m` computed `normalized = double(raw)/65535` and reconstructed in
double, so `abs(reconstructed - expected_gamma)` was **exactly 0.0** against a
tolerance of `eps(expected_gamma)`. It omitted the single-precision storage step
that is the entire source of the `6.01e-08` the issue reports, so it passed
regardless of what the library did.

It now models `icFloatNumber` with `single()`, asserts the same `gamma * 2^-24`
bound, and reproduces the library's emitted `2.2070311898824` **exactly** -- so
the two layers genuinely agree rather than one being vacuous.

## Red-tested

Both library paths, against the actual historical defect:

- `CIccTagJsonCurve::ToJson` reverted to `* 256.0` -> **12 assertions fail**
- `CIccTagCurve::Describe` reverted to `* 256.0` -> **12 assertions fail**

## Skip accounting

Both #2043 and #2044 show `SKIP: Docker interoperability` inside a run that ends
`0 failed` and goes green. `test_iccdev.m` had five skip paths and counted none
of them -- the summary reported only passes and failures, so a run that skipped a
whole group was indistinguishable from one that passed it. Skips are now counted,
listed again in the summary, and the suite states plainly that coverage was
reduced.

## Note on shared tag data

All four fixtures point `rTRC`, `gTRC` and `bTRC` at a single tag offset, so the
writer correctly emits `{"sameAs": "redTRCTag"}` for two of the three. The test
follows that link instead of reporting the shared channels as missing, which pins
the de-duplication as well.

## Pre-flight

| gate | result |
|---|---|
| clang 21.1.3, `-Wall -Wextra -Wpedantic -Werror` | 0 warnings, 0 errors |
| GCC 15.2.0 in `iccdev-ci-regression`, `-Werror` + LTO | 0 warnings, 0 errors |
| ASAN + UBSAN, `detect_leaks=1` | clean |
| actionlint / zizmor / yamllint (CI's config) | all clean |
| `ctest` | `iccdev.curve-gamma-u8fixed8` passes on every profile |

The test runs on the Windows MSVC and ClangCL legs: `run-recent-ctests.py` is
invoked without `--limit`, so those legs run every registered test, and
`ENABLE_ICCJSON` defaults `ON`. It is skipped in `ci-matlab`, which builds with
`-DENABLE_ICCJSON=OFF`.

Part of #2044. Restores coverage for #815 originally added in #808.
