### PR TITLE
fix(#2128): gate the release notification and clear stale borrowed IO on read

### DIFF
--- a/.github/ci/regression/profile-shared-io-detach.cpp
+++ b/.github/ci/regression/profile-shared-io-detach.cpp
@@ -65,6 +65,16 @@
 //      alone and NOT closed by fixing Cleanup(). Observed by counting the
 //      IO's destructor, not by leak detection, so it bites under CI's
 //      detect_leaks=0 sanitizer legs.
+//   8. NO RELEASE, NO NOTIFY: the notification is gated on m_pAttachIO, not on
+//      m_bSharedIO. Borrowing from a profile that holds no IO leaves this one
+//      flagged as sharing with nothing attached; releasing then frees nothing,
+//      so an inner profile carrying its own independently attached IO must be
+//      left alone. Guards the hoisted loop against over-reaching.
+//   9. READ CLEARS STALE IO: Read()/ReadValidate() carry the same tags-only
+//      Cleanup() guard, so a profile that borrowed an IO before it had tags
+//      carried that pointer through the read. HasIO() then lied, which makes
+//      CIccTagEmbeddedProfile::Read() defer to it and attach an inner profile
+//      over an IO the Read() caller owns and destroys on return.
 //
 // Entirely in-memory -- no corpus fixture, so this test cannot be silently
 // skipped by a missing or unbuilt fixture.
@@ -188,11 +198,12 @@ static void checkSharedRelease(bool bUseDetach)
   }
 
   CIccProfile lender;
-  if (!lender.Attach(pSource.release())) {
+  if (!lender.Attach(pSource.get())) {
     std::printf("FAIL: [%s] lender profile would not attach\n", szPath);
     g_failures++;
     return;
   }
+  pSource.release(); // Attach() took ownership only now that it succeeded
 
   std::unique_ptr<CIccProfile> pBorrower(lender.NewCopy());
   pBorrower->CopyAttach(&lender, true);
@@ -307,11 +318,12 @@ static void checkSharedFlagHygiene()
   }
 
   CIccProfile lender;
-  if (!lender.Attach(pSource.release())) {
+  if (!lender.Attach(pSource.get())) {
     std::printf("FAIL: [hygiene] lender profile would not attach\n");
     g_failures++;
     return;
   }
+  pSource.release(); // Attach() took ownership only now that it succeeded
 
   CIccProfile borrower;
   borrower.CopyAttach(&lender, true);
@@ -356,11 +368,12 @@ static void checkAttachClearsSharedFlag()
   }
 
   CIccProfile lender;
