### PR TITLE
fix(#2154): write SVG through the handle its regular-file check validated

### DIFF
--- a/.github/ci/regression/iccviz-writer-serialization.cpp
+++ b/.github/ci/regression/iccviz-writer-serialization.cpp
@@ -128,9 +128,9 @@ static bool slurpStream(FILE *f, std::vector<unsigned char> &out)
 // in-memory path produced.
 //
 // This is the one place platform differences reach this test, and it is not
-// optional. PDFWriter::CloseFile writes through icOpenRegularWriteTextFile,
-// i.e. fopen(name, "wt") (IccCmdLineUtil.h:240), and SVGOut::CloseFile uses a
-// default-mode std::ofstream: both are TEXT streams, so a Windows CRT expands
+// optional. PDFWriter::CloseFile and SVGOut::CloseFile both write through
+// icOpenRegularWriteTextFile, i.e. fopen(name, "wt") (IccCmdLineUtil.h:240):
+// both are TEXT streams, so a Windows CRT expands
 // every '\n' to "\r\n" on the way out, while Serialize() writes to an
 // ostringstream that expands nothing. Comparing raw bytes would report a size
 // difference that is the platform's line-ending policy rather than a

--- a/IccProfLib/IccCmdLineUtil.h
+++ b/IccProfLib/IccCmdLineUtil.h
@@ -262,4 +262,37 @@ inline bool icFlushAndClose(FILE* f)
 
 /******************************************************************************/
 
+// Write a whole document through an ALREADY-VALIDATED handle, then close it.
+//
+// Why this exists (#2154): icOpenRegularWriteFile() above earns its guarantee by
+// fstat()ing the descriptor it actually opened, not the path it was given. That
+// guarantee lives in the returned FILE* and nowhere else -- so a caller that
+// closes the handle and then reopens the same *path* through another stream has
+// thrown the check away and reintroduced the race it just paid for. Passing the
+// handle straight to this function is what keeps the validated object and the
+// written object the same object.
+//
+// The body mirrors the WritePdfTextFile() copies in MiniPDF.cpp, which already
+// do exactly this correctly; those are two more members of the duplicated
+// open/close helper family #2154 tracks, and they can collapse onto this one.
+inline bool icWriteAndClose(FILE* f, const std::string& text)
+{
+  bool failed = false;
+
+  if (!f)
+    return false;
+
+  if (!text.empty() && fwrite(text.data(), 1, text.size(), f) != text.size())
+    failed = true;
+
+  // icFlushAndClose() reports the deferred write errors that fwrite() can hide
+  // behind a full stdio buffer, so its verdict is part of the result.
+  if (!icFlushAndClose(f))
+    failed = true;
+
+  return !failed;
+}
+
+/******************************************************************************/
+
 #endif

--- a/Tools/CmdLine/IccProfilePlot/MiniSVG.cpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniSVG.cpp
@@ -105,13 +105,22 @@ void SVGOut::Finalize()
 
 /******************************************************************************/
 
-// Every byte the SVG writer emits is produced here (#2116). The body was
-// already accumulated in the m_buf ostringstream; only the header and footer
-// used to go straight to the std::ofstream, which is what kept this layer off
-// limits to a harness.
+// The public stream entry point (#2116): finalize, then emit. Every byte comes
+// from SerializeFinalized() below, which CloseFile() also calls, so the stream
+// path and the file path cannot produce different documents (#2154). The body
+// was already accumulated in the m_buf ostringstream; before #2116 the header
+// and footer went straight to a std::ofstream, which is what kept this layer
+// off limits to a harness.
 void SVGOut::Serialize( std::ostream &out )
 {
   Finalize();
+  SerializeFinalized(out);
+}
+
+/******************************************************************************/
+
+void SVGOut::SerializeFinalized( std::ostream &out )
+{
   WriteHeader(out);
   out << m_buf.str();
   WriteFooter(out);
@@ -128,20 +137,41 @@ void SVGOut::CloseFile()
   if (!m_filename.empty()) {
     if (m_pageCount > 0) {
       try  {
-        FILE* checkFile = icOpenRegularWriteTextFile(m_filename.c_str());
-        if (!checkFile || !icFlushAndClose(checkFile)) {
+        // Produce the whole document BEFORE anything is opened.  The scope
+        // releases the stringstream and its buffer while no descriptor exists,
+        // so an allocation failure on a dense multi-MB plot cannot unwind past
+        // an open handle -- and only `text` is still resident during the write.
+        std::string text;
+        {
+          std::ostringstream doc;
+          doc.exceptions(std::ios::badbit | std::ios::failbit);
+          SerializeFinalized(doc);
+          text = doc.str();
+        }
+
+        // Write through the handle the regular-file check validated (#2154).
+        // This used to open the file with icOpenRegularWriteTextFile(),
+        // immediately close it, and then reopen the same *path* with a
+        // std::ofstream -- so the check ran against a descriptor that was
+        // discarded, and the stream actually written was never checked at all.
+        // Anything that replaced the path between the close and the reopen with
+        // a non-regular file (a FIFO, a device node, or a symlink to either)
+        // was then written to unchecked.
+        FILE* outFile = icOpenRegularWriteTextFile(m_filename.c_str());
+        if (!outFile) {
+          // Kept distinct from the write failure below: a refused open is the
+          // regular-file guard doing its job, which is a different diagnosis
+          // from a write that started and then failed (ENOSPC, EIO).
           fprintf(stderr, "SVG writing error in '%s': unable to open regular output file\n", m_filename.c_str());
           m_filename.clear();
           return;
         }
 
-        std::ofstream out;
-        out.exceptions(std::ios::badbit | std::ios::failbit);
-        out.open(m_filename);
-        WriteHeader(out);
-        out << m_buf.str();
-        WriteFooter(out);
-        out.close();
+        if (!icWriteAndClose(outFile, text)) {
+          fprintf(stderr, "SVG writing error in '%s': unable to write regular output file\n", m_filename.c_str());
+          m_filename.clear();
+          return;
+        }
       }
       catch (const std::exception& e) {
         fprintf(stderr, "SVG writing error in '%s': '%s'\n", m_filename.c_str(), e.what() );

--- a/Tools/CmdLine/IccProfilePlot/MiniSVG.hpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniSVG.hpp
@@ -174,6 +174,18 @@ public:
   // a plain serializer.
   void Serialize( std::ostream &out );
 
+private:
+
+  // The one place the document bytes are produced.  Serialize() and CloseFile()
+  // both route through this, so the file path and the stream path cannot drift
+  // -- adding a DOCTYPE or a comment here reaches both by construction (#2154).
+  //
+  // Finalize() is deliberately the caller's job rather than this function's:
+  // that is what lets CloseFile() finalize once at its top, whether or not a
+  // file was ever opened, and still serialize without re-emitting Finalize's
+  // unbalanced-group warnings.
+  void SerializeFinalized( std::ostream &out );
+
 public:
 
   void AddCircle( float radius, float xCenter, float yCenter, bool isFilled ) {


### PR DESCRIPTION
## What this fixes

`SVGOut::CloseFile()` validated a descriptor and then wrote through a different one.

`icOpenRegularWriteFile()` earns its guarantee by `fstat()`ing the descriptor it
actually opened, not the path it was handed — that is what closes the
`stat`/`open` race. `CloseFile()` took that validated handle,
`icFlushAndClose()`d it, and then reopened the same **path** with a
`std::ofstream`, which performs no such check. A path replaced between the close
and the reopen with a non-regular file (a FIFO, a device node, or a symlink to
either) was written to unchecked.

The document is now produced up front and written through the validated handle,
which is what `MiniPDF.cpp`'s `WritePdfTextFile()` already does correctly.

## Evidence

**Mechanism** — `gdb 'catch syscall openat'` on the `iccviz-writer-serialization`
harness, counting opens of the output path (syscall entry only):

| | opens of the `.svg` path |
|---|---|
| `master` | `O_WRONLY\|O_CREAT\|O_TRUNC` **twice**, then `O_RDONLY` (harness read-back) |
| this PR | `O_WRONLY\|O_CREAT\|O_TRUNC` **once**, then `O_RDONLY` |

The second write-open is the discarded check.

**Bytes unchanged** — `iccdev.iccviz-writer-serialization` byte-compares
`CloseFile()` output against `Serialize()` output and passes. Red-tested:
injecting a marker into the file path fails it at 498 vs 510 bytes, so the
comparison discriminates rather than passing vacuously.

**Guard non-regression** — a FIFO left at the output path is still refused, still
reports the *open* diagnostic, and is still a FIFO afterwards.

**Gates** — clang 18 strict and GCC 15.2 strict + LTO in the CI regression
container (`strict warnings ENABLED (GNU 15.2.0)`): 0 warnings each. Full local
ctest 184/185; the single failure is `iccdev.spectral-tiff-preview`,
`ModuleNotFoundError: No module named 'imagecodecs'`, a missing local Python
module unrelated to this change.

## Three things worth stating plainly

**`SVGOut` is not reachable from any shipped tool.** `iccProfileVisualize.cpp`
declares `DrawAxisSVG` and an SVG graph function taking `SVGOut&` but never
constructs one. This defect is latent and **there is no CLI reproduction for
it** — the gdb measurement above is the substitute, and I would rather say so
than imply a reproduction that does not exist.

**The parallel copy under `Tools/CmdLine/IccProfileVisualize/` is deliberately
not touched.** It is in no CMake target, and it does not even compile
standalone: `mm2point`'s only definition is commented out in `vizShared.hpp` as
unused, so `g++ -fsyntax-only` fails on it today. Editing source that nothing
builds and nothing can validate would add diff surface with no signal. Flagging
it here because an entire orphaned, non-compiling translation unit in the tree
is itself relevant to the #2154 duplicate-tree question.

**Byte production moved into a private `SerializeFinalized()`** that both
`Serialize()` and `CloseFile()` call, so the header contract at `MiniSVG.hpp`
("CloseFile() is the file-writing wrapper around this call", #2116) stays true by
construction instead of by comment. The stringstream is built and released
before any descriptor exists, so an allocation failure cannot unwind past an
open handle. A refused open keeps its own diagnostic, distinct from a write that
failed partway — the refusal is the regular-file guard working, not an I/O error.

`icWriteAndClose()` lands in `Tools/CmdLine/IccCmdLineUtil.h` because both
callers already include it; it is placed to travel with that header when it
relocates into `IccProfLib`, and the two `WritePdfTextFile()` statics can
collapse onto it in that pass.

Part of #2154
