### PR TITLE
fix(#1853): reject trailing arguments after iccApplySearch -cfg, as iccApplyNamedCmm already does

### DIFF
--- a/.github/scripts/iccdev-applysearch-cli-args-regression.sh
+++ b/.github/scripts/iccdev-applysearch-cli-args-regression.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+###############################################################################
+# iccApplySearch command-line argument regression tests
+###############################################################################
+#
+# Sibling of iccdev-applynamedcmm-cli-args-regression.sh. Both tools publish a
+# "-cfg config_file_path" usage, and #1674 established for iccApplyNamedCmm that
+# an argument the tool silently drops is worse than one it rejects: the run still
+# reports success, so the caller cannot tell an honoured argument list from an
+# ignored one. iccApplySearch shares that usage but never got the guard, so
+# "cfg-extra" below is the case that fails against an unfixed tool. The remaining
+# rejects already hold on master and are pinned here so the argument surface has
+# a home of its own rather than living only inside the tool-coverage baseline.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for generated logs/configs
+###############################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-applysearch-cli-args}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/build-dbg/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect:$BUILD_ROOT/IccConnect/IccLibConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-/dev/null}"
+
+APPLY="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplySearch -type f 2>/dev/null | head -1)"
+DATA="$TESTING_DIR/ApplyDataFiles/rgb8bit.txt"
+SRGB="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+CFG="$OUTDIR/applysearch-cfg.json"
+
+fail() {
+  echo "  [FAIL] iccApplySearch-cli-args -- $1"
+  exit 1
+}
+
+check_sanitizers() {
+  local logfile="$1"
+
+  if grep -qE "ERROR: AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|LeakSanitizer|DEADLYSIGNAL" "$logfile" 2>/dev/null; then
+    sed -n '1,120p' "$logfile"
+    return 1
+  fi
+
+  return 0
+}
+
+require_file() {
+  local path="$1"
+
+  if [ ! -f "$path" ]; then
+    fail "missing fixture: $path"
+  fi
+}
+
+require_tool() {
+  local path="$1"
+
+  if [ ! -x "$path" ]; then
+    fail "missing executable: $path"
+  fi
+}
+
+run_expect_success() {
+  local name="$1"
+  shift
+  local logfile="$OUTDIR/$name.log"
+  local rc=0
+
+  rm -f "$logfile"
+  set +e
+  timeout 60 "$@" > "$logfile" 2>&1
+  rc=$?
+  set -e
+
+  check_sanitizers "$logfile" || fail "$name emitted sanitizer diagnostics"
+  if [ "$rc" -eq 124 ]; then
+    fail "$name timed out"
+  fi
+  if [ "$rc" -ne 0 ]; then
+    sed -n '1,80p' "$logfile"
+    fail "$name failed with exit=$rc"
+  fi
+}
+
+run_expect_reject() {
+  local name="$1"
+  shift
+  local logfile="$OUTDIR/$name.log"
+  local rc=0
+
+  rm -f "$logfile"
+  set +e
+  timeout 60 "$@" > "$logfile" 2>&1
+  rc=$?
+  set -e
+
+  check_sanitizers "$logfile" || fail "$name emitted sanitizer diagnostics"
+  if [ "$rc" -eq 124 ]; then
+    fail "$name timed out"
+  fi
+  # A signal is never an acceptable refusal. Checking it separately from the
+  # non-zero test below keeps a crash from reading as a rejection, which is the
+  # failure mode a "did it refuse?" assertion is otherwise blind to.
+  if [ "$rc" -ge 128 ] && [ "$rc" -le 192 ]; then
+    fail "$name crashed with signal $((rc - 128))"
+  fi
+  if [ "$rc" -eq 0 ]; then
+    sed -n '1,80p' "$logfile"
+    fail "$name accepted malformed arguments"
+  fi
+}
+
+require_tool "$APPLY"
+require_file "$DATA"
+require_file "$SRGB"
+
+echo "=== iccApplySearch CLI argument regression ==="
+
+# Let the tool write its own configuration rather than hand-authoring JSON here:
+# the schema then cannot drift out from under this test, and the export doubles as
+# a success case for the argument list that "cfg-extra" only extends by one token.
+run_expect_success export-cfg \
+  "$APPLY" -exportcfganddata "$CFG" "$DATA" 3 0 "$SRGB" 1 "$SRGB" 1 -INIT 1
+require_file "$CFG"
+
+run_expect_success valid-cfg "$APPLY" -cfg "$CFG"
+run_expect_success valid-legacy "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT 1
+
+# The #1674 guard this script exists for: everything past argv[2] used to be read
+# and dropped, leaving a zero exit behind.
+run_expect_reject cfg-extra "$APPLY" -cfg "$CFG" ignored-extra
+
+# Already rejected on master; pinned so the surface cannot regress quietly.
+run_expect_reject init-missing-value "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT
+run_expect_reject legacy-extra "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT 1 ignored-extra
+run_expect_reject env-short-name "$APPLY" "$DATA" 0 0 -ENV:abc 1 "$SRGB" 1 "$SRGB" 1 -INIT 1
+
+echo "  [PASS] iccApplySearch-cli-args"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5770,6 +5770,21 @@ if(TARGET iccApplyNamedCmm)
    )
 endif()
 
