### PR TITLE
fix(#2057): stop an expected-exit allow-list whitelisting a real signal

### DIFF
--- a/.github/scripts/iccdev-applyprofiles-spectral-pcs-regression.sh
+++ b/.github/scripts/iccdev-applyprofiles-spectral-pcs-regression.sh
@@ -1628,12 +1628,27 @@ run_replay()
     exit 1
   fi
 
-  if [ "$exit_code" -ge 128 ] && [ "$exit_matches" -ne 1 ]; then
-    if [ "$exit_code" -le 192 ]; then
-      echo "[FAIL] issue $issue replay crashed with signal $((exit_code - 128))"
-    else
-      echo "[FAIL] issue $issue replay returned non-graceful exit $exit_code"
-    fi
+  # Death by signal is checked independently of expected_exit, and deliberately
+  # so.  Consulting the expectation here -- whether as the single value this
+  # once compared against or as the '|' allow-list it is now -- lets a case name
+  # its own crash as an acceptable outcome: a case declaring '1|139' takes a real
+  # SIGSEGV straight to [PASS], which is the one thing an ASAN replay harness
+  # exists to prevent.  The hole is not new and the allow-list did not introduce
+  # it; a lone expected_exit of 139 opened it just as wide.  What the allow-list
+  # changed is how easily it is reached, because a case can now pair a plausible
+  # expectation with a signal value and still look deliberate.  No signal is ever
+  # an expected outcome here, so nothing may whitelist one.
+  #
+  # Bounding the band at 192 is what keeps that strictness compatible with the
+  # graceful refusals these replays actually assert.  128..192 is the signal
+  # range.  Above it sits main() returning an error, which these cases legitimately
+  # expect and which therefore stays governed by expected_exit via the equality
+  # check below: 1677's source image is unopenable and exits 255, while 1675's
+  # profile chain is rejected and exits 1 on this branch -- 255 on master, which
+  # still returns -1 there.  This is the same idiom master carries in
+  # iccdev-applyprofiles-observer-hbo-regression.sh.
+  if [ "$exit_code" -ge 128 ] && [ "$exit_code" -le 192 ]; then
+    echo "[FAIL] issue $issue replay crashed with signal $((exit_code - 128))"
     sed -n '1,80p' "$log"
     exit 1
   fi


### PR DESCRIPTION
Part of #2057, targeting `ci-qa-flags` because
`.github/scripts/iccdev-applyprofiles-spectral-pcs-regression.sh`
exists only on this branch. @xsscx asked for this as a PR against `ci-qa-flags`
on the issue, so here it is rather than a push onto your branch.

The other half of #2057 — the `json-cli-exercise.sh` fail policy — is #2063
against master.

## The defect

`run_replay`'s crash gate read

```sh
if [ "$exit_code" -ge 128 ] && [ "$exit_matches" -ne 1 ]; then
```

so death by signal was reported only when the exit code failed to match the
case's *own* expectation. A case can therefore name its own crash as an
acceptable outcome. Demonstrated by appending one synthetic case to this
harness:

```sh
run_replay 9999 '1|139' 'MARKER' bash -c 'echo MARKER; kill -SEGV $$'
```

```
before  [PASS] issue 9999 replay matched expected outcome ...   script exit 0
after   [FAIL] issue 9999 replay crashed with signal 11         script exit 1
```

A real SIGSEGV, reported `[PASS]`.

## The hole is older than the allow-list

I originally attributed this to `expected_exit` growing into a `|` allow-list.
That is wrong, and it would misplace the cause, so it is worth stating plainly.
Re-running the same probe against the pre-allow-list gate at `7662e8e5^`, which
compared a lone `expected_exit`, with the case declared as bare `139`:

```
[PASS] issue 9999 replay matched expected outcome ...           script exit 0
```

`-ne "$expected_exit"` was already escapable. What the allow-list changed is how
easily it is reached, since a case can now pair a plausible expectation with a
signal value and still look deliberate.

## The fix

Check the signal band independently of `expected_exit`, bounded at 192 — the
idiom master already carries in
`.github/scripts/iccdev-applyprofiles-observer-hbo-regression.sh`.

The bound is what keeps the strictness compatible with what these replays
actually assert. `128..192` is death by signal and can never be expected. Above
it sits `main()` returning an error, which these cases legitimately expect and
which stays governed by `expected_exit` through the equality check: 1677's
source image is unopenable and exits 255, while 1675's profile chain is rejected
and exits 1 on this branch. The `|` allow-list is untouched — it simply no
longer reaches the crash gate.

The now-unreachable "non-graceful exit" arm goes with it. An exit above 192 that
no longer matches is reported by the equality check below, which names both the
observed and the expected status.

## Pre-flight

Rebased onto `b52b3c85` and re-validated there, since the base was force-updated
from `a8f56a1f` while this was in progress. clang 21.1.3 Debug ASAN+UBSAN:

| check | result |
|---|---|
| all three real replays | 1671, 1675, 1677 `[PASS]`, exit 0 |
| SIGSEGV probe | `[FAIL] ... crashed with signal 11`, exit 1 |
| `grep -cE 'warning:'` on the build log | 0 |
| `shellcheck` 0.9.0, no flags | clean |

Red and green were both re-run *after* the rebase rather than carried over.

## Two related findings, not changed here

Recorded on #2057 with evidence, both yours to call:

1. **Harvest hazard for #1853.** `iccdev.applyprofiles-spectral-pcs-regression`
   is pinned to an unlanded one-line change in `iccApplyProfiles.cpp`
   (`return -1` → `return 1` at the `Begin()` failure site). Against master's
   library 1675 fails with `non-graceful exit 255`; against this branch it
   passes. Harvested to master on its own, the script goes red — the script and
   the tool change need to land together, or 1675 needs `'1|255'`.

2. **The 1677 replay may not be replaying.** Its fixture declares
   `height=65342` in 48334 bytes and libtiff rejects it inside `TIFFOpen`, so
   `iccApplyProfiles` returns at `iccApplyProfiles.cpp:358` before any iccDEV
   profile code runs — whereas the original #1677 stack reached
   `CIccPcsXform::pushBiRef2Rad` at `IccCmm.cpp:3597`. As written it asserts a
   truncated TIFF is unopenable. The embedded digest verifies, so the fixture is
   intact as harvested; if the upstream corpus file is larger, re-harvesting it
   would put the replay back on the bi-spectral path.

Scripts-only, so the build and CTest lanes do not auto-select; dispatching
`ci-pr-action.yml` with `ci_scope=full` per `docs/label-system.md:116-121`.
