### PR TITLE
fix(#2160): bound the XML text nodes iccToXml emits for large CLUTs

### DIFF
--- a/.github/scripts/iccdev-xml-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-xml-parser-regression-tests.sh
@@ -7,9 +7,9 @@
 # directions, which is why they share a script:
 #
 #   1. iccDEV must be able to read back the XML it just wrote. A profile whose
-#      CLUT serialises to a single text node larger than libxml2's
-#      XML_MAX_TEXT_LENGTH (10 MB) used to be refused on read, so iccToXml
-#      could emit a document iccFromXml then rejected.
+#      CLUT serialises past libxml2's XML_MAX_TEXT_LENGTH (10 MB) must be split
+#      into bounded text nodes, so iccToXml never emits a document iccFromXml
+#      rejects.
 #
 #   2. Relaxing that must not widen what the parser accepts: the nesting-depth
 #      and name-length caps have to stay armed. The hardening cases below fail
@@ -35,12 +35,10 @@
 #      bound below already does. A silent NULL is indistinguishable here from
 #      "parsed fine, but is not a profile".
 #
-#   b. Case 1's mechanism no longer holds on current libxml2. v2.13.0 moved the
-#      XML_MAX_TEXT_LENGTH check into xmlSAX2Text ("SAX2: Enforce size limit in
-#      xmlSAX2Text with XML_PARSE_HUGE"), so it applies however the input is
-#      delivered and parsing from a buffer no longer avoids it. Case 1 therefore
-#      fails against libxml2 >= 2.13 and is expected to keep failing until the
-#      reader is fixed, which is the other half of #2108.
+#   b. libxml2 v2.13.0 moved the XML_MAX_TEXT_LENGTH check into xmlSAX2Text
+#      ("SAX2: Enforce size limit in xmlSAX2Text with XML_PARSE_HUGE"), so the
+#      writer splits CLUT rows into text nodes below that cap rather than
+#      weakening the reader with XML_PARSE_HUGE.
 #
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
@@ -103,7 +101,7 @@ check_sanitizers() {
 }
 
 ###############################################################################
-# 1. Round-trip a profile whose XML carries a text node over the streaming cap
+# 1. Round-trip a profile whose XML exceeds the text-node cap
 ###############################################################################
 
 echo "=== Large text node round-trip (issue #1856) ==="
@@ -126,9 +124,8 @@ roundtrip_large_text_node() {
     return
   fi
 
-  # A grid-33 CMYK->RGB device link is the cheapest way to get a CLUT that
-  # serialises past the 10 MB text-node limit: 33^4 grid points x 3 channels
-  # is ~21 MB of whitespace-separated values in one element.
+  # A grid-33 CMYK->RGB device link is the cheapest way to get a CLUT whose
+  # numeric text exceeds 10 MB: 33^4 grid points x 3 channels is ~21 MB.
   if ! "$APPLYTOLINK" "$link" 0 33 0 "issue 1856 regression" 0 1 1 1 \
        "$src" 1 "$dst" 1 >"$logfile" 2>&1; then
     fail "$name" "iccApplyToLink failed to build the fixture link"
@@ -140,23 +137,46 @@ roundtrip_large_text_node() {
     return
   fi
 
-  # Confirm the fixture actually exercises the limit. If a future change to the
-  # writer shortens the node below the cap this test would silently stop
-  # testing anything, so treat that as a skip with the measured size.
-  local longest
-  longest="$(python3 - "$xml" <<'PY'
+  # Confirm the fixture exercises the limit while the writer keeps every text
+  # node under it. If the document becomes small, the fixture no longer covers
+  # the boundary; if a node exceeds the cap, current libxml2 rejects it.
+  # Assign in a separate statement from the command substitution so the exit
+  # status checked is python's and not the local builtin's -- otherwise a failed
+  # measurement yields empty values and reports as a skip with a blank size,
+  # silently retiring the one case that pins the boundary.
+  local measured total longest splits
+  if ! measured="$(python3 - "$xml" <<'PY'
 import re, sys
 data = open(sys.argv[1], "rb").read()
-print(max((len(m.group(1)) for m in re.finditer(rb">([^<]*)<", data)), default=0))
+nodes = [len(m.group(1)) for m in re.finditer(rb">([^<]*)<", data)]
+print(sum(nodes), max(nodes, default=0), data.count(b"<!-- TableData continuation -->"))
 PY
-)"
-  if [ -z "$longest" ] || [ "$longest" -le "$XML_MAX_TEXT_LENGTH" ]; then
-    skip "$name" "longest text node ${longest:-unknown} bytes does not exceed $XML_MAX_TEXT_LENGTH"
+)"; then
+    fail "$name" "could not measure the text nodes in $xml"
+    return
+  fi
+  read -r total longest splits <<<"$measured"
+
+  if [ -z "$total" ] || [ "$total" -le "$XML_MAX_TEXT_LENGTH" ]; then
+    skip "$name" "total CLUT text ${total:-unknown} bytes does not exceed $XML_MAX_TEXT_LENGTH"
+    return
+  fi
+  if [ -z "$longest" ] || [ "$longest" -gt "$XML_MAX_TEXT_LENGTH" ]; then
+    fail "$name" "longest text node ${longest:-unknown} bytes exceeds $XML_MAX_TEXT_LENGTH"
+    return
+  fi
+  # The size bounds above are necessary but not sufficient: "total" counts every
+  # indent and every unrelated element's text, so on its own it does not prove
+  # the CLUT approached the cap. Requiring the writer to have actually split
+  # ties the case to the mechanism under test, so removing the split turns this
+  # red here rather than only at the iccFromXml call below.
+  if [ -z "$splits" ] || [ "$splits" -lt 1 ]; then
+    fail "$name" "writer emitted no text-node split for ${total} bytes of CLUT text"
     return
   fi
 
   if ! "$FROMXML" "$xml" "$back" >>"$logfile" 2>&1; then
-    fail "$name" "iccFromXml refused a ${longest}-byte text node it had just written"
+    fail "$name" "iccFromXml refused ${total} bytes of CLUT text split into ${longest}-byte nodes"
     return
   fi
   check_sanitizers "$name" "$logfile" || return
@@ -175,7 +195,7 @@ def norm(path):
 sys.exit(0 if norm(sys.argv[1]) == norm(sys.argv[2]) else 1)
 PY
   then
-    pass "$name (${longest} byte text node, round-trip byte-identical)"
+    pass "$name (${total} bytes across ${splits} split(s), longest node ${longest} bytes, round-trip byte-identical)"
   else
     fail "$name" "round-trip profile differs from the original"
   fi

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -479,8 +479,11 @@ jobs:
               exit 1
               ;;
           esac
-          # #2108 remains known-red with libxml2 >= 2.13 until the XML reader
-          # handles XML_MAX_TEXT_LENGTH without weakening parser hardening.
+          # Generic escape hatch for tests quarantined as known failures. No
+          # test carries the label today: #2108 held it until #2160 bounded the
+          # emitted XML text nodes, and iccdev.xml-parser-regressions now runs
+          # here. Kept so a future quarantine needs no workflow edit -- but a
+          # test added to it stops being covered, so label sparingly.
           ctest_args+=(--label-exclude known-red)
           case "$CTEST_MODE" in
             fast)

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5531,11 +5531,23 @@ set_tests_properties(iccdev.pcc-zero-illuminant-regressions PROPERTIES
 # problem with XML_PARSE_HUGE turns this test red instead of quietly widening
 # what the parser accepts. Builds the fixture link with iccApplyToLink, so it
 # needs the generated profiles.
+#
+# The known-red label is deliberately absent (#2160): it was added while the
+# large-CLUT round trip could not pass against libxml2 >= 2.13, and the writer
+# now bounds each text node, so the quarantine no longer describes anything
+# true. Where that matters is ci-iccdev-tool-tests.yml run with ctest_mode=full
+# and the local check target; both exclude known-red and neither excludes slow.
+#
+# It does NOT put this test on the pull_request path: ci-pr-action.yml pins
+# ctest_mode=fast, which drops it on the slow label, and the Windows legs never
+# register it at all because the if(WIN32) branch above returns before the bash
+# script tests. Measured on dispatched run 31852372579 -- the case does not
+# execute on any PR leg. Widening that is a separate question from this fix.
 if(TARGET iccFromXml AND TARGET iccToXml AND TARGET iccApplyToLink)
   iccdev_add_script_test(
     iccdev.xml-parser-regressions
     600
-    "iccdev;xml;parser;regression;issue-1856;issue-2108;asan;slow;known-red"
+    "iccdev;xml;parser;regression;issue-1856;issue-2108;issue-2160;asan;slow"
     "${ICCDEV_REPO_ROOT}"
     "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-xml-parser-regression-tests.sh"
   )

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -275,9 +275,10 @@ public:
     int i;
     const size_t bufSize = 128;
     char buf[bufSize];
+    std::string row;
 
     if (!(m_nCurPixel % m_nPixelsPerRow))
-      *m_xml += m_blanks;
+      row += m_blanks;
 
     switch(m_nType) {
       case icConvert8Bit:
@@ -290,7 +291,7 @@ public:
           if (!(v >= 0.0)) v = 0.0;
           else if (v > 1.0) v = 1.0;
           snprintf(buf, bufSize, " %3d", (icUInt8Number)(v*255.0 + 0.5));
-          *m_xml += buf;
+          row += buf;
         }
         break;
       case icConvert16Bit:
@@ -299,21 +300,46 @@ public:
           if (!(v >= 0.0)) v = 0.0;
           else if (v > 1.0) v = 1.0;
           snprintf(buf, bufSize, " %5d", (icUInt16Number)(v*65535.0 + 0.5));
-          *m_xml += buf;
+          row += buf;
         }
         break;
       case icConvertFloat:
       default:
         for (i=0; i<m_nSamples; i++) {
           snprintf(buf, bufSize, " %13.8f", pData[i]);
-          *m_xml += buf;
+          row += buf;
         }
         break;
     }
     m_nCurPixel++;
     if (!(m_nCurPixel % m_nPixelsPerRow)) {
-      *m_xml += "\n";
+      row += "\n";
     }
