### PR TITLE
fix(#2146): accept icEncodeUnitFloat as a PCS source encoding

### DIFF
--- a/.github/ci/regression/pcs-unitfloat-source-encoding.cpp
+++ b/.github/ci/regression/pcs-unitfloat-source-encoding.cpp
@@ -1,0 +1,319 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression for #2146: CIccCmm::ToInternalEncoding() had no icEncodeUnitFloat
+// case for either PCS space, while FromInternalEncoding() pairs it with
+// icEncodeFloat in both -- so the library wrote data it then refused to read.
+//
+// FromInternalEncoding()'s two PCS branches accept the selector:
+//
+//   case icSigLabData:                     case icSigXYZData:
+//     case icEncodeUnitFloat:                case icEncodeFloat:
+//     case icEncodeFloat:                    case icEncodeUnitFloat:
+//       break;                                 icXyzFromPcs(pInput); break;
+//
+// ToInternalEncoding()'s did not: its icSigLabData arm listed icEncodeValue,
+// icEncodeFloat and the three integer encodings, and its icSigXYZData arm the
+// same plus icEncodePercent. icEncodeUnitFloat fell to the shared
+// "default: return icCmmStatBadColorEncoding".
+//
+// End to end through iccApplyNamedCmm, measured on 7828681a before the fix --
+// the tool refuses its own output:
+//
+//   iccApplyNamedCmm rgb8bit.txt 2 0 sRGB_v4_ICC_preference.icc 1
+//     -> 'Lab ' / icEncodeUnitFloat, rc=0
+//   iccApplyNamedCmm <that output> 3 0 sRGB_v4_ICC_preference.icc 1
+//     -> "Invalid source data encoding", rc=1
+//
+// Same break with an XYZ PCS profile (sRGB_D65_MAT.icc); the icEncodeFloat
+// control round-trips cleanly, which is what isolates the missing case from
+// any question about the values themselves.
+//
+// The fix pairs the selector with icEncodeFloat in both arms, mirroring the
+// destination side exactly rather than giving it a clipping body of its own.
+// That choice is load-bearing and is pinned by testXyzUnitFloatIsNotClipped()
+// below: icXyzFromPcs scales by 65535/32768, so the external XYZ float range
+// runs to ~2.0, and clipping a source to 0.0-1.0 -- the reading of "unit
+// float" that the *device* branch applies -- would silently discard every
+// legitimate value above 1.0 rather than harden anything. The device branch
+// can clip because its external range genuinely is 0.0-1.0; the PCS branches
+// cannot.
+//
+// Scope note: this pins the two PCS spaces only. Source/destination acceptance
+// is deliberately NOT asserted as a universal rule, because it is not one --
+// icSigRgbData reaches the shared default: arm, whose icEncodeValue case
+// rejects a source when the space is not CLR while the matching destination
+// case merely no-ops. That asymmetry is a separate question about what
+// icEncodeValue means for a device space, is unchanged by this fix, and is
+// measured rather than assumed by testDeviceValueAsymmetryIsUnchanged().
+
+// Sibling coverage, so the two are not later merged or duplicated:
+// tointernal-fixedint-roundtrip.cpp asserts From(To(x)) over the *fixed
+// integer* encodings for the CLR, Lab and XYZ paths. It is scoped to those
+// three selectors by its own header and never exercises icEncodeUnitFloat,
+// which is why it did not catch this. This file is the float-selector half and
+// composes the other way round, To(From(x)), because the defect is on the
+// source side of a value the destination side produced.
+
+#include <cstdio>
+#include <cmath>
+
+#include "IccCmm.h"
+
+// A -DENABLE_USEICCDEVNAMESPACE=ON build wraps IccProfLib in the iccDEV
+// namespace (Build/Cmake/CMakeLists.txt:709), so every name used below moves.
+// Guarded as the 24 sibling harnesses that carry this are. Carried on the same
+// grounds they are rather than on a passing build: that option does not
+// currently configure at all -- IccProfLib/IccTagEmbedIcc.h has none of the
+// namespace wrapping its siblings carry, so IccProfLib2 itself fails with 70
+// errors on unmodified master before any test is reached. This guard is
+// therefore correct-by-consistency and untested end to end.
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    std::printf("[pcs-unitfloat] FAIL: %s\n", what);
+    ++g_fail;
+  }
+}
+
+bool accepted(icStatusCMM rv)
+{
+  return rv == icCmmStatOk;
+}
+
+// A source-side acceptance probe. The values are irrelevant to whether the
+// selector is accepted -- the switch is reached before any of them is read --
+// so a single mid-range triple serves every encoding.
+bool toAccepts(icColorSpaceSignature space, icFloatColorEncoding enc)
+{
+  const icFloatNumber in[3] = {0.5f, 0.5f, 0.5f};
+  icFloatNumber out[3] = {0.0f, 0.0f, 0.0f};
+
+  return accepted(CIccCmm::ToInternalEncoding(space, enc, out, in));
+}
+
+bool fromAccepts(icColorSpaceSignature space, icFloatColorEncoding enc)
+{
+  const icFloatNumber in[3] = {0.5f, 0.5f, 0.5f};
+  icFloatNumber out[3] = {0.0f, 0.0f, 0.0f};
+
+  return accepted(CIccCmm::FromInternalEncoding(space, enc, out, in));
+}
+
+const char *encName(icFloatColorEncoding enc)
+{
+  switch (enc) {
+    case icEncodeValue:     return "icEncodeValue";
+    case icEncodePercent:   return "icEncodePercent";
+    case icEncodeUnitFloat: return "icEncodeUnitFloat";
+    case icEncodeFloat:     return "icEncodeFloat";
+    case icEncode8Bit:      return "icEncode8Bit";
+    case icEncode16Bit:     return "icEncode16Bit";
+    case icEncode16BitV2:   return "icEncode16BitV2";
+    default:                return "?";
+  }
+}
+
+// The whole per-space contract, both directions, written out rather than
+// derived. Each cell is what the library does after the fix; the two
+// icEncodeUnitFloat source cells are the ones #2146 changes, and every other
+// cell is recorded so a later edit that widens or narrows a PCS arm for some
+// unrelated reason is caught here too.
+struct Expectation {
+  icFloatColorEncoding enc;
+  bool                 toOk;
+  bool                 fromOk;
+};
+
+void testLabAcceptanceMatrix()
+{
+  const Expectation table[] = {
+    {icEncodeValue,     true,  true },
+    {icEncodePercent,   false, false},  // absent from both arms: the #2124 contract
+    {icEncodeUnitFloat, true,  true },  // #2146: the source half was missing
+    {icEncodeFloat,     true,  true },
+    {icEncode8Bit,      true,  true },
+    {icEncode16Bit,     true,  true },
+    {icEncode16BitV2,   true,  true },
+  };
+
+  for (const Expectation &e : table) {
+    char what[160];
+
+    std::snprintf(what, sizeof(what), "'Lab ' source must %s %s",
+                  e.toOk ? "accept" : "reject", encName(e.enc));
+    check(toAccepts(icSigLabData, e.enc) == e.toOk, what);
+
+    std::snprintf(what, sizeof(what), "'Lab ' destination must %s %s",
+                  e.fromOk ? "accept" : "reject", encName(e.enc));
+    check(fromAccepts(icSigLabData, e.enc) == e.fromOk, what);
+  }
+}
+
+void testXyzAcceptanceMatrix()
+{
+  const Expectation table[] = {
+    {icEncodeValue,     true,  true },
+    {icEncodePercent,   true,  true },
+    {icEncodeUnitFloat, true,  true },  // #2146: the source half was missing
+    {icEncodeFloat,     true,  true },
+    {icEncode8Bit,      false, false},  // absent from both arms: the #2124 contract
+    {icEncode16Bit,     true,  true },
+    {icEncode16BitV2,   true,  true },
+  };
+
+  for (const Expectation &e : table) {
+    char what[160];
+
+    std::snprintf(what, sizeof(what), "'XYZ ' source must %s %s",
+                  e.toOk ? "accept" : "reject", encName(e.enc));
+    check(toAccepts(icSigXYZData, e.enc) == e.toOk, what);
+
+    std::snprintf(what, sizeof(what), "'XYZ ' destination must %s %s",
+                  e.fromOk ? "accept" : "reject", encName(e.enc));
+    check(fromAccepts(icSigXYZData, e.enc) == e.fromOk, what);
+  }
+}
+
+// The defect stated as the property it broke: anything the destination side
+// can write, the source side must be able to read back to the value it started
+// from. Run over both PCS spaces for icEncodeUnitFloat, with icEncodeFloat
+// alongside as the control that always worked.
+void testPcsRoundTrip(icColorSpaceSignature space, icFloatColorEncoding enc,
+                      const icFloatNumber *internal, const char *label)
+{
+  icFloatNumber external[3] = {0.0f, 0.0f, 0.0f};
+  icFloatNumber back[3]     = {0.0f, 0.0f, 0.0f};
+  char what[160];
+
+  const bool wrote = accepted(CIccCmm::FromInternalEncoding(space, enc, external, internal));
+
+  std::snprintf(what, sizeof(what), "%s: destination must accept %s", label, encName(enc));
+  check(wrote, what);
+  if (!wrote)
+    return;  // the value comparisons below would report noise, not a second defect
+
+  std::snprintf(what, sizeof(what), "%s: source must accept %s", label, encName(enc));
+  check(accepted(CIccCmm::ToInternalEncoding(space, enc, back, external)), what);
+
+  for (int i = 0; i < 3; ++i) {
+    std::snprintf(what, sizeof(what), "%s: %s channel %d must round trip (%g -> %g -> %g)",
+                  label, encName(enc), i,
+                  (double)internal[i], (double)external[i], (double)back[i]);
+    check(std::fabs(back[i] - internal[i]) < 1.0e-5f, what);
+  }
+}
+
+void testUnitFloatRoundTrips()
+{
+  const icFloatNumber lab[3] = {0.62f, 0.48f, 0.55f};
+  const icFloatNumber xyz[3] = {0.42f, 0.45f, 0.38f};
+
+  testPcsRoundTrip(icSigLabData, icEncodeUnitFloat, lab, "'Lab '");
+  testPcsRoundTrip(icSigLabData, icEncodeFloat,     lab, "'Lab ' control");
+  testPcsRoundTrip(icSigXYZData, icEncodeUnitFloat, xyz, "'XYZ '");
+  testPcsRoundTrip(icSigXYZData, icEncodeFloat,     xyz, "'XYZ ' control");
+}
+
+// The anti-clipping pin. An internal XYZ of 0.9 leaves the destination side as
+// ~1.8 because icXyzFromPcs scales by 65535/32768. If the source arm is ever
+// given a 0.0-1.0 clip -- the plausible "but it is called unit float" edit --
+// that 1.8 is clamped to 1.0 and comes back as 0.5 instead of 0.9, so this
+// fails while the acceptance matrix above still passes.
+void testXyzUnitFloatIsNotClipped()
+{
+  const icFloatNumber internal[3] = {0.9f, 0.95f, 0.85f};
+  icFloatNumber external[3] = {0.0f, 0.0f, 0.0f};
+  icFloatNumber back[3]     = {0.0f, 0.0f, 0.0f};
+
+  check(accepted(CIccCmm::FromInternalEncoding(icSigXYZData, icEncodeUnitFloat, external, internal)),
+        "'XYZ ' destination must accept icEncodeUnitFloat above the unit range");
+
+  check(external[0] > 1.0f,
+        "the premise: an internal 0.9 must leave the destination side above 1.0");
+
+  check(accepted(CIccCmm::ToInternalEncoding(icSigXYZData, icEncodeUnitFloat, back, external)),
+        "'XYZ ' source must accept icEncodeUnitFloat above the unit range");
+
+  for (int i = 0; i < 3; ++i) {
+    char what[160];
+
+    std::snprintf(what, sizeof(what),
+                  "'XYZ ' icEncodeUnitFloat channel %d must survive un-clipped (%g -> %g -> %g)",
+                  i, (double)internal[i], (double)external[i], (double)back[i]);
+    check(std::fabs(back[i] - internal[i]) < 1.0e-5f, what);
+  }
+}
+
+// icEncodeUnitFloat and icEncodeFloat are aliases on these two spaces, in both
+// directions. Pinned so that a later change giving unit float its own PCS
+// semantics has to come through this file rather than silently diverging.
+void testUnitFloatAliasesFloat()
+{
+  const icColorSpaceSignature spaces[] = {icSigLabData, icSigXYZData};
+  const icFloatNumber in[3] = {0.37f, 0.61f, 0.44f};
+
+  for (icColorSpaceSignature space : spaces) {
+    icFloatNumber fromUnit[3] = {0.0f, 0.0f, 0.0f};
+    icFloatNumber fromFloat[3] = {0.0f, 0.0f, 0.0f};
+    icFloatNumber toUnit[3] = {0.0f, 0.0f, 0.0f};
+    icFloatNumber toFloat[3] = {0.0f, 0.0f, 0.0f};
+
+    CIccCmm::FromInternalEncoding(space, icEncodeUnitFloat, fromUnit, in);
+    CIccCmm::FromInternalEncoding(space, icEncodeFloat, fromFloat, in);
+    CIccCmm::ToInternalEncoding(space, icEncodeUnitFloat, toUnit, in);
+    CIccCmm::ToInternalEncoding(space, icEncodeFloat, toFloat, in);
+
+    for (int i = 0; i < 3; ++i) {
+      check(fromUnit[i] == fromFloat[i],
+            "destination icEncodeUnitFloat must equal icEncodeFloat on a PCS space");
+      check(toUnit[i] == toFloat[i],
+            "source icEncodeUnitFloat must equal icEncodeFloat on a PCS space");
+    }
+  }
+}
+
+// Measured, not assumed: the device branch's icEncodeValue asymmetry is real
+// and is NOT what #2146 fixes. Recorded here so the scope note at the top of
+// this file stays honest, and so that if someone does decide to reconcile it
+// the change surfaces as a failure here rather than passing unnoticed.
+void testDeviceValueAsymmetryIsUnchanged()
+{
+  check(!toAccepts(icSigRgbData, icEncodeValue),
+        "'RGB ' source still rejects icEncodeValue (unchanged by #2146)");
+  check(fromAccepts(icSigRgbData, icEncodeValue),
+        "'RGB ' destination still accepts icEncodeValue (unchanged by #2146)");
+
+  // The selector this issue is about is symmetric for device spaces already,
+  // which is what made the PCS arms the outlier.
+  check(toAccepts(icSigRgbData, icEncodeUnitFloat),
+        "'RGB ' source accepts icEncodeUnitFloat");
+  check(fromAccepts(icSigRgbData, icEncodeUnitFloat),
+        "'RGB ' destination accepts icEncodeUnitFloat");
+}
+
+}  // namespace
+
+int main()
+{
+  testLabAcceptanceMatrix();
+  testXyzAcceptanceMatrix();
+  testUnitFloatRoundTrips();
+  testXyzUnitFloatIsNotClipped();
+  testUnitFloatAliasesFloat();
+  testDeviceValueAsymmetryIsUnchanged();
+
+  if (!g_fail)
+    std::printf("[pcs-unitfloat] PASS\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -296,6 +296,56 @@ function(iccdev_add_cmmsearch_init_pcc_test)
   endforeach()
 endfunction()
 
+function(iccdev_add_pcs_unitfloat_source_encoding_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccPcsUnitFloatSourceEncodingTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/pcs-unitfloat-source-encoding.cpp"
+  )
+  target_link_libraries(iccPcsUnitFloatSourceEncodingTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+
+  add_dependencies(check iccPcsUnitFloatSourceEncodingTest)
+
+  # No fixture and no profile: the assertions call the two static encoding
+  # converters directly, so nothing is read from disk and the whole test is a
+  # few dozen scalar conversions. The 120 timeout matches its siblings rather
+  # than reflecting any measured need.
+  if(WIN32)
+    add_test(
+      NAME iccdev.pcs-unitfloat-source-encoding
+      COMMAND "$<TARGET_FILE:iccPcsUnitFloatSourceEncodingTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.pcs-unitfloat-source-encoding
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccPcsUnitFloatSourceEncodingTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.pcs-unitfloat-source-encoding PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;cmm;encoding;issue-2146;regression"
+  )
+  if(WIN32)
+    set(_pcs_unitfloat_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccPcsUnitFloatSourceEncodingTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _pcs_unitfloat_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.pcs-unitfloat-source-encoding PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_pcs_unitfloat_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_ndlut_input_channel_mismatch_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -4680,6 +4730,7 @@ if(WIN32)
   iccdev_add_cmmsearch_init_pcc_test()
   iccdev_add_cmmsearch_rebegin_test()
   iccdev_add_ndlut_input_channel_mismatch_test()
+  iccdev_add_pcs_unitfloat_source_encoding_test()
   iccdev_add_embedio_read8_bounds_test()
   iccdev_add_embedded_profile_onelevel_load_test()
   iccdev_add_embedded_profile_detachio_test()
@@ -4958,6 +5009,7 @@ iccdev_add_iccconnect_config_parser_test()
 iccdev_add_cmmsearch_init_pcc_test()
 iccdev_add_cmmsearch_rebegin_test()
 iccdev_add_ndlut_input_channel_mismatch_test()
+iccdev_add_pcs_unitfloat_source_encoding_test()
 iccdev_add_embedio_read8_bounds_test()
 iccdev_add_embedded_profile_onelevel_load_test()
 iccdev_add_embedded_profile_detachio_test()

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -9922,6 +9922,14 @@ icStatusCMM CIccCmm::ToInternalEncoding(icColorSpaceSignature nSpace, icFloatCol
             icLabToPcs(pInput);
             break;
           }
+        // #2146: icEncodeUnitFloat was absent here while FromInternalEncoding's
+        // icSigLabData branch pairs it with icEncodeFloat, so the library wrote
+        // Lab data it then refused to read back. Paired identically rather than
+        // given a clipping body of its own: the destination side applies no
+        // clip on this path, and matching it exactly is what restores the round
+        // trip. Lab float already IS the internal PCS encoding, so like
+        // icEncodeFloat this converts nothing.
+        case icEncodeUnitFloat:
         case icEncodeFloat:
           {
             break;
@@ -9977,6 +9985,12 @@ icStatusCMM CIccCmm::ToInternalEncoding(icColorSpaceSignature nSpace, icFloatCol
             icXyzToPcs(pInput);
             break;
           }
+        // #2146: the icSigLabData counterpart above, for the other PCS. Also
+        // deliberately unclipped: icXyzFromPcs scales by 65535/32768, so the
+        // external XYZ float range runs to ~2.0 and clipping a source to
+        // 0.0-1.0 here would discard legitimate values rather than harden
+        // anything.
+        case icEncodeUnitFloat:
         case icEncodeFloat:
           {
             icXyzToPcs(pInput);

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -1639,6 +1639,7 @@ public:
   'Lab '
     icEncodeValue: 0.0 <= L <= 100.0; -128.0 <= a,b <= 127.0
     icEncodeFloat: 0.0 <= L,a,b <= 1.0 - ICC PCS encoding (See ICC Specification)
+    icEncodeUnitFloat: accepted as a synonym of icEncodeFloat (#2146)
     icEncode8BIt: ICC 8 bit Lab Encoding - See ICC Specification
     icEncode16Bit: ICC 16 bit V4 Lab Encoding - See ICC Specification
     icEncode16BitV2: ICC 16 bit V2 Lab Encoding - See ICC Specification
@@ -1647,8 +1648,20 @@ public:
     icEncodeValue: 0.0 <= X,Y,Z < 1.999969482421875
     icEncodePercent: 0.0 <= X,Y,Z < 199.9969482421875
     icEncodeFloat: 0.0 <= L,a,b <= 1.0 - ICC PCS encoding (See ICC Specification
+    icEncodeUnitFloat: accepted as a synonym of icEncodeFloat (#2146). Note the
+      name: this is the PCS encoding, whose external range runs to ~2.0, and
+      neither converter clips it. Only the device spaces above take the 0.0-1.0
+      reading and clip to it.
     icEncode16Bit: ICC 16 bit XYZ Encoding - (icU1Fixed15) See ICC Specification
     icEncode16BitV2: ICC 16 bit XYZ Encoding - (icU1Fixed15) See ICC Specification
+
+  This table lists the encodings each space accepts, not a per-direction
+  contract: ToInternalEncoding() and FromInternalEncoding() do not accept
+  identical sets for every space. They agree for the two PCS spaces above --
+  which is what #2146 restored, icEncodeUnitFloat having been absent from the
+  source side only -- but not everywhere; a device space, for instance, accepts
+  icEncodeValue as a destination while rejecting it as a source unless the
+  space is CLR. Check the relevant switch when the direction matters.
  **************************************************************************
 */
 

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -224,8 +224,11 @@ void Usage()
   // regression greps for that exact line to prove a rejection happened, and
   // printing it here would let usage output satisfy those greps. For the same
   // reason the table is described as listing the per-space sets rather than
-  // "the full set" -- it omits icEncodeUnitFloat for 'Lab '/'XYZ ' and carries
-  // no source/destination axis, so it is a pointer, not a promise.
+  // "the full set" -- it carries no source/destination axis, and the two
+  // converters do not accept identical sets for every space, so it is a
+  // pointer, not a promise. (It also omitted icEncodeUnitFloat for the two PCS
+  // spaces when this note was written; #2146 fixed the source side that
+  // omission described and brought the table into line.)
   printf("    Not every encoding is valid for every colour space: a 'Lab '\n");
   printf("    destination refuses icEncodePercent and an 'XYZ ' destination\n");
   printf("    refuses icEncode8Bit, each rejected when the data is converted\n");


### PR DESCRIPTION
## The defect

`CIccCmm::ToInternalEncoding()` had no `icEncodeUnitFloat` case in either of its
PCS arms, while `FromInternalEncoding()` pairs the selector with `icEncodeFloat`
in both. The library wrote data it then refused to read:

```
iccApplyNamedCmm rgb8bit.txt 2 0 sRGB_v4_ICC_preference.icc 1
  ->  'Lab ' / icEncodeUnitFloat, rc=0
iccApplyNamedCmm <that output> 3 0 sRGB_v4_ICC_preference.icc 1
  ->  "Invalid source data encoding", rc=1
```

Same break against an XYZ PCS profile. The `icEncodeFloat` control round-trips
cleanly, which isolates the missing case from any question about the values.

## The fix, and the decision inside it

Pair the selector with `icEncodeFloat` in both arms, mirroring the destination
side exactly.

**It is deliberately not given a clipping body of its own**, and that is the
part worth reviewing rather than the two case labels. `icXyzFromPcs` scales by
65535/32768, so the external XYZ float range runs to ~2.0. Applying the
0.0-1.0 clip that the name "unit float" suggests — the reading the *device* arm
can afford, because its external range genuinely is 0.0-1.0 — would silently
discard every legitimate value above 1.0. That is a data-loss regression
dressed as hardening, so the round trip decides, not the name.

`testXyzUnitFloatIsNotClipped()` exists purely to hold that line, and it earns
its place: with the clip applied, the acceptance matrix and the ordinary round
trip **both still pass** and only that assertion fails, reporting
`0.9 -> 1.79997 -> 0.500008`.

## Coverage

A library-level harness, because the defect is in the two static converters —
no profile, no fixture, no I/O. It records the **full per-space acceptance
matrix in both directions**, not just the two cells that change, so a later
edit widening or narrowing a PCS arm for an unrelated reason surfaces here too.

Red-tested three ways:

| probe | result |
| --- | --- |
| unfixed library | 20 assertions fail, all and only the `icEncodeUnitFloat` source cells |
| the wrong 0.0-1.0 clip on the XYZ source arm | exactly 1 assertion fails |
| fixed library | PASS |

The existing `tointernal-fixedint-roundtrip.cpp` does **not** overlap: it is
scoped by its own header to the fixed-integer selectors and never exercises
`icEncodeUnitFloat`, which is why it did not catch this. The new file states
that relationship so the two are not later merged or duplicated.

## Header table

`IccCmm.h`'s `icFloatColorEncoding` block is brought into line, because
`iccApplyNamedCmm`'s usage text now points users at it as the authority for the
per-space valid set (#2124). Without this, the tool would direct a reader to a
table still saying selector 2 is invalid for a PCS destination. The block also
gains the caveat that it is per *space* and not per *direction* — the two
converters genuinely do not accept identical sets everywhere. The #2124 comment
that cited the old omission as part of its rationale is updated rather than
left to read as still-true.

## Scope

The two PCS spaces. Source/destination acceptance is deliberately **not**
asserted as a universal rule, because it is not one: `icSigRgbData` reaches the
shared `default:` arm, whose `icEncodeValue` case rejects a source when the
space is not CLR while the matching destination case merely no-ops. That is a
separate question about what `icEncodeValue` means for a device space, is
unchanged here, and is measured rather than assumed by
`testDeviceValueAsymmetryIsUnchanged()`.

## Pre-flight

| lane | result |
| --- | --- |
| Clang 21.1.3 `-Wall -Wextra -Wpedantic -Werror`, strict warnings ENABLED | `grep -cE 'warning:'` = 0, including test binaries |
| GCC 15.2.0 in CI's own container `sha-b572e972`, strict warnings ENABLED | `grep -cE 'warning:'` = 0, including test binaries |
| ASAN+UBSAN, `detect_leaks=1` | clean |
| full local `ctest` | 182/183; the one failure is `spectral-tiff-preview`, a missing local `imagecodecs` module |

Registered in **both** CMake call lists, since a test registered in only one is
silently absent.

CI evidence is the pre-PR dispatched run at `ci_scope=full`:
https://github.com/InternationalColorConsortium/iccDEV/actions/runs/31723511801

`full` rather than a narrower scope because this is new behavior in a core TU
built everywhere, plus a new CTest that runs on the Windows MSVC/ClangCL legs.

## Two adjacent findings, neither fixed here

**1. The tool path still clips this selector.** Both `iccApply*` tools remap a
PCS source signature to `icSigDevXYZData`/`icSigDevLabData` and grant the
`bClip = false` carve-out only for `icEncodeFloat`, so PCS `icEncodeUnitFloat`
data lands in the *device* arm at `bClip = true` and saturates:

```
internal {0.9, 0.95, 0.85} -> dest 'XYZ ' unitFloat -> {1.79997, 1.89997, 1.69997}
                           -> tool path 'dXYZ' bClip=true -> {1, 1, 1}
```

Measured identically against a **pre-fix** library, so it is pre-existing and
untouched by this PR — the remapped signature falls to the `default:` arm,
which this diff does not modify. Reported rather than folded in. Happy to file
it.

**2. `-DENABLE_USEICCDEVNAMESPACE=ON` does not build.**
`IccProfLib/IccTagEmbedIcc.h` carries none of the namespace wrapping its
siblings do (`IccTagBasic.h` and `IccCmm.h` have it), so `IccProfLib2` itself
fails with 70 errors. Verified on unmodified `origin/master` in a throwaway
worktree, so it is unrelated to this change. The new test carries the
`USEICCDEVNAMESPACE` guard on consistency with its 24 siblings rather than on a
passing build, and its comment says so rather than implying it was verified.

Fixes #2146
