### PR TITLE
fix(#2057): honour the json-cli-exercise tally instead of exiting 0

### DIFF
--- a/.github/scripts/json-cli-exercise.sh
+++ b/.github/scripts/json-cli-exercise.sh
@@ -1303,4 +1303,25 @@ rm -f /tmp/test-enc-*.json /tmp/test-prec-*.json /tmp/test-dig-*.json \
       /tmp/test-cli-data.txt /tmp/test-cli-8bit.txt /tmp/test-cli-16bit.txt \
       /tmp/test-real-tiff-*.json /tmp/json-tiff-*.tif /tmp/cli-tiff-*.tif 2>/dev/null
 
+# Everything above only *counts* outcomes.  Until now the script ended in an
+# unconditional `exit 0`, so the summary was advisory and iccdev.json-cli-exercise
+# reported [PASS] with failures still on the board -- which is how the two stale
+# encoding-selector [FAIL] lines recorded in #2052 survived a full CI cycle
+# without ever reddening the test that produced them.  Honour the tally instead.
+#
+# ASAN is counted in its own bucket rather than as a failure because a sanitizer
+# hit is not a wrong exit status, but it is at least as fatal: this test carries
+# the `asan` label and is run against instrumented builds, so treat both as red.
+#
+# One consequence is deliberate.  The CTest declares FIXTURES_REQUIRED
+# iccdev_profiles, and the cases below reference generated profiles such as
+# Testing/Display/sRGB_D65_MAT.icc by relative path.  Run standalone against a
+# tree where that fixture has never executed, 74 of the 125 cases fail on the
+# missing profiles and this script now exits non-zero.  That is the correct
+# signal -- a run that measured nothing should not report success -- and it is
+# why the exit status keys off the tally rather than off the last command.
+if [ "$FAIL" -gt 0 ] || [ "$ASAN" -gt 0 ]; then
+  exit 1
+fi
+
 exit 0


### PR DESCRIPTION
Part of #2057 — the first of the two items @xsscx asked me to take there. The
crash-gate item is not in this PR; it lives in a file that exists only on
`ci-qa-flags`, and is written up separately on the issue.

## The defect

`.github/scripts/json-cli-exercise.sh` counts 125 outcomes into `PASS`/`FAIL`/
`ASAN`, prints a summary, and then ends in an unconditional `exit 0`. The tally
was advisory: `iccdev.json-cli-exercise` reported `[PASS]` with failures on the
board.

That script **is** the body of the CTest, so the test could not fail on its own
findings. It is how the two stale encoding-selector `[FAIL]` lines recorded in
 #2052 survived a full CI cycle without ever reddening the test that produced
them.

## The change

One guard at the end of the script: exit non-zero when `FAIL` or `ASAN` is
non-zero. `ASAN` keeps its own bucket because a sanitizer hit is not a wrong
exit status, but it is treated as equally fatal — the test carries the `asan`
label and runs against instrumented builds.

## Measured

clang 21.1.3, Debug, ASAN+UBSAN, against this branch:

| run | result | exit |
|---|---|---|
| fixture run, tools present | 125 passed / 0 failed / 0 ASAN | **0** |
| fixture never run | 51 passed / 74 failed / 0 ASAN | **1** |
| `ctest -R iccdev.json-cli-exercise` | 2/2 pass | — |

The second row is a pristine worktree of this branch **with the tools supplied**,
so those 74 failures are the missing generated profiles alone, not missing
binaries.

## One deliberate consequence

The CTest declares `FIXTURES_REQUIRED iccdev_profiles`, and the cases reference
generated profiles such as `Testing/Display/sRGB_D65_MAT.icc` by relative path.
A run where that fixture never executed now exits non-zero instead of reporting
success. That is the correct signal — a run that measured nothing should not
report success — and it is recorded in a comment at the change so the next
reader does not take it for a regression.

The CTest is the only entry point in the tree
(`Build/Cmake/Testing/CMakeLists.txt:4693`), so no lane reaches this script
without the fixture. The stale copy under `docs/Testing/json-cli-exercise/` has
diverged and is referenced by nothing; it is deliberately left alone.

## Pre-flight

- `shellcheck` **0.9.0** — the version `ubuntu-24.04` installs for the pre-flight
  gate — clean on the file with no flags.
- No C/C++ changed, so the compiler-warning gate is not engaged by this diff.
- Scripts-only, so the build and CTest lanes do not auto-select. I am dispatching
  `ci-pr-action.yml` with `ci_scope=full` per `docs/label-system.md:116-121`, as
  ruled in #2058.