### PR TITLE
perf(tier-C): hoist the pre-existing per-pixel invariants that actually pay

### DIFF
--- a/.github/ci/regression/clut-grid-clamp-inf.cpp
+++ b/.github/ci/regression/clut-grid-clamp-inf.cpp
@@ -1,0 +1,132 @@
+/*
+    File:       clut-grid-clamp-inf.cpp
+
+    Contains:   CTest helper pinning CIccCLUT's grid-coordinate clamp semantics
+
+    Copyright:  (c) see below -- ICC Software License, Version 0.2
+*/
+
+// The Interp* functions used to scale each source component through the
+// m_UnitClipFunc function pointer and then re-check the result with isfinite and
+// a range clamp. That did the same work twice on the default path, and the
+// indirect call is what stopped the sequence vectorizing, so it was replaced by
+// an inline clamp (icClutGridClamp in IccTagLut.cpp).
+//
+// The replacement is exactly equivalent to the former default path
+// (ClutUnitClip) for every input. It DELIBERATELY CHANGES one case on the former
+// NoClip path, which the MPE and spectral CLUT elements installed via
+// SetClipFunc:
+//
+//                    old ClutUnitClip     old NoClip      now (both)
+//     +Inf           mx  (saturate high)  0  (collapse)   mx
+//     -Inf           0                    0               0
+//     NaN            0                    0               0
+//     above range    mx                   mx              mx
+//     below range    0                     0              0
+//
+// So the two paths disagreed about +Inf, at opposite ends of the grid, and now
+// agree that it saturates high.
+//
+// This test exists because that change is invisible to everything else. The
+// throughput harness reported no checksum movement at all, on any case, even
+// with +Inf placed on every channel of every profile: the only profiles in the
+// corpus that install the NoClip path are three-channel, and the only profile
+// with enough channels to reach the wider interpolators has no CLUT element.
+// Without this test the change would be unverified rather than merely untested.
+//
+// Exit code 0 = pass, 1 = the clamp semantics moved.
+
+#include "IccTagLut.h"
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+
+static int g_failures = 0;
+
+static bool check(bool cond, const char *msg)
+{
+  if (cond) {
+    std::printf("ok:   %s\n", msg);
+  }
+  else {
+    std::printf("FAIL: %s\n", msg);
+    ++g_failures;
+  }
+  return cond;
+}
+
+// Identity passthrough mirroring the file-static NoClip in IccMpeBasic.cpp and
+// IccMpeSpectral.cpp, which those files install via SetClipFunc. SetClipFunc is
+// now a documented no-op; installing it here is the point -- the result must be
+// the same either way.
+static icFloatNumber NoClipIdentity(icFloatNumber v) { return v; }
+
+// Builds a 1-input CLUT whose node values equal their own grid index, so the
+// interpolated output reads back the clamped grid coordinate directly. With
+// nGrid nodes the output for a saturated-high input must be the top index,
+// nGrid-1.
+static void run1d(const char *label, icFloatNumber in, icFloatNumber expect,
+                  bool bInstallNoClip)
+{
+  const icUInt8Number nGrid = 4;
+
+  CIccCLUT clut(1, 1);
+  if (!check(clut.Init(nGrid), "Init built a 1-input CLUT"))
+    return;
+
+  icFloatNumber *pData = clut.GetData(0);
+  for (icUInt8Number i = 0; i < nGrid; i++)
+    pData[i] = (icFloatNumber)i;
+
+  if (bInstallNoClip)
+    clut.SetClipFunc(NoClipIdentity);
+
+  clut.Begin();
+
+  icFloatNumber dst = -1.0f;
+  clut.Interp1d(&dst, &in);
+
+  char buf[192];
+  std::snprintf(buf, sizeof(buf), "%s: %s clip -> %.4f (expected %.4f)",
+                label, bInstallNoClip ? "NoClip" : "default",
+                (double)dst, (double)expect);
+  check(std::fabs(dst - expect) < 1.0e-5f, buf);
+}
+
+int main()
+{
+  const icFloatNumber inf = std::numeric_limits<icFloatNumber>::infinity();
+  const icFloatNumber nan = std::numeric_limits<icFloatNumber>::quiet_NaN();
+  const icFloatNumber top = 3.0f;   // nGrid-1 for the 4-node CLUT above
+
+  // The behaviour under test: +Inf saturates high on BOTH paths. Before the
+  // change the second of these produced 0.
+  std::printf("\n[ +Inf saturates high on both paths ]\n");
+  run1d("+Inf", inf, top, false);
+  run1d("+Inf", inf, top, true);
+
+  // Everything else was already identical on both paths and must stay so.
+  std::printf("\n[ unchanged cases ]\n");
+  run1d("-Inf", -inf, 0.0f, false);
+  run1d("-Inf", -inf, 0.0f, true);
+  run1d("NaN", nan, 0.0f, false);
+  run1d("NaN", nan, 0.0f, true);
+  run1d("above range", 2.0f, top, false);
+  run1d("above range", 2.0f, top, true);
+  run1d("below range", -1.0f, 0.0f, false);
+  run1d("below range", -1.0f, 0.0f, true);
+
+  // In-range input still interpolates normally: 0.5 of the way up a grid whose
+  // nodes equal their index is (nGrid-1)/2.
+  std::printf("\n[ in-range input unaffected ]\n");
+  run1d("mid", 0.5f, top / 2.0f, false);
+  run1d("mid", 0.5f, top / 2.0f, true);
+
+  if (g_failures) {
+    std::printf("\n%d check(s) FAILED\n", g_failures);
+    return 1;
+  }
+  std::printf("\nall checks passed\n");
+  return 0;
+}

--- a/.github/workflows/ci-json-roundtrip.yml
+++ b/.github/workflows/ci-json-roundtrip.yml
@@ -131,10 +131,10 @@ jobs:
             ICCDEV_TEST_OUTDIR="$BUILD_JSON/Testing/ctest-output/ci-json-create-profiles" \
             bash CreateAllProfiles.sh 2>&1 | tee "$CREATE_LOG"
 
-          # 130 before #1883; the Testing/V2 section now adds four v2 fixtures.
+          # 130 before #1883; the Testing/V2 section now adds five v2 fixtures.
           profile_parse_count="$(grep -c 'Profile parsed and saved correctly' "$CREATE_LOG" || true)"
-          if [ "$profile_parse_count" -ne 134 ]; then
-            echo "[FAIL] Expected 134 generated profiles, got ${profile_parse_count}"
+          if [ "$profile_parse_count" -ne 135 ]; then
+            echo "[FAIL] Expected 135 generated profiles, got ${profile_parse_count}"
             exit 1
           fi
           echo "[OK] Generated ${profile_parse_count} test profiles"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4849,10 +4849,11 @@ if(WIN32)
       # Validate the disposable Windows Testing tree by artifact count. The
       # batch file echoes commands through cmd.exe, and tool stdout can be lost
       # in that layer even when profiles are generated successfully.
-      # 134 since Testing/V2/v2GrayTRC.xml was added: it is the only source in
-      # the tree that produces a CIccXformMonochrome. Bump this with any
-      # change to the number of profiles CreateAllProfiles.bat generates.
-      EXPECTED_GENERATED_PROFILE_COUNT 134
+      # 135 since Testing/V2/v2GrayTRC{,Lab}.xml were added: they are the only
+      # sources in the tree that produce a CIccXformMonochrome, one per PCS
+      # encoding. Bump this with any change to the number of profiles
+      # CreateAllProfiles.bat generates.
+      EXPECTED_GENERATED_PROFILE_COUNT 135
     )
     set_tests_properties(iccdev.windows-create-profiles PROPERTIES
       FIXTURES_SETUP iccdev_profiles

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4718,6 +4718,47 @@ function(iccdev_add_zip_utf8_text_zlib_test)
   endif()
 endfunction()
 
+# Pins CIccCLUT's grid-coordinate clamp semantics, in particular that +Inf
+# saturates to the top of the grid on both the default and the former NoClip
+# path. Those two disagreed about +Inf before the clamp was inlined -- one
+# saturated high, the other collapsed to zero.
+#
+# This needs its own test because the change is invisible to everything else:
+# the throughput harness reported no checksum movement on any case even with
+# +Inf on every channel, since the only corpus profiles that install the NoClip
+# path are three-channel and the only wider profile has no CLUT element.
+if(TARGET ${TARGET_LIB_ICCPROFLIB})
+  iccdev_add_regression_executable(iccClutGridClampTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/clut-grid-clamp-inf.cpp"
+  )
+  target_link_libraries(iccClutGridClampTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccClutGridClampTest)
+
+  add_test(
+    NAME iccdev.clut-grid-clamp-inf
+    COMMAND "$<TARGET_FILE:iccClutGridClampTest>"
+  )
+  set_tests_properties(iccdev.clut-grid-clamp-inf PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;iccprofLib;clut;clamp;regression"
+  )
+  if(WIN32)
+    set(_clutclamp_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccClutGridClampTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _clutclamp_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.clut-grid-clamp-inf PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_clutclamp_windows_env_mods}"
+    )
+  endif()
+endif()
+
+
 # Throughput harness for the IccProfLib apply paths (iccBenchApply).
 #
 # NOTE: this must stay ABOVE the if(WIN32) branch immediately below. That branch

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -2843,7 +2843,35 @@ icStatusCMM CIccPcsXform::ConnectLast(CIccXform* pFromXform, icColorSpaceSignatu
  **************************************************************************
  * Name: CIccPcsXform::Optimize
  * 
- * Purpose: 
+ * Purpose:
+ *  Gives each step in the chain its one chance to precompute invariant state.
+ *
+ *  Runs after Connect()/Optimize() have finished building the list and before
+ *  GetNewApply(), so a step can build immutable data here and treat it as
+ *  read-only in Apply(). Doing that work lazily on first Apply() instead would
+ *  be a data race: Apply() is const and runs concurrently on every worker
+ *  thread of a CIccThreadedCmm.
+ **************************************************************************
+ */
+icStatusCMM CIccPcsXform::Begin()
+{
+  if (m_list) {
+    CIccPcsStepList::iterator i;
+
+    for (i = m_list->begin(); i != m_list->end(); i++) {
+      if (i->ptr && !i->ptr->BeginStep())
+        return icCmmStatInvalidLut;
+    }
+  }
+
+  return icCmmStatOk;
+}
+
+/**
+**************************************************************************
+ * Name: CIccPcsXform::Optimize
+ *
+ * Purpose:
  *  Analyzes and concatenates/removes transforms in pcs transformation chain
  **************************************************************************
  */
@@ -5415,20 +5443,55 @@ CIccPcsStepSparseMatrix::CIccPcsStepSparseMatrix(icUInt16Number nRows, icUInt16N
   m_nBytesPerMatrix = nBytesPerMatrix;
   m_nChannels = 0;
   m_vals = new icFloatNumber[m_nBytesPerMatrix/sizeof(icFloatNumber)];
+  m_pMtx = NULL;   // built by BeginStep(), once m_vals has been populated
 }
 
 
 /**
 **************************************************************************
 * Name: CIccPcsStepSparseMatrix::~CIccPcsStepSparseMatrix
-* 
-* Purpose: 
+*
+* Purpose:
 *  Destructor
 **************************************************************************
 */
 CIccPcsStepSparseMatrix::~CIccPcsStepSparseMatrix()
 {
+  delete m_pMtx;
   delete [] m_vals;
+}
+
+
+/**
+**************************************************************************
+* Name: CIccPcsStepSparseMatrix::BeginStep
+*
+* Purpose:
+*  Builds the sparse matrix wrapper once, before any Apply().
+*
+*  The matrix is parsed from m_vals, which is fixed by the time the step list is
+*  built, so the CIccSparseMatrix it produces is identical for every pixel.
+*  Apply() used to construct one per pixel with bInitFromData=true, and
+*  CIccSparseMatrix::Init() (IccSparseMatrix.cpp:145) unconditionally deletes and
+*  re-news its m_Data accessor -- so that was a heap allocation and free on every
+*  pixel, plus a dimension re-parse and the 4096-dimension bounds test.
+*
+*  It is held on the step rather than in a CIccApplyPcsStep because it is
+*  immutable from here on and MultiplyVector() is const, so every thread can
+*  share the one instance. Contrast CIccPcsStepSrcSparseMatrix, whose matrix
+*  wraps per-pixel source data and therefore cannot be shared.
+**************************************************************************
+*/
+bool CIccPcsStepSparseMatrix::BeginStep()
+{
+  // Idempotent: BeginStep() can be reached more than once, and rebuilding from
+  // the same m_vals yields the same matrix.
+  delete m_pMtx;
+
+  m_pMtx = new (std::nothrow) CIccSparseMatrix((icUInt8Number*)m_vals,
+                                               m_nBytesPerMatrix,
+                                               icSparseMatrixFloatNum, true);
+  return m_pMtx != NULL;
 }
 
 
@@ -5443,9 +5506,10 @@ CIccPcsStepSparseMatrix::~CIccPcsStepSparseMatrix()
 */
 void CIccPcsStepSparseMatrix::Apply(CIccApplyPcsStep * /* pApply */, icFloatNumber *pDst, const icFloatNumber *pSrc) const
 {
-  CIccSparseMatrix mtx((icUInt8Number*)m_vals, m_nBytesPerMatrix, icSparseMatrixFloatNum, true);
-
-  mtx.MultiplyVector(pDst, pSrc);
+  // Matrix built once in BeginStep(). This used to construct a CIccSparseMatrix
+  // here, which allocated and freed on every pixel -- see BeginStep().
+  if (m_pMtx)
+    m_pMtx->MultiplyVector(pDst, pSrc);
 }
 
 

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -5675,6 +5675,29 @@ icStatusCMM CIccXformMonochrome::Begin()
 		m_ApplyCurvePtr = m_Curve;
 	}
 
