### PR TITLE
test(#2116): give the Mini{PDF,SVG,TIFF} writers a hermetic entry and their first coverage

### DIFF
--- a/.github/ci/regression/iccviz-writer-serialization.cpp
+++ b/.github/ci/regression/iccviz-writer-serialization.cpp
@@ -1,0 +1,548 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression: the Mini{PDF,SVG,TIFF} serialization layer had no instrument
+// pointed at it (#2116).
+//
+// iccProfileVisualizePlot is two layers. The data layer -- iccviz::Enumerate /
+// RenderGraph / RenderRaster in IccVizModel -- already had coverage: two CTests
+// (#1712) and the in-process CFL harness on ci-qa-issue-1975, whose raster
+// observer reads result.raster.samples.size() and stops there. Everything below
+// that boundary, which is where bytes are actually produced, ran only when the
+// CLI ran: WriteTIFF's IFD layout and offset/strip arithmetic, PDFWriter's
+// object graph and xref offset table, and SVGOut, which the tool never even
+// constructs. The only way in was a function that derives every output path
+// from the input path and writes a PDF plus N TIFFs per call, so no harness
+// could reach it without a filesystem.
+//
+// #2116 added the seam: PDFWriter::Serialize(ostream&), SVGOut::Serialize
+// (ostream&), and a WriteTIFF overload taking an already-open FILE*. This test
+// is what proves the seam is worth having and that it did not change what the
+// tool writes.
+//
+// Why the writers deserve the attention. The dimensions WriteTIFF computes file
+// offsets from are profile-controlled: they come out of a CLUT via RenderRaster
+// and reach the writer unmodified (iccProfileVisualize.cpp:1388). Inside, they
+// are narrowed to uint32_t and turned into offsets.
+//
+// Being precise about what is and is not guarded there, because the loose
+// version of this claim is wrong. MiniTIFF.cpp does have returning checks -- on
+// ftell failure, on strip offsets exceeding UINT32_MAX, on a short fwrite, and
+// on a non-finite or out-of-range dpi. What none of them cover is the incoming
+// geometry: width, height, channels and depth are used to size rows and strips
+// with no returning check at all, and the only guards on them are three
+// assert()s (nrowBytes > 0, and the two UINT_MAX checks on the IFD offsets),
+// which CMake's default NDEBUG in CMAKE_CXX_FLAGS_RELEASE compiles out --
+// verified in this tree, not assumed. So the guarded quantities are the ones
+// derived from the stream, and the unguarded ones are the ones derived from the
+// profile.
+//
+// That is not a live bug, and this test does not claim one. The guards are in
+// buildClutRaster (IccVizModel.cpp:819-834), which refuses non-positive
+// geometry and caps the buffer at 256 MB, so every raster the engine can emit
+// is already in range. The point is that the contract keeping WriteTIFF's
+// unguarded arithmetic safe is enforced entirely by a *different file*, was
+// nowhere written down as a test, and would break silently. Level 4 below is
+// that contract, asserted against whatever the engine actually produces.
+//
+// Levels:
+//   1. PDF   -- Serialize(ostream) and CloseFile() produce identical bytes.
+//   2. SVG   -- same, and SVGOut's first coverage of any kind.
+//   3. TIFF  -- the FILE* overload and the name-taking overload produce
+//               identical bytes, driven by the real engine's raster.
+//   4. The raster geometry contract WriteTIFF's arithmetic depends on.
+//   5. The TIFF bytes are structurally what the geometry says they should be,
+//      so level 3 cannot pass by two paths being identically wrong.
+//
+// Behaviour preservation was also measured outside this test, against the
+// pre-split binary built from b5f8def1: iccProfileVisualizePlot on
+// sRGB_v4_ICC_preference.icc produces five files (four .tif, one .pdf) and all
+// five are byte-identical before and after the split, with identical stderr.
+//
+// Exit code 0 = pass, 1 = a case regressed, 2 = usage/setup error.
+
+#include "IccProfile.h"
+#include "IccVizModel.hpp"
+#include "MiniPDF.hpp"
+#include "MiniSVG.hpp"
+#include "MiniTIFF.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+static int g_failures = 0;
+
+static void fail(const char *what)
+{
+  std::printf("FAIL: %s\n", what);
+  ++g_failures;
+}
+
+static void pass(const char *what)
+{
+  std::printf("ok: %s\n", what);
+}
+
+// Read a whole file back, always in binary. Returns false if it could not be
+// opened or read; the caller reports, because "could not read what we just
+// wrote" is a failure of the test's own plumbing and not of the writer under
+// test.
+static bool slurp(const std::string &path, std::vector<unsigned char> &out)
+{
+  FILE *f = std::fopen(path.c_str(), "rb");
+  if (!f)
+    return false;
+
+  out.clear();
+  unsigned char buf[4096];
+  size_t got;
+  while ((got = std::fread(buf, 1, sizeof buf, f)) > 0)
+    out.insert(out.end(), buf, buf + got);
+
+  bool ok = (std::ferror(f) == 0);
+  std::fclose(f);
+  return ok;
+}
+
+// Read back everything written to an open stream, from the beginning.
+static bool slurpStream(FILE *f, std::vector<unsigned char> &out)
+{
+  if (std::fflush(f) != 0 || std::fseek(f, 0, SEEK_SET) != 0)
+    return false;
+
+  out.clear();
+  unsigned char buf[4096];
+  size_t got;
+  while ((got = std::fread(buf, 1, sizeof buf, f)) > 0)
+    out.insert(out.end(), buf, buf + got);
+
+  return std::ferror(f) == 0;
+}
+
+// Drop carriage returns so a CRLF file compares equal to the LF string the
+// in-memory path produced.
+//
+// This is the one place platform differences reach this test, and it is not
+// optional. PDFWriter::CloseFile writes through icOpenRegularWriteTextFile,
+// i.e. fopen(name, "wt") (IccCmdLineUtil.h:240), and SVGOut::CloseFile uses a
+// default-mode std::ofstream: both are TEXT streams, so a Windows CRT expands
+// every '\n' to "\r\n" on the way out, while Serialize() writes to an
+// ostringstream that expands nothing. Comparing raw bytes would report a size
+// difference that is the platform's line-ending policy rather than a
+// serialization defect -- measured on this test's own output, 1450 bytes on
+// disk against 1371 in memory for the PDF -- and would red the Windows ctest
+// legs while staying green everywhere else.
+//
+// Normalizing rather than reading the file back in text mode is deliberate.
+// The text-mode round-trip is only conditionally guaranteed (C17 7.21.2p2
+// excludes lines ending in a space, and this PDF's xref entries end in "n \n"),
+// so relying on it would make the test depend on CRT behaviour the standard
+// does not promise. Stripping '\r' depends on nothing. It is safe here because
+// no writer emits a bare CR and this test's content is fixed ASCII; TIFF is
+// binary on both sides and is compared strictly, without this.
+static std::vector<unsigned char> withoutCR(const std::vector<unsigned char> &in)
+{
+  std::vector<unsigned char> out;
+  out.reserve(in.size());
+  for (unsigned char c : in) {
+    if (c != '\r')
+      out.push_back(c);
+  }
+  return out;
+}
+
+static void compareBytes(const char *what,
+                         const std::vector<unsigned char> &streamPath,
+                         const std::vector<unsigned char> &filePath)
+{
+  if (streamPath.size() != filePath.size()) {
+    std::printf("  %s: %zu bytes via stream, %zu via file\n",
+                what, streamPath.size(), filePath.size());
+    fail(what);
+    return;
+  }
+  if (streamPath.empty()) {
+    std::printf("  %s: both paths produced nothing\n", what);
+    fail(what);
+    return;
+  }
+  for (size_t i = 0; i < streamPath.size(); ++i) {
+    if (streamPath[i] != filePath[i]) {
+      std::printf("  %s: first difference at byte %zu (0x%02x vs 0x%02x)\n",
+                  what, i, streamPath[i], filePath[i]);
+      fail(what);
+      return;
+    }
+  }
+  pass(what);
+}
+
+// -- level 1: PDF -------------------------------------------------------------
+//
+// Serialize() must not disturb the writer's state, because CloseFile() runs the
+// same four Write* calls again over the same object list and the recorded
+// object offsets have to come out the same. That is the whole reason object
+// cleanup stayed in CloseFile rather than moving into Serialize.
+static void checkPdf(const std::string &path)
+{
+  std::vector<unsigned char> viaStream, viaFile;
+
+  {
+    PDFWriter pdf;
+    pdf.OpenFile(path, 8 * inch2point, 8 * inch2point);
+
+    // Two pages sharing one named XObject, so the xref table, the page tree and
+    // the XObject resource dictionary all carry more than one entry -- a
+    // single-page document would let an offset-table bug stay invisible.
+    std::string axes = "0 0 m 100 100 l S\n";
+    pdf.AddXObject(Rect2D(0.0f, 200.0f, 0.0f, 200.0f), axes, "Axes");
+
+    for (int page = 0; page < 2; ++page) {
+      std::ostringstream commands;
+      commands << "BT /F1 12 Tf 20 " << (700 - 20 * page) << " Td (page) Tj ET\n";
+      pdf.AddObject(new PDFGraphic(commands.str()));
+      pdf.AddPage(pdf.ObjectCount(), "Axes");
+    }
+
+    if (pdf.PageCount() != 2) {
+      fail("pdf: two pages were added");
+      return;
+    }
+
+    std::ostringstream out;
+    out.exceptions(std::ios::badbit | std::ios::failbit);
+    pdf.Serialize(out);
+    const std::string &s = out.str();
+    viaStream.assign(s.begin(), s.end());
+
+    pdf.CloseFile();
+  }
+
+  if (!slurp(path, viaFile)) {
+    fail("pdf: CloseFile output could not be read back");
+    return;
+  }
+
+  // Line-ending-normalized: CloseFile wrote this through a text stream. See withoutCR().
+  compareBytes("pdf: Serialize(ostream) matches CloseFile bytes",
+               withoutCR(viaStream), withoutCR(viaFile));
+
+  // A document, not just a matching pair of empty strings.
+  if (viaFile.size() < 200 ||
+      std::memcmp(viaFile.data(), "%PDF-1.7", 8) != 0)
+    fail("pdf: output is a PDF document");
+  else
+    pass("pdf: output is a PDF document");
+}
+
+// -- level 2: SVG -------------------------------------------------------------
+//
+// SVGOut is dead in the shipping tool: iccProfileVisualize.cpp declares
+// DrawAxisSVG and an SVG graph function taking SVGOut&, but never constructs
+// one. So this is the class's first execution in any test, and the reason the
+// seam covers it even though nothing calls it today.
+//
+// Serialize() runs Finalize() before writing and CloseFile() runs it again, so
+// finalization has to be idempotent or the second serialization would carry an
+// extra closing </g>. It is idempotent because closing the page group clears
+// m_pageInProgress -- not because of any separate latch, which is worth stating
+// because the obvious assertion here does not test it: comparing Serialize
+// against CloseFile passes even with the guard removed, since by the time
+// CloseFile runs the flag is already false either way.
+//
+// What does discriminate is serializing twice from the same writer, below: drop
+// the m_pageInProgress guard and the second document gains a </g> the first
+// does not have.
+static void checkSvg(const std::string &path)
+{
+  std::vector<unsigned char> viaStream, viaFile, viaStreamAgain;
+
+  {
+    SVGOut svg;
+    svg.OpenFile(path);
+    svg.SetPageSize(200.0f, 200.0f);
+    svg.NextPage();
+    svg.StartGroup("curve");
+    svg.AddLine(0.0f, 0.0f, 100.0f, 100.0f);
+    svg.AddText(10.0f, 20.0f, "Input", 14.0f, "Helvetica", "Regular", "left");
+    svg.EndGroup();
+
+    // Deliberately left open: NextPage's group is closed by Finalize, not by
+    // the caller, which is the state Serialize has to reproduce.
+    std::ostringstream out;
+    out.exceptions(std::ios::badbit | std::ios::failbit);
+    svg.Serialize(out);
+    const std::string &s = out.str();
+    viaStream.assign(s.begin(), s.end());
+
+    // Second serialization of the same writer: this is the case that fails if
+    // finalization stops being idempotent.
+    std::ostringstream again;
+    again.exceptions(std::ios::badbit | std::ios::failbit);
+    svg.Serialize(again);
+    const std::string &s2 = again.str();
+    viaStreamAgain.assign(s2.begin(), s2.end());
+
+    svg.CloseFile();
+  }
+
+  if (!slurp(path, viaFile)) {
+    fail("svg: CloseFile output could not be read back");
+    return;
+  }
+
+  // Line-ending-normalized: CloseFile wrote this through a text stream. See withoutCR().
+  compareBytes("svg: Serialize(ostream) matches CloseFile bytes",
+               withoutCR(viaStream), withoutCR(viaFile));
+  // Both sides are in-memory here, so this one stays a strict byte comparison.
+  compareBytes("svg: repeated Serialize is idempotent", viaStreamAgain, viaStream);
+
+  std::string text(viaFile.begin(), viaFile.end());
+  // One closing tag for the StartGroup/EndGroup pair, one for the page group
+  // Finalize closes. Three would mean finalization ran its body twice; this is
+  // the absolute count behind the relative comparison above.
+  size_t closes = 0;
+  for (size_t at = text.find("</g>"); at != std::string::npos;
+       at = text.find("</g>", at + 1))
+    ++closes;
+
+  if (closes != 2) {
+    std::printf("  svg: %zu closing group tags, expected 2\n", closes);
+    fail("svg: exactly one closing tag per opened group");
+  }
+  else {
+    pass("svg: exactly one closing tag per opened group");
+  }
+}
+
+// -- levels 3-5: TIFF, driven by the real engine ------------------------------
+
+// Decode a host-order 32-bit field written by putLong.
+static uint32_t readLong(const std::vector<unsigned char> &bytes, size_t at)
+{
+  uint32_t v = 0;
+  std::memcpy(&v, bytes.data() + at, sizeof v);
+  return v;
+}
+
+static uint16_t readShort(const std::vector<unsigned char> &bytes, size_t at)
+{
+  uint16_t v = 0;
+  std::memcpy(&v, bytes.data() + at, sizeof v);
+  return v;
+}
+
+// Find an IFD entry by tag and return its value field. The directory starts at
+// offset 8 with a 2-byte entry count, then 12-byte entries.
+static bool findIfdValue(const std::vector<unsigned char> &bytes,
+                         uint16_t wantTag, uint32_t &value)
+{
+  if (bytes.size() < 10)
+    return false;
+
+  uint16_t entries = readShort(bytes, 8);
+  for (uint16_t i = 0; i < entries; ++i) {
+    size_t at = 10 + size_t(i) * 12;
+    if (at + 12 > bytes.size())
+      return false;
+    if (readShort(bytes, at) == wantTag) {
+      value = readLong(bytes, at + 8);
+      return true;
+    }
+  }
+  return false;
+}
+
+static void checkRaster(const iccviz::Raster &raster, const std::string &id,
+                        const std::string &pathPrefix, int index)
+{
+  // Level 4: the geometry contract. WriteTIFF narrows these to uint32_t and
+  // computes file offsets from them with no returning check, so every one of
+  // these has to be guaranteed by the producer. buildClutRaster is what
+  // guarantees them today; this is where that guarantee is written down.
+  bool geometryOk = true;
+  if (raster.width <= 0 || raster.height <= 0 || raster.channels <= 0) {
+    std::printf("  raster %s: non-positive geometry %dx%d x%d\n",
+                id.c_str(), raster.width, raster.height, raster.channels);
+    geometryOk = false;
+  }
+  if (raster.bitsPerChannel != 8 && raster.bitsPerChannel != 16) {
+    std::printf("  raster %s: bitsPerChannel %d is neither 8 nor 16\n",
+                id.c_str(), raster.bitsPerChannel);
+    geometryOk = false;
+  }
+
+  if (!geometryOk) {
+    fail("tiff: raster geometry is in range for the writer's arithmetic");
+    return;
+  }
+
+  // The sample buffer must be exactly what the geometry describes. WriteTIFF
+  // reads width*channels*(depth/8) bytes per row for height rows with no
+  // reference to the vector's actual length, so anything smaller is an
+  // out-of-bounds read and anything larger means the geometry is lying.
+  const size_t expectBytes = size_t(raster.width) * size_t(raster.height) *
+                             size_t(raster.channels) *
+                             size_t(raster.bitsPerChannel / 8);
+  if (raster.samples.size() != expectBytes) {
+    std::printf("  raster %s: %zu sample bytes, geometry describes %zu\n",
+                id.c_str(), raster.samples.size(), expectBytes);
+    fail("tiff: sample buffer matches the declared geometry");
+    return;
+  }
+
+  // Level 3: same bytes through both overloads.
+  //
+  // Each call gets its own copy of the samples. WriteTIFF rewrites the caller's
+  // buffer in place for CIELAB rasters (shiftTIFFLAB re-biases a* and b*), so
+  // handing the same vector to both calls would compare a shifted buffer
+  // against a twice-shifted one and report a difference that is the test's own
+  // doing.
+  std::vector<unsigned char> forStream(raster.samples);
+  std::vector<unsigned char> forFile(raster.samples);
+
+  const std::string tifPath = pathPrefix + "_" + std::to_string(index) + ".tif";
+
+  // tmpfile() is deliberately not used: on Windows it creates the file in the
+  // drive root and fails for a non-elevated process, which would turn this into
+  // three red Windows legs. A named file opened "w+b" behaves the same
+  // everywhere, and a freshly opened one satisfies the overload's precondition
+  // that the stream be positioned at 0 (the layout constants are absolute from
+  // the start of the file, so it refuses anything else).
+  FILE *stream = std::fopen((tifPath + ".stream").c_str(), "w+b");
+  if (!stream) {
+    fail("tiff: could not open a scratch stream");
+    return;
+  }
+
+  bool streamOk = WriteTIFF(stream, "in-memory", 100.0f, raster.photometric,
+                            forStream.data(), size_t(raster.width),
+                            size_t(raster.height), raster.channels,
+                            raster.bitsPerChannel);
+
+  std::vector<unsigned char> viaStream;
+  bool readBack = streamOk && slurpStream(stream, viaStream);
+  std::fclose(stream);
+
+  if (!streamOk) {
+    fail("tiff: FILE* overload wrote the raster");
+    return;
+  }
+  if (!readBack) {
+    fail("tiff: FILE* overload output could not be read back");
+    return;
+  }
+
+  if (!WriteTIFF(tifPath, 100.0f, raster.photometric, forFile.data(),
+                 size_t(raster.width), size_t(raster.height),
+                 raster.channels, raster.bitsPerChannel)) {
+    fail("tiff: name-taking overload wrote the raster");
+    return;
+  }
+
+  std::vector<unsigned char> viaFile;
+  if (!slurp(tifPath, viaFile)) {
+    fail("tiff: name-taking overload output could not be read back");
+    return;
+  }
+
+  compareBytes("tiff: FILE* overload matches the name-taking overload",
+               viaStream, viaFile);
+
+  // Level 5: the bytes are structurally what the geometry says. Without this,
+  // two identically-wrong outputs would pass level 3 -- the failure mode a pure
+  // A-equals-B pin cannot see.
+  uint32_t tagWidth = 0, tagHeight = 0, tagSamples = 0, tagByteCount = 0;
+  if (viaFile.size() < 10 ||
+      !findIfdValue(viaFile, 256 /* TIFF_WIDTH */, tagWidth) ||
+      !findIfdValue(viaFile, 257 /* TIFF_HEIGHT */, tagHeight) ||
+      !findIfdValue(viaFile, 277 /* TIFF_SAMPLESPERPIXEL */, tagSamples) ||
+      !findIfdValue(viaFile, 279 /* TIFF_STRIPBYTECOUNTS */, tagByteCount)) {
+    fail("tiff: the required IFD entries are present");
+    return;
+  }
+
+  if (tagWidth != uint32_t(raster.width) ||
+      tagHeight != uint32_t(raster.height) ||
+      tagSamples != uint32_t(raster.channels)) {
+    std::printf("  raster %s: IFD says %ux%u x%u, raster says %dx%d x%d\n",
+                id.c_str(), tagWidth, tagHeight, tagSamples,
+                raster.width, raster.height, raster.channels);
+    fail("tiff: IFD geometry matches the raster it came from");
+    return;
+  }
+
+  // One strip covering the whole image, which is what this writer emits.
+  if (tagByteCount != uint32_t(expectBytes)) {
+    std::printf("  raster %s: strip byte count %u, expected %zu\n",
+                id.c_str(), tagByteCount, expectBytes);
+    fail("tiff: strip byte count matches the pixel data written");
+    return;
+  }
+
+  pass("tiff: IFD geometry and strip byte count match the raster");
+}
+
+int main(int argc, char **argv)
+{
+  if (argc != 3) {
+    std::printf("usage: iccviz-writer-serialization <profile.icc> <output-prefix>\n");
+    return 2;
+  }
+
+  const std::string profilePath = argv[1];
+  const std::string prefix = argv[2];
+
+  checkPdf(prefix + ".pdf");
+  checkSvg(prefix + ".svg");
+
+  std::unique_ptr<CIccProfile> profile(ReadIccProfile(profilePath.c_str()));
+  if (!profile) {
+    std::printf("could not read profile: %s\n", profilePath.c_str());
+    return 2;
+  }
+
+  // Silent: the engine echoes diagnostics to stderr by default to match the
+  // CLI, and this test is not asserting on them.
+  iccviz::SetSilent(true);
+
+  // Counts rasters the engine handed over, NOT rasters that passed: a count of
+  // verified rasters would drop to zero the moment a writer case failed, and
+  // report "the engine produced nothing" for what is really a writer defect.
+  int rastersRendered = 0;
+  const std::vector<iccviz::Descriptor> descriptors = iccviz::Enumerate(profile.get());
+  for (const auto &d : descriptors) {
+    if (d.output != iccviz::Output::Raster)
+      continue;
+    iccviz::RasterResult res = iccviz::RenderRaster(profile.get(), d.id,
+                                                    iccviz::Verbosity::Silent);
+    if (!res.ok)
+      continue;
+    checkRaster(res.raster, d.id, prefix, rastersRendered);
+    ++rastersRendered;
+  }
+
+  // The profile this runs on has four CLUT tags (A2B0/A2B1/B2A0/B2A1), so a
+  // zero here means the engine stopped producing rasters and every TIFF case
+  // above silently checked nothing -- the discarded-coverage failure mode,
+  // where a green run means the test never ran rather than that it passed.
+  if (rastersRendered == 0) {
+    fail("tiff: the engine produced at least one raster to write");
+  }
+  else {
+    std::printf("ok: drove the writer with %d engine raster(s)\n", rastersRendered);
+  }
+
+  if (g_failures) {
+    std::printf("%d case(s) regressed\n", g_failures);
+    return 1;
+  }
+
+  std::printf("all cases passed\n");
+  return 0;
+}

--- a/.github/workflows/ci-matlab.yml
+++ b/.github/workflows/ci-matlab.yml
@@ -228,7 +228,7 @@ jobs:
         env:
           BASH_ENV: /dev/null
           ICCDEV_IMAGE: >-
-            ghcr.io/internationalcolorconsortium/iccdev@sha256:b003dcfdc04776035b51d9cdc03f90d62cc70c745da321ae29e182075bf2845d
+            ghcr.io/internationalcolorconsortium/iccdev@sha256:7cc0354c9a37671a681f20df9cdc164bd4859c7ccb40e50d60ffa510fcb2d628
         run: |
           set -euo pipefail
           git config --global credential.helper ""
@@ -242,7 +242,7 @@ jobs:
         uses: matlab-actions/run-command@75644028e1e2aa374bbfdc968a65718a178cc264
         env:
           ICCDEV_IMAGE: >-
-            ghcr.io/internationalcolorconsortium/iccdev@sha256:b003dcfdc04776035b51d9cdc03f90d62cc70c745da321ae29e182075bf2845d
+            ghcr.io/internationalcolorconsortium/iccdev@sha256:7cc0354c9a37671a681f20df9cdc164bd4859c7ccb40e50d60ffa510fcb2d628
         with:
           command: >-
             addpath('matlab');

--- a/.github/workflows/ci-pr-action.yml
+++ b/.github/workflows/ci-pr-action.yml
@@ -91,7 +91,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  REGRESSION_IMAGE_TAG: sha-b28cafe490a14bf1decbcef0e6caa56e1308f707
+  REGRESSION_IMAGE_TAG: sha-b572e9720aea9d306d39ee667967a1293dcf1bac
 
 jobs:
   detect-src:

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1998,6 +1998,85 @@ function(iccdev_add_iccviz_pdf_axis_test)
   endif()
 endfunction()
 
+# Guards the Mini{PDF,SVG,TIFF} serialization seam added for #2116.
+#
+# The three iccviz tests above all stop at the data layer or drive the whole CLI;
+# nothing exercised the byte-generating layer in isolation, and nothing could,
+# because the only entry to it was a CLI function that derives every output path
+# from the input path.  #2116 split out PDFWriter::Serialize(ostream&),
+# SVGOut::Serialize(ostream&) and a WriteTIFF overload taking an already-open
+# FILE*; this test asserts the split is behaviour-preserving (each writer emits
+# identical bytes through the stream path and the file path), and drives the
+# TIFF writer with the real engine's rasters so its IFD layout and offset
+# arithmetic execute -- under the sanitizer lanes, for the first time.
+#
+# It also pins the raster geometry contract that keeps that arithmetic in range.
+# MiniTIFF.cpp does check its stream-derived quantities (ftell failure, strip
+# offsets past UINT32_MAX, a short fwrite), but not the geometry handed to it:
+# width/height/channels/depth are guarded only by assert()s that a default
+# Release build compiles out.  The guards that make them safe live in
+# buildClutRaster (IccVizModel.cpp) instead, so the invariant spans two files
+# and was written down in neither.
+#
+# The Mini* writers are not in any library: they are listed directly in the
+# iccProfileVisualizePlot executable, so this test compiles the same three
+# translation units.  Deliberately the Tools/CmdLine/IccProfilePlot copy -- there
+# is a second, diverged copy under Tools/CmdLine/IccProfileVisualize that also
+# ships, and this test says nothing about it (#2116 records that split).
+# IccVizEngine supplies IccVizModel.cpp plus the engine include directory (#1975).
+function(iccdev_add_iccviz_writer_serialization_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+  if(NOT TARGET IccVizEngine)
+    return()
+  endif()
+
+  set(_viz_writer_dir "${ICCDEV_REPO_ROOT}/Tools/CmdLine/IccProfilePlot")
+  iccdev_add_regression_executable(iccVizWriterSerializationTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/iccviz-writer-serialization.cpp"
+    "${_viz_writer_dir}/MiniPDF.cpp"
+    "${_viz_writer_dir}/MiniSVG.cpp"
+    "${_viz_writer_dir}/MiniTIFF.cpp"
+  )
+  target_compile_features(iccVizWriterSerializationTest PRIVATE cxx_std_17)
+  # Name the writer directory explicitly rather than relying on IccVizEngine's
+  # interface include path to supply Mini*.hpp.  The two happen to be the same
+  # directory today, but the sources above are pinned to this copy by absolute
+  # path, and the other copy has no Serialize declaration -- so if the engine's
+  # include dir ever moved, the headers and the sources could silently come from
+  # different copies.
+  target_include_directories(iccVizWriterSerializationTest PRIVATE "${_viz_writer_dir}")
+  target_link_libraries(iccVizWriterSerializationTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB} IccVizEngine)
+  add_dependencies(check iccVizWriterSerializationTest)
+
+  add_test(
+    NAME iccdev.iccviz-writer-serialization
+    COMMAND "$<TARGET_FILE:iccVizWriterSerializationTest>"
+      "${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc"
+      "${ICCDEV_TEST_OUTDIR}/iccviz-writer-serialization"
+  )
+  set_tests_properties(iccdev.iccviz-writer-serialization PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofileplot;viz;pdf;svg;tiff;issue-2116;regression"
+  )
+  if(WIN32)
+    set(_iccviz_writer_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccVizWriterSerializationTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _iccviz_writer_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.iccviz-writer-serialization PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_iccviz_writer_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # Guards the IccVizModel CLUT->raster lattice walk against heap-buffer-overflow
 # reads (#1548): buildClutRaster() derived its tile-packing geometry
 # (tiles/tileWidth/tileHeight strides) from the grid arrangement, NOT from the
@@ -4496,6 +4575,7 @@ if(WIN32)
   iccdev_add_iccviz_metrics_test()
   iccdev_add_iccviz_degenerate_test()
   iccdev_add_iccviz_pdf_axis_test()
+  iccdev_add_iccviz_writer_serialization_test()
   iccdev_add_iccprofileplot_clut_oob_test()
   iccdev_add_iccprofileplot_pdf_leak_test()
   iccdev_add_iccprofileplot_exitcode_test()
@@ -4769,6 +4849,7 @@ iccdev_add_dpcc_pcc_replacement_test()
 iccdev_add_iccviz_metrics_test()
 iccdev_add_iccviz_degenerate_test()
 iccdev_add_iccviz_pdf_axis_test()
+iccdev_add_iccviz_writer_serialization_test()
 iccdev_add_iccprofileplot_clut_oob_test()
 iccdev_add_iccprofileplot_pdf_leak_test()
 iccdev_add_iccprofileplot_exitcode_test()

--- a/Tools/CmdLine/IccProfilePlot/MiniPDF.cpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniPDF.cpp
@@ -162,6 +162,21 @@ void PDFWriter::OpenFile( const std::string &filename, float widthPt, float heig
 
 /******************************************************************************/
 
+// Serialize the document into `out`. Every byte the PDF writer emits is
+// produced here, so this is also the hermetic entry a test or fuzz harness
+// drives (#2116) -- see the declaration in MiniPDF.hpp for why it is split out.
+// Object cleanup stays in CloseFile: the objects must survive this call so it
+// can be repeated, and the caller may still add pages afterwards.
+void PDFWriter::Serialize( std::ostream &out )
+{
+  WriteHeader(out);
+  WriteObjects(out);
+  WriteXRefs(out);
+  WriteFooter(out);
+}
+
+/******************************************************************************/
+
 void PDFWriter::CloseFile()
 {
   if (!m_filename.empty()) {
@@ -169,10 +184,10 @@ void PDFWriter::CloseFile()
         try  {
           std::ostringstream out;
           out.exceptions(std::ios::badbit | std::ios::failbit);
-          WriteHeader(out);
-          WriteObjects(out);
-          WriteXRefs(out);
-          WriteFooter(out);
+          // The four Write* calls this replaced now live in Serialize(); the
+          // exception mask above is still set here, because catching is this
+          // function's job and not Serialize's.
+          Serialize(out);
 
           // PDF export paths are intentional caller-selected output files after regular-file validation.
 

--- a/Tools/CmdLine/IccProfilePlot/MiniPDF.hpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniPDF.hpp
@@ -277,6 +277,26 @@ public:
   void OpenFile( const std::string &filename, float pageWidth, float pageHeight );
   void CloseFile();
 
+  // Write the complete PDF document to `out` -- header, object graph, xref
+  // offset table, trailer -- with no filesystem access, and WITHOUT freeing the
+  // object list (CloseFile still owns that).  CloseFile() is the file-writing
+  // wrapper around this call.
+  //
+  // Split out so the byte-generating layer has a hermetic entry: everything
+  // downstream of iccviz::RenderGraph -- the object offsets recorded in
+  // WriteObjects, the fixed-width xref table, the page tree -- was unreachable
+  // from a test or fuzz harness while it was buried inside a function that
+  // opens a file derived from the input path (#2116).
+  //
+  // Deliberately free of CloseFile's two policies, so it stays a serializer and
+  // nothing else:
+  //   * it does not catch -- a caller wanting CloseFile's behaviour sets
+  //     out.exceptions(badbit | failbit) and handles the throw itself;
+  //   * it does not skip empty documents. CloseFile writes no file when
+  //     PageCount() == 0; Serialize always emits a document, pages or not, so a
+  //     caller that wants the file-path behaviour checks PageCount() first.
+  void Serialize( std::ostream &out );
+
 public:
 
   void AddXObject( const Rect2D &bounds, std::string &content, std::string name,

--- a/Tools/CmdLine/IccProfilePlot/MiniSVG.cpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniSVG.cpp
@@ -87,8 +87,11 @@ void SVGOut::OpenFile( const std::string &filename )
 
 /******************************************************************************/
 
-void SVGOut::CloseFile()
+void SVGOut::Finalize()
 {
+  // Idempotent by construction: m_pageInProgress is cleared as the group is
+  // closed, so a second call adds nothing to m_buf and the document bytes are
+  // the same however many times Serialize() and CloseFile() run.
   if (m_pageInProgress) {
     m_buf << "</g>\n";
     m_pageInProgress = false;
@@ -98,6 +101,29 @@ void SVGOut::CloseFile()
     fprintf(stderr,"WARNING - SVG group levels not closed.\n");
   if (m_GroupLevel < 0)
     fprintf(stderr,"WARNING - Too many SVG group levels closed.\n");
+}
+
+/******************************************************************************/
+
+// Every byte the SVG writer emits is produced here (#2116). The body was
+// already accumulated in the m_buf ostringstream; only the header and footer
+// used to go straight to the std::ofstream, which is what kept this layer off
+// limits to a harness.
+void SVGOut::Serialize( std::ostream &out )
+{
+  Finalize();
+  WriteHeader(out);
+  out << m_buf.str();
+  WriteFooter(out);
+}
+
+/******************************************************************************/
+
+void SVGOut::CloseFile()
+{
+  // Runs whether or not a file was ever opened, exactly as this function's
+  // first half always did.
+  Finalize();
 
   if (!m_filename.empty()) {
     if (m_pageCount > 0) {

--- a/Tools/CmdLine/IccProfilePlot/MiniSVG.hpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniSVG.hpp
@@ -150,6 +150,30 @@ public:
   void OpenFile( const std::string &filename );
   void CloseFile();
 
+  // Close the page group still open and report unbalanced StartGroup/EndGroup
+  // pairs.  This was the first half of CloseFile(), which ran it whether or not
+  // a file was ever opened; it is separate now so Serialize() gets the same
+  // well-formed document without going through the file path (#2116).
+  //
+  // Idempotent as far as the document is concerned: closing the page group
+  // clears m_pageInProgress, so repeated calls add nothing to the body and
+  // every serialization of the same writer yields the same bytes.  An
+  // unbalanced-group warning is re-emitted per call; it reports a caller error
+  // and carries no document state.
+  void Finalize();
+
+  // Write the complete SVG document to `out` -- header, accumulated body,
+  // footer -- with no filesystem access.  CloseFile() is the file-writing
+  // wrapper around this call (#2116).
+  //
+  // Does NOT apply CloseFile's skip-empty-document policy: CloseFile writes no
+  // file when PageCount() == 0, whereas this always emits a document -- and for
+  // a pageless writer WriteHeader computes height = m_pageHeight * 0, giving a
+  // degenerate <svg height="0">.  A caller that wants the file-path behaviour
+  // checks PageCount() first; keeping the policy out of here is what makes this
+  // a plain serializer.
+  void Serialize( std::ostream &out );
+
 public:
 
   void AddCircle( float radius, float xCenter, float yCenter, bool isFilled ) {

--- a/Tools/CmdLine/IccProfilePlot/MiniTIFF.cpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniTIFF.cpp
@@ -210,12 +210,61 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
         size_t width, size_t height, int channels, int depth )
 {
   FILE *outfile = NULL;
-  bool writeFailed = false;
 
   // see if we can create or update this filename
   outfile = icOpenWriteBinaryFile(name.c_str());
   if(outfile==NULL) {
     fprintf(stderr,"Could not create output file %s\n", name.c_str());
+    return false;
+  }
+
+  // The stream overload owns none of the file's lifetime, so closing it is this
+  // wrapper's job on every path -- including the failure paths, which used to
+  // fclose() inline before the split (#2116).
+  bool wroteOk = WriteTIFF( outfile, name, dpi, color_model, buffer,
+                            width, height, channels, depth );
+
+  bool closedOk = icFlushAndClose(outfile);
+
+  // Report the close failure only when the write itself succeeded. Every inner
+  // failure path is reached with ferror() already set, and icFlushAndClose
+  // treats ferror as failure, so reporting unconditionally would print a
+  // second, redundant line after every real write error -- where the pre-split
+  // code called a bare fclose() and printed only the specific message. Keeping
+  // the condition here is what makes this split stderr-identical on the failure
+  // paths as well as the success path.
+  if (!closedOk && wroteOk) {
+    fprintf(stderr, "ERROR: fclose failed for %s\n", name.c_str() );
+    return false;
+  }
+
+  return wroteOk && closedOk;
+}
+
+/******************************************************************************/
+
+/// Write the image buffer as a TIFF into an already-open binary stream.
+/// See MiniTIFF.hpp: the stream is NOT closed here, on any path.
+bool WriteTIFF( FILE *outfile, const std::string &name, float dpi, int color_model,
+        uint8_t *buffer, size_t width, size_t height, int channels, int depth )
+{
+  bool writeFailed = false;
+
+  if (outfile == NULL)
+    return false;
+
+  // The stream must start at offset 0. Every layout constant below is absolute
+  // from the start of the FILE, not relative to where writing began: the header
+  // hard-codes 8 as the first-IFD offset, and for the single-strip case the
+  // STRIPOFFSETS tag is written from the computed pixelData_offset rather than
+  // from the ftell-derived stripStart. Appending to a non-empty stream would
+  // therefore emit a TIFF whose offsets are all short by the entry position --
+  // and silently, because the ftell-based backfill further down still lands in
+  // the right place, so nothing here would return false. Refuse instead.
+  long startPos = ftell( outfile );
+  if (startPos != 0) {
+    fprintf(stderr, "ERROR: TIFF writer requires a stream positioned at 0 (%s)\n",
+            name.c_str() );
     return false;
   }
 
@@ -235,7 +284,6 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   // check for early failure
   if (writeFailed || ferror(outfile)) {
     fprintf(stderr, "ERROR: I/O error writing TIFF header to %s\n", name.c_str() );
-    fclose(outfile);
     return false;
   }
 
@@ -302,7 +350,6 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   long byteCountOffset = ftell( outfile );
   if (byteCountOffset < 0) {
     fprintf(stderr, "ERROR: TIFF ftell failed\n");
-    (void)fclose(outfile);
     return false;
   }
   if (stripCount > 1)
@@ -372,7 +419,6 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
   // check again after writing the tag directory
   if (writeFailed || ferror(outfile)) {
     fprintf(stderr, "ERROR: I/O error writing TIFF directory to %s\n", name.c_str() );
-    fclose(outfile);
     return false;
   }
 
@@ -399,21 +445,18 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
     long stripStart = ftell( outfile );
     if (stripStart < 0 || (unsigned long)stripStart > UINT32_MAX) {
       fprintf(stderr, "ERROR: TIFF strip offset exceeds 32-bit range\n");
-      fclose(outfile);
       return false;
     }
 
     size_t pixelBytes = (size_t)width * (size_t)channels * (size_t)(depth/8);
     if (fwrite( buffer + offset, pixelBytes, rowCount, outfile ) != rowCount) {
       fprintf(stderr, "ERROR: TIFF failed to write pixel data\n");
-      fclose(outfile);
       return false;
     }
 
     long stripEnd = ftell( outfile );
     if (stripEnd < 0 || (unsigned long)stripEnd > UINT32_MAX) {
       fprintf(stderr, "ERROR: TIFF strip end offset exceeds 32-bit range\n");
-      fclose(outfile);
       return false;
     }
     stripOffsetList[strip] = uint32_t(stripStart);
@@ -439,15 +482,11 @@ bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *bu
 
   if (writeFailed || ferror(outfile)) {
     fprintf(stderr, "ERROR: I/O error writing TIFF data to %s\n", name.c_str() );
-    fclose(outfile);
     return false;
   }
 
-  if (!icFlushAndClose(outfile)) {
-    fprintf(stderr, "ERROR: fclose failed for %s\n", name.c_str() );
-    return false;
-  }
-
+  // No close here: the stream belongs to the caller (see MiniTIFF.hpp). The
+  // name-taking overload flushes and closes it for the CLI path.
   return true;
 }
 

--- a/Tools/CmdLine/IccProfilePlot/MiniTIFF.hpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniTIFF.hpp
@@ -137,6 +137,37 @@ enum {
 bool WriteTIFF( const std::string &name, float dpi, int color_model, uint8_t *buffer,
                 size_t width, size_t height, int channels, int depth );
 
+// Same writer against an already-open binary stream. Every byte of the IFD
+// layout and all of the offset/strip arithmetic lives here; the name-taking
+// overload above is now a thin open/close wrapper around it.
+//
+// Ownership of `outfile` stays with the caller: this function never closes it,
+// on success or on any failure path, so a test or fuzz harness can drive the
+// whole layout against tmpfile() and then read the bytes back. `diagName` only
+// labels the stderr diagnostics -- it is never opened -- so a harness can pass
+// any string it likes.
+//
+// PRECONDITION: the stream must be positioned at offset 0, and it is checked.
+// The layout constants are absolute from the start of the file, so appending a
+// second image to one stream would produce a TIFF whose offsets are short by
+// the entry position -- and would do it silently, since the ftell-based backfill
+// would still land correctly. One image per stream.
+//
+// Split out because the arithmetic here is profile-controlled (the dimensions
+// come straight from a CLUT via iccviz::RenderRaster) yet nothing downstream of
+// RenderRaster was reachable without writing files derived from the input path
+// (#2116).
+//
+// Note which quantities are checked and which are not. The stream-derived ones
+// are: ftell failure, strip offsets past UINT32_MAX and a short fwrite all
+// return false. The caller-supplied geometry is not -- width, height, channels
+// and depth size every row and strip below with no returning check, guarded
+// only by assert()s that a default Release build (-DNDEBUG) compiles out. The
+// contract that keeps them in range is the caller's to hold, not this
+// function's; iccviz::buildClutRaster is what holds it today.
+bool WriteTIFF( FILE *outfile, const std::string &diagName, float dpi, int color_model,
+                uint8_t *buffer, size_t width, size_t height, int channels, int depth );
+
 /******************************************************************************/
 
 #endif /* MiniTIFF_hpp */


### PR DESCRIPTION
## Summary

`iccProfileVisualizePlot` is two layers, and only one of them was reachable from a test.

The data layer — `iccviz::Enumerate` / `RenderGraph` / `RenderRaster` — already has coverage: two CTests from #1712, plus the in-process CFL harness on `ci-qa-issue-1975`, whose raster observer reads `result.raster.samples.size()` and stops there. Everything below that boundary, which is where bytes are actually produced, ran only when the CLI ran. The only way in was `processLuts()`, which derives every output path from the input path and writes a PDF plus N TIFFs per call — so no harness could reach the writers without a filesystem.

This adds the seam #2116 asked for, and the coverage that makes it worth having.

## The seam

In the `Tools/CmdLine/IccProfilePlot/` copy only (see Scope):

| | change |
|---|---|
| **MiniPDF** | `PDFWriter::Serialize(std::ostream&)`. `CloseFile` already assembled the whole document in an `ostringstream` and only touched the filesystem in its last few lines, so this is close to free. Object cleanup deliberately stays in `CloseFile`, so `Serialize` can be repeated and the recorded object offsets come out the same both times. |
| **MiniSVG** | `SVGOut::Serialize(std::ostream&)`, plus `SVGOut::Finalize()` for the page/group close that `CloseFile` always ran whether or not a file was opened. |
| **MiniTIFF** | `WriteTIFF(FILE*, ...)` — the entire IFD layout and every offset computation, against an already-open stream it never closes. The name-taking overload becomes an open/call/close wrapper. **Not one byte of the arithmetic moved.** |

## Why this layer earns an instrument — and a correction to my own issue text

The dimensions `WriteTIFF` computes file offsets from are profile-controlled: they come out of a CLUT via `RenderRaster` and reach the writer unmodified (`iccProfileVisualize.cpp:1388`).

**I overstated this in #2116 and am correcting it here.** I wrote that "those three `assert()`s are the only bounds guards in the file". That is wrong — `MiniTIFF.cpp` has eleven returning checks, several of them genuine bounds checks. The accurate split is:

- **Checked** (stream-derived): `ftell` failure, strip offsets past `UINT32_MAX`, a short `fwrite`, a non-finite or out-of-range dpi.
- **Unchecked** (profile-derived): `width`, `height`, `channels`, `depth`. These size every row and strip with no returning check, guarded only by three `assert()`s that a default Release build compiles out — `-DNDEBUG` is present in this tree's Release `CXX_FLAGS`, verified rather than assumed.

So the checked quantities come from the stream and the unchecked ones come from the profile. That is a sharper statement than the one I filed, not a weaker one.

**This is still not a live bug and this PR does not claim one.** `buildClutRaster` (`IccVizModel.cpp:819-834`) refuses non-positive geometry and caps the buffer at 256 MB, so every raster the engine can emit is already in range. The finding is that the contract keeping the writer's unchecked arithmetic safe is enforced in a *different file* and was written down in neither.

## The test

`iccdev.iccviz-writer-serialization`, registered in **both** CMake invocation lists:

1. **PDF** — `Serialize(ostream)` and `CloseFile()` produce identical bytes (line-ending-normalized; see the review round for why).
2. **SVG** — same, plus a repeated `Serialize` of the same writer, compared strictly since both sides are in memory. This is `SVGOut`'s first execution of any kind: the tool declares functions taking `SVGOut&` but never constructs one.
3. **TIFF** — the `FILE*` and name-taking overloads produce identical bytes, driven by the real engine's rasters (4 on the stock sRGB v4 profile), so the IFD layout executes under the sanitizer lanes.
4. **The geometry contract** above, asserted against whatever the engine actually produces.
5. **Structural cross-check** — the emitted IFD's width/height/samples-per-pixel and strip byte count against the raster they came from, so two identically-wrong outputs cannot pass an A-equals-B pin.

It also fails if the engine yields no rasters at all, so the TIFF cases cannot silently check nothing.

### Every case was measured red — and one did not survive

A latch making `Finalize()` idempotent was in the first draft, with a test case named after it. Removing the latch left that case **green**: closing the page group already clears `m_pageInProgress`, so by the time `CloseFile` runs the flag is false either way. The latch is gone and the case is now a second `Serialize()` of the same writer, which *does* fail when that guard is dropped.

The rest were confirmed by mutation, each turning the relevant assertion red:

| mutation | result |
|---|---|
| object cleanup moved into `PDFWriter::Serialize` | 2 PDF cases red |
| drop the `m_pageInProgress` guard | 3 SVG cases red |
| write a wrong `TIFF_WIDTH` | 4 red on IFD geometry — byte-equality stays **green**, which is exactly why level 5 exists |
| halve the strip byte count | 4 red |
| engine declares one channel too many | 4 red (sample-buffer contract) |
| engine emits a negative width | 4 red (geometry contract) |
| hand the `FILE*` overload a stream at offset 1 | refused, proved with a standalone probe |
| run on a CLUT-free profile | zero-raster guard red |

## Behaviour preservation — measured, not assumed

`iccProfileVisualizePlot` built from `b5f8def1` and from this branch produce **byte-identical output for all five files** on `sRGB_v4_ICC_preference.icc` (four `.tif`, one `.pdf`), with identical stderr. The same holds for the ASan/UBSan/LSan build of the CLI, which also re-walks the PDF object-cleanup path #1547 fixed.

stderr parity holds on the **failure** paths too, not just the success path — see the review round below for why that needed a deliberate condition rather than falling out for free.

## Pre-flight

| lane | result |
|---|---|
| Strict clang Release — `-Wall -Wextra -Wpedantic -Werror`, "strict warnings ENABLED (Clang 21.1.3)" | `grep -cE 'warning:'` = **0** (lib+tools and `build-test-binaries`) |
| GCC 15 in CI's pinned container (`sha-b28cafe4…`) — same flags + `-DENABLE_LTO=ON`, "strict warnings ENABLED (GNU 15.2.0)" | **0** |
| Clang ASan+UBSan+IntSan Debug in the same container — `-Werror -g -O0`, `-DENABLE_SANITIZERS=ON` | **0** |
| Full local `ctest` | 177/178; the one failure is `spectral-tiff-preview`, a missing local `imagecodecs` Python module, unrelated |
| Sanitized `ctest` in the container, **vs a master baseline** | this branch fails 9, master `b5f8def1` fails 11 under the identical config — my 9 are a strict subset, so **zero new failures**. Note this config is *harsher than CI*: it left `SANITIZER_RECOVER` at its `OFF` default (CI sets `ON` in `Dockerfile.ci-regression:218` and `ci-iccdev-tool-tests.yml:398`) and enabled IntSan, which CI's `SAN_FLAGS` does not. The 9 are pre-existing UB findings made fatal by that. The 2 extra on master are the known `tool-coverage` / `hybrid-pipeline` `-j` flakes. |
| New test under ASan/UBSan with `detect_leaks=1` | clean (CI's ctest env sets `detect_leaks=0`, so this was run explicitly) |

No shell or workflow files changed, so the shellcheck pre-flight gate does not apply.

## Review round

`/code-review` at high effort found a **certain-red Windows defect** that three green strict lanes and a passing red/green suite had not:

- **PDF and SVG byte-compares would have failed on every Windows ctest leg.** Both writers emit through *text* streams (`icOpenRegularWriteTextFile` is `fopen(name, "wt")`; `SVGOut` uses a default-mode `ofstream`), so a Windows CRT expands every `\n` on the way out, while `Serialize`'s `ostringstream` expands nothing. Fixed by normalizing line endings for those two comparisons and leaving TIFF strict. Verified by re-emitting this test's own output in CRLF — 1450 vs 1371 bytes for the PDF, 508 vs 498 for the SVG, equal after normalization. Reading back in text mode would also work on a typical CRT but was rejected: C17 7.21.2p2 does not promise a text round-trip for lines ending in a space, and this PDF's xref entries end in `"n \n"`.
- **The TIFF overload's precondition was undocumented.** The layout constants are absolute from file start, so appending a second image would emit offsets short by the entry position *silently*, since the `ftell`-based backfill still lands correctly. Now documented **and enforced**, proved with a probe: a fresh stream writes, a stream at offset 1 is refused.
- **Failure-path stderr parity.** Every inner failure path is reached with `ferror()` already set and `icFlushAndClose` treats that as failure, so the wrapper would have printed a second redundant line after every real write error. It now reports a close failure only when the write succeeded — making the "identical stderr" claim hold on failure paths, not just the success path.
- Also folded in: both `Serialize` overloads now document that they do *not* apply `CloseFile`'s skip-empty-document policy, and the test names its writer include directory explicitly rather than inheriting it from `IccVizEngine`.

All mutations were re-run after these changes; the counts in the table above are from that second pass.

`/security-review` returned no HIGH or MEDIUM findings. It noted that the `FILE*` overload is a second entry to an existing trust boundary rather than a new one — the same unvalidated geometry was already reachable through the name-taking overload — and that `Serialize` after `CloseFile` iterates an emptied vector, so there is no use-after-free.

### One finding spun out, not fixed here

`PDFWriter::CloseFile` records xref offsets against the in-memory `ostringstream` but writes the result through a **text-mode** `FILE*`, so on Windows every xref entry is understated by the number of preceding newlines and a strict PDF reader cannot use the table. **Pre-existing**, and the one-word fix (`icOpenRegularWriteBinaryFile`) changes the bytes this tool writes on Windows — a different change with different review needs, which I cannot exercise locally. Flagging rather than folding it in silently. Happy to file it if wanted.

## Scope and non-goals

- **The `IccProfilePlot` copy only.** A second, diverged copy of these writers ships under `Tools/CmdLine/IccProfileVisualize` (five writer translation units total) and is untouched. #2116 records that split; this PR says nothing about the other copy.
- **No de-duplication of the two copies**, and no restructuring of the writers beyond the seam.
- **`processLuts` stays `static`** — that part of #1975 was declined on the evidence and nothing here revisits it.

## Not in this PR

Scope item 2 of #2116, the CFL harness, is deliberately left out. It needs the in-process build scaffolding that exists only on `ci-qa-issue-1975` (compiling `IccVizModel.cpp` as a separate TU and linking the static lib), and adding a second copy of that scaffolding on master would collide with that branch on rebase. A harness source with no build wiring would also be dead code.

The seam is what the existing harness needs: `cfl/icc_profilevisualize_fuzzer.cpp`'s `observeRaster` can now call `WriteTIFF(tmpfile(), ...)` instead of reading `samples.size()`. Happy to write that half against `ci-qa-issue-1975` if wanted.

Part of #2116
