### PR TITLE
test(#2116): harvest the CFL visualization harnesses and add the writer serialization target

### DIFF
--- a/.github/prompts/maintainer-afl-smoke.prompt.md
+++ b/.github/prompts/maintainer-afl-smoke.prompt.md
@@ -38,9 +38,20 @@ version. For Clang/LLVM 22, build AFL++ `dev` with `CC=clang-22`,
 `afl-showmap`, `afl-cc`, `afl-compiler-rt.o`,
 `SanitizerCoveragePCGUARD.so`, and `cmplog-routines-pass.so`.
 
-The current core onboarding target set is
-`dump,toxml,fromxml,tojson,fromjson,roundtrip`. Stabilize those targets before
-adding more command-line tools.
+The target sets differ per lane, and are not interchangeable.
+
+- **AFL** accepts `dump,toxml,fromxml,tojson,fromjson,roundtrip,fromcube` — see
+  the allow-list in `.github/scripts/iccdev-afl-smoke.sh`.
+- **CFL** accepts
+  `dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize`.
+
+The two in-process targets are CFL-only; passing them to the AFL lane is an
+error. The first six CFL
+targets are command-line wrappers. `profilevisualize` and `writerserialize` are
+in-process public-API harnesses: compile the engine sources separately, include
+only public headers, and do not include a CLI implementation or call
+`processLuts()`. `writerserialize` additionally links `Mini{PDF,SVG,TIFF}.cpp`,
+whose serialization entries are not reachable through `IccVizModel` alone.
 
 Manual dispatches should expose the same operator controls on AFL and CFL:
 `target_ref` for a branch, tag, or ref, optional `target_sha` for a full
@@ -78,7 +89,7 @@ shellcheck .github/scripts/iccdev-afl-smoke.sh
 actionlint .github/workflows/ci-afl-smoke.yml
 yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci-afl-smoke.yml
 .github/scripts/iccdev-afl-smoke.sh --seconds 10 --targets dump --exec-timeout-ms 30000
-cfl/build.sh --targets dump,toxml,fromxml,tojson,fromjson,roundtrip --seconds 30
+cfl/build.sh --targets dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize --seconds 30
 ```
 
 Run `.github/scripts/preflight-safety-checks.sh --require-tools` before pushing

--- a/.github/skills/afl-smoke/SKILL.md
+++ b/.github/skills/afl-smoke/SKILL.md
@@ -29,7 +29,7 @@ Use this skill when changing `.github/workflows/ci-afl-smoke.yml`,
 
    ```bash
    .github/scripts/iccdev-afl-smoke.sh --seconds 10 --targets dump --exec-timeout-ms 30000
-   cfl/build.sh --targets dump,toxml,fromxml,tojson,fromjson,roundtrip --seconds 30
+   cfl/build.sh --targets dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize --seconds 30
    ```
 
 4. When changing AFL++ bootstrap behavior, validate the regression-container
@@ -75,9 +75,18 @@ Use this skill when changing `.github/workflows/ci-afl-smoke.yml`,
   `cmplog-routines-pass.so`. Avoid broad AFL++ targets that enter optional GCC
   plugin or Nyx paths.
 - Keep the target allow-list inside `.github/scripts/iccdev-afl-smoke.sh`.
-- Keep core onboarding focused on
-  `dump,toxml,fromxml,tojson,fromjson,roundtrip` until those AFL/CFL lanes are
-  stable.
+- Keep the two lanes' target sets distinct. AFL onboarding stays
+  `dump,toxml,fromxml,tojson,fromjson,roundtrip,fromcube` (the allow-list
+  above); CFL adds the two in-process targets,
+  `dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize`.
+  `profilevisualize` and `writerserialize` are CFL-only and are rejected by the
+  AFL runner. The first six CFL
+  targets remain CLI-fidelity wrappers. Build `profilevisualize` and
+  `writerserialize` in-process through public headers, with the engine sources
+  in separate translation units; never include a CLI implementation or call
+  `processLuts()` from either harness. `writerserialize` also links
+  `Mini{PDF,SVG,TIFF}.cpp` to reach the serialization entries (#2116), and
+  needs a corpus that still contains a CLUT seed (#2120).
 - Use `.github/ci/fuzz-patches/afl` and `.github/ci/fuzz-patches/cfl` for
   maintainer-local patch stacks when `--patches` is requested.
 - Keep `ci-docker.yml` push paths and regression-image verification in sync

--- a/.github/workflows/ci-cfl-smoke.yml
+++ b/.github/workflows/ci-cfl-smoke.yml
@@ -5,7 +5,7 @@
 #                 All rights reserved.
 #                 https://color.org
 #
-# Intent: Manual CFL smoke fuzzing for core iccDEV command-line tools.
+# Intent: Manual CFL smoke fuzzing for core iccDEV interfaces.
 #
 ###############################################################
 
@@ -31,9 +31,9 @@ permissions:
         default: ''
         type: string
       cfl_targets:
-        description: 'Comma-separated CFL targets: dump,toxml,fromxml,tojson,fromjson,roundtrip'
+        description: 'CFL targets: dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize'
         required: true
-        default: dump,toxml,fromxml,tojson,fromjson,roundtrip
+        default: dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize
         type: string
       duration_seconds:
         description: 'LibFuzzer seconds per target, 1-3600; total selected runtime <= 5400'
@@ -68,7 +68,7 @@ permissions:
       cfl_targets:
         description: 'Comma-separated CFL targets'
         required: false
-        default: dump,toxml,fromxml,tojson,fromjson,roundtrip
+        default: dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize
         type: string
       duration_seconds:
         description: 'LibFuzzer seconds per target, 1-3600; total selected runtime <= 5400'
@@ -106,7 +106,7 @@ jobs:
         shell: bash --noprofile --norc {0}
     env:
       BASH_ENV: /dev/null
-      ICCDEV_CFL_TARGETS_INPUT: ${{ inputs.cfl_targets || 'dump,toxml,fromxml,tojson,fromjson,roundtrip' }}
+      ICCDEV_CFL_TARGETS_INPUT: ${{ inputs.cfl_targets || 'dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize' }}
       ICCDEV_CFL_SECONDS_INPUT: ${{ inputs.duration_seconds || '30' }}
       ICCDEV_CFL_PATCH_MODE_INPUT: ${{ inputs.patch_mode || 'all' }}
       TARGET_REF_INPUT: ${{ inputs.target_ref || github.ref }}
@@ -181,7 +181,7 @@ jobs:
         working-directory: target
         env:
           BASH_ENV: /dev/null
-          ICCDEV_CFL_TARGETS: ${{ inputs.cfl_targets || 'dump,toxml,fromxml,tojson,fromjson,roundtrip' }}
+          ICCDEV_CFL_TARGETS: ${{ inputs.cfl_targets || 'dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize' }}
           ICCDEV_CFL_SECONDS: ${{ inputs.duration_seconds || '30' }}
           ICCDEV_CFL_APPLY_PATCHES: ${{ (inputs.patch_mode || 'all') == 'all' && '1' || '0' }}
           ICCDEV_FUZZ_PATCH_APPLICATOR: ${{ github.workspace }}/workflow-scripts/.github/scripts/iccdev-apply-fuzz-patches.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,6 +47,34 @@ shares one source of truth. Update rules here, not in the mirrors.
 | Python/Cython debug | `.github/prompts/debug-python-bindings.prompt.md` |
 | Documentation maintenance | `docs/documentation-maintenance.md` |
 
+## CFL Harness Scope
+
+Keep the six command-line CFL targets as filesystem-backed CLI wrappers. The
+in-process targets are the intentional exceptions: consume only public headers,
+compile the engine sources as separate translation units, and never include a
+CLI implementation or call `processLuts()`.
+
+| target | consumes | covers |
+| --- | --- | --- |
+| `icc_profilevisualize_fuzzer` | `IccVizModel.hpp` | the data-first model: `Enumerate`, `RenderGraph`, `RenderRaster` |
+| `icc_writerserialize_fuzzer` | `MiniPDF.hpp`, `MiniSVG.hpp`, `MiniTIFF.hpp` | the serialization layer the model feeds (#2116) |
+
+Keep them separate rather than folding serialization into the model target, so
+a crash stays attributable to one layer.
+
+An in-process target that needs a CLUT raster also needs a corpus that still
+contains one. `max_seed_bytes` and libFuzzer's `max_len` both removed the only
+CLUT-bearing seed at their old defaults (#2120), which left such a target
+reporting runs, coverage and a clean exit while never executing the layer it
+exists to cover. Both defaults now admit it, and dropping a seed committed
+under `.github/ci/test-data` is a hard error rather than a silent prune. Raise
+`max_len` alongside the cap when adding a target that consumes large structured
+inputs — they are independent gates. Validate with
+
+```bash
+cfl/build.sh --targets profilevisualize,writerserialize --seconds 30
+```
+
 ## WASM Scope
 
 WASM now ships as a staged Node/npm-style module package. Do not expect or

--- a/cfl/README.md
+++ b/cfl/README.md
@@ -1,8 +1,8 @@
 # CFL Smoke Fuzzing
 
 This directory contains the maintainer-owned CFL smoke entry point for the
-current AFL/CFL onboarding branch. It intentionally starts with the core
-iccDEV command-line surfaces:
+current AFL/CFL onboarding branch. It covers the core iccDEV command-line
+surfaces and the public profile-visualization model:
 
 The CFL smoke harnesses are experimental maintainer validation scaffolding.
 They are registered for manual or reusable workflow use from `master` and
@@ -17,6 +17,11 @@ input artifact.
 - `tojson`: `iccToJson input.icc output.json`
 - `fromjson`: `iccFromJson input.json output.icc`
 - `roundtrip`: `iccRoundTrip input.icc 1 0`
+- `profilevisualize`: parses an in-memory ICC profile, enumerates public
+  `IccVizModel.hpp` descriptors, and renders every graph or raster descriptor
+- `writerserialize`: renders the same descriptors and then serializes them
+  through `Mini{PDF,SVG,TIFF}` — the IFD layout and offset arithmetic, the PDF
+  object graph and xref table, and `SVGOut` (#2116)
 
 Run the local smoke with:
 
@@ -33,10 +38,34 @@ patch branches test local fixes before they are promoted to source PRs:
 cfl/build.sh --patches --seconds 30
 ```
 
-The default patch directory is `.github/ci/fuzz-patches/cfl`. The harnesses are
-CLI-fidelity wrappers: each libFuzzer input is written to a temporary file and
-replayed through the matching sanitized iccDEV tool. This keeps onboarding
-stable while deeper in-process harnesses mature separately.
+The default patch directory is `.github/ci/fuzz-patches/cfl`. The six command-
+line harnesses are CLI-fidelity wrappers: each libFuzzer input is written to a
+temporary file and replayed through the matching sanitized iccDEV tool.
+
+`profilevisualize` and `writerserialize` are in-process. They compile the engine
+sources as separate translation units and consume only public headers; do not
+include a CLI implementation file or call `processLuts()` from either.
+`writerserialize` links `Mini{PDF,SVG,TIFF}.cpp` in addition, because the
+serialization entries it drives are not reachable from `IccVizModel` alone.
+
+Build and run only the in-process harnesses with:
+
+```bash
+cfl/build.sh --targets profilevisualize,writerserialize --seconds 30
+```
+
+A CLUT-bearing seed has to survive into the corpus for either one to render a
+raster, and two independent gates used to remove the only such seed (#2120):
+`max_seed_bytes` deleted it from the corpus, and libFuzzer's `max_len`
+truncated whatever survived. Both defaults are now above it, and pruning a seed
+committed under `.github/ci/test-data` is a hard error rather than a silent
+`rm`, so a future oversized regression seed forces a decision about the cap
+instead of quietly costing coverage.
+
+Note the `.options` files are not read by `build.sh` — libFuzzer binaries do not
+consume them; they are the ClusterFuzz/OSS-Fuzz runner convention. `build.sh`
+passes `-max_len`, `-timeout`, `-rss_limit_mb` and `-use_value_profile`
+explicitly, so changing a value means changing it in both places.
 
 Do not commit generated `cfl/bin`, `.cfl-smoke`, build trees, crash artifacts,
 coverage output, or profiler data.

--- a/cfl/build.sh
+++ b/cfl/build.sh
@@ -7,23 +7,36 @@
 # This source file is licensed under the BSD 3-Clause "New" or "Revised"
 # License used by ICC software projects.
 #
-# Build and optionally smoke-test the core CFL command-line fuzzers.
+# Build and optionally smoke-test the core CFL fuzzers.
 ###############################################################################
 
 set -euo pipefail
 
 usage() {
   echo "Usage: $0 [--targets CSV] [--seconds N] [--build-dir DIR] [--work-dir DIR] [--patches [DIR]] [--skip-run]"
-  echo "Targets: dump, toxml, fromxml, tojson, fromjson, roundtrip"
+  echo "Targets: dump, toxml, fromxml, tojson, fromjson, roundtrip, profilevisualize, writerserialize"
 }
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 build_dir="${ICCDEV_CFL_BUILD_DIR:-$repo_root/build-cfl-smoke}"
 work_dir="${ICCDEV_CFL_WORK_DIR:-$repo_root/.cfl-smoke}"
-targets_csv="${ICCDEV_CFL_TARGETS:-dump,toxml,fromxml,tojson,fromjson,roundtrip}"
+targets_csv="${ICCDEV_CFL_TARGETS:-dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize}"
 seconds="${ICCDEV_CFL_SECONDS:-30}"
-max_seed_bytes="${ICCDEV_CFL_MAX_SEED_BYTES:-49152}"
+# Raised from 49152 to admit the whole committed seed corpus (#2120). The old
+# default sat below exactly one file in .github/ci/test-data --
+# fuzz-clut-hbo-69197729.icc at 61,015 bytes -- which is also the ONLY seed in
+# that corpus carrying a CLUT, i.e. the only one that reaches RenderRaster and
+# therefore the writers. Measured per seed: 1 of 11 reaches WriteTIFF, and it
+# was the one being pruned.
+#
+# IMPLICATION, deliberate: the icc seed corpus is shared, so this widens it for
+# ALL targets, not just the two in-process ones. The six fork/exec CLI targets
+# now also replay a 61 KB profile -- slower per execution, more coverage per
+# execution. Lower it per-run with ICCDEV_CFL_MAX_SEED_BYTES if that trade is
+# wrong for a given lane; dropping a committed seed is then a hard error rather
+# than a silent rm, so the choice stays visible (see prune_large_seeds).
+max_seed_bytes="${ICCDEV_CFL_MAX_SEED_BYTES:-262144}"
 apply_patches="${ICCDEV_CFL_APPLY_PATCHES:-0}"
 patch_dir="${ICCDEV_CFL_PATCH_DIR:-$repo_root/.github/ci/fuzz-patches/cfl}"
 skip_run=0
@@ -122,7 +135,7 @@ for target in "${requested_targets[@]}"; do
     exit 2
   fi
   case "$target" in
-    dump|toxml|fromxml|tojson|fromjson|roundtrip)
+    dump|toxml|fromxml|tojson|fromjson|roundtrip|profilevisualize|writerserialize)
       ;;
     *)
       echo "ERROR: unsupported CFL target: $target" >&2
