### PR TITLE
fix(#1853): guard CTiffImg::Create's bytes-per-line arithmetic like Open already does

### DIFF
--- a/.github/ci/regression/tiff-create-bytesperline-overflow.cpp
+++ b/.github/ci/regression/tiff-create-bytesperline-overflow.cpp
@@ -1,0 +1,132 @@
+// Regression for the CTiffImg::Create() integer-overflow gap harvested from ci-qa-flags
+// (#1853).
+//
+// CTiffImg computes bytes-per-line twice, once per direction, and only one of them was
+// checked. Open() routes it through calcBytesPerLine() (TiffImg.cpp:471, :489), which
+// multiplies in 64 bits and refuses a result that will not fit in unsigned int.
+// Create() did the same sums raw:
+//
+//   m_nBytesPerStripLine = m_nWidth * m_nBytesPerSample;
+//   m_nBytesPerLine      = m_nWidth * m_nBytesPerSample * m_nSamples;
+//   m_nStripSize         = (unsigned int)TIFFStripSize(m_hTif);   // tmsize_t is int64
+//
+// Why the wrap is reachable and not theoretical: Create() runs before any pixel data is
+// read (iccApplyProfiles.cpp:508), so a hostile source TIFF only has to *declare* a large
+// ImageWidth -- no matching pixel data has to exist on disk. The caller then sizes its
+// destination row buffer from GetBytesPerLine() (iccApplyProfiles.cpp:539) and writes a
+// full row through it.
+//
+// The large strip allocation in the same branch looks like it would stop this by failing,
+// and does not: it asks for the true (untruncated) size, which Linux overcommit happily
+// grants, so Create() returned true while reporting a bytes-per-line far smaller than one
+// row.
+//
+// SCOPE, stated plainly: this test asserts the REJECTION contract -- Create() must refuse
+// parameters whose bytes-per-line does not fit in unsigned int -- not the heap overflow
+// that follows from accepting them. Driving the overflow itself would mean writing a
+// multi-gigabyte row buffer, which is not something to do on a CI runner.
+//
+// On a machine where the 6 GB strip allocation genuinely fails (no overcommit, or a hard
+// ulimit), unfixed Create() also returns false, and case 1 below passes without the fix.
+// That is why case 2 exists: it overflows bytes-per-line while keeping every allocation
+// tiny, so nothing but the range check can reject it.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "TiffImg.h"
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[tiff-create-overflow] FAIL: %s\n", what);
+  }
+}
+
+const char *kOutPath = "tiff-create-overflow-should-not-exist.tif";
+
+void cleanup()
+{
+  std::remove(kOutPath);
+}
+
+// Create() with parameters whose bytes-per-line overflows unsigned int must fail.
+// bSep = true and nSamples > 1 selects the separated branch, which is where the
+// width * bytesPerSample * samples product lives.
+bool tryCreate(unsigned int nWidth, unsigned int nBPS, unsigned int nSamples,
+               bool bSep)
+{
+  CTiffImg img;
+  const bool ok = img.Create(kOutPath, nWidth, /*nHeight=*/4, nBPS,
+                             PHOTO_MINISBLACK, nSamples, /*nExtraSamples=*/0,
+                             72.0f, 72.0f, /*bCompress=*/false, bSep);
+  img.Close();
+  cleanup();
+  return ok;
+}
+
+} // namespace
+
+int main()
+{
+  // --- 1. The reported shape: a large declared width and a many-channel separated
+  // destination. 3e8 * 1 * 20 = 6e9, which wraps to about 1.7e9 in 32 bits.
+  {
+    const bool ok = tryCreate(300000000u, 8u, 20u, /*bSep=*/true);
+    check(!ok, "Create() rejects width 3e8 x 1 byte x 20 samples (6e9 bytes per line)");
+  }
+
+  // --- 2. The same overflow with every allocation kept small, so no allocation failure
+  // can stand in for the range check. 2^31 * 2 bytes * 2 samples = 2^33, which wraps to
+  // exactly 0 in 32 bits -- and a zero bytes-per-line is precisely the value that makes a
+  // caller's row buffer allocation meaningless.
+  {
+    const bool ok = tryCreate(2147483648u, 16u, 2u, /*bSep=*/true);
+    check(!ok, "Create() rejects a bytes-per-line product that wraps to zero");
+  }
+
+  // --- 3. A legitimate small image must still be created, so the guards above are not
+  // simply refusing everything.
+  {
+    CTiffImg img;
+    const bool ok = img.Create(kOutPath, 64u, 4u, 8u, PHOTO_MINISBLACK, 3u, 0u,
+                               72.0f, 72.0f, false, /*bSep=*/false);
+    check(ok, "Create() still accepts a 64x4 8-bit 3-channel image");
+    if (ok) {
+      // 64 px * 1 byte * 3 samples, contiguous.
+      check(img.GetBytesPerLine() == 64u * 3u,
+            "GetBytesPerLine() is the true row size for the accepted image");
+    }
+    img.Close();
+    cleanup();
+  }
+
+  // --- 4. The separated path must also still work for a sane image, since that is the
+  // branch the guards were added to.
+  {
+    CTiffImg img;
+    const bool ok = img.Create(kOutPath, 64u, 4u, 8u, PHOTO_MINISBLACK, 3u, 0u,
+                               72.0f, 72.0f, false, /*bSep=*/true);
+    check(ok, "Create() still accepts a 64x4 8-bit 3-channel separated image");
+    if (ok) {
+      check(img.GetBytesPerLine() == 64u * 3u,
+            "separated GetBytesPerLine() is the true row size");
+    }
+    img.Close();
+    cleanup();
+  }
+
+  if (g_fail)
+    std::fprintf(stderr, "[tiff-create-overflow] %d assertion(s) failed\n", g_fail);
+  else
+    std::printf("[tiff-create-overflow] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3219,6 +3219,82 @@ endfunction()
 # validity switch inline -- so they can drift apart silently; the test asserts they agree.
 # Adapted with credit from @xsscx's signature-utils.cpp on ci-qa-flags, which is what first
 # surfaced the MCS naming gap. Links IccProfLib only; header-inline contract, no fixture.
+# #1853 harvest: CTiffImg computes bytes-per-line in both directions and only checked one.
+# Open() routes it through calcBytesPerLine() (TiffImg.cpp:471,:489), which multiplies in 64
+# bits and refuses a result that will not fit in unsigned int; Create() did the same sums raw,
+# and additionally narrowed TIFFStripSize()'s signed 64-bit tmsize_t with a C cast. Reachable
+# because Create() runs before any pixel data is read (iccApplyProfiles.cpp:508), so a source
+# TIFF need only DECLARE a large ImageWidth -- and the big strip allocation that looks like it
+# would fail first is granted under Linux overcommit, so Create() returned true carrying a
+# bytes-per-line smaller than one row, which the caller then uses to size its row buffer
+# (iccApplyProfiles.cpp:539).
+#
+# This is the only regression test that compiles a Tools translation unit rather than linking
+# IccProfLib alone: CTiffImg lives in the tool, so the contract cannot be reached any other
+# way. It therefore needs libtiff, and is skipped when TIFF is unavailable.
+function(iccdev_add_tiff_create_overflow_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+  if(NOT TARGET TIFF::TIFF AND NOT TIFF_LIBRARY)
+    find_package(TIFF QUIET)
+  endif()
+  if(TARGET TIFF::TIFF)
+    set(_tiff_lib TIFF::TIFF)
+  elseif(TIFF_LIBRARY)
+    set(_tiff_lib ${TIFF_LIBRARY})
+  else()
+    message(STATUS "iccdev.tiff-create-overflow: libtiff not found, test skipped")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccTiffCreateOverflowTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/tiff-create-bytesperline-overflow.cpp"
+    "${ICCDEV_REPO_ROOT}/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp"
+  )
+  target_compile_features(iccTiffCreateOverflowTest PRIVATE cxx_std_17)
+  target_include_directories(iccTiffCreateOverflowTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+    "${ICCDEV_REPO_ROOT}/Tools/CmdLine/IccApplyProfiles"
+  )
+  target_link_libraries(iccTiffCreateOverflowTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB} ${_tiff_lib})
+  add_dependencies(check iccTiffCreateOverflowTest)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.tiff-create-overflow
+      COMMAND "$<TARGET_FILE:iccTiffCreateOverflowTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.tiff-create-overflow
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccTiffCreateOverflowTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.tiff-create-overflow PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 120
+    LABELS "iccdev;tools;tiff;overflow;regression"
+  )
+  if(WIN32)
+    set(_tiffcreate_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccTiffCreateOverflowTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _tiffcreate_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.tiff-create-overflow PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_tiffcreate_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_signature_utils_contract_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -4268,6 +4344,7 @@ if(WIN32)
   iccdev_add_struct_name_spelling_test()
   iccdev_add_mcs_colorspace_name_test()
   iccdev_add_signature_utils_contract_test()
+  iccdev_add_tiff_create_overflow_test()
   iccdev_add_mpexml_unknown_reserved_test()
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_proflib_exported_global_definitions_test()
@@ -4539,6 +4616,7 @@ iccdev_add_tag_name_spelling_test()
 iccdev_add_struct_name_spelling_test()
 iccdev_add_mcs_colorspace_name_test()
 iccdev_add_signature_utils_contract_test()
+iccdev_add_tiff_create_overflow_test()
 iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_proflib_exported_global_definitions_test()

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -366,16 +366,52 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
       return false;
     }
 