+# The iccApplySearch half of the same #1674 argument-contract family. It publishes
+# the identical "-cfg <path>" usage but never received the guard added above, so
+# "iccApplySearch -cfg cfg.json anything-else" ignored the tail and still exited 0.
+# Registered separately from the iccApplyNamedCmm block because the two tools are
+# built by independent targets and either can be configured out on its own.
+if(TARGET iccApplySearch)
+  iccdev_add_script_test(
+    iccdev.applysearch-cli-args
+    120
+    "iccdev;cmm;config;cli;security;issue-1674;issue-1853;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-applysearch-cli-args-regression.sh"
+   )
+endif()
+
 # Legacy v2 namedColor2Type stores each rootName in a fixed 32-byte field. A
 # malformed profile can fill all 32 bytes without a NUL terminator; the reader
 # must force termination before iccApplyNamedCmm echoes the selected name. The

--- a/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
+++ b/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
@@ -255,6 +255,19 @@ int main(int argc, const char* argv[])
   CIccCfgColorData cfgData;
 
   if (!stricmp(argv[1], "-cfg")) {
+    // Usage 1 is exactly "-cfg <path>"; every setting comes from the JSON file, so
+    // there is nothing a further argument could mean. Anything beyond argv[2] was
+    // silently discarded, and the run then reported success, so a caller could not
+    // tell an honoured argument list from an ignored one. That is the same defect
+    // #1674 fixed in the sibling tool, where iccApplyNamedCmm grew this identical
+    // argc guard (#1906); iccApplySearch shares the "-cfg" usage but never got it.
+    // The minargs test above has already established argc >= 3, so argv[2] is
+    // readable here and only a longer list can reach this branch.
+    if (argc != 3) {
+      printf("Unexpected extra arguments for -cfg\n");
+      return EXIT_FAILURE;
+    }
+
     json cfg;
     if (!loadJsonFrom(cfg, argv[2]) || !cfg.is_object()) {
       printf("Unable to read configuration from '%s'\n", argv[2]);


### PR DESCRIPTION
## What

`iccApplySearch -cfg cfg.json anything-else` read `argv[2]`, ignored the tail and exited 0, so a
caller could not tell an honoured argument list from an ignored one.

This is the sibling of a defect we already closed. #1674 established that shape for
`iccApplyNamedCmm`, and #1906 added the `argc != 3` guard there. `iccApplySearch` publishes the
identical `Usage 1: iccApplySearch -cfg config_file_path` — every setting comes from the JSON file,
so nothing a further argument could mean exists — but never received the guard.

Harvested from `ci-qa-flags` under #1853.

## The fix

The same `argc != 3` test as #1906, deliberately matching it in two ways:

- **Same diagnostic text** (`Unexpected extra arguments for -cfg`), so a script driving both tools
  sees one message.
- **Same `EXIT_FAILURE`.** This file otherwise uses `return -1` in 21 of 22 error paths, but the
  precedent for *this* check is #1906, and `EXIT_FAILURE` is already what this file's other
  argument-parse refusal returns.

`minargs` has already established `argc >= 3` at that point, so `argv[2]` is readable and only a
longer list can reach the guard. Verified the guard cannot catch a legitimate form: `-exportcfg`
and `-exportcfganddata` are parsed in the `else` branch and never combine with `-cfg`.

## Test

New `.github/scripts/iccdev-applysearch-cli-args-regression.sh`, modelled on the
`iccdev-applynamedcmm-cli-args-regression.sh` #1906 added, registered as CTest
`iccdev.applysearch-cli-args` under its own `if(TARGET iccApplySearch)` so either tool can be
configured out independently.

**Red/green, measured:** `cfg-extra` exits 0 against the unfixed tool and 1 after, and it is the
only case that moves. The other three rejects — `-INIT` without its value, a token trailing the
profile/intent pairs, and a malformed `-ENV:` tag — already hold on master and are pinned so a
later relaxation is caught.

Two deliberate choices in the harness:

- The config is produced by the tool's own `-exportcfganddata` rather than hand-authored, so the
  schema cannot drift out from under the test, and that export doubles as a success control that
  `cfg-extra` extends by exactly one token.
- Three success cases sit alongside the rejects, so the script cannot pass by the tool refusing
  everything — the failure mode #2052 was about.

## Pre-flight

| gate | result |
|---|---|
| strict clang 21.1.3 Release `-Wall -Wextra -Wpedantic -Werror` | **0 warnings, 0 errors** |
| strict GCC **15.2.0** + `-DENABLE_LTO=ON` in CI's own regression container | **0 warnings, 0 errors** |
| `shellcheck` (0.9.0, bare) | rc=0 |
| full `ctest` after a `check` build | **172/173** |
| new CTest | Passed, 0.62 s against a 120 s budget |

The single ctest failure is `iccdev.spectral-tiff-preview`, `ModuleNotFoundError: No module named
'imagecodecs'` — a missing local Python package, identical before and after this change.

Script committed `100755` (this repo has `core.fileMode=false`, so the bit needs
`git update-index --chmod=+x`).

Part of #1853.