@@ -137,8 +150,10 @@ for target in "${requested_targets[@]}"; do
   done
   selected_targets+=("$target")
 done
+cc="${CC:-clang}"
+cxx="${CXX:-clang++}"
 
-for tool in cmake clang++; do
+for tool in cmake "$cc" "$cxx"; do
   if ! command -v "$tool" >/dev/null 2>&1; then
     echo "ERROR: required tool not found: $tool" >&2
     exit 127
@@ -152,8 +167,8 @@ fi
 
 cmake -S "$repo_root/Build/Cmake" -B "$build_dir" \
   -DCMAKE_BUILD_TYPE=Debug \
-  -DCMAKE_C_COMPILER=clang \
-  -DCMAKE_CXX_COMPILER=clang++ \
+  -DCMAKE_C_COMPILER="$cc" \
+  -DCMAKE_CXX_COMPILER="$cxx" \
   -DCMAKE_C_FLAGS="-g -O1 -fno-omit-frame-pointer -fsanitize=address,undefined" \
   -DCMAKE_CXX_FLAGS="-g -O1 -fno-omit-frame-pointer -fsanitize=address,undefined" \
   -DENABLE_TOOLS=ON \
@@ -168,11 +183,92 @@ cmake --build "$build_dir" --parallel "$(nproc)"
 bin_dir="$script_dir/bin"
 mkdir -p "$bin_dir"
 for target in "${selected_targets[@]}"; do
