### PR TITLE
feat(#2227): harvest the iccSpecSepToTiff CLI rework from cl-qa-specsep

### DIFF
--- a/.github/scripts/iccdev-issue-1514-specsep-usage-exit-code-regression-tests.sh
+++ b/.github/scripts/iccdev-issue-1514-specsep-usage-exit-code-regression-tests.sh
@@ -7,16 +7,20 @@
 # returned 0 -- a success status for what is actually a malformed invocation,
 # so wrapper scripts / CI could not distinguish a no-op from a real conversion.
 # The fix makes the argc<minargs path return -1 (process status 255), matching
-# every other error exit in main().
+# every other error exit in main().  The tool now also has real -h/--help and
+# --version flags, so the "Usage() only ever fires on an error" assumption the
+# original test was written under no longer holds: which stream Usage() lands on
+# is what separates a help request from a malformed invocation.
 #
 # This test asserts:
-#   1. no-args            -> non-zero exit (the #1514 fix) + Usage printed
-#   2. too-few-args       -> non-zero exit (the #1514 fix) + Usage printed
-#   3. valid argc, missing input prefix -> exit 255 + "Cannot open input"
-#      (regression guard: the real-error path must keep failing non-zero)
+#   1. no-args and too-few-args -> exit 255, Usage on stderr, nothing on stdout
+#   2. -h/--help                -> exit 0, Usage on stdout, nothing on stderr
+#   3. --version                -> exit 0, version on stdout, nothing on stderr
+#   4. missing input prefix     -> exit 255, diagnostic on stderr, no output file
 #
-# Before the fix, cases 1 and 2 exit 0 and this script FAILs (red); after the
-# fix they exit 255 and it PASSes (green).
+# Before the #1514 fix, cases 1 and 2 exit 0 and this script FAILs (red).  Before
+# the stream split, every case above writes its diagnostic to stdout and the
+# empty-stream assertions FAIL (red).
 #
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
@@ -48,7 +52,8 @@ export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
 export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
 
 SPECSEP="$TOOLS_DIR/IccSpecSepToTiff/iccSpecSepToTiff"
-LOGFILE="$OUTDIR/specsep-usage-exit-code.log"
+STDOUT_LOG="$OUTDIR/specsep-usage.stdout.log"
+STDERR_LOG="$OUTDIR/specsep-usage.stderr.log"
 
 PASS=0
 FAIL=0
@@ -74,32 +79,75 @@ check_sanitizers() {
   return 0
 }
 
-# Cases 1 & 2: malformed (too few args) must fail non-zero AND still print Usage.
-run_usage_nonzero() {
+# Malformed invocations fail with Usage on stderr and no stdout payload.
+run_usage_error() {
   local name="$1"; shift
   TOTAL=$((TOTAL + 1))
   local exit_code=0
-  timeout 60 "$SPECSEP" "$@" > "$LOGFILE" 2>&1 || exit_code=$?
+  timeout 60 "$SPECSEP" "$@" > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
 
-  check_sanitizers "$name" "$LOGFILE" || { sed -n '1,20p' "$LOGFILE"; return; }
+  check_sanitizers "$name" "$STDOUT_LOG" || { sed -n '1,20p' "$STDOUT_LOG"; return; }
+  check_sanitizers "$name" "$STDERR_LOG" || { sed -n '1,20p' "$STDERR_LOG"; return; }
 
-  if [ "$exit_code" -eq 0 ]; then
-    fail_case "$name" "expected non-zero exit for malformed invocation, got exit=0 (#1514)"
-    sed -n '1,20p' "$LOGFILE"
+  if [ "$exit_code" -ne 255 ]; then
+    fail_case "$name" "expected exit=255 for malformed invocation, got exit=$exit_code"
+    sed -n '1,20p' "$STDERR_LOG"
     return
   fi
 
-  if ! grep -Fq "Usage:" "$LOGFILE" 2>/dev/null; then
-    fail_case "$name" "missing Usage text on malformed invocation"
-    sed -n '1,20p' "$LOGFILE"
+  if ! grep -Fq "Usage:" "$STDERR_LOG" 2>/dev/null; then
+    fail_case "$name" "missing Usage text on stderr"
+    sed -n '1,20p' "$STDERR_LOG"
     return
   fi
 
-  pass_case "$name" "malformed invocation rejected with exit=$exit_code and Usage printed"
+  if [ -s "$STDOUT_LOG" ]; then
+    fail_case "$name" "malformed invocation wrote to stdout"
+    sed -n '1,20p' "$STDOUT_LOG"
+    return
+  fi
+
+  pass_case "$name" "malformed invocation rejected with exit=255 and Usage on stderr"
 }
 
-# Case 3: well-formed argc but the input prefix resolves to no files -- the
-# pre-existing error path that already returned -1; guard it stays non-zero.
+run_meta_success() {
+  local name="$1"
+  local arg="$2"
+  local expected="$3"
+  local forbidden="${4:-}"
+  TOTAL=$((TOTAL + 1))
+  local exit_code=0
+
+  timeout 60 "$SPECSEP" "$arg" > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
+
+  check_sanitizers "$name" "$STDOUT_LOG" || return
+  check_sanitizers "$name" "$STDERR_LOG" || return
+
+  if [ "$exit_code" -ne 0 ] || ! grep -Eq "$expected" "$STDOUT_LOG" 2>/dev/null; then
+    fail_case "$name" "expected successful stdout matching: $expected"
+    sed -n '1,30p' "$STDOUT_LOG"
+    sed -n '1,30p' "$STDERR_LOG"
+    return
+  fi
+
+  # --version must not simply reprint the usage block: the synopsis lines carry
+  # the tool name too, so a name-only match cannot discriminate the two paths.
+  if [ -n "$forbidden" ] && grep -Eq "$forbidden" "$STDOUT_LOG" 2>/dev/null; then
+    fail_case "$name" "stdout unexpectedly matched: $forbidden"
+    sed -n '1,30p' "$STDOUT_LOG"
+    return
+  fi
+
+  if [ -s "$STDERR_LOG" ]; then
+    fail_case "$name" "successful metadata request wrote to stderr"
+    sed -n '1,30p' "$STDERR_LOG"
+    return
+  fi
+
+  pass_case "$name" "returned requested metadata on stdout with exit=0"
+}
+
+# A well-formed argc with a missing input remains a normal CLI failure.
 run_missing_input_reject() {
   local name="iccSpecSepToTiff missing-input-prefix still exits non-zero"
   TOTAL=$((TOTAL + 1))
@@ -107,19 +155,26 @@ run_missing_input_reject() {
   local out="$OUTDIR/should-not-exist.tif"
   rm -f "$out"
   # 8 args (no profile): output compress sep prefix start end incr
-  timeout 60 "$SPECSEP" "$out" 0 0 "$OUTDIR/no-such-prefix_" 0 0 1 > "$LOGFILE" 2>&1 || exit_code=$?
+  timeout 60 "$SPECSEP" "$out" 0 0 "$OUTDIR/no-such-prefix_" 0 0 1 > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
 
-  check_sanitizers "$name" "$LOGFILE" || { sed -n '1,20p' "$LOGFILE"; return; }
+  check_sanitizers "$name" "$STDOUT_LOG" || return
+  check_sanitizers "$name" "$STDERR_LOG" || return
 
   if [ "$exit_code" -ne 255 ]; then
     fail_case "$name" "expected exit=255 for missing input, got exit=$exit_code"
-    sed -n '1,20p' "$LOGFILE"
+    sed -n '1,20p' "$STDERR_LOG"
     return
   fi
 
-  if ! grep -Fq "Cannot open input" "$LOGFILE" 2>/dev/null; then
-    fail_case "$name" "missing 'Cannot open input' diagnostic"
-    sed -n '1,20p' "$LOGFILE"
+  if ! grep -Fq "Cannot open input" "$STDERR_LOG" 2>/dev/null; then
+    fail_case "$name" "missing 'Cannot open input' diagnostic on stderr"
+    sed -n '1,20p' "$STDERR_LOG"
+    return
+  fi
+
+  if [ -s "$STDOUT_LOG" ]; then
+    fail_case "$name" "missing-input failure wrote to stdout"
+    sed -n '1,20p' "$STDOUT_LOG"
     return
   fi
 
@@ -128,7 +183,7 @@ run_missing_input_reject() {
     return
   fi
 
-  pass_case "$name" "missing input rejected with exit=255"
+  pass_case "$name" "missing input rejected with exit=255 and stderr diagnostic"
 }
 
 if [ ! -x "$SPECSEP" ]; then
@@ -137,8 +192,11 @@ if [ ! -x "$SPECSEP" ]; then
 fi
 
 echo "=== iccSpecSepToTiff usage-path exit-code regression (#1514) ==="
-run_usage_nonzero "iccSpecSepToTiff no-args exits non-zero"
-run_usage_nonzero "iccSpecSepToTiff too-few-args exits non-zero" foo.bar 0 0
+run_usage_error "iccSpecSepToTiff no-args exits non-zero"
+run_usage_error "iccSpecSepToTiff too-few-args exits non-zero" foo.bar 0 0
+run_meta_success "iccSpecSepToTiff short help" -h "^Usage:"
+run_meta_success "iccSpecSepToTiff long help" --help "^Usage:"
+run_meta_success "iccSpecSepToTiff version" --version "^iccSpecSepToTiff [0-9]" "^Usage:"
 run_missing_input_reject
 echo "iccSpecSepToTiff usage-path exit-code regression: $PASS passed, $FAIL failed, $TOTAL total"
 

--- a/Tools/CmdLine/IccSpecSepToTiff/Readme.md
+++ b/Tools/CmdLine/IccSpecSepToTiff/Readme.md
@@ -6,7 +6,24 @@ profile whose channel model matches the generated TIFF.
 
 ## Usage
 
-Run without arguments to print the current command syntax and supported options.
+Use `-h` or `--help` for the command syntax and `--version` for the build
+version. Both exit with status 0 and print to standard output. Running without
+arguments, or with an incomplete or over-long command, names the problem and
+prints the syntax to standard error, then exits with status 255. A conversion is
+`argc=8` without a profile or `argc=9` with one:
+
+| `argv` | Name | Meaning |
+| --- | --- | --- |
+| `argv[0]` | program | Path or name used to invoke `iccSpecSepToTiff` |
+| `argv[1]` | output | TIFF file to create |
+| `argv[2]` | compress | `0` for none or `1` for LZW |
+| `argv[3]` | sep | `0` for interleaved or `1` for separate planes |
+| `argv[4]` | infile_prefix | Literal input filename prefix |
+| `argv[5]` | start | First channel number |
+| `argv[6]` | end | Last channel number, inclusive |
+| `argv[7]` | incr | Nonzero channel increment |
+| `argv[8]` | profile | Optional ICC profile to validate and embed |
+
 The fourth argument is a literal filename prefix. `iccSpecSepToTiff` appends the
 channel number to that prefix, so `spec_` with `start=1` opens `spec_1`, then
 `spec_2`, and so on. It is not a `printf` format string.
@@ -27,10 +44,13 @@ and match the output sample count:
 
 The command fails before creating output when these checks fail. This prevents
 TIFF files from carrying mislabeled `ICC Profile` tag data or profiles that
-cannot describe the image samples.
+cannot describe the image samples. Diagnostics for every rejection go to
+standard error; the accepted-profile line and the conversion summary go to
+standard output. Every error path exits with status 255.
 
 ```sh
-iccSpecSepToTiff
+iccSpecSepToTiff --help
+iccSpecSepToTiff --version
 ```
 
 Example:
@@ -57,13 +77,45 @@ single-channel TIFF inputs.
   read, and a resolution below 1 that survives that becomes 72.
 - Each input TIFF must have exactly one sample per pixel.
 - Photometric interpretation must be `MINISBLACK` or `MINISWHITE`; palette,
-  RGB, CMYK, and unknown photometrics are rejected.
+  RGB, CMYK, and unknown photometrics are rejected. Floating-point
+  `MINISWHITE` is rejected because the bytewise inversion it needs is not a
+  valid numeric conversion for IEEE floating-point samples.
 - `BitsPerSample` must be byte-aligned. Uncompressed output supports any
   byte-aligned sample size accepted by the TIFF helper. LZW compression is
   limited to 8-, 16-, or 32-bit samples.
 - Output uses explicit `ExtraSamples` metadata for every sample beyond the
   first. Very high channel-count spectral TIFFs can be valid but may exceed
   limits in display tools such as ImageMagick.
+- On POSIX, an existing output destination must be a regular file; a directory
+  or device is rejected before anything is written. If profile embedding,
+  reading, or writing fails after the output was created, the incomplete output
+  is removed, and a failed create removes the stub only when the destination did
+  not already exist.
+- A successful conversion reports the accepted profile, if any, followed by the
+  output path, dimensions, bit depth, sample count, planar configuration,
+  compression, and embedded-profile state. Nothing is written to standard output
+  until the output TIFF is complete, so an empty standard output means nothing
+  was produced.
+- Paths echoed in diagnostics are escaped: control characters and every byte
+  outside printable ASCII are rendered as `\xNN`, matching `iccTiffDump`. A
+  non-ASCII path therefore appears escaped rather than verbatim.
+
+## Limits
+
+- `start`, `end`, and `incr` are signed 32-bit integers.
+- TIFF `SamplesPerPixel` limits the generated image to 65,535 channels.
+- TIFF width and height are unsigned 32-bit values. Row-buffer and output-size
+  products are checked for `size_t` overflow before allocation.
+- Embedded ICC profile data is limited to 4,294,967,295 bytes by the ICC/TIFF
+  profile-length field.
+- LZW output supports 8, 16, or 32 bits per sample.
+- All input TIFFs remain open during conversion. The operating system's
+  per-process open-file limit can therefore impose a lower practical channel
+  cap than the TIFF field.
+
+There is no additional tool-specific cap on image dimensions, total pixels, or
+prefix length. Allocation failures and arithmetic overflow fail the conversion
+instead of producing a partial output.
 
 ## See Also
 

--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -74,6 +74,7 @@
 #include <cstdlib>
 #include <cerrno>
 #include <climits>
+#include <cstdarg>
 #include <cstdio>
 #include <cstring>
 #include <cmath>
@@ -88,11 +89,12 @@
 #include "IccDefs.h"
 #include "IccApplyBPC.h"
 #include "TiffImg.h"
+#include "IccCmdLineUtil.h"
 #include "IccProfLibVer.h"
 
 //===================================================
 
-void Usage(const char *name)
+static void Usage(FILE *stream, const char *name)
 {
   // remove path before command name
   const char *strippedName = strrchr( name, '/' );      // Unix/MacOS
@@ -104,28 +106,48 @@ void Usage(const char *name)
   else
     ++strippedName;
 
-  printf("Usage: %s output compress sep infile_prefix start end incr {profile}\n", strippedName ); // argv[0]
-  printf("Concatenates several spectral TIFF files into a single file, with optional embedded ICC profile.\n");
-  
-  printf("\toutput: path/name of the TIFF file to be created\n");                               // argv[1]
-  printf("\tcompress: boolean (0 | 1), should the output be compressed\n");                     // argv[2]
-  printf("\tsep: boolean (0 | 1), plane data are separated in the output TIFF\n");              // argv[3]
-  printf("\tinfile_prefix: literal input filename prefix; channel numbers are appended, example: \"spec_\"\n"); // argv[4]
-  printf("\tstart: integer, first channel number to process\n");                                // argv[5]
-  printf("\tend: integer, last channel number to process\n");                                   // argv[6]
-  printf("\tincrement: integer, increment between channels\n");                                 // argv[7]
-  printf("\tprofile: optional ICC profile to validate and embed in the output TIFF\n");         // argv[8]
-  printf("\n");
-  printf("Notes:\n");
-  printf("\t-h/--help are not option flags; run without arguments to print this usage.\n");
-  printf("\tinfile_prefix is not a printf format string; \"spec_00\" with start=1 opens \"spec_001\".\n");
-  printf("\tstart/end/increment must be plain decimal integers; whitespace, '+', NaN, and floats are rejected.\n");
-  printf("\tEmbedded profiles must parse and validate as ICC profiles. If a spectral PCS is present,\n");
-  printf("\tits channel count/range steps must match the generated TIFF SamplesPerPixel.\n");
-  printf("\tWithout a spectral PCS, profile data color-space samples must match TIFF SamplesPerPixel.\n");
-  printf("\tCI fixture images are intentionally tiny; use larger source TIFFs for visual display review.\n");
-  printf("Built with IccProfLib version " ICCPROFLIBVER "\n");
-  printf("\n");
+  // argv[0] is attacker-controlled in the same way every other argument is, so it
+  // gets the same escaping the sibling TIFF tool applies before echoing a name.
+  std::string safeName = icSanitizeConsoleText(strippedName);
+
+  fprintf(stream, "Usage:\n");
+  fprintf(stream, "  %s output compress sep infile_prefix start end incr [profile]\n", safeName.c_str());
+  fprintf(stream, "  %s -h | --help\n", safeName.c_str());
+  fprintf(stream, "  %s --version\n\n", safeName.c_str());
+  fprintf(stream, "Combine single-channel spectral TIFF files into one multi-sample TIFF.\n\n");
+
+  fprintf(stream, "Arguments:\n");
+  fprintf(stream, "  output         TIFF file to create\n");                                     // argv[1]
+  fprintf(stream, "  compress       0 for no compression, 1 for LZW\n");                         // argv[2]
+  fprintf(stream, "  sep            0 for interleaved samples, 1 for separate planes\n");        // argv[3]
+  fprintf(stream, "  infile_prefix  Literal prefix; the channel number is appended\n");          // argv[4]
+  fprintf(stream, "  start          First channel number\n");                                    // argv[5]
+  fprintf(stream, "  end            Last channel number, inclusive\n");                          // argv[6]
+  fprintf(stream, "  incr           Nonzero channel increment\n");                               // argv[7]
+  fprintf(stream, "  profile        Optional ICC profile to validate and embed\n\n");            // argv[8]
+
+  fprintf(stream, "Rules:\n");
+  fprintf(stream, "  compress and sep accept only 0 or 1.\n");
+  fprintf(stream, "  start, end, and incr accept plain decimal integers.\n");
+  fprintf(stream, "  The range must land exactly on end and may descend with a negative incr.\n");
+  fprintf(stream, "  infile_prefix is not a printf format string.\n");
+  fprintf(stream, "  Every input must be a matching single-channel grayscale TIFF.\n");
+  fprintf(stream, "  An optional profile must be conformant and match SamplesPerPixel.\n\n");
+
+  fprintf(stream, "Limits:\n");
+  fprintf(stream, "  SamplesPerPixel is limited to 65535 channels by the TIFF field.\n");
+  fprintf(stream, "  ICC profile data is limited to 4294967295 bytes.\n");
+  fprintf(stream, "  TIFF width and height are limited to 32-bit unsigned values.\n");
+  fprintf(stream, "  LZW output supports 8, 16, or 32 bits per sample.\n");
+  fprintf(stream, "  Inputs stay open concurrently; the OS open-file limit may be lower.\n\n");
+  fprintf(stream, "Built with IccProfLib version " ICCPROFLIBVER "\n");
+}
+
+//===================================================
+
+static void PrintVersion()
+{
+  printf("iccSpecSepToTiff " ICCPROFLIBVER "\n");
 }
 
 //===================================================
@@ -206,7 +228,36 @@ static void printFirstValidationLine(const std::string &report)
   size_t end = report.find('\n');
   std::string line = report.substr(0, end == std::string::npos ? report.size() : end);
   if (!line.empty())
-    printf("Profile validation detail: %s\n", line.c_str());
+    fprintf(stderr, "Profile validation detail: %s\n",
+            icSanitizeConsoleText(line).c_str());
+}
+
+// Renders the accepted-profile line into a string instead of printing it, so
+// main() can hold it back until the conversion has actually succeeded.  Kept as
+// a printf-style formatter rather than a stream so the two call sites below use
+// the exact format strings they printed before, and the attribute keeps the
+// compiler checking them.
+#if defined(__GNUC__) || defined(__clang__)
+__attribute__((format(printf, 2, 3)))
+#endif
+static void formatAcceptedSummary(std::string &out, const char *format, ...)
+{
+  va_list args;
+  va_start(args, format);
+  int needed = vsnprintf(NULL, 0, format, args);
+  va_end(args);
+
+  if (needed < 0) {
+    out.clear();
+    return;
+  }
+
+  std::vector<char> buffer((size_t)needed + 1);
+  va_start(args, format);
+  vsnprintf(buffer.data(), buffer.size(), format, args);
+  va_end(args);
+
+  out.assign(buffer.data());
 }
 
 static void sigToText(icUInt32Number sig, char *buf, size_t bufSize)
@@ -220,7 +271,8 @@ static void sigToText(icUInt32Number sig, char *buf, size_t bufSize)
 
 static bool validateProfileSampleCompatibility(const CIccProfile *profile,
                                                size_t nSamples,
-                                               const char *profilePath)
+                                               const char *profilePath,
+                                               std::string &acceptedSummary)
 {
   if (!profile)
     return false;
@@ -238,66 +290,84 @@ static bool validateProfileSampleCompatibility(const CIccProfile *profile,
     icUInt32Number spectralSamples = icGetSpaceSamples((icColorSpaceSignature)header.spectralPCS);
 
     if (!spectralSamples || spectralSamples != nSamples) {
-      printf("Profile %s spectral PCS samples (%u, %s) do not match TIFF SamplesPerPixel (%zu).\n",
-             profilePath, (unsigned int)spectralSamples, spectralPcs, nSamples);
+      fprintf(stderr, "Profile %s spectral PCS samples (%u, %s) do not match TIFF SamplesPerPixel (%zu).\n",
+              icSanitizeConsoleText(profilePath).c_str(),
+              (unsigned int)spectralSamples, spectralPcs, nSamples);
       return false;
     }
 
     if (!header.spectralRange.steps || header.spectralRange.steps != nSamples) {
-      printf("Profile %s spectral PCS range steps (%u) do not match TIFF SamplesPerPixel (%zu).\n",
-             profilePath, (unsigned int)header.spectralRange.steps, nSamples);
+      fprintf(stderr, "Profile %s spectral PCS range steps (%u) do not match TIFF SamplesPerPixel (%zu).\n",
+              icSanitizeConsoleText(profilePath).c_str(),
+              (unsigned int)header.spectralRange.steps, nSamples);
       return false;
     }
 
-    printf("ICC profile accepted: %s, status=conformant, data=%s, PCS=%s, spectralPCS=%s, spectralRangeSteps=%u, TIFFSamples=%zu\n",
-           profilePath, colorSpace, pcs, spectralPcs, (unsigned int)header.spectralRange.steps, nSamples);
+    formatAcceptedSummary(acceptedSummary,
+                          "ICC profile accepted: %s, status=conformant, data=%s, PCS=%s, spectralPCS=%s, spectralRangeSteps=%u, TIFFSamples=%zu",
+                          icSanitizeConsoleText(profilePath).c_str(), colorSpace, pcs, spectralPcs,
+                          (unsigned int)header.spectralRange.steps, nSamples);
     return true;
   }
 
   icUInt32Number dataSamples = profile->GetSpaceSamples();
   if (!dataSamples || dataSamples != nSamples) {
-    printf("Profile %s data color-space samples (%u, %s) do not match TIFF SamplesPerPixel (%zu).\n",
-           profilePath, (unsigned int)dataSamples, colorSpace, nSamples);
+    fprintf(stderr, "Profile %s data color-space samples (%u, %s) do not match TIFF SamplesPerPixel (%zu).\n",
+            icSanitizeConsoleText(profilePath).c_str(),
+            (unsigned int)dataSamples, colorSpace, nSamples);
     return false;
   }
 
-  printf("ICC profile accepted: %s, status=conformant, data=%s, PCS=%s, TIFFSamples=%zu\n",
-         profilePath, colorSpace, pcs, nSamples);
+  formatAcceptedSummary(acceptedSummary,
+                        "ICC profile accepted: %s, status=conformant, data=%s, PCS=%s, TIFFSamples=%zu",
+                        icSanitizeConsoleText(profilePath).c_str(), colorSpace, pcs, nSamples);
   return true;
 }
 
 static bool readValidateProfile(const char *profilePath,
                                 size_t nSamples,
                                 std::unique_ptr<unsigned char[]> &destProfile,
-                                size_t &destProfileLength)
+                                size_t &destProfileLength,
+                                std::string &acceptedSummary)
 {
   destProfile.reset();
   destProfileLength = 0;
+  acceptedSummary.clear();
 
   CIccFileIO io;
   if (!io.Open(profilePath, "rb")) {
-    printf("Cannot open profile %s\n", profilePath);
+    fprintf(stderr, "Cannot open profile %s\n",
+            icSanitizeConsoleText(profilePath).c_str());
     return false;
   }
 
   destProfileLength = io.GetLength();
   if (!destProfileLength) {
     io.Close();
-    printf("Profile %s is empty; refusing to embed zero-length ICC data.\n", profilePath);
+    fprintf(stderr, "Profile %s is empty; refusing to embed zero-length ICC data.\n",
+            icSanitizeConsoleText(profilePath).c_str());
     return false;
   }
 
   if (destProfileLength > (size_t)std::numeric_limits<icUInt32Number>::max()) {
     io.Close();
-    printf("Profile %s is too large to embed in TIFF ICCProfile tag: %zu bytes\n",
-           profilePath, destProfileLength);
+    fprintf(stderr, "Profile %s is too large to embed in TIFF ICCProfile tag: %zu bytes\n",
+            icSanitizeConsoleText(profilePath).c_str(), destProfileLength);
     return false;
   }
 
-  destProfile.reset(new unsigned char[destProfileLength]);
+  destProfile.reset(new (std::nothrow) unsigned char[destProfileLength]);
+  if (!destProfile) {
+    io.Close();
+    fprintf(stderr, "Unable to allocate %zu bytes for profile %s.\n",
+            destProfileLength, icSanitizeConsoleText(profilePath).c_str());
+    return false;
+  }
+
   if (io.Read8(destProfile.get(), destProfileLength) != destProfileLength) {
     io.Close();
-    printf("Cannot read complete profile %s\n", profilePath);
+    fprintf(stderr, "Cannot read complete profile %s\n",
+            icSanitizeConsoleText(profilePath).c_str());
     return false;
   }
   io.Close();
@@ -309,14 +379,16 @@ static bool readValidateProfile(const char *profilePath,
                                                          validateReport,
                                                          validateStatus));
   if (!profile) {
-    printf("Cannot parse profile %s as an ICC profile.\n", profilePath);
+    fprintf(stderr, "Cannot parse profile %s as an ICC profile.\n",
+            icSanitizeConsoleText(profilePath).c_str());
     printFirstValidationLine(validateReport);
     return false;
   }
 
   if (validateStatus >= icValidateNonCompliant) {
-    printf("Profile %s failed ICC validation: %s.\n",
-           profilePath, validateStatusName(validateStatus));
+    fprintf(stderr, "Profile %s failed ICC validation: %s.\n",
+            icSanitizeConsoleText(profilePath).c_str(),
+            validateStatusName(validateStatus));
     printFirstValidationLine(validateReport);
     return false;
   }
@@ -330,7 +402,8 @@ static bool readValidateProfile(const char *profilePath,
     profileForSamples = compatibilityProfile.get();
   }
 
-  if (!validateProfileSampleCompatibility(profileForSamples, nSamples, profilePath))
+  if (!validateProfileSampleCompatibility(profileForSamples, nSamples, profilePath,
+                                          acceptedSummary))
     return false;
 
   return true;
@@ -353,15 +426,38 @@ static void discardPartialOutput(CTiffImg &outfile, const char *path)
 
 int main(int argc, char* argv[]) {
   const int minargs = 8; // argc = 8 without profile, 9 with profile
-  
+
+  // An explicit help/version request is the one invocation that is *not* an
+  // error, so it prints on stdout and exits 0, matching iccRoundTrip and
+  // iccPawgReport.  Everything below keeps the #1514 contract: a malformed
+  // invocation reported success to the caller even though nothing was produced,
+  // so wrapper scripts/CI could not tell a no-op apart from a real conversion.
+  if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+    Usage(stdout, argv[0]);
+    return 0;
+  }
+
+  if (argc == 2 && !strcmp(argv[1], "--version")) {
+    PrintVersion();
+    return 0;
+  }
+
   if (argc < minargs || argc > 9) {
-    // Too few arguments is a usage *error*, not a successful help request: this
-    // tool has no explicit -h/--help flag, so Usage() only ever fires here, on a
-    // malformed invocation.  Returning 0 reported success to the caller even
-    // though nothing was produced (#1514), so wrapper scripts/CI could not tell
-    // a no-op apart from a real conversion.  Fail like every other error exit in
-    // main(), all of which return -1 (process status 255).
-    Usage(argv[0]);
+    // Say which way the invocation is malformed before the syntax block: a bare
+    // Usage() dump left the caller to diff their command against it.  The
+    // diagnostic and the usage both go to stderr because this path is a failure;
+    // -h/--help above is the only route to Usage() on stdout.  Fail like every
+    // other error exit in main(), all of which return -1 (process status 255).
+    if (argc < minargs)
+      fprintf(stderr, "Missing arguments: expected 7 or 8, received %d.\n",
+              argc > 0 ? argc - 1 : 0);
+    else
+      fprintf(stderr, "Unexpected extra argument: %s\n",
+              icSanitizeConsoleText(argv[9]).c_str());
+
+    // argc==0 is legal for execve, and Usage() runs strrchr() on the name before
+    // anything else can reject it, so substitute the tool's own name there.
+    Usage(stderr, argc > 0 ? argv[0] : "iccSpecSepToTiff");
     return -1;
   }
 
@@ -369,7 +465,9 @@ int main(int argc, char* argv[]) {
   bool bSep = false;
 
   if (!parseBoolArg(argv[2], bCompress) || !parseBoolArg(argv[3], bSep)) {
-    printf("Invalid boolean value for compress or sep: %s, %s\n", argv[2], argv[3]);
+    fprintf(stderr, "Invalid boolean value for compress or sep: %s, %s\n",
+            icSanitizeConsoleText(argv[2]).c_str(),
+            icSanitizeConsoleText(argv[3]).c_str());
     return -1;
   }
 
@@ -380,12 +478,15 @@ int main(int argc, char* argv[]) {
   if (!parseIntArg(argv[5], start) ||
       !parseIntArg(argv[6], end) ||
       !parseIntArg(argv[7], step)) {
-    printf("Invalid channel range: %s, %s, %s\n", argv[5], argv[6], argv[7]);
+    fprintf(stderr, "Invalid channel range: %s, %s, %s\n",
+            icSanitizeConsoleText(argv[5]).c_str(),
+            icSanitizeConsoleText(argv[6]).c_str(),
+            icSanitizeConsoleText(argv[7]).c_str());
     return -1;
   }
 
   if (step == 0) {
-    printf("Error: increment cannot be zero.\n");
+    fprintf(stderr, "Error: increment cannot be zero.\n");
     return -1;  // Exit the program with an error code
   }
 
@@ -394,7 +495,7 @@ int main(int argc, char* argv[]) {
 
   if ( ((range < 0) && (step > 0))
     || ((range > 0) && (step < 0)) ) {
-    printf("Bad steps values would overflow: %d, %d, %d\n", start, end, step );
+    fprintf(stderr, "Bad steps values would overflow: %d, %d, %d\n", start, end, step);
     return -1;
   }
 
@@ -402,7 +503,8 @@ int main(int argc, char* argv[]) {
   long long absStep = step < 0 ? -(long long)step : (long long)step;
 
   if (absRange % absStep) {
-    printf("Invalid channel range specified: increment does not land on end: %d, %d, %d\n", start, end, step);
+    fprintf(stderr, "Invalid channel range specified: increment does not land on end: %d, %d, %d\n",
+            start, end, step);
     return -1;
   }
 
@@ -410,23 +512,32 @@ int main(int argc, char* argv[]) {
 
   if (nSamples < 1 ||
       nSamples > (size_t)std::numeric_limits<icUInt16Number>::max()) {
-    printf("Invalid sample count specified: %d, %d, %d\n", start, end, step );
+    fprintf(stderr, "Invalid sample count specified: %d, %d, %d\n", start, end, step);
     return -1;
   }
 
   // open ALL input files
-  std::vector<CTiffImg> infile(nSamples);
+  std::vector<CTiffImg> infile;
+  try {
+    infile.resize(nSamples);
+  }
+  catch (const std::bad_alloc &) {
+    fprintf(stderr, "Unable to allocate input state for %zu channels.\n", nSamples);
+    return -1;
+  }
 
   for (size_t i=0; i<nSamples; i++) {
     long long channelNum = (long long)start + (long long)i * (long long)step;
     std::string filename = std::string(argv[4]) + std::to_string(channelNum);
     if (!infile[i].Open(filename.c_str())) {
-      printf("Cannot open input %s\n", filename.c_str());
+      fprintf(stderr, "Cannot open input %s\n",
+              icSanitizeConsoleText(filename).c_str());
       return -1;
     }
 
     if (infile[i].GetSamples() != 1) {
-      printf("input %s does not have 1 sample per pixel\n", filename.c_str());
+      fprintf(stderr, "input %s does not have 1 sample per pixel\n",
+              icSanitizeConsoleText(filename).c_str());
       return -1;
     }
 
@@ -435,7 +546,8 @@ int main(int argc, char* argv[]) {
     // PHOTO_PALETTE.  Comparing against PHOTOMETRIC_PALETTE never matched, so
     // palette input was wrongly accepted and converted (#1381).
     if (infile[i].GetPhoto() == PHOTO_PALETTE) {
-      printf("input %s is a palette based file\n", filename.c_str());
+      fprintf(stderr, "input %s is a palette based file\n",
+              icSanitizeConsoleText(filename).c_str());
       return -1;
     }
 
@@ -450,7 +562,8 @@ int main(int argc, char* argv[]) {
       infile[i].GetXRes() != infile[0].GetXRes() ||
       infile[i].GetYRes() != infile[0].GetYRes() ||
       infile[i].GetResolutionUnit() != infile[0].GetResolutionUnit())) {
-        printf("input %s does not have same format as other files\n", filename.c_str());
+        fprintf(stderr, "input %s does not have same format as other files\n",
+                icSanitizeConsoleText(filename).c_str());
         return -1;
     }
   }
@@ -467,7 +580,7 @@ int main(int argc, char* argv[]) {
   if (f->GetPhoto()==PHOTO_MINISWHITE)
     invert = true;
   else if (f->GetPhoto()!=PHOTO_MINISBLACK) {
-    printf("Input photometric interpretation must be MinIsWhite or MinIsBlack\n");
+    fprintf(stderr, "Input photometric interpretation must be MinIsWhite or MinIsBlack\n");
     return -1;
   }
 
@@ -478,12 +591,13 @@ int main(int argc, char* argv[]) {
   // reported success, so a float MinIsWhite input was silently converted to
   // garbage.  Refuse the combination rather than emit corrupt samples.
   if (invert && f->GetSampleFormat() == SAMPLEFORMAT_IEEEFP) {
-    printf("Floating point MinIsWhite input cannot be inverted: %s\n", argv[4]);
+    fprintf(stderr, "Floating point MinIsWhite input cannot be inverted: %s\n",
+            icSanitizeConsoleText(argv[4]).c_str());
     return -1;
   }
 
   if (f->GetBitsPerSample() % 8) {
-    printf("Input bits per sample must be byte aligned: %u\n", f->GetBitsPerSample());
+    fprintf(stderr, "Input bits per sample must be byte aligned: %u\n", f->GetBitsPerSample());
     return -1;
   }
 
@@ -495,7 +609,7 @@ int main(int argc, char* argv[]) {
   if (!checkedSizeProduct(bytePerLine, nSamples, inputSize) ||
       !checkedSizeProduct(f->GetWidth(), bytesPerSample, outWidthSize) ||
       !checkedSizeProduct(outWidthSize, nSamples, outSize)) {
-    printf("Image row size is too large\n");
+    fprintf(stderr, "Image row size is too large\n");
     return -1;
   }
   
@@ -509,7 +623,7 @@ int main(int argc, char* argv[]) {
   std::unique_ptr<icUInt8Number[]> inbufffer( new (std::nothrow) icUInt8Number[ inputSize ] );
   std::unique_ptr<icUInt8Number[]> outbuffer( new (std::nothrow) icUInt8Number[ outSize ] );
   if (!inbufffer || !outbuffer) {
-    printf("Cannot allocate image row buffers of %zu and %zu bytes\n", inputSize, outSize);
+    fprintf(stderr, "Cannot allocate image row buffers of %zu and %zu bytes\n", inputSize, outSize);
     return -1;
   }
   icUInt8Number *inbuf = inbufffer.get();
@@ -526,8 +640,14 @@ int main(int argc, char* argv[]) {
   // profile pointer lifetime needs to last until output file is written!
   std::unique_ptr<unsigned char[]> destProfile;
   size_t destProfileLength = 0;
+  // Held until the output is written: announcing the profile as accepted before
+  // Create()/SetIccProfile()/WriteLine() have had their chance to fail left a
+  // failed run with output on stdout, so "stdout empty" could not be read as
+  // "nothing was produced" -- the very distinction #1514 asked for.
+  std::string acceptedProfileSummary;
   if (argc>8) {
-    if (!readValidateProfile(argv[8], nSamples, destProfile, destProfileLength))
+    if (!readValidateProfile(argv[8], nSamples, destProfile, destProfileLength,
+                             acceptedProfileSummary))
       return -1;
   }
 
@@ -558,7 +678,7 @@ int main(int argc, char* argv[]) {
   if (!outfile.Create(argv[1], f->GetWidth(), f->GetHeight(), f->GetBitsPerSample(), PHOTO_MINISBLACK,
                      (unsigned int)nSamples, nExtraSamples, xRes, yRes, bCompress, bSep,
                      f->GetResolutionUnit())) {
-    printf("Unable to create %s\n", argv[1]);
+    fprintf(stderr, "Unable to create %s\n", icSanitizeConsoleText(argv[1]).c_str());
     if (!outputExisted)
       remove(argv[1]);
     return -1;
@@ -566,7 +686,8 @@ int main(int argc, char* argv[]) {
 
   if (destProfile) {
     if (!outfile.SetIccProfile( destProfile.get(), (unsigned int)destProfileLength )) {
-      printf("Unable to embed ICC profile in %s\n", argv[1]);
+      fprintf(stderr, "Unable to embed ICC profile in %s\n",
+              icSanitizeConsoleText(argv[1]).c_str());
       discardPartialOutput(outfile, argv[1]);
       return -1;
     }
@@ -577,7 +698,7 @@ int main(int argc, char* argv[]) {
     for (size_t j=0; j<nSamples; j++) {
       sptr = inbuf + j*bytePerLine;
       if (!infile[j].ReadLine(sptr)) {
-        printf("Error reading line %u of file %zu\n", i, j);
+        fprintf(stderr, "Error reading line %u of file %zu\n", i, j);
         discardPartialOutput(outfile, argv[1]);
         return -1;
       }
@@ -596,7 +717,8 @@ int main(int argc, char* argv[]) {
       }
     }
     if (!outfile.WriteLine(outbuf)) {
-      printf("Error writing line %d\n", i);
+      fprintf(stderr, "Error writing line %u to %s\n", i,
+              icSanitizeConsoleText(argv[1]).c_str());
       discardPartialOutput(outfile, argv[1]);
       return -1;
     }
@@ -605,6 +727,16 @@ int main(int argc, char* argv[]) {
   // We need to close output first, to use all pointer data before buffers are destructed.
   outfile.Close();
 
+  if (!acceptedProfileSummary.empty())
+    printf("%s\n", acceptedProfileSummary.c_str());
+
+  printf("Output:            %s\n", icSanitizeConsoleText(argv[1]).c_str());
+  printf("Size:              %u x %u pixels\n", f->GetWidth(), f->GetHeight());
+  printf("BitsPerSample:     %u\n", f->GetBitsPerSample());
+  printf("SamplesPerPixel:   %zu\n", nSamples);
+  printf("Planar:            %s\n", bSep ? "separate" : "interleaved");
+  printf("Compression:       %s\n", bCompress ? "LZW" : "none");
+  printf("Profile:           %s\n", destProfile ? "embedded" : "none");
   printf("Image successfully written!\n");
 
   // buffers and input files closed by destructors

--- a/iccdev-mcp/docs/cli-tool-reference.md
+++ b/iccdev-mcp/docs/cli-tool-reference.md
@@ -333,7 +333,7 @@ observer must be `spac` class.
 |----------|-------|
 | **MCP Tool** | `spec_sep_to_tiff` |
 | **CLI Binary** | `iccSpecSepToTiff` |
-| **Syntax** | `iccSpecSepToTiff output compress sep fmt start end incr {profile}` |
+| **Syntax** | `iccSpecSepToTiff output compress sep infile_prefix start end incr {profile}` |
 | **MCP Args** | `config_args` (list) |
 | **Exit Codes** | `0` success, `255` file/format error |
 
@@ -342,8 +342,10 @@ spectral TIFF. Input files must be MINISBLACK, 1 sample/pixel, 8-16 bit,
 identical dimensions.
 
 ```bash
-# Merge 81 channels (380-780nm, 5nm steps)
-iccSpecSepToTiff out.tiff 0 0 "spec_%06d.tiff" 380 780 5
+# Merge 81 channels (380-780nm, 5nm steps) from inputs named spec_380 .. spec_780
+# infile_prefix is a literal prefix, not a printf format string: the channel
+# number is appended and nothing can follow it, so inputs carry no extension
+iccSpecSepToTiff out.tiff 0 0 "spec_" 380 780 5
 ```
 
 ---


### PR DESCRIPTION
Part of #2227 — item (1) of the split confirmed in the thread: `iccSpecSepToTiff.cpp` + docs, plus the CTest that pins the new behaviour. Items (2) CI/QA harness and (3) agent/prompt files follow separately; (2) pins behaviour added here, so they serialize.

Harvested from `cl-qa-specsep` (`39fff6fc`), rebased onto `c1ddd7ea`.

## Taken

- **`-h` / `--help` / `--version`** — stdout, exit 0, matching `iccRoundTrip` and `iccPawgReport`. `Usage()` takes a `FILE*`, so a malformed command line names the problem (`Missing arguments: expected 7 or 8, received 3`) and puts diagnostic *and* syntax on stderr.
- **Every diagnostic to stderr**, every argument-derived string escaped with `icSanitizeConsoleText()` — the helper `iccTiffDump` already applies. Filenames, profile paths, and validation-report lines reached the terminal unescaped.
- **Nothing on stdout until the output TIFF is complete.** The accepted-profile line was printed during validation, before `Create()`, so a run that then failed exited 255 *with output on stdout* — "stdout empty" could not be read as "nothing was produced", the distinction #1514 asked for. Now held and emitted with the summary. (Found by `/code-review`, not on the branch.)
- **Non-throwing profile allocation.** The row buffers beside it already were (#2076); this was the remaining allocation a caller can size, up to the 4 GiB embed limit checked immediately above. Same for the input-file vector.
- **Success summary** — path, geometry, bit depth, sample count, planar layout, compression, profile state.
- `argc == 0` guard: legal for `execve`, reached `Usage()`'s `strrchr()` on a null pointer. Unreachable on Linux (an empty `argv` arrives as `argc=1, argv[0]=""`); reachable where `argv[0]` is not synthesized.

## Not taken, and why

| Branch change | Measurement |
|---|---|
| `-1` → `EXIT_FAILURE` | Convention swap, no defect fixed. Breaks the documented #1514 status-255 contract and ~30 assertions across three shipped suites. |
| Reworded `Floating point MinIsWhite…` / `Cannot allocate image row buffers` | Same — both texts are pinned by `iccdev-specsep-tiff-geometry-regression`. |
| `IsRegularOutputDestination()` + `<windows.h>` + `(std::numeric_limits<>::max)()` | `CTiffImg::Create` already refuses non-regular output via `canCreateRegularOutput` (`TiffImg.cpp:325`). Measured: a directory and `/dev/null` are both rejected today. The real gap is `stat` vs `lstat` (a symlink to a regular file is followed) and the Windows arm returning `true` — that belongs in `TiffImg.cpp`, where `iccApplyProfiles` gets it too, not as a tool-local copy. The `(max)()` parens are only needed *because* of the `<windows.h>` include. Happy to file it. |
| Dropping `discardPartialOutput()` / `outputExisted` | Regression. `Create()` can fail *after* `TIFFOpen` (the `EXTRASAMPLES` path, `TiffImg.cpp:340-352`), leaving a truncated stub the branch no longer removes. `iccdev.specsep-tiff-geometry-regression` pins both halves. |
| Reordering the `GetResolutionUnit()` comparison | Zero behaviour change; moving those lines is what re-minted CodeQL #2355/#2356 last time. |
| Deleting the #1381 / #1514 / #2076 / #2220 why-comments | Kept. |

## Coverage

`iccdev-issue-1514-specsep-usage-exit-code-regression-tests.sh` (already registered as `iccdev.specsep-usage-exit-code-regression`) grows to 6 cases: `-h`, `--help`, `--version` exit 0 with output on stdout and **nothing on stderr**; malformed invocations exit 255 with `Usage` on stderr and **nothing on stdout**. The `--version` case also requires the usage block to be absent, so it cannot pass on a `Usage()` reprint.

**Red-tested: 6/6 fail against the pre-change binary.** No assertion is vacuous.

The other two suites are untouched and still pass (21 + 8), so every message text and exit status they pin is unchanged.

## Evidence

- Pre-PR dispatch `ci_scope=source`, run **32503183433 — 12 success / 1 skipped**. MSVC and ClangCL both compiled `iccSpecSepToTiff.cpp` and linked the exe (the new `try`/`catch` and `<cstdarg>`/`vsnprintf` are the MSVC risk); MinGW UCRT64 green.
- Local: clang-18 Release, clang `-Wall -Wextra -Wpedantic -Werror`, GCC `-Wall -Wextra -Werror` — all clean.
- CTests `#106` / `#107` / `#108` pass; all 35 script assertions green plain and under ASan+UBSan.
- `preflight-safety-checks.sh`: 0 failures.

## Note for reviewers

`icSanitizeConsoleText()` renders every byte ≥ 0x7f as `\xNN`, so a non-ASCII path now appears escaped in diagnostics (house behaviour, same as `iccTiffDump`; stated in the Readme). A checkout or `ICCDEV_TEST_OUTDIR` containing non-ASCII bytes would break `iccdev-specsep-tiff-geometry-regression`'s raw-path grep. I left that suite alone rather than churn it here — say the word if you want it normalised.

Also corrected `iccdev-mcp/docs/cli-tool-reference.md`, which documented `"spec_%06d.tiff"` as the prefix argument — a printf pattern the tool rejects and that `specsep-printf-pattern-prefix` already pins as a rejection.
