### PR TITLE
fix(#2220): carry TIFFTAG_RESOLUTIONUNIT through CTiffImg::Create

### DIFF
--- a/.github/ci/regression/tiff-create-bytesperline-overflow.cpp
+++ b/.github/ci/regression/tiff-create-bytesperline-overflow.cpp
@@ -31,6 +31,15 @@
 // That is why case 2 exists: it overflows bytes-per-line while keeping every allocation
 // tiny, so nothing but the range check can reject it.
 //
+// ALSO COVERED HERE (#2220): Create()'s nResolutionUnit parameter. It belongs with the
+// cases above rather than in a binary of its own because it is the same contract on the
+// same entry point -- what Create() refuses, and what it must still accept -- and neither
+// tool caller can reach the rejection: their unit comes back out of Open(), and libtiff
+// discards an out-of-range RESOLUTIONUNIT while reading the directory, leaving the
+// defaulted RESUNIT_INCH behind. Calling Create() directly is the only way to exercise it.
+// End-to-end propagation through the three tools is covered by
+// .github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh.
+//
 // Returns 0 on success; the number of failed assertions otherwise (each printed).
 
 #include "TiffImg.h"
@@ -120,6 +129,93 @@ int main()
             "separated GetBytesPerLine() is the true row size");
     }
     img.Close();
+    cleanup();
+  }
+
+  // --- 5. An out-of-range ResolutionUnit must be refused rather than written as a unit
+  // the file cannot express. TIFF 6.0 defines only NONE, INCH and CENTIMETER.
+  {
+    CTiffImg img;
+    const bool ok = img.Create(kOutPath, 64u, 4u, 8u, PHOTO_MINISBLACK, 3u, 0u,
+                               72.0f, 72.0f, false, /*bSep=*/false,
+                               /*nResolutionUnit=*/7u);
+    check(!ok, "Create() rejects an out-of-range ResolutionUnit");
+    img.Close();
+    cleanup();
+  }
+
+  // --- 6. Each unit TIFF does define must still be accepted and reported back, so case 5
+  // is not simply refusing every value. The default is checked too: it is what every
+  // caller that omits the parameter gets, and it must stay RESUNIT_INCH.
+  {
+    const unsigned int units[] = { RESUNIT_NONE, RESUNIT_INCH, RESUNIT_CENTIMETER };
+    for (unsigned int unit : units) {
+      CTiffImg img;
+      const bool ok = img.Create(kOutPath, 64u, 4u, 8u, PHOTO_MINISBLACK, 3u, 0u,
+                                 72.0f, 72.0f, false, /*bSep=*/false, unit);
+      check(ok, "Create() accepts a ResolutionUnit TIFF defines");
+      if (ok)
+        check(img.GetResolutionUnit() == unit,
+              "GetResolutionUnit() reports the unit Create() was given");
+      img.Close();
+      cleanup();
+    }
+
+    CTiffImg img;
+    const bool ok = img.Create(kOutPath, 64u, 4u, 8u, PHOTO_MINISBLACK, 3u, 0u,
+                               72.0f, 72.0f, false, /*bSep=*/false);
+    check(ok, "Create() still accepts the call shape that omits the unit");
+    if (ok)
+      check(img.GetResolutionUnit() == RESUNIT_INCH,
+            "an omitted ResolutionUnit still defaults to inches");
+    img.Close();
+    cleanup();
+  }
+
+  // --- 7. Create() clamps a non-positive resolution to 96 and must write the value it
+  // adopted, not the argument it rejected. Writing the raw argument left the file
+  // declaring 0 while the object reported 96 -- and with a ResolutionUnit now written
+  // beside it, that file asserts "0 pixels per inch". Read back through Open() so the
+  // assertion is on what reached the file rather than on a member.
+  {
+    CTiffImg img;
+    const bool ok = img.Create(kOutPath, 64u, 4u, 8u, PHOTO_MINISBLACK, 3u, 0u,
+                               /*fXRes=*/0.0f, /*fYRes=*/0.0f, false, /*bSep=*/false);
+    check(ok, "Create() accepts a non-positive resolution and clamps it");
+
+    // Rows have to be written before Close(), or the directory carries no StripOffsets
+    // and the file cannot be reopened. Asserting on img.GetXRes() instead would be
+    // vacuous: that member held the clamped 96 before this fix as well -- the defect was
+    // only ever in what reached the file.
+    if (ok) {
+      unsigned char row[64u * 3u] = { 0 };
+      for (unsigned int line = 0; line < 4u; line++)
+        check(img.WriteLine(row), "the clamped-resolution image accepts a row");
+    }
+    img.Close();
+
+    // Read the tags back with libtiff rather than CTiffImg::Open(). Open() applies the
+    // very same non-positive-resolution fix-up, so it reports 96 whatever the file says
+    // and an assertion routed through it passes against the defect -- measured, not
+    // assumed. Plain TIFFGetField reports what is actually stored.
+    if (ok) {
+      TIFF *raw = TIFFOpen(kOutPath, "r");
+      check(raw != NULL, "the clamped-resolution file reopens");
+      if (raw) {
+        float fFileXRes = 0.0f;
+        float fFileYRes = 0.0f;
+        uint16_t nFileUnit = 0;
+        check(TIFFGetField(raw, TIFFTAG_XRESOLUTION, &fFileXRes) == 1 &&
+              TIFFGetField(raw, TIFFTAG_YRESOLUTION, &fFileYRes) == 1,
+              "the clamped-resolution file carries both resolution tags");
+        check(fFileXRes == 96.0f && fFileYRes == 96.0f,
+              "the file carries the clamped resolution Create() adopted");
+        check(TIFFGetField(raw, TIFFTAG_RESOLUTIONUNIT, &nFileUnit) == 1 &&
+              nFileUnit == RESUNIT_INCH,
+              "the clamped-resolution file states its unit");
+        TIFFClose(raw);
+      }
+    }
     cleanup();
   }
 