-    m_nStripSize = (unsigned int)TIFFStripSize(m_hTif);
-    m_nBytesPerStripLine = m_nWidth * m_nBytesPerSample;
+    // TIFFStripSize() returns a signed 64-bit tmsize_t, and the products below are
+    // computed from a width that comes straight out of the source image header. Open()
+    // already routes the identical arithmetic through calcBytesPerLine() (:471, :489)
+    // and checkedUInt32(); Create() did the same sums raw, so the write path had no
+    // guard where the read path had one.
+    //
+    // The wrap is reachable rather than theoretical. Create() runs before any pixel data
+    // is read (iccApplyProfiles.cpp:508), so a source TIFF only has to *declare* a large
+    // ImageWidth -- it needs no matching pixel data on disk. A width of 3e8 with a
+    // 20-channel separated destination makes m_nBytesPerLine 6e9, which wraps to ~1.7e9,
+    // while the strip allocation below asks for the true 6 GB and *succeeds* under Linux
+    // overcommit -- so Create() returned true carrying a bytes-per-line far smaller than
+    // a row. The caller then sizes its destination row buffer from exactly that value
+    // (iccApplyProfiles.cpp:539) and writes a full row through it. The big allocation is
+    // therefore not the accidental guard it looks like; measured, unfixed Create()
+    // returns true for that shape.
+    tmsize_t stripSize = TIFFStripSize(m_hTif);
+    if (stripSize <= 0 ||
+        !checkedUInt32(static_cast<icUInt64Number>(stripSize), m_nStripSize) ||
+        !checkedUInt32Product(m_nWidth, m_nBytesPerSample, m_nBytesPerStripLine)) {
+      Close();
+      return false;
+    }
 
     if (m_nStripSize!=m_nBytesPerStripLine) {
       Close();
       return false;
     }