-  clang++ -std=c++17 -g -O1 -fno-omit-frame-pointer \
+  # The library-linking targets are built by the loop below instead: they link
+  # iccDEV objects directly rather than fork/exec'ing a built CLI, so they do
+  # not come from icc_cli_fuzzer.cpp.
+  case "$target" in
+    profilevisualize|writerserialize) continue ;;
+  esac
+  "$cxx" -std=c++17 -g -O1 -fno-omit-frame-pointer \
     -fsanitize=fuzzer,address,undefined \
     -DICCDEV_CFL_TARGET="\"$target\"" \
     "$script_dir/icc_cli_fuzzer.cpp" \
     -o "$bin_dir/icc_${target}_fuzzer"
+done
+
+# Library-linking harnesses. Each one links iccDEV translation units directly,
+# so unlike the icc_cli_fuzzer.cpp targets above it needs its own source list.
+# Kept as a single loop with a per-target list rather than one copied block per
+# target: the same hand-maintained-list drift that #2034 fixed in the sanitizer
+# silence files applies here the moment a third target arrives.
+for target in "${selected_targets[@]}"; do
+  case "$target" in
+    profilevisualize|writerserialize) ;;
+    *) continue ;;
+  esac
+
+  profile_lib="$build_dir/IccProfLib/libIccProfLib2-staticd.a"
+  if [ ! -r "$profile_lib" ]; then
+    profile_lib="$build_dir/IccProfLib/libIccProfLib2-static.a"
+  fi
+  if [ ! -r "$profile_lib" ]; then
+    echo "ERROR: static IccProfLib library not found under $build_dir/IccProfLib" >&2
+    exit 1
+  fi
+
+  # Translation units this target links beside its own harness source.
+  # writerserialize adds the three writers because the serialization seam it
+  # drives (#2116) lives in Mini{PDF,SVG,TIFF}.cpp, which IccVizModel does not
+  # pull in -- that separation is exactly why the writers were unreachable from
+  # the data-API harness in the first place.
+  #
+  # Pinned to the IccProfilePlot copy by absolute path. There is a second,
+  # diverged copy of all three writers under Tools/CmdLine/IccProfileVisualize/
+  # and it has no Serialize declaration, so linking the wrong one would fail to
+  # compile rather than silently fuzz the other tool.
+  local_viz_dir="$repo_root/Tools/CmdLine/IccProfilePlot"
+  case "$target" in
+    profilevisualize)
+      extra_sources=( "$local_viz_dir/IccVizModel.cpp" )
+      ;;
+    writerserialize)
+      extra_sources=(
+        "$local_viz_dir/IccVizModel.cpp"
+        "$local_viz_dir/MiniPDF.cpp"
+        "$local_viz_dir/MiniSVG.cpp"
+        "$local_viz_dir/MiniTIFF.cpp"
+      )
+      ;;
+  esac
+
+  object_dir="$work_dir/objects/$target"
+  mkdir -p "$object_dir"
+  common_flags=(
+    "-std=c++17" "-g" "-O1" "-fno-omit-frame-pointer"
+    "-Wall" "-Wextra" "-Werror"
+    "-fsanitize=fuzzer-no-link,address,undefined"
+    "-I$repo_root/IccProfLib"
+    "-I$local_viz_dir"
+  )
+
+  objects=()
+  for source in "${extra_sources[@]}"; do
+    object="$object_dir/$(basename "${source%.cpp}").o"
+    "$cxx" "${common_flags[@]}" -c "$source" -o "$object"
+    objects+=("$object")
+  done
+
+  "$cxx" "${common_flags[@]}" \
+    -c "$script_dir/icc_${target}_fuzzer.cpp" \
+    -o "$object_dir/icc_${target}_fuzzer.o"
+  "$cxx" -g -O1 -fno-omit-frame-pointer \
+    -fsanitize=fuzzer,address,undefined \
+    "$object_dir/icc_${target}_fuzzer.o" \
+    "${objects[@]}" \
+    -Wl,--whole-archive "$profile_lib" -Wl,--no-whole-archive \
+    -lz -o "$bin_dir/icc_${target}_fuzzer"
+  cp "$script_dir/icc_${target}_fuzzer.options" \
+    "$bin_dir/icc_${target}_fuzzer.options"
 done
 
 seed_root="$work_dir/seeds"
