### PR TITLE
fix(#2085): register srng and uf32 in the JSON factory, and read uf32 as unsigned

### DIFF
--- a/.github/ci/regression/json-srng-uf32-roundtrip.cpp
+++ b/.github/ci/regression/json-srng-uf32-roundtrip.cpp
@@ -1,0 +1,443 @@
+// Regression for #2085: the JSON tag factory did not register spectralRangeType
+// ('srng') or u16Fixed16ArrayType ('uf32'), the two ICC.2 tag types that
+// IccProfLib and the XML factory both already carry.
+//
+// Mechanism. CIccTagJsonFactory::CreateTag's default arm returns a
+// CIccTagJsonUnknown rather than NULL, so once iccToJson/iccFromJson push the
+// factory it answers for *every* signature and nothing falls through to
+// CIccTagFactory. A missing case is therefore not a fall-back to the correct
+// tag -- it is a silent downgrade to Unknown, which serializes the tag as an
+// opaque byte blob and cannot parse one back. The XML side registers both
+// (IccTagXmlFactory.cpp: icSigU16Fixed16ArrayType, icSigSpectralRangeType), so
+// the same profile round-trips through XML and is lossy through JSON.
+//
+// 'uf32' had a second, independent defect underneath the missing case. The
+// typedef at IccTagJson.h:363 read
+//     typedef CIccTagFixedNum<icU16Fixed16Number, icSigU16Fixed16ArrayType> CIccTagJsonU16Fixed16;
+// -- the IccProfLib base template, not CIccTagJsonFixedNum -- so the alias was a
+// byte-for-byte copy of IccTagBasic.h:1070's CIccTagU16Fixed16 with only the name
+// changed, carrying no ToJson/ParseJson and no GetExtension() at all. That the
+// slip was unintended is settled by IccTagJson.cpp:1259-1260, where
+// CIccTagJsonFixedNum<>::GetClassName already returns "CIccTagJsonU16Fixed16"
+// for the non-S15 instantiation -- a branch that was dead code, because the only
+// explicit instantiation was the S15 one.
+//
+// Fixing the typedef alone is not enough, and that is what the value assertions
+// below exist to catch. CIccTagJsonFixedNum::ToJson/ParseJson hard-coded
+// icFtoD/icDtoF, the *signed* s15Fixed16 helpers. The XML mirror
+// CIccTagXmlFixedNum branches on Tsig in both directions and uses icUFtoD/icDtoUF
+// for the unsigned type (IccTagXml.cpp:1723,1757). Without that branch a
+// u16Fixed16 tag registers and then serializes through the wrong conversion, and
+// the two directions fail at different thresholds -- measured, not inferred:
+//   * writing:  values >= 32768 have the top bit of their raw word set, so
+//               icFtoD reads them as negative. 32768.0 is emitted as -32768.0.
+//   * reading:  icDtoF clamps its input at 32767.0 (IccUtil.cpp:569), so any
+//               value above that is truncated. 32767.5 reads back as 32767.0.
+// The reader therefore breaks lower than the writer does. A test that only
+// checked values above 32768 would still have covered both, but would have
+// misattributed the reader's boundary.
+//
+// Red-green, measured:
+//   * against master a62b3568, all six cases fail at registration: the factory
+//     yields CIccTagJsonUnknown for both signatures, so there is no typed tag to
+//     round-trip. Exit status 6.
+//   * with the typedef and the factory cases applied but the ToJson branch
+//     reverted, 32768.0 is emitted as -32768.0 and round-trips to 0.0.
+//   * with only the ParseJson branch reverted, 32767.5 round-trips to 32767.0,
+//     and it fails in both the full-range and small-value cases.
+// The small-value case is what stops a conversion fix applied in the wrong
+// direction (icUFtoD everywhere, breaking S15, or a branch inverted) from passing
+// by trading one half of the range for the other.
+//
+// srng's binary/library-level contract is already covered by
+// extended-device-colorspace.cpp (#626); this test covers only the JSON layer,
+// which that one explicitly leaves out.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccTagJson.h"
+#include "IccTagJsonFactory.h"
+#include "IccTagBasic.h"
+#include "IccTagFactory.h"
+#include "IccUtil.h"
+
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[json-srng-uf32] FAIL: %s\n", what);
+  }
+}
+
+// Reach the JSON serializer the way iccToJson does: through the extension
+// interface, not by naming a concrete Json class. Keeping the test to this API is
+// what lets it compile unchanged against a tree that has no CIccTagJsonSpectralRange.
+CIccTagJson *jsonExt(CIccTag *pTag)
+{
+  if (!pTag)
+    return NULL;
+  return dynamic_cast<CIccTagJson *>(pTag->GetExtension());
+}
+
+// ---------------------------------------------------------------------------
+// u16Fixed16ArrayType ('uf32')
+// ---------------------------------------------------------------------------
+
+// Values chosen as exact multiples of 1/65536 that are ALSO exactly representable
+// as float, so the round trip is lossless and any mismatch is a conversion defect
+// rather than rounding. The float constraint is real and not merely belt-and-braces:
+// icUFtoD returns icFloatNumber, which is float (IccDefs.h:88), so it carries 24
+// mantissa bits where a u16Fixed16 word needs up to 32. Exactness therefore holds
+// only below 256.0 -- measured, raw word 0x01000001 emits as 256.0 and reads back
+// 0x01000000, while 0x00FF0001 survives. Values above 256.0 are used below anyway
+// because they are what isolates the signed/unsigned defect, and they are chosen on
+// 1/65536 boundaries coarse enough for float. The precision limit is shared with
+// s15Fixed16 and the XML path and is noted in #2095; this test does not pin it. The
+// last
+// three sit above 32768, the region s15Fixed16 cannot hold -- they are the ones
+// that separate a correct icUFtoD/icDtoUF path from the hard-coded signed one.
+// Against the signed helpers these read back as -32768, a negative, and -1.0
+// respectively, because their raw words all have the top bit set.
+//
+// The table stops at 65535.0 rather than the type's true ceiling of 65535.99998
+// because icDtoUF (IccUtil.cpp:592) clamps its input at 65535.0, so the last
+// 1/65536 of the range is unreachable through the library's own encoder. That is
+// a separate question from this one -- filed as #2095 -- it predates #2085, and it
+// applies equally to the XML path, so this test pins what the library can actually
+// represent rather than asserting a bound it would have to change to meet.
+const double kU16Values[] = { 0.0, 0.5, 1.0, 32767.5, 32768.0, 49152.25, 65535.0 };
+const icUInt32Number kU16Count = (icUInt32Number)(sizeof(kU16Values) / sizeof(kU16Values[0]));
+
+// Case 1: the factory must build a real u16Fixed16 tag carrying a JSON extension.
+// Against master this is the assertion that fails first, and it fails because the
+// switch has no case rather than because the type is unsupported by the library.
+CIccTag *createU16Tag(const char *what)
+{
+  CIccTag *pTag = CIccTagCreator::CreateTag(icSigU16Fixed16ArrayType);
+  check(pTag != NULL, "uf32: factory returned nothing");
+  if (!pTag)
+    return NULL;
+
+  check(pTag->GetType() == icSigU16Fixed16ArrayType, "uf32: GetType() is not icSigU16Fixed16ArrayType");
+  check(dynamic_cast<CIccTagU16Fixed16 *>(pTag) != NULL, what);
+  check(jsonExt(pTag) != NULL, "uf32: tag carries no JSON extension");
+  return pTag;
+}
+
+void u16IsRegistered()
+{
+  CIccTag *pTag = createU16Tag("uf32: factory tag is not a CIccTagU16Fixed16");
+  if (pTag)
+    delete pTag;
+}
+
+// Shared body for cases 2 and 3: write nValues of the table through ToJson, read
+// them back into a second tag through ParseJson, and require exact equality.
+// Comparing tag-to-tag rather than tag-to-literal keeps the assertion on the
+// round trip itself; the emitted values are checked separately below.
+void u16RoundTrip(icUInt32Number nValues, const char *label)
+{
+  CIccTag *pSrcTag = createU16Tag("uf32: factory tag is not a CIccTagU16Fixed16");
+  if (!pSrcTag)
+    return;
+
+  CIccTagU16Fixed16 *pSrc = dynamic_cast<CIccTagU16Fixed16 *>(pSrcTag);
+  CIccTagJson *pSrcJson = jsonExt(pSrcTag);
+  if (!pSrc || !pSrcJson) {
+    delete pSrcTag;
+    return;
+  }
+
+  if (!pSrc->SetSize(nValues)) {
+    check(false, "uf32: SetSize failed");
+    delete pSrcTag;
+    return;
+  }
+  for (icUInt32Number i = 0; i < nValues; i++)
+    (*pSrc)[i] = icDtoUF((icFloatNumber)kU16Values[i]);
+
+  IccJson j;
+  check(pSrcJson->ToJson(j), "uf32: ToJson rejected the tag");
+  check(j.contains("values") && j["values"].is_array(), "uf32: no values array emitted");
+
+  if (j.contains("values") && j["values"].is_array()) {
+    check(j["values"].size() == nValues, "uf32: wrong element count emitted");
+
+    // The emitted numbers must be the values the tag holds. This is the assertion
+    // that the signed helper fails on: icFtoD(65535.5's raw word) reads -0.5.
+    if (j["values"].size() == nValues) {
+      for (icUInt32Number i = 0; i < nValues; i++) {
+        double got = j["values"][i].get<double>();
+        if (std::fabs(got - kU16Values[i]) > 1e-9) {
+          std::fprintf(stderr, "[json-srng-uf32]   %s: index %u emitted %.6f, expected %.6f\n",
+                       label, (unsigned)i, got, kU16Values[i]);
+          check(false, "uf32: emitted value does not match the tag");
+          break;
+        }
+      }
+    }
+  }
+
+  CIccTag *pDstTag = CIccTagCreator::CreateTag(icSigU16Fixed16ArrayType);
+  CIccTagU16Fixed16 *pDst = dynamic_cast<CIccTagU16Fixed16 *>(pDstTag);
+  CIccTagJson *pDstJson = jsonExt(pDstTag);
+  if (!pDst || !pDstJson) {
+    check(false, "uf32: could not create a destination tag");
+    delete pSrcTag;
+    delete pDstTag;
+    return;
+  }
+
+  std::string parseStr;
+  check(pDstJson->ParseJson(j, parseStr), "uf32: ParseJson rejected its own output");
+  check(pDst->GetSize() == nValues, "uf32: round trip changed the element count");
+
+  if (pDst->GetSize() == nValues) {
+    for (icUInt32Number i = 0; i < nValues; i++) {
+      // Raw-word equality: these are exact multiples of 1/65536, so a lossless
+      // round trip reproduces the stored word bit for bit. icDtoF's clamp at the
+      // s15Fixed16 ceiling shows up here as a changed word, not as a near miss.
+      if ((*pDst)[i] != (*pSrc)[i]) {
+        std::fprintf(stderr, "[json-srng-uf32]   %s: index %u round-tripped %.6f, expected %.6f\n",
+                     label, (unsigned)i, (double)icUFtoD((*pDst)[i]), (double)icUFtoD((*pSrc)[i]));
+        check(false, "uf32: round trip did not preserve the value");
+        break;
+      }
+    }
+  }
+
+  delete pSrcTag;
+  delete pDstTag;
+}
+
+// Case 2: the full table, including the values above 32768.
+void u16FullRangeRoundTrips()
+{
+  u16RoundTrip(kU16Count, "full range");
+}
+
+// Case 3: the first four values only -- everything s15Fixed16 could also have
+// carried. Three of them are genuinely below both defect thresholds and must stay
+// green through any conversion change, which is what an inverted branch would
+// break. The fourth, 32767.5, sits between the reader's clamp at 32767.0 and the
+// writer's sign flip at 32768.0, so this case also isolates the reader half on its
+// own: with only ParseJson reverted, it is the case that still fails.
+void u16SmallValuesRoundTrip()
+{
+  u16RoundTrip(4, "small values");
+}
+
+// ---------------------------------------------------------------------------
+// spectralRangeType ('srng')
+// ---------------------------------------------------------------------------
+
+// A 380..730nm visible range at 10nm, and a bi-spectral range that differs from it
+// in all three fields so a serializer that emitted one where the other belongs
+// cannot pass.
+const float kSpecStart = 380.0f, kSpecEnd = 730.0f;
+const icUInt16Number kSpecSteps = 36;
+const float kBiStart = 400.0f, kBiEnd = 700.0f;
+const icUInt16Number kBiSteps = 31;
+
+CIccTag *createSrngTag()
+{
+  CIccTag *pTag = CIccTagCreator::CreateTag(icSigSpectralRangeType);
+  check(pTag != NULL, "srng: factory returned nothing");
+  if (!pTag)
+    return NULL;
+
+  check(pTag->GetType() == icSigSpectralRangeType, "srng: GetType() is not icSigSpectralRangeType");
+  check(dynamic_cast<CIccTagSpectralRange *>(pTag) != NULL, "srng: factory tag is not a CIccTagSpectralRange");
+  check(jsonExt(pTag) != NULL, "srng: tag carries no JSON extension");
+  return pTag;
+}
+
+// Case 4: registration. Same shape as case 1 -- against master the factory hands
+// back CIccTagJsonUnknown even though CIccTagFactory has built srng since #626.
+void srngIsRegistered()
+{
+  CIccTag *pTag = createSrngTag();
+  if (pTag)
+    delete pTag;
+}
+
+// Shared body for cases 5 and 6. biSteps == 0 exercises the absent bi-spectral
+// range, which the XML writer omits entirely rather than emitting as zeros.
+void srngRoundTrip(icUInt16Number biSteps, const char *label)
+{
+  CIccTag *pSrcTag = createSrngTag();
+  if (!pSrcTag)
+    return;
+
+  CIccTagSpectralRange *pSrc = dynamic_cast<CIccTagSpectralRange *>(pSrcTag);
+  CIccTagJson *pSrcJson = jsonExt(pSrcTag);
+  if (!pSrc || !pSrcJson) {
+    delete pSrcTag;
+    return;
+  }
+
+  pSrc->m_spectralRange.start = icFtoF16(kSpecStart);
+  pSrc->m_spectralRange.end   = icFtoF16(kSpecEnd);
+  pSrc->m_spectralRange.steps = kSpecSteps;
+  pSrc->m_biSpectralRange.start = icFtoF16(kBiStart);
+  pSrc->m_biSpectralRange.end   = icFtoF16(kBiEnd);
+  pSrc->m_biSpectralRange.steps = biSteps;
+
+  IccJson j;
+  check(pSrcJson->ToJson(j), "srng: ToJson rejected the tag");
+
+  CIccTag *pDstTag = CIccTagCreator::CreateTag(icSigSpectralRangeType);
+  CIccTagSpectralRange *pDst = dynamic_cast<CIccTagSpectralRange *>(pDstTag);
+  CIccTagJson *pDstJson = jsonExt(pDstTag);
+  if (!pDst || !pDstJson) {
+    check(false, "srng: could not create a destination tag");
+    delete pSrcTag;
+    delete pDstTag;
+    return;
+  }
+
+  std::string parseStr;
+  check(pDstJson->ParseJson(j, parseStr), "srng: ParseJson rejected its own output");
+
+  // icFloat16Number words compare exactly: the constants above are chosen to be
+  // representable, so a half-float conversion applied twice or skipped shows up.
+  check(pDst->m_spectralRange.start == pSrc->m_spectralRange.start, "srng: spectral start not preserved");
+  check(pDst->m_spectralRange.end   == pSrc->m_spectralRange.end,   "srng: spectral end not preserved");
+  check(pDst->m_spectralRange.steps == pSrc->m_spectralRange.steps, "srng: spectral steps not preserved");
+
+  // All three bi-spectral fields must survive whatever the step count is. Write()
+  // emits all three unconditionally and Read() validates none, so a tag carrying
+  // start/end beside steps == 0 is readable-but-non-conformant, and the writer must
+  // not quietly conform it by dropping them -- before this type had a JSON class it
+  // fell to CIccTagJsonUnknown, whose hex blob preserved them exactly.
+  check(pDst->m_biSpectralRange.start == pSrc->m_biSpectralRange.start, "srng: bi-spectral start not preserved");
+  check(pDst->m_biSpectralRange.end   == pSrc->m_biSpectralRange.end,   "srng: bi-spectral end not preserved");
+  check(pDst->m_biSpectralRange.steps == pSrc->m_biSpectralRange.steps, "srng: bi-spectral steps not preserved");
+
+  std::fprintf(stdout, "[json-srng-uf32] srng %s round trip checked\n", label);
+
+  delete pSrcTag;
+  delete pDstTag;
+}
+
+// Case 5: both ranges populated.
+void srngBothRangesRoundTrip()
+{
+  srngRoundTrip(kBiSteps, "with bi-spectral");
+}
+
+// Case 6: zero step count but a populated start/end -- the non-conformant tag the
+// writer must not normalise. Keying the BiSpectralRange omission on steps alone
+// passes every other case here and fails only this one.
+void srngNoBiSpectralRoundTrip()
+{
+  srngRoundTrip(0, "zero-step bi-spectral");
+}
+
+// Case 7: a genuinely empty bi-spectral range -- all three fields zero. This is the
+// common non-bi-spectral profile, and it is the case that must still omit the key
+// rather than emit zeros, so the fix for case 6 cannot be "always emit".
+void srngEmptyBiSpectralIsOmitted()
+{
+  CIccTag *pTag = createSrngTag();
+  if (!pTag)
+    return;
+
+  CIccTagSpectralRange *pSrc = dynamic_cast<CIccTagSpectralRange *>(pTag);
+  CIccTagJson *pJson = jsonExt(pTag);
+  if (!pSrc || !pJson) {
+    delete pTag;
+    return;
+  }
+
+  pSrc->m_spectralRange.start = icFtoF16(kSpecStart);
+  pSrc->m_spectralRange.end   = icFtoF16(kSpecEnd);
+  pSrc->m_spectralRange.steps = kSpecSteps;
+  pSrc->m_biSpectralRange.start = 0;
+  pSrc->m_biSpectralRange.end   = 0;
+  pSrc->m_biSpectralRange.steps = 0;
+
+  IccJson j;
+  check(pJson->ToJson(j), "srng: ToJson rejected an empty bi-spectral range");
+  check(j.contains("SpectralRange"), "srng: SpectralRange key missing");
+  check(!j.contains("BiSpectralRange"), "srng: empty bi-spectral range was emitted anyway");
+
+  delete pTag;
+}
+
+// Case 8: a malformed steps value must be reported, not silently accepted as an
+// empty range. jGetValue leaves its out-param untouched and returns false when the
+// field is present but unholdable -- a string, or an integer wider than int -- so a
+// reader that discards that result sees the initialised 0, passes its own range
+// guard, and writes a degenerate range into the profile. Each of these fails only
+// if the jGetValue result is checked.
+void srngMalformedFieldsAreRejected()
+{
+  struct Case { const char *json; const char *what; };
+  const Case cases[] = {
+    { "{\"SpectralRange\":{\"start\":380,\"end\":730,\"steps\":4294967295}}",
+      "srng: an out-of-int-range steps was accepted" },
+    { "{\"SpectralRange\":{\"start\":380,\"end\":730,\"steps\":\"36\"}}",
+      "srng: a string steps was accepted" },
+    { "{\"SpectralRange\":{\"start\":\"380\",\"end\":730,\"steps\":36}}",
+      "srng: a string start was accepted" },
+    { "{\"SpectralRange\":{\"start\":380,\"end\":null,\"steps\":36}}",
+      "srng: a null end was accepted" },
+  };
+
+  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    CIccTag *pTag = createSrngTag();
+    CIccTagJson *pJson = jsonExt(pTag);
+    if (!pTag || !pJson) {
+      delete pTag;
+      return;
+    }
+
+    IccJson j = IccJson::parse(cases[i].json, NULL, false);
+    std::string parseStr;
+    check(!pJson->ParseJson(j, parseStr), cases[i].what);
+    check(!parseStr.empty(), "srng: a rejected document produced no diagnostic");
+
+    delete pTag;
+  }
+}
+
+} // namespace
+
+int main()
+{
+  // The JSON factory must be pushed before any CreateTag call, exactly as
+  // iccToJson/iccFromJson do it -- without it CIccTagCreator builds plain
+  // IccProfLib tags with no extension and every ToJson assertion below is
+  // vacuous rather than failing.
+  CIccTagCreator::PushFactory(new (std::nothrow) CIccTagJsonFactory());
+
+  u16IsRegistered();
+  u16FullRangeRoundTrips();
+  u16SmallValuesRoundTrip();
+
+  srngIsRegistered();
+  srngBothRangesRoundTrip();
+  srngNoBiSpectralRoundTrip();
+  srngEmptyBiSpectralIsOmitted();
+  srngMalformedFieldsAreRejected();
+
+  if (g_fail)
+    std::fprintf(stderr, "[json-srng-uf32] %d assertion(s) failed\n", g_fail);
+  else
+    std::printf("[json-srng-uf32] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3700,6 +3700,61 @@ function(iccdev_add_json_fixednum_size_cap_test)
   endif()
 endfunction()
 
+# #2085: CIccTagJsonFactory registered neither u16Fixed16ArrayType ('uf32') nor
+# spectralRangeType ('srng'), both of which IccProfLib and IccTagXmlFactory carry.
+# Because the JSON factory's default arm returns CIccTagJsonUnknown rather than
+# NULL, a missing case is a silent downgrade to an opaque blob, not a fall-back to
+# the right tag. This pins registration and a value-preserving JSON round trip for
+# both, including the upper uf32 values the signed icFtoD/icDtoF helpers -- which the
+# FixedNum template used unconditionally -- cannot carry: the writer misreads from
+# 32768 up, the reader truncates from 32767.0 up. It also pins the srng reader's
+# rejection of malformed start/end/steps and the writer's handling of a bi-spectral
+# range. Note "value-preserving" is bounded by icUFtoD returning icFloatNumber
+# (float), so uf32 words are exact only below 256.0 -- a limit shared with s15Fixed16
+# and the XML path, noted in #2095. Needs IccJSON + IccProfLib; skipped where IccJSON
+# is not built.
+function(iccdev_add_json_srng_uf32_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCJSON}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccJsonSrngUf32Test
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/json-srng-uf32-roundtrip.cpp"
+  )
+  target_compile_features(iccJsonSrngUf32Test PRIVATE cxx_std_17)
+  target_include_directories(iccJsonSrngUf32Test PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccJSON/IccLibJSON"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccJsonSrngUf32Test PRIVATE
+    ${TARGET_LIB_ICCJSON} ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccJsonSrngUf32Test)
+
+  add_test(
+    NAME iccdev.json-srng-uf32-roundtrip
+    COMMAND "$<TARGET_FILE:iccJsonSrngUf32Test>"
+  )
+  set_tests_properties(iccdev.json-srng-uf32-roundtrip PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;json;icc2;v5;issue-2085;regression"
+  )
+  if(WIN32)
+    set(_json_srng_uf32_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccJsonSrngUf32Test>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCJSON}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _json_srng_uf32_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.json-srng-uf32-roundtrip PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_json_srng_uf32_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1883: the Testing corpus carried no ICC v2 profile at all -- a clean checkout's
 # 210 profiles are 208 v5 and 2 v4, with 0 'mft2' and 0 'mft1' tags -- so every
 # UseLegacyPCS()==true branch was dead code as far as CI was concerned. That
@@ -4351,6 +4406,7 @@ if(WIN32)
   iccdev_add_json_bcd_version_test()
   iccdev_add_json_writer_move_test()
   iccdev_add_json_fixednum_size_cap_test()
+  iccdev_add_json_srng_uf32_test()
   iccdev_add_v2_legacy_pcs_test()
   iccdev_add_v2_xml_fixtures_test()
   iccdev_add_datetime_parse_test()
@@ -4623,6 +4679,7 @@ iccdev_add_proflib_exported_global_definitions_test()
 iccdev_add_json_bcd_version_test()
 iccdev_add_json_writer_move_test()
 iccdev_add_json_fixednum_size_cap_test()
+iccdev_add_json_srng_uf32_test()
 iccdev_add_v2_legacy_pcs_test()
 iccdev_add_v2_xml_fixtures_test()
 iccdev_add_datetime_parse_test()

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -850,6 +850,135 @@ bool CIccTagJsonSpectralViewingConditions::ParseJson(const IccJson &j, std::stri
 }
 
 // ===========================================================================
+// CIccTagJsonSpectralRange
+// ===========================================================================
+
+// Shared by the spectral and bi-spectral halves below, the way the XML reader
+// factors icXmlParseSpectralSteps, so the two ranges cannot drift in how strictly
+// they are checked. steps is the tag's icUInt16Number, and a count that does not
+// fit it means the document is describing a range this type cannot hold -- report
+// which range failed rather than truncating silently. Zero is accepted: that is
+// how an empty range is spelled, and it is the only legal value for a
+// BiSpectralRange the writer would have omitted.
+static bool icJsonParseSpectralRange(const IccJson &j, icSpectralRange &range,
+                                     const char *szRangeName, std::string &parseStr)
+{
+  icFloat32Number start = 0.0f, end = 0.0f;
+  int steps = 0;
+
+  // jGetValue leaves its out-param untouched and returns false when the field is
+  // present but not a number jsonToValue can hold -- a string, a null, or an
+  // integer wider than int. Discarding that result would leave the initialised 0
+  // and let the range guard below pass, so `"steps": 4294967295` would be accepted
+  // as an empty range rather than reported. Absent is a different case and stays
+  // legal: it keeps the zero, which is how the tag spells an unused range.
+  if (jsonExistsField(j, "start") && !jGetValue(j, "start", start)) {
+    parseStr += std::string("Invalid ") + szRangeName + " start\n";
+    return false;
+  }
+
+  if (jsonExistsField(j, "end") && !jGetValue(j, "end", end)) {
+    parseStr += std::string("Invalid ") + szRangeName + " end\n";
+    return false;
+  }
+
+  if (jsonExistsField(j, "steps") && !jGetValue(j, "steps", steps)) {
+    parseStr += std::string("Invalid ") + szRangeName + " steps\n";
+    return false;
+  }
+
+  if (steps < 0 || steps > 0xffff) {
+    parseStr += std::string("Invalid ") + szRangeName + " steps\n";
+    return false;
+  }
+
+  range.start = icFtoF16(start);
+  range.end   = icFtoF16(end);
+  range.steps = (icUInt16Number)steps;
+
+  return true;
+}
+
+// #2085. The key names follow CIccTagXmlSpectralRange's elements (SpectralRange /
+// BiSpectralRange) and the inner start/end/steps follow the shape the sibling
+// CIccTagJsonSpectralViewingConditions already emits for its own ranges, so an
+// srng reads the same way in JSON as the ranges embedded in an svcn do.
+bool CIccTagJsonSpectralRange::ToJson(IccJson &j)
+{
+  IccJson range;
+  range["start"] = (double)icF16toF(m_spectralRange.start);
+  range["end"]   = (double)icF16toF(m_spectralRange.end);
+  range["steps"] = (int)m_spectralRange.steps;
+  j["SpectralRange"] = std::move(range);
+
+  // A zero step count is how an absent bi-spectral range is spelled in the tag, so
+  // omit the key rather than emitting zeros a reader would have to special-case --
+  // what CIccTagXmlSpectralRange::ToXml does with the <BiSpectralRange> element.
+  //
+  // But test start/end too, not just steps. Write() emits all three fields
+  // unconditionally and Read() validates none of them, so a non-conformant tag can
+  // carry a non-zero start/end beside a zero step count. Keying the omission on
+  // steps alone would drop those two half-floats, and until this type had a JSON
+  // class at all it fell to CIccTagJsonUnknown, whose hex blob preserved them
+  // exactly -- so that would be a new lossy normalisation on a path that was not
+  // lossy before. Same reasoning as m_nReserved below: round-trip what the tag
+  // actually holds instead of quietly conforming it.
+  if (m_biSpectralRange.steps || m_biSpectralRange.start || m_biSpectralRange.end) {
+    IccJson biRange;
+    biRange["start"] = (double)icF16toF(m_biSpectralRange.start);
+    biRange["end"]   = (double)icF16toF(m_biSpectralRange.end);
+    biRange["steps"] = (int)m_biSpectralRange.steps;
+    j["BiSpectralRange"] = std::move(biRange);
+  }
+
+  // Required to be zero but carried by the tag, so round-trip it when it is not,
+  // rather than silently normalising a non-conformant profile on the way through.
+  // The XML writer drops it; emitting it only when non-zero keeps the common
+  // output identical to what a reader would infer anyway.
+  //
+  // Careful: CIccTagSpectralRange::m_nReserved (IccTagBasic.h:1839) *shadows*
+  // CIccTag::m_nReserved (:349), and this unqualified name resolves to the derived
+  // one -- which is the payload word Read()/Write() actually move, so this is the
+  // right member. The base one is separately round-tripped by CIccProfileJson as
+  // tagObj["Reserved"] (IccProfileJson.cpp:257,542) through a CIccTag*, so the two
+  // land at different depths -- ours under "data" -- and do not collide. They are
+  // genuinely different values despite the shared key name.
+  if (m_nReserved)
+    j["Reserved"] = (unsigned int)m_nReserved;
+
+  return true;
+}
+
+bool CIccTagJsonSpectralRange::ParseJson(const IccJson &j, std::string &parseStr)
+{
+  // Reset both ranges first: ParseJson runs on a tag the factory just built, but a
+  // caller reusing a tag must not inherit the previous document's bi-spectral range
+  // through the optional key below.
+  memset(&m_spectralRange, 0, sizeof(m_spectralRange));
+  memset(&m_biSpectralRange, 0, sizeof(m_biSpectralRange));
+  m_nReserved = 0;
+
+  if (!jsonExistsField(j, "SpectralRange") || !j["SpectralRange"].is_object()) {
+    parseStr += "No SpectralRange section found\n";
+    return false;
+  }
+
+  if (!icJsonParseSpectralRange(j["SpectralRange"], m_spectralRange, "SpectralRange", parseStr))
+    return false;
+
+  if (jsonExistsField(j, "BiSpectralRange") && j["BiSpectralRange"].is_object()) {
+    if (!icJsonParseSpectralRange(j["BiSpectralRange"], m_biSpectralRange, "BiSpectralRange", parseStr))
+      return false;
+  }
+
+  unsigned int reserved = 0;
+  jGetValue(j, "Reserved", reserved);
+  m_nReserved = (icUInt32Number)reserved;
+
+  return true;
+}
+
+// ===========================================================================
 // CIccTagJsonNamedColor2
 // ===========================================================================
 
@@ -1279,8 +1408,20 @@ bool CIccTagJsonFixedNum<T, Tsig>::ToJson(IccJson &j)
 
   IccJson arr = IccJson::array();
   arr.get_ref<IccJson::array_t &>().reserve(this->m_nSize);
-  for (icUInt32Number i = 0; i < this->m_nSize; i++)
-    arr.push_back(icFtoD(this->m_Num[i]));
+  // #2085: the conversion has to follow the signedness of Tsig, exactly as the XML
+  // mirror CIccTagXmlFixedNum::ToXml branches. icFtoD takes an icS15Fixed16Number,
+  // so applying it to a u16Fixed16 word reinterprets every value whose raw word has
+  // the top bit set -- that is everything from 32768 up -- as negative: 32768.0 is
+  // held as 2147483648 and emitted as -32768.0. The half of the range below that is
+  // unaffected, which is why the S15-only coverage this template had never saw it.
+  if (Tsig == icSigS15Fixed16ArrayType) {
+    for (icUInt32Number i = 0; i < this->m_nSize; i++)
+      arr.push_back(icFtoD(this->m_Num[i]));
+  }
+  else {
+    for (icUInt32Number i = 0; i < this->m_nSize; i++)
+      arr.push_back(icUFtoD(this->m_Num[i]));
+  }
   j["values"] = std::move(arr);
   return true;
 }
