### PR TITLE
fix(#2126): reject the trailing arguments iccApplyProfiles was discarding

### DIFF
--- a/.github/scripts/iccdev-applyprofiles-cli-args-regression.sh
+++ b/.github/scripts/iccdev-applyprofiles-cli-args-regression.sh
@@ -1,0 +1,208 @@
+#!/bin/bash
+###############################################################################
+# iccApplyProfiles command-line argument regression tests
+###############################################################################
+#
+# Third member of the #1674 argument-contract family, after
+# iccdev-applynamedcmm-cli-args-regression.sh (#1906) and
+# iccdev-applysearch-cli-args-regression.sh (#2075). The shared finding is that an
+# argument the tool silently drops is worse than one it rejects: the run still
+# reports success, so the caller cannot tell an honoured argument list from an
+# ignored one.
+#
+# iccApplyProfiles carried the defect in both of its usages, but not to the same
+# extent, and the two reject cases below are deliberately split to record that:
+#
+#   "cfg-extra"    -- the "-cfg <path>" usage ignored *any* number of trailing
+#                     tokens.
+#   "legacy-extra" -- the positional usage ignored exactly an *odd* leftover
+#                     token. CIccCfgProfileSequence::fromArgs() consumes the
+#                     profile group in pairs and stops when fewer than two
+#                     arguments remain, so two or more leftovers are already read
+#                     as a further profile/intent pair and rejected. That is what
+#                     "legacy-extra-pair" pins, and it is why the fix guards the
+#                     odd remainder only.
+#
+# "threads-cfg-extra" and "threads-cfg-valid" exist because the -cfg guard tests
+# argc *after* the optional "-threads N" pair has been consumed; a guard written
+# against the process-entry argc would wrongly reject "-threads 1 -cfg cfg.json".
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for generated logs/configs
+###############################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-applyprofiles-cli-args}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/build-dbg/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+# Both substitutions below must not be allowed to abort the script: under
+# "set -euo pipefail" a failing cd, or a find over a missing directory whose
+# non-zero status pipefail propagates, kills the run at the assignment itself --
+# before require_tool can report which executable was missing. CTest would then
+# show a bare non-zero exit with no output, making "the tool was not built in this
+# configuration" indistinguishable from "the argument contract regressed".
+BUILD_ROOT=""
+if [ -d "$TOOLS_DIR/.." ]; then
+  BUILD_ROOT="$(cd "$TOOLS_DIR/.." && pwd -P)"
+fi
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect:$BUILD_ROOT/IccConnect/IccLibConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-/dev/null}"
+
+APPLY="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplyProfiles -type f 2>/dev/null | head -1 || true)"
+SRC="$TESTING_DIR/ApplyDataFiles/seed-tiff-none-rgb-8x8.tif"
+SRGB="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+CFG="$OUTDIR/applyprofiles-cfg.json"
+
+fail() {
+  echo "  [FAIL] iccApplyProfiles-cli-args -- $1"
+  exit 1
+}
+
+check_sanitizers() {
+  local logfile="$1"
+
+  if grep -qE "ERROR: AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|LeakSanitizer|DEADLYSIGNAL" "$logfile" 2>/dev/null; then
+    sed -n '1,120p' "$logfile"
+    return 1
+  fi
+
+  return 0
+}
+
+require_file() {
+  local path="$1"
+
+  if [ ! -f "$path" ]; then
+    fail "missing fixture: $path"
+  fi
+}
+
+require_tool() {
+  local path="$1"
+
+  if [ ! -x "$path" ]; then
+    fail "missing executable: $path"
+  fi
+}
+
+run_expect_success() {
+  local name="$1"
+  shift
+  local logfile="$OUTDIR/$name.log"
+  local rc=0
+
+  rm -f "$logfile"
+  set +e
+  timeout 60 "$@" > "$logfile" 2>&1
+  rc=$?
+  set -e
+
+  check_sanitizers "$logfile" || fail "$name emitted sanitizer diagnostics"
+  if [ "$rc" -eq 124 ]; then
+    fail "$name timed out"
+  fi
+  if [ "$rc" -ne 0 ]; then
+    sed -n '1,80p' "$logfile"
+    fail "$name failed with exit=$rc"
+  fi
+}
+
+run_expect_reject() {
+  local name="$1"
+  shift
+  local logfile="$OUTDIR/$name.log"
+  local rc=0
+
+  rm -f "$logfile"
+  set +e
+  timeout 60 "$@" > "$logfile" 2>&1
+  rc=$?
+  set -e
+
+  check_sanitizers "$logfile" || fail "$name emitted sanitizer diagnostics"
+  if [ "$rc" -eq 124 ]; then
+    fail "$name timed out"
+  fi
+  # A signal is never an acceptable refusal. Checking it separately from the
+  # non-zero test below keeps a crash from reading as a rejection, which is the
+  # failure mode a "did it refuse?" assertion is otherwise blind to.
+  if [ "$rc" -ge 128 ] && [ "$rc" -le 192 ]; then
+    fail "$name crashed with signal $((rc - 128))"
+  fi
+  if [ "$rc" -eq 0 ]; then
+    sed -n '1,80p' "$logfile"
+    fail "$name accepted malformed arguments"
+  fi
+}
+
+# A refused command line must not leave a converted image behind: the whole point
+# of the guard is that the caller can tell a honoured argument list from an
+# ignored one, and an output file written anyway would re-create that ambiguity
+# for anyone reading the directory rather than the exit status.
+require_absent() {
+  local path="$1"
+  local name="$2"
+
+  if [ -e "$path" ]; then
+    fail "$name wrote '$path' despite refusing the command line"
+  fi
+}
+
+require_tool "$APPLY"
+require_file "$SRC"
+require_file "$SRGB"
+
+echo "=== iccApplyProfiles CLI argument regression ==="
+
+# Let the tool write its own configuration rather than hand-authoring JSON here:
+# the schema then cannot drift out from under this test, and the export doubles as
+# a success case for the legacy argument list the reject cases only extend.
+run_expect_success export-cfg \
+  "$APPLY" -exportcfg "$CFG" "$SRC" "$OUTDIR/export.tif" 0 0 0 0 1 "$SRGB" 1
+require_file "$CFG"
+
+run_expect_success valid-cfg "$APPLY" -cfg "$CFG"
+run_expect_success valid-legacy \
+  "$APPLY" "$SRC" "$OUTDIR/legacy.tif" 0 0 0 0 1 "$SRGB" 1
+run_expect_success threads-cfg-valid "$APPLY" -threads 1 -cfg "$CFG"
+
+# The two cases that fail against an unfixed tool: each ran the transform, wrote
+# its output and exited 0 with the trailing token discarded.
+rm -f "$OUTDIR/cfg-extra.tif" "$OUTDIR/legacy-extra.tif"
+run_expect_reject cfg-extra "$APPLY" -cfg "$CFG" ignored-extra
+run_expect_reject legacy-extra \
+  "$APPLY" "$SRC" "$OUTDIR/legacy-extra.tif" 0 0 0 0 1 "$SRGB" 1 ignored-extra
+require_absent "$OUTDIR/legacy-extra.tif" legacy-extra
+
+run_expect_reject cfg-extra-many "$APPLY" -cfg "$CFG" a b c
+run_expect_reject threads-cfg-extra "$APPLY" -threads 1 -cfg "$CFG" ignored-extra
+
+# Already rejected before the fix, pinned so the surrounding surface cannot
+# regress quietly while the odd-remainder guard above is in place.
+run_expect_reject legacy-extra-pair \
+  "$APPLY" "$SRC" "$OUTDIR/legacy-pair.tif" 0 0 0 0 1 "$SRGB" 1 extra1 extra2
+run_expect_reject legacy-bad-encoding \
+  "$APPLY" "$SRC" "$OUTDIR/legacy-enc.tif" 9 0 0 0 1 "$SRGB" 1
+
+echo "  [PASS] iccApplyProfiles-cli-args"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -6187,6 +6187,24 @@ if(TARGET iccApplySearch)
    )
 endif()
 
