### PR TITLE
docs(#2152): record ENABLE_USEICCDEVNAMESPACE=ON as a known defect

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -353,6 +353,84 @@ See `.github/ci/regression/README.md` for the test-side rules and
 `iccdev.proflib-exported-data-linkage`, which pins both the linkage and the
 literal values that dependent tests hard-code.
 
+## Namespace wrapping (known defect)
+
+`ENABLE_USEICCDEVNAMESPACE` defaults to `OFF`
+(`Build/Cmake/CMakeLists.txt:565`). **Turning it `ON` does not produce a
+library.** Configure succeeds and prints `>>> Namespace wrapping enabled
+(iccDEV)`, then `IccProfLib2` fails to compile; no tool or test is reached.
+This is tracked as #2152 and is documented here because the option looks
+supported at configure time.
+
+```bash
+cmake -S Build/Cmake -B build-ns -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release \
+  -DENABLE_USEICCDEVNAMESPACE=ON -DENABLE_TOOLS=OFF -DENABLE_TESTS=OFF \
+  -DENABLE_WXWIDGETS=OFF -DENABLE_SHARED_LIBS=ON -DENABLE_STATIC_LIBS=OFF
+cmake --build build-ns -j4
+# Clang 18.1.3: 70 errors, first at IccProfLib/IccCAM.cpp:81:
+#   use of undeclared identifier 'CIccCamConverter';
+#   did you mean 'iccDEV::CIccCamConverter'?
+# GCC 13.3.0: 925 errors, same first site:
+#   'CIccCamConverter' has not been declared
+```
+
+The two error counts are for the same tree and the same first failure. Take
+that as a warning about counts: the number depends on how far a compiler
+carries on after the first unresolved scope, so it measures diagnostic
+recovery, not how much work is left.
+
+The option is not broken so much as **half-applied**. It defines
+`USEICCDEVNAMESPACE=1` (`Build/Cmake/CMakeLists.txt:709-711`), which opens
+`namespace iccDEV` in `IccProfLib/IccProfLibConf.h:67` and closes it at `:200`.
+Every other file must opt in with its own `#ifdef USEICCDEVNAMESPACE` block,
+and many never did:
+
+| Location | Files with no guard |
+|----------|---------------------|
+| `IccProfLib/*.cpp` | 16 of 39 |
+| `IccProfLib/*.h` | 13 of 47 |
+| `IccXML/IccLibXML/*.cpp` | 2 of 7 |
+| `IccXML/IccLibXML/*.h` | 4 of 8 |
+| `IccConnect/IccLibConnect` | none - fully guarded |
+
+So a header that wraps declares `iccDEV::CIccFoo` while its unwrapped `.cpp`
+defines a global `CIccFoo`, and the definition matches no declaration.
+`IccCAM.h` (guards at `:74` and `:159`) against `IccCAM.cpp` (zero occurrences)
+is the cleanest instance, and is where the build stops first. The build never
+reaches `IccXML`, whose own gaps are listed above for completeness.
+
+Finishing the rollout would be a per-file decision, not a sweep, and the
+per-file question is open rather than settled. Not every unguarded header wants
+the guard: `IccProfLibVer.h` holds a single version macro, and
+`icProfileHeader.h` holds the on-disk ICC structures and signature enums in
+deliberately C-style form. Whether headers of that kind stay outside the
+namespace by design is part of what #2152 asks.
+
+Two traps are worth knowing before spending time here:
+
+> **A single-header syntax probe will not scope this.** `IccCmm.h` *has* the
+> guard, yet `clang++ -fsyntax-only -DUSEICCDEVNAMESPACE=1` on a file that
+> includes only it still errors, because it pulls in unguarded siblings such as
+> `IccTagEmbedIcc.h`. Such a probe reflects the include graph, not the work
+> remaining. Only a full library build says anything trustworthy.
+
+> **This is not the same defect as the export-annotation gap** described in the
+> section above, even though #176 is titled `Known Defect |
+> ENABLE_USEICCDEVNAMESPACE=ON`. That issue's body is about the vcpkg port
+> building static libraries only and shared builds failing for want of symbol
+> exports, and the #764/#784/#823/#966/#1193 history sits with it on the shared
+> library and visibility side. Namespace scoping is a separate incomplete
+> rollout that fails under both Clang and GCC on Linux before any linking
+> happens. Both are incomplete; they are unrelated defects.
+
+Test sources are written as though the option worked: 25 of the 91 regression
+sources under `.github/ci/regression/` carry `#ifdef USEICCDEVNAMESPACE`
+blocks, as does all of `IccConnect`. Those paths are currently unexercised,
+since no build can enable them.
+
+Measured on `master` `054eb006`, Ubuntu 24.04 (WSL2), Unix Makefiles, Release,
+with both Clang 18.1.3 and GCC 13.3.0.
+
 ## Instrumentation Builds
 
 Use CMake options instead of hand-written sanitizer flags. Clean the cache when


### PR DESCRIPTION
## PR Summary

Part of #2152. Documentation only, no behaviour change.

`-DENABLE_USEICCDEVNAMESPACE=ON` configures cleanly, prints
`>>> Namespace wrapping enabled (iccDEV)`, and then fails to build
`IccProfLib2`. Nothing in the tree said so, which is @xsscx's stated reason for
documenting it: the question is "on AI Repeat every few weeks". This adds a
`Namespace wrapping (known defect)` section to `docs/build.md`, placed directly
after `Shared library exports` because that section is the existing model for a
deliberate, incomplete build capability.

It documents the status and the mechanism, not a fix. Per #2152 the
configure-time fail-fast is @xsscx's, so this PR does not touch
`Build/Cmake/CMakeLists.txt` — only the line it cites.

### What the section records

- The option defaults to `OFF` (`Build/Cmake/CMakeLists.txt:565`) and turning it
  `ON` produces no library.
- The mechanism: `USEICCDEVNAMESPACE=1` opens `namespace iccDEV` in
  `IccProfLib/IccProfLibConf.h:67` and closes it at `:200`; every other file
  must opt in with its own `#ifdef`, and many never did. `IccCAM.h` (guards at
  `:74`/`:159`) against `IccCAM.cpp` (zero occurrences) is where the build stops.
- Guard coverage as a table: `IccProfLib` 16 of 39 `.cpp` and 13 of 47 headers
  unguarded, `IccXML/IccLibXML` 2 of 7 and 4 of 8, `IccConnect` fully guarded.
- That finishing the rollout is a per-file decision and that the per-file
  question is open, not settled.
- Two traps, both of which cost me time: a single-header syntax probe measures
  the include graph rather than the work left, and this is **not** the
  export-annotation gap that #176's title implies.
- That 25 of 91 regression sources under `.github/ci/regression/` carry
  `#ifdef USEICCDEVNAMESPACE` blocks no build can currently exercise.

### Measured, not carried over

Everything above was re-measured on `master` `054eb006`, Ubuntu 24.04 (WSL2),
Unix Makefiles, Release. Three figures in the #2152 issue body did not survive
that, and the section carries the corrected ones:

| Claim in #2152 | Measured |
|---|---|
| "70 errors", environment given as GCC 13.3.0 | 70 is Clang 18.1.3. GCC 13.3.0 gives **925** on the same tree, same first site `IccCAM.cpp:81` |
| Standalone probe of `IccCmm.h` shows 535 errors | Does not reproduce; a bare `-fsyntax-only` include gives 20. The mechanism holds (errors come from unguarded sibling `IccTagEmbedIcc.h`), so the doc makes the point without publishing a count |
| `icProfileHeader.h` "is the C-compatible header" | No `extern "C"` block, no in-tree `.c` includes it. Softened to what is actually there, and flagged as the open design question rather than a ruling |

The 70-vs-925 split is now used in the section to make the point that an error
count measures diagnostic recovery, not work remaining. I will correct the issue
body figures separately.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md` — both the failing namespace
      build (Clang and GCC) and the documented reproduction
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [ ] Ran relevant CTest/profile tests from `docs/ctest.md` — n/a, markdown only
- [x] Updated documentation for user-visible behavior changes — this is the change
- [ ] Ran sanitizer coverage for memory-safety or parser changes — n/a
- [ ] Added or updated regression coverage for behavior changes — n/a, no behaviour change
- [ ] For Python package changes, followed `docs/python-packaging-release.md` — n/a
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure
- [ ] New source files include the ICC copyright and BSD 3-Clause license header — n/a, no new files
- [x] Code style matches nearby code — matches the surrounding `docs/build.md` voice and wrapping

`ci-pr-action` was dispatched on the branch with `ci_scope=docs` before opening
this PR, per the suggested PR workflow:
[run 31754577783](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/31754577783)
— success, build lanes correctly skipped for a docs-only scope.