@@ -208,6 +304,22 @@ prune_large_seeds() {
     size="$(stat -c '%s' "$file")"
     printf '%s\t%s\t%s\n' "$kind" "$size" "$file" >> "$seed_inventory_tsv"
     if [ "$size" -gt "$max_seed_bytes" ]; then
+      # A seed committed under .github/ci/test-data is a deliberate regression
+      # artifact, not corpus bloat: dropping one silently removes whatever
+      # defect class it was added to cover, and the run still reports coverage
+      # and a clean exit. #2120 is exactly that -- the corpus's only CLUT seed
+      # was being pruned, taking the entire writer path with it, for as long as
+      # the cap sat below it.
+      #
+      # So committed seeds are never pruned, they are a hard error. Adding an
+      # oversized regression seed now forces an explicit decision about the cap
+      # instead of quietly costing coverage.
+      if [ -f "$repo_root/.github/ci/test-data/$(basename "$file")" ]; then
+        echo "ERROR: committed seed exceeds ICCDEV_CFL_MAX_SEED_BYTES and would be dropped:" >&2
+        echo "       $(basename "$file") is $size bytes, cap is $max_seed_bytes" >&2
+        echo "       Raise ICCDEV_CFL_MAX_SEED_BYTES, or remove the seed deliberately (#2120)." >&2
+        return 1
+      fi
       printf '%s\t%s\t%s\tlarger-than-%s-bytes\n' "$kind" "$size" "$file" "$max_seed_bytes" >> "$skipped_seeds_tsv"
       rm -f -- "$file"
     fi
@@ -239,12 +351,42 @@ if [ "$skip_run" -eq 0 ]; then
     esac
     log_file="$logs_dir/$target.log"
     set +e
+    fuzzer_args=(
+      -artifact_prefix="$artifacts_dir/$target-"
+      -max_total_time="$seconds"
+    )
+    case "$target" in
+      profilevisualize|writerserialize)
+        # max_len is load-bearing for BOTH in-process targets, and it is a
+        # second, independent gate from the seed cap above: the cap decides
+        # whether the file reaches the corpus, max_len decides how much of it
+        # libFuzzer feeds to the target.
+        #
+        # Only a CLUT-bearing profile reaches RenderRaster, and the corpus holds
+        # exactly one -- fuzz-clut-hbo-69197729.icc, 61,015 bytes. Measured by
+        # trapping inside the WriteTIFF FILE* overload and truncating that seed:
+        #
+        #   61,015 bytes -> writers reached
+        #   49,152 bytes -> writers reached
+        #    8,192 bytes -> DEAD, no raster rendered at all
+        #
+        # 8192 was the value this target originally carried, so its raster half
+        # never executed while the session still reported runs, coverage and a
+        # clean exit (#2120). 256 KiB admits the seed with headroom for larger
+        # real CMYK profiles.
+        fuzzer_args+=(
+          -max_len=262144
+          -timeout=30
+          -rss_limit_mb=4096
+          -use_value_profile=1
+        )
+        ;;
+    esac
     ICCDEV_CFL_TOOL_DIR="$build_dir/Tools" \
       ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:abort_on_error=1:allocator_may_return_null=1 \
       UBSAN_OPTIONS=halt_on_error=1:abort_on_error=1:print_stacktrace=1 \
       "$bin_dir/icc_${target}_fuzzer" \
-        -artifact_prefix="$artifacts_dir/$target-" \
-        -max_total_time="$seconds" "$corpus" 2>&1 | tee "$log_file"
+        "${fuzzer_args[@]}" "$corpus" 2>&1 | tee "$log_file"
     fuzzer_status="${PIPESTATUS[0]}"
     set -e
     if [ "$fuzzer_status" -eq 0 ]; then

--- a/cfl/icc_profilevisualize_fuzzer.cpp
+++ b/cfl/icc_profilevisualize_fuzzer.cpp
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and "The
+ *    International Color Consortium" must not be used to imply that the
+ *    ICC organization endorses or promotes products derived from this
+ *    software.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR ITS CONTRIBUTING
+ * MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file
+    LibFuzzer harness for the data-first iccDEV profile visualization API.
+
+    The harness links IccVizModel.cpp as a separate translation unit and calls
+    only its public header. This preserves the compile/link boundary without
+    including a command-line implementation file or depending on processLuts().
+ */
+
+#include "IccProfile.h"
+#include "IccVizModel.hpp"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include <memory>
+#include <vector>
+
+static constexpr size_t kMinIccInputSize = 132;
+static constexpr size_t kMaxIccInputSize = 5 * 1024 * 1024;
+static constexpr size_t kMaxProfileTags = 200;
+static constexpr size_t kMaxDescriptors = 256;
+
+static size_t observeGraph(const iccviz::GraphResult &result)
+{
+  size_t observations = result.error.size() + result.diagnostics.size();
+
+  if (!result.ok)
+    return observations;
+
+  observations += result.graph.title.size();
+  observations += result.graph.description.size();
+  for (const auto &series : result.graph.series)
+    observations += series.verts.size();
+
+  return observations;
+}
+
+static size_t observeRaster(const iccviz::RasterResult &result)
+{
+  size_t observations = result.error.size() + result.diagnostics.size();
+
+  if (result.ok)
+    observations += result.raster.samples.size();
+
+  return observations;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  if (!data || size < kMinIccInputSize || size > kMaxIccInputSize)
+    return 0;
+
+  std::unique_ptr<CIccProfile> profile(
+      OpenIccProfile(const_cast<icUInt8Number *>(data), size));
+  if (!profile || profile->m_Tags.size() > kMaxProfileTags)
+    return 0;
+
+  iccviz::SetSilent(true);
+  const std::vector<iccviz::Descriptor> descriptors =
+      iccviz::Enumerate(profile.get());
+  if (descriptors.size() > kMaxDescriptors)
+    return 0;
+
+  size_t observations = descriptors.size();
+  for (const auto &descriptor : descriptors) {
+    if (descriptor.output == iccviz::Output::Graph) {
+      observations += observeGraph(
+          iccviz::RenderGraph(profile.get(), descriptor.id,
+                              iccviz::Verbosity::Silent));
+    } else {
+      observations += observeRaster(
+          iccviz::RenderRaster(profile.get(), descriptor.id,
+                               iccviz::Verbosity::Silent));
+    }
+  }
+
+  volatile size_t resultSink = observations;
+  (void)resultSink;
+  return 0;
+}