--- a/.github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh
+++ b/.github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh
@@ -1,0 +1,512 @@
+#!/bin/bash
+###############################################################################
+# TIFFTAG_RESOLUTIONUNIT propagation regression (#2220)
+###############################################################################
+#
+# CTiffImg::Create() never wrote TIFFTAG_RESOLUTIONUNIT, so every tool that
+# copies a source image's XResolution/YResolution emitted them without the unit
+# that gives them meaning.  Readers then fall back to the TIFF 6.0 default of
+# inches: a 254-pixel row at 100 pixels/cm is 1.00 inch wide, and the converted
+# output read as 2.54 inches.
+#
+# The defect lives in shared code, so it is measured per CALLER: iccSpecSepToTiff
+# and iccApplyProfiles both reach it through the same Create(), and iccTiffDump
+# reads the same member back.
+#
+# Assertions read the ResolutionUnit tag out of the output file's IFD directly
+# rather than through a tool, so a tool reporting the unit wrongly cannot make a
+# case pass for the wrong reason.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-tiff-resolution-unit-regression}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+SPECSEP="$TOOLS_DIR/IccSpecSepToTiff/iccSpecSepToTiff"
+APPLYPROFILES="$TOOLS_DIR/IccApplyProfiles/iccApplyProfiles"
+TIFFDUMP="$TOOLS_DIR/IccTiffDump/iccTiffDump"
+SRGB_PROFILE="$REPO_ROOT/Testing/sRGB_v4_ICC_preference.icc"
+
+WORKDIR="$OUTDIR/tiff-resolution-unit"
+LOGFILE="$OUTDIR/tiff-resolution-unit.log"
+OUTPUT_TIFF="$WORKDIR/output.tif"
+
+# TIFF 6.0 ResolutionUnit codes.
+RESUNIT_NONE=1
+RESUNIT_INCH=2
+RESUNIT_CENTIMETER=3
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+
+fail_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [FAIL] $name -- $reason"
+  FAIL=$((FAIL + 1))
+}
+
+pass_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [PASS] $name -- $reason"
+  PASS=$((PASS + 1))
+}
+
+skip_case() {
+  local name="$1"
+  local reason="$2"
+  echo "  [SKIP] $name -- $reason"
+  SKIP=$((SKIP + 1))
+}
+
+# Emit a minimal single-strip TIFF carrying an explicit ResolutionUnit plus
+# XResolution/YResolution.  Written by hand rather than with a library so the
+# unit under test is exactly the byte the test intends, with no encoder
+# normalizing it on the way in.
+#   generate_tiff <path> <width> <height> <samples> <fill> <resunit> <res>
+generate_tiff() {
+  python3 - "$@" <<'PY'
+import pathlib
+import struct
+import sys
+
+path = pathlib.Path(sys.argv[1])
+width = int(sys.argv[2])
+height = int(sys.argv[3])
+samples = int(sys.argv[4])
+fill = int(sys.argv[5]) & 0xff
+resunit = int(sys.argv[6])
+res = int(sys.argv[7])
+path.parent.mkdir(parents=True, exist_ok=True)
+
+# RGB needs three BitsPerSample values, which do not fit inline in an IFD entry.
+photometric = 2 if samples == 3 else 1
+pixel_data = bytes([fill]) * (width * height * samples)
+
+data_offset = 8
+strip_bytes = len(pixel_data)
+cursor = data_offset + strip_bytes
+if cursor % 2:
+    # Pad only to keep the following IFD word-aligned.  StripByteCounts is computed
+    # from the unpadded length: counting the pad would declare a strip one byte longer
+    # than the row, and libtiff would read into whatever follows the pixel data.
+    pixel_data += b"\0"
+    cursor += 1
+
+bps_offset = cursor
+if samples > 1:
+    cursor += 2 * samples
+
+ifd_offset = cursor
+
+entries = [
+    (256, 4, 1, width),
+    (257, 4, 1, height),
+    (258, 3, samples, bps_offset if samples > 1 else 8),
+    (259, 3, 1, 1),
+    (262, 3, 1, photometric),
+    (273, 4, 1, data_offset),
+    (277, 3, 1, samples),
+    (278, 4, 1, height),
+    (279, 4, 1, strip_bytes),
+    (282, 5, 1, 0),
+    (283, 5, 1, 0),
+    (284, 3, 1, 1),
+    (296, 3, 1, resunit),
+]
+entries.sort()
+
+ifd_size = 2 + 12 * len(entries) + 4
+xres_offset = ifd_offset + ifd_size
+yres_offset = xres_offset + 8
+entries = [
+    (tag, kind, count, xres_offset if tag == 282 else yres_offset if tag == 283 else value)
+    for (tag, kind, count, value) in entries
+]
+
+data = bytearray(b"II" + struct.pack("<H", 42) + struct.pack("<I", ifd_offset))
+data.extend(pixel_data)
+if samples > 1:
+    data.extend(struct.pack("<H", 8) * samples)
+data.extend(struct.pack("<H", len(entries)))
+for tag, kind, count, value in entries:
+    data.extend(struct.pack("<HHI", tag, kind, count))
+    if kind == 3 and count == 1:
+        data.extend(struct.pack("<H", value))
+        data.extend(b"\0\0")
+    else:
+        data.extend(struct.pack("<I", value))
+data.extend(struct.pack("<I", 0))
+data.extend(struct.pack("<II", res, 1))
+data.extend(struct.pack("<II", res, 1))
+path.write_bytes(data)
+PY
+}
+
+# Print the ResolutionUnit stored in a TIFF's first IFD, or "absent" when the tag
+# is not written at all -- which is what the defect produced, and what a reader
+# silently resolves to inches.  Parsed from the bytes so the assertion does not
+# depend on the same code the tools use.
+read_resolution_unit() {
+  python3 - "$1" <<'PY'
+import pathlib
+import struct
+import sys
+
+data = pathlib.Path(sys.argv[1]).read_bytes()
+if len(data) < 8 or data[:2] not in (b"II", b"MM"):
+    print("unreadable")
+    sys.exit(0)
+
+endian = "<" if data[:2] == b"II" else ">"
+offset = struct.unpack_from(endian + "I", data, 4)[0]
+if offset + 2 > len(data):
+    print("unreadable")
+    sys.exit(0)
+
+count = struct.unpack_from(endian + "H", data, offset)[0]
+for index in range(count):
+    entry = offset + 2 + 12 * index
+    if entry + 12 > len(data):
+        break
+    tag, kind = struct.unpack_from(endian + "HH", data, entry)
+    if tag == 296:
+        print(struct.unpack_from(endian + "H", data, entry + 8)[0])
+        sys.exit(0)
+
+print("absent")
+PY
+}
+
+check_sanitizers() {
+  local name="$1"
+  local logfile="$2"
+
+  if grep -q "ERROR: AddressSanitizer" "$logfile" 2>/dev/null; then
+    fail_case "$name" "AddressSanitizer finding"
+    return 1
+  fi
+
+  if grep -q "runtime error:" "$logfile" 2>/dev/null; then
+    fail_case "$name" "undefined behavior"
+    return 1
+  fi
+
+  return 0
+}
+
+require_tool() {
+  local name="$1"
+  local tool="$2"
+
+  if [ ! -x "$tool" ]; then
+    fail_case "$name" "missing executable: $tool"
+    return 1
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip_case "$name" "python3 unavailable, cannot build or inspect TIFF fixtures"
+    return 1
+  fi
+
+  return 0
+}
+
+# iccSpecSepToTiff must hand the unit of its input channels to its output.  Run
+# for each of the three units TIFF defines, including RESUNIT_INCH: before the
+# fix no unit tag was written at all, so the inch case is a real assertion rather
+# than one that passes on both trees.
+run_specsep_unit_preserved() {
+  local unit="$1"
+  local label="$2"
+  local name="specsep-resolution-unit-$label-preserved"
+  local exit_code=0
+  local actual=""
+  local channel=""
+
+  TOTAL=$((TOTAL + 1))
+  rm -rf "$WORKDIR"
+  rm -f "$LOGFILE"
+  mkdir -p "$WORKDIR"
+
+  if ! require_tool "$name" "$SPECSEP"; then
+    return
+  fi
+
+  for channel in 1 2; do
+    if ! generate_tiff "$WORKDIR/spec_$channel" 254 1 1 $((channel * 17)) "$unit" 100; then
+      fail_case "$name" "TIFF fixture generation failed"
+      return
+    fi
+  done
+
+  timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$WORKDIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "expected a successful conversion, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  actual="$(read_resolution_unit "$OUTPUT_TIFF")"
+  if [ "$actual" != "$unit" ]; then
+    fail_case "$name" "output ResolutionUnit is $actual, expected $unit"
+    return
+  fi
+
+  pass_case "$name" "output carries the input ResolutionUnit ($unit)"
+}
+
+# Channel images are required to share a format, and the resolution unit is part
+# of that format: 100 pixels/inch and 100 pixels/cm are the same two numbers
+# describing different images.  Comparing only the resolution values accepted the
+# set and silently used the first channel's unit for all of them.
+run_specsep_unit_mismatch_rejected() {
+  local name="specsep-resolution-unit-mismatch-rejected"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -rf "$WORKDIR"
+  rm -f "$LOGFILE"
+  mkdir -p "$WORKDIR"
+
+  if ! require_tool "$name" "$SPECSEP"; then
+    return
+  fi
+
+  if ! generate_tiff "$WORKDIR/spec_1" 254 1 1 17 "$RESUNIT_INCH" 100 ||
+     ! generate_tiff "$WORKDIR/spec_2" 254 1 1 34 "$RESUNIT_CENTIMETER" 100; then
+    fail_case "$name" "TIFF fixture generation failed"
+    return
+  fi
+
+  timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$WORKDIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 255 ]; then
+    fail_case "$name" "expected graceful reject exit=255, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq "does not have same format as other files" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "missing the format-mismatch rejection text"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ -e "$OUTPUT_TIFF" ]; then
+    fail_case "$name" "output TIFF created despite mismatched resolution units"
+    return
+  fi
+
+  pass_case "$name" "mixed inch/centimeter channels rejected before output creation"
+}
+
+# The second caller of the same shared Create().  iccApplyProfiles copies the
+# source resolution onto its destination, so it dropped the unit the same way.
+run_applyprofiles_unit_preserved() {
+  local name="applyprofiles-resolution-unit-centimeter-preserved"
+  local exit_code=0
+  local actual=""
+
+  TOTAL=$((TOTAL + 1))
+  rm -rf "$WORKDIR"
+  rm -f "$LOGFILE"
+  mkdir -p "$WORKDIR"
+
+  if ! require_tool "$name" "$APPLYPROFILES"; then
+    return
+  fi
+
+  if [ ! -f "$SRGB_PROFILE" ]; then
+    fail_case "$name" "missing profile fixture: $SRGB_PROFILE"
+    return
+  fi
+
+  if ! generate_tiff "$WORKDIR/source.tif" 254 1 3 128 "$RESUNIT_CENTIMETER" 100; then
+    fail_case "$name" "TIFF fixture generation failed"
+    return
+  fi
+
+  timeout 120 "$APPLYPROFILES" "$WORKDIR/source.tif" "$OUTPUT_TIFF" 0 0 0 0 1 \
+    "$SRGB_PROFILE" 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "expected a successful conversion, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  actual="$(read_resolution_unit "$OUTPUT_TIFF")"
+  if [ "$actual" != "$RESUNIT_CENTIMETER" ]; then
+    fail_case "$name" "output ResolutionUnit is $actual, expected $RESUNIT_CENTIMETER"
+    return
+  fi
+
+  pass_case "$name" "destination carries the source ResolutionUnit ($RESUNIT_CENTIMETER)"
+}
+
+# The third consumer of the same member.  iccTiffDump printed "pixels per/inch"
+# for every image and computed the physical size by dividing pixels by the
+# resolution regardless of unit, so a centimeter-based image was reported at
+# 2.54x its real size with a label that contradicted the file.
+run_tiffdump_reports_unit() {
+  local name="tiffdump-reports-resolution-unit"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -rf "$WORKDIR"
+  rm -f "$LOGFILE"
+  mkdir -p "$WORKDIR"
+
+  if ! require_tool "$name" "$TIFFDUMP"; then
+    return
+  fi
+
+  # 254 pixels at 100 pixels/cm is 2.54 cm, i.e. exactly 1.00 inch.
+  if ! generate_tiff "$WORKDIR/source.tif" 254 1 1 17 "$RESUNIT_CENTIMETER" 100; then
+    fail_case "$name" "TIFF fixture generation failed"
+    return
+  fi
+
+  timeout 60 "$TIFFDUMP" "$WORKDIR/source.tif" > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "expected a successful dump, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq "pixels per/centimeter" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "resolution unit not reported as centimeters"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq '(1.00" x ' "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "physical width not converted to inches (254 px at 100 px/cm is 1.00 inch)"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  pass_case "$name" "centimeter resolution reported by unit and converted to inches"
+}
+
+# RESUNIT_NONE is not hypothetical: the checked-in
+# .github/ci/test-data/specsep-harvest/gray300/spec_* fixtures declare it, and specsep
+# output derived from them now inherits it.  Under that unit the resolution values fix
+# an aspect ratio and no absolute size exists, so the physical-size figure has to be
+# omitted rather than invented.
+run_tiffdump_relative_resolution() {
+  local name="tiffdump-relative-resolution-omits-physical-size"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -rf "$WORKDIR"
+  rm -f "$LOGFILE"
+  mkdir -p "$WORKDIR"
+
+  if ! require_tool "$name" "$TIFFDUMP"; then
+    return
+  fi
+
+  if ! generate_tiff "$WORKDIR/source.tif" 254 1 1 17 "$RESUNIT_NONE" 100; then
+    fail_case "$name" "TIFF fixture generation failed"
+    return
+  fi
+
+  timeout 60 "$TIFFDUMP" "$WORKDIR/source.tif" > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "expected a successful dump, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq "(relative, no absolute unit)" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "RESUNIT_NONE not reported as a relative resolution"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if grep -Eq '^Size:.*"' "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "physical size printed for an image that declares no absolute unit"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  pass_case "$name" "relative resolution reported without inventing a physical size"
+}
+
+echo "=== TIFF ResolutionUnit propagation regression ==="
+run_specsep_unit_preserved "$RESUNIT_CENTIMETER" "centimeter"
+run_specsep_unit_preserved "$RESUNIT_INCH" "inch"
+run_specsep_unit_preserved "$RESUNIT_NONE" "none"
+run_specsep_unit_mismatch_rejected
+run_applyprofiles_unit_preserved
+run_tiffdump_reports_unit
+run_tiffdump_relative_resolution
+
+if [ "$SKIP" -ne 0 ]; then
+  echo "TIFF ResolutionUnit propagation regression: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total"
+else
+  echo "TIFF ResolutionUnit propagation regression: $PASS passed, $FAIL failed, $TOTAL total"
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5510,6 +5510,20 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-cli-args-regression-tests.sh"
 )
 
