### PR TITLE
fix(#2200): reject float MinIsWhite input, bound row buffers, discard partial output

### DIFF
--- a/.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh
+++ b/.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh
@@ -39,11 +39,16 @@ PACKED_DIR="$OUTDIR/specsep-packed"
 PACKED_FILE="$PACKED_DIR/spec_1"
 VALID_DIR="$OUTDIR/specsep-valid"
 PALETTE_DIR="$OUTDIR/specsep-palette"
+FLOAT_DIR="$OUTDIR/specsep-float-miniswhite"
+OVERSIZE_DIR="$OUTDIR/specsep-oversized-row"
+TRUNC_DIR="$OUTDIR/specsep-truncated"
+BPS24_DIR="$OUTDIR/specsep-bps24"
 LOGFILE="$OUTDIR/specsep-tiff-geometry.log"
 OUTPUT_TIFF="$OUTDIR/specsep-geometry-output.tif"
 
 PASS=0
 FAIL=0
+SKIP=0
 TOTAL=0
 
 fail_case() {
@@ -58,6 +63,13 @@ pass_case() {
   local reason="$2"
   echo "  [PASS] $name -- $reason"
   PASS=$((PASS + 1))
+}
+
+skip_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [SKIP] $name -- $reason"
+  SKIP=$((SKIP + 1))
 }
 
 generate_malformed_tiff() {
@@ -416,12 +428,342 @@ run_specsep_palette_reject() {
   pass_case "$name" "palette input rejected (#1381) without sanitizer findings"
 }
 
+generate_tagged_tiff() {
+  # Writes a single-channel TIFF with explicit photometric/sample-format/geometry
+  # control, laying the IFD ahead of the pixel data so a caller can truncate the
+  # data without destroying the directory.
+  local path="$1"
+  local width="$2"
+  local height="$3"
+  local bps="$4"
+  local photometric="$5"
+  local sampleformat="$6"
+  local payload="$7"
+  local declared_bytes="$8"
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 1
+  fi
+
+  python3 - "$path" "$width" "$height" "$bps" "$photometric" "$sampleformat" "$payload" "$declared_bytes" <<'PY'
+import pathlib
+import struct
+import sys
+
+path = pathlib.Path(sys.argv[1])
+width, height, bps = int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+photometric, sampleformat = int(sys.argv[5]), int(sys.argv[6])
+payload_kind = sys.argv[7]
+declared_bytes = int(sys.argv[8])
+path.parent.mkdir(parents=True, exist_ok=True)
+
+if payload_kind == "float-ramp":
+    pixel_data = struct.pack("<4f", 0.0, 0.25, 0.5, 1.0)
+elif payload_kind == "short":
+    pixel_data = b"\x11" * 4
+else:
+    pixel_data = b"\x00" * 64
+
+entries = []
+def add(tag, tag_type, count, value):
+    entries.append((tag, tag_type, count, value))
+
+n_entries = 13
+ifd_offset = 8
+ifd_size = 2 + n_entries * 12 + 4
+xres_offset = ifd_offset + ifd_size
+yres_offset = xres_offset + 8
+data_offset = yres_offset + 8
+
+add(256, 4, 1, width)                                    # ImageWidth
+add(257, 4, 1, height)                                   # ImageLength
+add(258, 3, 1, bps)                                      # BitsPerSample
+add(259, 3, 1, 1)                                        # Compression: none
+add(262, 3, 1, photometric)                              # PhotometricInterpretation
+add(273, 4, 1, data_offset)                              # StripOffsets
+add(277, 3, 1, 1)                                        # SamplesPerPixel
+add(278, 4, 1, height)                                   # RowsPerStrip
+add(279, 4, 1, declared_bytes if declared_bytes else len(pixel_data))
+add(282, 5, 1, xres_offset)                              # XResolution
+add(283, 5, 1, yres_offset)                              # YResolution
+add(296, 3, 1, 2)                                        # ResolutionUnit: inch
+add(339, 3, 1, sampleformat)                             # SampleFormat
+assert len(entries) == n_entries
+entries.sort()
+
+data = bytearray(b"II" + struct.pack("<H", 42) + struct.pack("<I", ifd_offset))
+data.extend(struct.pack("<H", len(entries)))
+for tag, tag_type, count, value in entries:
+    data.extend(struct.pack("<HHI", tag, tag_type, count))
+    if tag_type == 3 and count == 1:
+        data.extend(struct.pack("<H", value) + b"\0\0")
+    else:
+        data.extend(struct.pack("<I", value))
+data.extend(struct.pack("<I", 0))
+data.extend(struct.pack("<II", 72, 1))
+data.extend(struct.pack("<II", 72, 1))
+data.extend(pixel_data)
+path.write_bytes(data)
+PY
+}
+
+tool_is_sanitized() {
+  # ASan/TSan/MSan-instrumented binaries reserve terabytes of shadow memory, so any
+  # `ulimit -v` cap makes it die at startup regardless of the defect under test.
+  # Detect instrumentation from the binary rather than from a CTest label.
+  # Fail closed: if neither probe is installed we cannot tell, and guessing
+  # "not sanitized" would run the ulimit case against an ASan build and produce
+  # a red leg caused by missing binutils rather than by the code.
+  if ! command -v nm >/dev/null 2>&1 && ! command -v strings >/dev/null 2>&1; then
+    return 0
+  fi
+
+  # Capture the output rather than piping it into `grep -q`: grep exits at the
+  # first match and kills nm with SIGPIPE, which `set -o pipefail` (line 10)
+  # reports as 141.  That made the guard read a genuinely instrumented binary as
+  # "not sanitized" and run it under the cap anyway, which is the red leg this
+  # function exists to prevent.
+  local symbols=""
+  symbols="$(nm -D "$SPECSEP" 2>/dev/null || true)"
+  case "$symbols" in
+    *__asan_init*|*__tsan_init*|*__msan_init*) return 0 ;;
+  esac
+
+  local text=""
+  text="$(strings "$SPECSEP" 2>/dev/null || true)"
+  case "$text" in
+    *libclang_rt.asan*|*libclang_rt.tsan*|*libclang_rt.msan*) return 0 ;;
+  esac
+
+  return 1
+}
+
+run_specsep_float_miniswhite_reject() {
+  local name="specsep-float-miniswhite-reject"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$LOGFILE" "$OUTPUT_TIFF"
+
+  if [ ! -x "$SPECSEP" ]; then
+    fail_case "$name" "missing executable: $SPECSEP"
+    return
+  fi
+
+  # MinIsWhite is applied as a per-byte XOR with 0xff.  On IEEE float samples
+  # that rewrites sign and exponent instead of the value, so 0.25 became
+  # -15.999999 and 0.0 became a NaN while the tool still reported success.
+  if ! generate_tagged_tiff "$FLOAT_DIR/spec_1" 2 2 32 0 3 "float-ramp" 0 ||
+     ! generate_tagged_tiff "$FLOAT_DIR/spec_2" 2 2 32 0 3 "float-ramp" 0; then
+    fail_case "$name" "python3 unavailable or float TIFF generation failed"
+    return
+  fi
+
+  timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$FLOAT_DIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 255 ]; then
+    fail_case "$name" "expected graceful reject exit=255, got exit=$exit_code (float samples silently corrupted)"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq "Floating point MinIsWhite input cannot be inverted" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "missing float MinIsWhite rejection text"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ -e "$OUTPUT_TIFF" ]; then
+    fail_case "$name" "output TIFF created despite float MinIsWhite rejection"
+    return
+  fi
+
+  pass_case "$name" "float MinIsWhite input rejected instead of silently inverted"
+}
+
+run_specsep_oversized_row_buffer_reject() {
+  local name="specsep-oversized-row-buffer-reject"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$LOGFILE" "$OUTPUT_TIFF"
+
+  if [ ! -x "$SPECSEP" ]; then
+    fail_case "$name" "missing executable: $SPECSEP"
+    return
+  fi
+
+  if tool_is_sanitized; then
+    skip_case "$name" "sanitizer build cannot run under a ulimit -v cap"
+    return
+  fi
+
+  # A 250-byte file may declare a 500,000,000-pixel wide float row, asking for a
+  # 2GB row buffer.  Throwing new turned the refusal into an unhandled
+  # std::bad_alloc and the tool died with SIGABRT (exit 134) instead of
+  # reporting the problem.  The cap makes the allocation fail deterministically
+  # rather than relying on the host's overcommit behaviour.
+  if ! generate_tagged_tiff "$OVERSIZE_DIR/spec_1" 500000000 1 32 1 3 "zero" 64; then
+    fail_case "$name" "python3 unavailable or oversized TIFF generation failed"
+    return
+  fi
+
+  ( ulimit -v 2000000; timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$OVERSIZE_DIR/spec_" 1 1 1 ) > "$LOGFILE" 2>&1 || exit_code=$?
+
+  # main() returns -1 on every error path, which the shell reports as 255; a
+  # real signal death lands in 129..192, so 255 must not be read as a signal.
+  if [ "$exit_code" -ge 128 ] && [ "$exit_code" -lt 255 ]; then
+    fail_case "$name" "tool died from signal $((exit_code - 128)) instead of reporting the allocation failure"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 255 ]; then
+    fail_case "$name" "expected graceful reject exit=255, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if grep -q "std::bad_alloc" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "unhandled std::bad_alloc reached the terminate handler"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  # Naming the diagnostic stops the case passing for the wrong reason: the
+  # pre-fix binary also exits 255 when the allocation is never reached, because
+  # the short strip makes ReadLine fail instead.
+  if grep -Fq "Cannot allocate image row buffers" "$LOGFILE" 2>/dev/null; then
+    pass_case "$name" "oversized row buffer refused without aborting"
+    return
+  fi
+
+  # Getting past the allocation at all means the address-space cap was not
+  # enforced -- `ulimit -v` is accepted but ignored under Git Bash on Windows
+  # and on Darwin.  The tool then reaches ReadLine and exits 255 on the short
+  # strip.  Neither build can be told apart there, so skip rather than report a
+  # red leg caused by the platform instead of by the code.
+  if grep -qE "Error reading line|Cannot open input" "$LOGFILE" 2>/dev/null; then
+    skip_case "$name" "address-space cap not enforced on this platform; allocation never refused"
+    return
+  fi
+
+  fail_case "$name" "did not refuse at the row-buffer allocation; the geometry no longer discriminates"
+  sed -n '1,40p' "$LOGFILE"
+}
+
+run_specsep_partial_output_discarded() {
+  local name="specsep-partial-output-discarded"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$LOGFILE" "$OUTPUT_TIFF"
+
+  if [ ! -x "$SPECSEP" ]; then
+    fail_case "$name" "missing executable: $SPECSEP"
+    return
+  fi
+
+  # Create() truncates any existing output, so a run that failed part way
+  # through left an unreadable stub in place of a previously good result while
+  # still exiting non-zero.  A failed conversion must leave no output at all.
+  if ! generate_tagged_tiff "$TRUNC_DIR/spec_1" 4 4 8 1 1 "short" 16 ||
+     ! generate_tagged_tiff "$TRUNC_DIR/spec_2" 4 4 8 1 1 "short" 16; then
+    fail_case "$name" "python3 unavailable or truncated TIFF generation failed"
+    return
+  fi
+
+  printf 'pre-existing output that must not survive a failed run' > "$OUTPUT_TIFF"
+
+  timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$TRUNC_DIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 255 ]; then
+    fail_case "$name" "expected graceful reject exit=255, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ -e "$OUTPUT_TIFF" ]; then
+    fail_case "$name" "incomplete output TIFF left behind after a failed conversion"
+    return
+  fi
+
+  pass_case "$name" "incomplete output discarded after a late read failure"
+}
+
+run_specsep_create_failure_preserves_existing_output() {
+  local name="specsep-create-failure-preserves-existing-output"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$LOGFILE"
+
+  if [ ! -x "$SPECSEP" ]; then
+    fail_case "$name" "missing executable: $SPECSEP"
+    return
+  fi
+
+  # Create() refuses compression for a 24 bit sample size *before* its
+  # TIFFOpen(...,"w"), so the destination is never touched.  Discarding the
+  # output unconditionally on a Create() failure would delete a pre-existing
+  # file this run never opened, which is worse than the stub it was meant to
+  # clean up.  24 bps clears both main()'s byte-alignment check and
+  # CTiffImg::Open, so it reaches Create() and fails there.
+  if ! generate_tagged_tiff "$BPS24_DIR/spec_1" 2 2 24 1 1 "short" 0 ||
+     ! generate_tagged_tiff "$BPS24_DIR/spec_2" 2 2 24 1 1 "short" 0; then
+    fail_case "$name" "python3 unavailable or 24 bps TIFF generation failed"
+    return
+  fi
+
+  printf 'pre-existing output that Create() never opened' > "$OUTPUT_TIFF"
+  local before
+  before="$(cksum < "$OUTPUT_TIFF")"
+
+  timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 1 0 "$BPS24_DIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! grep -Fq "Unable to create" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "expected a Create() refusal for a compressed 24 bps output"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ ! -e "$OUTPUT_TIFF" ]; then
+    fail_case "$name" "pre-existing output deleted after a Create() failure that never opened it"
+    return
+  fi
+
+  if [ "$(cksum < "$OUTPUT_TIFF")" != "$before" ]; then
+    fail_case "$name" "pre-existing output modified after a Create() failure that never opened it"
+    return
+  fi
+
+  pass_case "$name" "pre-existing output left intact when Create() refused before opening it"
+}
+
 echo "=== iccSpecSepToTiff malformed TIFF geometry regression ==="
 run_specsep_geometry_reject
 run_specsep_packed_bps_reject
 run_specsep_descending_range_accept
 run_specsep_palette_reject
