### PR TITLE
fix(#2046): attribute the D50 colorimetry gap to the illuminant data, not the reduction method

### DIFF
--- a/.github/workflows/ci-matlab.yml
+++ b/.github/workflows/ci-matlab.yml
@@ -79,15 +79,19 @@ jobs:
         with:
           release: R2026a
 
-      - name: Reproduce luminance normalization calculations
+      - name: Reproduce specification calculations
         # matlab-actions/run-command v3
+        # Both checks are pure arithmetic over checked-in tables and fixtures, so
+        # they run before the native build rather than depending on it.
         uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264
         with:
           command: >-
             addpath('matlab');
             addpath(fullfile('matlab', 'tests'));
             test_luminance_normalization();
-            run(fullfile('matlab', 'examples', 'luminance_normalization.m'))
+            run(fullfile('matlab', 'examples', 'luminance_normalization.m'));
+            test_colorimetry_issue_1475();
+            run(fullfile('matlab', 'examples', 'colorimetry_issue_1475.m'))
           generate-summary: false
 
       - name: Configure and build IccProfLib
@@ -125,12 +129,13 @@ jobs:
           }
 
           cmake --build out\matlab --config Release `
-            --target IccProfLib2-static iccLuminanceNormalizationTest --parallel
+            --target IccProfLib2-static iccLuminanceNormalizationTest `
+              iccColorimetryMethodsTest --parallel
           if ($LASTEXITCODE -ne 0) {
-            throw "Native luminance test build failed with exit code $LASTEXITCODE"
+            throw "Native regression test build failed with exit code $LASTEXITCODE"
           }
 
-      - name: Run native luminance regression
+      - name: Run native luminance and colorimetry regressions
         env:
           POWERSHELL_TELEMETRY_OPTOUT: "1"
           POWERSHELL_UPDATECHECK: Off
@@ -145,11 +150,11 @@ jobs:
           . .trusted-helpers/.github/scripts/sanitize.ps1
 
           ctest --test-dir out\matlab -C Release `
-            -R '^iccdev\.luminance-normalization$' `
+            -R '^iccdev\.(luminance-normalization|colorimetry-methods)$' `
             --output-on-failure `
             --no-tests=error
           if ($LASTEXITCODE -ne 0) {
-            throw "Native luminance regression failed with exit code $LASTEXITCODE"
+            throw "Native regressions failed with exit code $LASTEXITCODE"
           }
 
       - name: Build MATLAB MEX gateway

--- a/docs/matlab-bindings.md
+++ b/docs/matlab-bindings.md
@@ -111,6 +111,83 @@ Interpret the layers separately:
 - Agreement between both layers confirms the fixture evidence and the native
   implementation without making either test self-referential.
 