-    m_nBytesPerLine = m_nWidth * m_nBytesPerSample * m_nSamples;
 
-    m_pStripBuf = static_cast<unsigned char*>(malloc((size_t)m_nStripSize*m_nStripSamples));
+    // calcBytesPerLine() rather than repeating the product: it is what Open() uses, and
+    // with the nBPS % 8 rejection above it computes exactly m_nWidth * m_nBytesPerSample
+    // * m_nSamples -- the same number, in 64 bits, refused when it will not fit.
+    if (!calcBytesPerLine(m_nWidth, m_nBitsPerSample, m_nSamples, m_nBytesPerLine)) {
+      Close();
+      return false;
+    }
+
+    // Sized in 32 bits and rejected on overflow rather than left to malloc: relying on a
+    // >4 GiB request failing is exactly what does not hold under overcommit.
+    unsigned int nStripBufSize = 0;
+    if (!checkedUInt32Product(m_nStripSize, m_nStripSamples, nStripBufSize)) {
+      Close();
+      return false;
+    }
+
+    m_pStripBuf = static_cast<unsigned char*>(malloc((size_t)nStripBufSize));
 
     if (m_nRowsPerStrip == 0 || !m_pStripBuf) {
       Close();
@@ -384,7 +420,17 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
     m_nStripsPerSample = m_nHeight / m_nRowsPerStrip;
   }
   else {
-    m_nBytesPerLine = m_nStripSize = (unsigned int)TIFFStripSize(m_hTif);
+    // Same narrowing as the separated branch above: tmsize_t is signed and 64-bit, so a
+    // C cast can both truncate a large strip size and turn a libtiff error return into a
+    // very large unsigned one. m_nBytesPerLine feeds the caller's row-buffer allocation,
+    // so a wrong value here is the same class of defect on the contiguous path.
+    tmsize_t stripSize = TIFFStripSize(m_hTif);
+    if (stripSize <= 0 ||
+        !checkedUInt32(static_cast<icUInt64Number>(stripSize), m_nStripSize)) {
+      Close();
+      return false;
+    }
+    m_nBytesPerLine = m_nStripSize;
     m_nStripSamples = 1;
   }
 


### PR DESCRIPTION
`CTiffImg` computes bytes-per-line once per direction, and only the read path checked it.
Third harvest from `ci-qa-flags` under #1853, after #2072 and #2073.

## The asymmetry

`Open()` routes the calculation through `calcBytesPerLine()` (`TiffImg.cpp:471`, `:489`), which
multiplies in 64 bits and refuses a result that will not fit in `unsigned int`. `Create()` did
the same sums raw:

