### PR TITLE
refactor(#2154): retire the Windows static-link fallbacks for exported IccProfLib data

### DIFF
--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -30,11 +30,12 @@ Test 18 (Regression Bisect).
 | `iccdev.mpe-empty-identity` | #1809 | `CIccTagMultiProcessElement::Validate()` raised `icValidateWarning` for a zero-element tag with equal input and output channel counts, although `Read()`/`Write()`/`Begin()`/`Apply()` all define that shape as the identity transform; 79 reference profiles under `Testing/` (148 messages) sat in the warning cohort as a result | Validates a zero-element tag through a Lab/Lab profile and asserts the equal-channel case is `icValidateOK` reported at information level, the unequal-channel case stays a critical error, and the runtime behaviour that justifies the split (`Begin()` true / `Apply()` identity for equal channels, `Begin()` false for unequal) |
 | `iccdev.xml-curve-oversize-file` | #2006 | `CIccTagCurve::SetSize()` refuses a request above its 65536-entry cap by freeing the table, setting `m_nSize` to 0 and returning `true`; the three `File=`/`Format="text"` branches of `CIccTagXmlCurve::ParseXml` checked neither the return nor the resulting size and wrote the parsed samples through `GetData(0)`, which is NULL once the table has been freed — a hand-authored profile with a 65537-entry curve table took `iccFromXml` down with SIGSEGV | Generates the table and document in a build-tree scratch directory (the `File=` attribute resolves relative to the working directory and `IccXmlIsPathSafe` rejects absolute paths), then asserts the over-cap curve is refused with a parse message, a curve of exactly 65536 entries still parses, and the same values authored inline are refused too — the branch guarded since #1158 |
 | `iccdev.mpexml-unknown-reserved` | #1886 | `CIccMpeXmlUnknown::ToXml()` formatted the `Reserved` attribute into `line` but appended `buf`, which still held the element's type signature, so the value was dropped and the signature was injected into the attribute list before the start tag closed — the emitted document did not parse; `ParseXml()` had never read `Reserved` back either | Drives the writer on an element carrying a non-zero `Reserved`, parsing the output with libxml2 rather than grepping it (the defect produced text a substring check would accept), and asserts the value survives a parse/write round-trip, an out-of-range value is refused, and a document without the attribute still reads as zero |
-| `iccdev.proflib-exported-data-linkage` | #1888 | Exported IccProfLib global *variables* could not be linked from a regression executable on Windows shared builds — `WINDOWS_EXPORT_ALL_SYMBOLS` exports functions but not data, so the first test to reference `icMsgValidate*` failed with LNK2019 on the Windows leg alone | Links the exported globals through `${ICCDEV_TEST_LIB_ICCPROFLIB}` so the Windows leg fails here if that fallback is dropped, and pins all eight exported globals — the four report prefixes, both D50 arrays and both solver pointers — so a change to any of them fails here rather than leaving the tests that keep hard-coded copies (`mpe-empty-identity.cpp`, `pawg-q4-xyz-pcs-decode.cpp`) quietly asserting stale text. A ninth declaration, `icInfo`, was excluded here because it had no definition anywhere in the tree; #1897 removed it, and `iccdev.proflib-exported-global-definitions` now guards against another appearing |
+| `iccdev.proflib-exported-data-linkage` | #1888 | Exported IccProfLib global *variables* could not be linked from a regression executable on Windows shared builds — `WINDOWS_EXPORT_ALL_SYMBOLS` exports functions but not data, so the first test to reference `icMsgValidate*` failed with LNK2019 on the Windows leg alone | Links the exported globals through `${TARGET_LIB_ICCPROFLIB}`, so on Windows the link itself asserts that the `ICCPROFLIB_DATA_API` annotation added in #2219 still holds, and pins all eight exported globals — the four report prefixes, both D50 arrays and both solver pointers — so a change to any of them fails here rather than leaving the tests that keep hard-coded copies (`mpe-empty-identity.cpp`, `pawg-q4-xyz-pcs-decode.cpp`) quietly asserting stale text. A ninth declaration, `icInfo`, was excluded here because it had no definition anywhere in the tree; #1897 removed it, and `iccdev.proflib-exported-global-definitions` now guards against another appearing |
 | `iccdev.pcc-reflectance-observer-range` | #1853 | `IIccProfileConnectionConditions::getReflectanceObserver()` applied the illuminant to the combined observer/range-map matrix, which is `rangeRef.steps` wide, rather than to the observer matrix, which is as wide as the illuminant SPD is long — so a reflectance range finer than the illuminant read past the end of the SPD (CWE-125) and every mapped range weighted the reflectance axis instead of the wavelength axis; `Mult()` returns a new matrix without consuming its operands, so the observer matrix also leaked on every mapped range, and `CIccProfile::calcMediaWhiteXYZ()` dereferenced the result without a NULL check | Pins the physical invariant that resampling a flat unit reflectance over the same wavelength span must not move the white point, comparing a matched grid against coarser and finer grids and against hand-computed XYZ; the finer grid runs first so a sanitizer build reports the overflow rather than exiting on the value mismatch, and the no-viewing-conditions case exercises the NULL fall-through |
 | `iccdev.iccviz-pdf-axis-labels` | #1712, #1777 | `DrawAxisPDF` axis-label and custom start/mid/end tick parameterization could regress silently; the CLI also confirmed nothing on a successful run | Runs `iccProfileVisualizePlot` on `sRGB_v4_ICC_preference.icc` in a freshly recreated scratch dir and asserts the emitted LUT PDF carries the axis titles plus the default (`50%`/`100%`) vs reversed (`100`/`50`) tick operators, and that the run prints a success line naming the written PDF (#1777) |
 | `iccdev.v2-legacy-pcs` | #1883 | ICC v2 encodes 16-bit PCS Lab over 0..0xff00 rather than 0..0xffff, and `CIccXform::AdjustPCS` plus the PCS step `CIccCmm::Begin()` splices onto a legacy transform select that encoding on `UseLegacyPCS()`. A clean checkout's `Testing/` corpus is 210 profiles — 208 v5 and 2 v4 — with no v2 profile at all and 0 `mft2`, 0 `mft1` tags, so every `UseLegacyPCS()==true` branch was unreachable from CI | Builds a v2 `mft2` and a v4 `mAB ` profile over identical CLUT content in memory and drives both through `CIccCmm`, asserting the neutral chroma channels come back scaled by exactly 65535/65280 and paper-white L\* expands past 1.0. Also pins the predicate per tag class (`mft2`/`ncl2` true, `mft1`/`mAB `/`mBA ` false) and that `Lab2ToLab4`/`Lab4ToLab2` are exact inverses. Needs no fixture, so a corpus change cannot silently disable it |
 | `iccdev.v2-xml-fixtures` | #1883 | `Testing/**/*.icc` is gitignored, so the tracked artifact for the new v2 corpus entries is `Testing/V2/*.xml` and the profiles are generated from them by `CreateAllProfiles.sh`. Nothing pinned that those sources stay v2: a fixture that drifted to v4 would keep parsing and validating while quietly restoring the original coverage gap | Parses each fixture through the same `CIccProfileXml::LoadXml` path `iccFromXml` uses and asserts the header is still 2.x, the `AToB0Tag` still carries the type the fixture exists to provide (`mft2`, `mft1`, or none for matrix/TRC), and the profile still validates with no critical error |
+| `iccdev.proflib-exported-data-dll-linkage` | #2154 | The workaround for #1888 was to avoid the DLL — three tools and `iccdev.proflib-exported-data-linkage` linked `IccProfLib2-static` on Windows shared builds — so nothing exercised data linkage against `IccProfLib2.dll` at all and the defect could neither fail nor be shown fixed | Configures and compiles a consumer **out of tree** at test time against the built DLL and its import library, with `ICCPROFLIBDLL_DATA_IMPORTS` only, exactly as a `find_package()` consumer receives it. References all eight globals and checks their values, so a lost `ICCPROFLIB_DATA_API` annotation surfaces as one failing test naming the `LNK2019` rather than taking the Windows build down. Out of tree by necessity: a link error in a target the main tree builds fails the BUILD, not a test. Windows shared builds only |
 | `iccdev.proflib-exported-global-definitions` | #1897 | `IccUtil.h` declared `extern ICCPROFLIB_API CIccInfo icInfo;` from the 2015 import and nothing ever defined it. Nothing in-tree referenced it either, so no build ever attempted to resolve the symbol and CI stayed green for ten years while the public header promised a global that no consumer could link on any platform | Derives the list of exported globals from the headers rather than restating it — every `ICCPROFLIB_API extern` declaration in `IccUtil.h` and `IccSolve.h`, in both macro orderings — reads the built library's symbol table with `nm`, and fails naming any declared global the library does not define. Refuses to report success if the header scan finds fewer than 8 declarations or if the control symbol `icMsgValidateWarning` is absent, so a broken scan cannot pass vacuously. Skipped where `nm` is unavailable (MSVC); a missing definition is missing on every platform, so the Linux and macOS legs cover it |
 | `iccdev.struct-name-spelling` | #2028 | `g_icStructNames` listed `icSigBRDFStruct` and `icSigColorantInfoStruct` twice each with the wrong spelling first, and `GetStructSigName` returns the first match — so `brdfTransfromStructure` and `colorantInfoStruct` were published while the second entry for the same signature was reachable only on read. For `brdf` that broke JSON round-tripping outright: `CIccTagJsonStruct::ToJson` writes `GetDisplayName()`, which has always returned the correct `brdfTransformStructure`, and `ParseJson` reads back through this table, so the string iccDEV emitted matched neither entry — `sigStruct` stayed 0, `SetTagStructType` was never called, nothing was appended to `parseStr`, and the tag was rewritten as `privateStruct` with signature `NULL` while `iccFromJson` reported "Profile parsed and saved correctly". XML broke too and louder: `ToXml` emits the same display name as the element name, and `ParseXml`'s `<StructureSignature>` fallback is a form only hand-authored documents carry, so it could not fire — `Unable to find StructureSignature` and the whole document refused to load. Neither had a fixture: there is no BRDF struct tag anywhere in `Testing/` in either format, the three `<StructureSignature>brdf` references all sitting inside commented-out examples | Asserts the corrected name is the one published, that both legacy `brdf` spellings and `colorantInfoStruct` still resolve through the read-only `g_icAltStructNames` without ever being emitted again, and — the check nothing else made — that the factory table and `GetDisplayName()` agree and round-trip for **every** struct signature, not just the two corrected. Controls cover the six siblings that already agreed, an unknown name, and the empty string |
 | `iccdev.chromaticity-validate-oob` | #2094, #2106 | `CIccTagChromaticity::Validate()` checked that the tag carries three channels, reported anything else as a critical error, and then fell through into the colorant-encoding switch anyway — which compares `m_xy[0]`, `m_xy[1]` and `m_xy[2]` against three fixed xy pairs. On a shorter tag that is a 4-byte heap read past the end of the array (CWE-125); ASan puts it at `IccTagBasic.cpp:4563`, 0 bytes after the 8-byte region `SetSize()` allocated at `IccTagBasic.cpp:4514`. All three readers produce such a tag: `Read()` sizes the array from the tag's declared *size* — `nNum = (size - 12) / 8`, with the declared channel count only required not to exceed it and then discarded by `SetSize(nNum)`; `CIccTagXmlChromaticity::ParseXml()` sizes it from the number of `<Channel>` elements; and `CIccTagJsonChromaticity::ParseJson()` from the length of the `channels` array. So a 20-byte `chromaticityTag`, one `<Channel>`, or one `channels` entry is enough. Two more defects in the same class sit behind it — the constructor clamped the channel *count* up to three while allocating the caller's raw `nSize`, so `CIccTagChromaticity(1)` was a three-channel tag over a one-entry array before anything was parsed, and neither the copy constructor nor `operator=` copied `m_nColorantType` while the default constructor never initialised it (CWE-457, the #2000 defect in another tag), so a copied tag switched on an indeterminate encoding. No `chromaticityTag` exists anywhere in the corpus — not in the 208 tracked XML documents, the 105 tracked `.icc` files, or the 254 profiles `CreateAllProfiles.sh` generates under `Testing/` — so none of it had coverage | Validates one- and two-channel tags carrying the *correct* ITU values for the entries they do have — so the encoding mismatch can only be reported by reading entries that are not there — and asserts the count error is raised and the comparison does not run. Controls pin that a conforming three-channel ITU tag still validates OK, that wrong values in a full-length tag are still reported non-compliant (or the fix would "work" by disabling the check), and that a short tag claiming no encoding is still left alone. Also pins the constructor invariant and the encoding surviving copy construction, `NewCopy()` and `operator=`, with a non-zero fixture: measured against the unfixed library the lost member reads back as 0, which an `icColorantUnknown` fixture would have accepted. Levels 9-13 cover the #2106 punch-list item on the same tag's read path: `Read()` sized the tag from the tag-table size rather than from the channel count the element declares, so a three-channel tag inside a 92-byte element became a ten-channel tag and `Write()` re-emitted ten, persisting the rewrite for anything that round-tripped the profile — and with no colorant encoding claimed `Validate()` reports nothing, so it was silent end to end. `CIccTagNamedColor2::Read` faces the same two-source situation and uses its size-derived count only as a capacity guard. Controls pin that an element too short for its declared count is still rejected and that a padded element still parses at its declared count; a further level pins the one deliberate acceptance change, an element declaring zero channels |
@@ -64,18 +65,20 @@ Test 18 (Regression Bisect).
 | `.github/workflows/ci-pr-win.yml` | MinGW toolchain | Keep normal Windows PR CI from regressing MinGW CMake/tool support | Runs a UCRT64 MinGW Release static build and the full registered MinGW CTest set, including `iccdev.windows-icc-dump-profile-smoke` and `iccdev.iccconnect-threaded-cmm` |
 | `.github/workflows/ci-pr-win.yml` | #1025, #1036 | Keep Windows ClangCL warning output focused on source signal instead of known CRT/deprecation noise | Runs the ClangCL smoke build with ClangCL-only noise-control flags, classifies warning categories, and uploads sanitized warning logs |
 
-## Referencing exported IccProfLib globals (#1888)
+## Referencing exported IccProfLib globals (#1888, fixed in #2219)
 
-A test may call any exported IccProfLib **function** freely. Referencing an
-exported global **variable** is different, and gets it wrong on Windows only.
+A test may reference any exported IccProfLib **function or global variable**
+freely: link `${TARGET_LIB_ICCPROFLIB}` and include the header. Nothing special
+is required. The rest of this section is why that sentence is short, and what to
+do if a Windows leg ever contradicts it.
 
 On a Windows shared build the library is `IccProfLib2.dll`, exported by CMake's
 `WINDOWS_EXPORT_ALL_SYMBOLS` rather than by `__declspec` annotations — MSVC is
 deliberately excluded from the `ICCPROFLIBDLL_EXPORTS` definition, a decision
 taken in #764. That mechanism auto-exports functions but **not global data**, and
-IccProfLib carries no `dllexport`/`dllimport` on its variables. A test compiling
-with `ICCPROFLIB_API` empty therefore emits a direct data reference with no
-`__imp_` indirection, and the link fails:
+IccProfLib carried no `dllexport`/`dllimport` on its variables. A test compiling
+with `ICCPROFLIB_API` empty therefore emitted a direct data reference with no
+`__imp_` indirection, and the link failed:
 
 ```
 mpe-empty-identity.obj : error LNK2019: unresolved external symbol
@@ -83,10 +86,19 @@ mpe-empty-identity.obj : error LNK2019: unresolved external symbol
 fatal error LNK1120: 3 unresolved externals
 ```
 
-Linux and macOS have no import-library model, so **a green local pre-flight will
-not catch this** — only the Windows CI leg will.
+Linux and macOS have no import-library model, so **a green local pre-flight
+would not have caught it** — only the Windows CI leg did.
 
-The eight affected symbols:
+#2219 fixed it. The eight globals carry `ICCPROFLIB_DATA_API` — a macro kept
+separate from `ICCPROFLIB_API` so real `dllexport`/`dllimport` could be added
+without flipping the ~308 incomplete `ICCPROFLIB_API` annotations. The shared
+target defines `ICCPROFLIBDLL_DATA_EXPORTS` `PRIVATE` and
+`ICCPROFLIBDLL_DATA_IMPORTS` `INTERFACE`, so linking it is all a consumer needs
+to do. #2154 then retired the workarounds this section used to prescribe: the
+`${ICCDEV_TEST_LIB_ICCPROFLIB}` indirection is gone, and the three tools that
+linked `IccProfLib2-static` on Windows link the DLL like everything else.
+
+The eight symbols:
 
 | Symbol | Header |
 |---|---|
@@ -102,27 +114,24 @@ construct a `CIccInfo` where one is needed. `iccdev.proflib-exported-global-defi
 audits the headers against the built library so another one cannot appear
 unnoticed.
 
-Choose by what else the test links:
+Two CTests hold the fix in place, and they fail differently on purpose:
 
-- **IccProfLib only** — link `${ICCDEV_TEST_LIB_ICCPROFLIB}` instead of
-  `${TARGET_LIB_ICCPROFLIB}`. It resolves to the static library on Windows shared
-  builds, the same fallback `iccDumpProfile`, `iccProfilePlot` and
-  `wxProfileDump` already use.
-- **Also links IccXML or IccJson** — you cannot use that fallback. Those
-  libraries link `${TARGET_LIB_ICCPROFLIB}` `PUBLIC`, so pulling in the static
-  IccProfLib as well would load the library twice in one process, once inside
-  the DLL and once in the executable, giving two copies of its globals. Assert on
-  literal values instead. The tests in that position today are
-  `json-sparsematrix-huaf.cpp`, `xml-writer-graceful-degrade.cpp` and
-  `json-bcd-version-parse.cpp`.
+- `iccdev.proflib-exported-data-linkage` — in-tree, every platform. References
+  all eight globals and pins their values. On Windows its **link** is the
+  assertion, which means a lost annotation takes the whole build down rather
+  than turning one test red.
+- `iccdev.proflib-exported-data-dll-linkage` — Windows shared builds. Configures
+  and compiles a consumer **out of tree** at test time against the built DLL and
+  its import library, so the same loss surfaces as one failing test with the
+  `LNK2019` in its log. An in-tree target could never express that.
 
-`mpe-empty-identity.cpp` and `pawg-q4-xyz-pcs-decode.cpp` also assert on
-literals, but **not** for that reason — both link IccProfLib alone, so either
-could take the fallback. They were written before `${ICCDEV_TEST_LIB_ICCPROFLIB}`
-existed (#1887 landed hours ahead of #1894), which left hard-coding as the only
-way past the LNK2019 at the time. `mpe-empty-identity.cpp` records a second
-reason that still holds: the literal text is what a log scan greps for, so
-pinning it catches a rename that reading the global would hide.
+Several tests still assert on hard-coded copies of these values rather than
+reading the globals. `json-sparsematrix-huaf.cpp`, `xml-writer-graceful-degrade.cpp`
+and `json-bcd-version-parse.cpp` co-link IccXML or IccJson;
+`mpe-empty-identity.cpp` and `pawg-q4-xyz-pcs-decode.cpp` were written before the
+fix. `mpe-empty-identity.cpp` records a reason that still holds either way: the
+literal text is what a log scan greps for, so pinning it catches a rename that
+reading the global would hide.
 
 Literals copied out of the library drift silently, so
 `iccdev.proflib-exported-data-linkage` pins the real globals. If it fails after a

--- a/.github/ci/regression/mpe-empty-identity.cpp
+++ b/.github/ci/regression/mpe-empty-identity.cpp
@@ -59,10 +59,13 @@ bool contains(const std::string &haystack, const char *needle)
 }
 
 // The report-level prefixes are spelled out rather than taken from the exported
-// icMsgValidate* globals in IccUtil.h. Those globals do not resolve when a test
-// binary links IccProfLib under MSVC (LNK2019), and matching the literal text is
-// the stronger assertion anyway: it pins what a log scan actually greps for, so
-// renaming a global cannot quietly change the observable output.
+// icMsgValidate* globals in IccUtil.h. That began as a workaround -- those globals
+// would not resolve from a test binary under MSVC (LNK2019) until #2219 gave them
+// dllexport/dllimport -- but the literal text is the stronger assertion anyway: it
+// pins what a log scan actually greps for, so renaming a global cannot quietly
+// change the observable output. iccdev.proflib-exported-data-linkage pins these
+// three literals against the real globals -- and icMsgValidateNonCompliant,
+// which has no copy here -- so drift fails there.
 const char *const kInformation = "Information - ";
 const char *const kWarning     = "Warning! - ";
 const char *const kError       = "Error! - ";

--- a/.github/ci/regression/pawg-q4-xyz-pcs-decode.cpp
+++ b/.github/ci/regression/pawg-q4-xyz-pcs-decode.cpp
@@ -62,11 +62,12 @@ static void test_white_decode() {
   // Actual D50 white, and its *internal* PCS encoding (actual * 32768/65535).
   // This is what a CMM emits for a media-relative white; pcs_to_lab must decode
   // it back to L*=100, a*=b*=0.  Use the literal D50 constant (the value of the
-  // library's icD50XYZ) rather than the exported global: icD50XYZ is a DLL data
-  // symbol, and the Windows test links the static lib, so referencing it
-  // directly fails to resolve the __imp_ indirection (LNK2001) while functions
-  // like icXyzToPcs still thunk fine.  icXYZtoLab divides by this same constant
-  // internally, so the literal keeps the white decode exact.
+  // library's icD50XYZ) rather than the exported global.  That started as a
+  // workaround -- icD50XYZ is DLL data and would not resolve on Windows until
+  // #2219 gave it dllimport -- and is kept because icXYZtoLab divides by this
+  // same constant internally, so the literal keeps the white decode exact.
+  // iccdev.proflib-exported-data-linkage pins icD50XYZ against this triple, so
+  // a change to the global fails there rather than drifting past this copy.
   const icFloatNumber actualD50[3] = {0.9642f, 1.0000f, 0.8249f};
   icFloatNumber internalD50[3] = {actualD50[0], actualD50[1], actualD50[2]};
   icXyzToPcs(internalD50);  // actual -> internal PCS (the inverse of the fix)

--- a/.github/ci/regression/proflib-exported-data-linkage.cpp
+++ b/.github/ci/regression/proflib-exported-data-linkage.cpp
@@ -9,8 +9,8 @@
 // WINDOWS_EXPORT_ALL_SYMBOLS rather than from __declspec annotations -- MSVC is
 // deliberately excluded from the ICCPROFLIBDLL_EXPORTS definition, a decision
 // taken in #764. That mechanism auto-exports functions but not global data, and
-// IccProfLib carries no dllexport/dllimport on its data, so a consumer emits a
-// direct data reference with no __imp_ indirection and the link fails:
+// IccProfLib carried no dllexport/dllimport on its data, so a consumer emitted a
+// direct data reference with no __imp_ indirection and the link failed:
 //
 //   mpe-empty-identity.obj : error LNK2019: unresolved external symbol
 //     "char const * const icMsgValidateWarning" (?icMsgValidateWarning@@3PEBDEB)
@@ -21,11 +21,15 @@
 // Linux and macOS have no import-library model and are unaffected, so a green
 // local pre-flight proves nothing here -- only the Windows CI leg does.
 //
-// THIS TEST IS THE PROOF. Its value is that it links at all on Windows: it is
-// built against ${ICCDEV_TEST_LIB_ICCPROFLIB}, which falls back to the static
-// library on Windows shared builds exactly as the three affected tools already
-// do. If that fallback is removed or the export model changes, this stops
-// linking and the Windows leg goes red instead of the next author discovering it.
+// #2219 fixed that: the eight globals carry ICCPROFLIB_DATA_API, real
+// dllexport/dllimport kept separate from the incomplete ICCPROFLIB_API. This
+// test was written before the fix and linked IccProfLib2-static on Windows to
+// sidestep it, exactly as three tools did; #2154 retired that fallback, so it
+// now links IccProfLib2.dll like every other regression executable and its LINK
+// is once again an assertion. Note where the failure lands: an in-tree target
+// that cannot link takes the whole Windows BUILD down, which is why
+// iccdev.proflib-exported-data-dll-linkage exists to compile the same
+// references out of tree and report the loss as one red test instead.
 //
 // It covers all eight exported globals -- the four icMsgValidate* prefixes,
 // both icD50XYZ arrays, and both solver pointers. A ninth declaration, icInfo,
@@ -36,10 +40,8 @@
 // It also has a job on every platform. Several tests assert on hard-coded copies
 // of these values rather than reading the globals: mpe-empty-identity.cpp spells
 // out three of the icMsgValidate* prefixes and pawg-q4-xyz-pcs-decode.cpp spells
-// out the icD50XYZ triple. Both of those link IccProfLib alone and predate
-// ${ICCDEV_TEST_LIB_ICCPROFLIB}, so they hard-code by history rather than by
-// necessity; a test that also links IccXML or IccJson has no choice, because
-// adding the static IccProfLib would load the library twice in one process.
+// out the icD50XYZ triple. They hard-code by history rather than by necessity --
+// both were written while reading these globals still failed to link on Windows.
 // Hard-coded copies drift silently. Pinning the real globals here means a change
 // to icMsgValidateWarning or icD50XYZ fails HERE, naming the literals that must
 // be updated, rather than leaving those tests quietly asserting stale text.

--- a/Build/Cmake/Modules/FindRefIccMAX.cmake
+++ b/Build/Cmake/Modules/FindRefIccMAX.cmake
@@ -124,12 +124,23 @@ if(RefIccMAX_FOUND)
   # ---- Create IMPORTED targets ----
 
   # IccProfLib2 (shared)
+  #
+  # ICCPROFLIBDLL_DATA_IMPORTS matches what the CONFIG-mode package carries: the
+  # shared IccProfLib target sets it INTERFACE, so a consumer sees __declspec(
+  # dllimport) on the eight ICCPROFLIB_DATA_API globals (#2154, from #1888).
+  # Without it a Windows consumer that reaches iccDEV through THIS module rather
+  # than through install(EXPORT) compiles with the macro empty, emits a direct
+  # data reference with no __imp_ indirection, and still gets LNK2019 -- the one
+  # remaining way to hit the defect #2219 fixed. Deliberately not set on the
+  # -static target below, which must keep a plain extern. Inert off Windows:
+  # IccProfLibConf.h's non-PC branch does not read this macro.
   if(REFICCMAX_ICCPROFLIB_LIBRARY AND NOT TARGET RefIccMAX::IccProfLib2)
     add_library(RefIccMAX::IccProfLib2 UNKNOWN IMPORTED)
     set_target_properties(RefIccMAX::IccProfLib2 PROPERTIES
       IMPORTED_LOCATION "${REFICCMAX_ICCPROFLIB_LIBRARY}"
       INTERFACE_INCLUDE_DIRECTORIES "${REFICCMAX_ICCPROFLIB_INCLUDE_DIR}"
       INTERFACE_LINK_LIBRARIES "Threads::Threads"
+      INTERFACE_COMPILE_DEFINITIONS "ICCPROFLIBDLL_DATA_IMPORTS"
       INTERFACE_COMPILE_FEATURES "cxx_std_17"
     )
   endif()

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -50,40 +50,15 @@ function(iccdev_add_regression_executable TARGET_NAME)
   add_dependencies(build-test-binaries "${TARGET_NAME}")
 endfunction()
 
-# Link target for regression executables that reference an exported IccProfLib
-# global *variable* rather than only its functions (#1888).
-#
-# On a Windows shared build the library is IccProfLib2.dll, exported by CMake's
-# WINDOWS_EXPORT_ALL_SYMBOLS rather than by __declspec annotations: MSVC is
-# deliberately excluded from the ICCPROFLIBDLL_EXPORTS definition in
-# Build/Cmake/IccProfLib/CMakeLists.txt, a decision made in #764 and recorded in
-# the comment there. WINDOWS_EXPORT_ALL_SYMBOLS auto-exports functions; global
-# data still needs explicit dllexport/dllimport, which IccProfLib does not carry.
-# A consumer compiling with ICCPROFLIB_API empty therefore emits a direct data
-# reference with no __imp_ indirection and fails to link (LNK2019/LNK2001), while
-# every function in the same header thunks normally. Linux and macOS are immune,
-# so a green local pre-flight says nothing about this.
-#
-# The three tools with the same problem already resolve it this way -- see
-# Build/Cmake/Tools/{IccDumpProfile,IccProfilePlot,wxProfileDump}/CMakeLists.txt.
-#
-# USE THIS ONLY FOR TESTS THAT LINK IccProfLib ALONE. IccXML2 and IccJson link
-# ${TARGET_LIB_ICCPROFLIB} PUBLIC, so a test that links one of those *and* the
-# static IccProfLib pulls the library into the process twice -- once inside the
-# DLL, once in the executable -- giving two copies of its globals. Tests that
-# link IccXML/IccJson must keep using ${TARGET_LIB_ICCPROFLIB} and must not
-# reference exported library data at all; assert on literal values instead, as
-# .github/ci/regression/{json-sparsematrix-huaf,xml-writer-graceful-degrade,
-# json-bcd-version-parse}.cpp do -- those three are the tests that actually link
-# one of the two libraries. mpe-empty-identity.cpp and pawg-q4-xyz-pcs-decode.cpp
-# also hard-code literals, but they link IccProfLib alone and simply predate this
-# variable; they are eligible for it, not barred from it.
-if(WIN32 AND ENABLE_SHARED_LIBS AND TARGET IccProfLib2-static)
-  set(ICCDEV_TEST_LIB_ICCPROFLIB IccProfLib2-static)
-else()
-  set(ICCDEV_TEST_LIB_ICCPROFLIB ${TARGET_LIB_ICCPROFLIB})
-endif()
-message(STATUS "ICCDEV_TEST_LIB_ICCPROFLIB  = ${ICCDEV_TEST_LIB_ICCPROFLIB}")
+# Regression executables link ${TARGET_LIB_ICCPROFLIB}, functions and exported
+# global data alike. There used to be a second link target here,
+# ${ICCDEV_TEST_LIB_ICCPROFLIB}, which resolved to IccProfLib2-static on Windows
+# shared builds because WINDOWS_EXPORT_ALL_SYMBOLS auto-exports functions but not
+# data (#1888): a test referencing icMsgValidateWarning or icD50XYZ emitted a
+# direct data reference with no __imp_ indirection and failed with LNK2019. #2219
+# gave those eight globals real dllexport/dllimport via ICCPROFLIB_DATA_API, so
+# #2154 retired the fallback here and in the three tools that carried the same
+# workaround. See docs/build.md, "Exported global data".
 
 add_custom_target(check-fast
   COMMAND "${CMAKE_CTEST_COMMAND}"
@@ -527,10 +502,7 @@ endfunction()
 # copied from, the load never descending past one level, and the nLoaded==0
 # condition that drives the second-level dump fallback). See the long comment
 # at the top of .github/ci/regression/embedded-profile-onelevel-load.cpp for
-# the full story. This test links IccProfLib alone and calls functions only
-# (no exported library data), so ${TARGET_LIB_ICCPROFLIB} is correct here --
-# see the variable's own comment above for when ICCDEV_TEST_LIB_ICCPROFLIB is
-# needed instead.
+# the full story. This test links IccProfLib alone and calls functions only.
 #
 # Most of what this test checks is an in-memory nested profile built and
 # saved to a scratch file at runtime (path passed as argv[1]), so it needs no
@@ -774,14 +746,14 @@ function(iccdev_add_pawg_q4_xyz_pcs_decode_test)
 endfunction()
 
 function(iccdev_add_tointernal_fixedint_roundtrip_test)
-  if(NOT TARGET "${ICCDEV_TEST_LIB_ICCPROFLIB}")
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
   endif()
 
   iccdev_add_regression_executable(iccToInternalFixedIntRoundtripTest
     "${ICCDEV_REPO_ROOT}/.github/ci/regression/tointernal-fixedint-roundtrip.cpp"
   )
-  target_link_libraries(iccToInternalFixedIntRoundtripTest PRIVATE ${ICCDEV_TEST_LIB_ICCPROFLIB})
+  target_link_libraries(iccToInternalFixedIntRoundtripTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
   add_dependencies(check iccToInternalFixedIntRoundtripTest)
 
   add_test(
@@ -796,7 +768,7 @@ function(iccdev_add_tointernal_fixedint_roundtrip_test)
   if(WIN32)
     set(_tointernal_env_mods
       "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccToInternalFixedIntRoundtripTest>"
-      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${ICCDEV_TEST_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
     )
     foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
       list(APPEND _tointernal_env_mods
@@ -3972,14 +3944,16 @@ function(iccdev_add_calc_envsig_sign_extension_test)
 endfunction()
 
 # #1888: proves a regression executable can link an exported IccProfLib global
-# *variable*. WINDOWS_EXPORT_ALL_SYMBOLS exports functions but not data, so on a
-# Windows shared build this only links via ${ICCDEV_TEST_LIB_ICCPROFLIB}; if that
-# fallback is dropped the Windows leg fails here rather than in whichever new
-# test next reaches for library data. Also pins the values that the tests which
-# cannot link these symbols -- anything co-linking IccXML -- hard-code instead.
-# Links IccProfLib only, by design: co-linking IccXML would load IccProfLib twice.
+# *variable*. WINDOWS_EXPORT_ALL_SYMBOLS exports functions but not data, so until
+# #2219 gave the eight globals ICCPROFLIB_DATA_API this linked on a Windows shared
+# build only by falling back to IccProfLib2-static. That fallback is retired
+# (#2154): the test now links the DLL like every other, and if the annotation is
+# lost the Windows leg fails at BUILD time here -- while
+# iccdev.proflib-exported-data-dll-linkage, which builds its consumer out of tree,
+# reports the same loss as a test failure. Also pins the values that tests which
+# read no library data hard-code instead.
 function(iccdev_add_proflib_exported_data_linkage_test)
-  if(NOT TARGET "${ICCDEV_TEST_LIB_ICCPROFLIB}")
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
   endif()
 
@@ -3991,7 +3965,7 @@ function(iccdev_add_proflib_exported_data_linkage_test)
     "${ICCDEV_REPO_ROOT}/IccProfLib"
   )
   target_link_libraries(iccProfLibExportedDataLinkageTest PRIVATE
-    ${ICCDEV_TEST_LIB_ICCPROFLIB})
+    ${TARGET_LIB_ICCPROFLIB})
   add_dependencies(check iccProfLibExportedDataLinkageTest)
 
   add_test(
@@ -4006,7 +3980,7 @@ function(iccdev_add_proflib_exported_data_linkage_test)
   if(WIN32)
     set(_exported_data_windows_env_mods
       "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccProfLibExportedDataLinkageTest>"
-      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${ICCDEV_TEST_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
     )
     foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
       list(APPEND _exported_data_windows_env_mods
@@ -4288,8 +4262,7 @@ endfunction()
 # legacy transform. This test builds both a v2 'mft2' and a v4 'mAB ' profile
 # over identical CLUT content in memory and asserts the two disagree by exactly
 # the 65535/65280 factor, so it cannot be disabled by a corpus change. Links
-# IccProfLib alone and references no exported library data, so it is eligible for
-# ${ICCDEV_TEST_LIB_ICCPROFLIB}.
+# IccProfLib alone and references no exported library data.
 function(iccdev_add_v2_legacy_pcs_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -4302,7 +4275,7 @@ function(iccdev_add_v2_legacy_pcs_test)
   target_include_directories(iccV2LegacyPcsTest PRIVATE
     "${ICCDEV_REPO_ROOT}/IccProfLib"
   )
-  target_link_libraries(iccV2LegacyPcsTest PRIVATE ${ICCDEV_TEST_LIB_ICCPROFLIB})
+  target_link_libraries(iccV2LegacyPcsTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
   add_dependencies(check iccV2LegacyPcsTest)
 
   if(WIN32)
@@ -4346,8 +4319,7 @@ endfunction()
 # declares a 2.x header, still carries the LUT type it exists to provide, and
 # still validates without a critical error -- a fixture that silently drifted to
 # v4 would otherwise restore the original coverage gap while looking healthy.
-# Needs IccXML (CIccProfileXml) + IccProfLib; skipped where IccXML is not built,
-# and barred from ${ICCDEV_TEST_LIB_ICCPROFLIB} because it co-links IccXML.
+# Needs IccXML (CIccProfileXml) + IccProfLib; skipped where IccXML is not built.
 function(iccdev_add_v2_xml_fixtures_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
     return()
@@ -4986,11 +4958,11 @@ if(WIN32)
   endif()
 
   # #2154: the DLL-side counterpart to iccdev.proflib-exported-data-linkage.
-  # That test links IccProfLib2-static on Windows precisely to sidestep the
-  # exported-data problem, so it passes whether or not the eight globals carry a
-  # working dllexport/dllimport. This one links the DLL and therefore fails if
-  # the ICCPROFLIB_DATA_API annotation is lost. Out-of-tree by necessity: a link
-  # error in a target built here would fail the build rather than a test.
+  # Both now link the DLL, but they fail differently, which is why both stay: an
+  # in-tree target that cannot link takes the BUILD down, so it can never be
+  # expressed as a red test. This one configures and compiles its consumer out of
+  # tree at test time, so a lost ICCPROFLIB_DATA_API annotation surfaces as a
+  # single failing test with the LNK2019 in its log.
   if(ENABLE_SHARED_LIBS AND TARGET IccProfLib2)
     add_test(
       NAME iccdev.proflib-exported-data-dll-linkage

--- a/Build/Cmake/Testing/RunWindowsExportedDataLinkageTest.cmake
+++ b/Build/Cmake/Testing/RunWindowsExportedDataLinkageTest.cmake
@@ -9,10 +9,13 @@
 # consumer of IccProfLib2.dll referencing one of them failed to link with
 # LNK2019/LNK2001 while every function in the same header thunked normally.
 #
-# The tree's existing answer is to avoid the DLL: three tools and
-# iccdev.proflib-exported-data-linkage link IccProfLib2-static on Windows shared
-# builds instead. That workaround means no test exercised data linkage against
-# the DLL at all, so the defect could neither fail nor be shown fixed.
+# The tree's answer used to be to avoid the DLL: three tools and
+# iccdev.proflib-exported-data-linkage linked IccProfLib2-static on Windows
+# shared builds instead. That workaround meant no test exercised data linkage
+# against the DLL at all, so the defect could neither fail nor be shown fixed.
+# It was retired once this test proved the annotation works; all four now link
+# the DLL, and this test remains the one that fails as a TEST rather than a
+# build when the annotation is lost.
 #
 # This builds the consumer OUT OF TREE, configured and compiled at test time.
 # That is deliberate and is the only shape that works: a link error in a target

--- a/Build/Cmake/Tools/IccDumpProfile/CMakeLists.txt
+++ b/Build/Cmake/Tools/IccDumpProfile/CMakeLists.txt
@@ -1,16 +1,16 @@
 SET( SRC_PATH ../../../.. )
 SET( SOURCES  ${SRC_PATH}/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp )
 SET( TARGET_NAME iccDumpProfile )
-SET( ICC_DUMP_LINK_LIB ${TARGET_LIB_ICCPROFLIB} )
-
-IF(WIN32 AND ENABLE_SHARED_LIBS AND TARGET IccProfLib2-static)
-  # iccDumpProfile references exported data symbols that do not build
-  # cleanly through dllimport in the current public headers.
-  SET( ICC_DUMP_LINK_LIB IccProfLib2-static )
-ENDIF()
 
 ADD_EXECUTABLE( ${TARGET_NAME} ${SOURCES} )
-TARGET_LINK_LIBRARIES( ${TARGET_NAME} ${ICC_DUMP_LINK_LIB} )
+
+# Links ${TARGET_LIB_ICCPROFLIB} on every platform, including Windows shared
+# builds.  Until #2219 this tool linked IccProfLib2-static there instead: it
+# references the exported globals icMsgValidateWarning / icMsgValidateNonCompliant,
+# and WINDOWS_EXPORT_ALL_SYMBOLS auto-exports functions but never data, so those
+# references failed with LNK2019 against the DLL.  The eight exported globals now
+# carry ICCPROFLIB_DATA_API dllexport/dllimport, so the fallback is gone (#2154).
+TARGET_LINK_LIBRARIES( ${TARGET_NAME} ${TARGET_LIB_ICCPROFLIB} )
 IF(ENABLE_INSTALL_RIM)
   INSTALL (TARGETS ${TARGET_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 ENDIF(ENABLE_INSTALL_RIM)

--- a/Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt
+++ b/Build/Cmake/Tools/IccProfilePlot/CMakeLists.txt
@@ -5,19 +5,18 @@ SET( SRC_PATH ../../../.. )
 SET( SOURCES
   ${SRC_PATH}/Tools/CmdLine/IccProfilePlot/iccProfilePlot.cpp )
 SET( TARGET_NAME iccProfilePlot )
-SET( ICC_PLOT_LINK_LIB ${TARGET_LIB_ICCPROFLIB} )
 
-IF(WIN32 AND ENABLE_SHARED_LIBS AND TARGET IccProfLib2-static)
-  # Mirror iccDumpProfile: link the static lib on Windows shared builds, since
-  # the tool references exported data symbols that do not dllimport cleanly.
-  SET( ICC_PLOT_LINK_LIB IccProfLib2-static )
-ENDIF()
-
+# Both tools here link ${TARGET_LIB_ICCPROFLIB} on every platform, including
+# Windows shared builds.  Until #2219 they linked IccProfLib2-static there,
+# mirroring iccDumpProfile -- but neither of them, nor IccVizModel.cpp, ever
+# referenced one of the eight exported globals, so that fallback was inherited
+# rather than needed.  It is gone either way now that the globals carry
+# ICCPROFLIB_DATA_API dllexport/dllimport (#2154).
 ADD_EXECUTABLE( ${TARGET_NAME} ${SOURCES} )
 
 # IccVizEngine carries IccVizModel.cpp plus the include directory that makes
 # IccVizModel.hpp / IccVizMath.hpp / spectralLocus.hpp reachable.
-TARGET_LINK_LIBRARIES( ${TARGET_NAME} ${ICC_PLOT_LINK_LIB} IccVizEngine )
+TARGET_LINK_LIBRARIES( ${TARGET_NAME} ${TARGET_LIB_ICCPROFLIB} IccVizEngine )
 IF(ENABLE_INSTALL_RIM)
   INSTALL (TARGETS ${TARGET_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 ENDIF(ENABLE_INSTALL_RIM)
@@ -36,7 +35,7 @@ ADD_EXECUTABLE( ${VIZ_TARGET_NAME} ${VIZ_SOURCES} )
 
 # The Mini* writers stay listed above: they are this tool's rendering back end,
 # not part of the engine, and no other consumer compiles them.
-TARGET_LINK_LIBRARIES( ${VIZ_TARGET_NAME} ${ICC_PLOT_LINK_LIB} IccVizEngine )
+TARGET_LINK_LIBRARIES( ${VIZ_TARGET_NAME} ${TARGET_LIB_ICCPROFLIB} IccVizEngine )
 IF(ENABLE_INSTALL_RIM)
   INSTALL (TARGETS ${VIZ_TARGET_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 ENDIF(ENABLE_INSTALL_RIM)

--- a/Build/Cmake/Tools/wxProfileDump/CMakeLists.txt
+++ b/Build/Cmake/Tools/wxProfileDump/CMakeLists.txt
@@ -26,13 +26,12 @@ get_filename_component(PROJECT_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." AB
 set(SRC_PATH "${PROJECT_ROOT}")
 set(SOURCES ${SRC_PATH}/Tools/wxWidget/wxProfileDump/wxProfileDump.cpp)
 set(TARGET_NAME iccDumpProfileGui)
+# Links ${TARGET_LIB_ICCPROFLIB} on every platform, including Windows shared
+# builds.  Until #2219 this tool linked IccProfLib2-static there: it references
+# the exported data symbols icMsgValidateWarning / icMsgValidateNonCompliant,
+# which WINDOWS_EXPORT_ALL_SYMBOLS cannot export.  Those eight globals now carry
+# ICCPROFLIB_DATA_API dllexport/dllimport, so the fallback is gone (#2154).
 set(WX_LINK_LIB ${TARGET_LIB_ICCPROFLIB})
-
-IF(WIN32 AND ENABLE_SHARED_LIBS AND TARGET IccProfLib2-static)
-  # wxProfileDump references exported data symbols (icMsgValidateWarning,
-  # icMsgValidateNonCompliant) that WINDOWS_EXPORT_ALL_SYMBOLS cannot export.
-  SET(WX_LINK_LIB IccProfLib2-static)
-ENDIF()
 
 # Log configuration
 message(STATUS "SRC_PATH: ${SRC_PATH}")

--- a/IccProfLib/IccSolve.h
+++ b/IccProfLib/IccSolve.h
@@ -111,13 +111,13 @@ public:
 * with the status of false.
 *****************************************************************************
 */
-// Exported DATA rather than a function: on a Windows shared build this does not
-// link from outside the library, because WINDOWS_EXPORT_ALL_SYMBOLS covers
-// functions but not global data and IccProfLib carries no dllexport/dllimport
-// on its variables (see #764 and the note in IccUtil.h). A downstream consumer
-// installing its own solver against IccProfLib2.dll gets LNK2019. Prefer the
-// IccSetMatrixSolver() setter below, which is a function and therefore links
-// normally. See #1888.
+// Exported DATA rather than a function, so ICCPROFLIB_DATA_API rather than
+// ICCPROFLIB_API: WINDOWS_EXPORT_ALL_SYMBOLS covers functions but not global
+// data (see #764 and the note in IccUtil.h), so until #2219 a downstream
+// consumer installing its own solver against IccProfLib2.dll got LNK2019.
+// It links now, but prefer the IccSetMatrixSolver() setter below anyway -- a
+// function call does not depend on the caller writing through an imported
+// pointer. See #1888.
 ICCPROFLIB_DATA_API extern IIccMatrixSolver *g_pIccMatrixSolver;
 
 /**
@@ -180,8 +180,8 @@ public:
 * Purpose: Keep tracks of pointer to matrix inverter object.  
 *****************************************************************************
 */
-// Exported DATA: not linkable from outside the library on Windows shared
-// builds; prefer IccSetMatrixInverter(). See g_pIccMatrixSolver above and #1888.
+// Exported DATA, so ICCPROFLIB_DATA_API rather than ICCPROFLIB_API; prefer
+// IccSetMatrixInverter(). See g_pIccMatrixSolver above, #1888 and #2219.
 ICCPROFLIB_DATA_API extern IIccMatrixInverter *g_pIccMatrixInverter;
 
 /**

--- a/IccProfLib/IccUtil.h
+++ b/IccProfLib/IccUtil.h
@@ -133,8 +133,8 @@ ICCPROFLIB_API icFloatNumber icU16toF(icUInt16Number num);
 ICCPROFLIB_API icUInt8Number icABtoU8(icFloatNumber num);
 ICCPROFLIB_API icFloatNumber icU8toAB(icUInt8Number num);
 
-// Exported DATA: not linkable from outside the library on Windows shared
-// builds. See the note beside icMsgValidateWarning below and #1888.
+// Exported DATA, so ICCPROFLIB_DATA_API rather than ICCPROFLIB_API. See the
+// note beside icMsgValidateWarning below, #1888 and #2219.
 ICCPROFLIB_DATA_API extern icFloatNumber icD50XYZ[3];
 ICCPROFLIB_DATA_API extern icFloatNumber icD50XYZxx[3];
 
@@ -199,16 +199,16 @@ bool ICCPROFLIB_API icSameSpectralRange(const icSpectralRange &rng1, const icSpe
 
 ICCPROFLIB_API icUInt8Number icGetStorageTypeBytes(icUInt16Number nStorageType);
 
-// Exported DATA, not functions. On a Windows shared build these do not link
-// from outside the library: exports come from WINDOWS_EXPORT_ALL_SYMBOLS (see
-// Build/Cmake/IccProfLib/CMakeLists.txt and #764), which covers functions but
-// not global data, and IccProfLib carries no dllexport/dllimport annotation on
-// its variables. Referencing one from a tool or test gives LNK2019/LNK1120 on
-// MSVC while every function beside it links normally; Linux and macOS are
-// unaffected, so this does not show up in a local pre-flight. See #1888.
-// Tools work around it by linking IccProfLib2-static on Windows shared builds;
-// tests use ${ICCDEV_TEST_LIB_ICCPROFLIB}, or assert on literal values when
-// they also link IccXML. The literals are pinned by
+// Exported DATA, not functions, and therefore annotated ICCPROFLIB_DATA_API
+// rather than ICCPROFLIB_API. A shared MSVC build exports through
+// WINDOWS_EXPORT_ALL_SYMBOLS (see Build/Cmake/IccProfLib/CMakeLists.txt and
+// #764), which covers functions but not global data, so until #2219 these four
+// gave LNK2019/LNK1120 from any tool or test while every function beside them
+// linked normally. ICCPROFLIB_DATA_API supplies the real dllexport/dllimport,
+// kept separate from ICCPROFLIB_API so it does not disturb that arrangement;
+// linking IccProfLib2 is now all a consumer has to do, and the Windows-only
+// static-link workarounds tools and tests used to carry are gone (#2154).
+// The literals are pinned by
 // .github/ci/regression/proflib-exported-data-linkage.cpp -- update it if these
 // strings change.
 ICCPROFLIB_DATA_API extern const char *icMsgValidateWarning;

--- a/docs/build.md
+++ b/docs/build.md
@@ -335,45 +335,77 @@ That arrangement dates from #764, and the same file records why hidden visibilit
 is not used on GCC/Clang — `ICCPROFLIB_API` annotations are incomplete
 (~308 partial uses across 43 headers) and `IccXML` has none at all.
 
-One consequence is worth knowing before it costs a CI round (#1888):
+### Exported global data (#1888, fixed in #2219)
+
+One consequence of that arrangement cost several CI rounds before it was fixed:
 
 > `WINDOWS_EXPORT_ALL_SYMBOLS` auto-exports **functions**. Exported global
-> **variables** still require explicit `dllexport`/`dllimport`, which IccProfLib
-> does not carry. Referencing one from outside the library fails to link on
+> **variables** still require explicit `dllexport`/`dllimport`. IccProfLib
+> carried none, so referencing one from outside the library failed to link on
 > Windows shared builds with `LNK2019`/`LNK1120`, while every function in the
-> same header links normally.
+> same header linked normally.
 
-Linux and macOS have no import-library model and are unaffected, so this never
-appears in a local pre-flight on those platforms.
+Linux and macOS have no import-library model and were never affected, so this
+never appeared in a local pre-flight on those platforms.
 
-Affected symbols are `g_pIccMatrixSolver` and `g_pIccMatrixInverter`
+Eight globals are involved: `g_pIccMatrixSolver` and `g_pIccMatrixInverter`
 (`IccSolve.h`), and `icD50XYZ`, `icD50XYZxx` and the four `icMsgValidate*`
-message prefixes (`IccUtil.h`). Each declaration carries a note. `IccUtil.h` also
-declared `icInfo` until #1897, but that one had no definition anywhere in the tree
-and so failed to link on every platform — a dangling declaration rather than an
-export problem. It is gone; construct a `CIccInfo` where one is needed. The
-`iccdev.proflib-exported-global-definitions` CTest now checks every
-`ICCPROFLIB_API extern` declaration in these headers against the built library's
-symbol table, so a declaration added without a definition fails CI rather than
-reaching a consumer.
+message prefixes (`IccUtil.h`). They now carry `ICCPROFLIB_DATA_API`, a macro
+kept deliberately separate from `ICCPROFLIB_API` so real `dllexport`/`dllimport`
+could be added without flipping the ~308 incomplete `ICCPROFLIB_API` annotations
+and changing how every class and function is exported. The shared IccProfLib
+target defines `ICCPROFLIBDLL_DATA_EXPORTS` `PRIVATE` and
+`ICCPROFLIBDLL_DATA_IMPORTS` `INTERFACE`, so anything linking it — in-tree tools
+and `find_package()` consumers alike — sees `dllimport`. The static target
+deliberately gets neither and keeps a plain `extern`.
 
-Existing consumers handle it in one of two ways:
+Nothing special is needed to consume these symbols now. Link
+`RefIccMAX::IccProfLib2` and reference them; the workarounds the tree used to
+carry are gone (#2154):
 
-- **Tools** link `IccProfLib2-static` on Windows shared builds — see
-  `Build/Cmake/Tools/{IccDumpProfile,IccProfilePlot,wxProfileDump}/CMakeLists.txt`.
-  Regression executables get the same fallback through
-  `${ICCDEV_TEST_LIB_ICCPROFLIB}`.
-- **Consumers that also link `IccXML`/`IccJson`** cannot use that fallback, since
-  those libraries link `IccProfLib` `PUBLIC` and the static copy would load the
-  library twice in one process. They avoid the symbol and use literal values.
+- **Tools** — `iccDumpProfile`, `iccProfilePlot` and `wxProfileDump` linked
+  `IccProfLib2-static` on Windows shared builds; all three now link
+  `${TARGET_LIB_ICCPROFLIB}` on every platform.
+- **Regression executables** — the `${ICCDEV_TEST_LIB_ICCPROFLIB}` indirection
+  that applied the same fallback is retired; tests link
+  `${TARGET_LIB_ICCPROFLIB}` directly.
+- **Consumers that also link `IccXML`/`IccJson`** could never use that fallback
+  anyway, since those libraries link `IccProfLib` `PUBLIC` and a static copy
+  would load the library twice in one process. That constraint is moot now.
 
-Prefer the setter functions where they exist: `IccSetMatrixSolver()` and
-`IccSetMatrixInverter()` are functions, so they link normally and are the
-supported way to install a custom solver against the DLL.
+One case still needs a line of CMake: a **hand-built imported target**, which
+inherits nothing. `install(EXPORT)` carries the `INTERFACE` definition, and
+`Build/Cmake/Modules/FindRefIccMAX.cmake` and `examples/hello-iccdev` set it
+explicitly for the same reason — but a consumer that constructs its own
+`IMPORTED` target from a found library path must add
+`INTERFACE_COMPILE_DEFINITIONS "ICCPROFLIBDLL_DATA_IMPORTS"` to it, on the
+shared target only. Without it the macro compiles empty and Windows is back to
+`LNK2019`.
 
-See `.github/ci/regression/README.md` for the test-side rules and
-`iccdev.proflib-exported-data-linkage`, which pins both the linkage and the
-literal values that dependent tests hard-code.
+Two CTests hold the fix in place, and they fail differently on purpose. An
+in-tree target that cannot link takes the whole Windows build down rather than
+turning one test red, so `iccdev.proflib-exported-data-linkage` (in-tree, all
+platforms) pins the linkage and the literal values, while
+`iccdev.proflib-exported-data-dll-linkage` configures and compiles a consumer
+**out of tree** at test time and reports a lost annotation as a single failing
+test with the `LNK2019` in its log.
+
+`IccUtil.h` also declared `icInfo` until #1897, but that one had no definition
+anywhere in the tree and so failed to link on every platform — a dangling
+declaration rather than an export problem. It is gone; construct a `CIccInfo`
+where one is needed. The `iccdev.proflib-exported-global-definitions` CTest
+checks every `ICCPROFLIB_API extern` **and** `ICCPROFLIB_DATA_API extern`
+declaration in these headers — in both macro orderings — against the built
+library's symbol table, so a declaration added without a definition fails CI
+rather than reaching a consumer. Annotate a new exported *variable*
+`ICCPROFLIB_DATA_API`, not `ICCPROFLIB_API`: both are audited, but only the
+first exports data on Windows.
+
+`IccSetMatrixSolver()` and `IccSetMatrixInverter()` remain the supported way to
+install a custom solver: they are functions, and they do not depend on the
+caller writing through an imported pointer.
+
+See `.github/ci/regression/README.md` for the test-side rules.
 
 ## Namespace wrapping (known defect)
 

--- a/examples/hello-iccdev/CMakeLists.txt
+++ b/examples/hello-iccdev/CMakeLists.txt
@@ -158,11 +158,16 @@ if(NOT RefIccMAX_FOUND)
     message(STATUS "  IccProfLib2: ${ICCPROFLIB2_LIB}")
     message(STATUS "  IccXML2:     ${ICCXML2_LIB}")
 
-    # Create IMPORTED targets to keep target_link_libraries clean
+    # Create IMPORTED targets to keep target_link_libraries clean.
+    # ICCPROFLIBDLL_DATA_IMPORTS reproduces what the shared IccProfLib target
+    # carries INTERFACE, so the eight ICCPROFLIB_DATA_API globals are seen as
+    # dllimport here too; hand-built imported targets do not inherit it, and
+    # without it a Windows consumer referencing one gets LNK2019 (#2154, #1888).
     add_library(RefIccMAX::IccProfLib2 UNKNOWN IMPORTED)
     set_target_properties(RefIccMAX::IccProfLib2 PROPERTIES
         IMPORTED_LOCATION "${ICCPROFLIB2_LIB}"
         INTERFACE_INCLUDE_DIRECTORIES "${ICCDEV_ROOT}/IccProfLib;${ICCDEV_BUILD_DIR}/IccProfLib"
+        INTERFACE_COMPILE_DEFINITIONS "ICCPROFLIBDLL_DATA_IMPORTS"
     )
 
     add_library(RefIccMAX::IccXML2 UNKNOWN IMPORTED)


### PR DESCRIPTION
## What

Retires the Windows static-link fallbacks that #2219 made unnecessary.

`WINDOWS_EXPORT_ALL_SYMBOLS` auto-exports functions but not global data, so referencing one of the eight exported IccProfLib globals from outside `IccProfLib2.dll` failed with `LNK2019`/`LNK1120` on Windows shared builds (#1888). The tree's answer was to avoid the DLL: `iccDumpProfile`, `iccProfilePlot` and `wxProfileDump` linked `IccProfLib2-static` there, and regression executables took the same fallback through `${ICCDEV_TEST_LIB_ICCPROFLIB}`.

#2219 gave those eight globals `ICCPROFLIB_DATA_API` — real `dllexport`/`dllimport`, kept separate from the ~308 incomplete `ICCPROFLIB_API` annotations. **Removing the workarounds is what proves that fix matters rather than merely works**, and it was deliberately excluded from #2219 (stated in that PR body) because it has its own blast radius.

All four now link `${TARGET_LIB_ICCPROFLIB}` on every platform; `${ICCDEV_TEST_LIB_ICCPROFLIB}` is retired.

## One thing the survey turned up

`iccProfilePlot` never referenced one of the globals. Neither `iccProfilePlot.cpp`, `iccProfileVisualize.cpp` nor `IccVizModel.cpp` does — its comment said "Mirror iccDumpProfile", and the fallback was inherited rather than needed.

For contrast, 16 other tools under `Build/Cmake/Tools/` already link the DLL on Windows. The three were the only outliers, and only because of the data symbols.

## The one remaining way to hit the defect

The `INTERFACE` define that makes the globals `dllimport` reaches CONFIG-mode consumers through `install(EXPORT)`. A **hand-built `IMPORTED` target inherits nothing**, and two in-repo places construct `RefIccMAX::IccProfLib2` themselves with no compile definitions:

- `Build/Cmake/Modules/FindRefIccMAX.cmake` — the MODULE-mode fallback, described in its own header as "for standalone `find_package()`".
- `examples/hello-iccdev/CMakeLists.txt` — Path 3, manual discovery. It escapes today only because `hello-iccdev.cpp` happens to reference none of the eight.

A Windows consumer arriving either way compiled with `ICCPROFLIB_DATA_API` empty and still got `LNK2019` — exactly the #1888 failure. Both now set `INTERFACE_COMPILE_DEFINITIONS "ICCPROFLIBDLL_DATA_IMPORTS"` on the shared target only, never on `-static`, which must keep a plain `extern`.

Probed red/green against a staged prefix: `master`'s module reports the property `NOTFOUND`, this branch reports `ICCPROFLIBDLL_DATA_IMPORTS`, and a consumer referencing `icMsgValidateWarning` and `icD50XYZ` builds, links and runs — confirming the define is inert off Windows.

## Comments corrected

#2219 changed `ICCPROFLIB_API extern` to `ICCPROFLIB_DATA_API extern` but left the surrounding notes describing the pre-fix state. They are the first thing a consumer reads, and they still prescribed the workaround this PR deletes:

- `IccProfLib/IccUtil.h`, `IccProfLib/IccSolve.h` — the four declaration notes.
- `mpe-empty-identity.cpp`, `pawg-q4-xyz-pcs-decode.cpp` — both hard-code literals to dodge the link error. The literals stay (`mpe-empty-identity.cpp` records a second reason that still holds: literal text is what a log scan greps for); the stale "these do not resolve" claim goes.
- `docs/build.md` "Shared library exports", `.github/ci/regression/README.md`.

`.github/ci/regression/README.md` also gains a table row for `iccdev.proflib-exported-data-dll-linkage` — the out-of-tree CTest #2219 added without registering it in the index.

## Why the two CTests both stay

They fail differently, on purpose:

- `iccdev.proflib-exported-data-linkage` — in-tree, every platform. Now that it links the DLL, on Windows its **link** is the assertion, which means a lost annotation takes the whole build down rather than turning one test red.
- `iccdev.proflib-exported-data-dll-linkage` — configures and compiles its consumer **out of tree** at test time, so the same loss surfaces as one failing test with the `LNK2019` in its log. An in-tree target could never express that.

## Testing

### Dispatched pre-PR run — `ci_scope=source`, [32438921475](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32438921475), **success**

8 success / 3 skipped: GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL, MinGW UCRT64, Tool Smoke Tests ASAN+UBSAN Debug.

**Windows is where this change is provable, so I read the job log rather than the tick.** A lost annotation would fail the Windows *build*, not turn a test red, so "green" alone proves nothing here. From job 96645617266, both MSVC and ClangCL passes:

- `8/103 Test #8: iccdev.proflib-exported-data-dll-linkage ... Passed 3.25 sec` (and `3.22 sec` on the second pass)
- `46/103 Test #46: iccdev.proflib-exported-data-linkage ... Passed 0.01 sec`
- `100% tests passed, 0 tests failed out of 103` — twice
- All four tool targets built and linked: `iccDumpProfile.exe`, `iccProfilePlot.exe`, `iccProfileVisualizePlot.exe`, `iccDumpProfileGui.vcxproj` — the GUI included
- `Test #5: iccdev.windows-icc-dump-profile-smoke ... Passed` — runs `iccDumpProfile.exe` against the DLL, so the exported data resolves at *runtime*, not just at link time
- The only two `IccProfLib2-static` lines left in the whole Windows log are the static library building itself (`-> ...\IccProfLib2-staticd.lib`). Nothing links it as a fallback any more.

### Local pre-flight

- Strict clang-18 Release, `-Wall -Wextra -Wpedantic -Werror`; configure confirmed `strict warnings ENABLED (Clang 18.1.3)`, so the flags were live. Library + tools + `build-test-binaries`: `grep -cE 'warning:' build.log` → **0**.
- CTest 190/191, 2 skipped. The one failure is `iccdev.spectral-tiff-preview` → `ModuleNotFoundError: No module named 'imagecodecs'`, a missing local Python package.
- MODULE-mode red/green probe against a staged prefix (see above).

Every `.cpp`/`.h` hunk in this branch is comment-only — filtering non-comment, non-blank changed lines out of the diff leaves nothing. The behavioural change is entirely in CMake.

## Not covered by CI, worth knowing

No workflow or CTest builds `examples/hello-iccdev`, and the only `find_package(RefIccMAX)` in CI (`ci-vcpkg-ports.yml`) is CONFIG mode against a static-only port. So the MODULE-mode fix above is correct and locally probed, but **not** CI-provable today. Wiring an install + `find_package` CTest is roadmap item 3 of #2154, not this PR.

## Out of scope, noticed while here

`iccdev_add_tointernal_fixedint_roundtrip_test()` is called only from inside the `if(WIN32)` block in `Build/Cmake/Testing/CMakeLists.txt`, so `iccdev.tointernal-fixedint-roundtrip` never registers on Linux or macOS. That predates this branch (same single call site on `master`) and the test is platform-agnostic. Not touched here — happy to file it.

Part of #2154.