+
+    // libxml2 2.13.0 moved the XML_MAX_TEXT_LENGTH check into xmlSAX2Text, so
+    // a CLUT whose values exceed 10 MB in one text node is refused on read even
+    // though the document as a whole is bounded. Break the run into separate
+    // text nodes with a comment between them; the reader joins the text
+    // siblings and skips the comment when rebuilding the array.
+    //
+    // The decision is driven by the byte count alone, and is taken BEFORE this
+    // pixel is appended. Both details are load bearing:
+    //   - Gating it on a row boundary would never fire for a CLUT with one
+    //     input dimension, because Init() leaves NumPoints() == GridPoints[0]
+    //     == nPixelsPerRow (IccTagLut.cpp), i.e. the whole table is a single
+    //     row -- exactly the profile shape this is meant to bound.
+    //   - Deciding first keeps the invariant node <= kMaxTextNodeBytes. Testing
+    //     after the append would let a node reach the threshold plus a whole
+    //     pixel, and snprintf caps a sample at bufSize, so a wide float row is
+    //     not negligible against the margin below the cap.
+    // The split therefore lands between pixels rather than between rows.
+    static const size_t kMaxTextNodeBytes = 8ULL * 1024 * 1024;
+    if (m_nTextNodeBytes && m_nTextNodeBytes + row.size() > kMaxTextNodeBytes) {
+      *m_xml += m_blanks + "<!-- TableData continuation -->\n";
+      m_nTextNodeBytes = 0;
+    }
+    *m_xml += row;
+    m_nTextNodeBytes += row.size();
   }
 
   void Finish()