+# The iccApplyProfiles third of the same family (#2126). Both of its usages
+# dropped trailing arguments and still exited 0, but by different routes: "-cfg"
+# ignored any tail, while the positional usage ignored only an odd leftover token
+# because CIccCfgProfileSequence::fromArgs() consumes the profile group in pairs.
+# Timeout matches the two siblings: although every case here runs a real TIFF
+# transform rather than a text data file, the fixture is an 8x8 image and the
+# whole script measured under 1s against an ASAN+UBSAN build, so it needs no
+# larger budget than they do.
+if(TARGET iccApplyProfiles)
+  iccdev_add_script_test(
+    iccdev.applyprofiles-cli-args
+    120
+    "iccdev;cmm;config;cli;security;issue-1674;issue-2126;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-applyprofiles-cli-args-regression.sh"
+   )
+endif()
+
 # Legacy v2 namedColor2Type stores each rootName in a fixed 32-byte field. A
 # malformed profile can fill all 32 bytes without a NUL terminator; the reader
 # must force termination before iccApplyNamedCmm echoes the selected name. The

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -71,6 +71,7 @@
 
 
 #include <cstdio>
+#include <cstdlib>  // EXIT_FAILURE, used by the argument-contract guards in main()
 #include <memory>
 #include <string>
 #include "IccCmm.h"
