### PR TITLE
fix(#2097): escape trailing-NUL signatures so XML and JSON round trip

### DIFF
--- a/.github/scripts/iccdev-issue-2097-nul-signature-roundtrip-regression.sh
+++ b/.github/scripts/iccdev-issue-2097-nul-signature-roundtrip-regression.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+###############################################################################
+# Trailing-NUL signature XML/JSON round-trip regression (issue #2097)
+###############################################################################
+#
+# icGetSigStr() renders a signature as four characters when it can, and falls
+# back to an unambiguous "%08Xh" escape when it cannot.  The fallback used to be
+# selected only by a zero byte *followed* by a non-zero one, so a signature whose
+# zeros were all trailing took the four-character path -- where the zero simply
+# terminated the C string.  'DUP\0' (0x44555000) came out as "DUP", and the
+# inverse icGetSigVal() right-pads a three-character signature with 0x20, so the
+# value that came back was 'DUP ' (0x44555020).
+#
+# That matters because both machine-format writers serialize tag-table
+# identifiers through this display helper:
+#
+#   IccXML/IccLibXML/IccProfileXml.cpp   <PrivateTag TagSignature="...">
+#   IccJSON/IccLibJSON/IccProfileJson.cpp  "sig": "..."
+#
+# The live tag registry (registry.color.org/tag-signatures, checked 2026-08-11)
+# opens six of its assigned ranges on such a signature -- 44555000 and 64757000
+# (Dupont), 544B0000, 546B0000, 744B0000 and 746B0000 (Tektronix) -- so an
+# ICC -> XML -> ICC or ICC -> JSON -> ICC trip silently rewrote the tag-table
+# identifier of a conformant profile.  The damage is invisible
+# to the validator -- 0x44555020 is merely an *unregistered* signature, not a
+# malformed one -- so every assertion here is a byte comparison against the
+# profile the round trip started from, not a validation report.
+#
+# NOT covered here, deliberately: a signature that is zero in *all four* bytes.
+# icGetSigStr(0) returns the literal text "NULL", which is a display convention
+# the call sites work around by writing an empty value for zero; that is the
+# #1356 / #1361 / #1843 family and has its own three regressions.  This test is
+# about the partially-zero signatures, which no call-site guard can reach.
+#
+# Section 4 is the anti-overfit assertion: an ordinary printable signature must
+# still serialize as readable text.  Forcing every signature to hex would make
+# sections 1-3 pass while making every profile on disk unreadable.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit codes: 0 pass or clean skip; 1 regression.
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-2097-nul-signature-roundtrip}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+
+find_tool() {
+  find "$TOOLS_DIR" -maxdepth 2 -name "$1" -type f 2>/dev/null | head -1
+}
+
+TOXML="$(find_tool iccToXml)"
+FROMXML="$(find_tool iccFromXml)"
+TOJSON="$(find_tool iccToJson)"
+FROMJSON="$(find_tool iccFromJson)"
+
+SRC_XML="$REPO_ROOT/Testing/Encoding/ISO22028-Encoded-sRGB.xml"
+
+fail() {
+  echo "  [FAIL] issue-2097-nul-signature-roundtrip -- $1"
+  exit 1
+}
+
+echo "=== Trailing-NUL signature XML/JSON round-trip regression (issue #2097) ==="
+
+for tool in "$TOXML" "$FROMXML" "$TOJSON" "$FROMJSON"; do
+  if [ -z "$tool" ] || [ ! -x "$tool" ]; then
+    echo "  [SKIP] XML/JSON round-trip tools not all built under $TOOLS_DIR"
+    exit 0
+  fi
+done
+
+if [ ! -f "$SRC_XML" ]; then
+  echo "  [SKIP] missing fixture $SRC_XML"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# run <label> <tool> <args...> -- run a tool, showing its log if it fails.
+# ---------------------------------------------------------------------------
+run() {
+  local label="$1"; shift
+  local log="$OUTDIR/$label.log"
+
+  if ! "$@" > "$log" 2>&1; then
+    sed -n '1,20p' "$log"
+    fail "$label failed"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# make_profile <hex-signature> <output.icc>
+#
+# Adds one extra signatureType tag to the tracked ISO 22028 fixture, carrying
+# the requested tag-table identifier.  The reader takes the "%08Xh" form through
+# icGetSigVal()'s hexadecimal path, so the profile on disk holds those exact four
+# bytes whether or not the writer can render them -- which is what makes the
+# comparisons below a test of the writer alone.
+# ---------------------------------------------------------------------------
+make_profile() {
+  local sig="$1" out="$2"
+  local xml="$OUTDIR/in-$sig.xml"
+
+  awk -v sig="$sig" '
+    /<\/Tags>/ && !done {
+      printf "\t\t<signatureType>\n"
+      printf "\t\t\t<TagSignature>%sh</TagSignature>\n", sig
+      printf "\t\t\t<Signature>dorc</Signature>\n"
+      printf "\t\t</signatureType>\n"
+      done = 1
+    }
+    { print }
+  ' "$SRC_XML" > "$xml"
+
+  grep -q "<TagSignature>${sig}h</TagSignature>" "$xml" \
+    || fail "could not inject signature $sig into the fixture"
+
+  run "build-$sig" "$FROMXML" "$xml" "$out"
+}
+
+# ---------------------------------------------------------------------------
+# assert_roundtrip <label> <base.icc> <roundtripped.icc>
+#
+# The only assertion that catches this defect.  One trailing zero moves a single
+# byte (0x44555000 -> 0x44555020, measured at offset 172 of the fixture below);
+# two trailing zeros move two.  Either way both profiles report "Profile is valid
+# for version 5.00", because the rewritten signature is unregistered rather than
+# malformed -- so a validation report is not an assertion, and the bytes are.
+# ---------------------------------------------------------------------------
+assert_roundtrip() {
+  local what="$1" base="$2" rt="$3"
+
+  if ! cmp -s "$base" "$rt"; then
+    cmp -l "$base" "$rt" 2>/dev/null | sed -n '1,6p' | sed 's/^/    /'
+    fail "$what changed the bytes of a profile with a trailing-NUL signature (#2097)"
+  fi
+}
+
+# ===========================================================================
+# 1. The reported example, both lanes.  0x44555000 is a registered private tag
+#    signature; "DUP" in the serialized text is the corruption in flight.
+# ===========================================================================
+make_profile 44555000 "$OUTDIR/dup.icc"
+
+run dup-toxml "$TOXML" "$OUTDIR/dup.icc" "$OUTDIR/dup.xml"
+if grep -qF 'TagSignature="DUP"' "$OUTDIR/dup.xml"; then
+  grep -nF 'TagSignature="DUP"' "$OUTDIR/dup.xml" | sed -n '1,2p' | sed 's/^/    /'
+  fail "the XML writer truncated 'DUP\\0' to the three characters DUP (#2097)"
+fi
+grep -qF 'TagSignature="44555000h"' "$OUTDIR/dup.xml" \
+  || fail "the XML writer did not escape the trailing-NUL signature as 44555000h (#2097)"
+
+run dup-tojson "$TOJSON" "$OUTDIR/dup.icc" "$OUTDIR/dup.json"
+if grep -qF '"sig": "DUP"' "$OUTDIR/dup.json"; then
+  grep -nF '"sig": "DUP"' "$OUTDIR/dup.json" | sed -n '1,2p' | sed 's/^/    /'
+  fail "the JSON writer truncated 'DUP\\0' to the three characters DUP (#2097)"
+fi
+grep -qF '"sig": "44555000h"' "$OUTDIR/dup.json" \
+  || fail "the JSON writer did not escape the trailing-NUL signature as 44555000h (#2097)"
+
+run dup-fromxml  "$FROMXML"  "$OUTDIR/dup.xml"  "$OUTDIR/dup-rt-xml.icc"
+run dup-fromjson "$FROMJSON" "$OUTDIR/dup.json" "$OUTDIR/dup-rt-json.icc"
+
+assert_roundtrip "an ICC -> XML -> ICC round trip"  "$OUTDIR/dup.icc" "$OUTDIR/dup-rt-xml.icc"
+assert_roundtrip "an ICC -> JSON -> ICC round trip" "$OUTDIR/dup.icc" "$OUTDIR/dup-rt-json.icc"
+echo "    0x44555000 (DUP + NUL): both round trips byte-exact, both formats escaped"
+
+# ===========================================================================
+# 2. The rest of the family.  These are the registry signatures the sweep in
+#    #2097 measured as changing; one lane each is enough once section 1 has
+#    shown the two writers behave alike.
+# ===========================================================================
+for sig in 544B0000 546B0000 64757000 744B0000 746B0000; do
+  make_profile "$sig" "$OUTDIR/$sig.icc"
+  run "$sig-toxml"   "$TOXML"   "$OUTDIR/$sig.icc" "$OUTDIR/$sig.xml"
+  run "$sig-fromxml" "$FROMXML" "$OUTDIR/$sig.xml" "$OUTDIR/$sig-rt.icc"
+  assert_roundtrip "an ICC -> XML -> ICC round trip of $sig" "$OUTDIR/$sig.icc" "$OUTDIR/$sig-rt.icc"
+done
+echo "    the five remaining registry signatures ending in NUL: byte-exact through XML"
+
+# ===========================================================================
+# 3. The cross-format lane #2097 reported: a profile written by one text format
+#    and reparsed by the other.  Each hop is a separate opportunity to truncate.
+# ===========================================================================
+run cross-toxml   "$TOXML"   "$OUTDIR/dup-rt-json.icc" "$OUTDIR/cross.xml"
+run cross-fromxml "$FROMXML" "$OUTDIR/cross.xml"       "$OUTDIR/cross.icc"
+assert_roundtrip "the JSON -> ICC -> XML -> ICC lane" "$OUTDIR/dup.icc" "$OUTDIR/cross.icc"
+echo "    JSON -> ICC -> XML -> ICC: byte-exact"
+
+# ===========================================================================
+# 4. Anti-overfit.  Escaping *every* signature to hex would satisfy sections
+#    1-3 and make every serialized profile unreadable, so assert that an
+#    ordinary printable signature is still written as its four characters.
+# ===========================================================================
+make_profile 44555058 "$OUTDIR/plain.icc"
+run plain-toxml "$TOXML" "$OUTDIR/plain.icc" "$OUTDIR/plain.xml"
+grep -qF 'TagSignature="DUPX"' "$OUTDIR/plain.xml" \
+  || fail "a printable tag-table identifier stopped serializing as readable text (#2097)"
+grep -qF "<Signature>dorc</Signature>" "$OUTDIR/plain.xml" \
+  || fail "a printable payload signature stopped serializing as readable text (#2097)"
+run plain-fromxml "$FROMXML" "$OUTDIR/plain.xml" "$OUTDIR/plain-rt.icc"
+assert_roundtrip "an ICC -> XML -> ICC round trip of a printable signature" \
+  "$OUTDIR/plain.icc" "$OUTDIR/plain-rt.icc"
+echo "    printable signatures still serialize as text, not hex, and still round-trip"
+
+echo "  [PASS] issue-2097-nul-signature-roundtrip -- 6 trailing-NUL signatures survive XML and JSON"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5714,6 +5714,25 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1843-zero-signature-roundtrip-regression.sh"
 )
 