-echo "iccSpecSepToTiff malformed TIFF geometry regression: $PASS passed, $FAIL failed, $TOTAL total"
+run_specsep_float_miniswhite_reject
+run_specsep_oversized_row_buffer_reject
+run_specsep_partial_output_discarded
+run_specsep_create_failure_preserves_existing_output
+if [ "$SKIP" -ne 0 ]; then
+  echo "iccSpecSepToTiff malformed TIFF geometry regression: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total"
+else
+  echo "iccSpecSepToTiff malformed TIFF geometry regression: $PASS passed, $FAIL failed, $TOTAL total"
+fi
 
 if [ "$FAIL" -ne 0 ]; then
   exit 1

--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -81,6 +81,7 @@
 #include <vector>
 #include <memory>
 #include <limits>
+#include <new>
 #include <string>
 #include "IccCmm.h"
 #include "IccUtil.h"
@@ -337,6 +338,19 @@ static bool readValidateProfile(const char *profilePath,
 
 //===================================================
 
+// Once Create() has opened the output, every later failure path leaves a
+// partially written TIFF behind.  Create() truncates any existing file, so a
+// run that failed part way through also replaced a previously good output with
+// an unreadable stub that still looked like a result.  Discard the incomplete
+// file so a failed conversion leaves no output rather than a corrupt one.
+static void discardPartialOutput(CTiffImg &outfile, const char *path)
+{
+  outfile.Close();
+  remove(path);
+}
+
+//===================================================
+
 int main(int argc, char* argv[]) {
   const int minargs = 8; // argc = 8 without profile, 9 with profile
   
@@ -452,6 +466,17 @@ int main(int argc, char* argv[]) {
     return -1;
   }
 
+  // The MinIsWhite inversion below is a per-byte XOR with 0xff, which is only
+  // meaningful for integer samples.  Applying it to IEEE floats rewrites the
+  // sign and exponent instead of the sample value: 0.25 (0x3E800000) becomes
+  // 0xC17FFFFF (-15.999999) and 0.0 becomes a NaN.  The tool nevertheless
+  // reported success, so a float MinIsWhite input was silently converted to
+  // garbage.  Refuse the combination rather than emit corrupt samples.
+  if (invert && f->GetSampleFormat() == SAMPLEFORMAT_IEEEFP) {
+    printf("Floating point MinIsWhite input cannot be inverted: %s\n", argv[4]);
+    return -1;
+  }
+
   if (f->GetBitsPerSample() % 8) {
     printf("Input bits per sample must be byte aligned: %u\n", f->GetBitsPerSample());
     return -1;
@@ -470,8 +495,18 @@ int main(int argc, char* argv[]) {
   }
   
   // use unique_ptr to automatically free the buffers
-  std::unique_ptr<icUInt8Number[]> inbufffer( new icUInt8Number[ inputSize ] );
-  std::unique_ptr<icUInt8Number[]> outbuffer( new icUInt8Number[ outSize ] );
+  // The row buffers are sized from the input geometry, so a small crafted TIFF
+  // can request gigabytes: a 250-byte file declaring a 500,000,000-pixel wide
+  // float row asks for 2GB here.  Throwing new turned that into an unhandled
+  // std::bad_alloc and the tool died with SIGABRT (signal 6) instead of
+  // reporting the problem, so allocate without throwing and fail like every
+  // other input error.
+  std::unique_ptr<icUInt8Number[]> inbufffer( new (std::nothrow) icUInt8Number[ inputSize ] );
+  std::unique_ptr<icUInt8Number[]> outbuffer( new (std::nothrow) icUInt8Number[ outSize ] );
+  if (!inbufffer || !outbuffer) {
+    printf("Cannot allocate image row buffers of %zu and %zu bytes\n", inputSize, outSize);
+    return -1;
+  }
   icUInt8Number *inbuf = inbufffer.get();
   icUInt8Number *outbuf = outbuffer.get();
 
@@ -493,15 +528,36 @@ int main(int argc, char* argv[]) {
 
   CTiffImg outfile;
   unsigned int nExtraSamples = nSamples > 1 ? (unsigned int)nSamples - 1 : 0;
+
+  // Create() truncates the destination the moment its TIFFOpen(...,"w")
+  // succeeds, but it also refuses some requests before opening anything (an
+  // unsupported compression/sample-size pair, a destination that is not a
+  // regular file).  Removing unconditionally on failure would therefore delete
+  // a pre-existing file this run never touched, so only discard an output that
+  // did not exist beforehand.
+  bool outputExisted = false;
+  {
+    // Probed with CIccFileIO to match readValidateProfile() above; a bare
+    // fopen() here would add another MSVC C4996 deprecation to the surface
+    // #2171 is already tracking.
+    CIccFileIO existing;
+    outputExisted = existing.Open(argv[1], "rb");
+    if (outputExisted)
+      existing.Close();
+  }
+
   if (!outfile.Create(argv[1], f->GetWidth(), f->GetHeight(), f->GetBitsPerSample(), PHOTO_MINISBLACK,
                      (unsigned int)nSamples, nExtraSamples, xRes, yRes, bCompress, bSep)) {
     printf("Unable to create %s\n", argv[1]);
+    if (!outputExisted)
+      remove(argv[1]);
     return -1;
   }
 
   if (destProfile) {
     if (!outfile.SetIccProfile( destProfile.get(), (unsigned int)destProfileLength )) {
       printf("Unable to embed ICC profile in %s\n", argv[1]);
+      discardPartialOutput(outfile, argv[1]);
       return -1;
     }
   }
@@ -512,9 +568,10 @@ int main(int argc, char* argv[]) {
       sptr = inbuf + j*bytePerLine;
       if (!infile[j].ReadLine(sptr)) {
         printf("Error reading line %u of file %zu\n", i, j);
+        discardPartialOutput(outfile, argv[1]);
         return -1;
       }
-      if (invert) {     // NOTE - this will not work for floating point data, but that should never be inverted anyway
+      if (invert) {     // float samples are rejected above, so this XOR only ever sees integer data
         for (size_t k=0; k<bytePerLine; k++) {
           sptr[k] ^= 0xff;
         }
@@ -530,6 +587,7 @@ int main(int argc, char* argv[]) {
     }
     if (!outfile.WriteLine(outbuf)) {
       printf("Error writing line %d\n", i);
+      discardPartialOutput(outfile, argv[1]);
       return -1;
     }
   }


### PR DESCRIPTION
Part of #2200.

Three defects in `iccSpecSepToTiff`, measured on `master` `dfeb5a88` (clang 21.1.3, Release), found while working the QA surface in #2200. All three are reachable from ordinary or crafted TIFF input, and none needed a change to shared `TiffImg` code.

## 1. Float MinIsWhite input was silently corrupted

MinIsWhite is applied as a per-byte XOR with `0xff`, which only means anything for integer samples. On IEEE floats it rewrites sign and exponent instead of the value.

| input (float32, MinIsWhite) | master output | with fix |
|---|---|---|
| `0.0` | `NaN` | rejected |
| `0.25` | `-15.999999` | rejected |
| `0.5` | `-7.9999995` | rejected |
| `1.0` | `-3.9999998` | rejected |

Master printed `Image successfully written!` and **exited 0**. The arithmetic confirms the mechanism exactly: `0.25` is `0x3E800000`, and `0x3E800000 XOR 0xFFFFFFFF` is `0xC17FFFFF`, which is `-15.999999`.

The source comment already named the case — *"this will not work for floating point data, but that should never be inverted anyway"* — but nothing enforced it. `GetSampleFormat()` was already available on `CTiffImg`, so the guard is self-contained.

## 2. A 250-byte crafted TIFF killed the process

Row buffers are sized from the *declared* input geometry, so a file declaring a 500,000,000-pixel-wide float row asks for a 2GB allocation while occupying 250 bytes on disk. Throwing `new` turned the refusal into an unhandled `std::bad_alloc`:

```
terminate called after throwing an instance of 'std::bad_alloc'
  what():  std::bad_alloc
Aborted (core dumped)          <-- SIGABRT, signal 6
```

Allocation is now non-throwing and fails like every other input error.

## 3. A failed conversion left a corrupt output behind

`Create()` truncates any existing file the moment its `TIFFOpen(...,"w")` succeeds, so a late read or write failure replaced a previously good output with an unreadable stub while still exiting non-zero. Measured: a valid 508-byte result became a 174-byte file that libtiff rejects for a missing `StripOffsets` field.

`Create()` failure is handled **separately and deliberately**. Removing unconditionally there would be worse than the defect: `Create()` also refuses some requests *before* opening anything (an unsupported compression/sample-size pair, a non-regular destination), so a blanket `remove()` deletes a pre-existing file the run never touched. A compressed 24-bits-per-sample request reaches exactly that path, clearing `main()`'s byte-alignment check and `CTiffImg::Open` on the way. The output is therefore discarded only when it did not exist beforehand. The existence probe uses `CIccFileIO` to match `readValidateProfile()` rather than a bare `fopen()`, which would add another MSVC `C4996` deprecation to the surface #2171 is tracking.

## Verification

Valid conversions are **byte-identical to master**: 8-channel interleaved, LZW plus separate planes, a descending range, and an embedded sRGB v4 profile. ASan+UBSan with `detect_leaks=1` is clean on all three new rejection paths and on both normal conversions.

Coverage extends the existing specsep geometry suite (`ctest -R iccdev.specsep-tiff-geometry-regression`) with four cases:

| case | master | with fix |
|---|---|---|
| `specsep-float-miniswhite-reject` | FAIL (exit 0, corrupt output) | PASS |
| `specsep-oversized-row-buffer-reject` | FAIL (SIGABRT) | PASS |
| `specsep-partial-output-discarded` | FAIL (stub retained) | PASS |
| `specsep-create-failure-preserves-existing-output` | PASS (pin) | PASS |

Red before green: **5 passed / 3 failed** against a master build, **8 passed / 0 failed** with this change.

The create-failure case passes against master too, since master never removes anything, so it was checked against a build carrying the unconditional `remove()` instead — it fails there, which makes it a real pin rather than a vacuous one.

Two portability notes on the oversized-buffer case, both verified rather than assumed:

- It caps address space with `ulimit -v` so the allocation fails deterministically instead of depending on host overcommit, and asserts the row-buffer diagnostic by name so the case cannot pass for the wrong reason. Where the cap cannot be enforced — `ulimit -v` is accepted but ignored under Git Bash on Windows and on Darwin — neither build can be told apart, so it **skips** rather than reporting a red leg caused by the platform.
- It also skips on ASan/TSan/MSan builds, which reserve shadow memory no `ulimit -v` can accommodate. That detection reads the binary rather than the CTest label, and captures `nm`/`strings` output rather than piping into `grep -q`: grep exits at the first match and kills `nm` with SIGPIPE, which `set -o pipefail` reports as 141, silently reading a genuinely instrumented binary as unsanitized. Verified against a real ASan build of the tool, which now skips correctly.

Skips are counted separately so a sanitizer run cannot report a case it never executed as passed.

## Not included

`ResolutionUnit` is dropped by the tool: an input carrying `ResolutionUnit=3 (centimeter)` produces an output with the tag absent, so libtiff defaults to inch and the physical size shifts by 2.54x. Confirmed on master, but the fix needs a new `CTiffImg::Create` parameter in `TiffImg.h/.cpp`, which `IccApplyProfiles` also links. Different blast radius, so it belongs in its own PR.
