### PR TITLE
fix(#1853): harvest the ci-qa-flags library core — MCS naming, ZipUtf8Text failure reporting, execinfo portability

### DIFF
--- a/.github/ci/regression/mcs-colorspace-name.cpp
+++ b/.github/ci/regression/mcs-colorspace-name.cpp
@@ -1,0 +1,138 @@
+// Regression for the MCS colour-space naming gap harvested from ci-qa-flags (#1853).
+//
+// icSigSrcMCSChannelData ("mc" + a 16-bit channel count, icProfileHeader.h:941) is a
+// channel-count-encoding colour-space family exactly like icSigNChannelData and the
+// four spectral families. icNumColorSpaceChannels() has always decoded it, but three
+// naming functions omitted it from their case lists, so every MCS signature fell
+// through to a generic fallback:
+//
+//   icGetColorSig(0x6D630004)            'mc??' = 6D630004   instead of  "mc0004"
+//   icGetColorSigStr(0x6D630004)         6D630004h           instead of   mc0004
+//   GetColorSpaceSigName(0x6D630004)     0x4ColorData        instead of   0x0004ChannelMCSData
+//
+// icGetColorSigStr() is the XML and JSON header writer for <MCS> (IccProfileXml.cpp,
+// IccProfileJson.cpp), so the fallback reached serialized profiles. The value was not
+// lost -- icGetSigVal()'s 8/9-character branch parses the hex escape back to the same
+// signature -- so this pins legibility and cross-family consistency, and the
+// round-trip assertions below exist to keep the fix from trading one for the other.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccUtil.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[mcs-colorspace-name] FAIL: %s\n", what);
+  }
+}
+
+void checkStr(const char *got, const char *want, const char *what)
+{
+  if (!got || std::strcmp(got, want) != 0) {
+    ++g_fail;
+    std::fprintf(stderr, "[mcs-colorspace-name] FAIL: %s (got \"%s\", want \"%s\")\n",
+                 what, got ? got : "(null)", want);
+  }
+}
+
+// A four-channel and a fifteen-channel MCS signature. Fifteen is included because the
+// count is formatted with %04X: a single hex digit would expose any loss of the zero
+// padding the sibling families emit.
+const icUInt32Number kMcs4  = 0x6D630004;   // "mc" + 0x0004
+const icUInt32Number kMcs15 = 0x6D63000F;   // "mc" + 0x000F
+
+// --- 1. The channel count is decoded, which is what makes naming possible at all. ---
+void testChannelCountDecoding()
+{
+  check(icGetColorSpaceType((icColorSpaceSignature)kMcs4) == icSigSrcMCSChannelData,
+        "mc0004: icGetColorSpaceType() reports icSigSrcMCSChannelData");
+  check(icNumColorSpaceChannels((icColorSpaceSignature)kMcs4) == 4,
+        "mc0004: icNumColorSpaceChannels() == 4");
+  check(icNumColorSpaceChannels((icColorSpaceSignature)kMcs15) == 15,
+        "mc000F: icNumColorSpaceChannels() == 15");
+}
+
+// --- 2. The three naming functions emit the sibling form, not the fallback. ---
+void testNaming()
+{
+  icChar buf[256];
+
+  checkStr(icGetColorSig(buf, sizeof(buf), kMcs4), "\"mc0004\"",
+           "mc0004: icGetColorSig()");
+  checkStr(icGetColorSig(buf, sizeof(buf), kMcs15), "\"mc000F\"",
+           "mc000F: icGetColorSig()");
+
+  checkStr(icGetColorSigStr(buf, sizeof(buf), kMcs4), "mc0004",
+           "mc0004: icGetColorSigStr()");
+  checkStr(icGetColorSigStr(buf, sizeof(buf), kMcs15), "mc000F",
+           "mc000F: icGetColorSigStr()");
+
+  CIccInfo info;
+  checkStr(info.GetColorSpaceSigName((icColorSpaceSignature)kMcs4),
+           "0x0004ChannelMCSData", "mc0004: GetColorSpaceSigName()");
+  checkStr(info.GetColorSpaceSigName((icColorSpaceSignature)kMcs15),
+           "0x000FChannelMCSData", "mc000F: GetColorSpaceSigName()");
+}
+
+// --- 3. The XML/JSON header text still parses back to the same signature. ---
+// icGetSigVal() dispatches on strlen: the previous "6D630004h" took the 8/9-character
+// hex branch, the corrected "mc0004" takes the 6-character channel-signature branch.
+// Both are lossless, but they are different code paths, so the fix moves which one
+// runs for a real profile and that move is worth pinning.
+void testRoundTrip()
+{
+  icChar buf[256];
+
+  check(icGetSigVal(icGetColorSigStr(buf, sizeof(buf), kMcs4)) == kMcs4,
+        "mc0004: icGetColorSigStr() -> icGetSigVal() round-trips");
+  check(icGetSigVal(icGetColorSigStr(buf, sizeof(buf), kMcs15)) == kMcs15,
+        "mc000F: icGetColorSigStr() -> icGetSigVal() round-trips");
+}
+
+// --- 4. The sibling families are unchanged. ---
+// The fix adds a case to switches shared with icSigNChannelData and the spectral
+// families; these assertions fail if that case were ever added in a way that
+// reordered or shadowed them.
+void testSiblingsUnaffected()
+{
+  icChar buf[256];
+
+  checkStr(icGetColorSigStr(buf, sizeof(buf), 0x6E630004), "nc0004",
+           "nc0004: icGetColorSigStr() unchanged");
+  checkStr(icGetColorSigStr(buf, sizeof(buf), 0x7273001F), "rs001F",
+           "rs001F: icGetColorSigStr() unchanged");
+
+  CIccInfo info;
+  checkStr(info.GetColorSpaceSigName((icColorSpaceSignature)0x6E630004),
+           "0x0004ChannelData", "nc0004: GetColorSpaceSigName() unchanged");
+  checkStr(info.GetColorSpaceSigName((icColorSpaceSignature)0x7273001F),
+           "0x001FChannelReflectanceData",
+           "rs001F: GetColorSpaceSigName() unchanged");
+}
+
+} // namespace
+
+int main()
+{
+  testChannelCountDecoding();
+  testNaming();
+  testRoundTrip();
+  testSiblingsUnaffected();
+
+  if (g_fail)
+    std::fprintf(stderr, "[mcs-colorspace-name] %d assertion(s) failed\n", g_fail);
+  else
+    std::printf("[mcs-colorspace-name] all assertions passed\n");
+
+  return g_fail;
+}

