### PR TITLE
fix(#2106): stop the XML array parsers writing through a refused allocation

### DIFF
--- a/.github/scripts/iccdev-xml-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-xml-parser-regression-tests.sh
@@ -354,6 +354,143 @@ PY
 oversize_document
 
 ###############################################################################
+# 4. A refused array allocation must not be written through (issue #2106)
+###############################################################################
+#
+# CIccTagXYZ::SetSize refuses more than 65536 entries, and on that path it frees
+# the array, sets the pointer to NULL and returns false. CIccTagXmlXYZ::ParseXml
+# ignored the result and wrote m_XYZ[0..n-1] anyway, so a document holding one
+# entry more than the cap segfaulted iccFromXml. Nothing about it is exotic: the
+# fixture below is ordinary well-formed XML, under 3 MB, that violates no parser
+# limit -- which is why it belongs beside the hardening cases above rather than
+# among them. Neither libxml2 nor the document-size bound stops it.
+#
+# The assertion is not "exit non-zero". Every fixture in this script exits
+# non-zero, and a process killed inside ParseXml exits non-zero too. It is that
+# iccFromXml reaches its OWN error path and names the tag it could not parse:
+# that line is printed by the caller after ParseXml returns, so a crash cannot
+# produce it. Measured before the fix, the log was empty and the shell reported
+# signal 11.
+
+echo "=== Array sizing refusals are not written through ==="
+
+# Kept in step with CIccTagXYZ::SetSize in IccProfLib/IccTagBasic.cpp. A build
+# that retunes the cap makes the over-cap fixture parse successfully, which is
+# reported as a skip below rather than as a failure.
+XYZ_MAX_ENTRIES="${ICC_XYZ_MAX_ENTRIES:-65536}"
+
+# The diagnostic CIccProfileXml prints when a tag's ParseXml returns false.
+XYZ_TAG_DIAG='Unable to Parse .*XYZType.* Tag'
+
+write_xyz_document() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+path, n = sys.argv[1], int(sys.argv[2])
+with open(path, "w") as f:
+    f.write('<IccProfile>\n  <Header>\n'
+            '    <ProfileVersion>4.30</ProfileVersion>\n'
+            '    <ProfileDeviceClass>mntr</ProfileDeviceClass>\n'
+            '    <DataColourSpace>RGB </DataColourSpace>\n'
+            '    <PCS>XYZ </PCS>\n'
+            '    <RenderingIntent>Perceptual</RenderingIntent>\n'
+            '    <PCSIlluminant>\n'
+            '      <XYZNumber X="0.9642" Y="1.0" Z="0.8249"/>\n'
+            '    </PCSIlluminant>\n'
+            '  </Header>\n  <Tags>\n    <XYZType>\n'
+            '      <TagSignature>wtpt</TagSignature>\n')
+    f.write('      <XYZNumber X="0.5" Y="0.5" Z="0.5"/>\n' * n)
+    f.write('    </XYZType>\n  </Tags>\n</IccProfile>\n')
+PY
+}
+
+xyz_array_over_cap() {
+  local name="xml-xyz-array-over-cap-not-written-through"
+  local file="$OUTDIR/xyz-over-cap.xml"
+  local logfile="$OUTDIR/${name}.log"
+  local status
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  write_xyz_document "$file" $((XYZ_MAX_ENTRIES + 1))
+
+  "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1
+  status=$?
+
+  # An accepted document means the compiled cap is not the one this case was
+  # written against, so it is testing nothing. Report that rather than a
+  # failure -- a reverted fix crashes here, it does not succeed.
+  if [ "$status" -eq 0 ]; then
+    skip "$name" "$((XYZ_MAX_ENTRIES + 1)) entries were accepted; the ${XYZ_MAX_ENTRIES}-entry cap has moved"
+    rm -f "$file"
+    return
+  fi
+
+  if ! grep -qE "$XYZ_TAG_DIAG" "$logfile"; then
+    if [ "$status" -ge 128 ]; then
+      fail "$name" "iccFromXml was killed by signal $((status - 128)) writing through a refused allocation"
+    else
+      fail "$name" "iccFromXml exited $status without reporting the tag it could not parse"
+    fi
+    rm -f "$file"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || { rm -f "$file"; return; }
+  pass "$name ($((XYZ_MAX_ENTRIES + 1)) entries refused at the tag, process intact)"
+  rm -f "$file"
+}
+
+# The control for the case above. Without it, a change that made every XYZType
+# tag fail to parse would leave the over-cap case passing while the tag stopped
+# working entirely. This asserts the fixture sits exactly on the boundary: one
+# entry fewer and the same tag must still parse.
+xyz_array_at_cap() {
+  local name="xml-xyz-array-at-cap-still-parses"
+  local file="$OUTDIR/xyz-at-cap.xml"
+  local logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  write_xyz_document "$file" "$XYZ_MAX_ENTRIES"
+
+  # Exit status is deliberately not asserted: this fixture is a structurally
+  # incomplete profile, so what iccFromXml returns for it is a question about its
+  # validation policy, not about the tag. The tag is what is under test.
+  "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1
+
+  if grep -qE "$XYZ_TAG_DIAG" "$logfile"; then
+    fail "$name" "the tag was refused at exactly $XYZ_MAX_ENTRIES entries, so the over-cap case proves nothing"
+    rm -f "$file"
+    return
+  fi
+
+  # The absence of the diagnostic cannot carry this on its own. If some later
+  # change made iccFromXml give up earlier -- refusing the document while reading
+  # the header, say -- the diagnostic would never be printed, this control would
+  # stay green, and the over-cap case would silently lose the pairing that is the
+  # only reason this control exists. So require positive evidence that the tool
+  # got far enough to emit a profile. A validation policy that stops writing one
+  # for this fixture turns this red, which is the correct outcome: the control is
+  # no longer controlling anything and needs re-examining, not passing quietly.
+  if [ ! -s "$OUTDIR/${name}.icc" ]; then
+    fail "$name" "iccFromXml wrote no profile, so nothing proves it reached the tag at all"
+    rm -f "$file"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || { rm -f "$file"; return; }
+  pass "$name ($XYZ_MAX_ENTRIES entries parsed, profile written)"
+  rm -f "$file"
+}
+
+xyz_array_over_cap
+xyz_array_at_cap
+
+###############################################################################
 
 echo
 echo "=== Summary ==="

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -1275,7 +1275,18 @@ bool CIccTagXmlXYZ::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
 
   if (n) {
     icUInt32Number i;
-    SetSize(n);
+
+    // The sibling of the chromaticity fix below (#2094), but reachable from the
+    // document rather than only from an allocation failure: CIccTagXYZ::SetSize
+    // caps the array at 65536 entries, and over that cap it frees m_XYZ, sets it
+    // to NULL and returns false. Ignoring the result left the loop writing
+    // m_XYZ[0..n-1] through that null pointer, so a document carrying 65537
+    // <XYZNumber> elements -- about 2.8 MB of XML, nothing exotic -- was enough
+    // to take iccFromXml down. n is non-zero here by the enclosing test, so the
+    // icRealloc(p, 0) case that makes a false return legitimate elsewhere in
+    // this file cannot arise (#2106).
+    if (!SetSize(n))
+      return false;
 
     for (i=0; pNode; pNode=pNode->next) {
       if (pNode->type == XML_ELEMENT_NODE &&
@@ -1757,7 +1768,15 @@ bool CIccTagXmlFixedNum<T, Tsig>::ParseXml(xmlNode *pNode, std::string & /*parse
   icUInt32Number i, n = a.GetSize();
   icFloatNumber *buf = a.GetBuf();
 
-  this->SetSize(n);
+  // Same shape as the XYZ array above (#2106): the loop indexes m_Num[0..n-1]
+  // unconditionally, so a SetSize() that returned false -- which leaves m_Num
+  // NULL and m_nSize 0 -- would be written through. CIccTagFixedNum::SetSize
+  // carries no entry cap, so unlike the XYZ case this is reachable only on
+  // allocation failure; it is checked because the write below cannot tell the
+  // difference. The GetSize() test above guarantees n is non-zero, so the
+  // icRealloc(p, 0) path that makes a false return legitimate cannot arise.
+  if (!this->SetSize(n))
+    return false;
 
   for (i=0; i<n; i++) {
     if (Tsig==icSigS15Fixed16ArrayType) {
@@ -1859,7 +1878,10 @@ bool CIccTagXmlNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string & /*parseSt
   icUInt32Number i, n = a.GetSize();
   T *buf = a.GetBuf();
 
-  this->SetSize(n);
+  // As in CIccTagXmlFixedNum::ParseXml above (#2106): unchecked sizing in front
+  // of an unconditional m_Num[0..n-1] write. n is non-zero by the GetSize() test.
+  if (!this->SetSize(n))
+    return false;
 
   for (i=0; i<n; i++) {
     this->m_Num[i] = buf[i];
@@ -2087,7 +2109,13 @@ bool CIccTagXmlFloatNum<T, A, Tsig>::ParseXml(xmlNode *pNode, std::string &parse
   icUInt32Number i, n = a.GetSize();
   T *buf = a.GetBuf();
 
-  this->SetSize(n);
+  // Third instance of the pattern in this file (#2106). Two paths reach here: the
+  // inline array branch, where n is non-zero by the GetSize() test in the else
+  // clause, and the Format="text" branch, which falls through after its own
+  // ParseTextArray/GetSize test. The remaining file-format branches size and read
+  // their own buffers and return directly without reaching this point.
+  if (!this->SetSize(n))
+    return false;
 
   for (i=0; i<n; i++) {
     this->m_Num[i] = buf[i];
@@ -2257,6 +2285,17 @@ bool CIccTagXmlTagData::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
     icUInt32Number nSize = icXmlGetHexDataSize((const char *)pNode->children->content);
     SetSize(nSize, false);
     if (nSize) {
+      // SetSize cannot be checked here the way the four array parsers above are:
+      // a fresh CIccTagData is constructed with m_nSize == 1, so SetSize(0) for an
+      // empty <Data/> reaches icRealloc(p, 0), which frees and returns NULL, and
+      // reports failure for an entirely legal document. The write still has to be
+      // guarded, because on a genuine allocation failure m_pData is left NULL and
+      // icXmlGetHexData dereferences it without checking. Guarding the pointer
+      // rather than the return covers both, and matches what
+      // CIccTagXmlColorantOrder below already does (#2106).
+      if (!m_pData)
+        return false;
+
       icXmlGetHexData(m_pData, (const char*)pNode->children->content, nSize);
     }
 
@@ -2374,11 +2413,18 @@ bool CIccTagXmlColorantTable::ParseXml(xmlNode *pNode, std::string & /*parseStr*
 
     if (n) {
       icUInt32Number i;
-      SetSize(n);
+
+      // Fourth instance of the pattern fixed above (#2106): m_pData[i].name is
+      // strncpy'd unconditionally, and CIccTagColorantTable::SetSize leaves
+      // m_pData NULL and m_nCount 0 when the reallocation fails. n is non-zero by
+      // the enclosing test, so the icRealloc(p, 0) case that makes a false return
+      // legitimate in CIccTagXmlTagData above cannot arise here.
+      if (!SetSize(n))
+        return false;
 
       for (i=0; pNode; pNode=pNode->next) {
         if (pNode->type == XML_ELEMENT_NODE &&
-          !icXmlStrCmp(pNode->name, "Colorant") && 
+          !icXmlStrCmp(pNode->name, "Colorant") &&
           i<n) {
             std::string str;
             const icChar *name = icXmlAttrValue(pNode, "Name");


### PR DESCRIPTION
## Summary

`CIccTagXmlXYZ::ParseXml` sized its array with `SetSize(n)` and then wrote
`m_XYZ[0..n-1]` without checking the result. `CIccTagXYZ::SetSize` refuses more than
65536 entries, and on that path it frees the array, sets `m_XYZ` to NULL and returns
false — so a document carrying 65537 `<XYZNumber>` elements wrote through a null
pointer and took `iccFromXml` down.

The document is not exotic: about 2.8 MB of ordinary well-formed XML that violates no
parser limit. Neither the #1856 document-size bound nor any libxml2 cap stops it.

This is the sibling of #2094, where the same class of bug was fixed in
`CIccTagXmlChromaticity::ParseXml` forty lines below. The difference is **reachability**:
the chromaticity case needed an allocation failure, this one is driven by the document,
because `CIccTagXYZ::SetSize` is the only `SetSize` on these paths carrying an entry cap.

`Part of #2106` — this is item (c) of the punch list. Items (a) and (b) are untouched;
see the note at the end.

## Measured

Debug builds, `iccFromXml` on the over-cap document:

| build | entries | before | after |
| --- | --- | --- | --- |
| plain | 65537 | **SIGSEGV, core dumped, empty log** | tag refused, process intact |
| ASAN+UBSAN | 65537 | `runtime error: member access within null pointer of type 'icXYZNumber'` | tag refused, no sanitizer report |
| either | 65536 | parses, exit 0 | parses, exit 0 — unchanged |

After the fix both builds print `Unable to Parse "XYZArrayType" (XYZType) Tag on line 14`.

## Scope of the change

Five sites in `IccTagXml.cpp` size an array and then index it unconditionally. All five
now check the return:

- **`CIccTagXmlXYZ::ParseXml` (1272) — the fix.** Reachable from the document.
- `CIccTagXmlFixedNum` (1754), `CIccTagXmlNum` (1860), `CIccTagXmlFloatNum` (1979),
  `CIccTagXmlColorantTable` (2405) — **hardening, not fixes.** Their `SetSize` carries no
  cap, so they can only fail on allocation failure. They are checked because the write
  below cannot tell the difference.

All five are guarded by a preceding non-zero count test, which is what makes checking the
return safe — see below.

### Why a blanket check would be a parsing regression

`icRealloc(p, 0)` frees and returns NULL (`IccUtil.cpp:114`), and these `SetSize`
implementations forward to it — so **`SetSize(0)` reports failure for an entirely legal
empty array**. Adding `if (!SetSize(n)) return false;` indiscriminately across this file
would turn an empty `<Data/>` into a parse failure.

The discriminator is whether the count is provably non-zero at that point. The five sites
above are, each guarded by a preceding `if (n)` / `!a.GetSize()` test.

`CIccTagXmlTagData::ParseXml` (2276) is **not**, and gets the other half of the argument.
A fresh `CIccTagData` is constructed with `m_nSize == 1`, so `SetSize(0)` for an empty
`<Data/>` reaches `icRealloc(p, 0)` and reports failure for a legal document — checking
the return there really would be a regression. But the write still has to be guarded,
because on a genuine allocation failure `m_pData` is left NULL and `icXmlGetHexData`
dereferences it without checking. So the **pointer** is tested rather than the return,
which is the idiom `CIccTagXmlColorantOrder` (2354) already uses in this file.

### Deliberately not changed

- `CIccTagXmlColorantOrder` (2354) — already guards on the pointer.
- The four `CIccTagXmlFloatNum` file-format branches (2041-2083) —
  `CIccIO::Read16`/`Read64`/`ReadFloat16Float`/`ReadFloat32Float` each return 0 on a null
  buffer, so the caller bails without writing.
- The embedded height and normal image parsers — already guard the pointer before writing.

## Test

A fourth section in `.github/scripts/iccdev-xml-parser-regression-tests.sh`, already
registered as the `iccdev.xml-parser-regressions` CTest — no CMake change needed.

**The assertion is the diagnostic, not the exit code.** Every fixture in that script
exits non-zero, and a process killed inside `ParseXml` exits non-zero too, so exit status
cannot discriminate. The test asserts that `iccFromXml` reaches its *own* error path and
names the tag it could not parse — a line printed by the caller *after* `ParseXml`
returns, which a crashed process cannot produce.

A paired control at exactly 65536 entries asserts the same tag still parses, so the
over-cap case cannot pass by the tag having failed for some unrelated reason. The control
asserts **positively** that a profile was written, not merely that the diagnostic is
absent: otherwise a future change causing `iccFromXml` to give up before reaching the tag
would leave the control green while it silently stopped controlling anything.

A build that retunes the cap reports a skip rather than a spurious failure.

## Verification

- **8/8 pass** in plain clang-18 Debug and again under ASAN+UBSAN (instrumentation
  confirmed by symbol inspection, not by a build label).
- **Red/green proven:** reverting only the XYZ hunk and rebuilding gives
  `[FAIL] ... killed by signal 11` and script exit 1, while the at-cap control stays green.
- **No corpus regression, measured:** all 214 tracked `*.xml` swept through this build and
  through a build differing only by master's `IccTagXml.cpp`. Both produce an identical
  set of 33 non-zero exits — the deliberately-invalid `ub-*` / `relaxng-*` / `xxe-*`
  fixtures, plus import fragments and profiles whose sibling data files resolve only from
  `Testing/`. The sweep is meaningful for the two newly-guarded paths rather than
  vacuous: 3 tracked files exercise `<ColorantTable` and 95 exercise `<Data`.

## Items (a) and (b) remain open

The other two punch-list items concern `CIccTagChromaticity`. Both should start with a
fixture rather than a decision: **279 profiles scanned carry zero `chrm` tags, and no
tracked XML mentions `chromaticityType`**, so a change to either would land with nothing
exercising it.

## A related family, noted rather than folded in

`IccMpeXml.cpp` has four instances of the same shape at 502, 986, 1024 and 1057 —
`SetSize(data.GetSize())` in front of an unconditional write through `m_pSamples`, where
`CIccSampledCurveSegment::SetSize` leaves the pointer NULL on allocation failure. Lines
691 and 1236 in that same file already use the guarded form, so the omission looks
inconsistent rather than deliberate. Different file and different class, and it is
allocation-failure-only, so it is recorded here rather than widening this PR. Notably
`CIccSampledCurveSegment::SetSize` returns **true** for a count of zero, so unlike
`IccTagXml.cpp` the blanket check is safe there.