+# TIFFTAG_RESOLUTIONUNIT lives in shared CTiffImg code, so it is covered per caller:
+# iccSpecSepToTiff and iccApplyProfiles both write through the same Create(), and
+# iccTiffDump reads the same member back (#2220).  Guarded on all three targets
+# because the cases are not independent of any one of them.
+if(TARGET iccSpecSepToTiff AND TARGET iccApplyProfiles AND TARGET iccTiffDump)
+  iccdev_add_script_test(
+    iccdev.tiff-resolution-unit-regression
+    120
+    "iccdev;tools;tiff;resolution;regression;asan"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh"
+  )
+endif()
+
 iccdev_add_script_test(
   iccdev.dump-profile-header-regression
   120

--- a/Tools/CmdLine/IccApplyProfiles/Readme.md
+++ b/Tools/CmdLine/IccApplyProfiles/Readme.md
@@ -54,6 +54,12 @@ Practical consequences:
   the ICC profile (set `dstEmbedIcc: true` in the JSON config) so the
   reverse chain can recover the values.
 
+## Resolution
+
+The destination TIFF carries the source's `XResolution`, `YResolution` and
+`ResolutionUnit`. The unit tag is always written, so the output states its unit
+rather than relying on the reader defaulting an absent tag to inches.
+
 ## See Also
 
 - [CLI tool reference](../../../docs/tools-cli-reference.md)

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -167,6 +167,7 @@ CTiffImg::CTiffImg()
     m_nCompress(0),
     m_nSampleFormat(SAMPLEFORMAT_UINT),
     m_nOrientation(ORIENTATION_TOPLEFT),
+    m_nResolutionUnit(RESUNIT_INCH),
     m_fXRes(0.0f),
     m_fYRes(0.0f),
     m_nBytesPerLine(0),
@@ -230,6 +231,7 @@ void CTiffImg::Close()
   m_nCompress = 0;
   m_nSampleFormat = SAMPLEFORMAT_UINT;
   m_nOrientation = ORIENTATION_TOPLEFT;
+  m_nResolutionUnit = RESUNIT_INCH;
   m_fXRes = 0.0f;
   m_fYRes = 0.0f;
   m_nBytesPerLine = 0;
@@ -246,7 +248,8 @@ void CTiffImg::Close()
 
 bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHeight,
               unsigned int nBPS, unsigned int nPhoto, unsigned int nSamples, unsigned int nExtraSamples,
-              float fXRes, float fYRes, bool bCompress, bool bSep)
+              float fXRes, float fYRes, bool bCompress, bool bSep,
+              unsigned int nResolutionUnit)
 {
   Close();
   m_bRead = false;
@@ -260,6 +263,18 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
   if (nSamples == 0 || nSamples > kMaxTiffSamples || nExtraSamples > nSamples)
     return false;
 
+  // RESUNIT_NONE/INCH/CENTIMETER are the only units TIFF 6.0 defines, so anything else
+  // cannot be written faithfully.  Refuse rather than write a file whose stated unit
+  // disagrees with what the caller asked for -- silently dropping the request is the
+  // very defect #2220 reports.  Neither tool caller can reach this in practice: their
+  // unit comes back out of Open(), and libtiff rejects an out-of-range RESOLUTIONUNIT
+  // while reading the directory ("Bad value 7 for \"ResolutionUnit\" tag") and leaves
+  // the defaulted RESUNIT_INCH in place, so measured input can only yield a legal
+  // value.  The guard is for direct callers of this public API.
+  if (nResolutionUnit != RESUNIT_NONE && nResolutionUnit != RESUNIT_INCH &&
+      nResolutionUnit != RESUNIT_CENTIMETER)
+    return false;
+
   m_nWidth = nWidth;
   m_nHeight = nHeight;
   m_nBitsPerSample = (icUInt16Number)nBPS;
@@ -271,6 +286,7 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
   m_nPlanar = bSep ? PLANARCONFIG_SEPARATE : PLANARCONFIG_CONTIG;
   m_nCompress = bCompress ? COMPRESSION_LZW : COMPRESSION_NONE;
   m_nSampleFormat = SAMPLEFORMAT_UINT;
+  m_nResolutionUnit = (icUInt16Number)nResolutionUnit;
   
   // fix up some common errors from malformed TIFF files (which could cause errors down the line)
   if (m_fXRes <= 0.0)
@@ -342,8 +358,23 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
   TIFFSetField(m_hTif, TIFFTAG_ROWSPERSTRIP, m_nRowsPerStrip);
   TIFFSetField(m_hTif, TIFFTAG_COMPRESSION, m_nCompress);
   TIFFSetField(m_hTif, TIFFTAG_ORIENTATION, m_nOrientation);
-  TIFFSetField(m_hTif, TIFFTAG_XRESOLUTION, fXRes);
-  TIFFSetField(m_hTif, TIFFTAG_YRESOLUTION, fYRes);
+  // Written unconditionally, next to the values it qualifies.  libtiff omits the tag
+  // unless it is set and readers then fall back to their own default, so an output
+  // converted from a centimetre-based source came out silently claiming inches and
+  // its physical size shifted by 2.54x (#2220).  Stating the unit even when it is
+  // RESUNIT_INCH costs one IFD entry and makes the file say what it means instead of
+  // depending on the reader agreeing about the default.
+  TIFFSetField(m_hTif, TIFFTAG_RESOLUTIONUNIT, m_nResolutionUnit);
+  // m_fXRes/m_fYRes, not the raw parameters: a non-positive resolution was clamped to
+  // 96 above, and writing the unclamped argument put the file at odds with the object
+  // that produced it -- GetXRes() answered 96 while the file declared 0.  Harmless
+  // while the unit was absent; now that an authoritative RESUNIT_INCH is written beside
+  // them, the file would assert "0 pixels per inch".  Same class as #2220 itself, so it
+  // is corrected here.  Neither tool caller is affected: iccSpecSepToTiff substitutes
+  // its own value below 1, and iccApplyProfiles takes an already-clamped resolution out
+  // of Open(), so for both m_fXRes == fXRes.
+  TIFFSetField(m_hTif, TIFFTAG_XRESOLUTION, m_fXRes);
+  TIFFSetField(m_hTif, TIFFTAG_YRESOLUTION, m_fYRes);
   if (bCompress) {
     if (m_nBitsPerSample >= 32) {
       TIFFSetField(m_hTif, TIFFTAG_PREDICTOR, PREDICTOR_FLOATINGPOINT);
@@ -463,6 +494,9 @@ bool CTiffImg::Open(const char *szFname)
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_SAMPLEFORMAT, &m_nSampleFormat);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_ROWSPERSTRIP, &m_nRowsPerStrip);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_ORIENTATION, &m_nOrientation);
+  // Defaulted rather than plain Get: an absent RESOLUTIONUNIT means inches per TIFF
+  // 6.0, and libtiff supplies that, so this yields a usable unit for every input.
+  TIFFGetFieldDefaulted(m_hTif, TIFFTAG_RESOLUTIONUNIT, &m_nResolutionUnit);
   TIFFGetField(m_hTif, TIFFTAG_XRESOLUTION, &m_fXRes);
   TIFFGetField(m_hTif, TIFFTAG_YRESOLUTION, &m_fYRes);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_COMPRESSION, &m_nCompress);

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.h
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.h
@@ -104,9 +104,15 @@ public:
 
   void Close();
 
