### PR TITLE
fix(#1940): restore the Begin() idempotency contract CIccCmmSearch dropped

### DIFF
--- a/.github/ci/regression/cmmsearch-rebegin.cpp
+++ b/.github/ci/regression/cmmsearch-rebegin.cpp
@@ -1,0 +1,369 @@
+/*
+    File:       cmmsearch-rebegin.cpp
+
+    Contains:   CTest helper for CIccCmmSearch::Begin() idempotency
+                (issue #1940).
+
+    CIccCmm::Begin() opens with "if (m_pApply) return icCmmStatOk;", so calling
+    it twice on a CIccCmm is a defined no-op.  CIccCmmSearch::Begin() overrode it
+    without that guard while its body destroys state a second pass re-reads: the
+    two-profile branch deletes m_pDstProfile and sets it to nullptr, and the
+    -INIT initial-destination profile is nulled once consumed, but m_nAttached is
+    left describing the profile set that no longer exists.  The second pass then
+    bound those null members to the reference AddXform overload.
+
+    Callers cannot route around this by knowing which class they hold:
+    CIccConnectCmm stores a CIccCmm* and only dynamic_casts down in
+    GetSearchCmm(), so a second Begin() on the base handle reached the override.
+
+    Two sequences reproduced it against 6f58d47e, both reported by scan-build as
+    core.NonNullParamChecker "Forming reference to null pointer":
+
+      Begin(); Begin();                -> IccCmmSearch.cpp:423, null m_pDstProfile
+      Begin(); AddXform(); Begin();    -> IccCmmSearch.cpp:461, null m_pMidProfile
+
+    The second sequence is the same defect one step removed: AddXform's case 2
+    does "m_pMidProfile = m_pDstProfile" to shift the chain along, and the first
+    Begin() had already nulled m_pDstProfile, so it installs a null middle
+    profile and reports icCmmStatOk.
+
+    Both of those are the LOUD face.  With three chain profiles Begin() takes the
+    else branch, which never deletes m_pDstProfile, so a second Begin() finds
+    nothing null and survives: it returns icCmmStatOk, the transform results do
+    not move, and it quietly re-runs -- pushing duplicate chains and leaking the
+    CIccApplyCmm the first pass allocated (332 bytes in 6 allocations against
+    6f58d47e). That face is invisible without leak detection, which is why the
+    three-profile case is also registered as its own test with
+    ASAN_OPTIONS=detect_leaks=1.
+
+    This helper asserts the contract rather than merely surviving: the second
+    Begin() must report icCmmStatOk *and* leave the CMM producing the results the
+    first one built, which is what distinguishes a genuine no-op from a partial
+    rebuild.
+
+    Usage:
+      cmmsearch-rebegin <profile.icc>
+
+    Exit codes:
+      0 - base and search CMMs both idempotent across a second Begin()
+      1 - a Begin() reported failure, or the search results moved
+      2 - usage error
+*/
+
+#include "IccCmm.h"
+#include "IccCmmSearch.h"
+#include "IccProfile.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <memory>
+
+// The second Begin() is a no-op, so the search runs from identical state and
+// must reproduce its own output exactly.  A tolerance is kept only so the test
+// states a bound rather than relying on bit equality of an iterative search;
+// it is three orders of magnitude below the 0.05 residual that
+// cmmsearch-init-pcc allows for the search itself, so a rebuilt chain cannot
+// slip through it.
+static const icFloatNumber kDriftTolerance = 1.0e-5f;
+
+static const icFloatNumber kSamples[][3] = {
+  { 1.0f, 0.0f, 0.0f },
+  { 0.0f, 1.0f, 0.0f },
+  { 0.0f, 0.0f, 1.0f },
+  { 1.0f, 1.0f, 1.0f },
+  { 0.5f, 0.25f, 0.125f },
+};
+static const int kNumSamples = (int)(sizeof(kSamples) / sizeof(kSamples[0]));
+
+// Builds a two-profile search CMM over the same profile twice, which makes the
+// search a device->device identity and keeps the assertion about Begin() rather
+// than about color accuracy.
+static CIccCmmSearch* buildSearchCmm(const char* profilePath)
+{
+  std::unique_ptr<CIccCmmSearch> pCmm(new CIccCmmSearch());
+
+  CIccProfile* pSrc = OpenIccProfile(profilePath);
+  CIccProfile* pDst = OpenIccProfile(profilePath);
+  if (!pSrc || !pDst) {
+    std::fprintf(stderr, "cmmsearch-rebegin: unable to open '%s'\n", profilePath);
+    delete pSrc;
+    delete pDst;
+    return NULL;
+  }
+
+  // AddXform owns the profile on every path, including rejection (#1327), so
+  // there is nothing to free here on failure.
+  if (pCmm->AddXform(pSrc, icRelativeColorimetric) != icCmmStatOk ||
+      pCmm->AddXform(pDst, icRelativeColorimetric) != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: AddXform failed for '%s'\n", profilePath);
+    return NULL;
+  }
+
+  return pCmm.release();
+}
+
+// The control: the base class contract this override is being held to.  If this
+// ever fails, the premise of the fix has changed and the guard needs revisiting
+// rather than the search code.
+static int checkBaseIdempotent(const char* profilePath)
+{
+  // Stack-scoped and driven through the filename overload, matching the shapes
+  // the other regression helpers already compile on every lane.
+  CIccCmm cmm;
+
+  if (cmm.AddXform(profilePath, icRelativeColorimetric) != icCmmStatOk ||
+      cmm.AddXform(profilePath, icRelativeColorimetric) != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  base AddXform failed\n");
+    return 1;
+  }
+
+  icStatusCMM rv = cmm.Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  base Begin() #1 status %d\n", (int)rv);
+    return 1;
+  }
+
+  rv = cmm.Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  base Begin() #2 status %d\n", (int)rv);
+    return 1;
+  }
+
+  std::fprintf(stdout, "cmmsearch-rebegin: PASS  CIccCmm::Begin() is idempotent\n");
+  return 0;
+}
+
+// Sequence 1: Begin(); Begin().  Pre-fix this bound a null m_pDstProfile to the
+// reference AddXform overload at IccCmmSearch.cpp:423.
+static int checkSearchRebegin(const char* profilePath)
+{
+  std::unique_ptr<CIccCmmSearch> pCmm(buildSearchCmm(profilePath));
+  if (!pCmm)
+    return 1;
+
+  icStatusCMM rv = pCmm->Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  search Begin() #1 status %d\n", (int)rv);
+    return 1;
+  }
+
+  // Capture what the CMM produces while it is known good, so the second Begin()
+  // can be held to reproducing it rather than merely returning a status.
+  icFloatNumber before[kNumSamples][3];
+  for (int i = 0; i < kNumSamples; i++) {
+    rv = pCmm->Apply(before[i], kSamples[i]);
+    if (rv != icCmmStatOk) {
+      std::fprintf(stderr, "cmmsearch-rebegin: FAIL  Apply #1 status %d for sample %d\n",
+                   (int)rv, i);
+      return 1;
+    }
+  }
+
+  rv = pCmm->Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  search Begin() #2 status %d\n", (int)rv);
+    return 1;
+  }
+
+  int failures = 0;
+  for (int i = 0; i < kNumSamples; i++) {
+    icFloatNumber after[3] = { 0.0f, 0.0f, 0.0f };
+
+    rv = pCmm->Apply(after, kSamples[i]);
+    if (rv != icCmmStatOk) {
+      std::fprintf(stderr, "cmmsearch-rebegin: FAIL  Apply #2 status %d for sample %d\n",
+                   (int)rv, i);
+      failures++;
+      continue;
+    }
+
+    icFloatNumber worst = 0.0f;
+    for (int j = 0; j < 3; j++) {
+      icFloatNumber diff = (icFloatNumber)std::fabs(after[j] - before[i][j]);
+      if (diff > worst)
+        worst = diff;
+    }
+
+    if (worst > kDriftTolerance) {
+      std::fprintf(stderr,
+        "cmmsearch-rebegin: FAIL  sample %d moved across Begin() #2 "
+        "[%.6f %.6f %.6f] -> [%.6f %.6f %.6f] (max drift %.6f)\n",
+        i, (double)before[i][0], (double)before[i][1], (double)before[i][2],
+        (double)after[0], (double)after[1], (double)after[2], (double)worst);
+      failures++;
+    }
+  }
+
+  if (!failures)
+    std::fprintf(stdout,
+      "cmmsearch-rebegin: PASS  CIccCmmSearch::Begin() twice is a no-op over %d samples\n",
+      kNumSamples);
+
+  return failures ? 1 : 0;
+}
+
+// Sequence 2: Begin(); AddXform(); Begin().  The added profile shifts the chain
+// through AddXform's case 2, which copies the already-nulled m_pDstProfile into
+// m_pMidProfile; pre-fix the second Begin() then bound that null at
+// IccCmmSearch.cpp:461.  The contract being asserted is the base one -- once
+// Begin() has run, a further AddXform does not rebuild the CMM -- so the second
+// Begin() must report icCmmStatOk and leave the built chain alone.
+static int checkSearchAddXformAfterBegin(const char* profilePath)
+{
+  std::unique_ptr<CIccCmmSearch> pCmm(buildSearchCmm(profilePath));
+  if (!pCmm)
+    return 1;
+
+  icStatusCMM rv = pCmm->Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  search Begin() #1 status %d\n", (int)rv);
+    return 1;
+  }
+
+  CIccProfile* pThird = OpenIccProfile(profilePath);
+  if (!pThird) {
+    std::fprintf(stderr, "cmmsearch-rebegin: unable to reopen '%s'\n", profilePath);
+    return 1;
+  }
+
+  // AddXform owns pThird on every path, so this leaks nothing regardless of the
+  // status it reports.
+  pCmm->AddXform(pThird, icRelativeColorimetric);
+
+  rv = pCmm->Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr,
+      "cmmsearch-rebegin: FAIL  Begin() after a post-Begin AddXform status %d\n", (int)rv);
+    return 1;
+  }
+
+  // The chain must still work, not merely have avoided the null reference.
+  icFloatNumber dst[3] = { 0.0f, 0.0f, 0.0f };
+  rv = pCmm->Apply(dst, kSamples[0]);
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr,
+      "cmmsearch-rebegin: FAIL  Apply after a post-Begin AddXform status %d\n", (int)rv);
+    return 1;
+  }
+
+  std::fprintf(stdout,
+    "cmmsearch-rebegin: PASS  AddXform() after Begin() leaves the built chain intact\n");
+  return 0;
+}
+
+// The quiet face of the same defect.  With three chain profiles Begin() takes
+// the else branch, and that branch never deletes m_pDstProfile -- only the
+// two-profile branch does -- so a second Begin() finds nothing null, SURVIVES,
+// and returns icCmmStatOk with unchanged results.  What it does instead is
+// re-run: it pushes another chain into m_dst_to_mid and m_src_to_mid and
+// overwrites m_pApply, leaking the CIccApplyCmm the first pass allocated
+// (IccCmmSearch.cpp:528).  Measured against 6f58d47e that is 332 bytes in 6
+// allocations, and nothing about it is observable from the transform results,
+// so this case ships green wherever leak detection is off.  It is registered
+// separately with ASAN_OPTIONS=detect_leaks=1 for that reason.
+static int checkSearchThreeProfileRebegin(const char* profilePath)
+{
+  std::unique_ptr<CIccCmmSearch> pCmm(new CIccCmmSearch());
+
+  for (int i = 0; i < 3; i++) {
+    CIccProfile* pProfile = OpenIccProfile(profilePath);
+    if (!pProfile) {
+      std::fprintf(stderr, "cmmsearch-rebegin: unable to open '%s'\n", profilePath);
+      return 1;
+    }
+    if (pCmm->AddXform(pProfile, icRelativeColorimetric) != icCmmStatOk) {
+      std::fprintf(stderr, "cmmsearch-rebegin: AddXform %d failed\n", i);
+      return 1;
+    }
+  }
+
+  // The three-profile branch reports icCmmStatBadConnection unless a weighted
+  // connection condition is attached, so the shape needs one to be reachable.
+  CIccProfile* pPcc = OpenIccProfile(profilePath);
+  if (!pPcc || !pPcc->ReadPccTags()) {
+    std::fprintf(stderr, "cmmsearch-rebegin: unable to read PCC tags from '%s'\n", profilePath);
+    delete pPcc;
+    return 1;
+  }
+  pPcc->Detach();
+  // AttachPCC only takes ownership when it accepts, matching iccconnect-search-cost.
+  if (pCmm->AttachPCC(pPcc, 1.0f) != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: AttachPCC failed\n");
+    delete pPcc;
+    return 1;
+  }
+
+  icStatusCMM rv = pCmm->Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  3-profile Begin() #1 status %d\n", (int)rv);
+    return 1;
+  }
+
+  icFloatNumber before[3] = { 0.0f, 0.0f, 0.0f };
+  rv = pCmm->Apply(before, kSamples[kNumSamples - 1]);
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  3-profile Apply #1 status %d\n", (int)rv);
+    return 1;
+  }
+
+  rv = pCmm->Begin();
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  3-profile Begin() #2 status %d\n", (int)rv);
+    return 1;
+  }
+
+  icFloatNumber after[3] = { 0.0f, 0.0f, 0.0f };
+  rv = pCmm->Apply(after, kSamples[kNumSamples - 1]);
+  if (rv != icCmmStatOk) {
+    std::fprintf(stderr, "cmmsearch-rebegin: FAIL  3-profile Apply #2 status %d\n", (int)rv);
+    return 1;
+  }
+
+  for (int j = 0; j < 3; j++) {
+    icFloatNumber diff = (icFloatNumber)std::fabs(after[j] - before[j]);
+    if (diff > kDriftTolerance) {
+      std::fprintf(stderr,
+        "cmmsearch-rebegin: FAIL  3-profile result moved across Begin() #2 (drift %.6f)\n",
+        (double)diff);
+      return 1;
+    }
+  }
+
+  // The leak is the real assertion here and LeakSanitizer makes it, at exit,
+  // only when this process runs with detect_leaks=1.
+  std::fprintf(stdout,
+    "cmmsearch-rebegin: PASS  3-profile Begin() twice is a no-op (leak asserted by LSan)\n");
+  return 0;
+}
+
+int main(int argc, char** argv)
+{
+  if (argc < 2 || argc > 3) {
+    std::fprintf(stderr, "usage: %s <profile.icc> [--three-profile-only]\n",
+                 argv[0] ? argv[0] : "cmmsearch-rebegin");
+    return 2;
+  }
+
+  const char* profilePath = argv[1];
+  bool bThreeProfileOnly = (argc == 3 && !std::strcmp(argv[2], "--three-profile-only"));
+  if (argc == 3 && !bThreeProfileOnly) {
+    std::fprintf(stderr, "cmmsearch-rebegin: unknown option '%s'\n", argv[2]);
+    return 2;
+  }
+
+  // The three-profile check has to run in a process of its own.  The two-profile
+  // sequences below it bind a null reference on an unfixed library, and the
+  // sanitizer halts on that first report -- so bundled together the quiet
+  // three-profile leak would never be reached, and the leak test would be
+  // reporting somebody else's failure.
+  if (bThreeProfileOnly)
+    return checkSearchThreeProfileRebegin(profilePath) ? 1 : 0;
+
+  int failures = 0;
+  failures += checkBaseIdempotent(profilePath);
+  failures += checkSearchRebegin(profilePath);
+  failures += checkSearchAddXformAfterBegin(profilePath);
+
+  return failures ? 1 : 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -294,6 +294,96 @@ function(iccdev_add_cmmsearch_init_pcc_test)
   endforeach()
 endfunction()
 
+function(iccdev_add_cmmsearch_rebegin_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCmmSearchRebeginTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/cmmsearch-rebegin.cpp"
+  )
+  target_link_libraries(iccCmmSearchRebeginTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+
+  add_dependencies(check iccCmmSearchRebeginTest)
+
+  # Both profiles drive the same assertion about Begin(), so this is not a
+  # regression/control pair the way cmmsearch-init-pcc is: the v5 profile carries
+  # an 'svcn' and takes the PCC-resolution path through Begin(), the v4 one does
+  # not, and the idempotency guard has to hold on both.
+  set(_cmmsearch_rebegin_cases
+    "d65-svcn=${ICCDEV_TESTING_DIR}/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc"
+    "v4-no-svcn=${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc"
+  )
+
+  foreach(_case IN LISTS _cmmsearch_rebegin_cases)
+    string(REGEX REPLACE "=.*$" "" _case_name "${_case}")
+    string(REGEX REPLACE "^[^=]*=" "" _case_profile "${_case}")
+
+    if(WIN32)
+      add_test(
+        NAME iccdev.cmmsearch-rebegin.${_case_name}
+        COMMAND "$<TARGET_FILE:iccCmmSearchRebeginTest>" "${_case_profile}"
+      )
+    else()
+      add_test(
+        NAME iccdev.cmmsearch-rebegin.${_case_name}
+        COMMAND
+          "${CMAKE_COMMAND}" -E env
+          ${ICCDEV_TEST_ENV}
+          "$<TARGET_FILE:iccCmmSearchRebeginTest>"
+          "${_case_profile}"
+      )
+    endif()
+    set_tests_properties(iccdev.cmmsearch-rebegin.${_case_name} PROPERTIES
+      WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+      TIMEOUT 120
+      LABELS "iccdev;iccprofLib;cmmsearch;regression"
+    )
+    if(WIN32)
+      set(_cmmsearch_rebegin_windows_env_mods
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCmmSearchRebeginTest>"
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      )
+      foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+        list(APPEND _cmmsearch_rebegin_windows_env_mods
+          "PATH=path_list_prepend:${_runtime_path}")
+      endforeach()
+      set_tests_properties(iccdev.cmmsearch-rebegin.${_case_name} PROPERTIES
+        ENVIRONMENT_MODIFICATION "${_cmmsearch_rebegin_windows_env_mods}"
+      )
+    endif()
+  endforeach()
+
+  # The three-profile branch of Begin() fails quietly: a second call survives,
+  # returns icCmmStatOk and leaves the results alone while leaking the previous
+  # CIccApplyCmm, so the cases above cannot see it.  Only LeakSanitizer can, and
+  # both the CI tool-test job and ICCDEV_TEST_ENV export
+  # ASAN_OPTIONS=...detect_leaks=0, so run the same binary once more with
+  # detect_leaks=1 forced for this process alone -- the same approach
+  # iccdev.cmmsearch-namedcolor-ownership uses, including its MSVC carve-out.
+  if(MSVC)
+    message(STATUS
+      "Skipping iccdev.cmmsearch-rebegin-leak: MSVC AddressSanitizer "
+      "does not support LeakSanitizer detect_leaks=1")
+    return()
+  endif()
+
+  add_test(
+    NAME iccdev.cmmsearch-rebegin-leak
+    COMMAND
+      "${CMAKE_COMMAND}" -E env
+      "ASAN_OPTIONS=detect_leaks=1"
+      "$<TARGET_FILE:iccCmmSearchRebeginTest>"
+      "${ICCDEV_TESTING_DIR}/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc"
+      "--three-profile-only"
+  )
+  set_tests_properties(iccdev.cmmsearch-rebegin-leak PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;cmmsearch;leak;regression"
+  )
+endfunction()
+
 function(iccdev_add_embedio_read8_bounds_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -3995,6 +4085,7 @@ if(WIN32)
   iccdev_add_iccconnect_thread_test()
   iccdev_add_iccconnect_config_parser_test()
   iccdev_add_cmmsearch_init_pcc_test()
+  iccdev_add_cmmsearch_rebegin_test()
   iccdev_add_embedio_read8_bounds_test()
   iccdev_add_fileio_getlength_position_test()
   iccdev_add_profile_write_failure_test()
@@ -4262,6 +4353,7 @@ set(ICCDEV_TEST_ENV
 iccdev_add_iccconnect_thread_test()
 iccdev_add_iccconnect_config_parser_test()
 iccdev_add_cmmsearch_init_pcc_test()
+iccdev_add_cmmsearch_rebegin_test()
 iccdev_add_embedio_read8_bounds_test()
 iccdev_add_fileio_getlength_position_test()
 iccdev_add_profile_write_failure_test()

--- a/IccProfLib/IccCmmSearch.cpp
+++ b/IccProfLib/IccCmmSearch.cpp
@@ -378,8 +378,38 @@ icStatusCMM CIccCmmSearch::Begin(bool /* bAllocNewApply */, bool /* bUsePcsConve
 {
   icStatusCMM rv;
 
+  // Honor the same idempotency contract as the base (#1940).  CIccCmm::Begin
+  // opens with this exact test, so calling Begin() twice on a CIccCmm is a
+  // defined no-op -- and callers hold the base type (CIccConnectCmm keeps a
+  // CIccCmm* and only dynamic_casts down for GetSearchCmm()), so they cannot
+  // tell which override they have.  This one used to run its body again, and
+  // the body is not re-runnable: it deletes m_pDstProfile and nulls it at the
+  // end of the two-profile branch below, and nulls m_pDstInitProfile once it
+  // has been consumed, while leaving m_nAttached describing the profile set
+  // that no longer exists.  The second pass then bound those null members to
+  // the reference AddXform overload.  Guarding on m_pApply -- which the tail of
+  // this function sets -- also stops that second pass leaking the CIccApplyCmm
+  // the first one allocated and pushing a duplicate chain into m_dst_to_mid.
+  if (m_pApply)
+    return icCmmStatOk;
+
   if (m_nAttached < 2)
     return icCmmStatBadXform;
+
+  // The sub-chains below bind the src/mid/dst profiles to a reference parameter,
+  // so a null member here is a null reference and not a recoverable miss.  State
+  // what m_nAttached is supposed to guarantee and enforce it (#1940): AddXform
+  // fills the source slot at m_nAttached 0 and the destination slot at 1, and
+  // only shifts a profile into the middle slot on the way to 3, so at this point
+  // src and dst must both be set and mid must be set exactly when m_nAttached
+  // exceeds 2.  The check is not redundant with the m_pApply guard above -- a
+  // Begin() that fails after the delete at the end of the two-profile branch
+  // never reaches the m_pApply assignment, so a caller that retries on a failure
+  // status arrives here with a live m_nAttached and a dead m_pDstProfile.  The
+  // -INIT initial-destination profile stays optional: SetDstInitProfile need
+  // never be called, and every use of it below is already pointer-guarded.
+  if (!m_pSrcProfile || !m_pDstProfile || (m_nAttached > 2 && !m_pMidProfile))
+    return icCmmStatInvalidProfile;
 
   // Resolve every attached profile's connection conditions before any sub-CMM is
   // built (#1860).  The sub-chains below mix the two CIccCmm::AddXform overloads:
@@ -399,12 +429,10 @@ icStatusCMM CIccCmmSearch::Begin(bool /* bAllocNewApply */, bool /* bUsePcsConve
   // sub-chain agree and only genuinely differing PCCs get an adaptation.
   // CIccConnectCmm::CreateSearch() already does exactly this for the weighted PCC
   // profiles it attaches; this extends the same treatment to the chain profiles.
-  if (m_pSrcProfile)
-    m_pSrcProfile->ReadPccTags();
+  m_pSrcProfile->ReadPccTags();
   if (m_pMidProfile)
     m_pMidProfile->ReadPccTags();
-  if (m_pDstProfile)
-    m_pDstProfile->ReadPccTags();
+  m_pDstProfile->ReadPccTags();
   if (m_pDstInitProfile)
     m_pDstInitProfile->ReadPccTags();
 


### PR DESCRIPTION
Part of #1940.

`CIccCmm::Begin` opens with `if (m_pApply) return icCmmStatOk;` (`IccProfLib/IccCmm.cpp:9596`), so a second `Begin()` on a `CIccCmm` is a defined no-op. `CIccCmmSearch::Begin` overrode it **without that guard** while its body mutates state a second pass re-reads, leaving `m_nAttached` describing a profile set that no longer exists.

Callers cannot route around this by knowing the concrete type: `CIccConnectCmm` stores a `CIccCmm*` (`IccConnect.h:150`) and only `dynamic_cast`s down in `GetSearchCmm()`, so a second `Begin()` on the base handle reaches the override.

## The defect has two faces

**Loud — the two-profile branch**, which ends with `delete m_pDstProfile; m_pDstProfile = nullptr;`. Two sequences bind a null reference, and both are scan-build `core.NonNullParamChecker` reports posted on #1940:

| sequence | site | null member |
|---|---|---|
| `Begin(); Begin();` | `IccCmmSearch.cpp:423` | `m_pDstProfile` |
| `Begin(); AddXform(); Begin();` | `IccCmmSearch.cpp:461` | `m_pMidProfile` |

The second is the same defect one step removed: `AddXform`'s `case 2` shifts the chain with `m_pMidProfile = m_pDstProfile`, and `Begin()` had already nulled the destination — so it installs a **null middle profile and reports `icCmmStatOk`**.

Reproduced under UBSAN against `6f58d47e`:

```
IccCmmSearch.cpp:423:26: runtime error: reference binding to null pointer of type 'CIccProfile'
    #0 CIccCmmSearch::Begin(bool, bool) IccCmmSearch.cpp:423:17
```

**Quiet — the three-profile branch**, which never deletes `m_pDstProfile`. There a second `Begin()` finds nothing null and **survives**: it returns `icCmmStatOk`, the transform results do not move, and it silently re-runs — pushing duplicate chains into `m_dst_to_mid`/`m_src_to_mid` and overwriting `m_pApply`, leaking the `CIccApplyCmm` the first pass allocated (`IccCmmSearch.cpp:528`).

```
==1675838==ERROR: LeakSanitizer: detected memory leaks
SUMMARY: AddressSanitizer: 332 byte(s) leaked in 6 allocation(s).
```

Nothing about that is observable from the transform output, so it ships green wherever leak detection is off — **which includes CI's own ctest environment**.

The two do not compose: on the two-profile chain the null bind aborts the pass before it reaches the pushes or the `m_pApply` assignment, so the leak is reachable only through the three-profile shape.

## The change

Mirroring the base guard fixes all of it.

The four `ReadPccTags` null-guards become an **enforced precondition** instead. They were added by #1860 and are what let the analyzer constrain these members to null in the first place; stepping around a null there only defers it to the reference bind a few lines later. The check is *not* redundant with the `m_pApply` guard — a `Begin()` that fails after the delete never reaches the `m_pApply` assignment, so a caller retrying on a failure status arrives with a live `m_nAttached` and a dead `m_pDstProfile`. The `-INIT` profile stays optional.

## Triage of the other two scan-build reports

`:414` and `:470` are **false positives of those same guards**, and no code change is warranted:

- `:414` — `m_pSrcProfile` is assigned in `AddXform` `case 0` and never nulled afterwards, so `m_nAttached >= 2` implies it is set.
- `:470` — every sequence that nulls `m_pDstProfile` in the three-profile branch trips `:461` first.

## Test

`cmmsearch-rebegin` asserts the **contract**, not mere survival: the second `Begin()` must report `icCmmStatOk` *and* leave the CMM producing what the first one built, which is what separates a real no-op from a partial rebuild. It carries the base-class control alongside, so a change to the contract being mirrored fails loudly here.

The three-profile case runs as its own test with `ASAN_OPTIONS=detect_leaks=1` forced — following `iccdev.cmmsearch-namedcolor-ownership`, including its MSVC carve-out — and **in its own process**: bundled with the others the sanitizer halts on the null bind first and the leak is never reached.

Red/green verified by reverting only `IccProfLib/IccCmmSearch.cpp`: the two profile cases fail at `:423`, the leak case reports the 332-byte leak; with the fix restored all three pass.

## Pre-flight

| lane | flags | warnings | tests |
|---|---|---|---|
| clang 21.1.3 Release | `-Wall -Wextra -Wpedantic -Werror`, strict ENABLED | **0** | 167/168 |
| clang 21.1.3 Debug ASAN+UBSAN | same + `-g -O0`, strict ENABLED | **0** | 167/168 |
| **GCC 15.2.0** (CI's own regression container) | same + `-DENABLE_LTO=ON`, strict ENABLED | **0** | library, tools and the new test compile clean |

The single non-passing test in the local lanes is `iccdev.spectral-tiff-preview`, which fails on this box with `ModuleNotFoundError: No module named 'imagecodecs'` — an environment gap, unrelated to this change.

No shell or workflow files are touched, so the shellcheck/actionlint/zizmor gates do not apply.

## Scope

This is deliberately **`Part of #1940`, not a close**. The issue also covers the stream/resource warnings blamed to `c3ad932d` (#1204), which were never enumerated and are not addressed here. Its third item — the dead increment at `iccApplyNamedCmm.cpp:358` — is already resolved by #1958, and the comment at `:357-360` documents it.