@@ -329,6 +355,7 @@ public:
   icUInt16Number m_nSamples;
   icUInt8Number m_nPixelsPerRow;
   icUInt32Number m_nCurPixel;
+  size_t m_nTextNodeBytes = 0;
 };
 
 bool icCLUTDataToXml(std::string &xml, CIccCLUT *pCLUT, icConvertType nType, std::string blanks, 
@@ -533,18 +560,19 @@ bool icXmlValidateFileCount(size_t value, icUInt32Number &count, std::string &pa
 
 xmlDoc *icXmlReadFileBounded(const char *szFilename, int nOptions, std::string *parseStr)
 {
-  // libxml2's streaming reader hands character data to the tree builder in
-  // successive chunks, and the append path that joins those chunks is where
-  // XML_MAX_TEXT_LENGTH (10 MB) is enforced. A profile whose CLUT serialises
-  // to a larger single text node is therefore refused on read even though
-  // iccToXml had just written it - issue #1856. Parsing one contiguous buffer
-  // never takes that append path, so the round trip holds without
-  // XML_PARSE_HUGE, which would additionally have disabled the nesting-depth
-  // and name-length caps for every input.
+  // Reading the whole document into one buffer replaces libxml2's per-node
+  // XML_MAX_TEXT_LENGTH (10 MB) with a whole-document bound, which is the
+  // stricter promise: it limits total parsed size instead of the size of any
+  // one node, and the streamed path applies no document bound at all. Doing it
+  // here also avoids XML_PARSE_HUGE, which would have disabled the
+  // nesting-depth and name-length caps for every input - issue #1856.
   //
-  // What the per-node cap gave up is replaced by a whole-document bound, which
-  // is the stricter promise: it limits total parsed size instead of the size of
-  // any one node, and today the streamed path applies no document bound at all.
+  // It does NOT, however, exempt a large text node from the cap. That was the
+  // original claim here and it is wrong for libxml2 >= 2.13: v2.13.0 moved the
+  // check into xmlSAX2Text, so it applies however the input is delivered - see
+  // issue #2108. What keeps a large CLUT round-tripping is the writer bounding
+  // the text nodes it emits (CIccDumpXmlCLUT::PixelOp, issue #2160), not
+  // anything this function does.
   if (!szFilename || !*szFilename)
     return NULL;
 
@@ -735,17 +763,36 @@ bool CIccXmlArrayType<T, Tsig>::ParseArray(xmlNode *pNode)
     return ParseArray(m_pBuf, m_nSize, pNode);
   }
 
-  for ( ;pNode && pNode->type!= XML_TEXT_NODE; pNode=pNode->next);
+  for ( ;pNode && pNode->type!= XML_TEXT_NODE && pNode->type!= XML_CDATA_SECTION_NODE; pNode=pNode->next);
 
   if (!pNode || !pNode->content)
     return false;
 
-  n = ParseTextCount((const char*)pNode->content);
+  // The CLUT writer splits data that would exceed XML_MAX_TEXT_LENGTH into
+  // several text nodes separated by a comment (CIccDumpXmlCLUT::PixelOp), so
+  // one array's values can arrive as a run of siblings; step over the
+  // separators and concatenate. Stop at anything that is not text, CDATA or a
+  // comment rather than refusing the array outright: callers such as the three
+  // CIccTagXmlNamedColor2 device-coord branches ignore this return value and
+  // read GetSize(), so turning an odd-but-parseable node list into an empty
+  // array would silently drop data instead of reporting an error.
+  std::string text;
+  for (xmlNode *pText = pNode; pText; pText = pText->next) {
+    if (pText->type == XML_COMMENT_NODE)
+      continue;
+    if ((pText->type != XML_TEXT_NODE && pText->type != XML_CDATA_SECTION_NODE) ||
+        !pText->content) {
+      break;
+    }
+    text += (const char*)pText->content;
+  }
+
+  n = ParseTextCount(text.c_str());
 
   if (!n || !SetSize(n))
     return false;
 
-  return ParseArray(m_pBuf, m_nSize, pNode);
+  return ParseText(m_pBuf, m_nSize, text.c_str()) == m_nSize;
 }
 
 template <class T, icTagTypeSignature Tsig>
@@ -766,10 +813,27 @@ bool CIccXmlArrayType<T, Tsig>::ParseTextArray(const char *szText)
 template <class T, icTagTypeSignature Tsig>
 bool CIccXmlArrayType<T, Tsig>::ParseTextArray(xmlNode *pNode)
 {
-  if (pNode->children && pNode->children->type==XML_TEXT_NODE) {
-    return ParseTextArray((const char*)pNode->children->content);
+  // Same split-aware join as ParseArray above: the element may hold several
+  // text children with comment separators between them, so the first child
+  // alone is no longer necessarily the whole array. Stops at the first child
+  // that is not text, CDATA or a comment, which leaves the previous behaviour
+  // (first child must be text, or the array is refused) intact.
+  std::string text;
+
+  if (!pNode)
+    return false;
+
+  for (xmlNode *child = pNode->children; child; child = child->next) {
+    if (child->type == XML_COMMENT_NODE)
+      continue;
+    if ((child->type != XML_TEXT_NODE && child->type != XML_CDATA_SECTION_NODE) ||
+        !child->content) {
+      break;
+    }
+    text += (const char*)child->content;
   }
-  return false;
+
+  return !text.empty() && ParseTextArray(text.c_str());
 }
 
 template <class T, icTagTypeSignature Tsig>

--- a/IccXML/IccLibXML/IccUtilXml.h
+++ b/IccXML/IccLibXML/IccUtilXml.h
@@ -107,8 +107,10 @@ static const size_t icXmlMaxTextFileBytes = 256ULL * 1024 * 1024;
 // the caller owns the document and releases it with xmlFreeDoc. nOptions is
 // passed to libxml2 unchanged, so the caller keeps control of the parser flags.
 // The implementation comment explains why the buffer rather than the file is
-// what gets parsed - it is what lets a large CLUT round-trip without
-// XML_PARSE_HUGE. Diagnostics are appended to parseStr when one is supplied.
+// what gets parsed: it trades libxml2's per-node cap for a whole-document
+// bound without resorting to XML_PARSE_HUGE. It is NOT what lets a large CLUT
+// round-trip - the writer bounding its own text nodes is (issue #2160).
+// Diagnostics are appended to parseStr when one is supplied.
 xmlDoc *icXmlReadFileBounded(const char *szFilename, int nOptions, std::string *parseStr = NULL);
 
 #define icXmlStrCmp(x, y) strcmp((const char *)(x), (const char*)(y))


### PR DESCRIPTION
Part of #2160. Takes the patch from `ci-qa-issue-2160` (`5aed59b3`) after review, with one correction and the CI-metadata half added.

## The failure

libxml2 **2.13.0** moved the `XML_MAX_TEXT_LENGTH` check into `xmlSAX2Text`, so the 10 MB per-text-node limit applies however the input is delivered. A grid-33 CMYK→RGB device link serialises ~21 MB of CLUT values into a single text node, so `iccFromXml` refused a document `iccToXml` had just written:

```
[FAIL] xml-large-text-node-roundtrip -- iccFromXml refused a 21705957-byte text node it had just written
```

## The fix

Bound the **writer** rather than weaken the reader with `XML_PARSE_HUGE` — the second half of `iccdev.xml-parser-regressions` exists precisely to keep the depth, name-length and entity-amplification caps armed, and they stay armed here. Once a text node reaches 8 MiB, `CIccDumpXmlCLUT::PixelOp` emits a `<!-- TableData continuation -->` separator and starts a new one; `CIccXmlArrayType::ParseArray` / `ParseTextArray` join the text siblings back together and step over the separators.

## Review of the handoff patch

**Correction — the split must be byte-driven, not row-gated.** The patch's comment said *"Split CLUT data at row boundaries"* while the code tested per pixel. I first "fixed" that by gating the split on a completed row, which was wrong: `Init()` leaves `NumPoints() == GridPoints[0] == nPixelsPerRow` for a CLUT with **one input dimension** (`IccTagLut.cpp`), so the whole table is a single row and the gate only fires after the last pixel — emitting a trailing marker with nothing after it while the node stays unbounded. Proven with the threshold lowered to 4096 on a 1-input-dim CLUT:

| variant | markers | longest text node |
|---|---|---|
| row-gated | 1 (trailing, useless) | **7200** — over the threshold |
| byte-driven (this PR) | 1 | **4063** — bounded |

So the code was right and the comment was wrong. The comment now records why both the byte-driven test *and* its placement before the append are load-bearing: deciding first keeps the invariant `node <= kMaxTextNodeBytes`.

**Reader stops rather than refuses.** An earlier revision refused any sibling that was not text, CDATA or a comment. Three `CIccTagXmlNamedColor2` device-coord branches (`IccTagXml.cpp:1186/1207/1225`) discard this return value and read `GetSize()`, so refusing would have turned an odd-but-parseable node list into a silently empty coords array — a wrong profile instead of an error. It now stops at such a node, leaving the previous behaviour intact.

**Dropped the `known-red` label.** Added when #2108 closed, while this round trip could not pass against libxml2 >= 2.13. It was the only test carrying it, and the quarantine no longer describes anything true once the writer bounds its text nodes. The `--label-exclude known-red` machinery is kept so a future quarantine needs no workflow edit.

Being precise about what that buys, because I got this wrong twice before measuring it: removing the label re-enables the case only where `known-red` is the sole filter — `ci-iccdev-tool-tests.yml` at `ctest_mode=full`, and the local `check` target. It does **not** put the case on the `pull_request` path. `ci-pr-action.yml` pins `ctest_mode=fast`, which drops it on the `slow` label, and the Windows legs never register it at all because the `if(WIN32)` branch at `Build/Cmake/Testing/CMakeLists.txt:4596` returns before the bash script tests are added. Confirmed against the pre-PR dispatch below: the case executes on no PR leg, so this PR's own green checks do not exercise it — the container red/green in the Evidence table is what does.

That PR-path gap is pre-existing and orthogonal to this fix, but it is squarely the concern #2160 was split from (*"Failed Checks should Fail the Workflow"*), so it may be worth a follow-up: this test cannot fail a PR today, whatever its labels say.

## Evidence

Pre-PR dispatch on `ci_scope=source`: run [31852372579](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/31852372579) — 10 success, 2 skipped (Docker Clang 22 and the manual thread-linkage job).

Red → green in CI's own container, `ghcr.io/internationalcolorconsortium/iccdev-ci-regression:latest` (GCC 15.2.0, libxml2 **2.15.2**):

| tree | result |
|---|---|
| `origin/master` `432064a5` | `Failed: 1` — refused a 21705957-byte text node |
| this branch | `Passed: 8` — 21706933 bytes across 2 splits, longest node 8388614, round trip byte-identical |

| check | result |
|---|---|
| Target test — libxml2 2.9.14 / 2.13.8 / 2.15.2 | green on all three |
| Full CTest — libxml2 2.9.14 and 2.13.8 | 185/186 (the one failure is a local missing `imagecodecs` module, unrelated) |
| Strict clang 18.1.3, `-Wall -Wextra -Wpedantic -Werror` | `grep -cE 'warning:'` = **0** |
| Strict GCC 15.2.0 + LTO, in CI's container | `grep -cE 'warning:'` = **0** |
| `shellcheck` 0.9.0, bare, changed script | clean |
| Corpus: all 214 tracked `*.xml` through `iccFromXml` | 0 exit-code divergences vs master; 181 produce a profile |
| Those 181 profiles, master vs branch | 0 byte divergences |
| Those 181 re-serialised through `iccToXml` | 0 byte divergences |

Profile comparison masks `dateTime` (+24..35) and the profile ID (+84..99) of **every** header in the file, located by the `acsp` signature at +36 — both are stamped from the wall clock at write time, and some fixtures carry an embedded profile whose header drifts the same way. Without that mask the diff is exactly 17 bytes per affected header: the `dateTime` seconds field plus the 16-byte MD5 it feeds.

The test's anti-vacuity pin is also tightened: it now asserts the writer actually split, so removing the split turns the case red at the measurement rather than only at the `iccFromXml` call. The `python3` measurement's exit status is checked too — previously `read` swallowed it, so a failed measurement reported as a skip with a blank size.

## Notes

- **Interoperability:** XML emitted for a CLUT over 8 MiB is not readable by previously released iccDEV/DemoIccMAX — their `ParseArray` stops at the first text node and reports a count mismatch. It is a loud failure, not silent corruption, and the alternative is a document current libxml2 refuses outright.
- **Scope:** this bounds the CLUT serialiser. `DumpArray` still emits other large arrays as a single text node; those are entry-capped well below 10 MB today, so nothing else is widened here.
- The stale claim in `icXmlReadFileBounded`'s comment — that parsing a contiguous buffer exempts a large text node from the cap — is corrected; it was refuted by #2108 and is not what makes the round trip work.
