### PR TITLE
fix(#2098): correct the LgoS and MCML CMM enum values to the registered signatures

### DIFF
--- a/.github/ci/regression/cmm-registry-allowlist.cpp
+++ b/.github/ci/regression/cmm-registry-allowlist.cpp
@@ -28,6 +28,29 @@
 // Reverting the two-line IccProfile.cpp change flips the 'repr'/'iccd' cases from
 // no-warn to warn and fails this test.
 //
+// #2098 extension -- pinning enum VALUES, not just allow-list membership.
+//
+// The #1724 checks above all reach the allow-list through the enum *names*
+// (icSigReprointelligence, icSigICC, ...).  That is deliberately blind to the
+// defect class #2098 reported: an enum whose *value* does not match the
+// registry.  `case icSigLogoSync:` allow-lists whatever number the header
+// happens to assign, so a name-based check passes identically before and after
+// a value correction -- it cannot go red.  Two enums were wrong:
+//
+//   * icSigLogoSync      was 0x44676F53 ('DgoS'); registry says 0x4C676F53 ('LgoS')
+//   * icSigKonicaMinolta was 0x4D434D44 ('MCMD'); registry says 0x4D434D4C ('MCML')
+//
+// Effect of the defect, in both directions: a profile carrying the correctly
+// registered CMM was reported "Unregistered CMM signature.", while a profile
+// carrying the transposed non-registered value validated clean.  This is the
+// same shape as the icSigRefIccMAX 'RICC'/'RIMX' correction #1473 already made
+// (recorded as delta B3 in registry/PERMISSIVENESS_DELTAS.md), where the fix was
+// likewise to change the value and keep the comment's registered string.
+//
+// So the checks below drive the allow-list with the literal registered hex and
+// with the superseded values, which is what actually distinguishes fixed from
+// broken.  Verified against registry.color.org/cmm-signatures on 2026-08-11.
+//
 // Exit code 0 = pass, 1 = a case regressed.
 
 #include "IccProfile.h"
@@ -65,6 +88,20 @@ static bool cmmWarns(icUInt32Number cmm) {
   return report.find("Unregistered CMM signature") != std::string::npos;
 }
 
+// #2098: the header enum must carry the registered value.  These are compile-
+// time so a reverted value fails the build rather than the run -- the enum is a
+// public header constant, and a consumer that hardcodes the registered number
+// would silently stop matching it.
+static_assert(icSigLogoSync      == 0x4C676F53, "icSigLogoSync must be 'LgoS' per the CMM registry");
+static_assert(icSigKonicaMinolta == 0x4D434D4C, "icSigKonicaMinolta must be 'MCML' per the CMM registry");
+
+// icSigVivo's value was already correct; only its comment was wrong ('VIVO' for
+// a value of 'vivo').  Pinned anyway because it is the likeliest of the three to
+// be "corrected" in the wrong direction: the *manufacturer* registry lists Vivo
+// as 'VIVO' 0x5649564F, and reconciling the CMM enum against that row instead of
+// the CMM registry would reintroduce exactly the defect this change removes.
+static_assert(icSigVivo          == 0x7669766F, "icSigVivo must be 'vivo' per the CMM registry, not the manufacturer registry's 'VIVO'");
+
 int main() {
   // The #1724 fix: two registered CMMs that #1473 named but left warning.
   check(!cmmWarns(icSigReprointelligence), "'repr' (registered) validates without CMM warning");
@@ -81,6 +118,25 @@ int main() {
 
   // Negative control: unregistered junk must still warn.
   check(cmmWarns(0x5A5A5A5A /* 'ZZZZ' */), "'ZZZZ' (unregistered) still warns");
+
+  // #2098, red before the fix: driven by the literal registered value rather
+  // than the enum name, so the allow-list has to actually contain the number
+  // the registry publishes.
+  check(!cmmWarns(0x4C676F53), "'LgoS' (registered, GretagMacbeth) validates without CMM warning");
+  check(!cmmWarns(0x4D434D4C), "'MCML' (registered, Konica Minolta) validates without CMM warning");
+
+  // #2098, the other direction: the superseded values were never registered, so
+  // correcting the enum must stop accepting them.  Without these two, moving the
+  // enum to the registered value while leaving the old number allow-listed
+  // somewhere else would go unnoticed.
+  check(cmmWarns(0x44676F53), "'DgoS' (superseded icSigLogoSync typo, unregistered) warns");
+  check(cmmWarns(0x4D434D44), "'MCMD' (superseded icSigKonicaMinolta typo, unregistered) warns");
+
+  // #2098: 'vivo' needed no value change, but pin it by literal too -- and pin
+  // that the manufacturer registry's 'VIVO' is NOT a registered CMM, so the two
+  // registries stay distinguishable at the allow-list.
+  check(!cmmWarns(0x7669766F), "'vivo' (registered CMM, Vivo Mobile Communication) validates without CMM warning");
+  check(cmmWarns(0x5649564F),  "'VIVO' (manufacturer-registry sig, not a registered CMM) warns");
 
   if (g_failures) { std::printf("\n%d check(s) FAILED\n", g_failures); return 1; }
   std::printf("\nall checks passed\n");

--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -1053,13 +1053,13 @@ typedef enum {
     icSigFujiFilm                       = 0x46462020,  /* 'FF  ' */
     icSigHarlequinRIP                   = 0x48434d4d,  /* 'HCMM' */
     icSigArgyllCMS                      = 0x6172676C,  /* 'argl' */
-    icSigLogoSync                       = 0x44676f53,  /* 'LgoS' */
+    icSigLogoSync                       = 0x4c676f53,  /* 'LgoS' */
     icSigHeidelberg                     = 0x48444d20,  /* 'HDM ' */
     icSigLinoColor                      = 0x4C696E6F,  /* 'Lino' */
     icSigMonaco                         = 0x6D6E636F,  /* 'mnco' */
     icSigLittleCMS                      = 0x6C636D73,  /* 'lcms' */
     icSigKodak                          = 0x4b434d53,  /* 'KCMS' */
-    icSigKonicaMinolta                  = 0x4d434d44,  /* 'MCML' actually this is 'MCMD'- which is right? Sent email to Dr. Phil Green. */
+    icSigKonicaMinolta                  = 0x4d434d4c,  /* 'MCML' */
     icSigWindowsCMS                     = 0x57435320,  /* 'WCS ' */
     icSigMutoh                          = 0x5349474E,  /* 'SIGN' */
     icSigOnyxGraphics                   = 0x4f4e5958,  /* 'ONYX' */
@@ -1070,7 +1070,7 @@ typedef enum {
     icSigSampleICC                      = 0x53494343,  /* 'SICC' */
     icSigToshiba                        = 0x54434D4D,  /* 'TCMM' */
     icSigTheImagingFactory              = 0x33324254,  /* '32BT' */
-    icSigVivo                           = 0x7669766F,  /* 'VIVO' */
+    icSigVivo                           = 0x7669766F,  /* 'vivo' */
     icSigWareToGo                       = 0x57544720,  /* 'WTG ' */
     icSigZoran                          = 0x7a633030,  /* 'zc00' */
     icSigReprointelligence              = 0x72657072,  /* 'repr' */

--- a/Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md
+++ b/Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md
@@ -83,6 +83,41 @@ still warns.
 **Permissiveness direction:** this is a targeted correction for registered CMM
 signatures. Unknown or unregistered CMM signatures still warn.
 
+### B5. Two more value/comment mismatches - the issue-2098 change
+
+B3 was not the only instance of its class. Decoding every `0x`-literal signature
+enum in `icProfileHeader.h` against its own quoted comment (437 enums) found two
+further CMM rows whose value disagreed with the comment and with the registry:
+
+- `icSigLogoSync` held `0x44676F53` (ASCII `DgoS`); registry: `LgoS = 0x4C676F53`
+  (GretagMacbeth).
+- `icSigKonicaMinolta` held `0x4D434D44` (ASCII `MCMD`); registry:
+  `MCML = 0x4D434D4C` (Konica Minolta). That line also carried an inline question
+  - "actually this is 'MCMD' - which is right? Sent email to Dr. Phil Green" -
+  which the live registry answers.
+
+Both were corrected the same way as B3: the value changed, the comment's
+registered string kept. Re-verified against registry.color.org/cmm-signatures on
+2026-08-11.
+
+A third row, `icSigVivo`, needed no value change - `0x7669766F` is correct - but
+its comment read `'VIVO'`. Corrected to `'vivo'`. Note the **manufacturer**
+registry separately lists Vivo as `VIVO = 0x5649564F`; that is a different
+registry and a different header field, so the two do not conflict, and only the
+lower-case spelling applies to the CMM enum.
+
+**Permissiveness direction:** two-way, and this is the point. Before the change a
+profile carrying the *registered* `LgoS`/`MCML` was reported "Unregistered CMM
+signature", while one carrying the unregistered `DgoS`/`MCMD` validated clean and
+was given the registered CMM's name. Both directions are now pinned by
+`iccdev.cmm-registry-allowlist`, which drives the allow-list with literal
+registered hex plus `static_assert`s on the enum constants - the pre-existing
+checks in that test reach the allow-list through enum *names* and so could not
+detect a wrong value.
+
+No corpus impact: all 105 tracked `.icc`/`.icm` profiles were scanned and none
+carry any of the four values.
+
 ---
 
 ## C. Private tag-signature ranges - refreshed (data only)


### PR DESCRIPTION
Addresses the two enums reported in #2098, plus a third instance of the same
class found alongside them.

## The defect

| enum | was | registry | decoded |
| --- | --- | --- | --- |
| `icSigLogoSync` | `0x44676F53` | `0x4C676F53` | `DgoS` -> **`LgoS`** (GretagMacbeth) |
| `icSigKonicaMinolta` | `0x4D434D44` | `0x4D434D4C` | `MCMD` -> **`MCML`** (Konica Minolta) |

Confirming @xsscx's RCA: both consumers key on the enum *name* -- the allow-list
in `CIccProfile::CheckHeader` (`IccProfile.cpp:1972,1978`) and the name table in
`CIccInfo::GetCmmSigName` (`IccUtil.cpp:2053,2071`) -- so a wrong value is wrong
in both directions at once. A profile whose preferred-CMM field held the
correctly registered `LgoS` was reported

```
LgoS: Unregistered CMM signature.
```

while a profile holding the unregistered `DgoS` validated clean **and** was given
LogoSync's name. Re-verified against registry.color.org/cmm-signatures on
2026-08-11.

The `MCML` line also carried an inline question -- *"actually this is 'MCMD' -
which is right? Sent email to Dr. Phil Green."* The live registry answers it, so
the comment is now the plain registered form like every other row.

## Precedent for which side to fix

This is the same defect and the same remedy as `icSigRefIccMAX`, which carried
`0x52494343` (`RICC`) against a comment and registry saying `RIMX` until #1473
corrected the **value** and kept the comment. That is recorded as delta B3 in
`Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md`. The registry
string is authoritative; the hex is what drifted. This PR adds a **B5** section
recording these two -- that file states it flags every place the IccProfLib
signature tables diverge from the public registries, so landing two more
instances of a class it already tracks without a row would leave the governance
record understating the delta history.

## Third instance: `icSigVivo`

Found by the same sweep, needs no value change -- `0x7669766F` is correct -- but
its comment said `'VIVO'`, corrected to `'vivo'`. Pinned in both directions
anyway, because it is the likeliest of the three to be "corrected" the wrong way:
the **manufacturer** registry lists Vivo as `VIVO = 0x5649564F`, and reconciling
the CMM enum against that row would reintroduce exactly the defect this PR
removes. Different registry, different header field -- they do not conflict.

## How these were found

Decoded every `0x`-literal signature enum in `icProfileHeader.h` and compared it
with its own quoted comment: **437 enums, four disagreements**. Three are fixed
here. The fourth, `icSigDigitalCinemaProjector` (`icProfileHeader.h:531`), turned
out **not** to be an iccDEV defect and is deliberately excluded -- filed as
**#2101**. ICC.1-2022-05 itself gives that row as `'dcpj'` with hex `64636A70h`,
which decodes to `dcjp`; iccDEV faithfully carries the spec's hex. Extracting all
78 signature/hex pairs from the published ICC.1 PDF shows that row is the **only**
self-inconsistent one in the table (ICC.2-2023: 49 rows, 0 inconsistent), so it
needs an ICC editorial decision, not an implementation choosing a column.

## Test

Extends the existing `iccdev.cmm-registry-allowlist` rather than adding a CTest,
so the CMake wiring is untouched (definition at `Build/Cmake/Testing/CMakeLists.txt:547`,
invoked from both call sites at `:4423` and `:4695`).

The checks already in that file **cannot** catch this class -- they reach the
allow-list through enum names, and `case icSigLogoSync:` accepts whatever number
the header assigns, so they pass identically before and after. The new checks
drive it with literal registered hex, plus `static_assert`s on the constants:

- `0x4C676F53` / `0x4D434D4C` must NOT warn -- red before this change.
- `0x44676F53` / `0x4D434D44` must STILL warn -- catches a fix that adds the
  registered value while leaving the typo accepted.
- `0x7669766F` must NOT warn and `0x5649564F` must warn -- keeps the CMM and
  manufacturer registries distinguishable at the allow-list.

## Verification

- **Red/green measured, not asserted.** Reverting only `icProfileHeader.h` fails
  the build on the `static_assert`s; with those removed it fails **4 of 12**
  runtime checks. With the change applied, **12/12** pass.
- clang 18 and gcc Release, **zero warnings**.
- `ctest` **174/175**; the single failure is `iccdev.spectral-tiff-preview`, the
  known local python `imagecodecs` gap, unrelated to this change.
- **No corpus impact:** all 105 tracked `.icc`/`.icm` profiles were scanned and
  none carry any of the four values; no tracked XML or JSON references them
  either. That is also why no round-trip could ever have caught this.

Part of #2098
