### PR TITLE
fix(#1853): take the segment pointer past the end of the JPEG buffer arithmetically

### DIFF
--- a/.github/scripts/iccdev-issue-1382-jpegdump-app2-reassembly.sh
+++ b/.github/scripts/iccdev-issue-1382-jpegdump-app2-reassembly.sh
@@ -109,5 +109,36 @@ if [ "${chunks:-0}" -lt 2 ]; then
   fail "expected multiple ICC_PROFILE APP2 segments, found ${chunks:-0}"
 fi
 
-echo "  [PASS] issue-1382-jpegdump-app2-reassembly -- single + multi-segment ICC round-trip (${chunks} chunks)"
+# 3) Marker-walk edge case: a segment declaring the minimum length of 2 -- an empty
+#    payload -- as the last thing in the file leaves the walk's read cursor exactly
+#    at end-of-buffer.  The segment pointer is taken there before the payload length
+#    is examined, so it must be formed as data() + pos, not &data[pos]: subscripting
+#    one past the end is undefined and a hardened libstdc++ build aborts on it.
+#    This case therefore goes red only under _GLIBCXX_ASSERTIONS / _GLIBCXX_DEBUG;
+#    on an ordinary build it pins the orderly refusal that must follow.
+EDGE_JPEG="$OUTDIR/zero-length-app2-at-eof.jpg"
+EDGE_LOG="$OUTDIR/zero-length-app2-at-eof.log"
+printf '\xff\xd8\xff\xe2\x00\x02' > "$EDGE_JPEG"
+rm -f "$EDGE_LOG" "$OUTDIR/edge_out.icc"
+edge_rc=0
+"$JPEGDUMP" "$EDGE_JPEG" "$OUTDIR/edge_out.icc" > "$EDGE_LOG" 2>&1 || edge_rc=$?
+if ! check_sanitizers "$EDGE_LOG"; then
+  fail "zero-length APP2 at end-of-file produced a sanitizer finding"
+fi
+# A signal lands in 128..192; the tool's own refusal path is EXIT_FAILURE, so an
+# exit inside that band is a crash and anything else is a decision the tool made.
+if [ "$edge_rc" -ge 128 ] && [ "$edge_rc" -le 192 ]; then
+  sed -n '1,40p' "$EDGE_LOG"
+  fail "zero-length APP2 at end-of-file crashed with signal $((edge_rc - 128))"
+fi
+if [ "$edge_rc" -ne 1 ]; then
+  sed -n '1,40p' "$EDGE_LOG"
+  fail "zero-length APP2 at end-of-file expected EXIT_FAILURE, got $edge_rc"
+fi
+if ! grep -F -q "No ICC_PROFILE APP2 marker found." "$EDGE_LOG"; then
+  sed -n '1,40p' "$EDGE_LOG"
+  fail "zero-length APP2 at end-of-file did not report the expected diagnostic"
+fi
+
+echo "  [PASS] issue-1382-jpegdump-app2-reassembly -- single + multi-segment ICC round-trip (${chunks} chunks), zero-length APP2 at EOF refused cleanly"
 exit 0

--- a/Tools/CmdLine/IccJpegDump/iccJpegDump.cpp
+++ b/Tools/CmdLine/IccJpegDump/iccJpegDump.cpp
@@ -228,7 +228,14 @@ bool ExtractIccFromJpeg(const char* jpegPath, const char* iccOutPath) {
         pos += 2;
         if (segLen < 2 || pos + (segLen - 2) > n) break;
         size_t payloadLen = segLen - 2;
-        const unsigned char* seg = &data[pos];
+        // A segment may declare the minimum length of 2, i.e. an empty payload, and
+        // it may be the last thing in the file -- then pos == n here and the bounds
+        // check above passes, because pos + 0 > n is false.  &data[n] subscripts one
+        // past the end of the vector, which is undefined even though the reference is
+        // never read: a hardened libstdc++ (_GLIBCXX_ASSERTIONS) aborts on it.  Take
+        // the address arithmetically instead; data() + n is the valid end pointer, and
+        // the payloadLen >= 14 test below already stops seg from being dereferenced.
+        const unsigned char* seg = data.data() + pos;
 
         if (m == 0xE2 && payloadLen >= 14 && memcmp(seg, kSig, 12) == 0) {
             unsigned int seq = seg[12];


### PR DESCRIPTION
Part of #1853 — the Tools half of the `ci-qa-flags` harvest. One defect taken, with the
neighbouring hunks of the same fuzzing patch deliberately left behind and the reason stated.

## The defect

`iccJpegDump`'s APP2 marker walk formed its segment pointer as `&data[pos]`, where `data` is a
`std::vector<unsigned char>` holding the whole file and `pos` is the cursor just past the
segment's two-byte length field.

A JPEG segment may legitimately declare the minimum length of 2 — an empty payload — and may be
the last thing in the file. Then `pos == data.size()`, and the preceding bounds check does not
reject it, because for an empty payload

```cpp
if (segLen < 2 || pos + (segLen - 2) > n) break;   // segLen == 2  =>  pos > n  =>  false
```

Subscripting one past the end of a vector is undefined behaviour even though the resulting
reference is never bound to a load. A hardened libstdc++ turns it into an abort.

The fix takes the address arithmetically instead. `data.data() + pos` is the vector's valid end
pointer at that cursor, and the existing `payloadLen >= 14` test already prevents `seg` from
being dereferenced when the payload is empty — `&&` short-circuits before `memcmp` sees it.
Nothing changes on an ordinary build: the tool still walks to the end and reports
`No ICC_PROFILE APP2 marker found.`

## Measured

Red and green were both measured on a `-D_GLIBCXX_ASSERTIONS` build, against the six-byte JPEG
`ff d8 ff e2 00 02` — SOI, then an APP2 marker declaring the minimum length and ending the file:

| | binary | regression script |
|---|---|---|
| before | `stl_vector.h:1128: Assertion '__n < this->size()' failed` — SIGABRT (134) | `[FAIL] … crashed with signal 6` |
| after | `[ERROR] No ICC_PROFILE APP2 marker found.` — `EXIT_FAILURE` (1) | `[PASS]` |

The script's two pre-existing round-trip cases pass in **both** states, so the new case is the
only thing that moves.

## The test

The case joins the existing `iccdev.issue-1382-jpegdump-app2-reassembly` test, which already
covers this same marker walk, rather than adding another script and CTest registration for one
six-byte fixture.

Its exit-status band check is `128..192`, so that the tool's own `EXIT_FAILURE` refusal is read
as a decision rather than a crash — an exit code above 127 is not by itself a signal, and this
tool's refusal path is `exit(EXIT_FAILURE)`.

**Stated plainly because it bears on what the case is worth:** no build lane in this repository
defines `_GLIBCXX_ASSERTIONS` or `_GLIBCXX_DEBUG` — on `master` both have zero hits across
`Build/` and `.github/`, and the only occurrence after this change is the explanatory comment
in the script itself. So on CI this case pins the orderly refusal rather than going red on the
undefined behaviour, and the script comment says as much. Whether a hardened lane is worth
having is a question for the maintainers, not something I have added here.

## Deliberately not taken

The same `ci-qa-flags` hunk also rewrites `pos + 2 > n` to `n - pos < 2` and the payload bounds
check to `payloadLen > n - pos`. Both guard against a `size_t` overflow that cannot occur here:
`pos` is bounded by the file size on every path into those tests, and `segLen` is bounded by
`0xFFFF`, so neither sum can wrap. Taking them would be defensive churn against an unreachable
condition rather than a fix. Only the end-of-buffer subscript is reachable, so only it is taken.

This is also not a family. Across all of `Tools/CmdLine/`, the only other place that takes the
address of a subscript is `CTiffImg *f = &infile[0];` in `iccSpecSepToTiff.cpp`, and there the
vector cannot be empty — `nSamples` is `absRange / absStep + 1` and is separately rejected if
`< 1`, so that one is safe. This was the single reachable site.

## Pre-flight

| gate | result |
|---|---|
| strict clang 21.1.3 Release, `-Wall -Wextra -Wpedantic -Werror` | **0 warnings, 0 errors** |
| strict GCC 15.2.0 + LTO, in CI's own regression container | **0 warnings, 0 errors** |
| `shellcheck` (0.9.0, CI's version) on the changed script | rc=0 |
| full `ctest` | 172/173 — sole failure `iccdev.spectral-tiff-preview`, a local `imagecodecs` python dependency, unrelated |
| `iccdev.issue-1382-jpegdump-app2-reassembly` | passes on an ordinary build; red/green as tabled above on a hardened one |

Credit for the datapoint to @xsscx's fuzzing on `ci-qa-flags`.