--- a/.github/ci/regression/ziputf8-read-inflate-contract.cpp
+++ b/.github/ci/regression/ziputf8-read-inflate-contract.cpp
@@ -1,0 +1,232 @@
+// Regression for two CIccTagZipUtf8Text failure-reporting defects harvested from
+// ci-qa-flags (#1853). Both are the same class as #1743/#1521: a function that fails
+// without saying so, or that leaves the caller holding data it did not ask for.
+//
+// H3 -- GetText() contributed a partial decode on failure. The inflate loop appended
+// each 32767-byte chunk straight into the caller's std::string, then returned false
+// from inside the loop when a later chunk was rejected. A truncated or corrupt zip
+// stream therefore produced BOTH a false return AND up to hundreds of kilobytes of
+// partially-inflated, attacker-influenced bytes appended to the caller's string. The
+// no-zlib path a few lines above clears str before returning false, so the two
+// failure modes disagreed about what str means on failure. Measured against
+// unmodified master, a 264000-byte text truncated to 90% of its deflate stream
+// returned false after appending 237411 bytes.
+//
+// This half is a genuine red/green: cases A and B below fail on master and pass with
+// the fix, no allocation failure or platform interposition required.
+//
+// H2 -- Read() reported success when its buffer allocation failed. AllocBuffer()
+// returns NULL both for a legitimate zero-size request and for a failed
+// malloc/icRealloc, so Read() could not tell them apart; on failure it skipped the
+// guarded copy and still returned true, leaving a silently empty text tag.
+//
+// SCOPE, stated plainly, exactly as ziputf8-settext-contract.cpp had to for #1743:
+// this test does NOT reproduce the allocation failure. AllocBuffer() is public but
+// non-virtual, so there is no override hook, and forcing malloc to fail would need
+// platform-specific interposition that will not run portably in CI (this suite is
+// also built for Windows). Case C instead pins the invariant the bug violated --
+// "Read() returning true implies the tag holds the bytes the header declared" -- which
+// is green before and after the fix on a machine where allocation succeeds. It is a
+// contract guard, not a red-green reproduction of the OOM path.
+//
+// Built and registered only when ICC_USE_ZLIB is enabled (#1530); without zlib
+// GetText() always returns false after clearing str and none of this applies.
+
+#include "IccTag.h"
+#include "IccIO.h"
+
+#include <cstdio>
+#include <string>
+
+static int g_fail = 0;
+#define CHECK(c) do { if(!(c)){ std::printf("FAIL line %d: %s\n", __LINE__, #c); g_fail=1; } } while(0)
+
+namespace {
+
+// Large and mildly varied, so the deflate stream spans many blocks and a truncated
+// prefix still inflates well past GetText()'s 32767-byte chunk before it fails. That
+// matters: if the whole decode fit in one chunk there would be no partial append to
+// observe and the test would pass against master, proving nothing.
+std::string makeBigText()
+{
+  std::string s;
+  for (int i = 0; i < 8000; i++) {
+    char b[40];
+    std::snprintf(b, sizeof(b), "line %06d abcdefghijklmnopqrst\n", i);
+    s += b;
+  }
+  return s;
+}
+
+const char *kSentinel = "PRE-EXISTING CALLER CONTENT:";
+
+// The contract both failure cases share: a false return must leave the caller's
+// string exactly as it was found.
+void checkUntouchedOnFailure(CIccTagZipUtf8Text &tag, const char *what)
+{
+  std::string str(kSentinel);
+  const bool ok = tag.GetText(str);
+
+  if (ok) {
+    std::printf("FAIL: %s - GetText() reported success on a damaged stream\n", what);
+    g_fail = 1;
+    return;
+  }
+
+  if (str != kSentinel) {
+    std::printf("FAIL: %s - GetText() failed but appended %zu bytes to the caller's "
+                "string\n", what, str.size() - std::string(kSentinel).size());
+    g_fail = 1;
+  }
+}
+
+// --- A. A truncated deflate stream must contribute nothing. ---
+void testTruncatedStream()
+{
+  const std::string big = makeBigText();
+
+  // 90/50/30% of the stream: each inflates past one chunk, then hits Z_BUF_ERROR when
+  // the input runs out. Several ratios because the failure point relative to the chunk
+  // boundary differs, and only some of them produced a partial append historically.
+  const int pcts[] = { 90, 50, 30 };
+
+  for (size_t i = 0; i < sizeof(pcts) / sizeof(pcts[0]); i++) {
+    CIccTagZipUtf8Text tag;
+    if (!tag.SetText((const icChar *)big.c_str())) {
+      std::printf("FAIL: SetText() failed building the %d%% truncation case\n", pcts[i]);
+      g_fail = 1;
+      continue;
+    }
+
+    const icUInt32Number full = tag.BufferSize();
+    CHECK(full > 0);
+
+    // AllocBuffer() reallocs down and preserves the prefix, which is the truncation.
+    const icUInt32Number cut = (icUInt32Number)((double)full * pcts[i] / 100.0);
+    CHECK(cut > 0 && cut < full);
+    tag.AllocBuffer(cut);
+    CHECK(tag.BufferSize() == cut);
+
+    char what[64];
+    std::snprintf(what, sizeof(what), "truncated to %d%% of the deflate stream", pcts[i]);
+    checkUntouchedOnFailure(tag, what);
+  }
+}
+
+// --- B. A corrupt (not merely short) stream must contribute nothing. ---
+// Truncation ends in Z_BUF_ERROR; corruption mid-stream ends in Z_DATA_ERROR. Both
+// leave the loop from the same return, but exercising only one would leave the other
+// path unpinned.
+void testCorruptStream()
+{
+  const std::string big = makeBigText();
+
+  CIccTagZipUtf8Text tag;
+  if (!tag.SetText((const icChar *)big.c_str())) {
+    std::printf("FAIL: SetText() failed building the corruption case\n");
+    g_fail = 1;
+    return;
+  }
+
+  icUChar *buf = tag.GetBuffer();
+  const icUInt32Number size = tag.BufferSize();
+  CHECK(buf != NULL && size > 64);
+  if (!buf || size <= 64)
+    return;
+
+  // Damage well past the header so the stream starts inflating before it fails, and
+  // clear of the first four bytes that the xrite-quirk check in GetText() inspects.
+  for (icUInt32Number i = size / 2; i < size / 2 + 32 && i < size; i++)
+    buf[i] = (icUChar)(buf[i] ^ 0xFF);
+
+  checkUntouchedOnFailure(tag, "corrupted mid-stream");
+}
+
+// --- C. The success path is unchanged, and still appends rather than assigns. ---
+// The fix accumulates into a local and does str += out at the end. Assigning instead
+// would have been a silent behaviour change for any caller passing a non-empty string,
+// so pin the append.
+//
+// Note SetText() deflates strlen + 1 bytes -- the NUL terminator is inside the
+// compressed stream -- so a round trip yields the text plus a trailing '\0'. That is
+// long-standing behaviour on both sides and unrelated to this fix; assert what the
+// library does, not what the name suggests.
+void testSuccessStillAppends()
+{
+  const std::string text = "material connection space";
+
+  CIccTagZipUtf8Text tag;
+  if (!tag.SetText((const icChar *)text.c_str())) {
+    std::printf("FAIL: SetText() failed building the success case\n");
+    g_fail = 1;
+    return;
+  }
+
+  std::string str(kSentinel);
+  CHECK(tag.GetText(str));
+
+  const std::string expect = std::string(kSentinel) + text + std::string(1, '\0');
+  if (str != expect) {
+    std::printf("FAIL: success path did not append to the caller's string "
+                "(got %zu bytes, expected %zu)\n", str.size(), expect.size());
+    g_fail = 1;
+  }
+}
+
+// --- D. H2 contract: Read() returning true implies the declared bytes are held. ---
+// Not a reproduction of the allocation failure -- see the SCOPE note at the top.
+void testReadSuccessImpliesBuffer()
+{
+  const std::string text = "zip utf8 read contract";
+
+  CIccTagZipUtf8Text src;
+  if (!src.SetText((const icChar *)text.c_str())) {
+    std::printf("FAIL: SetText() failed building the Read case\n");
+    g_fail = 1;
+    return;
+  }
+  const icUInt32Number deflated = src.BufferSize();
+  CHECK(deflated > 0);
+
+  CIccMemIO io;
+  CHECK(io.Alloc(deflated + 64, true));
+  CHECK(src.Write(&io));
+
+  const icUInt32Number written = (icUInt32Number)io.GetLength();
+  io.Seek(0, icSeekSet);
+
+  CIccTagZipUtf8Text dst;
+  CHECK(dst.Read(written, &io));
+
+  // The invariant the defect violated: a true return must mean the payload is held.
+  if (dst.GetBuffer() == NULL || dst.BufferSize() == 0) {
+    std::printf("FAIL: Read() returned true but the tag holds no data "
+                "(buf=%p size=%u)\n",
+                (const void *)dst.GetBuffer(), (unsigned)dst.BufferSize());
+    g_fail = 1;
+  }
+  CHECK(dst.BufferSize() == deflated);
+
+  // And the payload must be the same stream, so it still inflates to the same text.
+  std::string out;
+  CHECK(dst.GetText(out));
+  CHECK(out.size() == text.size() + 1);
+  CHECK(out.compare(0, text.size(), text) == 0);
+}
+
+} // namespace
+
+int main()
+{
+  testTruncatedStream();
+  testCorruptStream();
+  testSuccessStillAppends();
+  testReadSuccessImpliesBuffer();
+
+  if (g_fail)
+    std::printf("[ziputf8-read-inflate-contract] FAILED\n");
+  else
+    std::printf("[ziputf8-read-inflate-contract] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2455,6 +2455,51 @@ function(iccdev_add_ziputf8_settext_contract_test)
   endif()
 endfunction()
 
+function(iccdev_add_ziputf8_read_inflate_contract_test)
+  if(NOT ICC_USE_ZLIB)
+    return()
+  endif()
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccZipUtf8ReadInflateContractTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/ziputf8-read-inflate-contract.cpp"
+  )
+  target_compile_features(iccZipUtf8ReadInflateContractTest PRIVATE cxx_std_17)
+  # Same linkage note as iccdev_add_ziputf8_settext_contract_test above: IccProfLib
+  # links ZLIB::ZLIB and defines ICC_USE_ZLIB=1 PUBLIC, so both propagate here; the
+  # explicit zlib link is belt-and-braces.
+  target_link_libraries(iccZipUtf8ReadInflateContractTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  if(TARGET ZLIB::ZLIB)
+    target_link_libraries(iccZipUtf8ReadInflateContractTest PRIVATE ZLIB::ZLIB)
+  endif()
+  add_dependencies(check iccZipUtf8ReadInflateContractTest)
+
+  add_test(
+    NAME iccdev.ziputf8-read-inflate-contract
+    COMMAND "$<TARGET_FILE:iccZipUtf8ReadInflateContractTest>"
+  )
+  set_tests_properties(iccdev.ziputf8-read-inflate-contract PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;tag;zlib;compression;issue-1853;regression"
+  )
+  if(WIN32)
+    set(_ziputf8_readinflate_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccZipUtf8ReadInflateContractTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _ziputf8_readinflate_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.ziputf8-read-inflate-contract PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_ziputf8_readinflate_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_parser_restore_calls_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -4151,6 +4196,7 @@ if(WIN32)
   iccdev_add_iccio_write_float_aliasing_test()
   iccdev_add_tagdata_zlib_roundtrip_test()
   iccdev_add_ziputf8_settext_contract_test()
+  iccdev_add_ziputf8_read_inflate_contract_test()
   iccdev_add_compression_describe_labels_test()
   iccdev_add_pawg_compression_paths_test()
   iccdev_add_json_sparsematrix_huaf_test()
@@ -4420,6 +4466,7 @@ iccdev_add_fileio_seek_tell_test()
 iccdev_add_iccio_write_float_aliasing_test()
 iccdev_add_tagdata_zlib_roundtrip_test()
 iccdev_add_ziputf8_settext_contract_test()
+iccdev_add_ziputf8_read_inflate_contract_test()
 iccdev_add_compression_describe_labels_test()
 iccdev_add_pawg_compression_paths_test()
 iccdev_add_json_sparsematrix_huaf_test()

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3156,6 +3156,64 @@ function(iccdev_add_struct_name_spelling_test)
   endif()
 endfunction()
 
+# #1853 harvest: icSigSrcMCSChannelData encodes its channel count in the signature the
+# same way icSigNChannelData and the spectral families do, and icNumColorSpaceChannels
+# already decoded it -- but icGetColorSig, icGetColorSigStr and GetColorSpaceSigName
+# left it out of their case lists, so MCS spaces reached a generic fallback and printed
+# as 'mc??' = 6D630004 / 6D630004h / 0x4ColorData. icGetColorSigStr is the XML and JSON
+# <MCS> writer, so the fallback was reaching serialized profiles. No value was lost
+# (icGetSigVal parses the hex escape back), which is why the test asserts the round trip
+# as well as the spelling: the fix changes which icGetSigVal branch a real profile takes.
+# Links IccProfLib only; the contract is the naming tables, not a profile round-trip.
+function(iccdev_add_mcs_colorspace_name_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccMcsColorSpaceNameTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/mcs-colorspace-name.cpp"
+  )
+  target_compile_features(iccMcsColorSpaceNameTest PRIVATE cxx_std_17)
+  target_include_directories(iccMcsColorSpaceNameTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccMcsColorSpaceNameTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccMcsColorSpaceNameTest)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.mcs-colorspace-name
+      COMMAND "$<TARGET_FILE:iccMcsColorSpaceNameTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.mcs-colorspace-name
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccMcsColorSpaceNameTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.mcs-colorspace-name PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;naming;mcs;regression"
+  )
+  if(WIN32)
+    set(_mcs_name_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccMcsColorSpaceNameTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _mcs_name_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.mcs-colorspace-name PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_mcs_name_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1886: CIccMpeXmlUnknown::ToXml formatted the Reserved attribute into `line`
 # and then appended `buf`, which still held the element's type signature from the
 # icGetSigStr call above it. The value was dropped and the signature was injected
@@ -4104,6 +4162,7 @@ if(WIN32)
   iccdev_add_luminance_normalization_test()
   iccdev_add_tag_name_spelling_test()
   iccdev_add_struct_name_spelling_test()
+  iccdev_add_mcs_colorspace_name_test()
   iccdev_add_mpexml_unknown_reserved_test()
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_proflib_exported_global_definitions_test()
@@ -4372,6 +4431,7 @@ iccdev_add_curve_gamma_u8fixed8_test()
 iccdev_add_luminance_normalization_test()
 iccdev_add_tag_name_spelling_test()
 iccdev_add_struct_name_spelling_test()
+iccdev_add_mcs_colorspace_name_test()
 iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_proflib_exported_global_definitions_test()

--- a/IccProfLib/IccSignatureUtils.h
+++ b/IccProfLib/IccSignatureUtils.h
@@ -153,7 +153,29 @@ inline bool IsSpaceSpectralPCS(icColorSpaceSignature sig)
 // TRACE_LOG(msg, ...)  - logs message and trace together
 // -----------------------------------------------------------------------------
 
-#ifdef __linux__
+// backtrace()/backtrace_symbols_fd() and the <execinfo.h> that declares them are a
+// glibc extension, not a Linux one. musl does not ship the header at all, so on
+// Alpine and other musl targets __linux__ is defined and the include below fails
+// outright -- a hard compile error rather than a missing feature. Probe for the
+// header instead of inferring it from the kernel, and fall through to the same
+// no-op definitions the non-Linux branch already provides when it is absent.
+//
+// This is preventive rather than a fix for an observed break: no translation unit in
+// the tree includes IccSignatureUtils.h today, and TRACE_CALLER/TRACE_LOG have no
+// callers, so nothing currently compiles the include. It becomes a real musl build
+// failure the moment anything does -- which is exactly what happens on ci-qa-flags,
+// where IccUtil.cpp picks the header up.
+//
+// __has_include is standard from C++17, which this project requires; the
+// defined(__has_include) test costs nothing and keeps the header usable if it is ever
+// pulled into a C or pre-C++17 consumer.
+#if defined(__linux__) && defined(__has_include)
+  #if __has_include(<execinfo.h>)
+    #define ICC_HAS_EXECINFO 1
+  #endif
+#endif
+
+#ifdef ICC_HAS_EXECINFO
   #include <execinfo.h>
   #define TRACE_CALLER() \
     do { \

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -1399,6 +1399,17 @@ bool CIccTagZipUtf8Text::Read(icUInt32Number size, CIccIO *pIO)
 
   icUChar *pBuf = AllocBuffer(nSize);
 
+  // #1743 again, at the call site that fix did not reach. AllocBuffer() returns NULL
+  // for two unrelated reasons -- a legitimate zero-size request, and a failed
+  // malloc/icRealloc -- so NULL on its own cannot be treated as an error. A non-zero
+  // nSize with a NULL buffer is unambiguously the allocation failure: the guarded copy
+  // below is then skipped and the tag is left empty (m_pZipBuf NULL, m_nBufSize 0),
+  // but the function still reported success. That is the same silent data loss as
+  // #1521 and #1743, here on the read path, where it turns a truncated allocation into
+  // a profile that loads with a silently empty text tag.
+  if (nSize && !pBuf)
+    return false;
+
   if (m_nBufSize && pBuf) {
     if (pIO->Read8(pBuf, m_nBufSize) != m_nBufSize) {
       return false;
@@ -1508,6 +1519,22 @@ bool CIccTagZipUtf8Text::GetText(std::string &str) const
   memset(&zstr, 0, sizeof(zstr));
   icUtf8Vector buf(32767, 0);
 
+  // Remember how much of str belongs to the caller, so a failed decode can hand back
+  // exactly what it was given. The loop below appends each inflated chunk to str and
+  // can then return false from inside the loop when inflate() rejects a later chunk --
+  // which left the caller holding a partial decode alongside a false return, while the
+  // no-zlib path a few lines above clears str before failing. The two configurations
+  // disagreed about what str means on failure: cleared in one, partially written in
+  // the other. Truncating back to nOrigSize on the failure path makes the failure
+  // atomic and makes both agree that false leaves nothing appended.
+  //
+  // Rewinding rather than inflating into a scratch string is deliberate. There is no
+  // bound on how much this can inflate -- the decompression cap is a separate open
+  // question -- so buffering the whole decode before handing it over would double peak
+  // memory for a hostile ratio, and would add a full copy to the success path that the
+  // existing in-place append does not pay.
+  const size_t nOrigSize = str.size();
+
   zstat = inflateInit(&zstr);
 
   if (zstat != Z_OK) {
@@ -1544,6 +1571,10 @@ bool CIccTagZipUtf8Text::GetText(std::string &str) const
     zstat = inflate(&zstr, Z_SYNC_FLUSH);
 
     if (zstat != Z_OK && zstat != Z_STREAM_END) {
+      // The only failure return that can be reached with chunks already appended, so
+      // the only one that has to rewind. The two earlier exits above run before the
+      // loop and leave str untouched by construction.
+      str.resize(nOrigSize);
       inflateEnd(&zstr);
       return false;
     }

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -1177,6 +1177,12 @@ const icChar *icGetColorSig(icChar *pBuf, size_t bufSize, icUInt32Number nSig, b
     case icSigRadiantSpectralData:
     case icSigBiSpectralReflectanceData:
     case icSigSparseMatrixReflectanceData:
+    // The material connection space encodes its channel count in the low half of
+    // the signature exactly as the families above do ("mc" + count), and
+    // icNumColorSpaceChannels() already decodes it. Omitting it here sent every MCS
+    // signature to the default branch below, which cannot render the count bytes as
+    // text -- 0x6D630004 printed as 'mc??' = 6D630004 rather than "mc0004".
+    case icSigSrcMCSChannelData:
 
       pBuf[0]='\"';
       pBuf[1] = (icUInt8Number)(sig>>24);
@@ -1237,6 +1243,13 @@ const icChar *icGetColorSigStr(icChar *pBuf, size_t bufSize, icUInt32Number nSig
     case icSigRadiantSpectralData:
     case icSigBiSpectralReflectanceData:
     case icSigSparseMatrixReflectanceData:
+    // Same omission as icGetColorSig() above, but this function is also the XML and
+    // JSON header writer for <MCS> (IccProfileXml.cpp, IccProfileJson.cpp), so the
+    // fallback leaked into serialized profiles as "6D630004h" where every sibling
+    // space writes its readable "mc0004" form. The value survived either way --
+    // icGetSigVal() parses the 9-character hex escape back to the same signature --
+    // so this is a legibility fix, not a round-trip repair.
+    case icSigSrcMCSChannelData:
 
       pBuf[0] = (icUInt8Number)(sig>>24);
       pBuf[1] = (icUInt8Number)(sig>>16);
@@ -1863,6 +1876,16 @@ const icChar *CIccInfo::GetColorSpaceSigName(icColorSpaceSignature sig)
 
     case icSigSparseMatrixReflectanceData:
       snprintf(m_szStr, m_bufSize, "0x%04XChannelSparseMatrixReflectanceData", (unsigned int) icNumColorSpaceChannels(sig));
+      return m_szStr;
+
+    // Without this case an MCS signature reached the default below, which reports
+    // icGetSpaceSamples() through a "0x%X" conversion -- so a 4-channel MCS space
+    // printed as "0x4ColorData", both naming it as though it were a plain colour
+    // space and dropping the zero padding every case above emits. Named here in the
+    // sibling form so iccDumpProfile's "MCS Color Space:" line identifies the space
+    // it is labelling.
+    case icSigSrcMCSChannelData:
+      snprintf(m_szStr, m_bufSize, "0x%04XChannelMCSData", (unsigned int) icNumColorSpaceChannels(sig));
       return m_szStr;
 
     default:


### PR DESCRIPTION
Harvests the library core of `ci-qa-flags` into master: three defects that were sitting in
shipped code, each written here rather than taken as a patch, each with a CTest.

Triage and evidence for the whole 14-file library diff are in
https://github.com/InternationalColorConsortium/iccDEV/issues/1853#issuecomment-5233014630,
including the four changes on that branch I am **not** taking and why. This PR is only the
part that survived that review.

## What is here

| commit | defect |
|---|---|
| `5d4532ca` | MCS colour spaces are unnamed in three functions |
| `462ddd9e`* | `CIccTagZipUtf8Text::Read` reports success on allocation failure; `GetText` leaves a partial decode on failure |
| `837d0efb`* | `execinfo.h` included on bare `__linux__` |

<sub>*SHAs as pushed.</sub>

The two `CIccTagZipUtf8Text` defects share one commit because they share one file; splitting
them would put two PRs on the same file, and stacked same-file PRs get no CI.

### 1 — MCS colour spaces are unnamed (`IccUtil.cpp`)

`icSigSrcMCSChannelData` encodes its channel count in the signature (`"mc"` + count) exactly as
`icSigNChannelData` and the four spectral families do, and `icNumColorSpaceChannels()` has
always decoded it. Three naming functions left it out of their case lists, so MCS signatures
fell through to a generic fallback. Measured:

| signature | `icGetColorSig` | `icGetColorSigStr` | `GetColorSpaceSigName` |
|---|---|---|---|
| `mc0004` (MCS, 4-ch) — before | `'mc??' = 6D630004` | `6D630004h` | `0x4ColorData` |
| `mc0004` — after | `"mc0004"` | `mc0004` | `0x0004ChannelMCSData` |
| `nc0004` (NChan, 4-ch) — unchanged | `"nc0004"` | `nc0004` | `0x0004ChannelData` |

`icGetColorSigStr` is the XML and JSON header writer for `<MCS>`
(`IccProfileXml.cpp:228`, `IccProfileJson.cpp:195`), so the fallback was reaching serialized
profiles.

**Scoped deliberately: no value was being lost.** `icGetSigVal` dispatches on `strlen` and its
8/9-character branch parses `6D630004h` back to `0x6D630004`. This is a legibility and
cross-family consistency fix, **not** a round-trip repair — it is not the #2028 situation where
the writer emitted a name its own reader rejected. It does change *which* `icGetSigVal` branch
a real profile takes (9-char hex → 6-char channel signature), so the CTest pins the round trip
on both sides as well as the spelling.

`GetSpectralColorSigName` and `IsValidSpace` also list `icSigNChannelData` and are left alone:
MCS is a material connection space, not a spectral or device colour space, so its absence there
reads as intentional rather than as the same omission.

### 2 — `CIccTagZipUtf8Text` fails silently, twice (`IccTagBasic.cpp`)

**`GetText()` contributed a partial decode on failure.** The inflate loop appended each
32767-byte chunk straight into the caller's `std::string`, then returned false from inside the
loop when a later chunk was rejected. Measured against unmodified master, with the caller's
string pre-loaded with a sentinel and the deflate stream of a 264000-byte text damaged four
ways:

```
truncated to 90% of the stream : GetText=false, appended 236421 bytes to the caller's string
truncated to 50% of the stream : GetText=false, appended 132009 bytes
truncated to 30% of the stream : GetText=false, appended  78911 bytes
corrupted mid-stream           : GetText=false, appended 262136 bytes
```

The no-zlib path a few lines above clears `str` before returning false, so the two build
configurations disagreed about what `str` means on failure. The fix records the caller's
original length and truncates back to it on the one failure return that can be reached
mid-append.

Rewinding rather than inflating into a scratch string is deliberate: nothing bounds how far
this can inflate — a decompression cap is a separate open question, not settled here — so
buffering the whole decode would double peak memory for a hostile ratio and add a full copy to
the success path that the in-place append does not pay. The success path stays byte-identical,
including for a caller passing a non-empty string.

**`Read()` reported success when its buffer allocation failed.** `AllocBuffer()` returns NULL
both for a legitimate zero-size request and for a failed `malloc`/`icRealloc`, so NULL alone
cannot be treated as an error — but a non-zero `nSize` with a NULL buffer is unambiguously the
failure. The guarded copy was skipped and the function still returned true, leaving a profile
that loads with a silently empty text tag. This is #1743 at the call site that fix did not
reach; the sibling in `SetText()` at `:1643` already carries the guard and the reasoning.

### 3 — `execinfo.h` on bare `__linux__` (`IccSignatureUtils.h`)

`backtrace()` and `<execinfo.h>` are a glibc extension, not a Linux one. musl does not ship the
header, so on Alpine `__linux__` is defined and the include is a hard compile error rather than
a gracefully missing feature. Probes with `__has_include` and falls through to the same no-op
`TRACE_CALLER`/`TRACE_LOG` the non-Linux branch already provides.

**Stated plainly because it affects urgency: this is preventive.** Nothing in the tree includes
`IccSignatureUtils.h` today and `TRACE_CALLER`/`TRACE_LOG` have no callers, so no translation
unit currently compiles the include. It stops being preventive the moment anything includes the
header — which is exactly what `ci-qa-flags` does when it adds the include to `IccUtil.cpp`.

## Tests

Two new CTests, both registered in **both** CMake call lists.

- `iccdev.mcs-colorspace-name` — naming, round trip, and sibling families unaffected.
- `iccdev.ziputf8-read-inflate-contract` — truncated and corrupt streams, the success path's
  append semantics, and the `Read()` contract.

**Where the tests are honest about their limits**, rather than leaving a reader to discover it:

- The `GetText` half is a **real red/green** — all four damage cases fail against master.
- The `Read` half is a **contract guard only**. `AllocBuffer()` is public but non-virtual, so
  there is no override hook, and forcing `malloc` to fail needs platform-specific interposition
  that will not run portably in CI (this suite is also built for Windows). It pins the
  invariant the bug violated — "`Read()` returning true implies the tag holds the declared
  bytes" — and is green before and after on a machine where allocation succeeds. Same limitation
  `ziputf8-settext-contract.cpp` had to state for #1743.
- Commit 3 has **no CTest**: it is conditional compilation with no runtime behaviour to assert,
  and a glibc lane cannot exercise the branch that matters. Both paths were verified directly
  instead — against the real header the backtrace calls survive preprocessing and
  `TRACE_CALLER` is live; against a copy with the `__has_include` probe forced false the no-op
  branch compiles and links, `TRACE_LOG` still logs, and no backtrace symbol remains.

Each fix was red-tested by reverting only its own source file to `origin/master` after
committing, rebuilding, and confirming the new test fails — then restoring from `HEAD`.

## Pre-flight

| profile | result |
|---|---|
| clang 21.1.3, Release, `-Wall -Wextra -Wpedantic -Werror` | **0 warnings, 0 errors** |
| GCC 15.2.0 in the CI regression container (`sha-b28cafe4`), Release, same flags + `-DENABLE_LTO=ON` | **0 warnings, 0 errors** |
| full `ctest` | 1 pre-existing failure, unrelated (below) |

`iccdev.spectral-tiff-preview` fails locally with
`ModuleNotFoundError: No module named 'imagecodecs'` — a missing Python package in this
environment, not a code change. It fails identically before and after. The two
`applyprofiles-hbo` tests skip for missing fixtures, also unchanged.

No shell scripts are touched, so the pre-flight shellcheck gate does not apply.

Part of #1853