+# #2097: the same three tests above all concern a signature that is zero in all
+# four bytes, which the call sites can (and now do) special-case.  This one is the
+# case no call-site guard reaches: a signature whose zeros are only trailing.
+# icGetSigStr() demanded its "%08Xh" escape for a zero *followed* by a non-zero
+# byte, so 'DUP\0' took the four-character path and the zero terminated the C
+# string -- "DUP", which icGetSigVal() pads back to 'DUP '.  Six registered tag
+# signatures were rewritten by every XML or JSON round trip.  Nothing in the
+# validator notices, since the corrupted value is unregistered rather than
+# malformed, so the assertions are byte comparisons plus one anti-overfit check
+# that printable signatures are still written as readable text.
+# Plain functional test -- skips cleanly if the tools/fixtures are absent.
+iccdev_add_script_test(
+  iccdev.issue-2097-nul-signature-roundtrip
+  90
+  "iccdev;xml;json;signature;roundtrip;issue-2097;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2097-nul-signature-roundtrip-regression.sh"
+)
+
 # #1355 - matrix/TRC (PCSXYZ) profiles must round-trip near-exactly. Guards the
 # two CMM/eval fixes (ConnectFirst actual->internal XYZ rescale; native-PCS
 # round-trip connection): iccRoundTrip RT1 mean dE was ~20 before, ~0 after.

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -1116,15 +1116,21 @@ const icChar *icGetSig(icChar *pBuf, size_t bufSize, icUInt32Number nSig, bool b
 
 const icChar *icGetSigStr(icChar *pBuf, size_t bufSize, icUInt32Number nSig)
 {
-  int i, j=-1;
+  int i;
   icUInt32Number sig=nSig;
   bool bGetHexVal = false;
 
+  // A signature that is entirely zero keeps the "NULL" display convention.  It is
+  // not round-trip safe either -- icGetSigVal("NULL") packs the ASCII bytes into
+  // 0x4E554C4C -- but that case is handled at the call sites, which write an empty
+  // value for zero and rely on the readers mapping empty text back to zero
+  // (#1356, #1361, #1843).  Only the partially-zero signatures below are the
+  // formatter's own problem.
   if (!nSig) {
     strcpy(pBuf, "NULL");
     return pBuf;
   }
-  
+
   if (bufSize < 5 || bufSize > 65535) {
     // this is caused by bad parameters, usually with bufSize replaced by the sig
     strcpy(pBuf, "BADP");
@@ -1133,10 +1139,17 @@ const icChar *icGetSigStr(icChar *pBuf, size_t bufSize, icUInt32Number nSig)
 
   for (i=0; i<4; i++) {
     icUInt8Number c = (icUInt8Number)(sig >> (24-(i*8)));
+    // A zero byte has no four-character text form: it terminates the C string this
+    // loop is filling.  The previous condition only demanded the "%08Xh" escape for
+    // a zero *followed* by a non-zero byte, so a signature whose zeros were all
+    // trailing was truncated instead -- 'DUP\0' (0x44555000) was written as "DUP",
+    // and icGetSigVal() right-pads a three-character signature with a space, giving
+    // back 'DUP ' (0x44555020).  Since IccProfileXml.cpp and IccProfileJson.cpp
+    // serialize tag-table identifiers through this helper, that silently rewrote
+    // six of the registered tag signatures on every XML or JSON round trip.  Any
+    // zero byte now takes the hex form, which icGetSigVal() parses back exactly
+    // (issue #2097).
     if (!c) {
-      j=i;
-    }
-    else if (j!=-1) {
       bGetHexVal = true;
     }
     else if (!isprint(c) || c==':' || c > 126) {
@@ -1259,16 +1272,17 @@ const icChar *icGetColorSigStr(icChar *pBuf, size_t bufSize, icUInt32Number nSig
     default:
       {
 
-        int i, j=-1;
+        int i;
         icUInt8Number c;
         bool bGetHexVal = false;
 
         for (i=0; i<4; i++) {
           c=(icUInt8Number)(sig>>(24-i*8));
+          // Same trailing-zero truncation icGetSigStr() carried, and this function is
+          // likewise a serialization writer -- it renders <DataColourSpace>, <PCS> and
+          // <MCS> for both text formats -- so a colour space whose low bytes are zero
+          // has to reach the reversible hex form here too (issue #2097).
           if (!c) {
-            j=i;
-          }
-          else if (j!=-1) {
             bGetHexVal = true;
           }
           else if (!isprint(c) || c==':' || c > 126) {


### PR DESCRIPTION
Part of #2097 — the trailing-NUL half. Confirming @xsscx's RCA in full.

## The defect

`icGetSigStr()` (`IccProfLib/IccUtil.cpp:1117`) renders a signature as four
characters when it can and falls back to an unambiguous `"%08Xh"` escape when it
cannot. The fallback was selected only by a zero byte **followed by** a non-zero
one. A signature whose zeros were all *trailing* therefore took the
four-character path, where the zero simply terminated the C string the loop was
filling:

```
0x44555000  ->  "DUP"          icGetSigStr()   three characters, zero eaten
"DUP"       ->  0x44555020     icGetSigVal()   three characters right-padded 0x20
```

Both machine-format writers serialize tag-table identifiers through this display
helper — `IccProfileXml.cpp:273` and `IccProfileJson.cpp:228` — so the value was
rewritten on every round trip in either format.

## Measured

Tracked fixture `Testing/Encoding/ISO22028-Encoded-sRGB.xml` plus one
`signatureType` tag carrying `0x44555000`:

| lane | before | after |
| --- | --- | --- |
| `ICC -> XML -> ICC` | `44 55 50 00` -> `44 55 50 20` | byte-exact |
| `ICC -> JSON -> ICC` | `44 55 50 00` -> `44 55 50 20` | byte-exact |
| `ICC -> JSON -> ICC -> XML -> ICC` | corrupted | byte-exact |

Exactly one byte moved, at offset 172. **Both the correct and the corrupted
profile validate as "Profile is valid for version 5.00"** — `0x44555020` is
merely *unregistered*, not malformed — which is why the regression asserts bytes
rather than a validation report.

Checked against the live registry (`registry.color.org/tag-signatures`,
2026-08-11): six assigned ranges open on such a signature — `44555000` and
`64757000` (Dupont), `544B0000`, `546B0000`, `744B0000`, `746B0000`
(Tektronix). All six now survive both formats.

## The fix

Any zero byte selects the hex form, which `icGetSigVal()` parses back exactly
(its 9-character case). Every reader on both sides already routes through
`icGetSigVal` — XML via `icXmlStrToSig`, JSON directly — so this is writer-only
and symmetric.

`icGetColorSigStr()` carried the identical condition and is likewise a
serializer (`<DataColourSpace>`, `<PCS>`, `<MCS>`, `<SpectralPCS>`), so it gets
the same treatment.

## Deliberately not addressed here

The seventh row of the issue's table, `00000000` (Sun Microsystems' assigned
range start), still round-trips to `4E554C4C`. `icGetSigStr(0)` returns the
literal text `"NULL"`, which is a *display* convention the call sites work
around by writing an empty value for zero — the #1356 / #1361 / #1843 family,
which has three regressions of its own and whose readers map empty text back to
zero. Changing it would alter `iccDumpProfile` output for every absent
signature, and the XML reader rejects an empty `TagSignature` attribute
outright, so a fix for the all-zero *tag-table identifier* needs a design
decision rather than a formatter change. Flagged for triage, not silently
folded in.

## Regression

`iccdev.issue-2097-nul-signature-roundtrip` — new script test, fixture derived
from tracked XML by `awk` (no new binaries). Four sections: the reported example
in both formats; the five remaining registry signatures; the cross-format lane;
and an anti-overfit check — escaping *every* signature to hex would satisfy the
first three while making every serialized profile unreadable, so a printable
signature must still be written as its four characters. Verified red against a
reverted library (fails at the first assertion) and green on restore.

## Pre-flight

| profile | result |
| --- | --- |
| clang-18 `-Wall -Wextra -Wpedantic -Werror` Release | built 100%, **0 warnings** |
| GCC 15.2.0 in the pinned CI container, strict + LTO (`strict warnings ENABLED`) | built 100%, **0 warnings** |
| clang-18 ASAN+UBSAN Debug strict | built 100%, **0 warnings**; new test clean under `detect_leaks=1` |
| full local `ctest` (serial and `-j4`) | 175/176; the one failure is `iccdev.spectral-tiff-preview`, a local-only missing python `imagecodecs` |
| `shellcheck` 0.9.0 on the new script | rc=0 |

The three sibling zero-signature regressions (#1356, #1361, #1843) all still
pass, confirming the `"NULL"` convention is untouched.