+## Spectral Colorimetry Cross-Check
+
+Issue
+[#1475](https://github.com/InternationalColorConsortium/iccDEV/issues/1475)
+distinguishes the legacy 5 nm observer/illuminant direct-sum path from the
+registry-aligned weighting tables exposed by `IccColorimetry`.
+
+Run the independent MATLAB calculation:
+
+```matlab
+test_colorimetry_issue_1475();
+run(fullfile('matlab', 'examples', 'colorimetry_issue_1475.m'));
+```
+
+The check reads the checked-in C++ table values and evaluates a perfect
+diffuser under D50 with the CIE 1931 2-degree observer:
+
+```text
+legacy 5 nm direct sum: X=0.964245566 Y=1.000000000 Z=0.824679094
+registry 10 nm table:   X=0.964240837 Y=1.000000000 Z=0.825128117
+legacy at 10 nm:        X=0.963956086 Y=1.000000000 Z=0.824057353
+canonical CIE 15:       X=0.964220000 Y=1.000000000 Z=0.825210000
+ICC PCS icD50XYZ:       X=0.964200000 Y=1.000000000 Z=0.824900000
+legacy - registry:      dX=+0.000004728 dY~0 dZ=-0.000449023
+legacy - canonical:     dX=+0.000025566 dY=0  dZ=-0.000530906
+registry - canonical:   dX=+0.000020837 dY~0 dZ=-0.000081883
+legacy - ICC PCS:       dX=+0.000045566 dY=0  dZ=-0.000220906
+registry - ICC PCS:     dX=+0.000040837 dY~0 dZ=+0.000228117
+```
+
+### Reading the difference
+
+The legacy and registry paths differ in three ways at once -- reduction method,
+sample grid, and the underlying illuminant data -- so the `-0.000449` gap cannot
+be attributed to any one of them without holding the others fixed. Two of the
+three are controlled:
+
+- **Reduction method is not the cause.** `iccdev.colorimetry-methods` asserts
+  `same-grid: DirectSum == Weighting` and `== SpragueTo1nm` to `TOL_EXACT`
+  (`1e-6`), which is already far inside the `4.5e-4` gap. Driving
+  `CIccColorimetricCalculator` with the real D50 SPD and 1931 CMFs instead of
+  that test's synthetic data, the three methods return the same `XYZ` to the
+  last bit -- measured spread `0.000e+00`. A weighting table is not
+  intrinsically closer to CIE than a direct sum is.
+- **Sample grid is not the cause either, and has the wrong sign.** Re-summing the
+  same legacy data on the 10 nm subgrid gives `Z=0.824057353`, moving `Z` by
+  `-0.000622` -- larger than the gap and in the opposite direction. The MATLAB
+  check computes this as `grid_effect` and asserts both properties.
+
+What remains is the data. This is consistent with the #1475 finding that all ten
+registry weighting tables match the published registry values exactly while
+iccDEV's own 5 nm D50 SPD (`icKnownIllums`, inherited in `889db62b`) is the
+divergent object.
+
+Which path is "closer" is therefore a choice of reference rather than a measure
+of accuracy, and the native test pins **two** references, not one: Part F checks
+the registry tables against CIE 15 (`0.96422 / 0.82521`), while Part E6 anchors
+the legacy path to the ICC PCS illuminant `icD50XYZ` (`0.9642 / 0.8249`) with an
+explicit note that the 5 nm tables sit ~5e-4 low on Z. Against CIE 15 the
+registry table is closer; against the ICC PCS white the legacy path is closer.
+The MATLAB check asserts both directions so neither reading can be quoted alone.
+
+Hosted CI also runs `iccdev.colorimetry-methods`, which exercises the compiled
+registry tables, loaded-table API, direct sum, weighting, Sprague resampling,
+normalization, and range reconciliation.
+
+Scope note: the registry tables are reachable through `IccColorimetry`, but
+`CIccColorimetricCalculator` is currently referenced only by that regression
+test -- no CMM or command-line path consumes it. The registry-aligned reduction
+is an available primitive, not a change to what the library computes today.
+
+Issue
+[#1451](https://github.com/InternationalColorConsortium/iccDEV/issues/1451)
+is downstream of this capability. The registry reduction primitive exists, but
+`iccPawgReport` still maps only measured Lab or XYZ columns; spectral-only
+characterization data needs a separate ingestion and reduction integration.
+
 Expected coverage includes profile open/read/header checks, CMM pipeline and
 bulk apply, per-thread apply handles, parent-close invalidation, native handle
 lifecycle checks, single-precision input, missing-profile errors, finite output,
@@ -231,8 +308,10 @@ image; interactive local use defaults to `latest`.
 - [ ] `build_mex` completes without unresolved dependencies.
 - [ ] `test_iccdev` passes without skipped CMM tests.
 - [ ] `run_local_qa` passes.
-- [ ] All three examples complete.
+- [ ] All documented examples complete.
 - [ ] `run_gamma_qa` decodes all three TRC tags as gamma 2.20703125.
+- [ ] Issue #1475 MATLAB QA reproduces the legacy and registry D50 XYZ values.
+- [ ] Native luminance and colorimetry CTests pass.
 - [ ] `run_docker_qa` passes when Docker is available.
 - [ ] Rebuild works after `clear classes` and `clear mex`.
 - [ ] Modified `.m` and Markdown files remain ASCII.
@@ -242,5 +321,6 @@ image; interactive local use defaults to `latest`.
 `.github/workflows/ci-matlab.yml` runs for MATLAB-related pull requests to
 `master`, selected MATLAB QA branches, and manual dispatch. It uses read-only
 permissions, trusted-base sanitizer helpers, SHA-pinned actions, a focused
-dependency-free Release build, checked-in profiles, a digest-pinned container
-interoperability job, and no cache or artifact publication.
+dependency-free MATLAB calculation stage, native luminance and colorimetry
+CTests, checked-in profiles, a digest-pinned container interoperability job,
+and no cache or artifact publication.

--- a/matlab/+iccdev/+qa/check_colorimetry_issue_1475.m
+++ b/matlab/+iccdev/+qa/check_colorimetry_issue_1475.m
@@ -1,0 +1,190 @@
+function result = check_colorimetry_issue_1475()
+%CHECK_COLORIMETRY_ISSUE_1475 Compare legacy and registry D50 reductions.
+%
+% Copyright (c) International Color Consortium.
+% BSD 3-Clause License. See LICENSE.md for details.
+%
+% Issue #1475 concerns the spectral-to-colorimetry path. Two D50/1931 white
+% points can be computed from data already in the tree, and they disagree:
+%
+%   legacy   0.964245566 / 1 / 0.824679094  - icKnownIllums D50 SPD times the
+%            icKnownObservers 1931 CMFs, summed on the built-in 380-780@5nm grid
+%   registry 0.964240837 / 1 / 0.825128117  - the column sums of the baked-in
+%            registry LWL weighting table kWtsObs1931D50, 380-780@10nm
+%
+% The two paths differ in THREE ways at once: reduction method (plain product
+% versus a weighting table), sample grid (5 nm versus 10 nm), and the underlying
+% illuminant data (iccDEV's inherited D50 SPD versus the CIE SPD that the
+% registry table was generated from). Attributing the 4.5e-4 Z difference to any
+% one of them requires holding the others fixed, so this check pins the two
+% controls that can be computed here, and defers the third to the native CTest:
+%
+%   method - NOT the cause. iccdev.colorimetry-methods asserts
+%            "same-grid: DirectSum == Weighting" and "== SpragueTo1nm" to
+%            TOL_EXACT (1e-6), so on one grid with one data set the three
+%            reduction methods agree far inside the 4.5e-4 gap. Driving the
+%            calculator with the real D50 SPD and 1931 CMFs rather than that
+%            test's synthetic data, the measured spread is 0.0. A weighting
+%            table is not intrinsically closer to CIE than a direct sum.
+%   grid   - NOT the cause either, and it does not even have the right sign.
+%            Re-summing the SAME legacy data on the 10 nm subgrid moves Z by
+%            about -6.2e-4, which is larger than the +4.5e-4 gap and points the
+%            other way. Pinned below as grid_effect.
+%   data   - what is left. The gap lives in the illuminant/observer data, not in
+%            how it is integrated. That matches the #1475 finding that iccDEV's
+%            5 nm D50 SPD (inherited in 889db62b, 2023-11-03) is the divergent
+%            object, while all ten registry weighting tables match the published
+%            registry values exactly.
+%
+% "Which one is right" is therefore a choice of reference, not a bug fix, and
+% the answer flips depending on which white point is adopted -- see the two
+% closer_to_* fields. Note also that this reads the C++ SOURCE TEXT as double.
+% The library stores these tables as icFloatNumber (float, IccDefs.h:88) and
+% computes in float, so the native CTest is authoritative for library behaviour;
+% this check is an independent arithmetic model of the checked-in data.
+
+  qa_dir = fileparts(mfilename('fullpath'));
+  matlab_dir = fileparts(fileparts(qa_dir));
+  repo_root = fileparts(matlab_dir);
+
+  tag_basic = fileread(fullfile(repo_root, 'IccProfLib', 'IccTagBasic.cpp'));
+  colorimetry = fileread(fullfile(repo_root, 'IccProfLib', ...
+    'IccColorimetry.cpp'));
+
+  d50 = extract_values(tag_basic, ...
+    '\{ icIlluminantD50,\s*\{(.*?)\}\s*\}', 81);
+  observer = extract_values(tag_basic, ...
+    '\{ icStdObs1931TwoDegrees,\s*\{(.*?)\}\s*\}', 243);
+  weights = extract_values(colorimetry, ...
+    'kWtsObs1931D50\[123\]\s*=\s*\{(.*?)\};', 123);
+
+  x_bar = observer(1:81);
+  y_bar = observer(82:162);
+  z_bar = observer(163:243);
+
+  legacy_xyz = direct_sum(d50, x_bar, y_bar, z_bar);
+
+  % The registry table is a complete operator on the CIE Y=100 scale: applied to
+  % a perfect diffuser it degenerates to the column sums, so no illuminant or
+  % observer is applied on top of it.
+  registry_xyz = [
+    sum(weights(1:41))
+    sum(weights(42:82))
+    sum(weights(83:123))
+  ] ./ 100.0;
+
+  % Grid control. Same SPD, same CMFs, same rectangular sum -- only every second
+  % sample, giving the registry table's 380-780@10nm grid. The k = 1/sum(ybar*S)
+  % normalization divides the sample spacing out, so this isolates the sampling
+  % rate on its own.
+  decimated = 1:2:81;
+  legacy10_xyz = direct_sum(d50(decimated), x_bar(decimated), ...
+    y_bar(decimated), z_bar(decimated));
+
+  expected_legacy = [0.964245565670359; 1.0; 0.824679093854306];
+  expected_registry = [0.9642408375; 1.0000000002; 0.8251281168];
+  expected_legacy10 = [0.963956085519434; 1.0; 0.824057352615889];
+
+  % Two references, deliberately both. CIE 15 is the external colorimetric truth;
+  % icD50XYZ is the PCS illuminant iccDEV has always encoded (IccUtil.cpp) and is
+  % what the native CTest anchors the legacy path to. They are 3.1e-4 apart in Z,
+  % which is comparable to the effect under study.
+  canonical_xyz = [0.96422; 1.0; 0.82521];      % CIE 15 D50/1931
+  icc_pcs_xyz = [0.9642; 1.0; 0.8249];          % icD50XYZ, the ICC PCS illuminant
+
+  assert(max(abs(legacy_xyz - expected_legacy)) < 1e-12, ...
+    'Legacy D50/1931 calculation changed unexpectedly.');
+  assert(max(abs(registry_xyz - expected_registry)) < 1e-10, ...
+    'Registry D50/1931 weighting-table calculation changed unexpectedly.');
+  assert(max(abs(legacy10_xyz - expected_legacy10)) < 1e-12, ...
+    'Decimated 10 nm legacy calculation changed unexpectedly.');
+
+  delta = legacy_xyz - registry_xyz;
+  assert(delta(3) < -4.4e-4 && delta(3) > -4.6e-4, ...
+    'Expected the legacy D50 Z value to be about 0.000449 below registry.');
+
+  % The grid control, asserted rather than merely reported: halving the sampling
+  % rate perturbs Z by MORE than the whole legacy-to-registry gap, and in the
+  % opposite direction. If this ever stopped holding, the "sampling artifact"
+  % explanation would be back on the table and this file's framing would need
+  % revisiting.
+  grid_effect = legacy10_xyz(3) - legacy_xyz(3);
+  assert(grid_effect < 0.0 && abs(grid_effect) > abs(delta(3)), ...
+    'Expected the 5 nm -> 10 nm grid effect to exceed the legacy/registry gap.');
+
+  legacy_error = legacy_xyz - canonical_xyz;
+  registry_error = registry_xyz - canonical_xyz;
+  legacy_pcs_error = legacy_xyz - icc_pcs_xyz;
+  registry_pcs_error = registry_xyz - icc_pcs_xyz;
+
+  % The reference-dependence, pinned in both directions. Against CIE 15 the
+  % registry table wins; against the ICC PCS illuminant the legacy path wins.
+  % Asserting only the first would read as "registry is more accurate", which
+  % the second half of this pair shows is not a statement the data supports on
+  % its own.
+  % These two are deliberately a tripwire for a CHANGE THAT IS EXPECTED: CIE
+  % TC1-102 has revised weighting tables pending, and #1475 records that the ICC
+  % registry will be regenerated once they publish. When that lands, the margin
+  % here (2.21e-4 versus 2.28e-4 against the PCS white) is small enough to flip.
+  % That is the point -- it should not regenerate silently -- so the messages say
+  % what to do rather than just reporting a failed comparison.
+  closer_to_cie = abs(registry_error(3)) < abs(legacy_error(3));
+  closer_to_icc_pcs = abs(legacy_pcs_error(3)) < abs(registry_pcs_error(3));
+  assert(closer_to_cie, ...
+    ['Registry D50 Z is no longer closer to CIE 15 than the legacy path. ' ...
+     'If the registry weighting tables were regenerated, re-derive the ' ...
+     'expected values above and revisit the #1475 framing in ' ...
+     'docs/matlab-bindings.md before re-pinning.']);
+  assert(closer_to_icc_pcs, ...
+    ['Legacy D50 Z is no longer closer to the ICC PCS illuminant than the ' ...
+     'registry table. Same follow-up as above: this pair records which ' ...
+     'reference each path favours, so a flip is a decision to make, not a ' ...
+     'number to update.']);
+
+  result = struct( ...
+    'legacy_xyz', legacy_xyz, ...
+    'legacy10_xyz', legacy10_xyz, ...
+    'registry_xyz', registry_xyz, ...
+    'canonical_xyz', canonical_xyz, ...
+    'icc_pcs_xyz', icc_pcs_xyz, ...
+    'delta_xyz', delta, ...
+    'grid_effect', grid_effect, ...
+    'legacy_error', legacy_error, ...
+    'registry_error', registry_error, ...
+    'legacy_pcs_error', legacy_pcs_error, ...
+    'registry_pcs_error', registry_pcs_error, ...
+    'closer_to_cie', closer_to_cie, ...
+    'closer_to_icc_pcs', closer_to_icc_pcs);
+end
+
+% Reduces a perfect diffuser the way the legacy spectral path does: a plain
+% rectangular sum of SPD times CMF, normalized by k = 1/sum(ybar*SPD) so that
+% Y == 1 by construction. Mirrors CIccPcc::getEmissiveObserver and the
+% icXYZCalcDirectSum branch of CIccColorimetricCalculator::Prepare.
+function xyz = direct_sum(spd, x_bar, y_bar, z_bar)
+  normalization = 1.0 / sum(y_bar .* spd);
+  xyz = normalization .* [
+    sum(x_bar .* spd)
+    sum(y_bar .* spd)
+    sum(z_bar .* spd)
+  ];
+end
+
+function values = extract_values(source, pattern, expected_count)
+  token = regexp(source, ['(?s)' pattern], 'tokens', 'once');
+  if isempty(token)
+    error('iccdev:colorimetrySourceMissing', ...
+      'Unable to locate a required colorimetry table in the C++ source.');
+  end
+
+  block = regexprep(token{1}, '//[^\r\n]*', '');
+  text_values = regexp(block, ...
+    '[-+]?(?:[0-9]+\.[0-9]+|[0-9]+)(?:[eE][-+]?[0-9]+)?', ...
+    'match');
+  values = str2double(text_values(:));
+  if numel(values) ~= expected_count || any(~isfinite(values))
+    error('iccdev:colorimetrySourceMalformed', ...
+      'Expected %d finite table values, found %d.', ...
+      expected_count, numel(values));
+  end
+end

--- a/matlab/README.md
+++ b/matlab/README.md
@@ -254,6 +254,47 @@ ctest --test-dir msvc -C Release `
   --output-on-failure --no-tests=error
 ```
 
+Reproduce issue
+[#1475](https://github.com/InternationalColorConsortium/iccDEV/issues/1475)
+by comparing the legacy 5 nm D50 direct sum with the registry-loaded 10 nm
+weighting table:
+
+```matlab
+test_colorimetry_issue_1475();
+run('matlab/examples/colorimetry_issue_1475.m');
+```
+
+The MATLAB check parses the tables directly from `IccTagBasic.cpp` and
+`IccColorimetry.cpp`. For a perfect diffuser under D50 with the CIE 1931
+2-degree observer, the legacy path produces `Z=0.824679094` while the registry
+table produces `Z=0.825128117`, a gap of `-0.000449`.
+
+That gap is a difference in the illuminant *data*, not in how it is integrated:
+
+- **Not the reduction method.** `iccdev.colorimetry-methods` asserts
+  `DirectSum == Weighting == SpragueTo1nm` to `TOL_EXACT` on a common grid, so a
+  weighting table is not intrinsically closer to CIE than a direct sum.
+- **Not the sample grid.** Re-summing the same legacy data on the 10 nm subgrid
+  moves `Z` by `-0.000622` -- larger than the gap and opposite in sign. The
+  check computes this as `grid_effect` and asserts it.
+
+Which path is "closer" is a choice of reference, so the check pins both
+directions: against CIE 15 (`Z=0.82521`) the registry table wins
+(`-0.000082` versus `-0.000531`), while against the ICC PCS illuminant
+`icD50XYZ` (`Z=0.8249`, what the native test anchors the legacy path to) the
+legacy path wins (`-0.000221` versus `+0.000228`).
+
+Note the registry table is reachable through `IccColorimetry` but is not yet on
+any live path: `CIccColorimetricCalculator` is referenced only by the
+colorimetry-methods regression test, so this is a parallel API rather than a
+change to what the CMM currently computes.
+
+Issue
+[#1451](https://github.com/InternationalColorConsortium/iccDEV/issues/1451)
+is related but remains a separate ingestion concern: `iccPawgReport` currently
+requires measured Lab or XYZ columns and does not derive PCS values from
+spectral-only characterization rows.
+
 The MATLAB check is an independent fixture/arithmetic model. The native CTest
 is authoritative for warning status and message behavior; both should pass.
 

--- a/matlab/examples/colorimetry_issue_1475.m
+++ b/matlab/examples/colorimetry_issue_1475.m
@@ -1,0 +1,63 @@
+%% colorimetry_issue_1475.m - Compare legacy and registry D50 reductions
+%
+% Copyright (c) International Color Consortium.
+% BSD 3-Clause License. See LICENSE.md for details.
+
+thisDir = fileparts(mfilename('fullpath'));
+matlabDir = fileparts(thisDir);
+addpath(matlabDir);
+
+result = iccdev.qa.check_colorimetry_issue_1475();
+
+fprintf('=== iccdev MATLAB QA: Issue #1475 Colorimetry ===\n\n');
+fprintf('Perfect diffuser, D50 / CIE 1931 2-degree observer:\n');
+fprintf('  Legacy 5 nm direct sum: X=%.9f Y=%.9f Z=%.9f\n', ...
+  result.legacy_xyz);
+fprintf('  Registry 10 nm table:   X=%.9f Y=%.9f Z=%.9f\n', ...
+  result.registry_xyz);
+fprintf('  Legacy - registry:      dX=%+.9f dY=%+.9f dZ=%+.9f\n', ...
+  result.delta_xyz);
+
+% The gap is not a reduction-method artifact and not a sampling artifact. The
+% method axis is pinned by the native iccdev.colorimetry-methods CTest, which
+% asserts DirectSum == Weighting == SpragueTo1nm to TOL_EXACT on a common grid.
+% The sampling axis is measured right here: re-summing the SAME legacy data at
+% 10 nm moves Z further than the whole gap, and the other way.
+fprintf('\nControl - same data, same method, 10 nm subgrid:\n');
+fprintf('  Legacy at 10 nm:        X=%.9f Y=%.9f Z=%.9f\n', ...
+  result.legacy10_xyz);
+fprintf('  Grid effect on Z:       %+.9f  (gap to explain: %+.9f)\n', ...
+  result.grid_effect, -result.delta_xyz(3));
+fprintf('  Sampling moves Z by %.1f%% of the gap, opposite in sign, so the\n', ...
+  100 * abs(result.grid_effect) / abs(result.delta_xyz(3)));
+fprintf('  difference lives in the illuminant data, not in the integration.\n');
+
+% Which path is "closer" is a choice of reference, not a measure of accuracy.
+fprintf('\nAgainst the two references in the tree:\n');
+fprintf('  CIE 15   %.5f:  legacy dZ=%+.9f  registry dZ=%+.9f\n', ...
+  result.canonical_xyz(3), result.legacy_error(3), result.registry_error(3));
+fprintf('  ICC PCS  %.5f:  legacy dZ=%+.9f  registry dZ=%+.9f\n', ...
+  result.icc_pcs_xyz(3), result.legacy_pcs_error(3), ...
+  result.registry_pcs_error(3));
+% Plain if/else rather than a helper: every other example in matlab/examples is a
+% flat script with no local functions, and a script-local function is a construct
+% no CI lane here has ever executed.
+if result.closer_to_cie
+  cieWinner = 'registry';
+else
+  cieWinner = 'legacy';
+end
+if result.closer_to_icc_pcs
+  pcsWinner = 'legacy';
+else
+  pcsWinner = 'registry';
+end
+fprintf('  Closer to CIE 15:            %s\n', cieWinner);
+fprintf('  Closer to the ICC PCS white: %s\n', pcsWinner);
+
+fprintf('\nThe registry table is reachable through IccColorimetry, but no CMM or\n');
+fprintf('tool path consumes it yet - CIccColorimetricCalculator is referenced\n');
+fprintf('only by the colorimetry-methods regression test, so this is a parallel\n');
+fprintf('API rather than a change to what the library currently computes.\n');
+fprintf('iccPawgReport issue #1451 still requires spectral-column ingestion.\n');
+fprintf('\nDone.\n');

--- a/matlab/tests/test_colorimetry_issue_1475.m
+++ b/matlab/tests/test_colorimetry_issue_1475.m
@@ -1,0 +1,22 @@
+function test_colorimetry_issue_1475()
+%TEST_COLORIMETRY_ISSUE_1475 Verify the independent MATLAB reproduction.
+%
+% Copyright (c) International Color Consortium.
+% BSD 3-Clause License. See LICENSE.md for details.
+
+  result = iccdev.qa.check_colorimetry_issue_1475();
+  assert(abs(result.legacy_xyz(2) - 1.0) < 1e-12);
+  assert(abs(result.registry_xyz(2) - 1.0) < 1e-9);
+  assert(result.delta_xyz(3) < 0.0);
+
+  % The controls, restated here so a reader of the test sees what is actually
+  % being claimed: the legacy/registry difference survives holding the sampling
+  % rate fixed (grid_effect is larger and opposite in sign), and "closer" flips
+  % depending on which of the tree's two D50 references is adopted.
+  assert(result.grid_effect < 0.0);
+  assert(abs(result.grid_effect) > abs(result.delta_xyz(3)));
+  assert(result.closer_to_cie);
+  assert(result.closer_to_icc_pcs);
+
+  fprintf('Issue #1475 colorimetry calculations passed.\n');
+end

--- a/matlab/tests/test_iccdev.m
+++ b/matlab/tests/test_iccdev.m
@@ -29,6 +29,8 @@ function test_iccdev()
   [nPass, nFail] = run_test(@test_interpolation_values, 'Interpolation values', nPass, nFail);
   [nPass, nFail] = run_test(@test_sig_to_str, 'sig_to_str', nPass, nFail);
   [nPass, nFail] = run_test(@test_curve_gamma_fixture, 'curveType gamma math', nPass, nFail);
+  [nPass, nFail] = run_test(@iccdev.qa.check_colorimetry_issue_1475, ...
+    'issue #1475 colorimetry math', nPass, nFail);
 
   % --- Profile tests (need test profiles) ---
   profilePath = find_test_profile();


### PR DESCRIPTION
## PR Summary

Cross-check of the #2046 handoff, built on the MATLAB reproduction @xsscx wrote on
`ci-qa-matlab-issue-1475` (`e27e30b0`).

**His arithmetic is exactly right and is kept as written.** Both white points
reproduce from the in-tree tables to `3.3e-16` and `1.1e-16`. His
`expected_registry` is literally the registry column sums recorded on #1475 on
2026-07-28 (`96.42408 / 100.00000 / 82.51281`).

What changes is the causal reading built on top of them.

### The finding

The check asserted only `abs(registry_error(3)) < abs(legacy_error(3))`, and the
docs read *"the registry loaded-table method is materially closer in Z than the
legacy fallback"*. But the legacy and registry paths differ in **three** ways at
once -- reduction method, sample grid, and the underlying illuminant data -- so
the `-0.000449` gap cannot be attributed to any one of them without holding the
others fixed. Two of the three are now controlled:

**Reduction method contributes exactly zero.** `iccdev.colorimetry-methods`
already asserts `same-grid: DirectSum == Weighting` and `== SpragueTo1nm` to
`TOL_EXACT` (`1e-6`), but only on synthetic data. Driving
`CIccColorimetricCalculator` with the real D50 SPD and 1931 CMFs:

```
  method                    X            Y            Z      dZ vs CIE    dZ vs ICC
  DirectSum       0.964245558  1.000000000  0.824679077   -0.000530923 -0.000220923
  Weighting       0.964245558  1.000000000  0.824679077   -0.000530923 -0.000220923
  SpragueTo1nm    0.964245558  1.000000000  0.824679077   -0.000530923 -0.000220923

  method spread (same data)      : 0.000e+00
  legacy -> registry gap (#2046)  : 4.490e-04
```

A weighting table is not intrinsically closer to CIE than a direct sum is.

**Sample grid is not the cause either, and has the wrong sign.** Re-summing the
*same* legacy data on the 10 nm subgrid gives `Z=0.824057353` -- a move of
`-0.000622`, larger than the gap and in the opposite direction. Added as
`legacy10_xyz` / `grid_effect` and asserted, so the sampling-artifact reading
stays refuted by a test rather than by a comment.

What remains is the **data**, consistent with the #1475 conformance result: all
ten registry tables match the published registry values exactly, while iccDEV's
own 5 nm D50 SPD (`icKnownIllums`, inherited in `889db62b`) is the divergent
object.

### The reference flip

The docs said *"The canonical CIE 15 white point is the external reference pinned
by that native test."* The native test pins **two**:

- Part F -- registry tables vs **CIE 15**, `0.96422 / 0.82521`
- Part E6 -- legacy path vs the **ICC PCS illuminant** `icD50XYZ`
  (`IccUtil.cpp:818`), `0.9642 / 0.8249`, with an explicit note that the 5 nm
  tables sit ~5e-4 low on Z

**"Closer" reverses between them.** Against CIE 15 the registry table wins
(`8.19e-05` vs `5.31e-04`); against the ICC PCS white **the legacy path wins**
(`2.21e-04` vs `2.28e-04`). Both directions are now asserted, so neither can be
quoted on its own. Those two assertions are deliberately a tripwire for the
CIE TC1-102 table revision #1475 anticipates -- their failure messages say to
revisit the framing rather than just re-pin the numbers.

### Scope note

`CIccColorimetricCalculator` is referenced **only** by
`.github/ci/regression/colorimetry-methods.cpp` -- no CMM, tool or MPE path
consumes it. The registry-aligned reduction is a parallel API, not a change to
what the library computes today. Recorded in the docs so the capability is not
read as a live accuracy improvement.

### Incidental fixes

- `docs/matlab-bindings.md` had an absolute local path (`E:\opt\iccDEV\...`)
  inside a runnable snippet; replaced with the repo-relative `fullfile()` form
  used everywhere else.
- the example defined a script-local function -- the only one in
  `matlab/examples/`, a shape no CI lane here has executed. Replaced with
  `if`/`else`.

### CI wiring

`ci-matlab.yml` runs the new MATLAB check alongside the luminance one and extends
the native ctest selection to `colorimetry-methods`. The target was already
registered in both CMake call lists and already compiles on Windows via
`build-test-binaries`, so this adds no new build surface. Flagging the workflow
edit explicitly per the checklist item on maintainer-owned CI: it is limited to
wiring this handoff in, and no trigger or permission was changed.

## Verification

- Configured with `ci-matlab.yml`'s exact CMake flags; built `IccProfLib2-static`
  + both regression targets. **CI's gate run mechanically: `grep -cE 'warning:'`
  on the build log = 0.**
- `iccdev.luminance-normalization` and `iccdev.colorimetry-methods` both pass
  (ctest re-run against a build made immediately beforehand).
- Pre-flight lint gates, exact scanner invocations from
  `.github/scripts/preflight-safety-checks.sh`: `actionlint` rc=0,
  `yamllint -d '{...line-length: {max: 120}}'` rc=0, `zizmor` rc=0. No shell
  scripts changed.
- **MATLAB is not available on this machine**, so the `.m` check was validated by
  a line-for-line port executing the same arithmetic and all seven assertions --
  worst residual `4.4e-16` against a `1e-12` tolerance. That the port agrees with
  @xsscx's MATLAB-produced constant to `3.3e-16` is what licenses the newly
  derived `expected_legacy10` constant. The Windows CI leg is nonetheless the
  first real MATLAB execution of this file.
- **Red-tested**: perturbing the D50 SPD, the 1931 CMFs, and the registry `Wx`/`Wz`
  blocks each fires the expected assertion; the three new assertions
  (`grid_effect`, `closer_to_cie`, `closer_to_icc_pcs`) each fire under a
  plausible table change, so none is a no-op.

Part of #2046