@@ -1297,13 +1438,24 @@ bool CIccTagJsonFixedNum<T, Tsig>::ParseJson(const IccJson &j, std::string & /*p
       double value = 0.0;
       if (!jsonToValue(arr[i], value))
         return false;
-      this->m_Num[i] = icDtoF(value);
+      // #2085: the reader mirrors the writer's branch above, and the XML reader's
+      // (CIccTagXmlFixedNum::ParseXml). icDtoF clamps its input at 32767.0
+      // (IccUtil.cpp:569), so parsing a u16Fixed16 through it truncates everything
+      // above that -- a lower threshold than the writer's, which only misreads from
+      // 32768 up. Note icDtoUF has a ceiling of its own at 65535.0, so the last
+      // 1/65536 of the type is unreachable either way; that is a separate question
+      // in IccProfLib, filed as #2095 and left alone here.
+      if (Tsig == icSigS15Fixed16ArrayType)
+        this->m_Num[i] = icDtoF(value);
+      else
+        this->m_Num[i] = icDtoUF(value);
     }
   }
   return true;
 }
 
 template class CIccTagJsonFixedNum<icS15Fixed16Number, icSigS15Fixed16ArrayType>;
+template class CIccTagJsonFixedNum<icU16Fixed16Number, icSigU16Fixed16ArrayType>;
 
 // ===========================================================================
 // CIccTagJsonNum template

--- a/IccJSON/IccLibJSON/IccTagJson.h
+++ b/IccJSON/IccLibJSON/IccTagJson.h
@@ -297,6 +297,21 @@ public:
   virtual bool ParseJson(const IccJson &j, std::string &parseStr);
 };
 
+// #2085: spectralRangeType ('srng') had no JSON class at all, so the factory fell
+// to CIccTagJsonUnknown and the deviceSpectralRangeTag the extended-device-colour-
+// space amendment introduced (#626) was opaque to iccToJson/iccFromJson. The XML
+// side has carried CIccTagXmlSpectralRange since the type was added.
+class CIccTagJsonSpectralRange : public CIccTagSpectralRange, public CIccTagJson
+{
+public:
+  virtual ~CIccTagJsonSpectralRange() {}
+  virtual const char *GetClassName() const { return "CIccTagJsonSpectralRange"; }
+  virtual IIccExtensionTag *GetExtension() { return this; }
+
+  virtual bool ToJson(IccJson &j);
+  virtual bool ParseJson(const IccJson &j, std::string &parseStr);
+};
+
 // ---------------------------------------------------------------------------
 // Named / colorant tags
 // ---------------------------------------------------------------------------
@@ -360,7 +375,12 @@ public:
 };
 
 typedef CIccTagJsonFixedNum<icS15Fixed16Number, icSigS15Fixed16ArrayType> CIccTagJsonS15Fixed16;
-typedef CIccTagFixedNum<icU16Fixed16Number, icSigU16Fixed16ArrayType>      CIccTagJsonU16Fixed16;
+// #2085: this aliased CIccTagFixedNum -- the IccProfLib base -- and so was a copy of
+// IccTagBasic.h's CIccTagU16Fixed16 with only the name changed, carrying no ToJson,
+// no ParseJson and no GetExtension(). CIccTagJsonFixedNum::GetClassName already
+// returned "CIccTagJsonU16Fixed16" for this instantiation, so the JSON template was
+// always the intended base; that branch was simply unreachable.
+typedef CIccTagJsonFixedNum<icU16Fixed16Number, icSigU16Fixed16ArrayType> CIccTagJsonU16Fixed16;
 
 // Forward declaration for array helper used by CIccTagJsonNum
 template <class T, icTagTypeSignature Tsig> class CIccJsonArrayType;

--- a/IccJSON/IccLibJSON/IccTagJsonFactory.cpp
+++ b/IccJSON/IccLibJSON/IccTagJsonFactory.cpp
@@ -79,6 +79,7 @@ CIccTag* CIccTagJsonFactory::CreateTag(icTagTypeSignature tagSig)
   case icSigUInt32ArrayType:         return new (std::nothrow) CIccTagJsonUInt32;
   case icSigUInt64ArrayType:         return new (std::nothrow) CIccTagJsonUInt64;
   case icSigS15Fixed16ArrayType:     return new (std::nothrow) CIccTagJsonS15Fixed16;
+  case icSigU16Fixed16ArrayType:     return new (std::nothrow) CIccTagJsonU16Fixed16;
   case icSigFloat16ArrayType:        return new (std::nothrow) CIccTagJsonFloat16;
   case icSigFloat32ArrayType:        return new (std::nothrow) CIccTagJsonFloat32;
   case icSigFloat64ArrayType:        return new (std::nothrow) CIccTagJsonFloat64;
@@ -104,6 +105,7 @@ CIccTag* CIccTagJsonFactory::CreateTag(icTagTypeSignature tagSig)
   case icSigViewingConditionsType:   return new (std::nothrow) CIccTagJsonViewingConditions;
   case icSigSpectralViewingConditionsType: return new (std::nothrow) CIccTagJsonSpectralViewingConditions;
   case icSigSpectralDataInfoType:    return new (std::nothrow) CIccTagJsonSpectralDataInfo;
+  case icSigSpectralRangeType:       return new (std::nothrow) CIccTagJsonSpectralRange;
   case icSigProfileSequenceDescType: return new (std::nothrow) CIccTagJsonProfileSeqDesc;
   case icSigResponseCurveSet16Type:  return new (std::nothrow) CIccTagJsonResponseCurveSet16;
   case icSigProfileSequceIdType:     return new (std::nothrow) CIccTagJsonProfileSequenceId;


### PR DESCRIPTION
Part of #2085. Covers the library half — the reproduction workflow #2090 asks for is
not in this PR, so the issue stays open.

## What was wrong

`CIccTagJsonFactory::CreateTag` handled neither `spectralRangeType` (`srng`) nor
`u16Fixed16ArrayType` (`uf32`), both of which `IccProfLib` and `IccTagXmlFactory`
already carry.

The mechanism is worth stating because it is not the usual "unsupported type" story.
The JSON factory's `default:` arm returns a `CIccTagJsonUnknown` rather than `NULL`, so
once `iccToJson`/`iccFromJson` push it the factory answers for **every** signature and
nothing falls through to `CIccTagFactory`. A missing case is therefore not a fall-back
to the correct tag — it is a silent downgrade to an opaque blob. `GetType()` still
reports the right signature and `GetExtension()` is still non-`NULL`, which is part of
why this held: the obvious assertions all pass against the broken tree.

## uf32 had a second defect underneath

```cpp
typedef CIccTagFixedNum<icU16Fixed16Number, icSigU16Fixed16ArrayType> CIccTagJsonU16Fixed16;
```

That is the `IccProfLib` base, not `CIccTagJsonFixedNum` — a copy of
`IccTagBasic.h:1070`'s `CIccTagU16Fixed16` with only the alias name changed, carrying no
`ToJson`, no `ParseJson` and no `GetExtension()`. The slip was unintended:
`CIccTagJsonFixedNum::GetClassName` already returned `"CIccTagJsonU16Fixed16"` for the
non-S15 instantiation, a branch that was unreachable because S15 was the only explicit
instantiation.

**Correcting the typedef is not sufficient, and this is the part most worth review.**
`CIccTagJsonFixedNum::ToJson/ParseJson` hard-coded `icFtoD`/`icDtoF`, the *signed*
helpers, where the XML mirror `CIccTagXmlFixedNum` branches on `Tsig` in both directions
(`IccTagXml.cpp:1723,1757`). Registering the type without that branch serializes it
through the wrong conversion, and the two directions fail at **different thresholds** —
measured, not inferred:

| direction | threshold | symptom |
|---|---|---|
| writing | from **32768** up | top bit of the raw word is set, `icFtoD` reads it negative — `32768.0` emits as `-32768.0` |
| reading | from **32767.0** up | `icDtoF` clamps its input there (`IccUtil.cpp:569`) — `32767.5` round-trips to `32767.0` |

The reader breaks lower than the writer does. Both new branches follow the XML mirror
rather than inventing a rule.

## srng

Gets the JSON class it never had, keyed on `CIccTagXmlSpectralRange`'s element names
with the `start`/`end`/`steps` shape the sibling `CIccTagJsonSpectralViewingConditions`
already emits for its own ranges, so an `srng` reads the same way in JSON as the ranges
embedded in an `svcn` do. Two decisions are deliberate and each is pinned by a test:

- **The reader checks every `jGetValue` result.** `jGetValue` leaves its out-param
  untouched and returns false for a field that is present but unholdable — a string, a
  `null`, an integer wider than `int`. Discarding the result would leave the initialised
  `0`, pass the range guard, and accept `{"steps": 4294967295}` as an empty range instead
  of reporting it.
- **The writer omits `BiSpectralRange` only when all three fields are zero**, not when
  `steps` alone is. `Write()` emits all three unconditionally and `Read()` validates
  none, so a non-conformant tag can hold `start`/`end` beside a zero step count; keying
  the omission on `steps` would drop those two half-floats, which the
  `CIccTagJsonUnknown` blob had preserved exactly. Same reasoning as the `m_nReserved`
  round trip.

Note `CIccTagSpectralRange::m_nReserved` **shadows** `CIccTag::m_nReserved`. The derived
one is what `Read()`/`Write()` move and what this code round-trips; `CIccProfileJson`
independently round-trips the base one at a different depth (`IccProfileJson.cpp:257,542`).
Two different variables sharing a key name, no collision — commented in place because it
is a trap.

## Test

`iccdev.json-srng-uf32-roundtrip` **compiles unchanged before and after the fix** — it
names only `IccProfLib` types and reaches the serializer through `GetExtension()`, never
a concrete `CIccTagJson*` class. So red/green is measured, not asserted:

- against master `a62b3568`, all six original cases fail at registration (**exit 6**)
- typedef + factory cases applied, `ToJson` branch reverted → `32768.0` emits `-32768.0`, round-trips `0.0`
- only the `ParseJson` branch reverted → `32767.5` round-trips `32767.0`
- `jGetValue` results discarded → all four malformed-input cases fail
- `BiSpectralRange` keyed on `steps` alone → the zero-step case fails while the all-zero
  case stays green, so "always emit" is excluded as the fix

Neither type appears in **any** tracked XML fixture, so no corpus sweep could have caught
this, and this is the only coverage either type has at the JSON layer. `srng`'s binary
contract is already covered by `extended-device-colorspace` (#626), which explicitly
leaves the JSON layer out.

## Known bound, deliberately not fixed here

`icUFtoD` returns `icFloatNumber` (`float`) — 24 mantissa bits against the 32 a
`u16Fixed16` word can need — so JSON values are exact only below `256.0`: raw
`0x01000001` emits as `256.0` and reads back `0x01000000`. That limit is shared with
`s15Fixed16` and the XML path, so changing it would move existing output. Filed with the
related `icDtoUF`/`icDtoF` range ceilings as **#2095**, which also records why that
family is low priority.

## Verification

clang and gcc Release, zero warnings. `ctest` 174/175 — the one failure is the local
`spectral-tiff-preview` python `imagecodecs` gap, unrelated and pre-existing.
