### PR TITLE
fix(#2128): notify tags on the shared-IO release paths

### DIFF
--- a/.github/ci/regression/profile-shared-io-detach.cpp
+++ b/.github/ci/regression/profile-shared-io-detach.cpp
@@ -1,0 +1,418 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression test for issue #2128: the two CIccProfile paths that released an
+// attached IO without notifying the profile's loaded tags.
+//
+// Background. CIccProfile::Detach() (IccProfLib/IccProfile.cpp) notifies tags
+// before freeing its own IO:
+//
+//     for (i = m_Tags.begin(); i != m_Tags.end(); i++)
+//       if (i->pTag) i->pTag->DetachIO();
+//     delete m_pAttachIO;
+//
+// A tag can hold IO derived from that IO -- today only CIccTagEmbeddedProfile,
+// whose inner profile CIccTagEmbeddedProfile::Read() attaches to a CIccEmbedIO
+// wrapping the IO passed in by the reading profile. The DetachIO() override
+// that makes this cascade work is covered by the sibling test
+// embedded-profile-detachio.cpp. This test covers the two paths that override
+// does NOT reach, because they never ran the notification loop at all:
+//
+//   Path 1 -- CopyAttach(nullptr). The release path the library actually
+//     exercises. IccCmm.cpp borrows the caller's IO with
+//     CopyAttach(&Profile, true) and hands it back with CopyAttach(nullptr);
+//     that release cleared m_pAttachIO with no notification whatsoever, so a
+//     fix confined to Detach() would have left the live path untouched.
+//
+//   Path 2 -- Detach()'s shared-IO branch. Reachable by any caller that does
+//     CopyAttach(p, true) and then Detach(). The notification loop sat inside
+//     the owning branch, so the shared branch returned true having told the
+//     tags nothing.
+//
+// In both cases the inner profile was left reporting HasIO()==true over an IO
+// its parent had released -- a later FindTag() on it reads through that IO,
+// and once the lender closes it, through freed memory.
+//
+// Semantics. On a shared release the borrowed IO is still alive; it belongs to
+// the lender. The conservative choice implemented here releases the child
+// anyway, because a borrower has no way to observe when the lender closes what
+// it lent. That costs the child its ability to read further, which assertion 5
+// below pins deliberately rather than by accident.
+//
+// Asserts:
+//   1. PATH 1: after borrower->CopyAttach(nullptr), the embedded tag's inner
+//      profile reports HasIO()==false.
+//   2. PATH 2: same, released with a shared Detach() instead.
+//   3. LOADED DATA SURVIVES: a tag loaded through the borrowed IO before the
+//      release still holds its text afterwards -- releasing IO must not
+//      destroy already-loaded tag objects.
+//   4. THE LENDER IS UNHARMED: after the borrower releases, the lender still
+//      reports HasIO()==true and can still load a tag it had not loaded yet.
+//      Borrowed IO must be dropped, never deleted; this assertion is what
+//      would catch the shared branch being "simplified" into the owning one.
+//   5. NO BOGUS SUCCESS: FindTag() on a tag the inner profile never loaded
+//      returns NULL after the release rather than reading through the IO.
+//   6. m_bSharedIO HYGIENE: Cleanup() (and therefore operator=, which calls
+//      it) resets m_bSharedIO. A formerly-shared profile used to sit at
+//      m_bSharedIO==true with a NULL IO, where Detach() took the shared branch
+//      and returned true having done nothing. It must now return false.
+//   7. ATTACH TAKES OWNERSHIP: Attach() clears the flag too. It calls
+//      Cleanup() only when tags are already present, so a profile that had
+//      just borrowed an IO (no tags yet) and was then attached to one of its
+//      own kept the flag set, and Cleanup() at destruction skipped the delete
+//      -- a leak of an IO the profile owned, reachable through public API
+//      alone and NOT closed by fixing Cleanup(). Observed by counting the
+//      IO's destructor, not by leak detection, so it bites under CI's
+//      detect_leaks=0 sanitizer legs.
+//
+// Entirely in-memory -- no corpus fixture, so this test cannot be silently
+// skipped by a missing or unbuilt fixture.
+
+#include "IccIO.h"
+#include "IccProfile.h"
+#include "IccTag.h"
+#include "IccTagBasic.h"
+#include "IccTagEmbedIcc.h"
+#include "IccUtil.h"
+#include "icProfileHeader.h"
+
+#include <cstdio>
+#include <cstring>
+#include <memory>
+#include <string>
+
+static int g_failures = 0;
+
+static void check(bool bCondition, const char *szMessage)
+{
+  if (bCondition) {
+    std::printf("ok:   %s\n", szMessage);
+  }
+  else {
+    std::printf("FAIL: %s\n", szMessage);
+    g_failures++;
+  }
+}
+
+// Counts its own destruction, so assertion 7 can observe whether the profile
+// freed an IO it owns without depending on a leak detector -- the CI
+// sanitizer legs run with detect_leaks=0, so a LeakSanitizer-only assertion
+// would never bite there.
+static int g_nOwnedIoDestroyed = 0;
+
+class CCountingMemIO : public CIccMemIO
+{
+public:
+  virtual ~CCountingMemIO() { g_nOwnedIoDestroyed++; }
+};
+
+static void initHeader(CIccProfile *p)
+{
+  p->m_Header.deviceClass = icSigAbstractClass;
+  p->m_Header.colorSpace  = icSigLabData;
+  p->m_Header.pcs         = icSigLabData;
+  p->m_Header.version     = icVersionNumberV5;
+  p->m_Header.magic       = icMagicNumber;
+  p->m_Header.platform    = icSigMicrosoft;
+  p->m_Header.renderingIntent = icPerceptual;
+  p->m_Header.illuminant.X = 0x0000f6d6;
+  p->m_Header.illuminant.Y = 0x00010000;
+  p->m_Header.illuminant.Z = 0x0000d32d;
+}
+
+static CIccTagText *makeText(const char *s)
+{
+  CIccTagText *p = new CIccTagText();
+  p->SetText(s);
+  return p;
+}
+
+// Outer profile carrying an embedded profile plus two text tags of its own.
+// The outer copyrightTag is loaded before the release (assertion 3); the outer
+// charTargetTag is deliberately left unloaded so assertion 5 has something
+// that must come back NULL afterwards. The inner profile carries a
+// copyrightTag it never loads, for the same purpose one level down.
+static CIccProfile *makeOuter()
+{
+  CIccProfile *pInner = new CIccProfile();
+  initHeader(pInner);
+  pInner->AttachTag(icSigCopyrightTag, makeText("inner-cprt"));
+
+  CIccProfile *pOuter = new CIccProfile();
+  initHeader(pOuter);
+  pOuter->AttachTag(icSigCopyrightTag, makeText("outer-cprt"));
+  pOuter->AttachTag(icSigCharTargetTag, makeText("outer-target"));
+
+  CIccTagEmbeddedProfile *pEmbed = new CIccTagEmbeddedProfile();
+  pEmbed->SetProfile(pInner); // takes ownership
+  pOuter->AttachTag(icSigEmbeddedV5ProfileTag, pEmbed);
+
+  return pOuter;
+}
+
+// Serialize a fixture profile into pMem so it can be re-opened with deferred
+// tag loading -- the only way to get an inner profile that is attached to a
+// CIccEmbedIO wrapping the reader's IO.
+static bool writeFixture(CIccMemIO &mem)
+{
+  std::unique_ptr<CIccProfile> pOuter(makeOuter());
+
+  if (!mem.Alloc(64 * 1024, true))
+    return false;
+
+  return pOuter->Write(&mem, icNeverWriteID);
+}
+
+// Exercises one release path end to end. bUseDetach selects Path 2 (a shared
+// Detach()) over Path 1 (CopyAttach(nullptr)).
+static void checkSharedRelease(bool bUseDetach)
+{
+  const char *szPath = bUseDetach ? "Detach()" : "CopyAttach(nullptr)";
+  char szMsg[256];
+
+  CIccMemIO written;
+  if (!writeFixture(written)) {
+    std::printf("FAIL: [%s] could not build the in-memory fixture\n", szPath);
+    g_failures++;
+    return;
+  }
+
+  // The lender owns the file IO; the borrower shares it, exactly as
+  // IccCmm.cpp's AddXform path does.
+  std::unique_ptr<CIccMemIO> pSource(new CIccMemIO);
+  if (!pSource->Attach(written.GetData(), written.GetLength(), false)) {
+    std::printf("FAIL: [%s] could not attach the fixture bytes\n", szPath);
+    g_failures++;
+    return;
+  }
+
+  CIccProfile lender;
+  if (!lender.Attach(pSource.release())) {
+    std::printf("FAIL: [%s] lender profile would not attach\n", szPath);
+    g_failures++;
+    return;
+  }
+
+  std::unique_ptr<CIccProfile> pBorrower(lender.NewCopy());
+  pBorrower->CopyAttach(&lender, true);
+
+  // Load through the borrowed IO: the embedded tag (which attaches the inner
+  // profile to a CIccEmbedIO over the lender's IO) and a text tag whose data
+  // must survive the release.
+  CIccTag *pEmbedTag = pBorrower->FindTag(icSigEmbeddedV5ProfileTag);
+  if (!pEmbedTag || pEmbedTag->GetType() != icSigEmbeddedProfileType) {
+    std::printf("FAIL: [%s] embedded profile tag did not load through the borrowed IO\n", szPath);
+    g_failures++;
+    return;
+  }
+  CIccTagEmbeddedProfile *pEmbed = (CIccTagEmbeddedProfile*)pEmbedTag;
+  CIccProfile *pInner = pEmbed->GetProfile();
+
+  CIccTag *pCprt = pBorrower->FindTag(icSigCopyrightTag);
+  std::string sCprtBefore;
+  if (pCprt && pCprt->GetType() == icSigTextType)
+    sCprtBefore = ((CIccTagText*)pCprt)->GetText();
+
+  // Anti-vacuity: if the fixture never gave the inner profile IO in the first
+  // place, every assertion below would pass for the wrong reason.
+  if (!pInner || !pInner->HasIO()) {
+    std::printf("FAIL: [%s] fixture vacuous -- inner profile never held IO to begin with\n", szPath);
+    g_failures++;
+    return;
+  }
+  if (sCprtBefore != "outer-cprt") {
+    std::printf("FAIL: [%s] fixture vacuous -- outer copyrightTag did not load through the borrowed IO\n",
+                szPath);
+    g_failures++;
+    return;
+  }
+
+  // --- The release itself ---
+  if (bUseDetach) {
+    std::snprintf(szMsg, sizeof(szMsg), "[%s] shared Detach() returns true", szPath);
+    check(pBorrower->Detach(), szMsg);
+  }
+  else {
+    pBorrower->CopyAttach(nullptr);
+  }
+
+  std::snprintf(szMsg, sizeof(szMsg), "[%s] borrower reports HasIO()==false after the release", szPath);
+  check(!pBorrower->HasIO(), szMsg);
+
+  // --- Assertions 1 and 2: the notification reached the embedded tag. ---
+  std::snprintf(szMsg, sizeof(szMsg),
+                "BUG FIX [%s]: inner profile reports HasIO()==false after the release "
+                "(fails without the notification on this path)", szPath);
+  check(!pInner->HasIO(), szMsg);
+
+  // --- Assertion 3: loaded data survives. ---
+  CIccTag *pCprtAfter = NULL;
+  for (TagEntryList::iterator i = pBorrower->m_Tags.begin(); i != pBorrower->m_Tags.end(); ++i) {
+    if (i->pTag && i->TagInfo.sig == icSigCopyrightTag) {
+      pCprtAfter = i->pTag;
+      break;
+    }
+  }
+  std::snprintf(szMsg, sizeof(szMsg),
+                "LOADED DATA SURVIVES [%s]: the copyrightTag loaded before the release is still "
+                "in the directory with its text intact", szPath);
+  check(pCprtAfter != NULL && pCprtAfter->GetType() == icSigTextType &&
+        std::string(((CIccTagText*)pCprtAfter)->GetText()) == "outer-cprt", szMsg);
+
+  // --- Assertion 5: no bogus success on what was never loaded. ---
+  std::snprintf(szMsg, sizeof(szMsg),
+                "NO BOGUS SUCCESS [%s]: FindTag() on the borrower's never-loaded charTargetTag "
+                "returns NULL after the release", szPath);
+  check(pBorrower->FindTag(icSigCharTargetTag) == NULL, szMsg);
+
+  std::snprintf(szMsg, sizeof(szMsg),
+                "NO BOGUS SUCCESS [%s]: FindTag() on the inner profile's never-loaded copyrightTag "
+                "returns NULL after the release", szPath);
+  check(pInner->FindTag(icSigCopyrightTag) == NULL, szMsg);
+
+  // --- Assertion 4: the lender is unharmed. ---
+  // Borrowed IO is dropped, never deleted. The lender had loaded nothing of
+  // its own, so a successful load here proves its IO is still usable and not
+  // merely still non-NULL.
+  std::snprintf(szMsg, sizeof(szMsg), "LENDER UNHARMED [%s]: lender still reports HasIO()==true", szPath);
+  check(lender.HasIO(), szMsg);
+
+  CIccTag *pLenderCprt = lender.FindTag(icSigCopyrightTag);
+  std::snprintf(szMsg, sizeof(szMsg),
+                "LENDER UNHARMED [%s]: lender can still load a tag through its own IO after the "
+                "borrower released it", szPath);
+  check(pLenderCprt != NULL && pLenderCprt->GetType() == icSigTextType &&
+        std::string(((CIccTagText*)pLenderCprt)->GetText()) == "outer-cprt", szMsg);
+}
+
+// Assertion 6. Cleanup() used to clear m_pAttachIO but leave m_bSharedIO set,
+// so a reused profile claimed to be sharing an IO it no longer had. Detach()
+// then took the shared branch and reported success having done nothing.
+// operator= is the reachable route to Cleanup() from public API.
+static void checkSharedFlagHygiene()
+{
+  CIccMemIO written;
+  if (!writeFixture(written)) {
+    std::printf("FAIL: [hygiene] could not build the in-memory fixture\n");
+    g_failures++;
+    return;
+  }
+
+  std::unique_ptr<CIccMemIO> pSource(new CIccMemIO);
+  if (!pSource->Attach(written.GetData(), written.GetLength(), false)) {
+    std::printf("FAIL: [hygiene] could not attach the fixture bytes\n");
+    g_failures++;
+    return;
+  }
+
+  CIccProfile lender;
+  if (!lender.Attach(pSource.release())) {
+    std::printf("FAIL: [hygiene] lender profile would not attach\n");
+    g_failures++;
+    return;
+  }
+
+  CIccProfile borrower;
+  borrower.CopyAttach(&lender, true);
+  check(borrower.HasIO(), "[hygiene] borrower holds the shared IO before reuse");
+
+  // Reuse the borrower for something else. Cleanup() runs inside operator=.
+  CIccProfile fresh;
+  initHeader(&fresh);
+  borrower = fresh;
+
+  check(!borrower.HasIO(), "[hygiene] reused profile reports HasIO()==false");
+  check(!borrower.Detach(),
+        "SHARED FLAG RESET: Detach() on a reused, formerly-shared profile returns false "
+        "(it used to take the shared branch and return true having done nothing)");
+
+  // The lender must be untouched by all of this.
+  check(lender.HasIO(), "[hygiene] lender still reports HasIO()==true");
+}
+
+// Assertion 7. The same stale flag, reached without Cleanup() ever running.
+// Attach() calls Cleanup() only when tags are already present, and a profile
+// that has just borrowed an IO via CopyAttach(p, true) has none -- so the flag
+// survived into a profile that then owned its IO outright, and Cleanup() at
+// destruction skipped the delete. Confirmed as a 48-byte LeakSanitizer leak
+// before Attach() was made to clear the flag. Observed here by counting the
+// IO's destructor rather than by leak detection, so it bites under CI's
+// detect_leaks=0 sanitizer legs too.
+static void checkAttachClearsSharedFlag()
+{
+  CIccMemIO written;
+  if (!writeFixture(written)) {
+    std::printf("FAIL: [attach-owns] could not build the in-memory fixture\n");
+    g_failures++;
+    return;
+  }
+
+  std::unique_ptr<CIccMemIO> pSource(new CIccMemIO);
+  if (!pSource->Attach(written.GetData(), written.GetLength(), false)) {
+    std::printf("FAIL: [attach-owns] could not attach the fixture bytes\n");
+    g_failures++;
+    return;
+  }
+
+  CIccProfile lender;
+  if (!lender.Attach(pSource.release())) {
+    std::printf("FAIL: [attach-owns] lender profile would not attach\n");
+    g_failures++;
+    return;
+  }
+
+  g_nOwnedIoDestroyed = 0;
+  {
+    CIccProfile p;
+    p.CopyAttach(&lender, true);
+
+    // Anti-vacuity: this route only matters because the borrower has no tags
+    // yet, which is exactly why Attach() skips Cleanup() below.
+    check(p.m_Tags.empty(),
+          "[attach-owns] borrower has no tags after CopyAttach (so Attach() will skip Cleanup())");
+
+    CCountingMemIO *pOwned = new CCountingMemIO;
+    if (!pOwned->Attach(written.GetData(), written.GetLength(), false)) {
+      std::printf("FAIL: [attach-owns] owned IO would not attach\n");
+      g_failures++;
+      delete pOwned;
+      return;
+    }
+    if (!p.Attach(pOwned)) {
+      std::printf("FAIL: [attach-owns] profile would not attach the owned IO\n");
+      g_failures++;
+      return;
+    }
+    // p leaves scope here: Cleanup() must delete the IO it now owns.
+  }
+
+  check(g_nOwnedIoDestroyed == 1,
+        "ATTACH TAKES OWNERSHIP: a profile that borrowed an IO and was then attached to its own "
+        "frees that IO at destruction (it used to keep the sharing flag set and leak it)");
+
+  check(lender.HasIO(), "[attach-owns] lender still reports HasIO()==true");
+}
+
+int main()
+{
+  std::printf("--- Path 1: CopyAttach(nullptr) ---\n");
+  checkSharedRelease(false);
+
+  std::printf("\n--- Path 2: shared Detach() ---\n");
+  checkSharedRelease(true);
+
+  std::printf("\n--- m_bSharedIO hygiene ---\n");
+  checkSharedFlagHygiene();
+
+  std::printf("\n--- Attach() clears the sharing flag ---\n");
+  checkAttachClearsSharedFlag();
+
+  if (g_failures) {
+    std::printf("\n%d check(s) FAILED\n", g_failures);
+    return 1;
+  }
+
+  std::printf("\nAll checks passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -636,6 +636,61 @@ function(iccdev_add_embedded_profile_detachio_test)
   endif()
 endfunction()
 
+# Issue #2128: the two CIccProfile release paths that skipped the DetachIO()
+# notification the sibling test above depends on. CIccProfile::Detach()
+# (IccProfLib/IccProfile.cpp) notified tags only in its owning branch, and
+# CIccProfile::CopyAttach(nullptr) notified nothing at all -- so an embedded
+# profile loaded through a borrowed IO was left reporting HasIO()==true over
+# an IO its parent had released. CopyAttach() is the path the library actually
+# exercises (IccProfLib/IccCmm.cpp borrows the caller's IO with
+# CopyAttach(&Profile, true) and returns it with CopyAttach(nullptr)), so a fix
+# confined to Detach() would not have reached it. Cleanup() also left
+# m_bSharedIO set after clearing m_pAttachIO, leaving a reused profile where
+# Detach() took the shared branch and returned true having done nothing.
+# The test drives both release paths against an in-memory fixture and asserts:
+# the inner profile reports HasIO()==false afterwards (the fix, on each path
+# independently); a tag loaded before the release keeps its data; a tag never
+# loaded comes back NULL rather than reading through the released IO; the
+# LENDER still has usable IO afterwards (borrowed IO is dropped, never deleted
+# -- this is what catches the shared branch being folded into the owning one);
+# and Detach() on a reused, formerly-shared profile now returns false. No
+# corpus fixture -- entirely in-memory -- so this cannot be silently disabled
+# by a missing fixture.
+function(iccdev_add_profile_shared_io_detach_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccProfileSharedIoDetachTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/profile-shared-io-detach.cpp"
+  )
+  target_link_libraries(iccProfileSharedIoDetachTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccProfileSharedIoDetachTest)
+
+  add_test(
+    NAME iccdev.profile-shared-io-detach
+    COMMAND "$<TARGET_FILE:iccProfileSharedIoDetachTest>"
+  )
+  set_tests_properties(iccdev.profile-shared-io-detach PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;iccprofLib;embedded-profile;shared-io;issue-2128;regression"
+  )
+  if(WIN32)
+    set(_profile_shared_io_detach_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccProfileSharedIoDetachTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _profile_shared_io_detach_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.profile-shared-io-detach PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_profile_shared_io_detach_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_tag_layout_shared_data_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -4783,6 +4838,7 @@ if(WIN32)
   iccdev_add_embedio_read8_bounds_test()
   iccdev_add_embedded_profile_onelevel_load_test()
   iccdev_add_embedded_profile_detachio_test()
+  iccdev_add_profile_shared_io_detach_test()
   iccdev_add_fileio_getlength_position_test()
   iccdev_add_profile_write_failure_test()
   iccdev_add_fileio_seek_tell_test()
@@ -5063,6 +5119,7 @@ iccdev_add_pcs_unitfloat_source_encoding_test()
 iccdev_add_embedio_read8_bounds_test()
 iccdev_add_embedded_profile_onelevel_load_test()
 iccdev_add_embedded_profile_detachio_test()
+iccdev_add_profile_shared_io_detach_test()
 iccdev_add_fileio_getlength_position_test()
 iccdev_add_profile_write_failure_test()
 iccdev_add_fileio_seek_tell_test()

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -259,8 +259,22 @@ void CIccProfile::Cleanup()
     delete m_pAttachIO;
   }
   m_pAttachIO = nullptr;
+  //Clearing m_pAttachIO without clearing m_bSharedIO left a formerly-shared
+  //profile claiming to share an IO it no longer has. Detach() then took its
+  //shared branch and reported true having done nothing, and with the tag
+  //notification below hoisted above that branch, the stale flag would decide
+  //which release path a reused profile takes. Restoring the flag to its
+  //constructor default on release is the same rule CIccXform::DetachAll()
+  //(IccCmm.cpp) follows for m_bOwnsProfile. operator= needs no separate reset
+  //- it calls Cleanup() before copying anything.
+  m_bSharedIO = false;
 
   TagPtrList::iterator i;
+
+  //Tags are destroyed below, so they need no DetachIO() notification here:
+  //~CIccTagEmbeddedProfile deletes its inner profile outright. Deleting
+  //m_pAttachIO first is safe because the inner profile's CIccEmbedIO was
+  //attached with bOwnIO false, so releasing it never touches what it wrapped.
 
   for (i=m_TagVals.begin(); i!=m_TagVals.end(); i++) {
     delete i->ptr;
@@ -729,6 +743,15 @@ bool CIccProfile::Attach(CIccIO *pIO, bool bUseSubProfile/*=false*/)
     }
   }
 
+  //Attach() takes ownership - Cleanup() deletes m_pAttachIO unless the profile
+  //is marked as sharing it - so the sharing flag has to be cleared here too,
+  //not just in Cleanup(). Attach() only calls Cleanup() when tags are already
+  //present, so a profile that had borrowed an IO (CopyAttach(p, true)) and was
+  //then attached to one of its own kept the flag set and never freed the IO it
+  //now owned. Confirmed as a 48-byte LeakSanitizer leak before this line.
+  //Same rule as CIccXform::DetachAll() (IccCmm.cpp) restoring m_bOwnsProfile:
+  //taking or releasing a resource resets the flag that says who owns it.
+  m_bSharedIO = false;
   m_pAttachIO = pIO;
 
   return true;
@@ -749,27 +772,50 @@ bool CIccProfile::Attach(CIccIO *pIO, bool bUseSubProfile/*=false*/)
 */
 bool CIccProfile::Detach()
 {
-  if (m_pAttachIO && !m_bSharedIO) {
-    TagEntryList::iterator i;
+  //Reproduces the previous return contract exactly, so that the notification
+  //loop can be hoisted above the branch split below: the only case that
+  //returned false was neither owning nor sharing an IO. Owning returned true,
+  //and sharing returned true whether or not m_pAttachIO was set.
+  if (!m_pAttachIO && !m_bSharedIO)
+    return false;
 
-    for (i = m_Tags.begin(); i != m_Tags.end(); i++) {
-      if (i->pTag)
-        i->pTag->DetachIO();
-    }
+  //Notify before either release. A tag holding IO derived from this profile's
+  //IO - today only CIccTagEmbeddedProfile, whose inner profile is attached to
+  //a CIccEmbedIO wrapping this IO - was left advertising HasIO() true over a
+  //released IO when the shared branch ran, because that branch never reached
+  //this loop.
+  //
+  //The child is released whether this profile owns the IO or borrowed it,
+  //which is what the library already does elsewhere: CIccXform::DetachAll()
+  //(IccCmm.cpp) drops m_pProfile regardless of m_bOwnsProfile, and
+  //CIccFileIO::Detach() (IccIO.cpp) drops a borrowed FILE* outright. The
+  //sharing flag governs who deletes, not whether a borrower may keep reading -
+  //see ShareProfile()'s "so it won't be deleted" (IccCmm.h/IccCmm.cpp) - and
+  //the borrowed IO is still dropped rather than deleted below. A borrower has
+  //no way to observe when the lender closes what it lent.
+  //
+  //Running the loop while the IO is still alive is what makes the inner
+  //profile's own Detach() safe; see CIccTagEmbeddedProfile::DetachIO().
+  TagEntryList::iterator i;
 
-    delete m_pAttachIO;
-
-    m_pAttachIO = NULL;
-    return true;
+  for (i = m_Tags.begin(); i != m_Tags.end(); i++) {
+    if (i->pTag)
+      i->pTag->DetachIO();
   }
-  else if (m_bSharedIO) {
+
+  if (m_bSharedIO) {
+    //Borrowed IO belongs to the profile that lent it, so it is dropped, never
+    //deleted.
     m_pAttachIO = NULL;
     m_bSharedIO = false;
 
     return true;
   }
 
-  return false;
+  delete m_pAttachIO;
+
+  m_pAttachIO = NULL;
+  return true;
 }
 
 
@@ -791,6 +837,20 @@ bool CIccProfile::Detach()
 void CIccProfile::CopyAttach(CIccProfile* pProfile, bool bSharedIO)
 {
   if (!pProfile) {
+    //This is the release path the library actually exercises - IccCmm.cpp
+    //borrows the caller's IO with CopyAttach(&Profile, true) and gives it
+    //back with CopyAttach(nullptr) - yet it dropped the IO without telling
+    //the tags, so a fix confined to Detach() would never reach it. Notify on
+    //the same terms Detach() does, while the borrowed IO is still alive.
+    if (m_pAttachIO || m_bSharedIO) {
+      TagEntryList::iterator i;
+
+      for (i = m_Tags.begin(); i != m_Tags.end(); i++) {
+        if (i->pTag)
+          i->pTag->DetachIO();
+      }
+    }
+
     m_pAttachIO = nullptr;
     m_bSharedIO = false;
   }


### PR DESCRIPTION
Part of #2128.

`CIccProfile` had two paths that released its attached IO without notifying its loaded tags. A tag holding IO derived from that IO — today only `CIccTagEmbeddedProfile`, whose inner profile is attached to a `CIccEmbedIO` wrapping the parent's — was left reporting `HasIO() == true` over an IO the parent had released.

The companion `CIccTagEmbeddedProfile::DetachIO()` already landed, so this covers the paths that override did not reach.

## The two paths

**Path 1 — `CopyAttach(nullptr)`.** Cleared `m_pAttachIO` with no notification at all. This is the path the library actually exercises: `IccCmm.cpp:9360` borrows the caller's IO with `CopyAttach(&Profile, true)` and returns it at `:9369` with `CopyAttach(nullptr)`. A fix confined to `Detach()` would not have reached the live caller.

**Path 2 — `Detach()`'s shared-IO branch.** The notification loop sat inside the owning branch, so the shared branch returned `true` having told the tags nothing.

The loop is hoisted above the branch split behind `if (!m_pAttachIO && !m_bSharedIO) return false;`, which reproduces the previous return contract exactly — the only case that returned `false` was neither owning nor sharing; owning returned `true`; sharing returned `true` whether or not `m_pAttachIO` was set.

## Why conservative semantics

#2128 asks for a deliberate choice between releasing the child on a shared release (conservative) and preserving its ability to read (optimistic). **This follows what the library already does rather than introducing a new rule:**

| Site | Behavior |
|---|---|
| `CIccXform::DetachAll()` — `IccCmm.cpp:493` | Drops `m_pProfile` **unconditionally, regardless of `m_bOwnsProfile`**, and resets that flag to its constructor default (`:450`) as part of the release |
| `CIccFileIO::Detach()` — `IccIO.cpp:623` | `m_fFile = NULL;` — drops a borrowed `FILE*` outright, without closing it |
| `ShareProfile()` — `IccCmm.h:436` | Governs **deletion only**: *"Indicate that profile is shared (so it won't be deleted)"* (`IccCmm.cpp:9549`), and `bOwnsProfile` is passed `false` at `:9547` to keep a failed `Create` from deleting a profile the caller still owns |

Nothing in the library treats a sharing flag as licence to keep reading a resource the lender has released. Borrowed IO is still dropped rather than deleted, so that half of the sharing contract is unchanged. A borrower has no way to observe when the lender closes what it lent.

I found no counterexample. The nearest is `CIccEmbedIO::Close()`, which no-ops when `!m_bOwnIO` and leaves `m_pIO` set — but it is reached from `~CIccEmbedIO`, so retaining a pointer in a dying object is not a keep-reading-after-release policy.

## One item beyond the issue's proposal

#2128 lists resetting `m_bSharedIO` in `Cleanup()`/`operator=` and calls the stale flag *"harmless today — there is no IO to dangle."* **That is not the whole picture, and the proposed fix does not close it.**

`Attach()` never resets `m_bSharedIO`, and it calls `Cleanup()` only when tags are already present — a profile that has just borrowed an IO has none:

```
p.CopyAttach(&lender, true);   // m_bSharedIO = true, no tags added
p.Attach(ownedIO);             // Cleanup() skipped; flag stays true
~p → Cleanup() → if (!m_bSharedIO) delete m_pAttachIO;   // skipped
```

That leaks an IO the profile owns, through public API alone. Measured, not inferred: **48 bytes, LeakSanitizer, on unmodified master** — and it still leaked with the three proposed items applied. `Attach()` gets the same reset, which is `DetachAll()`'s flag rule applied to `m_bSharedIO`. `operator=` needs no separate reset because it calls `Cleanup()` first.

## Regression test — `iccdev.profile-shared-io-detach`

In-memory fixture, no corpus dependency, so it cannot be silently skipped. Drives both release paths and pins, on each path independently:

- the inner profile reports `HasIO() == false` after the release
- a tag loaded before the release keeps its data (releasing IO must not destroy loaded tag objects)
- a tag never loaded reads back `NULL` rather than through the released IO
- **the lender still has usable IO afterwards** — it can still load a tag it had not loaded yet. This is the assertion that catches the shared branch being folded into the owning one
- `Detach()` on a reused, formerly-shared profile returns `false`
- a profile attached to its own IO after borrowing frees it, observed by **counting the IO's destructor** rather than by leak detection, so it bites under CI's `detect_leaks=0` sanitizer legs

**Red/green: 6 of its checks fail on unmodified master, 0 on this branch.** Each half of the fix was also disabled independently to confirm exactly the corresponding case fails — neither half is carried by the other.

## Blast radius

Behavior changes only on the two previously-unnotified paths plus the two flag resets. The sole in-tree shared-IO producer is `IccCmm.cpp:9360`, and no CMM or PCC code loads an embedded-profile tag, so `DetachIO()` there resolves to the empty base virtual for every tag present — an extra pass over the tag directory, no functional change. `IccConnect.cpp:572` and `CIccCmm::RemoveIO()` operate on profiles that own their IO and so already took the notifying branch.

## Pre-flight

- **Dispatched `ci-pr-action` `ci_scope=source` before opening this PR — run [31875538956](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/31875538956), concluded success.** 8 jobs green / 3 skipped, including GCC 15.2 Strict Release LTO, Tool Smoke Tests ASAN+UBSAN Debug, Windows MSVC + ClangCL, and MinGW UCRT64 — the MSVC leg is what exercises the new test target configuring and running there.
- Strict Clang 18.1.3 Release, `-Wall -Wextra -Wpedantic -Werror` (configure logged `strict warnings ENABLED`): **0 warnings, 0 errors**, library and new test target.
- GCC **15.2.0** Strict Release LTO in CI's own regression container (local `g++` is 13.3 and silently drops the strict flag set): **0 warnings, 0 errors**.
- Full local CTest suite: 187 tests, single failure `iccdev.spectral-tiff-preview`, which dies on `ModuleNotFoundError: No module named 'imagecodecs'` before any iccDEV code runs — a missing local Python module, not a code failure.
- New test under ASAN+UBSAN with `detect_leaks=1`: clean.

## Note on the open decision

#2128 asks for the semantics ruling to be made deliberately rather than folded into a bug fix. This PR implements conservative and shows the three sites where the library already made that choice, but the call remains @maxderhak's and @ChrisCoxArt's — hence *Part of* rather than a closing keyword. Happy to revert to optimistic semantics on the shared path if you'd rather; the two release paths and both flag resets stand either way.
