### PR TITLE
build(#1975): declare the iccviz engine once instead of at every consumer

### DIFF
--- a/Build/Cmake/CMakeLists.txt
+++ b/Build/Cmake/CMakeLists.txt
@@ -1677,6 +1677,53 @@ function(iccdev_fixup_msvc_compile_pdb TARGET_NAME)
   endif()
 endfunction()
 
+# The one declaration of the iccviz visualization engine (#1975, follow-on to
+# #1754).  IccVizModel is the data-first API (iccviz::Enumerate / RenderGraph /
+# RenderRaster) that Tools/CmdLine/IccProfilePlot exposes to consumers outside
+# the tool: both IccProfilePlot executables drive it and the iccviz regression
+# tests link it from their own translation units.  Each of those three restated
+# the source path and the include directory by hand, so adding a file to the
+# engine meant editing several unrelated CMakeLists -- the same hand-maintained
+# duplication that let the UBSAN silence list drift in #2034.  The fuzz harness
+# on the CFL branch (see the ENABLE_FUZZING notice above) is a fourth consumer
+# of the same shape, which is what makes these sources belong to a target
+# rather than to any one tool.
+#
+# Declared here rather than in Tools/IccProfilePlot because that subdirectory is
+# inside IF(ENABLE_TOOLS) below while Testing is added after ENDIF().  A target
+# declared there would vanish from an ENABLE_TOOLS=OFF build and take the iccviz
+# regression tests with it.
+#
+# INTERFACE rather than OBJECT or STATIC, for two reasons -- note that neither
+# is "so each consumer gets its own sanitizer flags": ENABLE_SANITIZERS folds
+# its flags into CMAKE_C/CXX_FLAGS globally (see FINAL_SAN_FLAGS above), so a
+# shared object library would be instrumented exactly like everything else.
+#
+#  * INTERFACE_SOURCES compile into each consumer, which keeps the compile graph
+#    identical to what the hand-written lists produced -- same objects in the
+#    same targets.  This is a de-duplication of the declarations, not a change
+#    to how anything is built; consolidating the three compiles into one shared
+#    object library is a separate decision, deliberately not taken here.
+#  * Per-target flags do reach the engine this way, and that is the model this
+#    build already uses for fuzzing: ENABLE_FUZZING deliberately does NOT apply
+#    its flags globally, handing them to fuzz targets through
+#    target_compile_options instead.  Options set that way on a consumer reach
+#    an INTERFACE source, because it compiles as part of that consumer; they
+#    would not reach an object library compiled once on its own.
+#
+# IccVizEngineHeaders is split out for consumers that need only the headers --
+# IccVizMath.hpp is header-only, so the degeneracy test compiles no engine
+# source at all and must not be handed IccVizModel.cpp.
+get_filename_component(ICCDEV_ICCVIZ_DIR
+  "${CMAKE_CURRENT_SOURCE_DIR}/../../Tools/CmdLine/IccProfilePlot" ABSOLUTE)
+
+add_library(IccVizEngineHeaders INTERFACE)
+target_include_directories(IccVizEngineHeaders INTERFACE "${ICCDEV_ICCVIZ_DIR}")
+
+add_library(IccVizEngine INTERFACE)
+target_link_libraries(IccVizEngine INTERFACE IccVizEngineHeaders)
+target_sources(IccVizEngine INTERFACE "${ICCDEV_ICCVIZ_DIR}/IccVizModel.cpp")
+
 IF(ENABLE_TOOLS)
   # Add XML-related tools
   IF(ENABLE_ICCXML)

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1874,13 +1874,12 @@ function(iccdev_add_iccviz_metrics_test)
 
   iccdev_add_regression_executable(iccVizMetricsTest
     "${ICCDEV_REPO_ROOT}/.github/ci/regression/iccviz-gamut-roundtrip-metrics.cpp"
-    "${ICCDEV_REPO_ROOT}/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp"
   )
   target_compile_features(iccVizMetricsTest PRIVATE cxx_std_17)
-  target_include_directories(iccVizMetricsTest PRIVATE
-    "${ICCDEV_REPO_ROOT}/Tools/CmdLine/IccProfilePlot"
-  )
-  target_link_libraries(iccVizMetricsTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  # IccVizEngine supplies IccVizModel.cpp and the engine include directory, so
+  # this stays a genuine second translation unit against the public header
+  # while naming neither path by hand (#1975).
+  target_link_libraries(iccVizMetricsTest PRIVATE ${TARGET_LIB_ICCPROFLIB} IccVizEngine)
   add_dependencies(check iccVizMetricsTest)
 
   add_test(
@@ -1925,10 +1924,11 @@ function(iccdev_add_iccviz_degenerate_test)
     "${ICCDEV_REPO_ROOT}/.github/ci/regression/iccviz-degenerate-detection.cpp"
   )
   target_compile_features(iccVizDegenerateTest PRIVATE cxx_std_17)
-  target_include_directories(iccVizDegenerateTest PRIVATE
-    "${ICCDEV_REPO_ROOT}/Tools/CmdLine/IccProfilePlot"
-  )
-  target_link_libraries(iccVizDegenerateTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  # Headers only, deliberately: principalStdDevs is inline in IccVizMath.hpp, so
+  # this test must NOT pull in IccVizModel.cpp.  IccVizEngineHeaders is the
+  # engine include directory without the engine source (#1975).
+  target_link_libraries(iccVizDegenerateTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB} IccVizEngineHeaders)
   add_dependencies(check iccVizDegenerateTest)
 
   add_test(

--- a/Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt
+++ b/Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt
@@ -1,7 +1,9 @@
 SET( SRC_PATH ../../../.. )
+# IccVizModel.cpp and the IccProfilePlot include directory are not listed here:
+# both arrive through the IccVizEngine INTERFACE target declared in the parent
+# CMakeLists (#1975).  Only this tool's own sources belong in this list.
 SET( SOURCES
-  ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/iccProfilePlot.cpp
-  ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp )
+  ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/iccProfilePlot.cpp )
 SET( TARGET_NAME iccProfilePlot )
 SET( ICC_PLOT_LINK_LIB ${TARGET_LIB_ICCPROFLIB} )
 
@@ -13,11 +15,9 @@ ENDIF()
 
 ADD_EXECUTABLE( ${TARGET_NAME} ${SOURCES} )
 
-# IccVizModel.hpp / IccVizMath.hpp / spectralLocus.hpp live alongside the sources.
-TARGET_INCLUDE_DIRECTORIES( ${TARGET_NAME} PRIVATE
-  ${SRC_PATH}/Tools/CmdLine/IccProfilePlot )
-
-TARGET_LINK_LIBRARIES( ${TARGET_NAME} ${ICC_PLOT_LINK_LIB} )
+# IccVizEngine carries IccVizModel.cpp plus the include directory that makes
+# IccVizModel.hpp / IccVizMath.hpp / spectralLocus.hpp reachable.
+TARGET_LINK_LIBRARIES( ${TARGET_NAME} ${ICC_PLOT_LINK_LIB} IccVizEngine )
 IF(ENABLE_INSTALL_RIM)
   INSTALL (TARGETS ${TARGET_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 ENDIF(ENABLE_INSTALL_RIM)
@@ -29,16 +29,14 @@ SET( VIZ_SOURCES
   ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/iccProfileVisualize.cpp
   ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/MiniPDF.cpp
   ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/MiniSVG.cpp
-  ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/MiniTIFF.cpp
-  ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/IccVizModel.cpp )
+  ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/MiniTIFF.cpp )
 SET( VIZ_TARGET_NAME iccProfileVisualizePlot )
 
 ADD_EXECUTABLE( ${VIZ_TARGET_NAME} ${VIZ_SOURCES} )
 
-TARGET_INCLUDE_DIRECTORIES( ${VIZ_TARGET_NAME} PRIVATE
-  ${SRC_PATH}/Tools/CmdLine/IccProfilePlot )
-
-TARGET_LINK_LIBRARIES( ${VIZ_TARGET_NAME} ${ICC_PLOT_LINK_LIB} )
+# The Mini* writers stay listed above: they are this tool's rendering back end,
+# not part of the engine, and no other consumer compiles them.
+TARGET_LINK_LIBRARIES( ${VIZ_TARGET_NAME} ${ICC_PLOT_LINK_LIB} IccVizEngine )
 IF(ENABLE_INSTALL_RIM)
   INSTALL (TARGETS ${VIZ_TARGET_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 ENDIF(ENABLE_INSTALL_RIM)


### PR DESCRIPTION
Part of #1975 — the reusable-target half of the #1754 review's blocking findings.

This deliberately does **not** implement the issue title's literal ask. `processLuts`
stays `static`; the reasoning and the evidence are in the issue reply, and the short
version is that @xsscx's own harness already established it is not needed.

## What this changes

`Tools/CmdLine/IccProfilePlot/IccVizModel.cpp` is the data-first visualization engine
(`iccviz::Enumerate` / `RenderGraph` / `RenderRaster`) that consumers outside the tool
drive through `IccVizModel.hpp`. On master its source path and its include directory
are restated by hand at four sites:

| site | source path | include dir |
|---|---|---|
| `Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt:4,18` (`iccProfilePlot`) | yes | yes |
| `Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt:33,39` (`iccProfileVisualizePlot`) | yes | yes |
| `Build/Cmake/Testing/CMakeLists.txt:1877,1881` (`iccVizMetricsTest`) | yes | yes |
| `Build/Cmake/Testing/CMakeLists.txt:1929` (`iccVizDegenerateTest`) | — | yes |

Adding a file to the engine therefore means remembering several unrelated CMakeLists.
That is the same hand-maintained duplication that let the UBSAN silence list drift in
#2034, and a libFuzzer harness that compiles the engine beside itself is a fifth
consumer of the identical shape.

Two INTERFACE libraries now carry it, declared once in `Build/Cmake/CMakeLists.txt`:

- **`IccVizEngineHeaders`** — the engine include directory.
- **`IccVizEngine`** — that, plus `IccVizModel.cpp`.

## Why INTERFACE, and why declared at the top level

Both choices are forced, not stylistic:

- **Declared in the top-level CMakeLists, not in `Tools/IccProfilePlot`.** That
  subdirectory is inside `IF(ENABLE_TOOLS)` (`Build/Cmake/CMakeLists.txt:1680-1879`)
  while `Testing` is added after `ENDIF()` at 1883. A real target declared there would
  vanish from an `ENABLE_TOOLS=OFF` build and take the two iccviz regression tests with
  it.
- **INTERFACE, not OBJECT or STATIC.** `INTERFACE_SOURCES` compile into each consumer
  exactly as the hand-written lists did, so every consumer keeps its own flags. That
  matters here: the sanitizer and fuzzer lanes build this engine with instrumentation
  the tool binaries do not use, and a shared object or static library would force one
  flag set on all of them.

The split into two targets preserves an existing distinction: `principalStdDevs` is
inline in `IccVizMath.hpp`, so `iccVizDegenerateTest` compiles no engine source at all
and must not be handed `IccVizModel.cpp`. It links `IccVizEngineHeaders`.

## Verification

**Build topology is unchanged — measured, not asserted.** Configuring master and this
branch and diffing the per-target object lists gives identical sets for all four
targets:

```
iccProfilePlot            IccVizModel.cpp.o, iccProfilePlot.cpp.o
iccProfileVisualizePlot   IccVizModel.cpp.o, MiniPDF/MiniSVG/MiniTIFF.cpp.o,
                          iccProfileVisualize.cpp.o
iccVizMetricsTest         iccviz-gamut-roundtrip-metrics.cpp.o, IccVizModel.cpp.o
iccVizDegenerateTest      iccviz-degenerate-detection.cpp.o
```

So the metrics test still compiles the engine as a genuine second translation unit
against the public header, and the degeneracy test still compiles none.

One real difference the diff does surface: the engine `-I` moves from position 9 to
position 11, after the generated-header directories. Checked rather than reasoned
about — none of the earlier `-I` directories, nor the repo root, contains any of
`IccVizModel.hpp`, `IccVizMath.hpp`, `spectralLocus.hpp`, `Mini{PDF,SVG,TIFF}.hpp`, so
no header resolution changes.

**Strict lanes, CI's own gate (`grep -cE 'warning:'` on the build log):**

| lane | result |
|---|---|
| clang 21.1.3, `-Wall -Wextra -Wpedantic -Werror`, Release ("strict warnings ENABLED") | **0 warnings, 0 errors** |
| GCC 15.2.0 in `iccdev-ci-regression:sha-b28cafe4`, same flags + `-DENABLE_LTO=ON` ("strict warnings ENABLED") | **0 warnings, 0 errors** |

**Tests:** 176/177 on the strict clang lane; the single failure is
`iccdev.spectral-tiff-preview`, which needs the Python `imagecodecs` module absent from
this box and is unrelated. All 7 `iccviz` / `iccprofileplot` CTests pass with
`ENABLE_TOOLS=ON`; with `ENABLE_TOOLS=OFF` both regression executables still build and
their 2 tests pass, which is the case the INTERFACE form exists to protect.

**Negative proof — the targets are load-bearing, not decoration:**

- deleting the `target_sources` line breaks all three source consumers with
  `undefined reference to 'iccviz::Enumerate(CIccProfile*)'` and siblings;
- deleting the include directory from `IccVizEngineHeaders` breaks the degeneracy test
  with `fatal error: 'IccVizMath.hpp' file not found`.

Both re-run after the rebase onto `b572e972`.

No source file moves and no tool behaviour changes. The Windows
`IccProfLib2-static` fallback in the tool CMakeLists is preserved as-is, so
`docs/build.md:341` stays accurate.