+  // nResolutionUnit names the unit fXRes/fYRes are expressed in (one of libtiff's
+  // RESUNIT_* codes).  It is a defaulted trailing parameter so the existing callers
+  // that do not care keep compiling unchanged and keep writing inch-based output,
+  // while the tools that copy a source image's resolution can now carry its unit
+  // across as well (#2220).
   bool Create(const char *szFname, unsigned int nWidth, unsigned int nHeight,
               unsigned int nBPS, unsigned int nPhoto, unsigned int nSamples, unsigned int nExtraSamples,
-              float fXRes, float fYRes, bool bCompress=true, bool bSep=false);
+              float fXRes, float fYRes, bool bCompress=true, bool bSep=false,
+              unsigned int nResolutionUnit=RESUNIT_INCH);
   bool Open(const char *szFname);
 
   bool ReadLine(unsigned char *pBuf);
@@ -114,8 +120,15 @@ public:
   
   unsigned int GetWidth() { return m_nWidth;}
   unsigned int GetHeight() { return m_nHeight;}
-  double GetWidthIn() { return (double)m_nWidth / m_fXRes; }
-  double GetHeightIn() { return (double)m_nHeight / m_fYRes; }
+  // Physical size in inches, as the names promise.  m_fXRes/m_fYRes are expressed in
+  // whatever unit TIFFTAG_RESOLUTIONUNIT names, so the bare division these used to do
+  // only yields inches when that unit is RESUNIT_INCH: a centimetre-based image was
+  // reported 2.54x too large.  RESUNIT_NONE carries no absolute size at all -- its
+  // resolution values fix only an aspect ratio (TIFF 6.0, TIFFTAG_RESOLUTIONUNIT) --
+  // so return 0 there and let the caller omit the figure rather than print a
+  // meaningless one (#2220).
+  double GetWidthIn() { return InchesFromPixels(m_nWidth, m_fXRes); }
+  double GetHeightIn() { return InchesFromPixels(m_nHeight, m_fYRes); }
   unsigned int GetBitsPerSample() { return m_nBitsPerSample;}
   unsigned int GetPhoto();
   unsigned int GetSamples() { return m_nSamples;}
