### PR TITLE
refactor(#2154): collapse the duplicate WritePdfTextFile copies onto icWriteAndClose

### DIFF
--- a/IccProfLib/IccCmdLineUtil.h
+++ b/IccProfLib/IccCmdLineUtil.h
@@ -272,9 +272,9 @@ inline bool icFlushAndClose(FILE* f)
 // handle straight to this function is what keeps the validated object and the
 // written object the same object.
 //
-// The body mirrors the WritePdfTextFile() copies in MiniPDF.cpp, which already
-// do exactly this correctly; those are two more members of the duplicated
-// open/close helper family #2154 tracks, and they can collapse onto this one.
+// The body came from the WritePdfTextFile() copies in MiniPDF.cpp, which already
+// did exactly this correctly. Both of those were members of the duplicated
+// open/close helper family #2154 tracks, and both now call this function instead.
 inline bool icWriteAndClose(FILE* f, const std::string& text)
 {
   bool failed = false;

--- a/Tools/CmdLine/IccProfilePlot/MiniPDF.cpp
+++ b/Tools/CmdLine/IccProfilePlot/MiniPDF.cpp
@@ -80,22 +80,6 @@ std::ostream& operator<<( std::ostream &os, const Rect2D &r )
   return os << r.left << " " << r.bottom << " " << r.right << " " << r.top;
 }
 
-static bool WritePdfTextFile(FILE* outFile, const std::string& text)
-{
-  bool failed = false;
-
-  if (!outFile)
-    return false;
-
-  if (!text.empty() && fwrite(text.data(), 1, text.size(), outFile) != text.size())
-    failed = true;
-
-  if (!icFlushAndClose(outFile))
-    failed = true;
-
-  return !failed;
-}
-
 /******************************************************************************/
 
 std::ostream& operator<<( std::ostream &os, const point2D &p )
@@ -193,7 +177,10 @@ void PDFWriter::CloseFile()
 
           // codeql[cpp/path-injection]
           FILE* outFile = icOpenRegularWriteTextFile(m_filename.c_str());
-          if (!WritePdfTextFile(outFile, out.str())) {
+          // icWriteAndClose() writes through the handle icOpenRegularWriteTextFile()
+          // just validated, then closes it (#2154). It replaced a byte-identical
+          // private WritePdfTextFile() copy that lived here.
+          if (!icWriteAndClose(outFile, out.str())) {
             fprintf(stderr, "PDF writing error in '%s': unable to open regular output file\n", m_filename.c_str());
             // Fall through (don't early-return) so the shared object-cleanup loop
             // at the end still frees every PDFObject on this failure path (#1547).

--- a/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
+++ b/Tools/CmdLine/IccProfileVisualize/MiniPDF.cpp
@@ -99,24 +99,6 @@ std::ostream& operator<<( std::ostream &os, const RGB8Color &col )
 
 /******************************************************************************/
 
-static bool WritePdfTextFile(FILE* outFile, const std::string& text)
-{
-  bool failed = false;
-
-  if (!outFile)
-    return false;
-
-  if (!text.empty() && fwrite(text.data(), 1, text.size(), outFile) != text.size())
-    failed = true;
-
-  if (!icFlushAndClose(outFile))
-    failed = true;
-
-  return !failed;
-}
-
-/******************************************************************************/
-
 // very approximate, not using real font metrics
 float PDFEstimateStringWidth( const std::string &str, float textSizePts )
 {
@@ -385,7 +367,10 @@ void PDFWriter::CloseFile()
 
           // codeql[cpp/path-injection]
           FILE* outFile = icOpenRegularWriteTextFile(m_filename.c_str());
-          if (!WritePdfTextFile(outFile, out.str())) {
+          // icWriteAndClose() writes through the handle icOpenRegularWriteTextFile()
+          // just validated, then closes it (#2154). It replaced a byte-identical
+          // private WritePdfTextFile() copy that lived here.
+          if (!icWriteAndClose(outFile, out.str())) {
             LogAnError(stderr, "PDF writing error in '%s': unable to open regular output file\n", m_filename.c_str());
             m_filename.clear();
             return;


### PR DESCRIPTION
Part of #2154.

Both `MiniPDF.cpp` trees carried a private `static WritePdfTextFile()`. Normalised for the function and parameter names, each body is identical to `icWriteAndClose()` in `IccProfLib/IccCmdLineUtil.h` — which is where the shared version came from when #2161 added it. Both files already included that header, so this is a delete plus a call-site rename with nothing else to reconcile.

Write-and-close goes from three implementations — two static copies plus the shared inline — to one.

## What is left of the family

The wider #1204 open/close family still has three static sites, deliberately untouched here:

| site | symbols | why not now |
| --- | --- | --- |
| `IccConnect/IccLibConnect/IccCmmConfig.cpp:95,124` | `icOpenWriteTextFile` / `icCloseWriteTextFile` | inside `namespace iccDEV {`; the shared header has no `USEICCDEVNAMESPACE` guard |
| `IccConnect/IccLibConnect/IccJsonUtil.cpp:99,128` | `icOpenWriteBinaryFile` / `icCloseWriteBinaryFile` | same |
| `IccProfLib/IccIO.cpp:109,114` | `icFileModeCanWrite` / `icFileIsRegular` | different shape — validates an already-open `FILE*`, POSIX-only |

The two `IccConnect` pairs raise a namespace question this change does not, so they are a separate slice. Asked on #2154.

## Evidence

`iccProfileVisualize` produces **no PDF pages for any of the 60 corpus profiles tried** — `outputDataToPDF()` returns 0 unless `data.pages` is non-empty — so its changed `CloseFile()` path is not reachable from the CLI. The proof is therefore at the object-code level, which covers both halves uniformly:

- `clang++-18 -fno-lto -S` emits **byte-identical assembly** before and after for both translation units: **4,664** lines (`IccProfilePlot`) and **18,844** lines (`IccProfileVisualize`).
- **Checked red first.** Substituting `icFlushAndClose()` for `icWriteAndClose()`, which drops the write, moves **3,760** lines. An earlier run of the same harness reported "identical" over *zero* lines because the object paths were wrong, so the comparison asserts a line-count floor.
- The `.o` files are LTO bitcode and cannot be disassembled directly; the assembly is regenerated with `-fno-lto` from the compile command in `compile_commands.json`.
- `iccProfileVisualizePlot` additionally produces **byte-identical PDFs** across three profiles. `MiniPDF` embeds no timestamp, so that comparison is deterministic.

## Pre-flight

Run on the merged tree, not the pre-merge one.

| lane | result |
| --- | --- |
| clang 18.1.3 strict Release (`-Wall -Wextra -Wpedantic -Werror`) | 0 warnings, 0 errors |
| GCC 15.2.0 strict Release LTO, in CI's own container | 0 warnings, 0 errors |
| CTest | 186/187 |
| ASAN+UBSAN Debug, `detect_leaks=1` | clean, both tools |

CMake printed `strict warnings ENABLED` for both compilers, so neither lane silently skipped the `-Wshadow -Wnull-dereference -Wundef -Wpointer-arith` set.

The single CTest failure is `iccdev.spectral-tiff-preview`, which needs a Python `imagecodecs` module that is not installed on this machine; it is unrelated to this change. All ten `iccviz` / `iccprofileplot` tests pass, including `iccdev.iccviz-writer-serialization`, which compiles these writers directly, and `iccdev.iccprofileplot-pdf-leak`.

Sanitizers were run with `detect_leaks=1` because CI's ctest environment sets `detect_leaks=0`.

## Note on the branch shape

This branch tracks master by **merge** rather than rebase. #2154 is a long-lived refactor expected to span several master changes, so the branch is kept current the same way `iccdev-hdr` is. Squash-merging this PR collapses that to a single commit on master as usual.

## CI

Dispatched `ci-pr-action` with `ci_scope=source` before opening this PR, per the suggested
PR workflow: [run 32277710901](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32277710901)
— **success**, 8 jobs green / 3 skipped, including GCC 15.2 Strict Release LTO, Windows
MSVC + ClangCL, MinGW UCRT64 and Tool Smoke Tests ASAN+UBSAN.