--- a/cfl/icc_profilevisualize_fuzzer.options
+++ b/cfl/icc_profilevisualize_fuzzer.options
@@ -1,0 +1,6 @@
+[libfuzzer]
+max_len = 262144
+timeout = 30
+rss_limit_mb = 4096
+detect_leaks = 0
+use_value_profile = 1

--- a/cfl/icc_writerserialize_fuzzer.cpp
+++ b/cfl/icc_writerserialize_fuzzer.cpp
@@ -1,0 +1,352 @@
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and "The
+ *    International Color Consortium" must not be used to imply that the
+ *    ICC organization endorses or promotes products derived from this
+ *    software.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR ITS CONTRIBUTING
+ * MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** @file
+    LibFuzzer harness for the iccDEV profile visualization *serialization* layer.
+
+    Companion to icc_profilevisualize_fuzzer.cpp, which drives the same
+    Enumerate/RenderGraph/RenderRaster data API but stops at the data boundary:
+    its observers read result.raster.samples.size() and never serialize, so
+    nothing downstream of the model executes.  This harness carries the render
+    results the last step into Mini{TIFF,PDF,SVG} -- the IFD layout and
+    offset/strip arithmetic, the PDF object graph and xref offset table, and
+    SVGOut -- which is the byte-generating layer #2116 named as uninstrumented.
+
+    Two targets rather than one on purpose: it keeps a crash attributable to one
+    layer (with the caveat at the end of this comment), and the data-API harness
+    keeps its existing signal and corpus without paying for serialization on
+    every iteration.
+
+    == Why this harness does not validate the raster geometry ==
+
+    The regression CTest for the same seam (.github/ci/regression/
+    iccviz-writer-serialization.cpp) checks that width/height/channels/
+    bitsPerChannel are in range and that samples.size() matches, and fails the
+    test when they are not.  That is right for a test: it pins the contract that
+    the *producer* is supposed to hold.
+
+    A fuzzer must do the opposite.  WriteTIFF narrows the caller's geometry into
+    uint32_t file offsets with no returning check, and the values come from a
+    profile-supplied CLUT by way of iccviz::buildClutRaster.  The entire
+    question this harness exists to answer is whether some profile can drive
+    buildClutRaster to produce geometry that breaks that arithmetic.  Screening
+    the geometry before the call would remove exactly the inputs worth finding.
+    So render results go into the writers unmodified, and ASan/UBSan is the
+    oracle.
+
+    Because only profile-derived values reach the writers, any report is
+    reachable from a real input by construction -- no need to argue afterwards
+    whether a synthesized width could ever occur.  Nothing here fabricates
+    geometry, and it should stay that way: a harness that made up dimensions
+    would be testing a contract these writers do not hold (see the note on the
+    WriteTIFF overload in MiniTIFF.hpp) and would report unreachable defects.
+
+    Two limits on that, both worth knowing before reading a report from here.
+
+    First, the asserts are LIVE in this build.  cfl/build.sh compiles at -O1 and
+    never defines NDEBUG, so MiniTIFF's assert(nrowBytes > 0) and its two
+    <= UINT_MAX asserts still fire.  An out-of-contract geometry therefore
+    aborts at the assert and ends the session BEFORE reaching the offset
+    arithmetic this target is pointed at.  That is a real signal, but it is not
+    the same failure this file argues is worth hunting -- the unguarded
+    narrowing only becomes reachable in a build that compiles the asserts out.
+
+    Second, attribution is not absolute.  raster.samples.data() is nullptr for
+    an empty-but-ok raster, and every raster this corpus produces is
+    photometric 8 (CIELAB), so WriteTIFF calls shiftTIFFLAB(nullptr, ...) before
+    any bounds-limited fwrite.  That report lands in MiniTIFF.cpp while the
+    actual contract violation is upstream in iccviz::buildClutRaster.  A crash
+    here is *usually* the writers; check the raster's geometry before concluding
+    it.
+
+    == The corpus and max_len decide whether this target does anything ==
+
+    Only a profile carrying a CLUT reaches RenderRaster, and therefore the TIFF
+    writer.  libFuzzer truncates every input to max_len, so a max_len below the
+    size of a CLUT-bearing profile makes the whole raster half of this harness
+    dead while it still reports runs, coverage and a clean exit.
+
+    That is not hypothetical, and the corpus is narrower than it looks.  The CFL
+    seed set is the eleven files in .github/ci/test-data, and exactly one of them
+    reaches the writers: fuzz-clut-hbo-69197729.icc, 61,015 bytes -- measured by
+    running each seed through this harness with a trap inside the WriteTIFF
+    FILE* overload.  That single seed is also the only one large enough to have
+    been hit by BOTH gates before #2120: build.sh's max_seed_bytes deleted it
+    outright at the old 49152 default, and max_len=8192 truncated it.  They fail
+    at different thresholds -- truncating the seed to 49,152 bytes still renders
+    a raster, truncating to 8,192 does not -- and either one alone leaves this
+    target reporting runs, coverage and a clean exit with the writers never
+    executed.
+
+    Both are now raised, and dropping a committed seed is a hard error rather
+    than a silent rm, so this cannot regress quietly; see #2120.
+
+    So: keep max_len above the size of the CLUT seeds, keep the seed cap above
+    them too, and check that the corpus still contains one.  The same caution
+    applies to any future target that reaches the raster path.
+
+    == Hermetic by construction ==
+
+    No filesystem access on any path.
+      * TIFF  -- the FILE* overload added by #2116, over an fmemopen() stream.
+      * PDF   -- PDFWriter::Serialize(ostream).  OpenFile() is still called, but
+                 it opens nothing: it names the document and builds the six
+                 preliminary objects (root, outline, page parent, procset, font,
+                 group) that AddPage/AddObject need.  Passing an empty name
+                 keeps ~PDFWriter's CloseFile() from writing anything while
+                 still letting it free the object list.
+      * SVG   -- SVGOut::Serialize(ostream).  OpenFile() is skipped entirely;
+                 it only resets state the constructor already set.
+ */
+
+#include "IccProfile.h"
+#include "IccVizModel.hpp"
+
+#include "MiniPDF.hpp"
+#include "MiniSVG.hpp"
+#include "MiniTIFF.hpp"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stddef.h>
+
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// Input bounds, matched to icc_profilevisualize_fuzzer.cpp so the two targets
+// can share a corpus: 132 is the ICC header plus tag count.
+static constexpr size_t kMinIccInputSize = 132;
+static constexpr size_t kMaxIccInputSize = 5 * 1024 * 1024;
+static constexpr size_t kMaxProfileTags  = 200;
+static constexpr size_t kMaxDescriptors  = 256;
+
+// Resource guards, NOT correctness guards -- see the note below on what they
+// can hide.
+//
+// kTiffSinkBytes bounds the TIFF sink.  This is the one number that lets the
+// geometry stay unscreened: fmemopen gives a seekable stream over a fixed
+// buffer, so the writer's arithmetic runs in full and only the bytes are
+// bounded.  A write past the end fails the fwrite, which WriteTIFF already
+// checks and reports by returning false, so an oversized raster ends the
+// iteration through the writer's own error path rather than filling a disk.
+// Sized against the rasters this corpus actually produces (~26 KB), not against
+// the worst case: the buffer is zero-filled on every raster descriptor of every
+// input, so an oversized sink is a per-exec memset tax. Measured at 8 MiB it
+// cost ~30% throughput (160 vs 208 exec/s) for no extra coverage. A raster that
+// overruns this ends through WriteTIFF's own short-fwrite check, which is a
+// legitimate outcome rather than a lost finding.
+static constexpr size_t kTiffSinkBytes = 1024u * 1024u;
+
+// kMaxVerts bounds how much of a graph is turned into PDF/SVG drawing
+// commands.  Both writers accumulate into memory (PDF into its object list,
+// SVG into m_buf), so an unbounded series would be an OOM rather than a
+// finding.
+static constexpr size_t kMaxVerts = 4096;
+
+// ---------------------------------------------------------------------------
+// Raster -> MiniTIFF
+//
+// The render result is handed over exactly as produced.  Note the samples
+// buffer is deliberately passed by non-const pointer into the writer: WriteTIFF
+// re-biases a* and b* in place for CIELAB rasters (shiftTIFFLAB), and since the
+// RasterResult is discarded at the end of the iteration there is nothing to
+// protect from that mutation.  The CTest copies the buffer per call only
+// because it calls the writer twice and compares the bytes.
+static size_t serializeRaster(iccviz::RasterResult &result)
+{
+  size_t observations = result.error.size() + result.diagnostics.size();
+  if (!result.ok)
+    return observations;
+
+  iccviz::Raster &raster = result.raster;
+
+  std::vector<char> sink(kTiffSinkBytes);
+  FILE *stream = fmemopen(sink.data(), sink.size(), "w+b");
+  if (!stream)
+    return observations;
+
+  // No screening of raster.width / height / channels / bitsPerChannel, and no
+  // check that samples.size() agrees with them.  A short buffer here is an
+  // out-of-bounds read inside WriteTIFF, which is the defect class this target
+  // is pointed at; ASan reports it.
+  const bool wrote = WriteTIFF(stream, "fuzz", 100.0f, raster.photometric,
+                               raster.samples.data(),
+                               static_cast<size_t>(raster.width),
+                               static_cast<size_t>(raster.height),
+                               raster.channels, raster.bitsPerChannel);
+
+  // NOT a measure of how much was written. WriteTIFF's last act is an fseek
+  // back to the STRIPBYTECOUNTS entry followed by a 12-byte putIFDLong, so for
+  // the single-strip case this lands at a fixed offset -- measured at 118 for
+  // both a 26,520-byte raster and a 48-byte one. It is fed back only as a
+  // stable success token; do not read it as a size.
+  if (wrote)
+    observations += 1;
+
+  fclose(stream);
+  return observations;
+}
+
+// ---------------------------------------------------------------------------
+// Graph -> MiniPDF and MiniSVG
+//
+// The profile-derived values that reach the byte layer are the vertex
+// coordinates and the title/description/axis/series strings, so both documents
+// are built from those rather than from constants.  The drawing itself is
+// deliberately crude -- this is not trying to reproduce the CLI's charts, only
+// to push profile-controlled floats and text through the writers' escaping,
+// object numbering and offset accounting.
+static size_t serializeGraph(const iccviz::GraphResult &result)
+{
+  size_t observations = result.error.size() + result.diagnostics.size();
+  if (!result.ok)
+    return observations;
+
+  const iccviz::Graph &graph = result.graph;
+
+  // Build one content stream from the series vertices, shared by both writers.
+  std::ostringstream path;
+  size_t emitted = 0;
+  for (const auto &series : graph.series) {
+    for (const auto &vertex : series.verts) {
+      if (emitted >= kMaxVerts)
+        break;
+      path << vertex.x << " " << vertex.y << (emitted == 0 ? " m\n" : " l\n");
+      ++emitted;
+    }
+    if (emitted >= kMaxVerts)
+      break;
+  }
+  path << "S\n";
+
+  {
+    PDFWriter pdf;
+    // Empty name: builds the object graph without ever naming a file, so the
+    // destructor's CloseFile() frees the objects and writes nothing.
+    pdf.OpenFile("", 8 * inch2point, 8 * inch2point);
+
+    std::string content = path.str();
+    pdf.AddXObject(Rect2D(0.0f, 200.0f, 0.0f, 200.0f), content, "Series");
+
+    // Two pages so the xref table and page tree carry more than one entry --
+    // a single-page document leaves offset-table arithmetic under-exercised.
+    for (int page = 0; page < 2; ++page) {
+      std::ostringstream commands;
+      commands << "BT /F1 12 Tf 20 " << (700 - 20 * page) << " Td ("
+               << graph.title << " " << graph.xAxis.label << " "
+               << graph.yAxis.label << ") Tj ET\n";
+      pdf.AddObject(new PDFGraphic(commands.str()));
+      pdf.AddPage(pdf.ObjectCount(), "Series");
+    }
+
+    std::ostringstream out;
+    pdf.Serialize(out);
+    observations += out.str().size();
+  }
+
+  {
+    SVGOut svg;
+    svg.SetPageSize(200.0f, 200.0f);
+    svg.NextPage();
+    svg.StartGroup(graph.title);
+
+    size_t drawn = 0;
+    for (const auto &series : graph.series) {
+      for (size_t i = 1; i < series.verts.size() && drawn < kMaxVerts; ++i, ++drawn)
+        svg.AddLine(series.verts[i - 1].x, series.verts[i - 1].y,
+                    series.verts[i].x, series.verts[i].y);
+      if (drawn >= kMaxVerts)
+        break;
+    }
+
+    // Profile-derived text straight into the document body. Note there is no
+    // escaping to exercise: AddText emits `text` verbatim between <text> tags,
+    // StartGroup emits `name` verbatim into an id="..." attribute, and the PDF
+    // branch above drops the title into a ( ... ) Tj literal without escaping
+    // '(', ')' or '\'. A profile whose desc carries '<', '"' or ')' therefore
+    // produces a malformed document rather than a crash -- which an ASan/UBSan
+    // oracle cannot see. Driving it here is still worth it for the buffer
+    // arithmetic, but well-formedness is NOT covered by this target.
+    svg.AddText(10.0f, 20.0f, graph.description, 14.0f,
+                "Helvetica", "Regular", "left");
+    svg.EndGroup();
+
+    std::ostringstream out;
+    svg.Serialize(out);
+    observations += out.str().size();
+  }
+
+  return observations;
+}
+
+// ---------------------------------------------------------------------------
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+  if (!data || size < kMinIccInputSize || size > kMaxIccInputSize)
+    return 0;
+
+  std::unique_ptr<CIccProfile> profile(
+      OpenIccProfile(const_cast<icUInt8Number *>(data), size));
+  if (!profile || profile->m_Tags.size() > kMaxProfileTags)
+    return 0;
+
+  // The library's own quiet switch, not a stderr redirect: ASan and UBSan
+  // reports share that stream, and silencing it would hide the oracle.
+  iccviz::SetSilent(true);
+
+  const std::vector<iccviz::Descriptor> descriptors =
+      iccviz::Enumerate(profile.get());
+  if (descriptors.size() > kMaxDescriptors)
+    return 0;
+
+  size_t observations = descriptors.size();
+  for (const auto &descriptor : descriptors) {
+    if (descriptor.output == iccviz::Output::Graph) {
+      observations += serializeGraph(
+          iccviz::RenderGraph(profile.get(), descriptor.id,
+                              iccviz::Verbosity::Silent));
+    } else {
+      iccviz::RasterResult raster =
+          iccviz::RenderRaster(profile.get(), descriptor.id,
+                               iccviz::Verbosity::Silent);
+      observations += serializeRaster(raster);
+    }
+  }
+
+  volatile size_t resultSink = observations;
+  (void)resultSink;
+  return 0;
+}