@@ -124,6 +137,9 @@ public:
   unsigned int GetPlanar() { return m_nPlanar; }
   unsigned int GetSampleFormat() { return m_nSampleFormat; }
   unsigned int GetOrientation() { return m_nOrientation; }
+  // The unit GetXRes()/GetYRes() are counted in; RESUNIT_INCH when the source image
+  // said nothing, which is what libtiff defaults an absent tag to.
+  unsigned int GetResolutionUnit() { return m_nResolutionUnit; }
   float GetXRes() {return m_fXRes;}
   float GetYRes() {return m_fYRes;}
 
@@ -133,6 +149,24 @@ public:
   bool SetIccProfile(unsigned char *pProfile, unsigned int  nLen);
 
 protected:
+  // Shared by GetWidthIn()/GetHeightIn(); see the comment on those.  Guards fRes as
+  // well as the unit because it is genuinely observable as zero: a freshly constructed
+  // object has it, and so does one whose Open() failed, since the failure path runs
+  // Close() and Close() resets it before the non-positive-resolution fix-up is reached.
+  // Both members are zero together in those states, so the old bare division computed
+  // 0.0/0.0 and returned a NaN.
+  double InchesFromPixels(unsigned int nPixels, float fRes)
+  {
+    if (fRes <= 0.0f || m_nResolutionUnit == RESUNIT_NONE)
+      return 0.0;
+
+    double dInches = (double)nPixels / (double)fRes;
+    if (m_nResolutionUnit == RESUNIT_CENTIMETER)
+      dInches /= 2.54;
+
+    return dInches;
+  }
+
   TIFF *m_hTif;
   bool m_bRead;
 