```cpp
m_nBytesPerStripLine = m_nWidth * m_nBytesPerSample;
m_nBytesPerLine      = m_nWidth * m_nBytesPerSample * m_nSamples;
m_nStripSize         = (unsigned int)TIFFStripSize(m_hTif);   // tmsize_t is signed int64
```

The third is a narrowing of libtiff's signed 64-bit `tmsize_t` by C cast, which both truncates a
large strip size and turns an error return into a very large unsigned one. Every helper this
needed — `checkedUInt32`, `checkedUInt32Product`, `calcBytesPerLine` — was **already in the
file**, used by the sibling path. Same shape as the #1743 call site #2072 fixed: a guard that
exists and was applied to one of two places.

## Why the wrap is reachable, not theoretical

`Create()` runs **before any pixel data is read** (`iccApplyProfiles.cpp:508`), so a hostile
source TIFF only has to *declare* a large `ImageWidth` — no matching pixel data has to exist on
disk.

```
1. source TIFF declares ImageWidth = 300,000,000   (header only)
2. SrcImg.Open()  -> calcBytesPerLine(3e8, 8, 1) = 3e8 <= UINT32_MAX, accepted
3. DstImg.Create(..., width=3e8, nSamples=20, bSeparation=true)
4.   m_nBytesPerLine = 3e8 * 1 * 20 = 6.0e9 -> wraps to ~1.705e9
5.   malloc((size_t)3e8 * 20) = 6 GB        -> SUCCEEDS under Linux overcommit
                                               so Create() returns true
6. pDBuf = malloc(DstImg.GetBytesPerLine())  -> allocates the WRAPPED ~1.7e9
   (iccApplyProfiles.cpp:539)
7. a full destination row is written through pDBuf
```

**Step 5 is the part worth stressing.** That large allocation looks like it would stop this by
failing, and it does not — it asks for the true, untruncated size, which Linux overcommit
grants. This is measured, not argued: against unmodified master the new test's first case
fails, i.e. `Create()` returned `true` while reporting a bytes-per-line smaller than one row.
The allocation is now sized with `checkedUInt32Product` and rejected on overflow rather than
left to `malloc`.

## Test

`iccdev.tiff-create-overflow`, red/green against master:

```
FAIL: Create() rejects width 3e8 x 1 byte x 20 samples (6e9 bytes per line)
FAIL: Create() rejects a bytes-per-line product that wraps to zero
```

**Scope, stated in the test header rather than left to be discovered:** it asserts the
*rejection contract* — `Create()` must refuse parameters whose bytes-per-line does not fit —
not the heap overflow that follows from accepting them. Driving that would mean writing a
multi-gigabyte row on a CI runner.

Case 2 exists for a specific reason: on a machine without overcommit (or under a hard ulimit)
the 6 GB allocation genuinely fails, so unfixed `Create()` also returns false and case 1 would
pass **without** the fix. Case 2 wraps bytes-per-line to exactly zero while keeping every
allocation tiny, so nothing but the range check can reject it. Cases 3 and 4 assert ordinary
images are still created on both the contiguous and separated paths, so the guards are not
simply refusing everything.

This is the **first regression test that compiles a Tools translation unit** rather than linking
`IccProfLib` alone — `CTiffImg` lives in the tool, so the contract is not reachable otherwise.
It links libtiff and is skipped where libtiff is unavailable. Registered in both CMake call
lists.

## Pre-flight

| profile | result |
|---|---|
| clang 21.1.3, Release, `-Wall -Wextra -Wpedantic -Werror` | **0 warnings, 0 errors** |
| GCC 15.2.0 in the CI regression container (`sha-b28cafe4`), Release + `-DENABLE_LTO=ON` | **0 warnings, 0 errors** |
| full `ctest` | no regressions |

Because this touches the shared TIFF write path, the TIFF consumers specifically:
`iccdev.hybrid-pipeline` (82s, writes TIFFs through `Create()`),
`iccdev.specsep-tiff-geometry-regression`, `iccdev.tiffdump-output-hardening` and
`iccdev.create-profiles` all pass. The only red is `iccdev.spectral-tiff-preview`, which fails
locally on a missing `imagecodecs` Python package — unrelated and identical before and after.

## Not taken from the same hunk

The branch also lowers `kMaxTiffSamples` from 65535 to 32. Master's `m_nSamples > kMaxTiffSamples`
check was **dead code** — `m_nSamples` is `icUInt16Number`, so it can never exceed 65535 —
and dropping it is right, but the constant is then repurposed as a magic `32` cap governing only
`m_nStripSamples` while still named for samples. That is a policy change wanting a rationale,
so it is left for @xsscx rather than folded in here. Detail in
https://github.com/InternationalColorConsortium/iccDEV/issues/1853#issuecomment-5234127604

Part of #1853
