### PR TITLE
fix(#2196): pack env() token bytes as unsigned in GetEnvSig

### DIFF
--- a/.github/ci/regression/calc-envsig-sign-extension.cpp
+++ b/.github/ci/regression/calc-envsig-sign-extension.cpp
@@ -1,0 +1,146 @@
+// Regression for #2196: CIccFuncTokenizer::GetEnvSig must pack env() token bytes as
+// unsigned, so a byte >= 0x80 cannot sign-extend over the signature it is building.
+//
+// GetEnvSig() accumulates the four characters of an "env(abcd)" token into an
+// icUInt32Number one byte at a time:
+//
+//     for (i=1; i<=4 && i<l-1; i++) { sig <<= 8; sig |= szToken[i]; }
+//
+// szToken is a const char*, and plain char is signed on x86/x86-64 and on Windows, so
+// a token byte >= 0x80 converted to icUInt32Number became 0xFFFFFFxx. OR-ing that in
+// set all 32 bits, destroying every byte accumulated before it. UBSan's integer
+// sanitizer reported the conversion at IccMpeCalc.cpp:2906 -- that is the breadcrumb
+// the issue was filed from -- but the damage is functional, not merely diagnostic:
+//
+//   * env(am<CF><8A>) and env(am<CE><8A>) are different environment variables, and
+//     both produced the signature 0xFFFFFF8A. Two distinct names aliased onto one
+//     signature, so a calculator element reads the wrong variable's value, and the
+//     wrong signature is what iccFromXml/iccFromJson write into the profile.
+//   * The leading "am" was erased entirely -- the accumulated bytes are unrecoverable
+//     once the sign-extended OR lands.
+//
+// The sibling packer in the same class, CIccFuncTokenizer::GetSig(), has read its
+// token through a `const unsigned char *` since the initial commit (1f0a9dd2).
+// GetEnvSig() arrived later, in 49318528 "Add env operator to Calculator Element" --
+// the commit this issue bisects to -- and copied the loop body without the cast.
+//
+// Both front ends reach this one site: IccMpeJson.cpp calls SetCalcFunc(), which runs
+// CIccCalculatorFunc::ParseFuncDef() and the same tokenizer, so there is no separate
+// JSON copy of the defect to fix.
+//
+// Every assertion below states the signature the ICC text encoding requires, so the
+// test is correct on any target. Note the *defect* was signedness-dependent: char is
+// unsigned by default on ARM and PowerPC, so the bug never reproduced there, and this
+// test is a red/green discriminator only where char is signed. Verified both ways by
+// rebuilding GetEnvSig with -funsigned-char.
+//
+// Red-green: reverting the cast to a bare `sig |= szToken[i]` fails 7 of the
+// assertions below, including both collision checks, while the ASCII controls keep
+// passing -- an ASCII-only test would be vacuous here.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccMpeCalc.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+// Runs one "env(....)" token through the tokenizer exactly as ParseFuncDef does and
+// reports the signature it produced, so a failure names the value rather than just
+// the case.
+bool envSigOf(const char *token, icUInt32Number &out)
+{
+  CIccFuncTokenizer scan(token);
+  icSigCmmEnvVar sig;
+
+  if (!scan.GetEnvSig(sig))
+    return false;
+
+  out = (icUInt32Number)sig;
+  return true;
+}
+
+void checkSig(const char *token, const char *label, icUInt32Number expected)
+{
+  icUInt32Number got = 0;
+
+  if (!envSigOf(token, got)) {
+    ++g_fail;
+    std::fprintf(stderr, "[calc-envsig] FAIL: %s -- GetEnvSig rejected the token\n",
+                 label);
+    return;
+  }
+
+  if (got != expected) {
+    ++g_fail;
+    std::fprintf(stderr, "[calc-envsig] FAIL: %s -- got 0x%08X, expected 0x%08X\n",
+                 label, (unsigned)got, (unsigned)expected);
+  }
+}
+
+void checkDistinct(const char *tokenA, const char *tokenB, const char *label)
+{
+  icUInt32Number a = 0, b = 0;
+
+  if (!envSigOf(tokenA, a) || !envSigOf(tokenB, b)) {
+    ++g_fail;
+    std::fprintf(stderr, "[calc-envsig] FAIL: %s -- GetEnvSig rejected a token\n",
+                 label);
+    return;
+  }
+
+  if (a == b) {
+    ++g_fail;
+    std::fprintf(stderr,
+                 "[calc-envsig] FAIL: %s -- distinct tokens collided on 0x%08X\n",
+                 label, (unsigned)a);
+  }
+}
+
+} // namespace
+
+int main()
+{
+  // Control: pure ASCII was never affected, and must stay exactly as it was. If the
+  // packing order or the 0x20 padding ever changes, these catch it.
+  checkSig("(ambL)", "ascii four-byte", 0x616D624CU);
+  checkSig("[MxLm]", "ascii bracket form", 0x4D784C6DU);
+  checkSig("(ab)", "ascii short token pads with spaces", 0x61622020U);
+
+  // The reported case: env(am<CF><8A>), the UTF-8 encoding of "am" + U+03CA, which is
+  // what the fuzzer's XML carried. 0xCF is the -49 in the issue's UBSan breadcrumb.
+  checkSig("(am\xCF\x8A)", "high-bit third byte", 0x616DCF8AU);
+
+  // A high bit in each remaining position. The first-byte case is a control, not a
+  // trigger: nothing has been accumulated yet, and the three following shifts push the
+  // sign-extended fill back out of the word, so it produced the right answer even
+  // unfixed. Every later position destroys real bytes and did fail.
+  checkSig("(\xCF\x62\x63\x64)", "high-bit first byte",  0xCF626364U);
+  checkSig("(a\xCF\x63\x64)",    "high-bit second byte", 0x61CF6364U);
+  checkSig("(abc\xCF)",          "high-bit fourth byte", 0x616263CFU);
+  checkSig("(\xFF\xFE\xFD\xFC)", "all bytes high",       0xFFFEFDFCU);
+
+  // Short tokens still pad with 0x20 after a high-bit byte rather than inheriting the
+  // sign-extended fill.
+  checkSig("(a\xCF)", "high-bit byte then padding", 0x61CF2020U);
+
+  // The defect that motivated the fix: distinct names must not alias. Under the bug
+  // both of these were 0xFFFFFF8A.
+  checkDistinct("(am\xCF\x8A)", "(am\xCE\x8A)", "distinct high-bit names");
+  checkDistinct("(a\xCF\x63\x64)", "(b\xCF\x63\x64)", "high-bit masks a differing prefix");
+
+  if (g_fail)
+    std::fprintf(stderr, "[calc-envsig] %d assertion(s) failed\n", g_fail);
+  else
+    std::printf("[calc-envsig] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -3936,6 +3936,41 @@ function(iccdev_add_mpexml_unknown_reserved_test)
   endif()
 endfunction()
 
+function(iccdev_add_calc_envsig_sign_extension_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCalcEnvSigSignExtensionTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/calc-envsig-sign-extension.cpp"
+  )
+  target_link_libraries(iccCalcEnvSigSignExtensionTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccCalcEnvSigSignExtensionTest)
+
+  add_test(
+    NAME iccdev.calc-envsig-sign-extension
+    COMMAND "$<TARGET_FILE:iccCalcEnvSigSignExtensionTest>"
+  )
+  set_tests_properties(iccdev.calc-envsig-sign-extension PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;calculator;issue-2196;regression"
+  )
+  if(WIN32)
+    set(_calc_envsig_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCalcEnvSigSignExtensionTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _calc_envsig_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.calc-envsig-sign-extension PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_calc_envsig_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #1888: proves a regression executable can link an exported IccProfLib global
 # *variable*. WINDOWS_EXPORT_ALL_SYMBOLS exports functions but not data, so on a
 # Windows shared build this only links via ${ICCDEV_TEST_LIB_ICCPROFLIB}; if that
@@ -4897,6 +4932,7 @@ if(WIN32)
   iccdev_add_signature_utils_contract_test()
   iccdev_add_tiff_create_overflow_test()
   iccdev_add_mpexml_unknown_reserved_test()
+  iccdev_add_calc_envsig_sign_extension_test()
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_proflib_exported_global_definitions_test()
   iccdev_add_json_bcd_version_test()
@@ -5179,6 +5215,7 @@ iccdev_add_mcs_colorspace_name_test()
 iccdev_add_signature_utils_contract_test()
 iccdev_add_tiff_create_overflow_test()
 iccdev_add_mpexml_unknown_reserved_test()
+iccdev_add_calc_envsig_sign_extension_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_proflib_exported_global_definitions_test()
 iccdev_add_json_bcd_version_test()

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -2903,7 +2903,13 @@ bool CIccFuncTokenizer::GetEnvSig(icSigCmmEnvVar &envSig)
 
     for (i=1; i<=4 && i<l-1; i++) {
       sig <<= 8;
-      sig |= szToken[i];
+      // Read the token byte through icUInt8Number: szToken is a char*, and char is
+      // signed on the usual targets, so a byte >= 0x80 sign-extends to 0xFFFFFFxx and
+      // the OR sets every bit already accumulated. "env(am<CF><8A>)" and
+      // "env(am<CE><8A>)" both collapsed to 0xFFFFFF8A, losing the leading characters
+      // and aliasing two distinct environment variables onto one signature (#2196).
+      // GetSig() above reads its token through an unsigned char* for the same reason.
+      sig |= (icUInt8Number)szToken[i];
     }
 
     for (;i<=4; i++) {


### PR DESCRIPTION
Fixes #2196.

## Mechanism

`CIccFuncTokenizer::GetEnvSig` packs the four characters of an `env(abcd)` token into an
`icUInt32Number` one byte at a time:

```cpp
for (i=1; i<=4 && i<l-1; i++) { sig <<= 8; sig |= szToken[i]; }
```

`szToken` is a `char*`, and plain `char` is signed on x86/x86-64 and on Windows, so a token
byte >= 0x80 converted to `icUInt32Number` became `0xFFFFFFxx`. OR-ing that in set all 32
bits, destroying every byte accumulated before it.

## Why this is functional, not just a sanitizer diagnostic

The UBSan integer-sanitizer report at `IccMpeCalc.cpp:2906` is the breadcrumb the issue was
filed from, but the damage is to the value. Measured end to end through `iccFromXml` in a
plain (non-sanitized) build, reading the `env ` operand straight out of the written profile:

| fixture | before | after |
|---|---|---|
| `env(am<CF><8A>)` | `0xFFFFFF8A` | `0x616DCF8A` |
| `env(am<CE><8A>)` | `0xFFFFFF8A` | `0x616DCE8A` |
| `env(ambL)` (ASCII control) | `0x616D624C` | `0x616D624C` |

Two **different** environment variables collided on one signature, and the wrong signature is
what gets written into the profile. The leading `am` was erased outright.

## Why it exists

The sibling packer in the same class, `CIccFuncTokenizer::GetSig()`, has read its token
through a `const unsigned char *` since the initial commit (`1f0a9dd2`). `GetEnvSig` arrived
later, in `49318528` "Add env operator to Calculator Element" -- the commit the issue bisects
to -- and copied the loop body without the cast.

## The JSON cross-check

Same bug, not a second copy. `IccMpeJson.cpp` calls `SetCalcFunc()`, which runs
`CIccCalculatorFunc::ParseFuncDef()` and the same tokenizer, so both front ends reach this one
site. One fix covers both; there is no separate JSON parser to patch.

## Scope checks

- **No writer-side companion defect.** `icGetSigStr()` takes the `%08Xh` escape for any byte
  above 126, producing a 10-char token that `GetEnvSig`'s `l==10` hex branch parses back
  exactly. Full round trip verified: XML -> ICC -> XML -> ICC preserves `0x616DCF8A`.
- **No corpus churn.** No tracked `.xml`/`.json` fixture uses a high-bit `env` token.
- **Pre-existing binary profiles are unaffected** -- binary reads never go through `GetEnvSig`.

## Test

Adds `iccdev.calc-envsig-sign-extension` (labels `iccdev;calculator;issue-2196;regression`).

Red/green: reverting the cast to a bare `sig |= szToken[i]` fails 7 assertions, including both
collision checks, while the three ASCII controls keep passing -- an ASCII-only test would have
been vacuous here.

The defect is signedness-dependent, so the test's discriminating power is too. Verified by
rebuilding `GetEnvSig` with `-funsigned-char`:

| | signed `char` (x86) | unsigned `char` (ARM) |
|---|---|---|
| fixed | pass | pass |
| unfixed | **7 fail** | pass |

The assertions state the signature the ICC text encoding requires, so they are correct on any
target; only the red/green discrimination is x86/Windows-specific. Noted in the test header so
nobody reads an ARM pass as coverage.

## Pre-flight

| lane | result |
|---|---|
| Strict clang, `-Wall -Wextra -Wpedantic -Werror`, Release | `strict warnings ENABLED (Clang 21.1.3)`; **0 warnings, 0 errors** |
| GCC 15.2.0 in `iccdev-ci-regression:latest`, `-Werror` + LTO Release | `strict warnings ENABLED (GNU 15.2.0)`; **0 warnings, 0 errors** |
| Full local CTest suite | 188/189; the one failure is `spectral-tiff-preview`, a missing local `imagecodecs` Python module, unrelated |
| ASAN + `detect_leaks=1` | clean, with a positive control confirming LSAN actually discriminates on this binary |
| UBSan + IntSan on the issue's PoC | clean, profile written, rc=0 |