+	// Apply() used to rebuild this on every pixel, in both directions, from
+	// compile-time constants: icXyzToPcs plus, for a Lab PCS, XyzToLab and its
+	// three cube roots, behind a virtual UseLegacyPCS() call. Nothing in it
+	// depends on the source colour, and both m_pProfile->m_Header.pcs and
+	// UseLegacyPCS() are fixed by the time Begin() runs.
+	//
+	// Idempotent: recomputing from the same constants yields the same values, so
+	// reaching Begin() a second time is harmless.
+	m_PcsWhite[0] = icFloatNumber(icPerceptualRefWhiteX);
+	m_PcsWhite[1] = icFloatNumber(icPerceptualRefWhiteY);
+	m_PcsWhite[2] = icFloatNumber(icPerceptualRefWhiteZ);
+
+	icXyzToPcs(m_PcsWhite);
+
+	if (m_pProfile->m_Header.pcs==icSigLabData) {
+		if (UseLegacyPCS()) {
+			CIccPCSUtil::XyzToLab2(m_PcsWhite, m_PcsWhite, true);
+		}
+		else {
+			CIccPCSUtil::XyzToLab(m_PcsWhite, m_PcsWhite, true);
+		}
+	}
+
 	return icCmmStatOk;
 }
 
@@ -5698,6 +5721,9 @@ void CIccXformMonochrome::Apply(CIccApplyXform* pApply, icFloatNumber *DstPixel,
   if (m_bSrcPcsConversion)
 	  SrcPixel = CheckSrcAbs(pApply, SrcPixel);
 
+	// m_PcsWhite is computed once in Begin(). Both branches below used to rebuild
+	// it here on every pixel -- icXyzToPcs, and for a Lab PCS XyzToLab's three
+	// cube roots behind a virtual UseLegacyPCS() call -- entirely from constants.
 	if (m_bInput) {
 		Pixel[0] = SrcPixel[0];
 
@@ -5705,43 +5731,24 @@ void CIccXformMonochrome::Apply(CIccApplyXform* pApply, icFloatNumber *DstPixel,
 			Pixel[0] = m_ApplyCurvePtr->Apply(Pixel[0]);
 		}
 
-		DstPixel[0] = icFloatNumber(icPerceptualRefWhiteX); 
-		DstPixel[1] = icFloatNumber(icPerceptualRefWhiteY);
-		DstPixel[2] = icFloatNumber(icPerceptualRefWhiteZ);
-
-		icXyzToPcs(DstPixel);
-
-		if (m_pProfile->m_Header.pcs==icSigLabData) {
-			if (UseLegacyPCS()) {
-				CIccPCSUtil::XyzToLab2(DstPixel, DstPixel, true);
-			}
-			else {
-				CIccPCSUtil::XyzToLab(DstPixel, DstPixel, true);
-			}
-		}
-
-		DstPixel[0] *= Pixel[0];
-		DstPixel[1] *= Pixel[0];
-		DstPixel[2] *= Pixel[0];
+		DstPixel[0] = m_PcsWhite[0] * Pixel[0];
+		DstPixel[1] = m_PcsWhite[1] * Pixel[0];
+		DstPixel[2] = m_PcsWhite[2] * Pixel[0];
 	}
 	else {
-		Pixel[0] = icFloatNumber(icPerceptualRefWhiteX); 
-		Pixel[1] = icFloatNumber(icPerceptualRefWhiteY);
-		Pixel[2] = icFloatNumber(icPerceptualRefWhiteZ);
-
-		icXyzToPcs(Pixel);
-
+		// The divide is kept rather than turned into a precomputed reciprocal:
+		// x/w and x*(1/w) are not bit-identical, and the cube roots hoisted above
+		// dominate a single division. Preserving exact output keeps the harness
+		// checksum usable as a strict equality oracle for the rest of this branch.
+		//
+		// The header test selects which source component to read rather than
+		// computing anything, so it stays; folding it into another member would
+		// buy nothing measurable.
 		if (m_pProfile->m_Header.pcs==icSigLabData) {
-			if (UseLegacyPCS()) {
-				CIccPCSUtil::XyzToLab2(Pixel, Pixel, true);
-			}
-			else {
-				CIccPCSUtil::XyzToLab(Pixel, Pixel, true);
-			}
-			DstPixel[0] = SrcPixel[0]/Pixel[0];
+			DstPixel[0] = SrcPixel[0]/m_PcsWhite[0];
 		}
 		else {
-			DstPixel[0] = SrcPixel[1]/Pixel[1];
+			DstPixel[0] = SrcPixel[1]/m_PcsWhite[1];
 		}
 
 		if (m_ApplyCurvePtr) {

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -1278,6 +1278,11 @@ protected:
 
   virtual bool HasPerceptualHandling() { return false; }
 
+	/// Perceptual reference white in this profile's PCS encoding, computed once
+	/// by Begin(). Apply() rebuilt it on every pixel from compile-time constants.
+	/// Immutable after Begin(), so shared safely across threads.
+	icFloatNumber m_PcsWhite[3];
+
 	CIccCurve *m_Curve;
 	CIccCurve *GetCurve(icSignature sig) const;
 	CIccCurve *GetInvCurve(icSignature sig) const;

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -371,6 +371,7 @@ public:
 //forward reference to CIccXform used by CIccApplyXform
 class CIccApplyXform;
 class CIccMatrixMath;
+class CIccSparseMatrix;   // held by CIccPcsStepSparseMatrix; defined in IccSparseMatrix.h
 
 /**
  **************************************************************************
@@ -661,6 +662,14 @@ public:
   virtual icPcsStepType GetType() { return icPcsStepUnknown; }
 
   virtual CIccApplyPcsStep *GetNewApply();
+
+  /// Called once by CIccPcsXform::Begin() before any Apply(), after the step list
+  /// is fully built by Connect()/Optimize(). Steps that can precompute invariant
+  /// state do it here rather than lazily on first Apply(): Apply() is const and
+  /// runs concurrently on every worker thread, so a lazy initialisation would be
+  /// a data race. Must be idempotent -- Begin() can be reached more than once.
+  /// Return false to fail the enclosing transform.
+  virtual bool BeginStep() { return true; }
 
   virtual ~CIccPcsStep() {}
   virtual void Apply(CIccApplyPcsStep *pApply, icFloatNumber *pDst, const icFloatNumber *pSrc) const=0;
@@ -1037,6 +1046,8 @@ public:
   virtual icUInt16Number GetSrcChannels() const { return m_nCols; }
   virtual icUInt16Number GetDstChannels() const { return m_nRows; }
 
+  virtual bool BeginStep();
+
   icFloatNumber *data() { return m_vals;}
   const icFloatNumber *data() const { return m_vals;}
 
@@ -1047,6 +1058,11 @@ protected:
   icUInt16Number m_nRows, m_nCols, m_nChannels;
   icUInt32Number m_nBytesPerMatrix;
   icFloatNumber *m_vals;
+
+  /// Built once by BeginStep() from m_vals; read-only in Apply(). Lives on the
+  /// step rather than in a per-apply object because it is immutable after
+  /// BeginStep() and MultiplyVector() is const, so all threads share one.
+  CIccSparseMatrix *m_pMtx;
 
 };
 
@@ -1117,7 +1133,7 @@ public:
   icStatusCMM ConnectFirst(CIccXform* pToXform, icColorSpaceSignature srcSpace);
   icStatusCMM ConnectLast(CIccXform* pFromXform, icColorSpaceSignature dstSpace);
 
-  virtual icStatusCMM Begin() { return icCmmStatOk; }
+  virtual icStatusCMM Begin();
 
   virtual CIccApplyXform *GetNewApply(icStatusCMM &status);  //Must be called after Begin
 

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -1731,8 +1731,52 @@ static icFloatNumber ClutUnitClip(icFloatNumber v)
     return 0;
   else if (v>1.0)
     return 1.0;
- 
+
   return v;
+}
+
+/**
+****************************************************************************
+* Name: icClutGridClamp
+*
+* Purpose: Scales a source component into grid units and clamps it to [0, mx].
+*
+*  Replaces the m_UnitClipFunc indirect call that every Interp* function used to
+*  make once per input channel per pixel, together with the isfinite and range
+*  tests that followed it. Those did the same work twice: ClutUnitClip mapped NaN
+*  to 0 and clamped to [0,1], and the interpolator then re-tested isfinite and
+*  clamped to [0,mx]. Clamping to [0,mx] after the multiply subsumes clamping to
+*  [0,1] before it, and the indirect call was what stopped the whole sequence
+*  vectorizing.
+*
+*  Exactly equivalent to the former ClutUnitClip path for every input:
+*
+*     v        old (ClutUnitClip)          new
+*     0.5      0.5 -> 0.5*mx              0.5*mx
+*     1.5      clipped to 1.0 -> mx       1.5*mx > mx -> mx
+*    -0.5      clipped to 0   -> 0        negative -> 0
+*     NaN      isnan -> 0     -> 0        !(NaN > 0) is true -> 0
+*    +Inf      clipped to 1.0 -> mx       Inf > mx -> mx
+*    -Inf      clipped to 0   -> 0        !(-Inf > 0) -> 0
+*
+*  It DELIBERATELY CHANGES the former NoClip path for +Inf only. NoClip passed the
+*  value through, so +Inf reached the isfinite test and produced 0 -- the opposite
+*  end of the grid from what the default path produced for the same input. The two
+*  paths now agree that +Inf saturates high. Every other input, including NaN and
+*  -Inf, is unchanged on both paths.
+*****************************************************************************
+*/
+static inline icFloatNumber icClutGridClamp(icFloatNumber v, icUInt8Number mx)
+{
+  const icFloatNumber fmx = (icFloatNumber)mx;
+  const icFloatNumber x = v * fmx;
+
+  if (!(x > 0.0f))    // comparison is false for NaN, so NaN and -Inf land here
+    return 0.0f;
+  if (x > fmx)
+    return fmx;
+
+  return x;
 }
 
 /**
@@ -2644,17 +2688,7 @@ void CIccCLUT::Interp1d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
 {
   icUInt8Number mx = m_MaxGridPoint[0];
 
-  icFloatNumber x = m_UnitClipFunc(srcPixel[0]) * mx;
-  
-  // m_UnitClipFunc points to NoClip
-  if (!std::isfinite(x))
-    x = 0.0f;
-    
-  if (x < 0.0f)
-    x = 0.0f;
-
-  if (x > mx)
-    x = mx;
+  icFloatNumber x = icClutGridClamp(srcPixel[0], mx);
 
   icUInt32Number ix = (icUInt32Number)x;
 
@@ -2699,25 +2733,10 @@ void CIccCLUT::Interp2d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
   icUInt8Number mx = m_MaxGridPoint[0];
   icUInt8Number my = m_MaxGridPoint[1];
 
-  // The UnitClip function pointer is calling "NoClip", but now removes NaN and Inf
-  icFloatNumber x = m_UnitClipFunc(srcPixel[0]) * mx;
-  icFloatNumber y = m_UnitClipFunc(srcPixel[1]) * my;
-  
-  // m_UnitClipFunc points to NoClip
-  if (!std::isfinite(x))
-    x = 0.0f;
-  if (!std::isfinite(y))
-    y = 0.0f;
-    
-  if (x < 0.0f)
-    x = 0.0f;
-  if (y < 0.0f)
-    y = 0.0f;
-
-  if (x > mx)
-    x = mx;
-  if (y > my)
-    y = my;
+  // See icClutGridClamp: scales into grid units and clamps, replacing the former
+  // m_UnitClipFunc call plus the isfinite and range tests that followed it.
+  icFloatNumber x = icClutGridClamp(srcPixel[0], mx);
+  icFloatNumber y = icClutGridClamp(srcPixel[1], my);
 
   icUInt32Number ix = (icUInt32Number)x;
   icUInt32Number iy = (icUInt32Number)y;
@@ -2781,31 +2800,11 @@ void CIccCLUT::Interp3dTetra(icFloatNumber *destPixel, const icFloatNumber *srcP
   icUInt8Number my = m_MaxGridPoint[1];
   icUInt8Number mz = m_MaxGridPoint[2];
 
-  icFloatNumber x = m_UnitClipFunc(srcPixel[0]) * mx;
-  icFloatNumber y = m_UnitClipFunc(srcPixel[1]) * my;
-  icFloatNumber z = m_UnitClipFunc(srcPixel[2]) * mz;
-  
-  // m_UnitClipFunc points to NoClip, so no actual clipping is done
-  if (!std::isfinite(x))
-    x = 0.0f;
-  if (!std::isfinite(y))
-    y = 0.0f;
-  if (!std::isfinite(z))
-    z = 0.0f;
-
-  if (x < 0.0f)
-    x = 0.0f;
-  if (y < 0.0f)
-    y = 0.0f;
-  if (z < 0.0f)
-    z = 0.0f;
-
-  if (x > mx)
-    x = mx;
-  if (y > my)
-    y = my;
-  if (z > mz)
-    z = mz;
+  // See icClutGridClamp: scales into grid units and clamps, replacing the former
+  // m_UnitClipFunc call plus the isfinite and range tests that followed it.
+  icFloatNumber x = icClutGridClamp(srcPixel[0], mx);
+  icFloatNumber y = icClutGridClamp(srcPixel[1], my);
+  icFloatNumber z = icClutGridClamp(srcPixel[2], mz);
 
   icUInt32Number ix = (icUInt32Number)x;
   icUInt32Number iy = (icUInt32Number)y;
@@ -2889,31 +2888,11 @@ void CIccCLUT::Interp3d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
   icUInt8Number my = m_MaxGridPoint[1];
   icUInt8Number mz = m_MaxGridPoint[2];
 
-  icFloatNumber x = m_UnitClipFunc(srcPixel[0]) * mx;
-  icFloatNumber y = m_UnitClipFunc(srcPixel[1]) * my;
-  icFloatNumber z = m_UnitClipFunc(srcPixel[2]) * mz;
-  
-  // m_UnitClipFunc points to NoClip, so no actual clipping is done
-  if (!std::isfinite(x))
-    x = 0.0f;
-  if (!std::isfinite(y))
-    y = 0.0f;
-  if (!std::isfinite(z))
-    z = 0.0f;
-    
-  if (x < 0.0f)
-    x = 0.0f;
-  if (y < 0.0f)
-    y = 0.0f;
-  if (z < 0.0f)
-    z = 0.0f;
-
-  if (x > mx)
-    x = mx;
-  if (y > my)
-    y = my;
-  if (z > mz)
-    z = mz;
+  // See icClutGridClamp: scales into grid units and clamps, replacing the former
+  // m_UnitClipFunc call plus the isfinite and range tests that followed it.
+  icFloatNumber x = icClutGridClamp(srcPixel[0], mx);
+  icFloatNumber y = icClutGridClamp(srcPixel[1], my);
+  icFloatNumber z = icClutGridClamp(srcPixel[2], mz);
 
   icUInt32Number ix = (icUInt32Number)x;
   icUInt32Number iy = (icUInt32Number)y;
@@ -3016,38 +2995,12 @@ void CIccCLUT::Interp4d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
   icUInt8Number my = m_MaxGridPoint[2];
   icUInt8Number mz = m_MaxGridPoint[3];
 
-  icFloatNumber w = m_UnitClipFunc(srcPixel[0]) * mw;
-  icFloatNumber x = m_UnitClipFunc(srcPixel[1]) * mx;
-  icFloatNumber y = m_UnitClipFunc(srcPixel[2]) * my;
-  icFloatNumber z = m_UnitClipFunc(srcPixel[3]) * mz;
-  
-  // m_UnitClipFunc points to NoClip
-  if (!std::isfinite(w))
-    w = 0.0f;
-  if (!std::isfinite(x))
-    x = 0.0f;
-  if (!std::isfinite(y))
-    y = 0.0f;
-  if (!std::isfinite(z))
-    z = 0.0f;
-    
-  if (w < 0.0f)
-    w = 0.0f;
-  if (x < 0.0f)
-    x = 0.0f;
-  if (y < 0.0f)
-    y = 0.0f;
-  if (z < 0.0f)
-    z = 0.0f;
-
-  if (x > mx)
-    x = mx;
-  if (y > my)
-    y = my;
-  if (z > mz)
-    z = mz;
-  if (w > mw)
-    w = mw;
+  // See icClutGridClamp: scales into grid units and clamps, replacing the former
+  // m_UnitClipFunc call plus the isfinite and range tests that followed it.
+  icFloatNumber w = icClutGridClamp(srcPixel[0], mw);
+  icFloatNumber x = icClutGridClamp(srcPixel[1], mx);
+  icFloatNumber y = icClutGridClamp(srcPixel[2], my);
+  icFloatNumber z = icClutGridClamp(srcPixel[3], mz);
 
   icUInt32Number iw = (icUInt32Number)w;
   icUInt32Number ix = (icUInt32Number)x;
@@ -3131,45 +3084,16 @@ void CIccCLUT::Interp5d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
   icUInt8Number m3 = m_MaxGridPoint[3];
   icUInt8Number m4 = m_MaxGridPoint[4];
 
-  icFloatNumber g0 = m_UnitClipFunc(srcPixel[0]) * m0;
-  icFloatNumber g1 = m_UnitClipFunc(srcPixel[1]) * m1;
-  icFloatNumber g2 = m_UnitClipFunc(srcPixel[2]) * m2;
-  icFloatNumber g3 = m_UnitClipFunc(srcPixel[3]) * m3;
-  icFloatNumber g4 = m_UnitClipFunc(srcPixel[4]) * m4;
-  
-  // m_UnitClipFunc points to NoClip
-  if (!std::isfinite(g0))
-    g0 = 0.0f;
-  if (!std::isfinite(g1))
-    g1 = 0.0f;
-  if (!std::isfinite(g2))
-    g2 = 0.0f;
-  if (!std::isfinite(g3))
-    g3 = 0.0f;
-  if (!std::isfinite(g4))
-    g4 = 0.0f;
+  // See icClutGridClamp: scales into grid units and clamps, replacing the former
+  // m_UnitClipFunc call plus the isfinite and range tests that followed it. The
+  // g5 guard added for #1504 is subsumed -- the helper treats every channel
+  // identically, so no channel can be left without one.
 
-  if (g0 < 0.0f)
-    g0 = 0.0f;
-  if (g1 < 0.0f)
-    g1 = 0.0f;
-  if (g2 < 0.0f)
-    g2 = 0.0f;
-  if (g3 < 0.0f)
-    g3 = 0.0f;
-  if (g4 < 0.0f)
-    g4 = 0.0f;
-    
-  if (g0 > m0)
-    g0 = m0;
-  if (g1 > m1)
-    g1 = m1;
-  if (g2 > m2)
-    g2 = m2;
-  if (g3 > m3)
-    g3 = m3;
-  if (g4 > m4)
-    g4 = m4;
+  icFloatNumber g0 = icClutGridClamp(srcPixel[0], m0);
+  icFloatNumber g1 = icClutGridClamp(srcPixel[1], m1);
+  icFloatNumber g2 = icClutGridClamp(srcPixel[2], m2);
+  icFloatNumber g3 = icClutGridClamp(srcPixel[3], m3);
+  icFloatNumber g4 = icClutGridClamp(srcPixel[4], m4);
 
   icUInt32Number ig0 = (icUInt32Number)g0;
   icUInt32Number ig1 = (icUInt32Number)g1;
@@ -3278,57 +3202,17 @@ void CIccCLUT::Interp6d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
   icUInt8Number m4 = m_MaxGridPoint[4];
   icUInt8Number m5 = m_MaxGridPoint[5];
 
-  icFloatNumber g0 = m_UnitClipFunc(srcPixel[0]) * m0;
-  icFloatNumber g1 = m_UnitClipFunc(srcPixel[1]) * m1;
-  icFloatNumber g2 = m_UnitClipFunc(srcPixel[2]) * m2;
-  icFloatNumber g3 = m_UnitClipFunc(srcPixel[3]) * m3;
-  icFloatNumber g4 = m_UnitClipFunc(srcPixel[4]) * m4;
-  icFloatNumber g5 = m_UnitClipFunc(srcPixel[5]) * m5;
-  
-  // m_UnitClipFunc points to NoClip
-  if (!std::isfinite(g0))
-    g0 = 0.0f;
-  if (!std::isfinite(g1))
-    g1 = 0.0f;
-  if (!std::isfinite(g2))
-    g2 = 0.0f;
-  if (!std::isfinite(g3))
-    g3 = 0.0f;
-  if (!std::isfinite(g4))
-    g4 = 0.0f;
-  // g5 needs the same NaN/Inf guard as g0..g4: the < 0 and > m5 clamps below
-  // cannot catch a non-finite value (NaN compares false against both bounds),
-  // so without this an Inf/NaN srcPixel[5] would reach the (icUInt32Number)g5
-  // cast unguarded -- undefined behaviour. (g0..g4 were guarded here; g5 was
-  // missed when this finiteness block was added.)
-  if (!std::isfinite(g5))
-    g5 = 0.0f;
+  // See icClutGridClamp: scales into grid units and clamps, replacing the former
+  // m_UnitClipFunc call plus the isfinite and range tests that followed it. The
+  // g5 guard added for #1504 is subsumed -- the helper treats every channel
+  // identically, so no channel can be left without one.
 
-  if (g0 < 0.0f)
-    g0 = 0.0f;
-  if (g1 < 0.0f)
-    g1 = 0.0f;
-  if (g2 < 0.0f)
-    g2 = 0.0f;
-  if (g3 < 0.0f)
-    g3 = 0.0f;
-  if (g4 < 0.0f)
-    g4 = 0.0f;
-  if (g5 < 0.0f)
-    g5 = 0.0f;
-
-  if (g0 > m0)
-    g0 = m0;
-  if (g1 > m1)
-    g1 = m1;
-  if (g2 > m2)
-    g2 = m2;
-  if (g3 > m3)
-    g3 = m3;
-  if (g4 > m4)
-    g4 = m4;
-  if (g5 > m5)
-    g5 = m5;
+  icFloatNumber g0 = icClutGridClamp(srcPixel[0], m0);
+  icFloatNumber g1 = icClutGridClamp(srcPixel[1], m1);
+  icFloatNumber g2 = icClutGridClamp(srcPixel[2], m2);
+  icFloatNumber g3 = icClutGridClamp(srcPixel[3], m3);
+  icFloatNumber g4 = icClutGridClamp(srcPixel[4], m4);
+  icFloatNumber g5 = icClutGridClamp(srcPixel[5], m5);
 
   icUInt32Number ig0 = (icUInt32Number)g0;
   icUInt32Number ig1 = (icUInt32Number)g1;
@@ -3488,13 +3372,9 @@ void CIccCLUT::InterpND(icFloatNumber *destPixel, const icFloatNumber *srcPixel,
     return;
 
   for (i=0; i<m_nInput; i++) {
-    g[i] = m_UnitClipFunc(srcPixel[i]) * m_MaxGridPoint[i];
-    if (!std::isfinite(g[i]))
-      g[i] = 0.0;
-    if (g[i] < 0)
-      g[i] = 0.0;
-    if (g[i] > m_MaxGridPoint[i])
-      g[i] = m_MaxGridPoint[i];
+    // See icClutGridClamp: scales into grid units and clamps, replacing the
+    // former m_UnitClipFunc call plus the isfinite and range tests.
+    g[i] = icClutGridClamp(srcPixel[i], m_MaxGridPoint[i]);
     ig[i] = (icUInt32Number)g[i];
     s[m_nInput-1-i] = g[i] - ig[i];
     if (ig[i]==m_MaxGridPoint[i]) {

--- a/IccProfLib/IccTagLut.h
+++ b/IccProfLib/IccTagLut.h
@@ -389,6 +389,14 @@ public:
   void Iterate(IIccCLUTExec* pExec);
   icValidateStatus Validate(std::string sigPath, std::string &sReport, const CIccProfile* pProfile=NULL)  const;
 
+  /// Retained for source compatibility; has no effect.
+  ///
+  /// The Interp* functions now clamp inline via icClutGridClamp rather than
+  /// calling through a function pointer, and they do so uniformly -- the former
+  /// ClutUnitClip and NoClip behaviours are unified, differing only in that
+  /// +Inf now saturates to the top of the grid on both paths instead of
+  /// collapsing to the bottom on the NoClip one. The stored pointer is kept so
+  /// existing callers still compile, but nothing reads it.
   void SetClipFunc(icCLUTCLIPFUNC ClipFunc) { m_UnitClipFunc = ClipFunc; }
 
   icUInt8Number GetPrecision() { return m_nPrecision; }

--- a/IccProfLib/IccTagMPE.cpp
+++ b/IccProfLib/IccTagMPE.cpp
@@ -102,6 +102,10 @@ CIccApplyMpe::CIccApplyMpe(CIccMultiProcessElement *pElem)
 {
   m_pElem = pElem;
   m_pApplyTag = NULL;
+
+  // Resolved here rather than per pixel; see IsAcsElem(). An element's ACS-ness
+  // is fixed once the list is read, so this is a load-time property.
+  m_bIsAcs = pElem ? pElem->IsAcs() : false;
 }
 
 
@@ -1547,9 +1551,17 @@ void CIccTagMultiProcessElement::Apply(CIccApplyTagMpe *pApply, icFloatNumber *p
     pApplyBuf->Switch();
 
     while (next != pApply->end()) {
-      CIccMultiProcessElement *pElem = i->ptr->GetElem();
-
-      if (!pElem->IsAcs()) {
+      // Cached at apply-object construction; this used to be GetElem() plus a
+      // virtual IsAcs() for every middle element of every pixel, paid whether or
+      // not the chain contains any ACS element at all.
+      //
+      // The apply list itself is deliberately left intact rather than having ACS
+      // elements filtered out of it: Apply() only skips them in the middle of the
+      // chain, so a first or last ACS element is applied, and omitting them would
+      // change which element occupies those positions. No profile in the corpus
+      // has an ACS element and no test exercises CIccMpeAcs, so that change could
+      // not have been verified.
+      if (!i->ptr->IsAcsElem()) {
         i->ptr->Apply(pApplyBuf->GetDstBuf(), pApplyBuf->GetSrcBuf());
 
 #ifdef DEBUG_MPE_APPLY

--- a/IccProfLib/IccTagMPE.h
+++ b/IccProfLib/IccTagMPE.h
@@ -209,12 +209,21 @@ public:
 
   CIccMultiProcessElement *GetElem() const { return m_pElem; }
 
+  /// Whether the element this wraps is an ACS marker, resolved once at
+  /// construction. CIccTagMultiProcessElement::Apply's middle loop used to ask
+  /// via GetElem()->IsAcs(), which is two calls -- one of them virtual -- for
+  /// every middle element of every pixel, whether or not any ACS element is
+  /// present. The answer is fixed once the element list is read.
+  bool IsAcsElem() const { return m_bIsAcs; }
+
   void Apply(icFloatNumber *pDestPixel, const icFloatNumber *pSrcPixel) { m_pElem->Apply(this, pDestPixel, pSrcPixel); }
 
 protected:
   CIccApplyTagMpe *m_pApplyTag;
 
   CIccMultiProcessElement *m_pElem;
+
+  bool m_bIsAcs;
 };
 
 

--- a/Testing/CreateAllProfiles.bat
+++ b/Testing/CreateAllProfiles.bat
@@ -266,6 +266,7 @@ iccFromXml v2CmykLut16.xml v2CmykLut16.icc
 iccFromXml v2RgbLut8.xml v2RgbLut8.icc
 iccFromXml v2RgbMatrixTRC.xml v2RgbMatrixTRC.icc
 iccFromXml v2GrayTRC.xml v2GrayTRC.icc
+iccFromXml v2GrayTRCLab.xml v2GrayTRCLab.icc
 @echo off
 :end_V2
 

--- a/Testing/CreateAllProfiles.sh
+++ b/Testing/CreateAllProfiles.sh
@@ -298,16 +298,21 @@ echo "====================== V2 =========================="
 
 # Issue #1883: before these, the corpus held no ICC v2 profile at all -- a clean
 # checkout's 210 profiles are 208 v5 and 2 v4, with no 'mft2' or 'mft1' tag
-# anywhere -- so the v2 legacy Lab encoding path was exercised by nothing. These four cover
+# anywhere -- so the v2 legacy Lab encoding path was exercised by nothing. These five cover
 # the v2 shapes that path depends on: lut16Type ('mft2', which is what selects
 # UseLegacyPCS), lut8Type ('mft1'), the matrix/TRC form most real v2 display
-# profiles take, and grayTRC ('kTRC').
+# profiles take, and grayTRC ('kTRC') at both PCS encodings.
 #
-# The last was added because no profile in the tree produced a
+# The grayTRC pair was added because no profile in the tree produced a
 # CIccXformMonochrome at all, so that xform's apply path was exercised by
 # nothing. Display/GrayGSDF is the only other Gray profile and it is link class
 # with GRAY for both device space and PCS, so it builds a devicelink and never
 # reaches the monochrome xform.
+#
+# Both encodings are needed, not just one: CIccXformMonochrome::Apply takes a
+# different branch for a Lab PCS, and only that branch reaches XyzToLab and its
+# three cube roots. With the XYZ fixture alone, changes to that branch are
+# invisible to both the test suite and the throughput harness.
 cd V2
 find . -iname "*\.icc" -delete
 if [ "$1" != "clean" ]
@@ -317,6 +322,7 @@ then
 	iccFromXml v2RgbLut8.xml     v2RgbLut8.icc
 	iccFromXml v2RgbMatrixTRC.xml v2RgbMatrixTRC.icc
 	iccFromXml v2GrayTRC.xml     v2GrayTRC.icc
+	iccFromXml v2GrayTRCLab.xml  v2GrayTRCLab.icc
 	set +x
 fi
 cd ..

--- a/Testing/V2/v2GrayTRCLab.xml
+++ b/Testing/V2/v2GrayTRCLab.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>2.10</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>GRAY</DataColourSpace>
+    <PCS>Lab </PCS>
+    <CreationDateTime>2026-08-20T00:00:00</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Perceptual</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/>
+    </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+  </Header>
+  <Tags>
+    <grayTRCTag> <curveType>
+      <Curve>
+         563
+      </Curve>
+    </curveType> </grayTRCTag>
+
+    <profileDescriptionTag> <textDescriptionType>
+      <TextData><![CDATA[iccDEV v2 grayscale display profile (grayTRC, Lab PCS)]]></TextData>
+    </textDescriptionType> </profileDescriptionTag>
+
+    <copyrightTag> <textType>
+      <TextData><![CDATA[Copyright (C) 2026 The International Color Consortium. Generated fixture, no measured data.]]></TextData>
+    </textType> </copyrightTag>
+
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/>
+    </XYZArrayType> </mediaWhitePointTag>
+
+  </Tags>
+</IccProfile>

--- a/Testing/qa-profile-manifest.tsv
+++ b/Testing/qa-profile-manifest.tsv
@@ -244,6 +244,7 @@ SpecRef/argbRef.icc	compatibility	warning	0	none	generated	-	baselined: spectral
 SpecRef/srgbRef.icc	compatibility	warning	0	none	generated	-	baselined: spectralViewingConditions XYZ carries normalized luminance (#1811)
 V2/v2CmykLut16.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
 V2/v2GrayTRC.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
+V2/v2GrayTRCLab.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
 V2/v2RgbLut8.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
 V2/v2RgbMatrixTRC.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean
 mcs/17ChanWithSpots-MVIS.icc	positive	valid	0	none	generated	-	conformant example profile; validates clean

--- a/Tools/CmdLine/IccBenchApply/BenchCases.cpp
+++ b/Tools/CmdLine/IccBenchApply/BenchCases.cpp
@@ -102,10 +102,16 @@
 //   lut-3d-tetra  3DLut -> PCS -> 3DLut
 //   spectral-6ch  Mpe -> PCS -> 3DLut
 //   monochrome    Monochrome -> MatrixTRC          (no PCS step: XYZ both sides)
+//   mono-lab      Monochrome -> PCS -> 3DLut        (Lab PCS: reaches XyzToLab)
 //   mpe-calc      Mpe -> PCS -> Mpe
 //   mpe-tonemap   Mpe -> Mpe                       (no PCS step)
 //   pcs-rel       3DLut -> PCS -> Mpe
 //   pcs-abs       3DLut -> PCS -> Mpe               (absolute intent)
+//
+// monochrome and mono-lab differ only in the PCS encoding of the source
+// profile, and both are needed: CIccXformMonochrome::Apply takes a different
+// branch for a Lab PCS, and only that branch reaches XyzToLab and its three cube
+// roots. With the XYZ fixture alone, a change to that branch is unmeasured.
 //
 // spectral-6ch is deliberately NOT called lut-nd. SixChanCameraRef is MPE-based,
 // so it resolves to an Mpe xform and never reaches CIccXformNDLut: Interp5d,
@@ -121,6 +127,7 @@ static const struct {
   { "lut-3d-tetra", 1, "V2/v2RgbLut8.icc:1|V2/v2CmykLut16.icc:1" },
   { "spectral-6ch", 1, "SpecRef/SixChanCameraRef.icc:1|V2/v2CmykLut16.icc:1" },
   { "monochrome",   1, "V2/v2GrayTRC.icc:1|V2/v2RgbMatrixTRC.icc:1" },
+  { "mono-lab",     1, "V2/v2GrayTRCLab.icc:1|V2/v2CmykLut16.icc:1" },
   { "mpe-calc",     1, "Calc/srgbCalcTest.icc:1|ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc:1" },
   { "mpe-tonemap",  1, "Display/Rec2100HlgFull.icc:1|ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc:1" },
   { "pcs-rel",      1, "V2/v2RgbLut8.icc:1|ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc:1" },

--- a/Tools/CmdLine/IccBenchApply/BenchTimer.h
+++ b/Tools/CmdLine/IccBenchApply/BenchTimer.h
@@ -142,18 +142,33 @@ inline icUInt32Number icBenchChecksum(const icFloatNumber *pData, size_t nFloats
   return h;
 }
 
-// Deterministic fill. Rows 0..n-2 are in-gamut; the final row is pathological.
+/// Number of trailing rows icBenchFill reserves for pathological values.
+static const icUInt32Number kBenchPathologicalRows = 5;
+
+// Deterministic fill. The last kBenchPathologicalRows rows are pathological, one
+// value per row, filling every channel.
 //
-// The pathological row is deliberate. Several of the checks this harness exists
-// to measure concern clamping and non-finite handling -- ClutUnitClip, the
-// isfinite tests in the interpolators and the sampled curves. A happy-path-only
-// buffer would leave them unexercised, and would let a wrong hoist pass the
-// checksum oracle unnoticed.
+// The pathological rows are deliberate. Several of the checks this harness exists
+// to measure concern clamping and non-finite handling -- the clamp in the CLUT
+// interpolators, the isfinite tests in the sampled curves. A happy-path-only
+// buffer would leave them unexercised and let a wrong change pass the checksum
+// oracle unnoticed.
+//
+// One value per row, rather than a single row cycling through the values by
+// channel index. The cycling version had a real blind spot: it placed +Inf only
+// at channel index 4, so no profile with fewer than five input channels ever saw
+// one. That hid a deliberate change to +Inf handling in the CLUT clamp -- the
+// only profiles in the corpus that install the affected clip path are
+// three-channel, and the only >=5-channel case has no CLUT element at all, so
+// every checksum was unchanged and the change looked verified when it was
+// simply untested.
 inline void icBenchFill(icFloatNumber *pBuf, icUInt32Number nPixels,
                         icUInt16Number nSamples, icUInt32Number nSeed)
 {
   icUInt32Number state = nSeed ? nSeed : 1u;
-  const icUInt32Number nNormal = nPixels ? nPixels - 1 : 0;
+  const icUInt32Number nPath   = nPixels < kBenchPathologicalRows
+                                   ? nPixels : kBenchPathologicalRows;
+  const icUInt32Number nNormal = nPixels - nPath;
 
   for (icUInt32Number i = 0; i < nNormal; i++) {
     for (icUInt16Number s = 0; s < nSamples; s++) {
@@ -163,21 +178,21 @@ inline void icBenchFill(icFloatNumber *pBuf, icUInt32Number nPixels,
     }
   }
 
-  if (nPixels) {
-    static const icFloatNumber pathological[6] = {
-      (icFloatNumber)-1.0,
-      (icFloatNumber) 2.0,
-      (icFloatNumber) 0.0,
-      (icFloatNumber) 1.0,
-      std::numeric_limits<icFloatNumber>::infinity(),
-      -std::numeric_limits<icFloatNumber>::infinity(),
-    };
-    icFloatNumber *pLast = pBuf + (size_t)nNormal * nSamples;
-    for (icUInt16Number s = 0; s < nSamples; s++) {
-      pLast[s] = (s == nSamples - 1)
-                   ? std::numeric_limits<icFloatNumber>::quiet_NaN()
-                   : pathological[s % 6];
-    }
+  const icFloatNumber inf = std::numeric_limits<icFloatNumber>::infinity();
+  const icFloatNumber pathological[kBenchPathologicalRows] = {
+    (icFloatNumber)-1.0,                                    // below range
+    (icFloatNumber) 2.0,                                    // above range
+    inf,
+    -inf,
+    std::numeric_limits<icFloatNumber>::quiet_NaN(),
+  };
+
+  // Fill from the end, so a tiny buffer still gets the most interesting values.
+  for (icUInt32Number r = 0; r < nPath; r++) {
+    icFloatNumber *pRow = pBuf + (size_t)(nPixels - 1 - r) * nSamples;
+    const icFloatNumber v = pathological[kBenchPathologicalRows - 1 - r];
+    for (icUInt16Number s = 0; s < nSamples; s++)
+      pRow[s] = v;
   }
 }
 

--- a/docs/superpowers/plans/2026-08-20-hoist-invariants-tier-c.md
+++ b/docs/superpowers/plans/2026-08-20-hoist-invariants-tier-c.md
@@ -1,0 +1,886 @@
+# Tier C: Hoist Pre-Existing Per-Pixel Invariants Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove eight pieces of per-pixel work that `Begin()` can do once, none of which came from the hardening effort, verifying each against the harness for both speed and numerical equivalence.
+
+**Architecture:** Each finding moves invariant computation out of an `Apply()` and into the `Begin()` of the object that owns it. Placement follows one rule: state that is immutable after `Begin()` lives on the shared object (`CIccXform`, `CIccPcsStep`, `CIccTag`); state written during `Apply()` lives in the per-apply object allocated by `GetNewApply()`. The harness from `bench/throughput-harness` is the acceptance test — a checksum that moves without a documented reason is a failure, not a result.
+
+**Tech Stack:** C++17, IccProfLib, `iccBenchApply` from the parent branch.
+
+**Spec:** `docs/superpowers/specs/2026-08-20-apply-throughput-harness-design.md` (sections "Branch plan" and "Conventions binding branches 2 and 3")
+
+## Global Constraints
+
+- **Branch:** `perf/hoist-invariants`, stacked on `bench/throughput-harness`. Do not rebase onto master until #2207 merges.
+- **Every removed or moved check leaves a comment** that lets the next reader re-derive the argument, naming where the condition is now decided. Never "removed for perf".
+- **Placement by mutability.** Immutable after `Begin()` → shared object. Written during `Apply()` → per-apply object from `GetNewApply()`. When in doubt, ask whether two threads applying concurrently could both write it; if yes, it is per-apply.
+- **All Begin-time precomputation must be idempotent.** `CIccCmm::Begin()` returns early when `m_pApply` is set (the contract `e4e05c3a` restored for #1940), but `CIccXform::Begin()` itself can be reached more than once through other paths. The harness checks this on `lut-3d-tetra`.
+- **Checksums must not move**, with exactly one authorised exception: Task 6 (C6) deliberately changes `+inf` handling on the `NoClip` path. Every other task must reproduce the baseline checksums bit-identically.
+- **No behaviour change is in scope beyond Task 6.** If a hoist appears to require one, stop and report it.
+
+## Baseline
+
+Captured on this branch at 1M pixels, 9 repeats, median, single thread. Every task compares against these.
+
+| case | Mpx/s | checksum |
+|---|---|---|
+| `matrix-trc` | 7.504 | `0x2f8ddb88` |
+| `lut-3d-tetra` | 13.021 | `0x03759972` |
+| `spectral-6ch` | 3.883 | `0x469230ed` |
+| `monochrome` | 29.213 | `0x54ce851f` |
+| `mpe-calc` | 0.140 | `0xe275c18d` |
+| `mpe-tonemap` | 0.604 | `0xdc6eb214` |
+| `pcs-rel` | 3.419 | `0x2416f560` |
+| `pcs-abs` | 3.466 | `0xbf684583` |
+
+Re-capture with:
+
+```bash
+BENCH=out/vs2022-x64/bin/Release/iccBenchApply.exe
+cmake --build out/vs2022-x64 --config Release --target iccBenchApply
+$BENCH -suite -csv -pixels 1048576 -repeats 9
+```
+
+**Timing on a busy machine is noise.** A task's speed result is informational; its
+checksum result is the gate. Do not hold a task back because the Mpx/s did not
+move — several of these are small by design, and one (Task 5) is known from the
+baseline to be worth about 1.4%.
+
+## Testing approach
+
+Same as the parent branch: this repo has no unit-test framework. Each task's test
+is the harness plus, where behaviour is subtle, the existing CTest suite.
+
+Every task ends with:
+
+```bash
+cmake --build out/vs2022-x64 --config Release --target iccBenchApply
+$BENCH -suite -csv -pixels 1048576 -repeats 9        # checksums vs baseline
+ctest --test-dir out/vs2022-x64 -C Release --label-exclude known-red   # 101/101
+```
+
+The full CTest run matters more here than on the parent branch: these edits are
+inside `IccProfLib`, so they can break correctness tests the harness cannot see.
+
+---
+
+### Task 1: C1 — stop allocating a sparse matrix per pixel
+
+`CIccPcsStepSparseMatrix::Apply` constructs a `CIccSparseMatrix` with
+`bInitFromData=true` on every pixel, and `CIccSparseMatrix::Init`
+(`IccSparseMatrix.cpp:145`) does `delete m_Data; m_Data = new CIccSparseMatrix<T>()`.
+That is a heap allocation and free per pixel, plus a dimension re-parse and the
+4096-dimension bounds test, all from `m_vals`, which never changes.
+
+**Files:**
+- Modify: `IccProfLib/IccCmm.h` — `CIccPcsStep` gains an init hook; `CIccPcsStepSparseMatrix` gains a member
+- Modify: `IccProfLib/IccCmm.cpp` — `CIccPcsXform::Begin`, `CIccPcsStepSparseMatrix::{ctor,dtor,Apply}`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `virtual bool CIccPcsStep::BeginStep() { return true; }`, overridden by
+  `CIccPcsStepSparseMatrix`. Task 2 onward does not depend on it, but branch 3 may
+  reuse the hook.
+
+- [ ] **Step 1: Confirm the allocation is real before optimising it**
+
+```bash
+grep -n "bInitFromData && pMatrix" -A 5 IccProfLib/IccSparseMatrix.cpp
+grep -n "delete m_Data" IccProfLib/IccSparseMatrix.cpp
+```
+Expected: `Init()` unconditionally `delete`s and `new`s `m_Data`, and the ctor calls
+it when `bInitFromData` is set. If that is not what the code does, stop — the
+finding is wrong and the rest of this task is pointless.
+
+- [ ] **Step 2: Add the init hook to `CIccPcsStep`**
+
+In `IccProfLib/IccCmm.h`, in the `CIccPcsStep` public block (around `:661`):
+
+```cpp
+  /// Called once by CIccPcsXform::Begin() before any Apply(), after the step
+  /// list is fully built. Steps that can precompute invariant state do it here
+  /// rather than lazily in Apply(): Apply() is const and runs concurrently on
+  /// every worker thread, so a lazy first-call initialisation would be a race.
+  /// Return false to fail the enclosing transform.
+  virtual bool BeginStep() { return true; }
+```
+
+- [ ] **Step 3: Call it from `CIccPcsXform::Begin()`**
+
+`CIccPcsXform::Begin()` is currently `{ return icCmmStatOk; }` inline in the
+header (around `:1120`). Move it to `IccCmm.cpp` and walk the step list. First
+confirm the member name holding the steps:
+
+```bash
+grep -n "class  ICCPROFLIB_API CIccPcsXform" -A 40 IccProfLib/IccCmm.h | grep -E "m_list|CIccPcsStepList|protected"
+```
+
+Then, with `<name>` as that member:
+
+```cpp
+icStatusCMM CIccPcsXform::Begin()
+{
+  // Give each step its one chance to precompute. Runs after Connect()/Optimize()
+  // have finished building the list, and before GetNewApply(), so a step can
+  // build immutable state here and treat it as read-only in Apply().
+  if (m_list) {
+    CIccPcsStepList::iterator i;
+    for (i = m_list->begin(); i != m_list->end(); i++) {
+      if (i->ptr && !i->ptr->BeginStep())
+        return icCmmStatInvalidLut;
+    }
+  }
+  return icCmmStatOk;
+}
+```
+
+Remove the inline body from the header, leaving `virtual icStatusCMM Begin();`.
+
+- [ ] **Step 4: Build the matrix once**
+
+`IccProfLib/IccCmm.h`, `CIccPcsStepSparseMatrix` protected block (`:1046`):
+
+```cpp
+  CIccSparseMatrix *m_pMtx;   ///< built once by BeginStep(); read-only in Apply()
+```
+
+Declare `virtual bool BeginStep();` in its public block. In `IccCmm.cpp`:
+
+```cpp
+// The matrix is parsed from m_vals, which is fixed once the step is built, so
+// the CIccSparseMatrix it produces is identical for every pixel. Building it
+// here rather than in Apply() removes a heap allocation and free per pixel:
+// CIccSparseMatrix::Init() (IccSparseMatrix.cpp:145) unconditionally deletes and
+// re-news its m_Data accessor, and the ctor calls Init() when bInitFromData is
+// set, which Apply() was doing on every call.
+//
+// It lives on the step, not on a CIccApplyPcsStep, because it is immutable after
+// this point -- MultiplyVector() is const and writes only the caller's output
+// buffer -- so every thread can share the one instance. Contrast
+// CIccPcsStepSrcSparseMatrix, whose matrix is re-pointed at per-pixel source
+// data and therefore cannot be shared.
+bool CIccPcsStepSparseMatrix::BeginStep()
+{
+  delete m_pMtx;   // idempotent: BeginStep() may be reached more than once
+  m_pMtx = new (std::nothrow) CIccSparseMatrix((icUInt8Number*)m_vals,
+                                               m_nBytesPerMatrix,
+                                               icSparseMatrixFloatNum, true);
+  return m_pMtx != NULL;
+}
+```
+
+Initialise `m_pMtx = NULL;` in the constructor and `delete m_pMtx;` in the
+destructor. Then `Apply()` becomes:
+
+```cpp
+void CIccPcsStepSparseMatrix::Apply(CIccApplyPcsStep * /* pApply */, icFloatNumber *pDst, const icFloatNumber *pSrc) const
+{
+  // Matrix built once in BeginStep(); this used to construct a CIccSparseMatrix
+  // per pixel, which allocated and freed on every call. See BeginStep().
+  if (m_pMtx)
+    m_pMtx->MultiplyVector(pDst, pSrc);
+}
+```
+
+- [ ] **Step 5: Build and check the gate**
+
+```bash
+cmake --build out/vs2022-x64 --config Release --target iccBenchApply
+$BENCH -suite -csv -pixels 1048576 -repeats 9
+```
+Expected: **`spectral-6ch` checksum still `0x469230ed`** and its Mpx/s up from
+3.883. Every other checksum unchanged. If the checksum moved, the prebuilt matrix
+is not equivalent to the per-pixel one — investigate, do not proceed.
+
+- [ ] **Step 6: Run the full suite**
+
+```bash
+ctest --test-dir out/vs2022-x64 -C Release --label-exclude known-red
+```
+Expected: 101/101. `CIccPcsXform::Begin()` moving out of line changes a vtable
+entry's definition site, so a link-level mistake shows up here.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add IccProfLib/IccCmm.h IccProfLib/IccCmm.cpp
+git commit -m "perf(cmm): build the sparse PCS matrix once instead of per pixel
+
+CIccPcsStepSparseMatrix::Apply constructed a CIccSparseMatrix with
+bInitFromData=true on every pixel, and CIccSparseMatrix::Init unconditionally
+deletes and re-news its m_Data accessor -- a heap allocation and free per pixel,
+plus a dimension re-parse and a bounds test, all derived from m_vals, which is
+fixed once the step is built.
+
+Adds CIccPcsStep::BeginStep(), called once by CIccPcsXform::Begin() after the
+step list is built, and builds the matrix there. It lives on the step rather than
+in a per-apply object because it is immutable afterwards and MultiplyVector() is
+const, so all threads can share one instance. Doing it lazily in Apply() instead
+would have been a race: Apply() is const and runs on every worker thread.
+
+spectral-6ch checksum unchanged.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: C2 — precompute the monochrome reference white
+
+`CIccXformMonochrome::Apply` (`IccCmm.cpp:5630`) converts the perceptual
+reference white through `icXyzToPcs` and, for a Lab PCS, `XyzToLab` — three cube
+roots — on every pixel, from compile-time constants. Both branches are
+invariant: the input branch's `DstPixel` vector before the final multiply, and
+the output branch's divisor.
+
+This is the largest single win in the file: baseline `monochrome` is 29.213 Mpx/s.
+
+**Files:**
+- Modify: `IccProfLib/IccCmm.h` — `CIccXformMonochrome` protected members
+- Modify: `IccProfLib/IccCmm.cpp` — `CIccXformMonochrome::{Begin,Apply}`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing later tasks use.
+
+- [ ] **Step 1: Read the current Apply and identify exactly what is invariant**
+
+```bash
+sed -n '5630,5690p' IccProfLib/IccCmm.cpp
+```
+Confirm before changing anything: in the `m_bInput` branch, everything from
+`DstPixel[0] = icPerceptualRefWhiteX` down to the `XyzToLab` call depends only on
+`m_pProfile->m_Header.pcs` and `UseLegacyPCS()`. In the else branch, `Pixel[]` is
+built from the same constants and only `Pixel[0]` or `Pixel[1]` is used, as a
+divisor.
+
+- [ ] **Step 2: Add the precomputed members**
+
+`IccProfLib/IccCmm.h`, `CIccXformMonochrome` protected block (around `:1261`):
+
+```cpp
+  /// Reference white in PCS encoding, computed once by Begin(). The input branch
+  /// of Apply() scales this by the curve output; the output branch divides by
+  /// m_fWhiteRecip. Immutable after Begin(), so shared across threads.
+  icFloatNumber m_PcsWhite[3];
+  icFloatNumber m_fWhiteRecip;
+```
+
+- [ ] **Step 3: Compute them in `Begin()`**
+
+At the end of `CIccXformMonochrome::Begin()`, before `return icCmmStatOk;`:
+
+```cpp
+  // Apply() used to rebuild this on every pixel from compile-time constants --
+  // icXyzToPcs plus, for a Lab PCS, XyzToLab and its three cube roots. Nothing
+  // in it depends on the source colour, and both m_pProfile->m_Header.pcs and
+  // UseLegacyPCS() (a virtual call) are fixed by the time Begin() runs.
+  //
+  // Idempotent: recomputing from the same constants yields the same values, so a
+  // second Begin() is harmless.
+  m_PcsWhite[0] = icFloatNumber(icPerceptualRefWhiteX);
+  m_PcsWhite[1] = icFloatNumber(icPerceptualRefWhiteY);
+  m_PcsWhite[2] = icFloatNumber(icPerceptualRefWhiteZ);
+
+  icXyzToPcs(m_PcsWhite);
+
+  if (m_pProfile->m_Header.pcs == icSigLabData) {
+    if (UseLegacyPCS())
+      CIccPCSUtil::XyzToLab2(m_PcsWhite, m_PcsWhite, true);
+    else
+      CIccPCSUtil::XyzToLab(m_PcsWhite, m_PcsWhite, true);
+  }
+
+  // The output branch divides by component 0 for a Lab PCS and component 1
+  // otherwise. Precompute the reciprocal so Apply() multiplies.
+  {
+    const icFloatNumber d = (m_pProfile->m_Header.pcs == icSigLabData)
+                              ? m_PcsWhite[0] : m_PcsWhite[1];
+    m_fWhiteRecip = icNotZero(d) ? (icFloatNumber)(1.0 / d) : (icFloatNumber)0.0;
+  }
+```
+
+**Verify `icNotZero` is reachable here** — it is a macro in `IccUtil.h`
+(`:85`), which `IccCmm.cpp` already includes. If the divisor was previously
+allowed to be zero and produce an infinity, note that this changes that to zero;
+check whether any test depends on it before assuming it is safe. The baseline
+`monochrome` checksum is the arbiter.
+
+- [ ] **Step 4: Rewrite `Apply()` to use them**
+
+```cpp
+void CIccXformMonochrome::Apply(CIccApplyXform* pApply, icFloatNumber *DstPixel, const icFloatNumber *SrcPixel) const
+{
+  if (m_bSrcPcsConversion)
+    SrcPixel = CheckSrcAbs(pApply, SrcPixel);
+
+  if (m_bInput) {
+    icFloatNumber v = SrcPixel[0];
+    if (m_ApplyCurvePtr)
+      v = m_ApplyCurvePtr->Apply(v);
+
+    // m_PcsWhite computed once in Begin(); this block used to redo icXyzToPcs
+    // and XyzToLab -- three cube roots -- per pixel from constants.
+    DstPixel[0] = m_PcsWhite[0] * v;
+    DstPixel[1] = m_PcsWhite[1] * v;
+    DstPixel[2] = m_PcsWhite[2] * v;
+  }
+  else {
+    // Same hoist, reciprocal form: the divisor is a fixed component of the
+    // PCS-encoded reference white, so Begin() precomputed 1/d.
+    const icFloatNumber s = (m_pProfile->m_Header.pcs == icSigLabData)
+                              ? SrcPixel[0] : SrcPixel[1];
+    DstPixel[0] = s * m_fWhiteRecip;
+
+    if (m_ApplyCurvePtr)
+      DstPixel[0] = m_ApplyCurvePtr->Apply(DstPixel[0]);
+  }
+
+  if (m_bDstPcsConversion)
+    CheckDstAbs(DstPixel);
+}
+```
+
+The `m_pProfile->m_Header.pcs == icSigLabData` test in the else branch is still a
+per-pixel read of an invariant. Leave it for now — it selects which *source*
+component to read, not a computation, and folding it in needs a second member.
+Note it in the commit as deliberately left.
+
+- [ ] **Step 5: Build and check the gate**
+
+Expected: **`monochrome` checksum still `0x54ce851f`**, Mpx/s well above 29.213.
+Everything else unchanged.
+
+If the checksum moved, the most likely cause is the division-to-multiplication
+change: `x/d` and `x*(1/d)` are not bit-identical in general. **This is the one
+place in tier C where a moved checksum may be legitimate.** If it moved, confirm
+that is the cause by temporarily reverting just the reciprocal (keep `s / d`) and
+re-running; if the checksum returns, decide whether to keep the division for exact
+equivalence or accept the delta and document it. Prefer keeping the division —
+the cube-root hoist is the real win, and a divide per pixel is cheap next to it.
+
+- [ ] **Step 6: Run the full suite**
+
+Expected: 101/101.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add IccProfLib/IccCmm.h IccProfLib/IccCmm.cpp
+git commit -m "perf(cmm): precompute the monochrome reference white in Begin()
+
+CIccXformMonochrome::Apply rebuilt the PCS-encoded perceptual reference white on
+every pixel from compile-time constants -- icXyzToPcs plus, for a Lab PCS,
+XyzToLab and its three cube roots, and a virtual UseLegacyPCS() call. Nothing in
+that block depends on the source colour.
+
+Precomputed in Begin() and held on the xform, which is safe because it is
+immutable afterwards. The one invariant left in Apply() is the header PCS test
+that selects which source component the output branch reads; it picks a component
+rather than computing anything, so folding it in would need another member for
+no measurable gain.
+
+monochrome checksum unchanged.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: C3 — cache the MPE source and destination encodings
+
+`CIccXformMpe::Apply` calls `GetSrcSpace()` (`:8394`) and `GetDstSpace()`
+(`:8420`) per pixel. `CIccXform::GetSrcSpace()` (`:1827`) branches four ways and
+dereferences the profile header. The two intent guards at `:8387` and `:8433` are
+invariant too.
+
+**Note:** an earlier draft of the audit called those intent guards a likely
+`&&`/`||` slip. They are correct — short-circuit makes the second clause
+reachable only when `m_nIntent == icAbsoluteColorimetric`, where
+`m_nIntent != m_nTagIntent` is equivalent to the intended
+`m_nTagIntent != icAbsoluteColorimetric`. This task hoists them; it does not
+change them.
+
+**Files:**
+- Modify: `IccProfLib/IccCmm.h` — `CIccXformMpe` protected members
+- Modify: `IccProfLib/IccCmm.cpp` — `CIccXformMpe::{Begin,Apply}`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Confirm `CIccXformMpe` has a `Begin()` to extend**
+
+```bash
+grep -n "class ICCPROFLIB_API CIccXformMpe" -A 30 IccProfLib/IccCmm.h | grep -E "Begin|protected|m_pTag"
+```
+If it has no `Begin()` override, add one that calls the base and then does the
+caching. Do not put this in the constructor: `GetSrcSpace()` reads
+`m_bPcsAdjustXform` and `m_bUseSpectralPCS`, which are set after construction.
+
+- [ ] **Step 2: Add the cached members**
+
+```cpp
+  /// Src/dst PCS encodings and the two abs-conversion decisions, resolved once
+  /// in Begin(). Apply() called GetSrcSpace()/GetDstSpace() per pixel, and each
+  /// branches four ways through the profile header.
+  icColorSpaceSignature m_cachedSrcSpace;
+  icColorSpaceSignature m_cachedDstSpace;
+  bool                  m_bDoSrcAbs;
+  bool                  m_bDoDstAbs;
+```
+
+- [ ] **Step 3: Populate in `Begin()`**
+
+```cpp
+  // Everything below is fixed once the profile and intent are attached.
+  // GetSrcSpace()/GetDstSpace() each branch on m_bInput, m_bPcsAdjustXform,
+  // m_bUseSpectralPCS and the profile header, and Apply() called them per pixel.
+  m_cachedSrcSpace = GetSrcSpace();
+  m_cachedDstSpace = GetDstSpace();
+
+  // The guard is correct as written and is preserved exactly: when m_nIntent is
+  // not absolute the first clause is already true, and when it is absolute the
+  // second reduces to m_nTagIntent != icAbsoluteColorimetric -- the "B2D3 tags
+  // don't need abs conversion" case the original comment describes.
+  const bool bIntentNeedsAbs = (m_nIntent != icAbsoluteColorimetric ||
+                                m_nIntent != m_nTagIntent);
+  m_bDoSrcAbs = bIntentNeedsAbs && m_bSrcPcsConversion;
+  m_bDoDstAbs = bIntentNeedsAbs && m_bDstPcsConversion;
+```
+
+- [ ] **Step 4: Use them in `Apply()`**
+
+Replace `if (m_nIntent != ... ) { if (m_bSrcPcsConversion) SrcPixel = CheckSrcAbs(...); }`
+with `if (m_bDoSrcAbs) SrcPixel = CheckSrcAbs(pApply, SrcPixel);`, the destination
+equivalent with `m_bDoDstAbs`, and both `switch (GetSrcSpace())` /
+`switch(GetDstSpace())` with the cached members. Leave a comment at each site
+naming `Begin()` as where the value now comes from.
+
+- [ ] **Step 5: Build and check the gate**
+
+Expected: **`mpe-calc` `0xe275c18d`, `mpe-tonemap` `0xdc6eb214`, `matrix-trc`
+`0x2f8ddb88`, `pcs-rel` `0x2416f560`, `pcs-abs` `0xbf684583` all unchanged.**
+Several cases resolve to `Mpe` xforms, so this touches more of the table than it
+looks like.
+
+- [ ] **Step 6: Run the full suite.** Expected 101/101.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add IccProfLib/IccCmm.h IccProfLib/IccCmm.cpp
+git commit -m "perf(cmm): cache the MPE PCS encodings and abs-conversion decisions
+
+CIccXformMpe::Apply called GetSrcSpace() and GetDstSpace() on every pixel. Each
+branches four ways on m_bInput, m_bPcsAdjustXform, m_bUseSpectralPCS and the
+profile header, none of which changes after Begin().
+
+Also folds the two intent guards and the m_bSrcPcsConversion /
+m_bDstPcsConversion tests into one precomputed bool per direction. The guards are
+preserved exactly, not rewritten: an earlier reading of
+'m_nIntent != icAbsoluteColorimetric || m_nIntent != m_nTagIntent' took it for a
+&&/|| slip, but short-circuit makes the second clause reachable only when
+m_nIntent is absolute, where it is equivalent to the intended
+m_nTagIntent != icAbsoluteColorimetric.
+
+All MPE-path checksums unchanged.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: C4 — filter ACS elements out of the MPE apply list
+
+`CIccTagMultiProcessElement::Apply` (`IccTagMPE.cpp:1552`) makes a virtual
+`IsAcs()` call per element per pixel to skip elements that are structural
+markers. Whether an element is one is known when the apply list is built.
+
+**Files:**
+- Modify: `IccProfLib/IccTagMPE.cpp` — where the apply list is built, and `Apply`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Find where the apply list is built and confirm ACS elements can be omitted**
+
+```bash
+grep -n "CIccTagMultiProcessElement::Begin\|GetNewApply" IccProfLib/IccTagMPE.cpp | head
+grep -rn "IsAcs" IccProfLib/ Tools/ IccXML/ 2>/dev/null
+```
+**This step is a genuine investigation, not a formality.** If anything other than
+`CIccTagMultiProcessElement::Apply` consults `IsAcs()` — element counting,
+channel validation, `Describe`, XML round-trip — then omitting ACS elements from
+the apply list may change those. If any other consumer exists, do not omit;
+instead precompute a `std::vector<bool>` or store the already-filtered pointers
+alongside the full list, and report what you found.
+
+- [ ] **Step 2: Make the change indicated by Step 1**
+
+If ACS elements are safe to omit from the *apply* list only, skip appending them
+where the list is built, with:
+
+```cpp
+        // ACS elements are structural markers with an identity Apply(). Whether
+        // an element is one is fixed at load, so they are omitted here rather
+        // than skipped per pixel: Apply() previously made a virtual IsAcs() call
+        // for every element of every pixel. The full element list is unchanged --
+        // only this apply list is filtered.
+```
+
+Then remove the `if (!pElem->IsAcs())` test and its `GetElem()` call from the
+middle loop of `Apply`, leaving a comment pointing at the filter.
+
+- [ ] **Step 3: Build and check the gate**
+
+Expected: `mpe-calc`, `mpe-tonemap`, `spectral-6ch`, `matrix-trc` checksums
+unchanged.
+
+- [ ] **Step 4: Run the full suite.** Expected 101/101. This is the task most
+likely to break an XML or Describe test, so read any failure carefully rather
+than assuming it is unrelated.
+
+- [ ] **Step 5: Commit** with a message stating what Step 1 found about other
+`IsAcs()` consumers.
+
+---
+
+### Task 5: C5 — cache the AdjustPCS dispatch
+
+`CIccXform::AdjustPCS` (`IccCmm.cpp:1728`) re-reads `m_pProfile->m_Header.pcs`
+and makes two virtual `UseLegacyPCS()` calls per pixel.
+
+**The baseline says this is worth about 1.4%** (`pcs-abs` 3.466 vs `pcs-rel`
+3.419), so it is a tidiness task. Do it because the code is clearer, not because
+it is fast.
+
+**Files:**
+- Modify: `IccProfLib/IccCmm.h` — a cached enum on `CIccXform`
+- Modify: `IccProfLib/IccCmm.cpp` — `CIccXform::Begin`, `AdjustPCS`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the cached mode**
+
+In `CIccXform`'s protected block:
+
+```cpp
+  /// Which PCS adjustment AdjustPCS() performs, resolved once in Begin().
+  /// AdjustPCS() ran per pixel and re-read the profile header and called the
+  /// virtual UseLegacyPCS() twice to rediscover this.
+  enum icPcsAdjustMode { icPcsAdjustXyz, icPcsAdjustLab, icPcsAdjustLab2 };
+  icPcsAdjustMode m_nPcsAdjustMode;
+```
+
+- [ ] **Step 2: Resolve it in `CIccXform::Begin()`**
+
+```cpp
+  // Fixed once the profile is attached. AdjustPCS() rediscovered it per pixel.
+  if (m_pProfile && m_pProfile->m_Header.pcs == icSigLabData)
+    m_nPcsAdjustMode = UseLegacyPCS() ? icPcsAdjustLab2 : icPcsAdjustLab;
+  else
+    m_nPcsAdjustMode = icPcsAdjustXyz;
+```
+
+Confirm `CIccXform::Begin()` exists and that derived `Begin()` overrides call it;
+if some do not, put the assignment in a small helper both paths call, or in the
+constructor plus a re-resolve in `Begin()`. **Do not assume every derived
+`Begin()` chains to the base** — check:
+
+```bash
+grep -n "CIccXform::Begin()" IccProfLib/IccCmm.cpp
+```
+
+- [ ] **Step 3: Switch on it in `AdjustPCS`**, replacing both
+`if (Space==icSigLabData) { if (UseLegacyPCS()) ... }` blocks. Comment each with
+where the mode is decided.
+
+- [ ] **Step 4: Also collapse the `CheckSrcAbs`/`CheckDstAbs` double test.**
+Every `Apply` does `if (m_bSrcPcsConversion) SrcPixel = CheckSrcAbs(...)`, and
+`CheckSrcAbs` then re-tests `m_bAdjustPCS && !m_bInput`. Add
+`m_bDoSrcAbsAdjust` / `m_bDoDstAbsAdjust` bools resolved in `Begin()` and test
+those instead. Note that Task 3 already did this for `CIccXformMpe`; keep the
+naming consistent.
+
+- [ ] **Step 5: Build and check the gate.** All eight checksums unchanged.
+
+- [ ] **Step 6: Run the full suite.** Expected 101/101.
+
+- [ ] **Step 7: Commit**, saying in the message that the measured win is ~1.4% and
+the change is for clarity.
+
+---
+
+### Task 6: C6 — remove the CLUT clip indirect call
+
+Every CLUT interpolator calls `m_UnitClipFunc` once per channel per pixel — an
+indirect call that blocks vectorising the clamp — and then redoes the same work
+inline with `isfinite` and two comparisons.
+
+**This is the one task authorised to move a checksum.** Per the decision recorded
+for this branch, the two paths are unified on `+inf -> mx`: the default
+`ClutUnitClip` already maps `+inf` to `1.0` and thence to `mx`, while the
+spectral `NoClip` path let it reach the `isfinite` test and produced `0`. Unifying
+makes `NoClip` agree with the default. `spectral-6ch`, and any other case whose
+profile installs `NoClip`, will report a new checksum. That is expected and must
+be recorded in the commit.
+
+**Files:**
+- Modify: `IccProfLib/IccTagLut.cpp` — `Interp1d`, `Interp2d`, `Interp3dTetra`,
+  `Interp3d`, `Interp4d`, `Interp5d`, `Interp6d`, `InterpND`
+- Modify: `IccProfLib/IccTagLut.h` — `m_UnitClipFunc` and `SetClipFunc`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: nothing.
+
+- [ ] **Step 1: Record the pre-change checksums for every case.** Not just
+`spectral-6ch` — you need to know exactly which cases move, because any case that
+moves *without* installing `NoClip` indicates a mistake in the clamp rewrite
+rather than the intended semantic change.
+
+- [ ] **Step 2: Rewrite one interpolator first — `Interp1d`**
+
+```cpp
+  // Clamp inline rather than through m_UnitClipFunc. That call was an indirect
+  // call per channel per pixel which the surrounding code had already made
+  // redundant: on the default path ClutUnitClip did isnan plus a clamp to [0,1],
+  // and the interpolator then redid the work as isfinite plus two comparisons.
+  // Clamping to [0,mx] after the multiply subsumes clamping to [0,1] before it.
+  //
+  // The form below reproduces ClutUnitClip's semantics exactly for NaN (-> 0),
+  // -inf (-> 0) and +inf (-> mx), and deliberately UNIFIES the NoClip path onto
+  // the same behaviour: NoClip previously let +inf reach the isfinite test and
+  // yield 0, disagreeing with the default path for no stated reason. See #NNNN.
+  icFloatNumber x = srcPixel[0] * mx;
+  if (!(x > 0.0f)) x = 0.0f;      // false for NaN, so NaN lands here too
+  else if (x > mx) x = mx;
+```
+
+Build and check: `lut-3d-tetra` (which uses `ClutUnitClip`) must be
+**unchanged**, since this form is exactly equivalent on that path. If it moves,
+the clamp is wrong — fix it before touching the other seven.
+
+- [ ] **Step 3: Apply the same form to the remaining seven interpolators**, one
+per channel, keeping the full comment only in `Interp1d` and a one-line
+back-reference in the others.
+
+- [ ] **Step 4: Retire `m_UnitClipFunc`**
+
+Once no interpolator calls it, `m_UnitClipFunc`, `SetClipFunc`, `icCLUTCLIPFUNC`,
+`ClutUnitClip`, and the `NoClip` statics in `IccMpeBasic.cpp` and
+`IccMpeSpectral.cpp` are all dead. `SetClipFunc` is **public API** — removing it
+breaks any external caller. Keep it as a no-op with a comment explaining that
+clipping is now unconditional and why, rather than deleting it:
+
+```cpp
+  /// Retained for source compatibility. Clipping is now performed inline by the
+  /// Interp* functions, uniformly for both the former ClutUnitClip and NoClip
+  /// behaviours, so this no longer has any effect. See #NNNN.
+  void SetClipFunc(icCLUTCLIPFUNC /* ClipFunc */) {}
+```
+
+Leave the seven `SetClipFunc(NoClip)` call sites in `IccMpeBasic.cpp` and
+`IccMpeSpectral.cpp` in place — they become no-ops and removing them is churn on
+a branch that is already the behaviour-changing one.
+
+- [ ] **Step 5: Build and check the gate**
+
+Expected: `lut-3d-tetra`, `matrix-trc`, `monochrome`, `pcs-rel`, `pcs-abs`
+unchanged. `spectral-6ch` **moves** — record the new value. Determine whether
+`mpe-calc` and `mpe-tonemap` move and explain either outcome.
+
+- [ ] **Step 6: Run the full suite, and read `interp6d-nan-cast` specifically**
+
+```bash
+ctest --test-dir out/vs2022-x64 -C Release --label-exclude known-red
+ctest --test-dir out/vs2022-x64 -C Release -R interp6d --output-on-failure
+```
+That test asserts only that `Interp6d` returns **finite** output for a non-finite
+`srcPixel[5]`, which `+inf -> mx` satisfies. It must still pass. If it fails, the
+clamp is wrong, not the test.
+
+- [ ] **Step 7: Commit**, with the old and new `spectral-6ch` checksums both in
+the message and the semantic change stated in the first paragraph, not buried.
+
+---
+
+### Task 7: C7 — precompute the XYZ-to-Lab white point reciprocals
+
+`icXYZtoLab` (`IccUtil.cpp:897`) calls `icSafeXYZRatio` three times, each a
+two-comparison `icNotZero` plus a divide, against a white point that is invariant
+per step.
+
+Per the decision for this branch, this adds a **public overload** in `IccUtil.h`;
+the existing `icXYZtoLab` is untouched.
+
+**Files:**
+- Modify: `IccProfLib/IccUtil.h`, `IccProfLib/IccUtil.cpp` — new overload
+- Modify: `IccProfLib/IccCmm.h`, `IccProfLib/IccCmm.cpp` — `CIccPcsStepXYZToLab`
+- Modify: `IccProfLib/IccMpeSpectral.cpp` — `CIccMpeSpectralObserver`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  ```cpp
+  void icXYZtoLabRecip(icFloatNumber *Lab, const icFloatNumber *XYZ,
+                       const icFloatNumber *WhiteRecip);
+  ```
+  Task 8 also touches `CIccMpeSpectralObserver`; do Task 7 first and Task 8 on top.
+
+- [ ] **Step 1: Add the overload**
+
+`IccUtil.h`, beside the existing declaration:
+
+```cpp
+/// As icXYZtoLab, but takes the reciprocal of each white-point component instead
+/// of the component itself, so a caller with an invariant white point can
+/// precompute 1/w once and pay three multiplies per call rather than three
+/// divides and six comparisons. A zero reciprocal reproduces icSafeXYZRatio's
+/// zero result for a zero white-point component.
+ICCPROFLIB_API void icXYZtoLabRecip(icFloatNumber *Lab, const icFloatNumber *XYZ,
+                                    const icFloatNumber *WhiteRecip);
+```
+
+`IccUtil.cpp`:
+
+```cpp
+void icXYZtoLabRecip(icFloatNumber *Lab, const icFloatNumber *XYZ,
+                     const icFloatNumber *WhiteRecip)
+{
+  const icFloatNumber Xn = icCubeth(XYZ[0] * WhiteRecip[0]);
+  const icFloatNumber Yn = icCubeth(XYZ[1] * WhiteRecip[1]);
+  const icFloatNumber Zn = icCubeth(XYZ[2] * WhiteRecip[2]);
+
+  Lab[0] = (icFloatNumber)(116.0 * Yn - 16.0);
+  Lab[1] = (icFloatNumber)(500.0 * (Xn - Yn));
+  Lab[2] = (icFloatNumber)(200.0 * (Yn - Zn));
+}
+```
+
+**Check the `ICCPROFLIB_API` spelling against the neighbouring declarations** —
+`IccUtil.h` may not decorate free functions the same way as classes.
+
+- [ ] **Step 2: Add a helper for building the reciprocals**, so the three call
+sites do not each re-derive the zero rule:
+
+```cpp
+/// Fills WhiteRecip with 1/w per component, or 0 where the component is zero,
+/// matching what icXYZtoLab's internal icSafeXYZRatio produces for that case.
+ICCPROFLIB_API void icXYZWhiteRecip(icFloatNumber *WhiteRecip,
+                                    const icFloatNumber *WhiteXYZ);
+```
+
+- [ ] **Step 3: Move `CIccPcsStepXYZToLab` over.** Add an
+`icFloatNumber m_xyzWhiteRecip[3];` member, fill it in the constructor beside the
+`m_xyzWhite` memcpy (the white point is a constructor argument, so no `BeginStep`
+is needed), and call `icXYZtoLabRecip` in `Apply`.
+
+- [ ] **Step 4: Move `CIccMpeSpectralObserver::Apply` over**, filling its
+reciprocals in the same `Begin()` that Task 8 will touch.
+
+- [ ] **Step 5: Build and check the gate**
+
+**Expect checksums to move here, and decide deliberately.** `x/w` and `x*(1/w)`
+are not bit-identical. Run first and see:
+
+- If nothing moves, keep the reciprocal form.
+- If `pcs-rel`/`pcs-abs`/`spectral-6ch` move, that is float reassociation, not a
+  defect — but it costs the exact-equality property the oracle relies on for the
+  rest of tier C. Given the divide is not the dominant cost in these cases
+  (baseline `pcs-rel` 3.419 with three divides per pixel), **prefer reverting to
+  the division form and keeping only the six comparisons hoisted**: pass the
+  white point *and* a precomputed "all components non-zero" bool, and skip
+  `icNotZero` rather than the divide. Report which you chose and why.
+
+- [ ] **Step 6: Run the full suite.** Expected 101/101.
+
+- [ ] **Step 7: Commit**, recording the Step 5 decision.
+
+---
+
+### Task 8: C8 — hoist the observer flag decode and the named-colour dispatch
+
+Two small invariant re-derivations:
+`CIccMpeSpectralObserver::Apply` (`IccMpeSpectral.cpp:2004`) decodes `m_flags`
+into two bools per pixel; `CIccApplyNamedColorCmm::Apply` (`IccCmm.cpp:10843`)
+re-calls `GetXform()`, `GetXformType()` and `GetInterface()` per xform per pixel.
+
+The named-colour half is not on any benchmark case, so it is justified by
+inspection only. Say so in the commit rather than implying it was measured.
+
+**Files:**
+- Modify: `IccProfLib/IccMpeSpectral.cpp` — `CIccMpeSpectralObserver::{Begin,Apply}`
+- Modify: `IccProfLib/IccMpeSpectral.h` — two bool members
+- Modify: `IccProfLib/IccCmm.cpp` — `CIccApplyNamedColorCmm::Apply`
+
+**Interfaces:**
+- Consumes: Task 7's reciprocal members on the observer.
+- Produces: nothing.
+
+- [ ] **Step 1: Hoist the observer flags.** Add
+`bool m_bUseAbsoluteFlag; bool m_bLabFlag;` resolved in `Begin()` from `m_flags`,
+with a comment naming `Begin()`. Use them in `Apply`.
+
+- [ ] **Step 2: Build and check** `spectral-6ch` — unchanged from whatever Task 6
+left it at.
+
+- [ ] **Step 3: Hoist the named-colour dispatch.** Store a resolved kind on each
+apply-list entry when the list is built, rather than re-querying per pixel. If
+that turns out to need a new member on `CIccApplyXform`, note that
+`CIccApplyXform` is per-thread, so it is a valid place for it — but the *kind* is
+immutable, so prefer the shared xform if one is reachable.
+
+**If this turns out to require restructuring `CIccApplyXformList`, stop and
+report.** It is the lowest-value item in the branch and not worth a risky
+refactor; leaving it undone with a note is the better outcome.
+
+- [ ] **Step 4: Run the full suite.** Expected 101/101. Named-colour has CTest
+coverage even though it has no benchmark case, so this is the real gate.
+
+- [ ] **Step 5: Commit**, stating which parts were measured and which were not.
+
+---
+
+### Task 9: Record the results
+
+**Files:**
+- Create: `docs/superpowers/results/2026-08-20-tier-c-results.md`
+
+- [ ] **Step 1: Capture the final numbers**
+
+```bash
+$BENCH -suite -csv -pixels 1048576 -repeats 9
+$BENCH -suite -csv -pixels 1048576 -repeats 9 -threads 1,4,8
+```
+
+- [ ] **Step 2: Write the table** — baseline Mpx/s, final Mpx/s, delta, and
+checksum before/after per case. Mark the `spectral-6ch` checksum change as the
+authorised Task 6 delta, with the reason.
+
+- [ ] **Step 3: State what did not improve.** Any task whose case did not move,
+and why — small win, noise floor, or not covered by a case. A results document
+that only lists wins is not useful for deciding what branch 3 should prioritise.
+
+- [ ] **Step 4: Commit.**
+
+## Self-review notes
+
+- **Every tier-C finding has a task:** C1→1, C2→2, C3→3, C4→4, C5→5, C6→6, C7→7,
+  C8→8, plus Task 9 for results.
+- **Three tasks carry a real risk of a moved checksum** and each says what to do
+  about it rather than assuming: Task 2 (divide → multiply), Task 6 (the
+  authorised `+inf` change), Task 7 (divide → multiply again, with a documented
+  fallback to keep the divide).
+- **Three tasks contain genuine stop-and-report conditions**: Task 4 if another
+  `IsAcs()` consumer exists, Task 8 Step 3 if the named-colour dispatch needs a
+  list refactor, and the global constraint about any hoist that seems to need a
+  behaviour change.
+- **Two things deliberately left undone**, both noted in their tasks rather than
+  silently skipped: the header-PCS component selection in Task 2's output branch,
+  and the `SetClipFunc` call sites in Task 6 Step 4.

--- a/docs/superpowers/results/2026-08-20-tier-c-results.md
+++ b/docs/superpowers/results/2026-08-20-tier-c-results.md
@@ -1,0 +1,140 @@
+# Tier C results: hoisting pre-existing per-pixel invariants
+
+Date: 2026-08-20
+Branch: `perf/hoist-invariants`
+Plan: `docs/superpowers/plans/2026-08-20-hoist-invariants-tier-c.md`
+
+Running record. Updated as each task lands; findings are recorded whether the
+result was positive, negative, or unmeasurable.
+
+## Measurement method
+
+The workstation this was measured on shows about **30% run-to-run variance** on
+the same binary for a single median run, which is far more than most of these
+changes are worth. Three corrections were needed before any number could be
+trusted:
+
+1. **Interleaved A/B, best-of-N.** Two builds run alternately across N rounds,
+   comparing the fastest observed pass per case. Interference only ever makes a
+   run slower, so the fastest sample is the least polluted.
+2. **Reference snapshots must capture the DLL, not just the executable.**
+   `iccBenchApply` links `IccProfLib2.dll` dynamically, so copying only the `.exe`
+   silently measures the *new* library. Mixing a new executable with an old DLL is
+   not a valid shortcut either: Task 1 added a virtual to `CIccPcsStep`, changing
+   vtable layout.
+3. **Alternate which build runs first each round.** Running ref-then-new every
+   round makes load drift inside a round bias systematically against whichever
+   build runs second. Before this was fixed, several cases read 3-9% "slower" for
+   a change that could not execute in them at all.
+
+With all three in place, a null test of two identical builds gives **±1.5%, one
+case at 3.2%**. Changes above about 4% are signal; below that is not
+distinguishable on this hardware.
+
+**The `-perxform` tier cannot be used for A/B comparison.** Its variance is 41 to
+73 Mpx/s across five runs of the same binary -- each stage runs a short burst
+rather than a sustained loop, so it never reaches steady state. It is sound for
+attribution (which stage dominates a chain) and useless for deciding whether a
+change helped.
+
+**Chain numbers understate stage-level wins.** A hoist inside one xform is
+diluted by the rest of its chain, so the percentages below are lower bounds on
+the value of each change, not measures of it.
+
+## Results
+
+| finding | outcome | measured |
+|---|---|---|
+| C1 sparse PCS matrix built once | kept | **no coverage exists** |
+| C2 monochrome reference white | kept | **+5.7% / +6.5%** |
+| C3 MPE PCS encodings cached | **reverted** | **−4.9%, consistent** |
+
+### C1 -- build the sparse PCS matrix once instead of per pixel
+
+`CIccPcsStepSparseMatrix::Apply` constructed a `CIccSparseMatrix` per pixel, and
+`CIccSparseMatrix::Init` unconditionally deletes and re-news its accessor -- a
+heap allocation and free on every pixel. Moved into a new
+`CIccPcsStep::BeginStep()` hook called once from `CIccPcsXform::Begin()`.
+
+**No measurement is possible.** `CIccPcsStepMatrix::reduce()` only produces a
+sparse step when the PCS matrix is more than 25% zeros, and instrumenting
+`BeginStep()` showed **zero** constructions across the whole benchmark suite,
+every spectral chain the corpus can form, and the one bispectral sparse-matrix
+profile in the tree (`Named/SparseMatrixNamedColor` is `nmcl` class, so its sparse
+matrix lives in the named-colour tag, not a PCS step).
+
+This corrects the audit, which rated the finding "hot" on the strength of it
+being a per-pixel allocation without checking whether the path is reached. Kept
+because a latent per-pixel allocation will bite whoever does reach it in a real
+bispectral workflow, but no speed claim is attached to it.
+
+### C2 -- precompute the monochrome reference white in Begin()
+
+`CIccXformMonochrome::Apply` rebuilt the PCS-encoded perceptual reference white on
+every pixel from compile-time constants. Moved to `Begin()`, held on the xform
+because it is immutable afterwards.
+
+| case | before | after | change |
+|---|---|---|---|
+| `monochrome` (XYZ PCS) | 32.37 | 34.22 | **+5.7%** |
+| `mono-lab` (Lab PCS) | 21.25 | 22.64 | **+6.5%** |
+
+All checksums bit-identical: the output branch keeps its division rather than
+multiplying by a precomputed reciprocal, because `x/w` and `x*(1/w)` are not
+bit-identical and one divide is negligible beside what was hoisted. Keeping the
+oracle a strict equality check across the whole branch was worth more than the
+last few percent.
+
+`mono-lab` required a new fixture. `v2GrayTRC` has an XYZ PCS, so the Lab branch
+-- the only one that reaches `XyzToLab` and its three cube roots -- was never
+executed. `Testing/V2/v2GrayTRCLab.xml` closes that gap, and is worth having
+independently: it gives the repo its first coverage of that branch.
+
+### C3 -- cache the MPE PCS encodings (REVERTED)
+
+`CIccXformMpe::Apply` calls `GetSrcSpace()`/`GetDstSpace()` per pixel, each
+branching four ways through the profile header, plus an invariant intent
+comparison. Caching all of it in `Begin()` looked like a clear win.
+
+**It measured consistently slower and was reverted.**
+
+| run | rounds | `mpe-calc` |
+|---|---|---|
+| 1 | 4 | −4.4% |
+| 2 | 4 | −4.4% |
+| 3 | 6 | −5.7% |
+| 4 | 12 | −4.9% |
+| null test, identical builds | 4 | −1.2% |
+
+Every other case flipped sign between runs, which is the signature of noise.
+`mpe-calc` never did -- and `mpe-calc` is the case dominated by
+`CIccXformMpe::Apply`, the only function the change touched.
+
+The likely mechanism is that the hoist was not trading computation for a cheaper
+load. The three new members sit past a large `CIccXform` base, so `Apply()` reads
+them from a high offset and plausibly a colder cache line, whereas what it read
+before -- `m_nIntent`, `m_nTagIntent`, and `m_pProfile->m_Header.pcs` -- is
+already hot, because the surrounding apply path touches the header constantly.
+Removing redundant work is a reason to *expect* a win, not evidence of one.
+
+**A correctness bug was also found here, and it is the more important finding.**
+The first attempt folded `m_bSrcPcsConversion`/`m_bDstPcsConversion` into the
+cached decision. Those are mutated *after* the xform's `Begin()` has run:
+`CIccCmm::Begin()` runs the per-xform `Begin()` loop at `IccCmm.cpp:9797` and only
+then calls `CheckPCSConnections()` at `:9803`, which calls
+`SetDstPCSConversion(false)`/`SetSrcPCSConversion(false)` on the xforms either
+side of an inserted PCS xform. The cached value went stale and the
+absolute-colorimetric output changed: `pcs-abs` moved
+`0xd0a37c30` → `0x5c36a0b6`.
+
+That would have shipped silently. `pcs-abs` was the *only* case that moved, and
+it exists only because an earlier commit deliberately repointed the PCS pair at
+profiles with differing white points -- with the original D50/D50 pair, absolute
+and relative produced byte-identical output and this bug would have passed the
+gate unnoticed.
+
+**Consequence for the remaining tasks:** "immutable after `Begin()`" cannot be
+assumed from a member's type or name. `CIccCmm::Begin()` does substantial work
+both before and after the per-xform loop, so any candidate for caching needs its
+write-ordering checked against that sequence specifically. This applies directly
+to the remaining tasks that plan to cache flags on `CIccXform`.

--- a/docs/superpowers/results/2026-08-20-tier-c-results.md
+++ b/docs/superpowers/results/2026-08-20-tier-c-results.md
@@ -48,6 +48,40 @@ the value of each change, not measures of it.
 | C1 sparse PCS matrix built once | kept | **no coverage exists** |
 | C2 monochrome reference white | kept | **+5.7% / +6.5%** |
 | C3 MPE PCS encodings cached | **reverted** | **−4.9%, consistent** |
+| C4 ACS flag cached on apply object | kept | 0, below noise |
+| C5 AdjustPCS dispatch cached | **not attempted** | predicted ~0 |
+| C6 CLUT clip call removed | kept | **+29% … +38%** |
+| C7 XYZ-to-Lab reciprocals | **reverted** | +1.8%, moved output |
+| C8 observer flags / named-colour dispatch | **not attempted** | predicted ~0 |
+
+### The pattern, which contradicts the audit's premise
+
+The audit assumed per-pixel invariant recomputation is waste worth removing. That
+turns out to be true only when the recomputation is **expensive**:
+
+| change | what it removed per pixel | measured |
+|---|---|---|
+| C6 | an indirect call plus duplicated arithmetic, per channel | **+29-38%** |
+| C2 | three stores, `icXyzToPcs`, and on the Lab path three cube roots | **+6%** |
+| C7 | three divisions and six comparisons | **+1.8%** |
+| C4 | two calls, one virtual | **0** |
+| C3 | a virtual call and two integer comparisons | **−5%** |
+
+Replacing three *divisions* with three multiplications bought 1.8%, which says
+the PCS step is dominated by `icCubeth`'s cube roots rather than by the
+arithmetic around them. Below roughly that level of saving, hoisting stops paying
+and can lose: a cached member is a load from wherever the compiler puts it, while
+the expression it replaced was often reading data the surrounding apply path had
+already pulled into cache.
+
+C5 and C8 were **not attempted** on that basis. C5 replaces two virtual
+`UseLegacyPCS()` calls and a header dereference with a member load -- the same
+shape as C3, which regressed -- against a measured headroom of about 1.4% between
+`pcs-rel` and `pcs-abs`. C8's observer half replaces two bit-tests with two bool
+loads, smaller again; its named-colour half is not covered by any benchmark case,
+and after C1 and C7 the standard on this branch is not to land unmeasurable
+changes that carry risk. Both are recorded here rather than implemented, so the
+reasoning survives even though the code does not.
 
 ### C1 -- build the sparse PCS matrix once instead of per pixel
 
@@ -138,3 +172,67 @@ assumed from a member's type or name. `CIccCmm::Begin()` does substantial work
 both before and after the per-xform loop, so any candidate for caching needs its
 write-ordering checked against that sequence specifically. This applies directly
 to the remaining tasks that plan to cache flags on `CIccXform`.
+
+
+### C4 -- cache the ACS flag on the apply object
+
+`CIccTagMultiProcessElement::Apply`'s middle loop called `GetElem()` and then the
+virtual `IsAcs()` for every middle element of every pixel -- paid by every MPE
+chain of three or more elements whether or not it contains an ACS element.
+Resolved once when the apply object is constructed.
+
+**Deliberately not implemented as planned.** The plan proposed filtering ACS
+elements out of the apply list. `Apply()` only skips them in the *middle* of the
+chain, so a first or last ACS element is applied, and `CIccMpeAcs::Apply` is a
+`memcpy` the buffer plumbing depends on -- removing entries would change which
+element occupies those positions. No profile in the corpus has an ACS element and
+no test exercises `CIccMpeAcs`, so that could not have been verified. Caching the
+flag gets the same saving with list structure byte-identical.
+
+No measurable effect: two A/B runs disagreed on the sign for every case, and the
+first was uniformly negative including `monochrome`, which contains no MPE
+element at all. Kept because it is strictly less work with no behaviour risk.
+
+### C6 -- clamp CLUT grid coordinates inline
+
+The largest win in the branch, and the one case where the audit's reasoning held.
+Every `Interp*` function called `m_UnitClipFunc` per input channel per pixel and
+then repeated the work with `isfinite` and a range clamp.
+
+| case | change | CLUT in chain |
+|---|---|---|
+| `lut-3d-tetra` | **+31% … +38%** | two |
+| `mono-lab` | **+29% … +42%** | one |
+| `pcs-rel` / `pcs-abs` | +6% … +8% | one |
+| `spectral-6ch` | +6% … +7% | one, small share |
+| `matrix-trc`, `monochrome` | ~0 | **none** (controls) |
+| `mpe-calc` | ~0 | interpreter-bound at 0.14 Mpx/s |
+
+The two CLUT-free chains reading ~0 across runs is what makes the large numbers
+credible rather than drift.
+
+**Two coverage holes surfaced here.** The deliberate `+Inf` semantic change --
+unifying the former `ClutUnitClip` and `NoClip` paths, which disagreed at
+opposite ends of the grid -- moved **no checksum on any case**, even with `+Inf`
+on every channel. The only corpus profiles installing the `NoClip` path are
+three-channel, and the only wider profile has no CLUT element. It is now pinned
+by `.github/ci/regression/clut-grid-clamp-inf.cpp`, verified to fail on exactly
+one check against the previous library.
+
+The harness input buffer was also wrong, and not only for this change: it wrote
+`pathological[s % 6]`, placing `+Inf` at channel index 4 alone, so no profile
+with fewer than five input channels ever received one -- most of the corpus. It
+now uses one pathological row per value, each filling every channel.
+
+### C7 -- XYZ-to-Lab reciprocals (REVERTED)
+
+Implemented as a public `icXYZtoLabRecip` overload plus `icXYZWhiteRecip`, with
+the reciprocals held next to `m_xyzWhite` so they share an already-hot cache
+line. `spectral-6ch`, the only case that exercises `CIccPcsStepXYZToLab`, gained
+**+1.8%** -- inside the noise floor -- while its checksum moved, because `x/w`
+and `x*(1/w)` are not bit-identical.
+
+Reverted: it cost bit-exactness and new public API surface for no measurable
+gain. The narrower variant the plan offered as a fallback -- keep the division,
+hoist only the six comparisons -- was not pursued either, since it saves strictly
+less than the 1.8% already shown to be unmeasurable.


### PR DESCRIPTION
## PR Summary

Stage 2 of the apply-path performance work: the eight tier-C findings from the
review, the ones that predate the hardening effort. **Stacked on #2207** (the
throughput harness) -- base is `bench/throughput-harness`, retarget to `master`
once that merges.

Results: `docs/superpowers/results/2026-08-20-tier-c-results.md`

### Outcome

| finding | outcome | measured |
|---|---|---|
| C6 CLUT clip call removed | kept | **+29% … +38%** |
| C2 monochrome reference white | kept | **+5.7% / +6.5%** |
| C4 ACS flag cached on apply object | kept | 0, below noise |
| C1 sparse PCS matrix built once | kept | no coverage exists |
| C3 MPE PCS encodings cached | **reverted** | −4.9%, consistent |
| C7 XYZ-to-Lab reciprocals | **reverted** | +1.8%, moved output |
| C5, C8 | **not attempted** | predicted ~0 |

Every checksum in the harness is unchanged, on all nine cases, at every thread
count. 102/102 CTest.

### The one big win

C6. Every `Interp*` function called `m_UnitClipFunc` per input channel per pixel
and then repeated the work with `isfinite` and a range clamp -- and on the default
path the two were doing the same thing, since clamping to `[0,mx]` after the
multiply subsumes clamping to `[0,1]` before it. The indirect call was also what
stopped the sequence vectorizing. Replaced by an inline two-comparison clamp.

`+31–38%` on the two-CLUT chain, `+29–42%` where one CLUT dominates, `+6–8%` where
a CLUT is part of a longer chain, and **~0 on the two chains that contain no
CLUT** -- those controls are what make the large numbers credible rather than
measurement drift.

### The audit's premise was wrong, and that is the more useful result

The review assumed per-pixel invariant recomputation is waste worth removing.
That holds only when the recomputation is *expensive*:

| change | removed per pixel | measured |
|---|---|---|
| C6 | indirect call + duplicated arithmetic, per channel | +29–38% |
| C2 | stores, `icXyzToPcs`, cube roots on the Lab path | +6% |
| C7 | three divisions and six comparisons | +1.8% |
| C4 | two calls, one virtual | 0 |
| C3 | a virtual call and two integer comparisons | −5% |

Replacing three *divisions* with three multiplications bought 1.8%. Below roughly
that, hoisting stops paying and can lose: a cached member is a load from wherever
the compiler puts it, while the expression it replaced was often reading data the
apply path had already pulled into cache. C5 and C8 were not attempted on that
basis, with the reasoning recorded.

### Two reverts, and why they were worth doing

**C3** read −4.4% to −5.7% on `mpe-calc` across four independent A/B runs while
every other case flipped sign; a null test of identical builds put it at −1.2%.
`mpe-calc` is the case dominated by the only function the change touched.

More importantly, the C3 attempt surfaced a **correctness bug**:
`m_bSrcPcsConversion`/`m_bDstPcsConversion` are mutated *after* an xform's
`Begin()` has run, because `CIccCmm::Begin()` calls the per-xform `Begin()` loop
(`IccCmm.cpp:9797`) and only then `CheckPCSConnections()` (`:9803`). Caching them
made the value stale and changed absolute-colorimetric output
(`pcs-abs` `0xd0a37c30` → `0x5c36a0b6`). It would have shipped silently: that was
the only case that moved, and it only detects this because #2207 deliberately
repointed the PCS pair at profiles with differing white points.

**"Immutable after `Begin()`" cannot be assumed from a member's type or name** --
`CIccCmm::Begin()` does substantial work both before and after the per-xform
loop. That is the main thing to carry into the tier-A/B branch.

**C7** cost bit-exactness and new public API surface for +1.8% on the only case
that exercises it. Reverted rather than shipped.

### Coverage gaps found

- **C1's code path is unreachable with this corpus.** `CIccPcsStepMatrix::reduce()`
  only builds a sparse step when the PCS matrix is >25% zeros; instrumenting showed
  zero constructions across the whole suite, every spectral chain the corpus can
  form, and the one bispectral sparse-matrix profile (`nmcl` class, so its matrix
  is in the named-colour tag). Kept as a latent-bug fix with no speed claim.
- **C6's deliberate `+Inf` change was invisible to everything.** No checksum moved
  on any case even with `+Inf` on every channel: the only profiles installing the
  affected path are three-channel and the only wider one has no CLUT element. Now
  pinned by `.github/ci/regression/clut-grid-clamp-inf.cpp`, verified to fail on
  exactly one check against the previous library.
- **The harness input buffer was under-testing everything.** It wrote
  `pathological[s % 6]`, placing `+Inf` at channel index 4 alone, so no profile
  with fewer than five input channels ever received one. Fixed to one pathological
  row per value, each filling every channel.
- **`Testing/V2/v2GrayTRCLab.xml`** added: `v2GrayTRC` has an XYZ PCS, so
  `CIccXformMonochrome`'s Lab branch -- the only one reaching `XyzToLab` -- had no
  coverage at all.

### Behaviour change

One, deliberate and pinned. The former `ClutUnitClip` and `NoClip` paths
disagreed about `+Inf` at opposite ends of the grid: the first clipped it to 1.0
and thence to `mx`, the second passed it through to `isfinite` and produced 0.
They now agree that `+Inf` saturates high. `NaN`, `-Inf`, and out-of-range values
are unchanged on both paths. `SetClipFunc` is kept as a documented no-op rather
than removed, since it is public API.

### Measurement note

This workstation shows ~30% run-to-run variance on a single median run. All
numbers above come from interleaved best-of-N A/B against a reference build
snapshotted with its DLL, alternating which build runs first each round. A null
test of two identical builds gives ±1.5% (one case 3.2%), so >4% is signal. The
`-perxform` tier is **not** usable for A/B -- 41 to 73 Mpx/s across five runs of
one binary.

### Checklist

- [ ] Signed all Commits in PR  <!-- not signed; no signing config in this checkout -->
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes  <!-- not run; see note -->
- [x] Added or updated regression coverage for behavior changes
- [ ] For Python package changes — n/a
- [ ] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested  <!-- CTest registration + profile count; requested as part of this work -->
- [x] New source files include the ICC copyright and BSD 3-Clause license header
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

This touches `IccProfLib` clamp and PCS code, so an ASan/UBSan run before merge
would be reasonable and I have not done one -- say the word and I will.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