@@ -257,6 +258,20 @@ int main(int argc, const char** argv)
   }
 
   if (argc > 2 && !stricmp(argv[1], "-cfg")) {
+    // Usage 1 is exactly "-cfg <path>"; every setting comes from the JSON file, so
+    // there is nothing a further argument could mean. Anything beyond argv[2] was
+    // silently discarded and the run still reported success, so a caller could not
+    // tell an honoured argument list from an ignored one. Same defect and same
+    // guard as the sibling tools: iccApplyNamedCmm (#1906) and iccApplySearch
+    // (#2075). The argc test above has already established argc >= 3, so argv[2] is
+    // readable here and only a longer list can reach this branch. Note argc is the
+    // count left after the optional "-threads N" pair above, which is why the
+    // comparison is against 3 rather than the process-entry argc.
+    if (argc != 3) {
+      printf("Unexpected extra arguments for -cfg\n");
+      return EXIT_FAILURE;
+    }
+
     json cfg;
     if (!loadJsonFrom(cfg, argv[2]) || !cfg.is_object()) {
       printf("Unable to read configuration from '%s'\n", argv[2]);
@@ -305,6 +320,27 @@ int main(int argc, const char** argv)
       printf("Unable to parse profile sequence arguments\n");
       Usage();
       return -1;
+    }
+    // CIccCfgProfileSequence::fromArgs() consumes the profile group in pairs and
+    // stops once fewer than two arguments remain, reporting how many it used. An
+    // odd token left at the end was therefore neither consumed nor rejected: the
+    // transform ran as though it had not been given and the tool exited 0, so a
+    // mistyped trailing path or intent looked like a honoured command line. Two or
+    // more leftover tokens already fail, because fromArgs() reads them as a further
+    // profile/intent pair and returns 0, which is why only the odd remainder needs
+    // this guard (#1674). Compare the consumed count against what was offered
+    // rather than advancing argv/argc once more: this is the last use of the
+    // argument vector, so the pointer bump that pairs with the count above would be
+    // a store no later read could observe (#1958).
+    // Not covered here: a trailing "-ENV:sig value" pair is *counted* as consumed
+    // even when the profile pair it precedes never arrives, so fromArgs() reports
+    // it as used and this comparison cannot see it. That shape pushes a profile
+    // entry with an empty file path, which the embedded-profile branch below then
+    // treats as "-embedded" -- a defect in fromArgs() itself rather than in the
+    // argument count, and so out of scope for this guard.
+    if (nArg != argc) {
+      printf("Unexpected extra arguments\n");
+      return EXIT_FAILURE;
     }
 
     if (bThreadArg)

--- a/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
+++ b/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
@@ -78,6 +78,7 @@
 #include "IccSearch.h"
 #include "IccConnect.h"
 #include "../IccCmdLineUtil.h"
+#include <cstdlib>  // EXIT_FAILURE, used by the -cfg argument guard added in #2075
 #include <memory>
 #include <vector>
 #if !defined(_WIN32)


### PR DESCRIPTION
## Summary

`iccApplyProfiles` accepted arguments it never honoured and still exited 0, in both of its
usages, so a caller could not tell an honoured command line from an ignored one. This is the
third instance of the #1674 argument-contract family, after `iccApplyNamedCmm` (#1906) and
`iccApplySearch` (#2075).

Part of #2126.

## The two usages failed by different routes

The issue describes them as one defect. They are not, and the fix guards each where it
actually leaks:

| Usage | Behaviour before | Scope |
| --- | --- | --- |
| `-cfg <path>` | Ignored **any** number of trailing tokens | Broad |
| legacy positional | Ignored **only an odd** leftover token | Narrow |

The legacy case is narrow because `CIccCfgProfileSequence::fromArgs()`
(`IccConnect/IccLibConnect/IccCmmConfig.cpp:1071`) consumes the profile group in pairs and
stops once fewer than two arguments remain. Two or more leftovers are therefore already read
as a further profile/intent pair, fail to parse, and are rejected. Measured:

```
iccApplyProfiles src.tif out.tif 0 0 0 0 1 sRGB.icc 1 ignored-extra   -> rc=0   (defect)
iccApplyProfiles src.tif out.tif 0 0 0 0 1 sRGB.icc 1 extra1 extra2   -> rc=255 (already rejected)
iccApplyProfiles -cfg cfg.json ignored-extra                          -> rc=0   (defect)
iccApplyProfiles -cfg cfg.json a b c                                  -> rc=0   (defect)
```

So only the odd remainder needed a guard on the legacy path.

## The change

- **`-cfg`**: the same `argc` guard both sibling tools already carry. It compares against the
  count left *after* the optional `-threads N` pair, so `-threads 1 -cfg cfg.json` keeps
  working; a guard written against the process-entry `argc` would wrongly reject it.
- **legacy**: `if (nArg != argc)` after the profile-sequence parse. This compares the consumed
  count against what was offered rather than advancing `argv`/`argc` once more, matching
  `iccApplyNamedCmm`: it is the last use of the argument vector, so the pointer bump that pairs
  with the count would be a store no later read could observe (#1958).
- **`<cstdlib>`** added to `iccApplyProfiles.cpp` for `EXIT_FAILURE`, and to
  `iccApplySearch.cpp`, which has used `EXIT_FAILURE` since #2075 while relying on a transitive
  include to declare it.

### One residual is recorded in the comment rather than fixed here

A trailing `-ENV:sig value` pair is **counted as consumed** even when the profile pair it
precedes never arrives, so `fromArgs()` reports it as used and an argument-count comparison
cannot see it:

```
iccApplyProfiles src.tif out.tif 0 0 0 0 1 -ENV:abcd 1.0   -> rc=0, writes out.tif
```

That command line names no profile at all, yet runs and reports success — the entry pushed
with an empty `m_iccFile` is then read by the embedded-profile branch as if `-embedded` had
been given. The root cause is in `CIccCfgProfileSequence::fromArgs()` itself
(`IccCmmConfig.cpp:1113` pushes an entry that never received a file/intent), which is shared by
all four `iccApply*` tools, so it is out of scope for a fix to this tool's argument count and is
reported separately. It reproduces unchanged on master and is unaffected by this PR.

## Test

Registers `iccdev.applyprofiles-cli-args`, alongside its two siblings.

Every reject case was confirmed to exit 0 before the change and non-zero after, individually
rather than in aggregate:

| Case | before | after |
| --- | --- | --- |
| `cfg-extra` | 0 | 1 |
| `cfg-extra-many` | 0 | 1 |
| `threads-cfg-extra` | 0 | 1 |
| `legacy-extra` | 0 | 1 |

The four valid invocations still succeed: `-cfg`, `-threads 1 -cfg`, legacy, and a two-profile
chain. `legacy-extra-pair` and `legacy-bad-encoding` were already rejected and are pinned so
the surrounding surface cannot regress quietly. A refused legacy command line is additionally
asserted to leave no output image behind. Run against an unfixed binary the script fails at
`cfg-extra`, so it genuinely bites.

The script also resolves its tool without letting `set -euo pipefail` abort at the assignment.
Previously a missing executable killed the run before `require_tool` could name it, so CTest
showed a bare non-zero exit with no output and "the tool was not built in this configuration"
was indistinguishable from "the argument contract regressed".

## Pre-flight

CI's own gate (`grep -cE 'warning:' build.log`) is **0** on all three strict profiles, each
confirmed to report `strict warnings ENABLED` and to have compiled both changed TUs:

- strict clang 18.1.3 Release, `-Wall -Wextra -Wpedantic -Werror`
- **GCC 15.2.0** Release + LTO, in CI's own container
  (`iccdev-ci-regression:sha-b572e972`), since local gcc is below the strict-flag floor
- clang ASAN+UBSAN Debug, strict flags

Clean under ASAN+UBSAN with `detect_leaks=1` (CI's ctest env sets `detect_leaks=0`), against a
build verified as genuinely instrumented. `shellcheck` 0.9.0 — matching CI's ubuntu-24.04 apt
version — is clean at default severity.

All 13 apply-related CTests pass locally. Both ASAN-gated scripts and the QA mutation corpus
were checked for reliance on trailing arguments: `nArg == argc` holds for every invocation, so
none are affected.

Pre-PR dispatched run (`ci_scope=auto`):
[31658351850](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/31658351850)
— 10 success / 2 skipped, in which `iccdev.applyprofiles-cli-args` ran and passed in 1.09s in
the GCC Strict ASAN+UBSAN lane.