@@ -147,6 +181,7 @@ protected:
   icUInt16Number m_nCompress;
   icUInt16Number m_nSampleFormat;
   icUInt16Number m_nOrientation;
+  icUInt16Number m_nResolutionUnit;
 
   float m_fXRes;
   float m_fYRes;

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -541,7 +541,11 @@ int main(int argc, const char** argv)
   unsigned long dbpp = (nDestSamples * dbps  + 7)/ 8;
 
   //Open up output image using information from SrcImg and theCmm
-  if (!DstImg.Create(cfgApply.m_dstImgFile.c_str(), SrcImg.GetWidth(), SrcImg.GetHeight(), dbps, photo, nDestSamples, nExtraSamples, SrcImg.GetXRes(), SrcImg.GetYRes(), bCompress, bSeparation)) {
+  // GetXRes()/GetYRes() are taken from the source, so its RESOLUTIONUNIT has to come
+  // with them; without it a centimetre-based source produced an inch-defaulted output
+  // and the physical size shifted by 2.54x.  Same defect as iccSpecSepToTiff, because
+  // both tools reach it through the same shared CTiffImg::Create() (#2220).
+  if (!DstImg.Create(cfgApply.m_dstImgFile.c_str(), SrcImg.GetWidth(), SrcImg.GetHeight(), dbps, photo, nDestSamples, nExtraSamples, SrcImg.GetXRes(), SrcImg.GetYRes(), bCompress, bSeparation, SrcImg.GetResolutionUnit())) {
     printf("Unable to create Tiff file - '%s'\n", cfgApply.m_dstImgFile.c_str());
     return -1;
   }

--- a/Tools/CmdLine/IccSpecSepToTiff/Readme.md
+++ b/Tools/CmdLine/IccSpecSepToTiff/Readme.md
@@ -46,8 +46,15 @@ single-channel TIFF inputs.
 
 ## Input and Output Notes
 
-- Input TIFFs must have identical dimensions, resolution, sample format,
-  photometric interpretation, and `BitsPerSample`.
+- Input TIFFs must have identical dimensions, resolution, resolution unit,
+  sample format, photometric interpretation, and `BitsPerSample`. The unit is
+  part of the resolution: 300 pixels/inch and 300 pixels/cm are the same two
+  numbers describing images of different physical size.
+- The output carries the inputs' `ResolutionUnit`, and their `XResolution` and
+  `YResolution` with them. Two long-standing substitutions can still make the
+  output resolution values differ from the input's, both in the unit the input
+  declared: an absent or non-positive resolution becomes 96 when the input is
+  read, and a resolution below 1 that survives that becomes 72.
 - Each input TIFF must have exactly one sample per pixel.
 - Photometric interpretation must be `MINISBLACK` or `MINISWHITE`; palette,
   RGB, CMYK, and unknown photometrics are rejected.

--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -439,12 +439,17 @@ int main(int argc, char* argv[]) {
       return -1;
     }
 
+    // The resolution unit belongs in this check alongside the resolution values it
+    // qualifies: 300 pixels/inch and 300 pixels/cm are the same two numbers describing
+    // images of different physical size, so comparing only GetXRes()/GetYRes() accepted
+    // a channel set that does not actually share a format (#2220).
     if (i && (infile[i].GetWidth() != infile[0].GetWidth() ||
       infile[i].GetHeight() != infile[0].GetHeight() ||
       infile[i].GetBitsPerSample() != infile[0].GetBitsPerSample() ||
       infile[i].GetPhoto() != infile[0].GetPhoto() ||
       infile[i].GetXRes() != infile[0].GetXRes() ||
-      infile[i].GetYRes() != infile[0].GetYRes())) {
+      infile[i].GetYRes() != infile[0].GetYRes() ||
+      infile[i].GetResolutionUnit() != infile[0].GetResolutionUnit())) {
         printf("input %s does not have same format as other files\n", filename.c_str());
         return -1;
     }
@@ -546,8 +551,13 @@ int main(int argc, char* argv[]) {
       existing.Close();
   }
 