--- a/cfl/icc_writerserialize_fuzzer.options
+++ b/cfl/icc_writerserialize_fuzzer.options
@@ -1,0 +1,6 @@
+[libfuzzer]
+max_len = 262144
+timeout = 30
+rss_limit_mb = 4096
+detect_leaks = 0
+use_value_profile = 1

--- a/docs/afl-fuzzing.md
+++ b/docs/afl-fuzzing.md
@@ -270,14 +270,21 @@ The matching CFL smoke entry point is `cfl/build.sh` and the manual
 cfl/build.sh --seconds 30
 
 gh workflow run ci-cfl-smoke.yml \
-  -f cfl_targets=dump,toxml,fromxml,tojson,fromjson,roundtrip \
+  -f cfl_targets=dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize \
   -f duration_seconds=30
 ```
 
-The current CFL harnesses are conservative CLI-fidelity wrappers: libFuzzer
-writes each input to a temporary file and replays the matching sanitized iccDEV
-tool. This keeps the branch stable while deeper in-process harnesses are
-reviewed separately.
+The six command-line CFL harnesses are conservative CLI-fidelity wrappers:
+libFuzzer writes each input to a temporary file and replays the matching
+sanitized iccDEV tool. `profilevisualize` and `writerserialize` are in-process
+harnesses. Both parse the input from memory and consume only public headers,
+with the engine sources compiled as separate translation units:
+`profilevisualize` stops at the `IccVizModel.hpp` data API, and
+`writerserialize` carries the rendered result on into `Mini{PDF,SVG,TIFF}`,
+which is where the byte-level layout and offset arithmetic live (#2116).
+
+Both need a CLUT-bearing seed to reach the raster path at all, and the seed
+caps remove the only one at their defaults — see #2120.
 
 CFL smoke duration is wall-clock seconds per selected target, implemented with
 LibFuzzer `-max_total_time`. It is not an iteration or execution count.

--- a/docs/regression-container.md
+++ b/docs/regression-container.md
@@ -315,7 +315,7 @@ Run the current core CFL smoke:
 ```bash
 cfl/build.sh \
   --patches \
