### PR TITLE
fix(#2175): bound the matrix element pushXYZConvert promotes to a PCS step

### DIFF
--- a/.github/ci/regression/pcs-xyzconvert-matrix-channels.cpp
+++ b/.github/ci/regression/pcs-xyzconvert-matrix-channels.cpp
@@ -1,0 +1,249 @@
+/*
+    File:       pcs-xyzconvert-matrix-channels.cpp
+
+    Contains:   CTest helper for CIccPcsXform::pushXYZConvert() matrix-element
+                bounds checking (issue #2175).
+
+    pushXYZConvert() checks the channel counts of the customToStandardPcc /
+    standardToCustomPcc MPE, then reaches into element 0 when the MPE holds a
+    single matrix element. Those are two different objects: the container can
+    declare 3x3 while the CIccMpeMatrix inside it declares something else.
+    CIccMpeMatrix::SetSize allocates inChannels*outChannels matrix entries and
+    outChannels constants (IccMpeBasic.cpp), so for a 1x1 element the offset
+    test reads pOffset[1..2] and the memcpy copies 9 floats out of a 1-float
+    allocation.
+
+    PR #632 added exactly this guard -- but only to the standardToCustomPcc arm.
+    The customToStandardPcc arm kept the unguarded read; its one later edit
+    (#1081) only made the allocations std::nothrow. That arm is what the AFL PoC
+    in #2175 reaches (ASAN: heap-buffer-overflow, READ of size 4, in
+    CIccCmm::Begin -> CheckPCSConnections -> Connect -> pushXYZConvert).
+
+    The assertion here does NOT depend on a sanitizer. Before the fix the bogus
+    matrix step is built from out-of-bounds data and Begin() reports success;
+    after it, the malformed MPE falls through to the CIccPcsStepMpe path, whose
+    Begin() rejects it and yields icCmmStatBadConnection. So this is red-green
+    in a plain build: pre-fix Begin()==icCmmStatOk, post-fix != icCmmStatOk.
+
+    Both arms are covered: the src profile carries the malformed MPE as its
+    customToStandardPcc tag, and a second case moves it to standardToCustomPcc
+    so the already-fixed arm stays pinned against a future edit.
+
+    Returns 0 on success; the number of failed assertions otherwise.
+*/
+
+#include "IccCmm.h"
+#include "IccDefs.h"
+#include "IccMpeBasic.h"
+#include "IccProfile.h"
+#include "IccTag.h"
+#include "IccTagBasic.h"
+#include "IccTagLut.h"
+#include "IccTagMPE.h"
+
+#include <cstdio>
+
+static int g_failures = 0;
+
+static void check(bool cond, const char *msg)
+{
+  if (cond) {
+    std::printf("ok:   %s\n", msg);
+  }
+  else {
+    std::printf("FAIL: %s\n", msg);
+    ++g_failures;
+  }
+}
+
+static void attach_xyz(CIccProfile &p, icSignature sig, double x, double y, double z)
+{
+  CIccTagXYZ *t = new CIccTagXYZ;
+  (*t)[0].X = icDtoF(x);
+  (*t)[0].Y = icDtoF(y);
+  (*t)[0].Z = icDtoF(z);
+  p.AttachTag(sig, t);
+}
+
+// A 3-in/3-out identity LUT so CIccCmm::AddXform has a transform to use.
+static CIccTagLut16 *make_identity_lut(icColorSpaceSignature src, icColorSpaceSignature dst)
+{
+  CIccTagLut16 *pLut = new CIccTagLut16;
+  pLut->Init(3, 3);
+
+  // Fill the curves BEFORE SetColorSpaces. For an XYZ input it moves the B
+  // curves to M and installs its own zero-size B curves (IccTagLut.cpp:5745),
+  // so calling it first and then assigning over NewCurvesB() would overwrite
+  // -- and leak -- the ones it just created.
+  LPIccCurve *aCurves = pLut->NewCurvesA();
+  LPIccCurve *bCurves = pLut->NewCurvesB();
+  if (!aCurves || !bCurves) {
+    delete pLut;
+    return NULL;
+  }
+  for (int i = 0; i < 3; i++) {
+    CIccTagCurve *ca = new CIccTagCurve();
+    ca->SetSize(2, icInitIdentity);
+    aCurves[i] = ca;
+
+    CIccTagCurve *cb = new CIccTagCurve();
+    cb->SetSize(2, icInitIdentity);
+    bCurves[i] = cb;
+  }
+
+  pLut->SetColorSpaces(src, dst);
+
+  icUInt8Number grid[3] = {2, 2, 2};
+  if (!pLut->NewCLUT(grid, 2)) {
+    delete pLut;
+    return NULL;
+  }
+
+  CIccCLUT *clut = pLut->GetCLUT();
+  icFloatNumber *data = clut->GetData(0);
+  const icUInt32Number n = clut->NumPoints() * 3;
+  for (icUInt32Number i = 0; i < n; i++)
+    data[i] = 0.5f;
+
+  return pLut;
+}
+
+// The MPE always declares 3x3, so pushXYZConvert's own container check passes.
+// nElemChannels sets what the single matrix element inside it declares:
+//   3 -> well formed, and the control case for this test
+//   1 -> the #2175 shape; GetMatrix() owns 1 float, GetConstants() owns 1 float
+static CIccTagMultiProcessElement *make_single_matrix_mpe(icUInt16Number nElemChannels)
+{
+  CIccTagMultiProcessElement *pMpe = new CIccTagMultiProcessElement(3, 3);
+
+  CIccMpeMatrix *pMtx = new CIccMpeMatrix();
+  pMtx->SetSize(nElemChannels, nElemChannels, true);
+
+  // Identity down the diagonal, zero constants -- the shape pushXYZConvert
+  // wants to promote to a CIccPcsStepMatrix.
+  icFloatNumber *pMat = pMtx->GetMatrix();
+  if (pMat) {
+    for (icUInt16Number i = 0; i < nElemChannels; i++)
+      pMat[i * nElemChannels + i] = 1.0f;
+  }
+
+  pMpe->Attach(pMtx);
+  return pMpe;
+}
+
+// Non-D50 viewing conditions, which is what makes isStandardPcc() false and so
+// routes the CMM into the pushXYZConvert arms at all.
+static CIccTagSpectralViewingConditions *make_d65_viewing_conditions()
+{
+  CIccTagSpectralViewingConditions *pSvc = new CIccTagSpectralViewingConditions();
+
+  icSpectralRange range;
+  range.start = icFtoF16(400.0f);
+  range.end   = icFtoF16(700.0f);
+  range.steps = 4;
+  const icFloatNumber spd[4] = {1.0f, 1.0f, 1.0f, 1.0f};
+  pSvc->setIlluminant(icIlluminantD65, range, spd, 6504.0f);
+
+  return pSvc;
+}
+
+static void attach_description(CIccProfile &p, const char *text)
+{
+  for (icSignature s : {icSigProfileDescriptionTag, icSigCopyrightTag}) {
+    CIccTagMultiLocalizedUnicode *m = new CIccTagMultiLocalizedUnicode();
+    m->SetText(text);
+    p.AttachTag(static_cast<icSignature>(s), m);
+  }
+}
+
+// One builder for both ends of the chain. When mpeTagSig is 0 the profile is
+// left with standard (D50/1931) connection conditions; otherwise it gets D65
+// viewing conditions -- which is what makes isStandardPcc() false and routes
+// pushXYZConvert into the arm that reads the named tag -- plus the MPE itself.
+//
+// Which end carries it decides which arm runs: pushXYZConvert takes the
+// customToStandardPcc branch for a non-standard SOURCE and the
+// standardToCustomPcc branch for a non-standard DESTINATION.
+static void build_profile(CIccProfile &p, double wpX, double wpY, double wpZ,
+                          icSignature mpeTagSig, icUInt16Number nElemChannels)
+{
+  p.InitHeader();
+  p.m_Header.deviceClass = icSigOutputClass;
+  p.m_Header.colorSpace  = icSigRgbData;
+  p.m_Header.pcs         = icSigXYZData;
+  p.m_Header.version     = icVersionNumberV4_3;
+
+  attach_xyz(p, icSigMediaWhitePointTag, wpX, wpY, wpZ);
+  p.AttachTag(icSigAToB1Tag, make_identity_lut(icSigRgbData, icSigXYZData));
+  p.AttachTag(icSigBToA1Tag, make_identity_lut(icSigXYZData, icSigRgbData));
+
+  if (mpeTagSig) {
+    p.AttachTag(icSigSpectralViewingConditionsTag, make_d65_viewing_conditions());
+    p.AttachTag(mpeTagSig, make_single_matrix_mpe(nElemChannels));
+  }
+
+  attach_description(p, "pcs-xyzconvert-matrix-channels");
+}
+
+// Drives CIccCmm::Begin(), which is the call chain the PoC crashes through:
+// Begin -> CheckPCSConnections -> CIccPcsXform::Connect -> pushXYZConvert.
+static icStatusCMM begin_chain(icSignature mpeTagSig, icUInt16Number nElemChannels)
+{
+  const bool bOnSource = (mpeTagSig == icSigCustomToStandardPccTag);
+
+  CIccProfile *pSrc = new CIccProfile();
+  CIccProfile *pDst = new CIccProfile();
+  build_profile(*pSrc, 0.9505, 1.0, 1.0890,
+                bOnSource ? mpeTagSig : (icSignature)0, nElemChannels);
+  build_profile(*pDst, 0.9642, 1.0, 0.8249,
+                bOnSource ? (icSignature)0 : mpeTagSig, nElemChannels);
+
+  // AddXform "takes ownership of the profile, or deletes the profile on error"
+  // (IccCmm.cpp:9219), so a profile handed to it must never be deleted here --
+  // only the one that was not passed yet.
+  CIccCmm cmm(icSigRgbData, icSigRgbData, true);
+  if (cmm.AddXform(pSrc, icRelativeColorimetric, icInterpTetrahedral) != icCmmStatOk) {
+    delete pDst;
+    return icCmmStatBadXform;
+  }
+  if (cmm.AddXform(pDst, icRelativeColorimetric, icInterpTetrahedral) != icCmmStatOk) {
+    return icCmmStatBadXform;
+  }
+
+  return cmm.Begin();
+}
+
+int main()
+{
+  // Anti-vacuity controls. A well-formed 3x3 element must build the chain, which
+  // is what proves the malformed cases below actually reach pushXYZConvert and
+  // are refused there rather than dying earlier for some unrelated reason. These
+  // fail if the profiles ever stop being usable, instead of the test quietly
+  // passing on a chain that never got that far.
+  const icStatusCMM c2sOk = begin_chain(icSigCustomToStandardPccTag, 3);
+  std::printf("control customToStandardPcc 3x3: Begin() = %d\n", (int)c2sOk);
+  check(c2sOk == icCmmStatOk,
+        "control: a well-formed 3x3 matrix element builds the PCS chain");
+
+  const icStatusCMM s2cOk = begin_chain(icSigStandardToCustomPccTag, 3);
+  std::printf("control standardToCustomPcc 3x3: Begin() = %d\n", (int)s2cOk);
+  check(s2cOk == icCmmStatOk,
+        "control: a well-formed 3x3 matrix element builds the PCS chain (dst arm)");
+
+  // customToStandardPcc -- the arm PR #632 missed, and the one #2175 reaches.
+  const icStatusCMM c2s = begin_chain(icSigCustomToStandardPccTag, 1);
+  std::printf("customToStandardPcc 1x1: Begin() = %d\n", (int)c2s);
+  check(c2s != icCmmStatOk,
+        "customToStandardPcc: a 1x1 matrix element in a 3x3 MPE is refused, not read out of bounds");
+
+  // standardToCustomPcc -- already guarded by #632; pinned so it stays that way.
+  const icStatusCMM s2c = begin_chain(icSigStandardToCustomPccTag, 1);
+  std::printf("standardToCustomPcc 1x1: Begin() = %d\n", (int)s2c);
+  check(s2c != icCmmStatOk,
+        "standardToCustomPcc: a 1x1 matrix element in a 3x3 MPE is refused, not read out of bounds");
+
+  if (g_failures)
+    std::printf("%d assertion(s) failed\n", g_failures);
+
+  return g_failures;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2104,6 +2104,41 @@ function(iccdev_add_unsupported_profile_class_test)
   endif()
 endfunction()
 
+function(iccdev_add_pcs_xyzconvert_matrix_channels_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccPcsXyzConvertMatrixChannelsTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/pcs-xyzconvert-matrix-channels.cpp"
+  )
+  target_link_libraries(iccPcsXyzConvertMatrixChannelsTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccPcsXyzConvertMatrixChannelsTest)
+
+  add_test(
+    NAME iccdev.pcs-xyzconvert-matrix-channels
+    COMMAND "$<TARGET_FILE:iccPcsXyzConvertMatrixChannelsTest>"
+  )
+  set_tests_properties(iccdev.pcs-xyzconvert-matrix-channels PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;cmm;pcc;security;issue-2175;regression"
+  )
+  if(WIN32)
+    set(_pcsxyz_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccPcsXyzConvertMatrixChannelsTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _pcsxyz_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.pcs-xyzconvert-matrix-channels PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_pcsxyz_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_dpcc_pcc_replacement_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -4908,6 +4943,7 @@ if(WIN32)
   iccdev_add_extended_device_colorspace_test()
   iccdev_add_unsupported_profile_class_test()
   iccdev_add_dpcc_pcc_replacement_test()
+  iccdev_add_pcs_xyzconvert_matrix_channels_test()
   iccdev_add_iccviz_metrics_test()
   iccdev_add_iccviz_degenerate_test()
   iccdev_add_iccviz_pdf_axis_test()
@@ -5188,6 +5224,7 @@ iccdev_add_utf8_textarray_test()
 iccdev_add_extended_device_colorspace_test()
 iccdev_add_unsupported_profile_class_test()
 iccdev_add_dpcc_pcc_replacement_test()
+iccdev_add_pcs_xyzconvert_matrix_channels_test()
 iccdev_add_iccviz_metrics_test()
 iccdev_add_iccviz_degenerate_test()
 iccdev_add_iccviz_pdf_axis_test()

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -3362,10 +3362,30 @@ icStatusCMM CIccPcsXform::pushXYZConvert(CIccXform *pFromXform, CIccXform *pToXf
         if (pElem->GetType()==icSigMatrixElemType) {
           CIccMpeMatrix *pMatElem = (CIccMpeMatrix*)pElem;
 
-          icFloatNumber *pMat = pMatElem->GetMatrix();
-          icFloatNumber *pOffset = pMatElem->GetConstants();
+          const icFloatNumber *pMat = pMatElem->GetMatrix();
+          const icFloatNumber *pOffset = pMatElem->GetConstants();
+          icUInt16Number inChannels = pMatElem->NumInputChannels();
+          icUInt16Number outChannels = pMatElem->NumOutputChannels();
 
-          if (pMat && (!pOffset || (pOffset[0]==0.0 && pOffset[1]==0.0 && pOffset[2]==0.0))) {
+          // The guard above checks the containing MPE's channel counts, not this
+          // element's, and the two can disagree in a profile that Validate()
+          // rejects but nothing here re-checks. CIccMpeMatrix::SetSize allocates
+          // inChannels*outChannels matrix entries and outChannels constants, so a
+          // 1x1 element leaves pOffset[1..2] and 8 of the 9 copied matrix entries
+          // out of bounds (#2175). PR #632 added this same guard to the
+          // standardToCustomPcc arm below; this arm was missed.
+          bool offsetsZero = true;
+          if (pOffset) {
+            for (int i = 0; i < outChannels; ++i) {
+              if (pOffset[i] != 0.0) {
+                offsetsZero = false;
+                break;
+              }
+            }
+          }
+
+          // make sure the matrix is the expected size and offsets are zero
+          if (pMat && (inChannels == 3) && (outChannels == 3) && (!pOffset || offsetsZero) ) {
             CIccPcsStepMatrix *pStepMtx = new (std::nothrow) CIccPcsStepMatrix(3, 3);
 
             if (pStepMtx ) {


### PR DESCRIPTION
Part of #2175.

## What the defect is

`CIccPcsXform::pushXYZConvert()` validates the channel counts of the
`customToStandardPcc` / `standardToCustomPcc` **MPE** (`IccCmm.cpp:3353`), then reaches into
element 0 when that MPE holds a single matrix element. Those are two different objects: the
container can declare 3x3 while the `CIccMpeMatrix` inside it declares something else, and
nothing on this path re-checks.

`CIccMpeMatrix::SetSize` allocates `inChannels*outChannels` matrix entries and `outChannels`
constants (`IccMpeBasic.cpp:5107-5119`), so for a 1x1 element:

- `pOffset[1..2]` is read from a 1-float allocation
- the `memcpy` copies 9 floats out of a 1-float allocation

## This arm was missed by an earlier fix, not newly broken

`git blame` on the destination arm points at **PR #632, "Fix: SBO in
CIccPcsXform::pushXYZConvert()"**. That PR added *exactly* this guard as a single hunk, and the
function has two structurally identical blocks — it landed on `standardToCustomPcc` only. The
`customToStandardPcc` arm kept the unguarded read (its one later edit, #1081, only made the
allocations `std::nothrow`), and that is the arm the AFL PoC in #2175 reaches.

This change applies the same guard there, so the two arms now match.

## Reproduction

ASAN on the attached PoC, and on a deterministic fixture built for this PR (a `c2sp` MPE
declaring 3x3 that holds a 1x1 matrix element) — byte-identical signature from both:

```
ERROR: AddressSanitizer: heap-buffer-overflow
READ of size 4 ... SCARINESS: 17 (4-byte-read-heap-buffer-overflow)
    #0 CIccPcsXform::pushXYZConvert(...)  IccCmm.cpp:3368
    #1 CIccPcsXform::Connect(...)         IccCmm.cpp:2380
    #2 CIccCmm::CheckPCSConnections(bool) IccCmm.cpp:9447
    #3 CIccCmm::Begin(bool, bool)         IccCmm.cpp:9685
allocated by thread T0 here:
    #1 CIccMpeMatrix::SetSize(...)        IccMpeBasic.cpp:5116
```

`iccFromXml` reports the fixture invalid (`Mis-matching number of input channels in first
process element!`) and still writes it — `pushXYZConvert` never calls `Validate()`.

## Impact is not sanitizer-only

In a plain Release build the old code did not merely read out of bounds: it built a
`CIccPcsStepMatrix` from that data and reported success, so `iccApplyToLink` **exited 0 and
wrote a device link**. After the fix the malformed MPE falls through to the `CIccPcsStepMpe`
path, whose `Begin()` rejects it, and the tool exits 255 with
`status 14: Invalid profile connection`.

Three pre-fix runs produced byte-identical output after masking `dateTime`/profile ID, so the
adjacent bytes are deterministic in this layout — no claim of varying heap disclosure is made.

## Regression test

`iccdev.pcs-xyzconvert-matrix-channels` is red/green **without** a sanitizer, so it bites on
every CI leg rather than only the ASAN ones:

| case | pre-fix | post-fix |
|---|---|---|
| control, well-formed 3x3, both arms | 0, 0 | 0, 0 |
| `customToStandardPcc` 1x1 | **0 — FAIL** | 14 |
| `standardToCustomPcc` 1x1 | 14 | 14 |

Only the `customToStandardPcc` row flips, so the test discriminates exactly the missing guard.
The two **controls** assert `icCmmStatOk` on a well-formed element: without them the case could
pass by dying earlier for an unrelated reason. That is not hypothetical — the first version of
this test did exactly that (`icCmmStatProfileMissingTag`, green against both trees) and was
rewritten. The `standardToCustomPcc` row pins #632's arm so it cannot regress.

## Pre-flight

CI's gate is `grep -cE 'warning:' build.log` == 0, run on each profile:

| profile | result |
|---|---|
| Clang 21.1.3 strict Release (`-Wall -Wextra -Wpedantic -Werror`) | 0 warnings, configure reports `strict warnings ENABLED` |
| GCC 15.2.0 strict Release LTO, in `iccdev-ci-regression:latest` | 0 warnings, configure reports `strict warnings ENABLED` |
| Clang ASAN+UBSAN Debug strict | 0 warnings |
| `ctest` (188 tests) | 187 pass; the one failure is `iccdev.spectral-tiff-preview`, a missing local `imagecodecs` python module, unrelated |

Run with `detect_leaks=1` (CI sets `0`): no leaks. LSAN was verified live against a
deliberately leaking probe first, so that is a measured result rather than an absent message.

Dispatched `ci-pr-action` with `ci_scope=source` before opening this PR:
**run 31935266639, success** (8 jobs, 3 skipped). The new test is confirmed to have *executed*
there, not merely been built: `Windows MSVC + ClangCL` #87 Passed, `MinGW UCRT64` #88 Passed,
`GCC Strict ASAN+UBSAN (Debug)` #85 Passed.

## Deliberately not in this PR

1. **`CIccPcsStepScale::Mult` (`IccCmm.cpp:4953`) dereferences `GetMatrix()` without a NULL
   check.** `CIccMpeMatrix::Read`'s "constants with no matrix" branch
   (`IccMpeBasic.cpp:5241-5250`) calls `SetSize(0, nOutputChannels)` — leaving `m_pMatrix ==
   NULL` — then restores `m_nInputChannels`, so an element can report 3x3 with no matrix
   payload and reach `Mult` via `concat`. Pre-existing, a different function, and the `pMat &&`
   test in this change already keeps `pushXYZConvert` out of it. Mechanism read from source; I
   have not built a PoC. Happy to file it as its own issue.
2. **Factoring the two identical arms into one helper.** The duplication is the root cause here,
   but that is a refactor of core `IccProfLib` rather than a security fix, so it is left as a
   maintainer call.
