### PR TITLE
refactor(#2154): give the eight exported IccProfLib globals real dllexport/dllimport

### DIFF
--- a/Build/Cmake/IccProfLib/CMakeLists.txt
+++ b/Build/Cmake/IccProfLib/CMakeLists.txt
@@ -183,6 +183,20 @@ IF(ENABLE_SHARED_LIBS)
   if(NOT MSVC)
     target_compile_definitions(${TARGET_NAME} PRIVATE ICCPROFLIBDLL_EXPORTS)
   endif()
+
+  # Exported global DATA (#2154, from #1888). WINDOWS_EXPORT_ALL_SYMBOLS below
+  # auto-exports functions but not data, so the eight ICCPROFLIB_DATA_API globals
+  # need real dllexport here and real dllimport in consumers. Kept separate from
+  # ICCPROFLIBDLL_EXPORTS so this does not flip the ~308 incomplete
+  # ICCPROFLIB_API annotations and change how every class and function exports.
+  #
+  # PRIVATE for the export side; INTERFACE for the import side so anything
+  # linking THIS shared target -- in-tree tools and find_package() consumers
+  # alike -- sees __declspec(dllimport). The static target deliberately gets
+  # neither, since a static consumer must keep a plain extern.
+  target_compile_definitions(${TARGET_NAME}
+    PRIVATE   ICCPROFLIBDLL_DATA_EXPORTS
+    INTERFACE ICCPROFLIBDLL_DATA_IMPORTS)
   if(ICC_USE_ZLIB)
     target_compile_definitions(${TARGET_NAME} PUBLIC ICC_USE_ZLIB=1)
   endif()

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4943,6 +4943,37 @@ if(WIN32)
     add_dependencies(check IccProfLib2)
   endif()
 
+  # #2154: the DLL-side counterpart to iccdev.proflib-exported-data-linkage.
+  # That test links IccProfLib2-static on Windows precisely to sidestep the
+  # exported-data problem, so it passes whether or not the eight globals carry a
+  # working dllexport/dllimport. This one links the DLL and therefore fails if
+  # the ICCPROFLIB_DATA_API annotation is lost. Out-of-tree by necessity: a link
+  # error in a target built here would fail the build rather than a test.
+  if(ENABLE_SHARED_LIBS AND TARGET IccProfLib2)
+    add_test(
+      NAME iccdev.proflib-exported-data-dll-linkage
+      COMMAND
+        "${CMAKE_COMMAND}"
+        "-DICCDEV_TEST_NAME=iccdev.proflib-exported-data-dll-linkage"
+        "-DICCDEV_TEST_OUTDIR=${ICCDEV_TEST_OUTDIR}/iccdev-proflib-exported-data-dll-linkage"
+        "-DICCDEV_REPO_ROOT=${ICCDEV_REPO_ROOT}"
+        "-DICCDEV_BUILD_DIR=${CMAKE_BINARY_DIR}"
+        "-DICCDEV_CONFIG=$<CONFIG>"
+        "-DICCDEV_ICCPROFLIB_DLL=$<TARGET_FILE:IccProfLib2>"
+        "-DICCDEV_ICCPROFLIB_IMPLIB=$<TARGET_LINKER_FILE:IccProfLib2>"
+        "-DICCDEV_GENERATOR=${CMAKE_GENERATOR}"
+        "-DICCDEV_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}"
+        "-DICCDEV_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+        -P "${CMAKE_CURRENT_LIST_DIR}/RunWindowsExportedDataLinkageTest.cmake"
+    )
+    set_tests_properties(iccdev.proflib-exported-data-dll-linkage PROPERTIES
+      WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+      TIMEOUT 180
+      LABELS "iccdev;windows;shared;linkage;issue-1888;issue-2154;regression"
+    )
+    add_dependencies(check IccProfLib2)
+  endif()
+
   if(ENABLE_SHARED_LIBS AND TARGET IccJSON2)
     add_test(
       NAME iccdev.issue-1009-iccjson-profilejson-export

--- a/Build/Cmake/Testing/RunProfLibExportedGlobalDefinitionsTest.cmake
+++ b/Build/Cmake/Testing/RunProfLibExportedGlobalDefinitionsTest.cmake
@@ -22,8 +22,9 @@
 # So this audit derives the list from the headers instead of restating it:
 #
 #   1. scan the given headers for exported-global declarations, accepting both
-#      macro orderings in use -- `ICCPROFLIB_API extern <type> <name>;` (the
-#      eight live globals) and `extern ICCPROFLIB_API <type> <name>;` (which is
+#      macro orderings in use -- `ICCPROFLIB_DATA_API extern <type> <name>;` (the
+#      eight live globals, moved off ICCPROFLIB_API by #2154 so they can carry
+#      real dllexport/dllimport) and `extern ICCPROFLIB_API <type> <name>;` (which is
 #      how icInfo was spelled, and is itself a sign it was never touched when
 #      the others were);
 #   2. read the symbol table of the library those headers describe;
@@ -75,7 +76,7 @@ foreach(_header IN LISTS HEADERS)
   get_filename_component(_header_name "${_header}" NAME)
 
   foreach(_line IN LISTS _lines)
-    if(NOT _line MATCHES "^[ \t]*(ICCPROFLIB_API[ \t]+extern|extern[ \t]+ICCPROFLIB_API)[ \t]+(.+)$")
+    if(NOT _line MATCHES "^[ \t]*(ICCPROFLIB_API[ \t]+extern|ICCPROFLIB_DATA_API[ \t]+extern|extern[ \t]+ICCPROFLIB_API|extern[ \t]+ICCPROFLIB_DATA_API)[ \t]+(.+)$")
       continue()
     endif()
     set(_decl "${CMAKE_MATCH_2}")
@@ -217,7 +218,7 @@ if(_missing)
   string(REPLACE ";" "\n  " _missing_text "${_missing}")
   message(FATAL_ERROR
     "[proflib-exported-global-definitions] FAIL: the following global(s) are "
-    "declared ICCPROFLIB_API extern in the public headers but defined nowhere "
+    "declared ICCPROFLIB_API/ICCPROFLIB_DATA_API extern in the public headers but defined nowhere "
     "in ${LIBRARY}:\n  ${_missing_text}\n"
     "Any consumer that references one gets an unresolved external on every "
     "platform. Either define it in the corresponding .cpp or remove the "

--- a/Build/Cmake/Testing/RunWindowsExportedDataLinkageTest.cmake
+++ b/Build/Cmake/Testing/RunWindowsExportedDataLinkageTest.cmake
@@ -1,0 +1,255 @@
+#################################################################################
+# Windows DLL data-linkage regression for the eight exported IccProfLib globals
+# Copyright (c) 2026 The International Color Consortium.
+#                                        All rights reserved.
+#################################################################################
+#
+# #2154 (from #1888). WINDOWS_EXPORT_ALL_SYMBOLS auto-exports functions but not
+# data, so before the eight exported globals carried ICCPROFLIB_DATA_API a
+# consumer of IccProfLib2.dll referencing one of them failed to link with
+# LNK2019/LNK2001 while every function in the same header thunked normally.
+#
+# The tree's existing answer is to avoid the DLL: three tools and
+# iccdev.proflib-exported-data-linkage link IccProfLib2-static on Windows shared
+# builds instead. That workaround means no test exercised data linkage against
+# the DLL at all, so the defect could neither fail nor be shown fixed.
+#
+# This builds the consumer OUT OF TREE, configured and compiled at test time.
+# That is deliberate and is the only shape that works: a link error in a target
+# built by the main tree fails the BUILD, not a test, so it could never be
+# expressed as a failing CTest.  Modelled on RunWindowsSharedExportTest.cmake
+# (iccdev.issue-987-shared-mpe-export), which exercises a member FUNCTION across
+# the same boundary.
+
+set(_required_vars
+  ICCDEV_TEST_NAME
+  ICCDEV_TEST_OUTDIR
+  ICCDEV_REPO_ROOT
+  ICCDEV_BUILD_DIR
+  ICCDEV_CONFIG
+  ICCDEV_ICCPROFLIB_DLL
+  ICCDEV_ICCPROFLIB_IMPLIB
+  ICCDEV_GENERATOR
+)
+
+foreach(_required_var IN LISTS _required_vars)
+  if(NOT DEFINED ${_required_var} OR "${${_required_var}}" STREQUAL "")
+    message(FATAL_ERROR "${_required_var} is required")
+  endif()
+endforeach()
+
+if(NOT EXISTS "${ICCDEV_ICCPROFLIB_DLL}")
+  message(FATAL_ERROR "IccProfLib DLL not found: ${ICCDEV_ICCPROFLIB_DLL}")
+endif()
+
+if(NOT EXISTS "${ICCDEV_ICCPROFLIB_IMPLIB}")
+  message(FATAL_ERROR "IccProfLib import library not found: ${ICCDEV_ICCPROFLIB_IMPLIB}")
+endif()
+
+file(REMOVE_RECURSE "${ICCDEV_TEST_OUTDIR}")
+file(MAKE_DIRECTORY "${ICCDEV_TEST_OUTDIR}")
+set(_log_file "${ICCDEV_TEST_OUTDIR}/output.log")
+
+# Same %TEMP% relocation and path-digest rationale as
+# RunWindowsSharedExportTest.cmake: the nested configure pushes several levels
+# deeper and the 260-character limit still applies, and the digest keeps two
+# build trees at one configuration from clearing each other's sources.
+set(_consumer_root "${ICCDEV_TEST_OUTDIR}/consumer-work")
+if(DEFINED ENV{TEMP} AND NOT "$ENV{TEMP}" STREQUAL "")
+  string(SHA256 _consumer_hash "${ICCDEV_BUILD_DIR}|${ICCDEV_TEST_NAME}|${ICCDEV_CONFIG}")
+  string(SUBSTRING "${_consumer_hash}" 0 12 _consumer_hash)
+  set(_consumer_root "$ENV{TEMP}/iccdev-expdata-${_consumer_hash}")
+endif()
+set(_consumer_src_dir "${_consumer_root}/consumer")
+set(_consumer_build_dir "${_consumer_root}/consumer-build")
+file(REMOVE_RECURSE "${_consumer_root}")
+file(MAKE_DIRECTORY "${_consumer_src_dir}")
+
+# ICCPROFLIBDLL_DATA_IMPORTS only -- deliberately NOT ICCPROFLIBDLL_IMPORTS.
+# That mirrors exactly what a real consumer receives: the shared IccProfLib
+# target carries the data import define as INTERFACE, and nothing sets the
+# whole-API one. Setting both here would test a configuration no consumer uses.
+file(WRITE "${_consumer_src_dir}/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.18...3.29)
+project(IccDevExportedDataConsumer LANGUAGES CXX)
+
+add_library(IccProfLib2Runtime SHARED IMPORTED GLOBAL)
+set_target_properties(IccProfLib2Runtime PROPERTIES
+  IMPORTED_IMPLIB "${ICCPROFLIB_IMPLIB}"
+  IMPORTED_LOCATION "${ICCPROFLIB_DLL}"
+  INTERFACE_COMPILE_DEFINITIONS "ICCPROFLIBDLL_DATA_IMPORTS"
+  INTERFACE_INCLUDE_DIRECTORIES "${ICCDEV_BUILD_DIR}/IccProfLib;${ICCDEV_REPO_ROOT}/IccProfLib;${ICCDEV_REPO_ROOT}"
+)
+
+add_executable(iccdev-exported-data-consumer iccdev-exported-data-consumer.cpp)
+target_compile_features(iccdev-exported-data-consumer PRIVATE cxx_std_17)
+target_link_libraries(iccdev-exported-data-consumer PRIVATE IccProfLib2Runtime)
+
+add_custom_command(TARGET iccdev-exported-data-consumer POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+    "${ICCPROFLIB_DLL}"
+    "$<TARGET_FILE_DIR:iccdev-exported-data-consumer>"
+)
+]=])
+
+file(WRITE "${_consumer_src_dir}/iccdev-exported-data-consumer.cpp" [=[
+// Reference every one of the eight exported IccProfLib globals across the DLL
+// boundary. The LINK is the assertion this test exists for; the value checks
+// then confirm the data actually crossed intact rather than resolving to a
+// second copy. Values are pinned by iccdev.proflib-exported-data-linkage.
+#include "IccUtil.h"
+#include "IccSolve.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+
+static int gFailures = 0;
+
+static void expectNear(const char *what, double got, double want)
+{
+  if (std::fabs(got - want) > 1e-4) {
+    std::fprintf(stderr, "FAIL %s: got %f want %f\n", what, got, want);
+    ++gFailures;
+  }
+}
+
+static void expectText(const char *what, const char *got, const char *want)
+{
+  if (!got || std::strcmp(got, want) != 0) {
+    std::fprintf(stderr, "FAIL %s: got '%s' want '%s'\n", what, got ? got : "(null)", want);
+    ++gFailures;
+  }
+}
+
+int main()
+{
+  expectNear("icD50XYZ[0]", icD50XYZ[0], 0.9642);
+  expectNear("icD50XYZ[1]", icD50XYZ[1], 1.0000);
+  expectNear("icD50XYZ[2]", icD50XYZ[2], 0.8249);
+
+  expectNear("icD50XYZxx[0]", icD50XYZxx[0], 96.42);
+  expectNear("icD50XYZxx[1]", icD50XYZxx[1], 100.00);
+  expectNear("icD50XYZxx[2]", icD50XYZxx[2], 82.49);
+
+  expectText("icMsgValidateWarning", icMsgValidateWarning, "Warning! - ");
+  expectText("icMsgValidateNonCompliant", icMsgValidateNonCompliant, "NonCompliant! - ");
+  expectText("icMsgValidateCriticalError", icMsgValidateCriticalError, "Error! - ");
+  expectText("icMsgValidateInformation", icMsgValidateInformation, "Information - ");
+
+  if (!g_pIccMatrixSolver) {
+    std::fprintf(stderr, "FAIL g_pIccMatrixSolver is null\n");
+    ++gFailures;
+  }
+  if (!g_pIccMatrixInverter) {
+    std::fprintf(stderr, "FAIL g_pIccMatrixInverter is null\n");
+    ++gFailures;
+  }
+
+  if (gFailures) {
+    std::fprintf(stderr, "exported-data-consumer: %d failure(s)\n", gFailures);
+    return 1;
+  }
+
+  std::printf("exported-data-consumer: all 8 globals linked and matched\n");
+  return 0;
+}
+]=])
+
+set(_configure_args
+  -S "${_consumer_src_dir}"
+  -B "${_consumer_build_dir}"
+  -G "${ICCDEV_GENERATOR}"
+  "-DICCDEV_REPO_ROOT=${ICCDEV_REPO_ROOT}"
+  "-DICCDEV_BUILD_DIR=${ICCDEV_BUILD_DIR}"
+  "-DICCPROFLIB_IMPLIB=${ICCDEV_ICCPROFLIB_IMPLIB}"
+  "-DICCPROFLIB_DLL=${ICCDEV_ICCPROFLIB_DLL}"
+)
+if(DEFINED ICCDEV_GENERATOR_PLATFORM AND NOT "${ICCDEV_GENERATOR_PLATFORM}" STREQUAL "")
+  list(APPEND _configure_args -A "${ICCDEV_GENERATOR_PLATFORM}")
+endif()
+if(DEFINED ICCDEV_CXX_COMPILER AND NOT "${ICCDEV_CXX_COMPILER}" STREQUAL "")
+  list(APPEND _configure_args "-DCMAKE_CXX_COMPILER=${ICCDEV_CXX_COMPILER}")
+endif()
+if(NOT ICCDEV_GENERATOR MATCHES "Visual Studio|Xcode|Multi-Config")
+  list(APPEND _configure_args "-DCMAKE_BUILD_TYPE=${ICCDEV_CONFIG}")
+endif()
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" ${_configure_args}
+  RESULT_VARIABLE _configure_result
+  OUTPUT_VARIABLE _configure_stdout
+  ERROR_VARIABLE _configure_stderr
+)
+
+execute_process(
+  COMMAND "${CMAKE_COMMAND}" --build "${_consumer_build_dir}" --config "${ICCDEV_CONFIG}" --parallel
+  RESULT_VARIABLE _build_result
+  OUTPUT_VARIABLE _build_stdout
+  ERROR_VARIABLE _build_stderr
+)
+
+set(_consumer_exe "${_consumer_build_dir}/iccdev-exported-data-consumer.exe")
+if(NOT EXISTS "${_consumer_exe}" AND NOT "${ICCDEV_CONFIG}" STREQUAL "")
+  set(_consumer_exe "${_consumer_build_dir}/${ICCDEV_CONFIG}/iccdev-exported-data-consumer.exe")
+endif()
+
+set(_consumer_result "not run")
+set(_consumer_stdout "")
+set(_consumer_stderr "")
+if(_build_result EQUAL 0 AND EXISTS "${_consumer_exe}")
+  get_filename_component(_dll_dir "${ICCDEV_ICCPROFLIB_DLL}" DIRECTORY)
+  execute_process(
+    COMMAND
+      "${CMAKE_COMMAND}" -E env
+        "PATH=${_dll_dir};$ENV{PATH}"
+        "${_consumer_exe}"
+    RESULT_VARIABLE _consumer_result
+    OUTPUT_VARIABLE _consumer_stdout
+    ERROR_VARIABLE _consumer_stderr
+  )
+endif()
+
+file(WRITE "${_log_file}"
+  "CTest test: ${ICCDEV_TEST_NAME}\n"
+  "Configuration: ${ICCDEV_CONFIG}\n"
+  "DLL: ${ICCDEV_ICCPROFLIB_DLL}\n"
+  "Import library: ${ICCDEV_ICCPROFLIB_IMPLIB}\n\n"
+  "----- consumer configure stdout -----\n${_configure_stdout}\n"
+  "----- consumer configure stderr -----\n${_configure_stderr}\n"
+  "----- consumer build stdout -----\n${_build_stdout}\n"
+  "----- consumer build stderr -----\n${_build_stderr}\n"
+  "----- consumer stdout -----\n${_consumer_stdout}\n"
+  "----- consumer stderr -----\n${_consumer_stderr}\n"
+)
+message(STATUS "Wrote ${ICCDEV_TEST_NAME} log to ${_log_file}")
+
+if(NOT _configure_result EQUAL 0)
+  message(FATAL_ERROR "Consumer configure failed with ${_configure_result}; see ${_log_file}")
+endif()
+
+# The expected pre-fix failure mode. Name it explicitly so a future reader does
+# not have to rediscover that LNK2019 here means exported data, not a missing
+# function: WINDOWS_EXPORT_ALL_SYMBOLS covers functions and never covered data.
+if(NOT _build_result EQUAL 0)
+  message(FATAL_ERROR
+    "Consumer failed to link against ${ICCDEV_ICCPROFLIB_DLL} (result ${_build_result}).\n"
+    "If this is LNK2019/LNK2001 on one of the eight exported globals, the "
+    "ICCPROFLIB_DATA_API dllexport/dllimport annotation has been lost -- see "
+    "IccProfLib/IccProfLibConf.h and Build/Cmake/IccProfLib/CMakeLists.txt (#2154).\n"
+    "See ${_log_file}")
+endif()
+
+if(NOT EXISTS "${_consumer_exe}")
+  message(FATAL_ERROR "Consumer executable not found: ${_consumer_exe}; see ${_log_file}")
+endif()
+
+if(NOT _consumer_result EQUAL 0)
+  message(FATAL_ERROR "Consumer exited with ${_consumer_result}; see ${_log_file}")
+endif()
+
+if(NOT _consumer_stdout MATCHES "all 8 globals linked and matched")
+  message(FATAL_ERROR "Consumer did not confirm all eight globals; see ${_log_file}")
+endif()
+
+message(STATUS "${ICCDEV_TEST_NAME} completed successfully")

