### PR TITLE
fix(#1940): detach the closed stream when CIccFileIO::Open refuses a reopen

### DIFF
--- a/.github/ci/regression/fileio-reopen-nonregular.cpp
+++ b/.github/ci/regression/fileio-reopen-nonregular.cpp
@@ -1,0 +1,101 @@
+// Regression test for #1940: a rejected write-mode reopen must leave
+// CIccFileIO closed, not holding a FILE* it has already fclose()d.
+//
+// CIccFileIO::Open closes any stream it is already holding before opening the
+// new one.  That fclose() has never nulled m_fFile, which was harmless while
+// the very next statement was the fopen() assignment.  #1204 inserted the
+// POSIX regular-file check between the two, and its early "return false" hands
+// the destructor -- and every other member -- a freed FILE*.
+//
+// Observed before the fix, on the same source:
+//   plain -O2       SIGSEGV inside fread() on the first read after the reopen
+//   ASAN Debug      "attempting double-free" in CIccFileIO::CloseFile
+//
+// The check is compiled out on Windows, so the defect and this test are both
+// POSIX-only.  The Windows arm exits 77, which the SKIP_RETURN_CODE on the
+// registration turns into a ctest Skipped rather than a green tick over a
+// binary that asserted nothing.
+
+#include "IccIO.h"
+
+#include <cstdio>
+#include <cstring>
+
+int main()
+{
+#if defined(_WIN32) || defined(WIN32)
+  std::printf("SKIP: the regular-file reopen check is POSIX-only\n");
+  return 77;
+#else
+  const char scratch_file[] = "fileio-reopen-nonregular-scratch.bin";
+  const char payload[] = "abcd";
+  const size_t payload_len = sizeof(payload) - 1;
+
+  {
+    FILE *seed = std::fopen(scratch_file, "wb");
+    if (!seed) {
+      std::printf("could not create %s\n", scratch_file);
+      return 1;
+    }
+    std::fwrite(payload, 1, payload_len, seed);
+    std::fclose(seed);
+  }
+
+  CIccFileIO io;
+  if (!io.Open(scratch_file, "rb")) {
+    std::printf("open failed: %s\n", scratch_file);
+    std::remove(scratch_file);
+    return 1;
+  }
+
+  // Reopen the same object in write mode on a character device.  The
+  // regular-file check refuses it, and must not leave the stream it closed on
+  // the way in still attached.
+  if (io.Open("/dev/null", "wb")) {
+    std::printf("write-mode reopen on a character device unexpectedly "
+                "succeeded\n");
+    std::remove(scratch_file);
+    return 1;
+  }
+
+  // Both of these run through m_fFile.  With the stale pointer in place the
+  // first is a read through freed memory and the second is a second fclose()
+  // of the same stream.  The read's return value is not a reliable
+  // discriminator on its own -- under ASAN the quarantined FILE still yields 0
+  // -- so the failure signal is the crash or the sanitizer report, and the
+  // check below only guards against a stream that stayed genuinely readable.
+  char buf[8];
+  std::memset(buf, 0, sizeof buf);
+  size_t nRead = io.Read8(buf, sizeof buf);
+  io.Close();
+
+  if (nRead != 0) {
+    std::printf("refused reopen left a readable stream: %zu bytes\n", nRead);
+    std::remove(scratch_file);
+    return 1;
+  }
+
+  // A refused Open must leave the object reusable, not merely non-crashing:
+  // the same handle has to open and read a regular file afterwards.
+  if (!io.Open(scratch_file, "rb")) {
+    std::printf("object was not reusable after a refused reopen\n");
+    std::remove(scratch_file);
+    return 1;
+  }
+
+  std::memset(buf, 0, sizeof buf);
+  size_t nReopened = io.Read8(buf, payload_len);
+  io.Close();
+  std::remove(scratch_file);
+
+  if (nReopened != payload_len || std::memcmp(buf, payload, payload_len) != 0) {
+    std::printf("reuse after a refused reopen read %zu bytes, expected %zu\n",
+                nReopened, payload_len);
+    return 1;
+  }
+
+  std::printf("CIccFileIO refused reopen left no attached stream, and the "
+              "object stayed reusable\n");
+  return 0;
+#endif
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2629,6 +2629,55 @@ function(iccdev_add_fileio_seek_tell_test)
   endif()
 endfunction()
 
+# Guards the reopen half of #1940. CIccFileIO::Open fclose()s the stream it is
+# already holding without nulling m_fFile, which only stayed safe while the
+# fopen() assignment was the next statement. #1204 put the POSIX regular-file
+# check in between, so a refused write-mode reopen returns with a freed FILE*
+# still attached: plain builds segfault in the next fread(), sanitizer builds
+# reach the following Close() and report a double-free. That check is compiled
+# out on Windows, so the test exits 77 there and SKIP_RETURN_CODE turns it into
+# a ctest Skipped instead of a false pass. Core IccProfLib only.
+function(iccdev_add_fileio_reopen_nonregular_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccFileIoReopenNonRegularTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/fileio-reopen-nonregular.cpp"
+  )
+  target_link_libraries(iccFileIoReopenNonRegularTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccFileIoReopenNonRegularTest)
+
+  add_test(
+    NAME iccdev.fileio-reopen-nonregular
+    COMMAND
+      "$<TARGET_FILE:iccFileIoReopenNonRegularTest>"
+  )
+  set_tests_properties(iccdev.fileio-reopen-nonregular PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    SKIP_RETURN_CODE 77
+    LABELS "iccdev;fileio;issue-1940;regression"
+  )
+  if(WIN32)
+    set(_fileio_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccFileIoReopenNonRegularTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _fileio_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.fileio-reopen-nonregular PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_fileio_windows_env_mods}"
+    )
+  else()
+    set_tests_properties(iccdev.fileio-reopen-nonregular PROPERTIES
+      ENVIRONMENT "${ICCDEV_TEST_ENV}"
+    )
+  endif()
+endfunction()
+
 # Guards the strict-aliasing fix in CIccIO::Write16/Write32/Write64 (#1948).
 # Those writers used to load the caller's buffer through the wide integer type,
 # which is undefined behaviour when the buffer holds floats -- as it does on
@@ -4737,6 +4786,7 @@ if(WIN32)
   iccdev_add_fileio_getlength_position_test()
   iccdev_add_profile_write_failure_test()
   iccdev_add_fileio_seek_tell_test()
+  iccdev_add_fileio_reopen_nonregular_test()
   iccdev_add_iccio_write_float_aliasing_test()
   iccdev_add_tagdata_zlib_roundtrip_test()
   iccdev_add_ziputf8_settext_contract_test()
@@ -5016,6 +5066,7 @@ iccdev_add_embedded_profile_detachio_test()
 iccdev_add_fileio_getlength_position_test()
 iccdev_add_profile_write_failure_test()
 iccdev_add_fileio_seek_tell_test()
+iccdev_add_fileio_reopen_nonregular_test()
 iccdev_add_iccio_write_float_aliasing_test()
 iccdev_add_tagdata_zlib_roundtrip_test()
 iccdev_add_ziputf8_settext_contract_test()

--- a/IccProfLib/IccIO.cpp
+++ b/IccProfLib/IccIO.cpp
@@ -554,8 +554,17 @@ bool CIccFileIO::Open(const icChar *szFilename, const icChar *szAttr)
   }
 #endif
 