-  if (!lender.Attach(pSource.release())) {
+  if (!lender.Attach(pSource.get())) {
     std::printf("FAIL: [attach-owns] lender profile would not attach\n");
     g_failures++;
     return;
   }
+  pSource.release(); // Attach() took ownership only now that it succeeded
 
   g_nOwnedIoDestroyed = 0;
   {
@@ -382,6 +395,7 @@ static void checkAttachClearsSharedFlag()
     if (!p.Attach(pOwned)) {
       std::printf("FAIL: [attach-owns] profile would not attach the owned IO\n");
       g_failures++;
+      delete pOwned; // Attach() only takes ownership on success
       return;
     }
     // p leaves scope here: Cleanup() must delete the IO it now owns.
@@ -392,6 +406,108 @@ static void checkAttachClearsSharedFlag()
         "frees that IO at destruction (it used to keep the sharing flag set and leak it)");
 
   check(lender.HasIO(), "[attach-owns] lender still reports HasIO()==true");
+}
+
+// Assertion 8. The notification is gated on m_pAttachIO, not m_bSharedIO.
+// CopyAttach(p, true) where p holds no IO leaves this profile flagged as
+// sharing with nothing attached; releasing then frees nothing, so there is no
+// parent-derived view for a tag to be holding. Notifying anyway would detach an
+// inner profile that SetProfile() gave its own independently attached IO --
+// CIccTagEmbeddedProfile::DetachIO() releases the inner profile whatever the
+// origin of its IO -- which the pre-fix shared branch never did. Guards against
+// the hoisted loop over-reaching.
+static void checkNoReleaseNoNotify()
+{
+  CIccMemIO innerBytes;
+  if (!writeFixture(innerBytes)) {
+    std::printf("FAIL: [no-release] could not build the in-memory fixture\n");
+    g_failures++;
+    return;
+  }
+
+  // An inner profile holding IO of its own, not derived from any parent.
+  std::unique_ptr<CIccProfile> pInner(new CIccProfile());
+  std::unique_ptr<CIccMemIO> pInnerIO(new CIccMemIO);
+  if (!pInnerIO->Attach(innerBytes.GetData(), innerBytes.GetLength(), false) ||
+      !pInner->Attach(pInnerIO.get())) {
+    std::printf("FAIL: [no-release] inner profile would not attach its own IO\n");
+    g_failures++;
+    return;
+  }
+  pInnerIO.release(); // Attach() took ownership only now that it succeeded
+
+  CIccProfile *pInnerRaw = pInner.get();
+  CIccProfile outer;
+  initHeader(&outer);
+  CIccTagEmbeddedProfile *pEmbed = new CIccTagEmbeddedProfile();
+  pEmbed->SetProfile(pInner.release()); // takes ownership
+  if (!outer.AttachTag(icSigEmbeddedV5ProfileTag, pEmbed)) {
+    std::printf("FAIL: [no-release] could not attach the embedded tag\n");
+    g_failures++;
+    delete pEmbed;
+    return;
+  }
+
+  // Borrow from a profile that has no IO: flagged shared, nothing attached.
+  CIccProfile lenderWithoutIo;
+  outer.CopyAttach(&lenderWithoutIo, true);
+  check(!outer.HasIO(), "[no-release] borrowing from an IO-less profile leaves nothing attached");
+  check(pInnerRaw->HasIO(), "[no-release] inner profile holds its own IO before the release");
+
+  check(outer.Detach(), "[no-release] Detach() still reports true on the shared branch");
+  check(pInnerRaw->HasIO(),
+        "NO RELEASE, NO NOTIFY: releasing a profile that had nothing attached leaves an inner "
+        "profile's own independently attached IO alone");
+}
+
+// Assertion 9. Read() and ReadValidate() carry the same tags-only Cleanup()
+// guard Attach() does, so a profile that borrowed an IO before it had tags
+// carried that borrowed pointer straight through the read. HasIO() then lied,
+// which is what makes CIccTagEmbeddedProfile::Read() defer to it and attach an
+// inner profile over an IO the Read() caller owns and destroys on return.
+// Read() loads eagerly and attaches nothing, so HasIO() must be false after it.
+static void checkReadClearsStaleBorrowedIo()
+{
+  CIccMemIO written;
+  if (!writeFixture(written)) {
+    std::printf("FAIL: [read-stale] could not build the in-memory fixture\n");
+    g_failures++;
+    return;
+  }
+
+  std::unique_ptr<CIccMemIO> pSource(new CIccMemIO);
+  if (!pSource->Attach(written.GetData(), written.GetLength(), false)) {
+    std::printf("FAIL: [read-stale] could not attach the fixture bytes\n");
+    g_failures++;
+    return;
+  }
+
+  CIccProfile lender;
+  if (!lender.Attach(pSource.get())) {
+    std::printf("FAIL: [read-stale] lender profile would not attach\n");
+    g_failures++;
+    return;
+  }
+  pSource.release(); // Attach() took ownership only now that it succeeded
+
+  CIccProfile p;
+  p.CopyAttach(&lender, true);
+  check(p.HasIO() && p.m_Tags.empty(),
+        "[read-stale] borrower holds the shared IO and has no tags (so Read() skips Cleanup())");
+
+  CIccMemIO readFrom;
+  if (!readFrom.Attach(written.GetData(), written.GetLength(), false)) {
+    std::printf("FAIL: [read-stale] could not attach the read source\n");
+    g_failures++;
+    return;
+  }
+
+  check(p.Read(&readFrom), "[read-stale] Read() succeeds");
+  check(!p.HasIO(),
+        "READ CLEARS STALE IO: a profile that borrowed an IO before it had tags reports "
+        "HasIO()==false after Read(), which loads eagerly and attaches nothing");
+
+  check(lender.HasIO(), "[read-stale] lender still reports HasIO()==true");
 }
 
 int main()
@@ -407,6 +523,12 @@ int main()
 
   std::printf("\n--- Attach() clears the sharing flag ---\n");
   checkAttachClearsSharedFlag();