--- a/IccProfLib/IccProfLibConf.h
+++ b/IccProfLib/IccProfLibConf.h
@@ -103,6 +103,28 @@ namespace iccDEV {
     #define ICCPROFLIB_EXTERN extern
   #endif
 
+  // Exported global *data* needs its own annotation (#2154, from #1888).
+  //
+  // A shared MSVC build exports through CMake's WINDOWS_EXPORT_ALL_SYMBOLS
+  // rather than __declspec, because ICCPROFLIB_API annotation is incomplete
+  // (~308 partial uses across 43 headers) -- see Build/Cmake/IccProfLib/
+  // CMakeLists.txt and the #764 decision recorded there. That auto-exports
+  // functions but NOT data, so a consumer referencing one of the eight
+  // exported globals emitted a direct data reference with no __imp_
+  // indirection and failed to link (LNK2019/LNK2001) while every function in
+  // the same header thunked normally.
+  //
+  // ICCPROFLIB_DATA_API is deliberately separate from ICCPROFLIB_API so the
+  // data symbols can carry real dllexport/dllimport without flipping those 308
+  // annotations, which would change how every class and function is exported.
+  #if defined(ICCPROFLIBDLL_EXPORTS) || defined(ICCPROFLIBDLL_DATA_EXPORTS)
+    #define ICCPROFLIB_DATA_API __declspec(dllexport)
+  #elif defined(ICCPROFLIBDLL_IMPORTS) || defined(ICCPROFLIBDLL_DATA_IMPORTS)
+    #define ICCPROFLIB_DATA_API __declspec(dllimport)
+  #else //static lib, or a consumer of one
+    #define ICCPROFLIB_DATA_API
+  #endif
+
   //Since msvc doesn't support cbrtf use pow instead
   #define ICC_CBRTF(v) pow((double)(v), 1.0/3.0)
 
@@ -150,6 +172,14 @@ namespace iccDEV {
   #else
     #define ICCPROFLIB_API
     #define ICCPROFLIB_EXTERN extern
+  #endif
+
+  // See the MSVC arm above. There is no import-library model here, so data and
+  // functions link the same way and this only needs to track ICCPROFLIB_API.
+  #if defined(ICCPROFLIBDLL_EXPORTS) || defined(ICCPROFLIBDLL_DATA_EXPORTS)
+    #define ICCPROFLIB_DATA_API __attribute__((visibility("default")))
+  #else
+    #define ICCPROFLIB_DATA_API
   #endif
   #define stricmp strcasecmp
   #define strnicmp strncasecmp

--- a/IccProfLib/IccSolve.cpp
+++ b/IccProfLib/IccSolve.cpp
@@ -137,7 +137,7 @@ public:
 CIccEigenMatrixSolver g_EigenSolver;
 
 //Define the global g_pIccMatrixSolver variable pointer
-ICCPROFLIB_API IIccMatrixSolver *g_pIccMatrixSolver = &g_EigenSolver;
+ICCPROFLIB_DATA_API IIccMatrixSolver *g_pIccMatrixSolver = &g_EigenSolver;
 
 #else
 
@@ -183,7 +183,7 @@ public:
 CIccSimpleMatrixSolver g_SimpleSolver;
 
 //Define the global g_pIccMatrixSolver variable pointer
-ICCPROFLIB_API IIccMatrixSolver *g_pIccMatrixSolver = &g_SimpleSolver;
+ICCPROFLIB_DATA_API IIccMatrixSolver *g_pIccMatrixSolver = &g_SimpleSolver;
 
 #endif
 
@@ -256,7 +256,7 @@ public:
 CIccSimpleMatrixInverter g_SimpleInverter;
 
 //Define the global g_pIccMatrixSolver variable pointer
-ICCPROFLIB_API IIccMatrixInverter *g_pIccMatrixInverter = &g_SimpleInverter;
+ICCPROFLIB_DATA_API IIccMatrixInverter *g_pIccMatrixInverter = &g_SimpleInverter;
 
 
 

--- a/IccProfLib/IccSolve.h
+++ b/IccProfLib/IccSolve.h
@@ -118,7 +118,7 @@ public:
 // installing its own solver against IccProfLib2.dll gets LNK2019. Prefer the
 // IccSetMatrixSolver() setter below, which is a function and therefore links
 // normally. See #1888.
-ICCPROFLIB_API extern IIccMatrixSolver *g_pIccMatrixSolver;
+ICCPROFLIB_DATA_API extern IIccMatrixSolver *g_pIccMatrixSolver;
 
 /**
 ****************************************************************************
@@ -182,7 +182,7 @@ public:
 */
 // Exported DATA: not linkable from outside the library on Windows shared
 // builds; prefer IccSetMatrixInverter(). See g_pIccMatrixSolver above and #1888.
-ICCPROFLIB_API extern IIccMatrixInverter *g_pIccMatrixInverter;
+ICCPROFLIB_DATA_API extern IIccMatrixInverter *g_pIccMatrixInverter;
 
 /**
 ****************************************************************************

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -90,10 +90,10 @@
 namespace iccDEV {
 #endif
 
-ICCPROFLIB_API const char *icMsgValidateWarning = "Warning! - ";
-ICCPROFLIB_API const char *icMsgValidateNonCompliant = "NonCompliant! - ";
-ICCPROFLIB_API const char *icMsgValidateCriticalError = "Error! - ";
-ICCPROFLIB_API const char* icMsgValidateInformation = "Information - ";
+ICCPROFLIB_DATA_API const char *icMsgValidateWarning = "Warning! - ";
+ICCPROFLIB_DATA_API const char *icMsgValidateNonCompliant = "NonCompliant! - ";
+ICCPROFLIB_DATA_API const char *icMsgValidateCriticalError = "Error! - ";
+ICCPROFLIB_DATA_API const char* icMsgValidateInformation = "Information - ";
 
 
 /**
@@ -815,8 +815,8 @@ icFloatNumber icU8toAB(icUInt8Number num)
   return (icFloatNumber)num - 128.0f;
 }
 
-ICCPROFLIB_API icFloatNumber icD50XYZ[3] = { 0.9642f, 1.0000f, 0.8249f };
-ICCPROFLIB_API icFloatNumber icD50XYZxx[3] = { 96.42f, 100.00f, 82.49f };
+ICCPROFLIB_DATA_API icFloatNumber icD50XYZ[3] = { 0.9642f, 1.0000f, 0.8249f };
+ICCPROFLIB_DATA_API icFloatNumber icD50XYZxx[3] = { 96.42f, 100.00f, 82.49f };
 
 static icFloatNumber icSafeXYZRatio(icFloatNumber value, icFloatNumber white)
 {

--- a/IccProfLib/IccUtil.h
+++ b/IccProfLib/IccUtil.h
@@ -135,8 +135,8 @@ ICCPROFLIB_API icFloatNumber icU8toAB(icUInt8Number num);
 
 // Exported DATA: not linkable from outside the library on Windows shared
 // builds. See the note beside icMsgValidateWarning below and #1888.
-ICCPROFLIB_API extern icFloatNumber icD50XYZ[3];
-ICCPROFLIB_API extern icFloatNumber icD50XYZxx[3];
+ICCPROFLIB_DATA_API extern icFloatNumber icD50XYZ[3];
+ICCPROFLIB_DATA_API extern icFloatNumber icD50XYZxx[3];
 
 ICCPROFLIB_API void icNormXYZ(icFloatNumber *XYZ, icFloatNumber *WhiteXYZ=NULL);
 ICCPROFLIB_API void icDeNormXYZ(icFloatNumber *XYZ, icFloatNumber *WhiteXYZ=NULL);
@@ -211,10 +211,10 @@ ICCPROFLIB_API icUInt8Number icGetStorageTypeBytes(icUInt16Number nStorageType);
 // they also link IccXML. The literals are pinned by
 // .github/ci/regression/proflib-exported-data-linkage.cpp -- update it if these
 // strings change.
-ICCPROFLIB_API extern const char *icMsgValidateWarning;
-ICCPROFLIB_API extern const char *icMsgValidateNonCompliant;
-ICCPROFLIB_API extern const char *icMsgValidateCriticalError;
-ICCPROFLIB_API extern const char* icMsgValidateInformation;
+ICCPROFLIB_DATA_API extern const char *icMsgValidateWarning;
+ICCPROFLIB_DATA_API extern const char *icMsgValidateNonCompliant;
+ICCPROFLIB_DATA_API extern const char *icMsgValidateCriticalError;
+ICCPROFLIB_DATA_API extern const char* icMsgValidateInformation;
 
 #ifdef ICC_BYTE_ORDER_LITTLE_ENDIAN
 inline void icSwab16Ptr(void *pVoid)


### PR DESCRIPTION
Part of #2154 — item 2, the `ICCPROFLIB_API` export surface. Follows #2198 and #2206.

`WINDOWS_EXPORT_ALL_SYMBOLS` auto-exports **functions but not data**. A consumer of `IccProfLib2.dll` referencing one of the eight exported globals therefore emitted a direct data reference with no `__imp_` indirection and failed to link with `LNK2019`/`LNK2001`, while every function in the same header thunked normally (#1888).

The tree's existing answer is to avoid the DLL: three tools and `iccdev.proflib-exported-data-linkage` link `IccProfLib2-static` on Windows shared builds instead. That is deliberate and documented, and it is why **no test exercised data linkage against the DLL at all** — so the defect could neither fail nor be shown fixed.

This gives those eight symbols a real annotation, and adds the test that proves it.

## Red / green

Same test, same leg, same test number. The only difference between the two branches is the `ICCPROFLIB_DATA_API` commit.

| | run | Windows MSVC + ClangCL |
| --- | --- | --- |
| **RED** — test alone, no fix | [32425775267](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32425775267) | `6/101 Test #6 ***Failed 3.21 sec`, "Consumer failed to link against …" — **the only failure of 101** |
| **GREEN** — fix + test | [32428735140](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32428735140) | `7/102 Test #7 Passed 3.39 sec` — **100% passed, 0 failed of 102** |

## Why a separate macro

`ICCPROFLIB_DATA_API` is deliberately **not** `ICCPROFLIB_API`. Reusing the latter would turn all ~308 partial annotations across 43 headers into real `dllexport`/`dllimport` and change how every class and function in the library is exported — a far larger change, and the one called out as a big project. Keeping the data macro separate confines this to the eight symbols that actually need it.

- `PRIVATE ICCPROFLIBDLL_DATA_EXPORTS` on the shared target for the export side.
- `INTERFACE ICCPROFLIBDLL_DATA_IMPORTS` for the import side, so in-tree tools and `find_package()` consumers alike see `__declspec(dllimport)`.
- The **static target gets neither**, so a static consumer keeps a plain `extern` and the existing fallback still links unchanged.

Eight declarations, **nine definition sites** — `g_pIccMatrixSolver` is defined twice under mutually exclusive `#if` arms (Eigen and Simple solvers).

Combining explicit `dllexport` with `WINDOWS_EXPORT_ALL_SYMBOLS`, which generates its own `.def`, does **not** produce `LNK4197` here. That was the unknown that could not be settled locally.

## The test has to be out-of-tree

A link error in a target built by the main tree fails the **build**, not a test. That is precisely why no in-tree failing test for this was ever possible, and why the workaround exists instead. `RunWindowsExportedDataLinkageTest.cmake` configures and compiles a consumer at test time, so `LNK2019` becomes a CTest failure. It is modelled on `RunWindowsSharedExportTest.cmake` (`iccdev.issue-987-shared-mpe-export`), which crosses the same boundary but only exercises a member function.

The consumer sets `ICCPROFLIBDLL_DATA_IMPORTS` and deliberately **not** `ICCPROFLIBDLL_IMPORTS`, mirroring exactly what a real consumer receives; setting both would test a configuration nobody uses. It references all eight globals and then checks their values, so a link that silently resolved to a second copy would still fail.

Windows-only, like its #987 sibling — there is no import-library model elsewhere and the consumer would link either way.

## One existing test needed teaching

`iccdev.proflib-exported-global-definitions` audits every `ICCPROFLIB_API extern` declaration against the built symbol table. Renaming the macro would have silently emptied its scan, and **only its anti-vacuity floor (`_declared_count LESS 8` → FATAL) would have caught it.**

Its regex now matches both spellings, written as four explicit alternatives rather than `ICCPROFLIB(_DATA)?_API` — CMake has no non-capturing groups, and the extra group would have shifted `CMAKE_MATCH_2`, the declaration body, to `CMAKE_MATCH_4` with no error at all. Verified it still scans exactly 8, and red-tested: an `ICCPROFLIB_DATA_API extern` with no definition fails the test by name.

## Pre-flight

| lane | result |
| --- | --- |
| clang 18.1.3 strict Release | 0 warnings, 0 errors |
| GCC 15.2.0 strict Release LTO, CI's container | 0 warnings, 0 errors |
| CTest (Linux) | 189/190 |

Both configures printed `strict warnings ENABLED`. The single failure is `iccdev.spectral-tiff-preview`, which needs a Python `imagecodecs` module absent on this machine and is unrelated.

## Follow-up, deliberately not in this PR

The static-link fallbacks this makes unnecessary — three tools and `iccdev.proflib-exported-data-linkage` — can now be retired and tested. Removing them is what would prove the fix *matters* rather than merely works, but it is a separate change with its own blast radius.

This branch is **rebased** onto master `df8fe1a3` -- two commits, no merge commits -- per the repo's rebase + `--force-with-lease` convention. Squash-merging collapses that to one commit as usual.