-  if (m_fFile)
+  // Detach the closed stream before any path that can return without
+  // reassigning m_fFile.  The regular-file check below returns early, so
+  // leaving the stale pointer in place would hand the destructor -- and every
+  // other member -- a FILE* that fclose() has already freed.  The wide-char
+  // overload and Attach() below keep the bare fclose() because nothing can
+  // return between it and their own assignment; add this line there too if
+  // that ever stops being true.
+  if (m_fFile) {
     fclose(m_fFile);
+    m_fFile = NULL;
+  }
 
 #if !defined(_WIN32) && !defined(WIN32)
   if (icFileModeCanWrite(szAttr)) {

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -118,6 +118,7 @@ before running the suite.
 | `iccdev.create-profiles` | `Testing/CreateAllProfiles.sh` |
 | `iccdev.embedio-read8-bounds` | `.github/ci/regression/embedio-read8-bounds.cpp` |
 | `iccdev.fileio-getlength-preserves-position` | `.github/ci/regression/fileio-getlength-position.cpp` |
+| `iccdev.fileio-reopen-nonregular` | `.github/ci/regression/fileio-reopen-nonregular.cpp` |
 | `iccdev.fileio-seek-tell` | `.github/ci/regression/fileio-seek-tell.cpp` |
 | `iccdev.iccconnect-config-parser` | `.github/ci/regression/iccconnect-config-parser.cpp` |
 | `iccdev.iccconnect-threaded-cmm` | `.github/ci/regression/iccconnect-threaded-cmm.cpp` |
@@ -218,6 +219,7 @@ Windows full tool builds register these tests when all targets are available:
 |------|--------|
 | `iccdev.embedio-read8-bounds` | `.github/ci/regression/embedio-read8-bounds.cpp` |
 | `iccdev.fileio-getlength-preserves-position` | `.github/ci/regression/fileio-getlength-position.cpp` |
+| `iccdev.fileio-reopen-nonregular` | `.github/ci/regression/fileio-reopen-nonregular.cpp` (skipped: POSIX-only check) |
 | `iccdev.fileio-seek-tell` | `.github/ci/regression/fileio-seek-tell.cpp` |
 | `iccdev.iccconnect-threaded-cmm` | `.github/ci/regression/iccconnect-threaded-cmm.cpp` |
 | `iccdev.windows-iccdevcmm-smoke` | `Tools/Winnt/IccDEVCmm/tests/IccDEVCmmSmoke.cpp` |


### PR DESCRIPTION
## Summary

`CIccFileIO::Open` has always closed the stream it was already holding without
nulling `m_fFile`. That stayed safe only because the very next statement was
the `fopen()` assignment, so the stale pointer never outlived the call.
`c3ad932d` (#1204) inserted the POSIX regular-file check between the two, and
its early `return false` now leaves the object holding a `FILE*` that
`fclose()` has already freed.

`IccProfLib/IccIO.cpp:557`, before this change:

```cpp
  if (m_fFile)
    fclose(m_fFile);          // closed, but m_fFile is left pointing at it

#if !defined(_WIN32) && !defined(WIN32)
  if (icFileModeCanWrite(szAttr)) {
    struct stat st;
    if (stat(szFilename, &st) == 0 && !S_ISREG(st.st_mode))
      return false;           // <-- added by #1204; m_fFile never reassigned
  }
#endif

  m_fFile = fopen(szFilename, szAttr);
```

Every other member tests `m_fFile` for NULL and then uses it, and
`~CIccFileIO()` calls `Close()` -> `CloseFile()` -> `fclose()`. So a refused
write-mode reopen leaves the object one member call away from a use-after-free
and one destructor away from a double free (CWE-416 / CWE-415).

## Reproduction

```cpp
CIccFileIO io;
io.Open("some.icc", "rb");     // succeeds
io.Open("/dev/null", "wb");    // refused by the #1204 check -- m_fFile dangles
io.Close();                    // second fclose() of the same stream
```

Measured on the same source, both directions, on master `ae3238dc`. The branch
is rebased onto `19da6a06`, which is a version bump touching none of these
files.

| build | before | after |
| --- | --- | --- |
| plain `-O2` (clang 21.1.3) | **SIGSEGV** inside the next `fread()`, exit 139 | exit 0 |
| ASAN Debug (`ENABLE_SANITIZERS=ON`) | **`AddressSanitizer: attempting double-free`** in `CIccFileIO::CloseFile`, exit 1 | exit 0 |

The two builds fail differently because ASAN quarantines the freed `FILE`, so
the read returns 0 and the following `Close()` trips instead, while glibc
recycles the chunk and the read faults first. The use-after-free read is
**silent** under ASAN -- which is why the new test does not rely on a return
value as its only signal.

## Fix

Null `m_fFile` at the point it is closed, matching what the block twenty lines
below already does when the post-`fopen()` `fstat` check rejects the stream.

`Open(const icWChar*)` (`:588`) and `Attach()` (`:609`) carry the same
`fclose()`-without-null shape, but both always reassign `m_fFile` before
returning, so they are left unchanged.

## Test

`iccdev.fileio-reopen-nonregular`
(`.github/ci/regression/fileio-reopen-nonregular.cpp`), registered in both
CMake call lists and listed in `docs/ctest.md`. It drives the public API
directly: open a regular file for read, reopen the same object in write mode
on a character device, then read and close -- and then reopen the regular file
and read its bytes back, because a refused `Open()` has to leave the object
*reusable*, not merely non-crashing.

Proven red against the pre-fix source in **both** lane types, so this is not
sanitizer-only coverage:

```
plain -O2   exit 139 (SIGSEGV)   ASAN Debug   exit 1 (double-free)
```

The regular-file check is inside `#if !defined(_WIN32)`, so the defect and the
test are both POSIX-only. The Windows arm exits 77 and the registration
carries `SKIP_RETURN_CODE 77`, so ctest records a Skipped rather than a green
tick over a binary that asserted nothing -- the same convention as
`iccdev.embedded-profile-onelevel-load`.

## Pre-flight

| lane | result |
| --- | --- |
| Clang 21.1.3 Release, `-Wall -Wextra -Wpedantic -Werror` (`strict warnings ENABLED`) | **0 warnings**, 183/184 ctest |
| GCC 15.2.0 in `iccdev-ci-regression:sha-b572e972`, same flags + `-DENABLE_LTO=ON` (`strict warnings ENABLED`) | **0 warnings** |
| ASAN+UBSAN Debug, full ctest sweep | new test green, `detect_leaks=1` clean |

The single ctest failure in every local lane is `iccdev.spectral-tiff-preview`
(`ModuleNotFoundError: No module named 'imagecodecs'`), environmental and
present on unmodified master.

`ci-pr-action` was dispatched on this branch before the PR was opened, with
`ci_scope=source` -- the narrowest scope that still sets `include_windows=true`
and `ctest_recent_limit=0`, both of which the new test target needs:
[run 31762988907](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/31762988907),
**success**. GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL, MinGW UCRT64
and Tool Smoke Tests (ASAN+UBSAN Debug) all green.

## Scope

`Part of #1940`. That issue covers three things; this is the third:

1. null-reference family -- landed in #2053
2. dead increment at `iccApplyNamedCmm.cpp:358` -- already fixed by #1958
3. **stream/resource paths blamed to `c3ad932d` (#1204)** -- this change

The scan-build enumeration behind item 3, including why the analyzer's ten
`unix.Stream` warnings are all one false positive and none of them is this
defect, is posted on the issue.
