### PR TITLE
fix(#1472): stop iccPawgReport offering 'none' as a pending registration

### DIFF
--- a/.github/scripts/iccdev-pawg-report-regression-tests.sh
+++ b/.github/scripts/iccdev-pawg-report-regression-tests.sh
@@ -1481,10 +1481,13 @@ run_s3_header_signature_tests() {
 
   # 'none' (0x6E6F6E65) is a pervasive "no manufacturer" placeholder (AdobeRGB1998,
   # ROMM-RGB, ...). It is neither zero nor registered, so S3 still WARNs per
-  # section 7.2.17, but with softened wording flagging it as a known placeholder
-  # rather than suspect data (issue #1459).
+  # section 7.2.17, but with softened wording rather than presenting it as suspect
+  # data. The ICC ruled on issue #1472 that the specification requires the zero
+  # signature here, so 'none' can never be registered: the detail must NOT offer
+  # it as a pending registration ("not yet in the registry"), which is what this
+  # needle pins.
   run_s3_header_signature_case "manufacturer-none-placeholder-warn" \
-    "6e6f6e65" "00000000" "WARN" "known 'no manufacturer' placeholder"
+    "6e6f6e65" "00000000" "WARN" "so 'none' is not registrable"
 
   # 'ICC ' (0x49434320) is used by the ICC's own reference profiles (and the
   # iccDEV regression fixtures). Still WARNs (not in the Manufacturer Signatures

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -353,22 +353,33 @@ bool IsRegisteredManufacturerOrZero(uint32_t sig)
   return sig == 0 || FindRegisteredManufacturer(sig) != NULL;
 }
 
-// Some signatures are pervasive conventions that are not (yet) in the
-// Manufacturer Signatures registry and are not the zero signature, so they still
-// fail the strict ICC.1:2022-05 section 7.2.17 check and warrant a WARN -- but
-// they are well-understood placeholders rather than malformed/unknown 4CCs, so
-// S3 reports them with softened wording and they are tracked for ICC registry
-// submission (issue #1459 Segment A) rather than presented as suspect data:
-//   'none' (0x6E6F6E65) -- explicit "no manufacturer" placeholder
+// Some signatures are pervasive conventions that are not the zero signature, so
+// they still fail the strict ICC.1:2022-05 section 7.2.17 check and warrant a
+// WARN -- but they are well-understood 4CCs rather than malformed/unknown data,
+// so S3 reports them with softened wording rather than presenting them as
+// suspect. The two differ in whether ICC registration is even possible, so each
+// carries its own complete explanation instead of a shared "not yet in the
+// registry" suffix (ICC ruling on issue #1472, 2026-07-24):
+//   'none' (0x6E6F6E65) -- "no manufacturer" placeholder. NOT registrable: the
+//                          ICC ruled that the specification requires the zero
+//                          signature here, so 'none' is a producer error, not a
+//                          registration that is pending. Saying "not yet in the
+//                          registry" would wrongly imply it is on its way in.
 //   'ICC ' (0x49434320) -- the International Color Consortium's own reference
-//                          profiles (also used by the iccDEV regression fixtures)
+//                          profiles (also used by the iccDEV regression
+//                          fixtures). Registration is undecided rather than
+//                          refused, so "not yet" is accurate here.
+// Returns the entire parenthetical body, so a caller must not append a registry
+// snapshot reference of its own.
 const char *KnownUnregisteredConventionNote(uint32_t sig)
 {
   switch (sig) {
   case 0x6E6F6E65:  // 'none'
-    return "known 'no manufacturer' placeholder";
+    return "\"no manufacturer\" placeholder; ICC.1:2022-05 section 7.2.17 requires the "
+           "zero signature (00h) here, so 'none' is not registrable";
   case 0x49434320:  // 'ICC '
-    return "International Color Consortium reference-profile signature";
+    return "International Color Consortium reference-profile signature, not yet in "
+           "Manufacturer Signatures registry snapshot " ICCPAWG_REGISTRY_SNAPSHOT_DATE;
   default:
     return NULL;
   }
@@ -376,6 +387,9 @@ const char *KnownUnregisteredConventionNote(uint32_t sig)
 
 // Append the per-field "(<sig> ...)" explanation for an unregistered manufacturer
 // or creator signature, softening the wording for the known conventions above.
+// A known-convention note supplies the whole explanation (the registrable and
+// non-registrable cases need different ones), so only the generic case appends
+// the registry snapshot reference.
 void AppendUnregisteredSigDetail(std::ostringstream &detail, uint32_t sig)
 {
   if (!IsZeroOrPrintable(sig)) {
@@ -384,13 +398,13 @@ void AppendUnregisteredSigDetail(std::ostringstream &detail, uint32_t sig)
   const char *note = KnownUnregisteredConventionNote(sig);
   detail << " (" << SigString(sig) << " ";
   if (note) {
-    detail << note << ", not yet in";
+    detail << note;
   }
   else {
-    detail << "not in";
+    detail << "not in Manufacturer Signatures registry snapshot "
+           << ICCPAWG_REGISTRY_SNAPSHOT_DATE;
   }
-  detail << " Manufacturer Signatures registry snapshot "
-         << ICCPAWG_REGISTRY_SNAPSHOT_DATE << ")";
+  detail << ")";
 }
 
 std::string HeaderSignatureDetail(const RawProfile &raw,

--- a/Tools/CmdLine/IccPawgReport/registry/GOVERNANCE_SUBMISSIONS.md
+++ b/Tools/CmdLine/IccPawgReport/registry/GOVERNANCE_SUBMISSIONS.md
@@ -21,7 +21,7 @@ zero nor present in the Manufacturer Signatures registry snapshot (2026-06-20):
 |-----------|-----|-------------|--------------------|-------------|
 | `XRCM` | `0x5852434D` | 16 | `CGATS21_CRPC2..7`, `GRACoL2013*`, `SWOP2013C3_CRPC5`, `APTEC_PC1x_*` | **Submit** — creator of the entire ICC CRPC/GRACoL/SWOP/APTEC characterization-profile family; clearly an ICC/X-Rite production signature missing from the public list |
 | `ICC ` | `0x49434320` | 23 | `sRGB_D65_colorimetric`, `sRGB_D65_MAT` (and iccDEV regression fixtures) | **Clarify/Register** — the ICC's own reference-profile signature. Registry lists `SICC` and `iccd` for the consortium but not `'ICC '`. Either register `'ICC '` or document the canonical consortium signature |
-| `none` | `0x6E6F6E65` | 25 | `AdobeRGB1998`, `ISO22028-2_ROMM-RGB`, `sRGB_v4_ICC_preference_displayclass` | **Policy** — pervasive "no manufacturer" placeholder. Decide whether the registry/spec should bless `'none'` as a sanctioned placeholder (equivalent to zero) or whether producers should emit zero |
+| `none` | `0x6E6F6E65` | 25 | `AdobeRGB1998`, `ISO22028-2_ROMM-RGB`, `sRGB_v4_ICC_preference_displayclass` | **RULED 2026-07-24 (issue #1472) — not registrable.** The ICC ruled that the specification requires `00h` here, so `'none'` is a producer error rather than a placeholder awaiting registration. S3 still WARNs, and its detail must not describe `'none'` as "not yet" registered |
 | `LOGO` | `0x4C4F474F` | 2 | `MCPPiPF5000Glossy` | **Investigate/Submit** — likely Logo/GretagMacbeth-era tooling; confirm owner and submit |
 | `ccox` | `0x63636F78` | 1 | (corpus) | **Investigate/Submit** — probably CHROMiX (registry has `CMiX` `0x434D6958`); confirm and submit or map |
 
@@ -39,7 +39,9 @@ maintainers; tracked in `PERMISSIVENESS_DELTAS.md` §B as an IccProfLib change):
 1. Register `XRCM` (and confirm its owner — X-Rite production?) so the ICC's own
    published CRPC/GRACoL/SWOP/APTEC profiles validate cleanly.
 2. Register or canonically document the `'ICC '` consortium signature.
-3. Decide policy on the `'none'` placeholder (sanction vs. recommend zero).
+3. ~~Decide policy on the `'none'` placeholder (sanction vs. recommend zero).~~
+   **Answered 2026-07-24 (issue #1472): the specification says `00h`, so `'none'`
+   is not registrable and producers should emit the zero signature.**
 4. Confirm and register `LOGO` and `ccox` (or provide the correct mappings).
 
 ## What the code does in the meantime

--- a/Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md
+++ b/Tools/CmdLine/IccPawgReport/registry/PERMISSIVENESS_DELTAS.md
@@ -148,7 +148,7 @@ corpus with the #1459-fixed tool:
 |-----------|-------|-------------|---------|--------|
 | `XRCM` | `0x5852434D` | 16 | CRPC2..7 / GRACoL2013 / SWOP2013 / APTEC | submit to ICC |
 | `ICC ` | `0x49434320` | 23 | ICC reference profiles (sRGB_D65_*), iccDEV fixtures | register/clarify consortium sig |
-| `none` | `0x6E6F6E65` | 25 | AdobeRGB1998, ROMM-RGB, sRGB displayclass | policy: sanction placeholder vs. require zero |
+| `none` | `0x6E6F6E65` | 25 | AdobeRGB1998, ROMM-RGB, sRGB displayclass | **ruled 2026-07-24 (#1472): spec says `00h`, not registrable** |
 | `LOGO` | `0x4C4F474F` | 2 | MCPPiPF5000Glossy | investigate/submit |
 | `ccox` | `0x63636F78` | 1 | corpus | investigate/submit (likely CHROMiX) |
 
@@ -161,6 +161,13 @@ distinct unregistered one.)
 to identify them as known placeholders/consortium signatures rather than suspect
 data - but the verdict stays WARN and nothing is silently accepted. The other
 sigs keep the plain "not in Manufacturer Signatures registry" wording.
+
+**Amended 2026-07-24 by the ICC ruling on #1472:** the two softened cases are no
+longer worded alike, because they differ in whether registration is even possible.
+`'none'` is **not registrable** (the spec requires `00h`), so its detail states that
+and must not say "not yet in the registry", which would imply a pending submission.
+`'ICC '` is undecided rather than refused, so it keeps the "not yet in ... snapshot"
+wording. Each case therefore supplies its own complete parenthetical.
 
 ---
 


### PR DESCRIPTION
Part of #1472.

## Problem

iccPawgReport's S3 header-signature detail described `'none'` (`0x6E6F6E65`) as:

```
('none' known 'no manufacturer' placeholder, not yet in Manufacturer Signatures registry snapshot 2026-06-20)
```

"**not yet in**" offers `'none'` as a registration on its way in. On #1472 (2026-07-24) the ICC
ruled the opposite: *"none - the specification says 00h"*. Under ICC.1:2022-05 §7.2.17 the field
must carry the **zero** signature, so `'none'` is a producer error that can never be registered.
The tool was inviting readers to wait for a submission that will never arrive.

## Change

`KnownUnregisteredConventionNote` now returns the **entire** parenthetical body rather than a
fragment that the caller completes with a shared `", not yet in <snapshot>"` suffix. That shared
suffix was the defect: the two softened cases are not alike.

| Signature | Detail after this change |
|---|---|
| `'none'` | `"no manufacturer" placeholder; ICC.1:2022-05 section 7.2.17 requires the zero signature (00h) here, so 'none' is not registrable` |
| `'ICC '` | `International Color Consortium reference-profile signature, not yet in Manufacturer Signatures registry snapshot 2026-06-20` |
| any other | `not in Manufacturer Signatures registry snapshot 2026-06-20` |

`'ICC '` keeps "not yet" deliberately — the ICC's position there is *undecided* ("could be
discussed"), not refused, so a pending registration is still the accurate reading.

**No verdict changes.** Every unregistered signature still WARNs under §7.2.17, and nothing is
silently accepted. This is the wording of the explanation only.

## Registry notes

`registry/GOVERNANCE_SUBMISSIONS.md` and `registry/PERMISSIVENESS_DELTAS.md` both still listed
`'none'` as an **open** ICC policy question ("sanction placeholder vs. require zero"). That
question has been answered, so both now record the answer instead of re-asking it.

## Test

The regression case `manufacturer-none-placeholder-warn` pinned the old phrasing as its needle,
so it would have passed unchanged and let the stale wording ride. It now guards the ruling:

```
run_s3_header_signature_case "manufacturer-none-placeholder-warn" \
  "6e6f6e65" "00000000" "WARN" "so 'none' is not registrable"
```

Red/green, `.github/scripts/iccdev-pawg-report-regression-tests.sh`:

| Tree | Result |
|---|---|
| pre-fix wording restored, rebuilt | `[FAIL] manufacturer-none-placeholder-warn -- S3 detail missing expected text` — **23 passed, 1 failed** |
| with the fix | **24 passed, 0 failed** |
| re-run on current master base `d529ece3` | **24 passed, 0 failed** |

## Pre-flight

- `shellcheck` 0.9.0 (CI's apt version) on the modified script — rc=0
- Strict clang Release `-Wall -Wextra -Wpedantic -Werror -std=c++17`, CI's own gate
  `grep -cE 'warning:'` on the build log — **0**
- Live registry re-checked: `XRCM`, `ccox`, `LOGO`, `'ICC '` all still absent, and the
  `IccSignatureRegistry.h` snapshot (279 entries) diffs clean against registry.color.org,
  so these warnings are correct output rather than a stale table

## CI

Dispatched `ci-pr-action` with `ci_scope=source` before opening this PR, per the
maintainer's suggested workflow: [run 31831625011](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/31831625011)
— **10 success, 2 skipped**, covering GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL,
MinGW UCRT64 smoke, and Tool Smoke Tests ASAN+UBSAN (Debug).