-  --targets dump,toxml,fromxml,tojson,fromjson,roundtrip \
+  --targets dump,toxml,fromxml,tojson,fromjson,roundtrip,profilevisualize,writerserialize \
   --seconds 30
 ```
 


### PR DESCRIPTION
## What this is

A harvest of @xsscx's `ci-qa-issue-1975` CFL work onto `master`, at his request on
[#1975](https://github.com/InternationalColorConsortium/iccDEV/issues/1975#issuecomment-5260276211)
("If you can harvest that would be great"), plus the writer-layer target that
[#2116](https://github.com/InternationalColorConsortium/iccDEV/issues/2116) scoped and
[#2118](https://github.com/InternationalColorConsortium/iccDEV/pull/2118) left undelivered.

**Attribution.** `cfl/icc_profilevisualize_fuzzer.cpp`, its `.options`, the library-linking
build recipe and the doc/workflow updates are @xsscx's work from that branch. The writer
target, the loop generalization and the seed-cap fix are mine.

## ⚠️ What was deliberately NOT harvested

That branch's `.github/workflows/ci.yml` **does not extend master's file — it replaces it.**

| | master | `ci-qa-issue-1975` |
| --- | --- | --- |
| `name:` | `vcpkg platform packages` | `Maintainer IccVizModel and CFL Harness Test` |
| vcpkg/CPack references | **89** | **0** |

Harvesting that diff would delete the vcpkg/CPack packaging CI. The branch used the file as
scratch space for a one-off proof run, so it is excluded here and `ci.yml` is untouched by
this PR.

## What lands

**`cfl/icc_profilevisualize_fuzzer.cpp` + `.options`** — in-process harness over the public
`IccVizModel.hpp` API, compiling `IccVizModel.cpp` as a separate translation unit and not
depending on `processLuts()`.

**`cfl/icc_writerserialize_fuzzer.cpp` + `.options`** — carries the rendered result on into
`Mini{PDF,SVG,TIFF}`: the IFD layout and offset/strip arithmetic, the PDF object graph and
xref table, and `SVGOut`. This is the layer #2118 gave a hermetic entry to and which a
data-API harness cannot reach — its observer reads `raster.samples.size()` and never
serializes.

Kept as a second target rather than an extension of the first, so a crash stays attributable
to one layer and the data-API target keeps its existing signal.

**`cfl/build.sh`** — the library-linking block generalized from one hardcoded target into a
loop with a per-target source list. A second copy of the link recipe would be exactly the
hand-maintained-list drift #2034 already fixed once.

**Docs / workflow** — `AGENTS.md`, `cfl/README.md`, `docs/afl-fuzzing.md`,
`docs/regression-container.md`, the AFL smoke prompt and skill, and `ci-cfl-smoke.yml` target
lists, adjusted for two in-process targets rather than one.

## One deliberate difference from the CTest

The harness does **not** screen raster geometry before handing it to `WriteTIFF`. The
regression test added in #2118 does, and is right to — it asserts the contract the *producer*
holds. A fuzzer doing the same would discard the only inputs worth finding, because the open
question is whether a profile can drive `buildClutRaster` to geometry that breaks the
writer's unchecked narrowing.

Only profile-derived values reach the writers, so anything reported is reachable from a real
input by construction. `fmemopen` is what makes that safe to do: it bounds resource use
*without* clamping the arithmetic, so an oversized raster exits through the writer's own
short-`fwrite` check rather than filling a disk.

## The corpus fix (#2120)

Both in-process targets need a CLUT-bearing seed. The corpus holds exactly one —
`fuzz-clut-hbo-69197729.icc`, 61,015 bytes, added in #1517 alongside the tool — and two
independent gates removed it:

| gate | old default | effect |
|---|---|---|
| `max_seed_bytes` (`cfl/build.sh`) | 49152 | **deleted** the file from the corpus |
| `max_len` (libFuzzer) | 8192 | **truncated** whatever survived |

Measured with a trap inside the `WriteTIFF` `FILE*` overload, using a clean/trap control pair
so the probe is known to discriminate (exit 0 vs 77 on a known CLUT profile): **1 of the 11
committed seeds reaches the writers, and it was the one being pruned.** The two gates also
fail at different thresholds — that seed still renders a raster truncated to 49,152 bytes,
but not at 8,192.

Fixed per @xsscx's choice of **option 3** on #2120:

- `max_seed_bytes` default **49152 → 262144**, so the committed corpus fits;
- pruning a seed committed under `.github/ci/test-data` is now a **hard error**, not a silent
  `rm` — a future oversized regression seed forces an explicit decision about the cap instead
  of quietly costing coverage;
- `-max_len` raised to 262144 for **both** in-process targets.

### ⚠️ Implication, deliberate and worth stating plainly

The `icc` seed corpus is **shared**, so raising the cap widens it for **all eight targets**,
not just the two in-process ones. The six fork/exec CLI targets now also replay a 61 KB
profile — slower per execution, more coverage per execution. `ICCDEV_CFL_MAX_SEED_BYTES`
still lowers it per run, and the new hard error keeps that choice visible rather than silent.

This is a change to shared CI behaviour and is called out here so it is reviewed as one.

## What a code review of the first draft caught

Worth recording, because one finding was the exact failure this PR exists to warn about:
the first draft raised the seed cap for `profilevisualize` but left its `-max_len` at 8192,
so its raster path stayed dead **while the docs claimed the problem was handled for both
targets**. Fixed, with the effect measured:

| target | `lim:` | cov | ft |
|---|---:|---:|---:|
| `profilevisualize` before | 8192 | 677 | 4528 |
| `profilevisualize` after | 61030 | **766** | **5651** |
| `writerserialize` (unchanged) | 61015 | 1221 → 1222 | 9366 → 9390 |

Also corrected, all of them false statements in my own comments: the `.options` files are not
read on this path (libFuzzer does not consume them; `build.sh` passes the flags explicitly),
there is no SVG/PDF escaping to exercise, `ftell` after `WriteTIFF` is a fixed offset rather
than a size, this build never defines `NDEBUG` so the asserts the rationale called
compiled-out are live, and an empty-but-`ok` raster reports in `MiniTIFF` though the contract
violation is upstream in `buildClutRaster`.

## Verification

- `shellcheck` clean on `cfl/build.sh`; `bash -n` clean; `ci-cfl-smoke.yml` parses.
- All five translation units compile under `-Wall -Wextra -Werror`.
- Each of the three writer entry points red-tested **individually** with `__builtin_trap`
  and confirmed reached — `WriteTIFF(FILE*)`, `PDFWriter::Serialize`, `SVGOut::Serialize` —
  reverting between each.
- `cfl/build.sh --targets profilevisualize,writerserialize` passes both — `profilevisualize`
  33,589 runs at `lim 61030`, `writerserialize` 5,547 at `lim 61015`, CLUT seed present.
- The new hard error is red/green tested: `ICCDEV_CFL_MAX_SEED_BYTES=49152` exits 1 naming
  the seed; the default admits it with `skipped-seeds.tsv` empty.
- `/security-review` on this diff: no findings — it ships no library or tool code.

**No crashing profile found.** As with #2116, the claim is coverage of the layer, not a
demonstrated defect. Nothing here is reported as a security finding.

## ⚠️ Note on CI signal — green here does not cover this change

Build lanes **do** run on this PR — GCC 15.2 Strict Release LTO, Tool Smoke ASAN+UBSAN,
Windows MSVC + ClangCL, MinGW UCRT64 — so the check list looks substantive. For this diff
specifically it is not: those lanes build IccProfLib and the tools, and **this PR changes
neither.**

Nothing in PR CI compiles the CFL harnesses. `ci-cfl-smoke.yml` is the only workflow that
builds them, and it carries only `workflow_dispatch` and `workflow_call` — no
`pull_request` trigger. So a fully green run here is **not** evidence that
`icc_writerserialize_fuzzer.cpp` compiles, that `cfl/build.sh` still works, or that either
target reaches the writers.

The evidence for those is local, under Verification above: `-Wall -Wextra -Werror` across all
five translation units, the red/green test of the new hard error, and two `cfl/build.sh` runs
that build and execute both targets.

To get CI confirmation, dispatch `ci-cfl-smoke.yml` against this branch with
`cfl_targets=profilevisualize,writerserialize`. I have not done that — it is a maintainer
dispatch.

*(An earlier version of this note claimed the PR drew no build lanes at all, citing
#2020/#2021. That was wrong — the lanes run, they just do not touch the changed code.)*

Part of #2116
Part of #2120