+
+  std::printf("\n--- releasing nothing notifies nobody ---\n");
+  checkNoReleaseNoNotify();
+
+  std::printf("\n--- Read() clears a stale borrowed IO ---\n");
+  checkReadClearsStaleBorrowedIo();
 
   if (g_failures) {
     std::printf("\n%d check(s) FAILED\n", g_failures);

--- a/IccProfLib/IccProfile.cpp
+++ b/IccProfLib/IccProfile.cpp
@@ -796,11 +796,20 @@ bool CIccProfile::Detach()
   //
   //Running the loop while the IO is still alive is what makes the inner
   //profile's own Detach() safe; see CIccTagEmbeddedProfile::DetachIO().
-  TagEntryList::iterator i;
+  //
+  //Gated on m_pAttachIO, not on m_bSharedIO: CopyAttach(p, true) where p had
+  //no IO leaves this profile flagged as sharing with nothing attached, and
+  //there is then no IO being released for a tag to be holding a view of.
+  //Notifying anyway would tear down an inner profile that SetProfile() gave
+  //its own independently attached IO - DetachIO() detaches whatever the origin
+  //of that IO - which the pre-fix shared branch never did.
+  if (m_pAttachIO) {
+    TagEntryList::iterator i;
 
-  for (i = m_Tags.begin(); i != m_Tags.end(); i++) {
-    if (i->pTag)
-      i->pTag->DetachIO();
+    for (i = m_Tags.begin(); i != m_Tags.end(); i++) {
+      if (i->pTag)
+        i->pTag->DetachIO();
+    }
   }
 
   if (m_bSharedIO) {
@@ -841,8 +850,10 @@ void CIccProfile::CopyAttach(CIccProfile* pProfile, bool bSharedIO)
     //borrows the caller's IO with CopyAttach(&Profile, true) and gives it
     //back with CopyAttach(nullptr) - yet it dropped the IO without telling
     //the tags, so a fix confined to Detach() would never reach it. Notify on
-    //the same terms Detach() does, while the borrowed IO is still alive.
-    if (m_pAttachIO || m_bSharedIO) {
+    //the same terms Detach() does, while the borrowed IO is still alive, and
+    //gated on m_pAttachIO for the same reason: with nothing attached there is
+    //no released IO for a tag to be holding a view of.
+    if (m_pAttachIO) {
       TagEntryList::iterator i;
 
       for (i = m_Tags.begin(); i != m_Tags.end(); i++) {
@@ -851,6 +862,12 @@ void CIccProfile::CopyAttach(CIccProfile* pProfile, bool bSharedIO)
       }
     }
 
+    //Note this drops m_pAttachIO without deleting it even when this profile
+    //owned it, so a caller doing Attach(io) then CopyAttach(nullptr) leaks io;
+    //the else branch below has the same gap when it overwrites a live IO.
+    //Pre-existing and left alone deliberately - making either path delete would
+    //change what CopyAttach() means for existing callers, which is a separate
+    //decision from the tag notification added above.
     m_pAttachIO = nullptr;
     m_bSharedIO = false;
   }
@@ -1010,8 +1027,24 @@ bool CIccProfile::FindAllTags()
  */
 bool CIccProfile::Read(CIccIO *pIO, bool bUseSubProfile/*=false*/)
 {
-  if (m_Tags.size())
+  //Cleanup() releases IO left over from a previous use, but it only runs when
+  //tags are present. A profile that borrowed an IO before it had any tags
+  //(CopyAttach(p, true)) therefore carried that borrowed pointer into this
+  //read, where HasIO() reporting true makes CIccTagEmbeddedProfile::Read()
+  //take its deferred branch and attach an inner profile over pIO - an IO this
+  //call's caller owns and typically destroys on return, leaving the inner
+  //profile dangling. Release it here on the same ownership terms Cleanup()
+  //uses. Attach() carries the same guard and clears the flag where it takes
+  //ownership.
+  if (m_Tags.size()) {
     Cleanup();
+  }
+  else {
+    if (!m_bSharedIO)
+      delete m_pAttachIO;
+    m_pAttachIO = nullptr;
+    m_bSharedIO = false;
+  }
 
   if (!ReadBasic(pIO)) {
     Cleanup();
@@ -1074,8 +1107,17 @@ icValidateStatus CIccProfile::ReadValidate(CIccIO *pIO, std::string &sReport)
 {
   icValidateStatus rv = icValidateOK;
 
-  if (m_Tags.size())
+  //Same stale-borrowed-IO release as Read() above - this entry point carries
+  //the identical tags-only Cleanup() guard.
+  if (m_Tags.size()) {
     Cleanup();
+  }
+  else {
+    if (!m_bSharedIO)
+      delete m_pAttachIO;
+    m_pAttachIO = nullptr;
+    m_bSharedIO = false;
+  }
 
   if (!ReadBasic(pIO)) {
     sReport += icMsgValidateCriticalError;


### PR DESCRIPTION
Part of #2128. Follow-up to #2174 (`2df4d207`).

A post-merge review pass found two defects: one #2174 introduced, one it left in place. Both are in the same `CIccProfile` IO-lifetime area, so they are fixed together.

## 1. The release notification fired when nothing was being released

#2174 hoisted the `DetachIO()` loop above `Detach()`'s branch split and added the same loop to `CopyAttach(nullptr)`, but guarded it on *owning or sharing* rather than on actually holding an IO:

```cpp
if (m_pAttachIO || m_bSharedIO) {   // #2174
if (m_pAttachIO) {                  // here
```

`CopyAttach(p, true)` where `p` holds no IO leaves a profile flagged as sharing with nothing attached. Releasing then frees nothing, so no tag can be holding a view derived from it — but the loop ran anyway, and `CIccTagEmbeddedProfile::DetachIO()` releases the inner profile **whatever the origin of its IO**, as its own doc comment states. So an inner profile that `SetProfile()` had given its own independently attached IO was torn down by a release that freed nothing.

The pre-#2174 shared branch skipped the loop entirely, so this was a **behavior regression on that path**, introduced by #2174. Both sites are now gated on `m_pAttachIO`.

## 2. `Read()` and `ReadValidate()` carry the same guard `Attach()` does

All three entry points start with the identical tags-only guard:

```cpp
if (m_Tags.size())
    Cleanup();      // the only thing that releases carried-over IO state
```

#2174 cleared the stale sharing state in `Attach()` and stopped there. A profile that borrowed an IO **before it had any tags** therefore carried that borrowed pointer straight through a read.

On `Attach()` the cost was a leak. On these two it is worse. They load eagerly and attach nothing, so a carried-over pointer leaves `HasIO()` reporting `true` when it should be `false` — and that is exactly the condition `CIccTagEmbeddedProfile::Read()` branches on:

```
after CopyAttach: p.HasIO()=1
p.Read(ioB)=1   p.HasIO() after Read=1     <-- stale borrowed pointer survives
inner->HasIO()=1                            <-- deferred over ioB, because HasIO() lied
ioB destroyed by its owner; inner->HasIO()=1 -> dangling
```

`HasIO()` returning true makes the embedded tag take its **deferred** branch and attach the inner profile to a `CIccEmbedIO` over the `CIccIO*` passed into `Read()` — an IO the caller owns and typically destroys on return. The inner profile is left pointing at freed memory rather than merely leaking.

**This one predates #2174.** That PR did not cause it; it fixed the sibling entry point and did not carry the fix across. Both now release any carried-over IO on the same ownership terms `Cleanup()` uses — respecting `m_bSharedIO`, so a borrowed IO is dropped and an owned one is deleted.

`Attach()`'s existing reset is unchanged.

## Test

Two new checks, and three ownership fixes to the test itself.

- **`NO RELEASE, NO NOTIFY`** — an inner profile holding its own IO survives a release by a profile that had nothing attached.
- **`READ CLEARS STALE IO`** — `HasIO()` is false after `Read()`, which loads eagerly and attaches nothing.

The test is about IO ownership and should not model ownership wrongly, so: `unique_ptr::release()` was being called *before* `Attach()` rather than after it succeeded (`Attach()` takes ownership only on success, so the failure branch leaked), at three sites; and one failure path dropped an IO it had just allocated.

## Red/green

| Target | Result |
|---|---|
| **Current master (`2df4d207`)** | **exactly 2 checks fail** — the two above |
| This branch | 0 fail |

Every other check is unchanged and passes on both, so the scope of this change is precisely those two paths and nothing else. The gate in part 1 was separately confirmed load-bearing by running the test against #2174's own pre-squash commit, where `NO RELEASE, NO NOTIFY` fails — the over-reach was real, not theoretical.

## Pre-flight

- Strict Clang 18.1.3 Release, `-Wall -Wextra -Wpedantic -Werror` (configure logged `strict warnings ENABLED`), touched TUs genuinely recompiled: **0 warnings, 0 errors**.
- GCC **15.2.0** Strict Release LTO in CI's regression container, same flags, touched TUs recompiled: **0 warnings, 0 errors**.
- Full local CTest: 187 tests, single failure `iccdev.spectral-tiff-preview`, which dies on `ModuleNotFoundError: No module named 'imagecodecs'` before any iccDEV code runs — a missing local Python module, not a code failure.
- New test under ASAN+UBSAN with `detect_leaks=1`: clean.

## Not changed

`CopyAttach(nullptr)` still drops `m_pAttachIO` without deleting it even when the profile owned it, so `Attach(io)` followed by `CopyAttach(nullptr)` leaks `io`; the `else` branch has the same gap when it overwrites a live IO. Both are pre-existing and left alone deliberately — making either delete would change what `CopyAttach()` means for existing callers, which is a separate decision from the notification. Named in a comment at the site so the next reader does not mistake the added notification for a complete release.