+  // xRes/yRes above are copied straight from the input, so the input's unit has to be
+  // carried across with them.  Leaving it to default meant a centimetre-based source
+  // produced an output with no RESOLUTIONUNIT tag at all, which every reader takes as
+  // inches -- the same numbers, a physical size 2.54x off (#2220).
   if (!outfile.Create(argv[1], f->GetWidth(), f->GetHeight(), f->GetBitsPerSample(), PHOTO_MINISBLACK,
-                     (unsigned int)nSamples, nExtraSamples, xRes, yRes, bCompress, bSep)) {
+                     (unsigned int)nSamples, nExtraSamples, xRes, yRes, bCompress, bSep,
+                     f->GetResolutionUnit())) {
     printf("Unable to create %s\n", argv[1]);
     if (!outputExisted)
       remove(argv[1]);

--- a/Tools/CmdLine/IccTiffDump/Readme.md
+++ b/Tools/CmdLine/IccTiffDump/Readme.md
@@ -31,6 +31,12 @@ temporary file and atomically renamed only after the complete write succeeds.
 Existing regular files may be replaced atomically; device files, directories,
 and symbolic links are rejected as extraction destinations.
 
+The `Resolution:` line names the unit the file declares -- `pixels per/inch`,
+`pixels per/centimeter`, or `(relative, no absolute unit)` for `RESUNIT_NONE`,
+where the resolution values fix an aspect ratio and no absolute size exists. The
+`Size:` line reports the physical size in inches, converted from centimeters when
+needed, and omits it entirely under `RESUNIT_NONE`.
+
 The no-argument form is a help/syntax path and exits successfully. Other
 malformed invocations fail: extra trailing arguments are rejected, missing input
 files fail, and export requests fail when the TIFF has no embedded ICC profile.

--- a/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
+++ b/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
@@ -114,6 +114,17 @@ IdList photo_types[] = {
   {UNKNOWNID,        "Unknown"},
 };
 
+// TIFFTAG_RESOLUTIONUNIT was never reported, so every image was printed as though its
+// resolution were counted in inches.  A centimetre-based file therefore read as 2.54x
+// its real physical size and the label actively contradicted the file (#2220).  The
+// inch wording is kept verbatim so existing output and any log grep for it still match.
+IdList resolution_units[] = {
+  {RESUNIT_NONE,       "(relative, no absolute unit)"},
+  {RESUNIT_INCH,       "pixels per/inch"},
+  {RESUNIT_CENTIMETER, "pixels per/centimeter"},
+  {UNKNOWNID,          "pixels per/unrecognized unit"},
+};
+
 IdList compression_types[] = {
   {COMPRESSION_NONE,         "None"},
   {COMPRESSION_LZW,          "LZW"},
@@ -368,9 +379,19 @@ int main(int argc, icChar* argv[])
 
   printf("-------------------->Tiff Image Dump<---------------------------\n");
   printf("Filename:          %s\n", srcName.c_str());
-  printf("Size:              (%d x %d) pixels, (%.2lf\" x %.2lf\")\n",
-    SrcImg.GetWidth(), SrcImg.GetHeight(),
-    SrcImg.GetWidthIn(), SrcImg.GetHeightIn());
+  // A physical size only exists when RESOLUTIONUNIT names an absolute unit; under
+  // RESUNIT_NONE the resolution values fix an aspect ratio and nothing else, so
+  // GetWidthIn()/GetHeightIn() report 0 and printing inches would invent a measurement
+  // the file never made.  They also convert from centimetres now, which the bare
+  // division they used to do did not (#2220).
+  const double dWidthIn = SrcImg.GetWidthIn();
+  const double dHeightIn = SrcImg.GetHeightIn();
+  if (dWidthIn > 0.0 && dHeightIn > 0.0)
+    printf("Size:              (%d x %d) pixels, (%.2lf\" x %.2lf\")\n",
+      SrcImg.GetWidth(), SrcImg.GetHeight(), dWidthIn, dHeightIn);
+  else
+    printf("Size:              (%d x %d) pixels\n",
+      SrcImg.GetWidth(), SrcImg.GetHeight());
   printf("Planar:            %s\n", GetId(SrcImg.GetPlanar(), planar_types));
   printf("BitsPerSample:     %d (%s)\n", SrcImg.GetBitsPerSample(),
             GetSampleFormatDescription( SrcImg.GetSampleFormat()) );
@@ -381,7 +402,8 @@ int main(int argc, icChar* argv[])
     printf("ExtraSamples:      %d\n", nExtra);
   printf("Photometric:       %s\n", GetId(SrcImg.GetPhoto(), photo_types));
   printf("BytesPerLine:      %d\n", SrcImg.GetBytesPerLine());
-  printf("Resolution:        (%lf x %lf) pixels per/inch\n", SrcImg.GetXRes(), SrcImg.GetYRes());
+  printf("Resolution:        (%lf x %lf) %s\n", SrcImg.GetXRes(), SrcImg.GetYRes(),
+    GetId(SrcImg.GetResolutionUnit(), resolution_units));
   printf("Compression:       %s\n", GetId(SrcImg.GetCompress(), compression_types));
 
   unsigned char *pProfMem = nullptr;

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -134,6 +134,7 @@ before running the suite.
 | `iccdev.hybrid-pipeline` | `.github/scripts/iccdev-hybrid-pipeline-tests.sh` |
 | `iccdev.searchvec-uio-regression` | `.github/scripts/iccdev-searchvec-uio-regression.sh` |
 | `iccdev.specsep-tiff-geometry-regression` | `.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh` |
+| `iccdev.tiff-resolution-unit-regression` | `.github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh` |
 | `iccdev.dump-profile-header-regression` | `.github/scripts/iccdev-dump-profile-header-regression-tests.sh` |
 | `iccdev.basic-string-regressions` | `.github/scripts/iccdev-basic-string-regression-tests.sh` |
 | `iccdev.pawg-report-regressions` | `.github/scripts/iccdev-pawg-report-regression-tests.sh` |


### PR DESCRIPTION
Closes #2220.

`CTiffImg::Create()` never wrote `TIFFTAG_RESOLUTIONUNIT`. Every tool that copies a source image's `XResolution`/`YResolution` therefore emitted them without the unit that gives them meaning, and readers fall back to the TIFF 6.0 default of inches.

Measured on `master` `b39faa88`, clang 21.1.3 Release. A 254-pixel row at 100 pixels/cm is 2.54 cm, i.e. exactly 1.00 inch:

| | source | master output | with fix |
|---|---|---|---|
| `tiffinfo` | `300, 300 pixels/cm` | `300, 300` (no unit tag) | `300, 300 pixels/cm` |
| `iccTiffDump` physical size | 1.00" | **2.54"** | 1.00" |

## Measured per caller, because the defect is in shared code

`TiffImg.cpp` is linked by three tools. Each was checked by running it, not by reading:

| tool | master | with fix |
|---|---|---|
| `iccSpecSepToTiff` | cm source produces output with the tag **absent** | output states cm |
| `iccApplyProfiles` | cm source produces output with the tag **absent** | output states cm |
| `iccTiffDump` | prints `pixels per/inch` for every image, and divides pixels by resolution regardless of unit | prints the actual unit, converts cm to inches |

`iccApplyProfiles` was not in the issue text. It reaches the same `Create()` with `SrcImg.GetXRes()/GetYRes()`, so it had the identical defect.

## The change

`Create()` takes the unit as a **defaulted trailing parameter**, so the existing callers that do not care keep compiling unchanged and keep producing inch-based output. `Open()` reads the tag back with `TIFFGetFieldDefaulted`, which supplies the inch default for an absent tag.

An out-of-range unit is refused alongside `Create()`'s other unrepresentable-request guards (`nBPS % 8`, the compression/sample-size pairing, the sample-count range), and before `TIFFOpen`, so a refusal never truncates a destination. **Neither tool caller can reach that path**, and this is measured rather than assumed: libtiff discards a bad `RESOLUTIONUNIT` while reading the directory —

```
_TIFFVSetField: u7_1: Bad value 7 for "ResolutionUnit" tag.
```

— and leaves the defaulted `RESUNIT_INCH` in place, so input can only ever yield a legal value. The guard exists for direct callers of this public API, and is tested there rather than left as unfalsifiable code.

`iccSpecSepToTiff` also compares the unit when checking that its channel images share a format. 300 pixels/inch and 300 pixels/cm are the same two numbers describing images of different physical size; comparing only `GetXRes()`/`GetYRes()` accepted a mixed set and silently resolved every channel to the first one's unit. The checked-in `.github/ci/test-data/specsep-harvest/gray300/spec_*` fixtures are all `RESUNIT_NONE` and internally consistent, so no existing fixture set is rejected by the new check.

## Second defect of the same class, found by review

`Create()` clamps a non-positive resolution to 96 but wrote the **raw argument** to the file, so the file declared `0` while the object reported `96`. That was latent while no unit accompanied it; with an authoritative `RESUNIT_INCH` now written beside them, the file would assert "0 pixels per inch". It is the same object-disagrees-with-file class this PR fixes for the unit, so `Create()` now writes `m_fXRes`/`m_fYRes`. Unreachable from either tool — `iccSpecSepToTiff` substitutes its own value and `iccApplyProfiles` takes an already-clamped resolution out of `Open()` — so for both, `m_fXRes == fXRes`.

## Behaviour changes worth calling out

Outputs now carry a `ResolutionUnit` IFD entry they previously omitted, including when the unit is inches. Pixel data and every other tag are unchanged. Stating the unit costs one IFD entry and makes the file say what it means instead of depending on the reader agreeing about the default. No CTest byte-compares tool TIFF output against a checked-in reference, so nothing was pinned to the previous absence.

`GetWidthIn()`/`GetHeightIn()` now return what their names promise: inches, converted from centimetres, and 0 under `RESUNIT_NONE`, where the resolution values fix an aspect ratio and no absolute size exists. Their only caller is `iccTiffDump`, which omits the figure rather than printing a size the file never stated. They also stop returning a NaN for a default-constructed or failed-`Open()` object, where both members are zero and the old bare division computed `0.0/0.0`.

`iccTiffDump`'s and `iccApplyProfiles`' Readmes record the observable changes, alongside `iccSpecSepToTiff`'s.

## Coverage

New `iccdev.tiff-resolution-unit-regression` (`ctest -R iccdev.tiff-resolution-unit-regression`) covers all three tools. Assertions read the `ResolutionUnit` tag out of the output's IFD **bytes** with a small parser, not through a tool, so a tool that reports the unit wrongly cannot make a case pass for the wrong reason.

| case | master | with fix |
|---|---|---|
| `specsep-resolution-unit-centimeter-preserved` | FAIL (absent) | PASS |
| `specsep-resolution-unit-inch-preserved` | FAIL (absent) | PASS |
| `specsep-resolution-unit-none-preserved` | FAIL (absent) | PASS |
| `specsep-resolution-unit-mismatch-rejected` | FAIL (exit 0, converted) | PASS |
| `applyprofiles-resolution-unit-centimeter-preserved` | FAIL (absent) | PASS |
| `tiffdump-reports-resolution-unit` | FAIL (reports inch, 2.54") | PASS |
| `tiffdump-relative-resolution-omits-physical-size` | FAIL (reports inch) | PASS |

Red before green: **0 passed / 7 failed** against a master build, **7 passed / 0 failed** with this change. The inch case is a real assertion rather than one that passes on both trees, because master wrote no unit tag at all.

`iccdev.tiff-create-overflow` gains the direct-`Create()` cases no end-to-end path can reach: the out-of-range rejection, each defined unit accepted and reported back, the omitted-parameter call shape still defaulting to inches, and the clamped-resolution round trip. Each was red-tested by perturbing the source, so none is vacuous — and the clamped-resolution case had to be rewritten after the first version proved vacuous. It originally read back through `CTiffImg::Open()`, which applies the *same* clamp and so reports 96 whatever the file says; it passed against the defect. It now reads the tags with plain `TIFFGetField`.

## Pre-flight

| profile | result |
|---|---|
| GCC 13.3 Release, full build + test binaries | 0 warnings |
| Clang 21.1.3 `-Wall -Wextra -Wpedantic -Werror`, strict warnings **ENABLED** | 0 warnings, 0 errors |
| GCC 15.2.0 in `iccdev-ci-regression:latest`, `-Werror` + LTO, strict warnings **ENABLED** | 0 warnings, 0 errors |
| ASAN+UBSAN Debug clang, `detect_leaks=1` | clean on all new cases and the direct-`Create()` binary |
| `shellcheck` 0.9.0 on the new script | rc=0 |

Full local `ctest`: 191/192. The single failure is `iccdev.spectral-tiff-preview`, which stops at `ModuleNotFoundError: No module named 'imagecodecs'` before any iccDEV binary runs; installed into a venv it passes, including its `iccTiffDump` leg, which greps `SamplesPerPixel:` and `Spectral Range:` — neither a line this change touches.

## CI

Dispatched `ci-pr-action` with `ci_scope=source` before opening this PR, per the reduced-check workflow: [run 32445685359](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32445685359) — **9 success, 2 skipped, conclusion success**. That scope engaged GCC 15.2 Strict Release LTO, Tool Smoke Tests ASAN+UBSAN, Windows MSVC + ClangCL, MinGW UCRT64 and both risk gates.

Both new tests were confirmed to have *run*, not merely not failed:

- `iccdev.tiff-resolution-unit-regression` — **Passed, 1.08 sec**, test #108 of 189 on the GCC Strict ASAN+UBSAN leg (120 s timeout, so ample margin). Full leg: 189/189.
- `iccdev.tiff-create-overflow` — **Passed, 0.01 sec**, test #43 on Windows MSVC + ClangCL. That is the portability check that mattered here, since the added cases use a range-`for`, `uint16_t`, and direct `TIFFOpen`/`TIFFGetField`.

The script-based test does not register on the Windows legs, which is not new: no `iccdev.specsep*` script test appears there either. Windows registers the C++ regression binaries, and the C++ half of this change is covered there.
