### PR TITLE
fix(#2052): make the observer HBO replay actually replay, and correct the stale float selector

### DIFF
--- a/.github/scripts/iccdev-applyprofiles-observer-hbo-regression.sh
+++ b/.github/scripts/iccdev-applyprofiles-observer-hbo-regression.sh
@@ -68,7 +68,15 @@ for tool in base64 sha256sum timeout; do
   fi
 done
 
-SRC_TIF="$TESTING_DIR/ApplyDataFiles/seed-tiff-none-rgb-8x8.tif"
+# Both replay profiles declare a 6CLR device space, so the source image has to
+# carry six samples per pixel or iccApplyProfiles refuses the pair up front with
+# "Number of samples 3 ... doesn't match device samples 6 in first profile" and
+# never calls Begin() -- the very path these profiles exist to drive.  The
+# seed-tiff-none-rgb-8x8.tif this used to name is 8x8 RGB, three samples, so the
+# replay had been bailing before it reached getEmissiveObserver().  This is the
+# only six-sample TIFF in the tracked corpus and is what the sibling spectral-PCS
+# replay harness already uses for the same profiles (#2052).
+SRC_TIF="$TESTING_DIR/mcs/CMYKSS-Numbered-Overprint.tif"
 if [ ! -f "$SRC_TIF" ]; then
   echo "[FAIL] missing TIFF fixture: $SRC_TIF"
   exit 1
@@ -159,10 +167,21 @@ run_profile() {
   profile="$(decode_profile "$name" "$expected")"
   rm -f "$out_tif" "$log"
 
+  # dst_sample_encoding 3 is icEncodeFloat.  This used to pass 4, which the
+  # iccApplyProfiles usage text advertised as float from 1f0a9dd2 until #1996
+  # corrected it; the selector switch answered every out-of-range value with
+  # 8 bit and exit 0, so following the shipped documentation looked like it
+  # worked.  #1996 made the switch reject what it does not define, turning the
+  # stale 4 into "Unable to parse configuration arguments" and Usage() (#2052).
+  # The replays do real work now that they are fed a source they can pair with:
+  # about 4 s each in a local Debug sanitizer build, against the 30 s this used to
+  # allow while it was exiting immediately.  45 s keeps a full order of magnitude
+  # of headroom for a slower CI container and still leaves both replays inside the
+  # 120 s the CTest budgets for the script.
   set +e
   ASAN_OPTIONS="symbolize=0:halt_on_error=1:abort_on_error=1:detect_leaks=0" \
   UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1" \
-    timeout 30 "$APPLY" "$SRC_TIF" "$out_tif" 4 1 1 1 1 "$profile" 40 > "$log" 2>&1
+    timeout 45 "$APPLY" "$SRC_TIF" "$out_tif" 3 1 1 1 1 "$profile" 40 > "$log" 2>&1
   exit_code=$?
   set -e
 
@@ -184,7 +203,31 @@ run_profile() {
     exit 1
   fi
 
-  echo "[PASS] $name completed without sanitizer findings"
+  # Everything above only rejects a crash, so any orderly refusal -- a bad
+  # selector, a device-space mismatch, an unreadable profile -- used to reach the
+  # [PASS] below having replayed nothing at all.  A regression guard that cannot
+  # distinguish "ran clean" from "declined to run" is what let both defects
+  # #2052 records sit here undetected, so assert the replay actually happened:
+  # a zero status, the writer's completion marker, and a non-empty output image.
+  if [ "$exit_code" -ne 0 ]; then
+    echo "[FAIL] iccApplyProfiles refused to replay $name (exit $exit_code)"
+    sed -n '1,80p' "$log"
+    exit 1
+  fi
+
+  if ! grep -q '100%' "$log"; then
+    echo "[FAIL] $name did not run to completion: no progress marker in $log"
+    sed -n '1,80p' "$log"
+    exit 1
+  fi
+
+  if [ ! -s "$out_tif" ]; then
+    echo "[FAIL] $name produced no output image at $out_tif"
+    sed -n '1,80p' "$log"
+    exit 1
+  fi
+
+  echo "[PASS] $name replayed to completion without sanitizer findings"
 }
 
 run_profile reflectance-clut 3ae8248544e08837bef71f66df02139cbbc8007fe1969ce7fcfe3b7aa473dd5a

--- a/.github/scripts/json-cli-exercise.sh
+++ b/.github/scripts/json-cli-exercise.sh
@@ -1121,12 +1121,17 @@ elif [ "$rc" -eq 0 ]; then PASS=$((PASS+1)); echo "[PASS] #$TOTAL profiles cli: 
 else FAIL=$((FAIL+1)); echo "[FAIL] #$TOTAL profiles cli: 16bit (exit=$rc)"; fi
 
 # 24d: Float output
+# icEncodeFloat is selector 3, not 4.  The 4 here came from the iccApplyProfiles
+# usage text, which advertised "4 - icEncodeFloat" from 1f0a9dd2 until #1996
+# corrected it; the selector switch used to answer every out-of-range value with
+# 8 bit and exit 0, so this case reported [PASS] while quietly measuring the same
+# 8-bit path as 24b.  Since #1996 it is refused outright and the case fails (#2052).
 TOTAL=$((TOTAL+1))
-output=$("$PROFILES" "$TEST_DATA_DIR/rgb-4x4-8bit.tif" "/tmp/cli-tiff-float.tif" 4 0 0 0 1 "Testing/Display/sRGB_D65_MAT.icc" 1 2>&1)
+output=$("$PROFILES" "$TEST_DATA_DIR/rgb-4x4-8bit.tif" "/tmp/cli-tiff-float.tif" 3 0 0 0 1 "Testing/Display/sRGB_D65_MAT.icc" 1 2>&1)
 rc=$?
 asan_hit=$(echo "$output" | grep -c 'AddressSanitizer\|runtime error:' || true)
 if [ "$asan_hit" -gt 0 ]; then ASAN=$((ASAN+1)); echo "[ASAN] #$TOTAL profiles cli: float (exit=$rc)"
-elif [ "$rc" -eq 0 ]; then PASS=$((PASS+1)); echo "[PASS] #$TOTAL profiles cli: float enc(4) (exit=$rc)"
+elif [ "$rc" -eq 0 ]; then PASS=$((PASS+1)); echo "[PASS] #$TOTAL profiles cli: float enc(3) (exit=$rc)"
 else FAIL=$((FAIL+1)); echo "[FAIL] #$TOTAL profiles cli: float (exit=$rc)"; fi
 
 # 24e: LZW compression + embed ICC
@@ -1148,8 +1153,9 @@ elif [ "$rc" -eq 0 ]; then PASS=$((PASS+1)); echo "[PASS] #$TOTAL profiles cli: 
 else FAIL=$((FAIL+1)); echo "[FAIL] #$TOTAL profiles cli: lin+abs (exit=$rc)"; fi
 
 # 24g: 16-bit source TIFF -> float output
+# Selector 3, for the same reason as 24d above.
 TOTAL=$((TOTAL+1))
-output=$("$PROFILES" "$(tif_path rgb-4x4-16bit.tif)" "/tmp/cli-tiff-16to-float.tif" 4 0 0 1 1 "Testing/Display/sRGB_D65_MAT.icc" 1 2>&1)
+output=$("$PROFILES" "$(tif_path rgb-4x4-16bit.tif)" "/tmp/cli-tiff-16to-float.tif" 3 0 0 1 1 "Testing/Display/sRGB_D65_MAT.icc" 1 2>&1)
 rc=$?
 asan_hit=$(echo "$output" | grep -c 'AddressSanitizer\|runtime error:' || true)
 if [ "$asan_hit" -gt 0 ]; then ASAN=$((ASAN+1)); echo "[ASAN] #$TOTAL profiles cli: 16->float (exit=$rc)"


### PR DESCRIPTION
Part of #2052.

@xsscx's diagnosis is confirmed: the encoding selector `4` is undefined since #1996, and it is a stale value that the `iccApplyProfiles` usage text itself taught. Cross-checking it against master turned up two further faults on the same harness, and the selector alone is not sufficient there.

## The line in the handoff is from a different harness than the failing check

The pasted diff is `.github/scripts/iccdev-applyprofiles-observer-hbo-regression.sh:165` on master. The CI report comes from `iccdev-applyprofiles-spectral-pcs-regression.sh`, which lives only on `ci-qa-flags` — there the `4 -> 3` change in `ecb3f3af` is correct and sufficient, because that harness feeds a six-channel source and grades on an expected exit plus a pattern.

On master's harness it fixes nothing observable, for two reasons.

## 1. The source image cannot be paired with the profiles

Both replay profiles declare a `6CLR` device space. The harness handed them `Testing/ApplyDataFiles/seed-tiff-none-rgb-8x8.tif`, which is 8x8 with **three** samples per pixel, so `iccApplyProfiles` refuses the pair before opening anything:

```
Number of samples 3 in image[.../seed-tiff-none-rgb-8x8.tif] doesn't match device samples 6 in first profile
```

`getEmissiveObserver()` — the function these AFL profiles exist to drive — was never reached. Probed against `e4e05c3a` with every selector the tool accepts, plus the stale one:

| selector | meaning | result with the 3-sample source |
|---|---|---|
| 0 | same as src | exit 255, no output |
| 1 | icEncode8Bit | exit 255, no output |
| 2 | icEncode16Bit | exit 255, no output |
| 3 | icEncodeFloat | exit 255, no output |
| 4 | undefined | exit 255, no output |

Of the ten TIFFs in the tracked corpus, `Testing/mcs/CMYKSS-Numbered-Overprint.tif` is the only six-sample one, and it is what the `ci-qa-flags` spectral-PCS harness already feeds these same profiles — its `1671` case uses a fixture whose digest `483c6b36…` is byte-identical to the `reflectance-observer` profile here. Three registered CTests already consume `Testing/mcs/`.

With that source, all four defined selectors run to completion and write real output.

## 2. The selector is one the tool no longer defines

`iccApplyProfiles` advertised `4 - icEncodeFloat` from `1f0a9dd2` onward while float has always been `3`, and `CIccCfgImageApply::fromArgs` shared its `default:` label with `case 1`:

```cpp
    default:
    case 1:
      m_dstEncoding = icEncode8Bit;
```

So a caller following the shipped documentation got an 8-bit file and exit 0, indistinguishable from a request that was honoured. #1996 made the switch refuse what it does not define, which turns the stale `4` into `Unable to parse configuration arguments` plus `Usage()`.

The same stale `4` sits in two `json-cli-exercise.sh` cases — 24d "Float output" and 24g "16-bit source TIFF -> float output". Those *do* assert `rc -eq 0`, so both have been printing `[FAIL]` since #2007. Case 24d had also been silently measuring the same 8-bit path as its own 24b neighbour.

## 3. Neither fault was visible, because the grader could not fail

`run_profile` rejected only sanitizer findings, a `124` timeout, and a `128..192` signal. `iccApplyProfiles` refuses by returning `-1`, i.e. **255**, which falls through all three onto `[PASS]`. Running master's harness unmodified against a fresh ASAN build gives three `[PASS]` lines whose logs contain nothing but the parse error and the usage text.

The guard now asserts the replay actually happened: a zero exit, the writer's completion marker, and a non-empty output image.

## Test

Red/green, each fault isolated against the fixed harness:

| reverted element | result |
|---|---|
| selector `3` -> `4` only | `[FAIL] iccApplyProfiles refused to replay reflectance-clut (exit 255)` + `Unable to parse configuration arguments` |
| source TIFF only | `[FAIL] … (exit 255)` + `doesn't match device samples 6` |
| neither (as fixed) | both replays `[PASS]`, logs reach `100%`, output images written |

The harness as it stands on master reports `[PASS]` for both reverted states, which is the defect. `json-cli-exercise.sh` goes from 123/125 with 2 failures to **125/125**.

Both replays are clean under `ASAN_OPTIONS=detect_leaks=1`, which CI's ctest environment disables — worth stating because these replays had never executed library code before.

The per-replay `timeout` goes 30 -> 45: the replays do real work now, about 4 s each in a local Debug sanitizer build. Both still finish well inside the 120 s the CTest already budgets, so **that budget is unchanged** and `Build/Cmake/Testing/CMakeLists.txt` is untouched.

## Pre-flight

No translation units are changed, so the compiler-warning gate does not apply; the CMake configure gate is clean and the test registration is byte-identical to master (`TIMEOUT 120`, `SKIP_RETURN_CODE 77`, labels unchanged).

| gate | result |
|---|---|
| `shellcheck` 0.9.0, bare, both changed scripts | rc=0 |
| `iccdev.applyprofiles-observer-hbo-regression` | Passed, 11.8 s |
| `iccdev.json-cli-exercise` | Passed |
| full suite, clang 21 Debug ASAN+UBSAN, 168 tests | 2 failures, both pre-existing and unrelated: `tool-coverage` (passes when run serially — a `-j` flake) and `spectral-tiff-preview` (`ModuleNotFoundError: No module named 'imagecodecs'`) |

## Two things left for the maintainer

Neither is changed here.

1. **`json-cli-exercise.sh` ends in an unconditional `exit 0`**, so its tally is advisory — the two `[FAIL]` lines above never reddened the CTest. With the selector corrected the tally is now 0 failures, so honouring it is a one-line change. I have left it out deliberately: the script carries no platform guard, so flipping whole-script fail policy could redden a lane I cannot exercise locally. Happy to do it as its own PR if wanted.

2. **The crash gate in the `ci-qa-flags` spectral-PCS harness.** As of `003cd0fd` it reads `[ "$exit_code" -ge 128 ] && [ "$exit_matches" -ne 1 ]`, with `expected_exit` now a `|`-separated allow-list. That lets an expected value *whitelist a real signal* — a case declaring `1|139` would accept a SIGSEGV as its expected outcome. Master's harness already carries the narrower idiom, which does not have that property:

   ```sh
   if [ "$exit_code" -ge 128 ] && [ "$exit_code" -le 192 ]; then   # signals only
   ```

   Bounding the band that way lets 255 fall through to the existing equality check — which is what the 1677 case wants — while keeping a genuine crash unmaskable. Also worth a second look: `1675` and `1677` are structurally identical invocations, both passing a `.icc` as `src_tiff_file`, and `1677` now accepts either outcome while `1675` still pins one.
