### PR TITLE
perf: synchronize AVX2 CLUT and threaded CMM paths

### DIFF
--- a/.github/ci/regression/README.md
+++ b/.github/ci/regression/README.md
@@ -44,6 +44,7 @@ Test 18 (Regression Bisect).
 
 | Script | Issue | Bug | Check |
 |--------|-------|-----|-------|
+| `.github/scripts/iccdev-windows-clut-avx2-benchmark.ps1` | AVX2 CLUT performance follow-up | Process-level timing hid compiler- and tail-specific regressions in the opt-in AVX2 path | Compiles the in-process `clut-avx2-benchmark.cpp` helper against separate baseline and AVX2 Windows builds, alternates execution order, covers 8-16 outputs, and records median throughput plus bit-exact per-lane parity |
 | `.github/scripts/iccdev-mluc-setter-regression-tests.sh` | #928 | `multiLocalizedUnicodeType` setters included safety terminators in serialized `mluc` string lengths | Rebuilds `sRGB_D65_MAT.icc` and `NamedColor.icc` from XML and verifies canonical `desc`/`mluc` sizes |
 | `.github/scripts/iccdev-mluc-read-utf16-regression-tests.sh` | #928 follow-up | `multiLocalizedUnicodeType` reader accepted malformed record lengths, string offsets, and UTF-16 surrogate data | Mutates `sRGB_D65_MAT.icc` in `/tmp` and verifies malformed `mluc` records are rejected without sanitizer findings |
 | `.github/scripts/iccdev-pcc-zero-illuminant-regression-tests.sh` | #958 | Non-standard PCC viewing-condition illuminant XYZ with zero Y divided by zero or fell back to D50 | Compiles a small PCC helper and verifies zero-Y custom illuminants are rejected without sanitizer findings or D50 substitution |

--- a/.github/ci/regression/clut-avx2-benchmark.cpp
+++ b/.github/ci/regression/clut-avx2-benchmark.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. The names "ICC" and "International Color Consortium" must not be used to
+ *    imply endorsement without prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT WARRANTY OF ANY KIND.
+ */
+
+#include <windows.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "IccTagLut.h"
+
+int main(int argc, char **argv)
+{
+  const int outputs = argc > 1 ? std::atoi(argv[1]) : 8;
+  const int iterations = argc > 2 ? std::atoi(argv[2]) : 5000000;
+  const int repetitions = argc > 3 ? std::atoi(argv[3]) : 7;
+  const int affinityCpu = argc > 4 ? std::atoi(argv[4]) : 0;
+
+  if (outputs < 8 || outputs > 16 || iterations < 1 || repetitions < 1 ||
+      affinityCpu < 0 || affinityCpu > 63)
+    return 2;
+
+  if (!SetThreadAffinityMask(
+        GetCurrentThread(), static_cast<DWORD_PTR>(1ull << affinityCpu)))
+    return 4;
+  SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
+
+  CIccCLUT clut(3, static_cast<icUInt16Number>(outputs), 4);
+  if (!clut.Init(2))
+    return 3;
+
+  icFloatNumber *data = clut.GetData(0);
+  for (int i = 0; i < 8 * outputs; i++)
+    data[i] = static_cast<icFloatNumber>((i % 64) * 0.01f);
+  clut.Begin();
+
+  const icFloatNumber src[3] = {0.25f, 0.50f, 0.75f};
+  icFloatNumber dst[16] = {};
+  for (int i = 0; i < 10000; i++)
+    clut.Interp3d(dst, src);
+
+  std::vector<double> samples;
+  samples.reserve(static_cast<size_t>(repetitions));
+  for (int sample = 0; sample < repetitions; sample++) {
+    const auto start = std::chrono::steady_clock::now();
+    for (int i = 0; i < iterations; i++)
+      clut.Interp3d(dst, src);
+    const auto end = std::chrono::steady_clock::now();
+    samples.push_back(
+        std::chrono::duration<double, std::nano>(end - start).count() /
+        static_cast<double>(iterations));
+  }
+
+  std::sort(samples.begin(), samples.end());
+  const double median = samples[samples.size() / 2];
+  double checksum = 0.0;
+  for (int i = 0; i < outputs; i++)
+    checksum += dst[i];
+  std::printf(
+      "outputs=%d iterations=%d repetitions=%d affinity_cpu=%d median_ns=%.3f calls_per_s=%.3f checksum=%.6f outputs_hex=",
+      outputs, iterations, repetitions, affinityCpu, median,
+      1000000000.0 / median, checksum);
+  for (int i = 0; i < outputs; i++) {
+    std::uint32_t bits;
+    std::memcpy(&bits, &dst[i], sizeof(bits));
+    std::printf("%s%08x", i ? "," : "", static_cast<unsigned int>(bits));
+  }
+  std::printf("\n");
+  return 0;
+}

--- a/.github/ci/regression/iccconnect-threaded-cmm.cpp
+++ b/.github/ci/regression/iccconnect-threaded-cmm.cpp
@@ -98,7 +98,7 @@ int main(int argc, char** argv)
     return 1;
   }
 
-  const icUInt32Number nPixels = 8;
+  const icUInt32Number nPixels = 1024;
   std::vector<icFloatNumber> src = MakeZeroVector(nPixels * nSrcSamples);
   std::vector<icFloatNumber> scalarDst = MakeZeroVector(nPixels * nDstSamples);
   std::vector<icFloatNumber> threadedDst = MakeZeroVector(nPixels * nDstSamples);
@@ -114,9 +114,11 @@ int main(int argc, char** argv)
     std::fprintf(stderr, "scalar multi-pixel apply failed\n");
     return 1;
   }
-  if (pThreadedCmm->Apply(threadedDst.data(), src.data(), nPixels) != icCmmStatOk) {
-    std::fprintf(stderr, "threaded multi-pixel apply failed\n");
-    return 1;
+  for (int pass = 0; pass < 8; pass++) {
+    if (pThreadedCmm->Apply(threadedDst.data(), src.data(), nPixels) != icCmmStatOk) {
+      std::fprintf(stderr, "threaded multi-pixel apply failed on pass %d\n", pass);
+      return 1;
+    }
   }
 
   for (size_t i = 0; i < scalarDst.size(); ++i) {

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,14 @@ use `.github/skills/regression-container-maintainer/SKILL.md` and
 - Workflow governance: `.github/instructions/workflow-governance.instructions.md`
 - Windows session helper: dot-source `.\.github\scripts\icc-session.ps1`, then
   run `icc-session` to create the next `DD-mmm-YYYY-NNN` workspace directory.
+- AVX2 CLUT debugging and optimization handoff:
+  `docs/avx2-clut-diagnostics.md`, with
+  `vs2022-clangcl-x64-avx2-diagnostics` for tracepoints and
+  `vs2022-clangcl-x64-avx2-qa-flags` for measurements. Use
+  `.github/scripts/iccdev-windows-clut-avx2-benchmark.ps1` for interleaved
+  8-16-output comparisons, and require `output_vector_match=True` for every
+  row; AVX2 dispatch is limited to 15 outputs, and native MSVC intentionally
+  retains SSE2.
 
 ## Pull Requests
 
@@ -135,6 +143,7 @@ Key safety rules:
 | Debug Python/Cython bindings | `.github/prompts/debug-python-bindings.prompt.md` |
 | Debug MATLAB bindings | `.github/prompts/debug-matlab-bindings.prompt.md` |
 | Debug WASM build | `.github/prompts/debug-wasm-build.prompt.md` |
+| AVX2 CLUT diagnostics | `.github/prompts/avx2-clut-diagnostics.prompt.md` |
 
 ## Skills
 
@@ -151,6 +160,7 @@ Key safety rules:
 | Python bindings tests | `.github/skills/python-bindings-test/SKILL.md` |
 | MATLAB bindings tests | `.github/skills/matlab-bindings-test/SKILL.md` |
 | WASM build tests | `.github/skills/wasm-build-test/SKILL.md` |
+| AVX2 CLUT diagnostics | `.github/skills/avx2-clut-diagnostics/SKILL.md` |
 
 ## WASM Notes
 

--- a/.github/instructions/build-system.instructions.md
+++ b/.github/instructions/build-system.instructions.md
@@ -104,6 +104,13 @@ Preset equivalents live in `Build/Cmake/CMakePresets.json`:
 | `linux-clang-profiling` | gprof/perf `-pg` profiling |
 | `macos-clang-sanitizers` | macOS ASan + UBSan + IntSan + float checks |
 | `macos-clang-guard-malloc` | macOS Debug tool build for libgmalloc |
+| `vs2022-clangcl-x64-avx2-qa-flags` | Windows ClangCL QA build with runtime-dispatched AVX2 CLUT interpolation |
+| `vs2022-clangcl-x64-avx2-diagnostics` | Windows ClangCL AVX2 build with dispatch, kernel-input, and timing tracepoints |
+| `vs2022-clangcl-x64-avx512-qa-flags` | Windows ClangCL QA build with AVX-512, AVX2, and scalar/SSE CLUT fallbacks |
+| `vs2022-clangcl-x64-clut-baseline-qa-flags` | Matching Windows ClangCL CLUT baseline with legacy CRT compatibility warnings suppressed |
+| `linux-clang-clut-baseline-qa-flags` | Linux/WSL2 Clang Release baseline for CLUT ISA comparisons |
+| `linux-clang-clut-avx2-qa-flags` | Linux/WSL2 Clang Release build with runtime-dispatched AVX2 CLUT interpolation |
+| `linux-clang-clut-avx512-qa-flags` | Linux/WSL2 Clang Release build with AVX-512, AVX2, and scalar/SSE fallbacks |
 
 Example:
 
@@ -111,6 +118,22 @@ Example:
 cmake --preset linux-clang-sanitizers -S Build/Cmake -B out/linux-clang-sanitizers
 cmake --build out/linux-clang-sanitizers -j"$(nproc)"
 ```
+
+The AVX2 and AVX-512 presets are opt-in QA configurations. Their ISA-specific
+translation units use scoped compiler flags; do not apply `/arch:AVX2`,
+`/arch:AVX512`, `-mavx2`, or `-mavx512f` globally. Runtime selection must keep
+the CPUID and XGETBV checks in `CIccCLUT::Interp3d()`. Compiler-flag probes use
+compile-only static-library checks so sanitizer link settings cannot produce a
+false unsupported result. On Linux, enable `ICCDEV_ENABLE_AVX2` and
+`ICCDEV_ENABLE_AVX512` directly; AVX-512 does not implicitly enable AVX2.
+`ICC_AVX2_CLUT_DEBUG` is diagnostic-only: it logs dispatch selection, corner
+offsets, interpolation weights, and per-kernel elapsed time through
+`IccSignatureUtils.h`. Keep it `OFF` for performance measurements and release
+builds.
+Windows AVX2 is enabled with ClangCL. Native MSVC reports a configure-time
+skip and retains SSE2 because the measured MSVC AVX2 path was slower. Recheck
+that decision only with the interleaved
+`.github/scripts/iccdev-windows-clut-avx2-benchmark.ps1` helper.
 
 On macOS, use GuardMalloc separately from sanitizer builds:
 

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -43,10 +43,19 @@ profile write failure regressions, two batch-backed suites through
 `Build/Cmake/Testing/RunWindowsBatchTest.cmake`, the
 iccDumpProfile smoke suite, the IccDEVCmm DLL smoke suite, the issue-987 shared
 export suite, the issue-1009 IccJson export suite, and the PAWG report smoke
-suite. Windows
+suite. They also register `iccdev.clut-eight-output-regression` through the
+native `RunClutEightOutputRegression.cmake` runner; do not rely on the Unix
+shell runner for this test because the Windows CTest branch returns before
+script-test registration. Windows
 feature-disabled builds register the subset whose targets are available. The
 Windows batch wrapper runs scripts from a disposable copy of `Testing/` under
 the build tree and must not dirty the source `Testing/` directory.
+
+AVX2 CLUT performance is not asserted by CTest. After the focused correctness
+test passes, use `.github/scripts/iccdev-windows-clut-avx2-benchmark.ps1` with
+separate baseline and AVX2 Release build directories. The helper alternates
+execution order, covers output counts 8-16, and verifies bit-exact output
+parity for every lane.
 
 Windows CTest wrappers source runtime DLL directories from `CMakeCache.txt`
 through `Build/Cmake/Testing/WindowsRuntimePaths.cmake`. Keep that helper in

--- a/.github/prompts/avx2-clut-diagnostics.prompt.md
+++ b/.github/prompts/avx2-clut-diagnostics.prompt.md
@@ -1,0 +1,47 @@
+# AVX2 CLUT Diagnostics and Optimization
+
+Use this prompt to inspect the runtime-dispatched AVX2 3D CLUT path without
+changing scalar, SSE, or AVX-512 behavior.
+
+## Windows Debug Build
+
+```cmd
+cmake --preset vs2022-clangcl-x64-avx2-diagnostics -S Build/Cmake -B out/vs2022-clangcl-x64-avx2-diagnostics
+cmake --build out/vs2022-clangcl-x64-avx2-diagnostics --config Debug -- /m /maxcpucount
+ctest --test-dir out/vs2022-clangcl-x64-avx2-diagnostics -C Debug --output-on-failure --no-tests=error -R "^iccdev\.clut-eight-output-regression$"
+```
+
+Set source breakpoints in `IccTraceAvx2ClutDispatch()` and
+`IccTraceAvx2ClutKernel()` in `IccProfLib/IccSignatureUtils.h`. Capture:
+
+- CPU AVX2 availability and selected dispatch path.
+- Output channel count, corner offsets, and interpolation weights.
+- Eight-lane vector work and the seven-output masked tail for fifteen outputs.
+
+## Optimization Rules
+
+1. Preserve CPUID and XGETBV runtime dispatch in `CIccCLUT::Interp3d()`.
+2. Keep ISA flags scoped to `IccTagLutAvx2.cpp`; never apply `/arch:AVX2`
+   globally.
+3. Validate the eight-, nine-, eleven-, fourteen-, and fifteen-output fixtures
+   before and after each change; fifteen outputs is the focused AVX2
+   masked-tail case.
+4. Measure throughput only with `ICC_AVX2_CLUT_DEBUG=OFF`; trace timing is
+   diagnostic evidence, not a benchmark.
+5. Retain scalar/SSE fallback behavior for unsupported CPUs and output counts.
+6. Do not treat the default `ci-regression-checks` result as AVX2 execution:
+   it does not enable `ICCDEV_ENABLE_AVX2`. The Windows PR ClangCL lane does;
+   use an explicit diagnostics build when trace evidence is required.
+7. Compare all output counts from 8 through 16 with
+   `.github/scripts/iccdev-windows-clut-avx2-benchmark.ps1`.
+   Require `output_vector_match=True` for every row; aggregate checksums are
+   not sufficient to prove per-lane parity.
+8. Treat native MSVC as SSE-only unless new measurements demonstrate a
+   repeatable improvement; the supported Windows AVX2 measurement compiler is
+   ClangCL.
+
+## Handoff
+
+Record the branch, commit, compiler, CPU model, build preset, test command,
+trace summary, benchmark command, and the bit-exact output-vector comparison
+in the handoff. See `docs/avx2-clut-diagnostics.md` for the complete checklist.

--- a/.github/scripts/iccdev-clut-eight-output-regression-tests.sh
+++ b/.github/scripts/iccdev-clut-eight-output-regression-tests.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+###############################################################################
+# High-output 3D CLUT regression test
+###############################################################################
+#
+# Converts the checked-in ICC v5 fixtures, validates them, and applies their 3D
+# CLUTs. The eight-output case covers a full vector, the nine-output case
+# covers fallback behavior, and the eleven-output case covers the AVX2 masked
+# tail and AVX-512 masking. Other builds retain the
+# same expected scalar/SSE results. Each grid point is distinct so the expected
+# vectors also check corner offsets and weights.
+###############################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-clut-eight-output}"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+    for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+        if [ -d "$candidate" ]; then
+            TOOLS_DIR="$candidate"
+            break
+        fi
+    done
+fi
+
+BUILD_ROOT=""
+if [ -d "$TOOLS_DIR/.." ]; then
+    BUILD_ROOT="$(cd "$TOOLS_DIR/.." && pwd -P)"
+fi
+if [ -n "$BUILD_ROOT" ]; then
+    export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+
+FROM_XML="$TOOLS_DIR/IccFromXml/iccFromXml"
+DUMP_PROFILE="$TOOLS_DIR/IccDumpProfile/iccDumpProfile"
+APPLY_NAMED_CMM="$TOOLS_DIR/IccApplyNamedCmm/iccApplyNamedCmm"
+FIXTURE_INPUT="$TESTING_DIR/CLUT/avx2-3d-8-output.txt"
+
+fail() {
+    echo "[FAIL] clut-eight-output-regression: $1" >&2
+    exit 1
+}
+
+require_file() {
+    [ -f "$1" ] || fail "missing fixture: $1"
+}
+
+require_tool() {
+    [ -x "$1" ] || fail "missing executable: $1"
+}
+
+check_sanitizers() {
+    local logfile="$1"
+
+    if grep -qE "ERROR: AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|LeakSanitizer|DEADLYSIGNAL" "$logfile"; then
+        sed -n '1,120p' "$logfile"
+        fail "sanitizer diagnostic in $(basename "$logfile")"
+    fi
+}
+
+mkdir -p "$OUTDIR"
+require_tool "$FROM_XML"
+require_tool "$DUMP_PROFILE"
+require_tool "$APPLY_NAMED_CMM"
+require_file "$FIXTURE_INPUT"
+
+run_case() {
+    local name="$1"
+    local expected="$2"
+    local fixture_xml="$TESTING_DIR/CLUT/$name.xml"
+    local fixture_icc="$OUTDIR/$name.icc"
+    local from_xml_log="$OUTDIR/$name-from-xml.log"
+    local dump_log="$OUTDIR/$name-dump.log"
+    local apply_log="$OUTDIR/$name-apply.log"
+
+    require_file "$fixture_xml"
+    "$FROM_XML" "$fixture_xml" "$fixture_icc" > "$from_xml_log" 2>&1 ||
+        fail "could not convert $name fixture to ICC"
+    "$DUMP_PROFILE" -v 100 "$fixture_icc" > "$dump_log" 2>&1 ||
+        fail "$name fixture validation command failed"
+    "$APPLY_NAMED_CMM" "$FIXTURE_INPUT" 3 0 "$fixture_icc" 0 > "$apply_log" 2>&1 ||
+        fail "could not apply $name fixture"
+
+    check_sanitizers "$from_xml_log"
+    check_sanitizers "$dump_log"
+    check_sanitizers "$apply_log"
+
+    grep -q "Profile is valid for version 5.10" "$dump_log" ||
+        fail "converted $name fixture is not ICC-valid"
+    grep -qE "$expected" "$apply_log" ||
+        fail "$name CLUT output differs from the expected vector"
+}
+
+run_case \
+    "avx2-3d-8-output" \
+    "0\\.2200 +0\\.2300 +0\\.2400 +0\\.2500 +0\\.2600 +0\\.2700 +0\\.2800 +0\\.2900"
+run_case \
+    "avx2-3d-9-output" \
+    "0\\.2200 +0\\.2300 +0\\.2400 +0\\.2500 +0\\.2600 +0\\.2700 +0\\.2800 +0\\.2900 +0\\.3000"
+run_case \
+    "avx2-3d-11-output" \
+    "0\\.2200 +0\\.2300 +0\\.2400 +0\\.2500 +0\\.2600 +0\\.2700 +0\\.2800 +0\\.2900 +0\\.3000 +0\\.3100 +0\\.3200"
+
+echo "[PASS] clut-eight-output-regression"

--- a/.github/scripts/iccdev-clut-isa-local-report.sh
+++ b/.github/scripts/iccdev-clut-isa-local-report.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# Markdown backticks in report printf format strings are intentionally literal.
+# shellcheck disable=SC2016
+###############################################################################
+# Compare portable, AVX2, and AVX-512 CLUT regression builds locally.
+###############################################################################
+
+set -euo pipefail
+
+if [ "$#" -lt 3 ] || [ "$#" -gt 4 ]; then
+    echo "usage: $0 REPORT_DIR PORTABLE_BUILD AVX2_BUILD [AVX512_BUILD]" >&2
+    exit 2
+fi
+
+report_dir="$1"
+portable_build="$2"
+avx2_build="$3"
+avx512_build="${4:-}"
+runs="${ICCDEV_CLUT_ISA_RUNS:-5}"
+affinity="${ICCDEV_CLUT_ISA_AFFINITY:-}"
+test_name="iccdev.clut-eight-output-regression"
+samples_file="$report_dir/samples.tsv"
+report_file="$report_dir/report.md"
+
+case "$runs" in
+    ''|*[!0-9]*|0)
+        echo "ICCDEV_CLUT_ISA_RUNS must be a positive integer" >&2
+        exit 2
+        ;;
+esac
+
+if [ "$runs" -gt 20 ]; then
+    echo "ICCDEV_CLUT_ISA_RUNS must not exceed 20" >&2
+    exit 2
+fi
+
+if ! command -v ctest >/dev/null 2>&1; then
+    echo "ctest is required" >&2
+    exit 1
+fi
+
+if ! command -v /usr/bin/time >/dev/null 2>&1; then
+    echo "/usr/bin/time is required" >&2
+    exit 1
+fi
+
+runner=()
+if [ -n "$affinity" ]; then
+    if ! command -v taskset >/dev/null 2>&1; then
+        echo "ICCDEV_CLUT_ISA_AFFINITY requires taskset" >&2
+        exit 1
+    fi
+    runner=(taskset -c "$affinity")
+fi
+
+mkdir -p "$report_dir"
+if [ -e "$samples_file" ] || [ -e "$report_file" ]; then
+    echo "report directory already contains report output: $report_dir" >&2
+    exit 1
+fi
+
+cache_value()
+{
+    local build_dir="$1"
+    local name="$2"
+
+    awk -F= -v name="$name" 'index($1, name ":") == 1 { print $2; exit }' \
+        "$build_dir/CMakeCache.txt"
+}
+
+require_variant()
+{
+    local label="$1"
+    local build_dir="$2"
+    local expected_avx2="$3"
+    local expected_avx512="$4"
+    local avx2
+    local avx512
+    local avx2_effective
+    local avx512_effective
+    local listing
+
+    if [ ! -f "$build_dir/CMakeCache.txt" ]; then
+        echo "$label build lacks CMakeCache.txt: $build_dir" >&2
+        exit 1
+    fi
+
+    avx2="$(cache_value "$build_dir" ICCDEV_ENABLE_AVX2)"
+    avx512="$(cache_value "$build_dir" ICCDEV_ENABLE_AVX512)"
+    avx2_effective="$(cache_value "$build_dir" ICCDEV_AVX2_EFFECTIVE)"
+    avx512_effective="$(cache_value "$build_dir" ICCDEV_AVX512_EFFECTIVE)"
+    if [ "$avx2" != "$expected_avx2" ] || [ "$avx512" != "$expected_avx512" ]; then
+        echo "$label has ICCDEV_ENABLE_AVX2=$avx2 and ICCDEV_ENABLE_AVX512=$avx512; expected $expected_avx2/$expected_avx512" >&2
+        exit 1
+    fi
+    if [ "$avx2_effective" != "$expected_avx2" ] ||
+       [ "$avx512_effective" != "$expected_avx512" ]; then
+        echo "$label requested AVX2/AVX-512=$avx2/$avx512 but compiled $avx2_effective/$avx512_effective" >&2
+        exit 1
+    fi
+
+    listing="$(ctest --test-dir "$build_dir" -N -R "^${test_name}$" --no-tests=error)"
+    if ! printf '%s\n' "$listing" | grep -q "$test_name"; then
+        echo "$label does not register $test_name" >&2
+        exit 1
+    fi
+}
+
+median_seconds()
+{
+    local label="$1"
+
+    awk -F '\t' -v label="$label" '$1 == label && $3 == 0 { print $2 }' \
+        "$samples_file" | sort -n | awk '
+            { values[NR] = $1 }
+            END {
+                if (NR == 0) {
+                    print "n/a"
+                } else if (NR % 2) {
+                    printf "%.6f", values[(NR + 1) / 2]
+                } else {
+                    printf "%.6f", (values[NR / 2] + values[NR / 2 + 1]) / 2
+                }
+            }'
+}
+
+cache_summary()
+{
+    local build_dir="$1"
+
+    printf 'compiler=%s; build_type=%s; avx2=%s; avx512=%s; avx2_debug=%s' \
+        "$(cache_value "$build_dir" CMAKE_CXX_COMPILER)" \
+        "$(cache_value "$build_dir" CMAKE_BUILD_TYPE)" \
+        "$(cache_value "$build_dir" ICCDEV_AVX2_EFFECTIVE)" \
+        "$(cache_value "$build_dir" ICCDEV_AVX512_EFFECTIVE)" \
+        "$(cache_value "$build_dir" ICC_AVX2_CLUT_DEBUG)"
+}
+
+run_variant()
+{
+    local label="$1"
+    local build_dir="$2"
+    local run
+    local log
+    local time_log
+    local status
+    local elapsed
+
+    for run in $(seq 1 "$runs"); do
+        log="$report_dir/${label}-${run}.log"
+        time_log="$report_dir/${label}-${run}.time"
+        status=0
+        /usr/bin/time \
+            -f 'elapsed_s=%e\nuser_s=%U\nsystem_s=%S\nmax_rss_kb=%M' \
+            -o "$time_log" \
+            "${runner[@]}" \
+            ctest --test-dir "$build_dir" -R "^${test_name}$" \
+            --output-on-failure --no-tests=error > "$log" 2>&1 || status=$?
+        elapsed="$(awk -F= '$1 == "elapsed_s" { print $2; exit }' "$time_log")"
+        printf '%s\t%s\t%s\t%s\t%s\n' \
+            "$label" "${elapsed:-n/a}" "$status" "$run" "$log" >> "$samples_file"
+    done
+}
+
+require_variant portable "$portable_build" OFF OFF
+require_variant avx2 "$avx2_build" ON OFF
+if [ -n "$avx512_build" ]; then
+    require_variant avx512 "$avx512_build" ON ON
+fi
+
+printf 'variant\telapsed_s\tstatus\trun\tlog\n' > "$samples_file"
+run_variant portable "$portable_build"
+run_variant avx2 "$avx2_build"
+if [ -n "$avx512_build" ]; then
+    run_variant avx512 "$avx512_build"
+fi
+
+{
+    printf '# Local CLUT ISA Coverage and Timing Report\n\n'
+    printf '## Scope\n\n'
+    printf 'This report executes `%s` against independently configured builds.\n' \
+        "$test_name"
+    printf 'The regression covers eight- and nine-output AVX2 fallbacks plus an eleven-output full vector and masked tail; AVX-512 may select its own eligible paths.\n\n'
+    printf '## Environment\n\n'
+    printf '| Field | Value |\n|---|---|\n'
+    printf '| Kernel | `%s` |\n' "$(uname -srmo)"
+    printf '| CPU affinity | `%s` |\n' "${affinity:-not pinned}"
+    printf '| Repetitions | %s |\n' "$runs"
+    if command -v lscpu >/dev/null 2>&1; then
+        printf '| CPU | `%s` |\n' "$(lscpu | awk -F: '/Model name/ { sub(/^[[:space:]]+/, "", $2); print $2; exit }')"
+    fi
+    printf '\n## Build and Functional Coverage\n\n'
+    printf '| Variant | Build configuration | Focused regression | Median end-to-end time (s) |\n'
+    printf '|---|---|---|---:|\n'
+    printf '| Portable | `%s` | 8-, 9-, and 11-output scalar/SSE fallback | %s |\n' \
+        "$(cache_summary "$portable_build")" "$(median_seconds portable)"
+    printf '| AVX2 | `%s` | 8- and 9-output fallback; 11-output vector plus masked tail | %s |\n' \
+        "$(cache_summary "$avx2_build")" "$(median_seconds avx2)"
+    if [ -n "$avx512_build" ]; then
+        printf '| AVX-512 | `%s` | 8-, 9-, and 11-output eligible paths | %s |\n' \
+            "$(cache_summary "$avx512_build")" "$(median_seconds avx512)"
+    fi
+    printf '\n## Timing Samples\n\n'
+    printf '```text\n'
+    cat "$samples_file"
+    printf '```\n\n'
+    printf '## Interpretation\n\n'
+    printf 'These are end-to-end CTest timings: XML conversion, profile validation, CMM setup, one CLUT application, and process startup are included. They are repeatable regression-envelope measurements, not isolated CLUT-kernel throughput claims. Keep `ICC_AVX2_CLUT_DEBUG=OFF` while collecting them. Use the diagnostic build only to establish dispatch evidence, and collect a separate kernel-level benchmark before claiming an ISA speedup.\n'
+} > "$report_file"
+
+if awk -F '\t' 'NR > 1 && $3 != 0 { exit 1 }' "$samples_file"; then
+    echo "[PASS] report: $report_file"
+else
+    echo "[FAIL] one or more focused regressions failed; report retained at $report_file" >&2
+    exit 1
+fi

--- a/.github/scripts/iccdev-iccapplyprofiles-threading-benchmark.py
+++ b/.github/scripts/iccdev-iccapplyprofiles-threading-benchmark.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# Copyright (c) 2026 The International Color Consortium. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import argparse
+import hashlib
+import platform
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+
+def find_executable(build_dir, name):
+    candidates = [
+        build_dir / "bin" / "Release" / f"{name}.exe",
+        build_dir / "bin" / f"{name}.exe",
+        build_dir / "Tools" / "IccApplyProfiles" / name,
+        build_dir / "Tools" / "IccFromXml" / name,
+    ]
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    raise FileNotFoundError(f"{name} not found under {build_dir}")
+
+
+def parse_size(value):
+    parts = value.lower().split("x", 1)
+    if len(parts) != 2:
+        raise argparse.ArgumentTypeError(f"invalid image size: {value}")
+    width, height = (int(part) for part in parts)
+    if width <= 0 or height <= 0:
+        raise argparse.ArgumentTypeError(f"invalid image size: {value}")
+    return width, height
+
+
+def create_tiff(path, width, height):
+    try:
+        from PIL import Image
+    except ImportError as exc:
+        raise RuntimeError("Pillow is required to generate benchmark TIFFs") from exc
+
+    x_axis = Image.linear_gradient("L").rotate(90, expand=True).resize((width, height))
+    y_axis = Image.linear_gradient("L").resize((width, height))
+    blue = Image.blend(x_axis, y_axis, 0.5)
+    Image.merge("RGB", (x_axis, y_axis, blue)).save(
+        path, format="TIFF", compression="raw"
+    )
+
+
+def file_sha256(path):
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def run_command(command):
+    result = subprocess.run(
+        command,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = result.stderr.strip()
+        raise RuntimeError(
+            f"command failed with exit {result.returncode}: {' '.join(map(str, command))}"
+            + (f"\n{detail}" if detail else "")
+        )
+
+
+def main():
+    repo_root = Path(__file__).resolve().parents[2]
+    parser = argparse.ArgumentParser(
+        description="Benchmark iccApplyProfiles thread scaling with TIFF input."
+    )
+    parser.add_argument("--build-dir", required=True, type=Path)
+    parser.add_argument(
+        "--output", type=Path, default=Path("iccapplyprofiles-threading.tsv")
+    )
+    parser.add_argument("--repetitions", type=int, default=5)
+    parser.add_argument(
+        "--sizes",
+        nargs="+",
+        type=parse_size,
+        default=[(256, 256), (512, 512), (1024, 1024), (4096, 2048)],
+    )
+    args = parser.parse_args()
+
+    if args.repetitions <= 0:
+        parser.error("--repetitions must be positive")
+
+    build_dir = args.build_dir.resolve()
+    apply_profiles = find_executable(build_dir, "iccApplyProfiles")
+    from_xml = find_executable(build_dir, "iccFromXml")
+    profile_xml = repo_root / "Testing" / "Display" / "sRGB_D65_MAT.xml"
+    output = args.output.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+
+    rows = []
+    with tempfile.TemporaryDirectory(prefix="iccdev-thread-benchmark-") as temp_name:
+        temp_dir = Path(temp_name)
+        profile = temp_dir / "sRGB_D65_MAT.icc"
+        run_command([from_xml, profile_xml, profile])
+
+        for width, height in args.sizes:
+            source = temp_dir / f"source-{width}x{height}.tif"
+            destination = temp_dir / "output.tif"
+            create_tiff(source, width, height)
+
+            for repetition in range(1, args.repetitions + 1):
+                order = [1, 2, 0] if repetition % 2 else [0, 2, 1]
+                for threads in order:
+                    command = [
+                        apply_profiles,
+                        "-threads",
+                        str(threads),
+                        source,
+                        destination,
+                        "0",
+                        "0",
+                        "0",
+                        "0",
+                        "1",
+                        profile,
+                        "1",
+                        profile,
+                        "1",
+                    ]
+                    start = time.perf_counter_ns()
+                    run_command(command)
+                    elapsed_ms = (time.perf_counter_ns() - start) / 1_000_000.0
+                    rows.append(
+                        (
+                            platform.system(),
+                            platform.machine(),
+                            width,
+                            height,
+                            threads,
+                            repetition,
+                            elapsed_ms,
+                            file_sha256(destination),
+                        )
+                    )
+                    destination.unlink()
+
+    with output.open("w", encoding="ascii", newline="\n") as stream:
+        stream.write(
+            "platform\tmachine\twidth\theight\tthreads\trepetition\t"
+            "elapsed_ms\tsha256\n"
+        )
+        for row in rows:
+            stream.write(
+                "{}\t{}\t{}\t{}\t{}\t{}\t{:.3f}\t{}\n".format(*row)
+            )
+
+    for width, height in args.sizes:
+        size_rows = [row for row in rows if row[2:4] == (width, height)]
+        hashes = {row[7] for row in size_rows}
+        if len(hashes) != 1:
+            raise RuntimeError(f"output mismatch for {width}x{height}")
+        for threads in (0, 1, 2):
+            samples = [row[6] for row in size_rows if row[4] == threads]
+            print(
+                f"{width}x{height}\tthreads={threads}\t"
+                f"median_ms={statistics.median(samples):.3f}"
+            )
+
+    print(f"[PASS] benchmark report: {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except (FileNotFoundError, RuntimeError, ValueError) as exc:
+        print(f"[FAIL] {exc}", file=sys.stderr)
+        sys.exit(1)

--- a/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
+++ b/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
@@ -10,8 +10,8 @@
 #   -threads  N   wrapper with N workers (default N=4 here)
 #
 # Catches partitioning regressions in CIccApplyThreadedCmm::Apply()'s strip
-# split / async-launch / last-strip-on-caller logic, and any future ownership
-# regression in CIccConnectCmm threaded initialization.
+# split / persistent-worker / last-strip-on-caller logic, and any future
+# ownership regression in CIccConnectCmm threaded initialization.
 #
 # Input: a deterministic 512x512 sRGB TIFF generated on the fly so this test
 # does not depend on a checked-in image with a specific colour space. Python 3

--- a/.github/scripts/iccdev-windows-clut-avx2-benchmark.ps1
+++ b/.github/scripts/iccdev-windows-clut-avx2-benchmark.ps1
@@ -1,0 +1,183 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$BaselineBuildDir,
+
+  [Parameter(Mandatory = $true)]
+  [string]$Avx2BuildDir,
+
+  [ValidateSet('Release', 'Debug')]
+  [string]$Configuration = 'Release',
+
+  [ValidateRange(1, 1000000000)]
+  [int]$Iterations = 5000000,
+
+  [ValidateRange(1, 101)]
+  [int]$Repetitions = 7,
+
+  [ValidateRange(0, 63)]
+  [int]$AffinityCpu = [math]::Max(1, [Environment]::ProcessorCount - 2),
+
+  [string]$OutputPath = 'clut-avx2-benchmark.tsv'
+)
+
+$ErrorActionPreference = 'Stop'
+$PSDefaultParameterValues['*:ErrorAction'] = 'Stop'
+
+if ($Repetitions % 2 -eq 0) {
+  throw 'Repetitions must be odd so the median is unambiguous'
+}
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+$source = Join-Path $repoRoot '.github\ci\regression\clut-avx2-benchmark.cpp'
+$vswhere = Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+
+if (-not (Test-Path $source -PathType Leaf)) {
+  throw "Benchmark source not found: $source"
+}
+if (-not (Test-Path $vswhere -PathType Leaf)) {
+  throw "Visual Studio locator not found: $vswhere"
+}
+$installationPath = & $vswhere -latest -products * `
+  -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 `
+  -property installationPath
+if ($LASTEXITCODE -ne 0 -or -not $installationPath) {
+  throw 'A Visual Studio installation with the x64 C++ tools was not found'
+}
+$devShell = Join-Path $installationPath 'Common7\Tools\Launch-VsDevShell.ps1'
+if (-not (Test-Path $devShell -PathType Leaf)) {
+  throw "Visual Studio developer shell not found: $devShell"
+}
+
+$savedEnvironment = @{
+  PATH = $env:PATH
+  INCLUDE = $env:INCLUDE
+  LIB = $env:LIB
+  LIBPATH = $env:LIBPATH
+}
+$env:PATH = @(
+  "$env:SystemRoot\System32"
+  "$env:SystemRoot"
+  "$env:SystemRoot\System32\WindowsPowerShell\v1.0"
+  (Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer')
+) -join ';'
+Remove-Item env:INCLUDE, env:LIB, env:LIBPATH -ErrorAction SilentlyContinue
+try {
+  . $devShell -Arch amd64 -HostArch amd64 -SkipAutomaticLocation
+
+function Resolve-Build {
+  param(
+    [string]$Label,
+    [string]$BuildDir
+  )
+
+  $resolved = (Resolve-Path $BuildDir).Path
+  $cache = Join-Path $resolved 'CMakeCache.txt'
+  $binDir = Join-Path $resolved "bin\$Configuration"
+  $library = Join-Path $resolved "IccProfLib\$Configuration\IccProfLib2.lib"
+  if (-not (Test-Path $cache -PathType Leaf) -or
+      -not (Test-Path $library -PathType Leaf) -or
+      -not (Test-Path (Join-Path $binDir 'IccProfLib2.dll') -PathType Leaf)) {
+    throw "$Label build is incomplete: $resolved"
+  }
+
+  $sourceDirLine = Select-String -Path $cache -Pattern '^RefIccMAX_SOURCE_DIR:STATIC='
+  $toolsetLine = Select-String -Path $cache -Pattern '^CMAKE_GENERATOR_TOOLSET:INTERNAL='
+  if (-not $sourceDirLine -or -not $toolsetLine) {
+    throw "$Label build cache is missing source or compiler metadata"
+  }
+
+  $cmakeSourceDir = ($sourceDirLine.Line -split '=', 2)[1]
+  $sourceDir = Split-Path -Parent (Split-Path -Parent $cmakeSourceDir)
+  $toolset = ($toolsetLine.Line -split '=', 2)[1]
+  [pscustomobject]@{
+    Label = $Label
+    BuildDir = $resolved
+    BinDir = $binDir
+    Library = $library
+    SourceDir = $sourceDir
+    Compiler = if ($toolset -eq 'ClangCL') { 'clang-cl.exe' } else { 'cl.exe' }
+  }
+}
+
+$builds = @(
+  Resolve-Build -Label 'baseline' -BuildDir $BaselineBuildDir
+  Resolve-Build -Label 'avx2' -BuildDir $Avx2BuildDir
+)
+
+$executables = @{}
+foreach ($build in $builds) {
+  $exe = Join-Path $build.BinDir 'clut-avx2-benchmark.exe'
+  $includeDir = Join-Path $build.SourceDir 'IccProfLib'
+  & $build.Compiler /nologo /O2 /EHsc /DICCPROFLIBDLL_IMPORTS `
+    "/I$includeDir" $source /link "/OUT:$exe" $build.Library
+  if ($LASTEXITCODE -ne 0) {
+    throw "$($build.Label) benchmark compile failed with exit $LASTEXITCODE"
+  }
+  $executables[$build.Label] = $exe
+}
+
+$comparison = foreach ($outputs in 8..16) {
+  $samples = @{
+    baseline = [Collections.Generic.List[double]]::new()
+    avx2 = [Collections.Generic.List[double]]::new()
+  }
+  $outputVectors = @{}
+  for ($sample = 0; $sample -lt $Repetitions; $sample++) {
+    $order = if (($sample + $outputs) % 2 -eq 0) {
+      @('baseline', 'avx2')
+    }
+    else {
+      @('avx2', 'baseline')
+    }
+    foreach ($label in $order) {
+      $line = & $executables[$label] $outputs $Iterations 1 $AffinityCpu
+      if ($LASTEXITCODE -ne 0) {
+        throw "$label benchmark failed for $outputs outputs"
+      }
+      if ($line -notmatch 'median_ns=([0-9.]+) calls_per_s=([0-9.]+) checksum=([0-9.]+) outputs_hex=([0-9a-f,]+)') {
+        throw "Unexpected benchmark output: $line"
+      }
+      $samples[$label].Add([double]$Matches[1])
+      $outputVectors[$label] = $Matches[4]
+    }
+  }
+
+  $baselineSamples = $samples.baseline | Sort-Object
+  $avx2Samples = $samples.avx2 | Sort-Object
+  $middle = [int][math]::Floor($Repetitions / 2)
+  $baselineMedian = $baselineSamples[$middle]
+  $avx2Median = $avx2Samples[$middle]
+  [pscustomobject]@{
+    outputs = $outputs
+    affinity_cpu = $AffinityCpu
+    baseline_median_ns = $baselineMedian
+    avx2_median_ns = $avx2Median
+    improvement_pct = [math]::Round(
+      (($baselineMedian - $avx2Median) / $baselineMedian) * 100.0, 3)
+    output_vector_match = $outputVectors.baseline -ceq $outputVectors.avx2
+  }
+}
+
+$outputMismatch = $comparison | Where-Object { -not $_.output_vector_match }
+if ($outputMismatch) {
+  $failedOutputs = ($outputMismatch.outputs -join ', ')
+  throw "Baseline and AVX2 output vectors differ for outputs: $failedOutputs"
+}
+
+$resolvedOutput = [IO.Path]::GetFullPath($OutputPath)
+$comparison | Export-Csv -Delimiter "`t" -NoTypeInformation -Encoding ascii -Path $resolvedOutput
+$comparison | Format-Table -AutoSize
+Write-Output "[PASS] benchmark report: $resolvedOutput"
+}
+finally {
+  $env:PATH = $savedEnvironment.PATH
+  foreach ($name in 'INCLUDE', 'LIB', 'LIBPATH') {
+    $value = $savedEnvironment[$name]
+    if ($null -eq $value) {
+      Remove-Item "env:$name" -ErrorAction SilentlyContinue
+    }
+    else {
+      Set-Item "env:$name" $value
+    }
+  }
+}

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -18,6 +18,7 @@ long command references.
 | `regression-workflow-governance` | Adding regression gates or updating tool-test workflows. |
 | `vcpkg-export-consumer-debug` | Fixing vcpkg, install/export, uninstall, or packaged consumer CI failures. |
 | `version-bump` | Updating iccDEV release version references. |
+| `avx2-clut-diagnostics` | Debugging AVX2 CLUT dispatch, collecting trace evidence, and preparing a performance handoff. |
 
 Prompts remain better for one-off drafting. Skills are better for repeatable
 multi-step repository workflows.

--- a/.github/skills/avx2-clut-diagnostics/SKILL.md
+++ b/.github/skills/avx2-clut-diagnostics/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: avx2-clut-diagnostics
+description: >
+  Diagnose runtime-dispatched AVX2 3D CLUT interpolation, collect trace
+  evidence, validate vector and masked-tail output, and prepare optimization
+  handoff data.
+allowed-tools:
+  - bash
+  - read
+  - grep
+  - glob
+  - shell(git:*)
+---
+
+# AVX2 CLUT Diagnostics
+
+Use this skill for source-level AVX2 CLUT debugging and performance handoff.
+Do not use diagnostic traces as throughput benchmarks.
+
+## 1. Build the Diagnostic Configuration
+
+On Windows:
+
+```cmd
+cmake --preset vs2022-clangcl-x64-avx2-diagnostics -S Build/Cmake -B out/vs2022-clangcl-x64-avx2-diagnostics
+cmake --build out/vs2022-clangcl-x64-avx2-diagnostics --config Debug -- /m /maxcpucount
+```
+
+On Linux, configure with `-DICCDEV_ENABLE_AVX2=ON` and
+`-DICC_AVX2_CLUT_DEBUG=ON`.
+
+The default `ci-regression-checks` build does not enable
+`ICCDEV_ENABLE_AVX2`; it validates the portable fallback rather than the AVX2
+kernel. The Windows PR ClangCL lane enables AVX2, but use this explicit
+diagnostic configuration when trace evidence is required.
+
+## 2. Inspect the Dispatch
+
+Set breakpoints in `IccTraceAvx2ClutDispatch()` and
+`IccTraceAvx2ClutKernel()` in `IccProfLib/IccSignatureUtils.h`. Confirm AVX2
+is selected only with CPU support and the measured winning output count: 15.
+Record offsets, weights, vector outputs, masked outputs, and elapsed time.
+
+## 3. Validate Behavior
+
+```cmd
+ctest --test-dir out/vs2022-clangcl-x64-avx2-diagnostics -C Debug --output-on-failure --no-tests=error -R "^iccdev\.clut-eight-output-regression$"
+```
+
+The eight-, nine-, eleven-, and fourteen-output fixtures pin SSE2 fallback
+behavior. The fifteen-output fixture exercises a full AVX2 vector plus a
+seven-output masked tail.
+
+## 4. Measure Separately
+
+Reconfigure with `ICC_AVX2_CLUT_DEBUG=OFF` before measuring. Preserve CPUID,
+XGETBV, scalar/SSE fallback behavior, and bit-exact per-lane regression output.
+
+Use the interleaved native benchmark for the performance decision:
+
+```powershell
+.github\scripts\iccdev-windows-clut-avx2-benchmark.ps1 `
+  -BaselineBuildDir C:\path\to\baseline-build `
+  -Avx2BuildDir C:\path\to\avx2-build `
+  -Iterations 20000000 -Repetitions 11
+```
+
+Measure output counts 8 through 16. Windows AVX2 measurements use ClangCL;
+native MSVC remains on SSE2 because its AVX2 implementation regressed.
+Require `output_vector_match=True` for every result row.
+
+## Handoff
+
+Provide the branch and commit, target CPU, compiler, diagnostic trace summary,
+debug and release validation results, measurement command, and any pending
+Windows-specific investigation.
+
+## Reference
+
+`../../../docs/avx2-clut-diagnostics.md`

--- a/.github/workflows/ci-pr-win.yml
+++ b/.github/workflows/ci-pr-win.yml
@@ -557,6 +557,7 @@ jobs:
            '-DENABLE_TOOLS=ON',
            '-DENABLE_CMM_TOOLS=ON',
            '-DENABLE_TESTS=ON',
+           '-DICCDEV_ENABLE_AVX2=ON',
            '-Wno-dev'
           ) $configureLog
           Invoke-NativeLogged cmake @(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ shares one source of truth. Update rules here, not in the mirrors.
 | Need | File |
 |------|------|
 | Build, test, style, CI | `.github/copilot-instructions.md` |
+| AVX2 CLUT diagnostics and optimization handoff | `docs/avx2-clut-diagnostics.md` |
 | Pull request preparation and handoff | `docs/pre-pr-security-cycle.md` |
 | Pre-PR security skill | `.github/skills/pre-pr-security-cycle/SKILL.md` |
 | Pre-PR security prompt | `.github/prompts/pre-pr-security-cycle.prompt.md` |
@@ -82,3 +83,17 @@ WASM now ships as a staged Node/npm-style module package. Do not expect or
 restore legacy `wasm/*.html`, `wasm/*.css`, or `wasm/*.js` browser UI assets.
 Use `.github/skills/wasm-build-test/SKILL.md` for the current module smoke and
 profile parity checks.
+
+## AVX2 CLUT Diagnostics
+
+Use `vs2022-clangcl-x64-avx2-diagnostics` for a Windows source-level AVX2
+debugging session. It enables `ICC_AVX2_CLUT_DEBUG`, which traces runtime
+dispatch and kernel inputs through `IccSignatureUtils.h`. Do not use the
+diagnostic preset for throughput comparisons; use the matching
+`vs2022-clangcl-x64-avx2-qa-flags` build for measurements. The focused
+regression is `iccdev.clut-eight-output-regression`.
+Use `.github/scripts/iccdev-windows-clut-avx2-benchmark.ps1` for interleaved
+Release comparisons across 8-16 outputs. Windows AVX2 is a ClangCL path;
+native MSVC intentionally retains SSE2 after measured AVX2 regressions.
+Runtime AVX2 dispatch is limited to 15 outputs. Require
+`output_vector_match=True` for every benchmark row.

--- a/Build/Cmake/CMakeLists.txt
+++ b/Build/Cmake/CMakeLists.txt
@@ -538,11 +538,21 @@ if(ICC_JSON_ORDERED AND _ICC_JSON_ORDERED_DEFAULT)
 endif()
 option(ICC_TRACE_NAN_ENABLED      "Enable tracing NaN inputs in debug builds"           OFF)
 option(ICC_CLUT_DEBUG             "Enable CLUT debugging support"                       OFF)
+option(ICC_AVX2_CLUT_DEBUG        "Enable AVX2 CLUT dispatch and timing diagnostics"    OFF)
 option(ICC_ENABLE_ASSERTS         "Enable ICC_ASSERT traps and debug assertions"        OFF)
 option(ICC_LOG_SAFE               "Enable ICC_LOG_SAFE_VAL bounds-checked logging"      OFF)
 option(ICC_VERBOSE_CALC_APPLY     "Enable verbose CIccMpeCalculator Apply debugging"    OFF)
 option(ICC_USE_ZLIB               "Enable zlib-backed compressed ICC text tags"         ON)
 option(ICCDEV_ENABLE_QA_FLAGS     "Enable opt-in maintainer QA evidence options"        OFF)
+option(ICCDEV_SUPPRESS_LEGACY_CRT_WARNINGS
+  "Suppress Microsoft CRT compatibility warnings in scoped comparison builds"
+  OFF)
+option(ICCDEV_ENABLE_AVX2
+  "Build runtime-dispatched AVX2 CLUT interpolation on supported x86-64 toolchains"
+  OFF)
+option(ICCDEV_ENABLE_AVX512
+  "Build runtime-dispatched AVX-512 CLUT interpolation on supported x86-64 toolchains"
+  OFF)
 option(ENABLE_SANITIZERS          "Enable runtime sanitizers (ASan, UBSan, etc.)"       OFF)
 option(ENABLE_ASAN                "Enable AddressSanitizer only"                        OFF)
 option(ENABLE_FUZZING             "Enable libFuzzer harnesses (Clang only)"             OFF)
@@ -736,6 +746,12 @@ if(ICCDEV_ENABLE_QA_FLAGS)
   add_compile_definitions(ICCDEV_ENABLE_QA_FLAGS=1)
 endif()
 
+if(ICCDEV_SUPPRESS_LEGACY_CRT_WARNINGS AND MSVC)
+  add_compile_definitions(
+    _CRT_NONSTDC_NO_WARNINGS
+    _CRT_SECURE_NO_WARNINGS)
+endif()
+
 # ----------------------------------------------------------------------
 # Build Status Output
 # ----------------------------------------------------------------------
@@ -753,11 +769,15 @@ message(STATUS "ENABLE_IIS_TOOLS           = ${ENABLE_IIS_TOOLS}")
 message(STATUS "ICCDEV_WINDOWS_UNIFIED_RUNTIME = ${ICCDEV_WINDOWS_UNIFIED_RUNTIME}")
 message(STATUS "ICC_TRACE_NAN_ENABLED      = ${ICC_TRACE_NAN_ENABLED}")
 message(STATUS "ICC_CLUT_DEBUG             = ${ICC_CLUT_DEBUG}")
+message(STATUS "ICC_AVX2_CLUT_DEBUG        = ${ICC_AVX2_CLUT_DEBUG}")
 message(STATUS "ICC_ENABLE_ASSERTS         = ${ICC_ENABLE_ASSERTS}")
 message(STATUS "ICC_LOG_SAFE               = ${ICC_LOG_SAFE}")
 message(STATUS "ICC_VERBOSE_CALC_APPLY     = ${ICC_VERBOSE_CALC_APPLY}")
 message(STATUS "ICC_USE_ZLIB               = ${ICC_USE_ZLIB}")
 message(STATUS "ICCDEV_ENABLE_QA_FLAGS     = ${ICCDEV_ENABLE_QA_FLAGS}")
+message(STATUS "ICCDEV_SUPPRESS_LEGACY_CRT_WARNINGS = ${ICCDEV_SUPPRESS_LEGACY_CRT_WARNINGS}")
+message(STATUS "ICCDEV_ENABLE_AVX2         = ${ICCDEV_ENABLE_AVX2}")
+message(STATUS "ICCDEV_ENABLE_AVX512       = ${ICCDEV_ENABLE_AVX512}")
 message(STATUS "ENABLE_SANITIZERS          = ${ENABLE_SANITIZERS}")
 message(STATUS "ENABLE_ASAN                = ${ENABLE_ASAN}")
 message(STATUS "ENABLE_UBSAN               = ${ENABLE_UBSAN}")

--- a/Build/Cmake/CMakePresets.json
+++ b/Build/Cmake/CMakePresets.json
@@ -67,6 +67,39 @@
       "displayName": "Windows MSVC (VS2026) QA flags"
     },
     {
+      "name": "vs2022-clangcl-x64-clut-baseline-qa-flags",
+      "inherits": ["vs2022-clangcl-x64-qa-flags"],
+      "displayName": "Windows ClangCL (VS2022) CLUT baseline QA flags",
+      "cacheVariables": {
+        "ICCDEV_SUPPRESS_LEGACY_CRT_WARNINGS": "ON"
+      }
+    },
+    {
+      "name": "vs2022-clangcl-x64-avx2-qa-flags",
+      "inherits": ["vs2022-clangcl-x64-clut-baseline-qa-flags"],
+      "displayName": "Windows ClangCL (VS2022) AVX2 QA flags",
+      "cacheVariables": {
+        "ICCDEV_ENABLE_AVX2": "ON"
+      }
+    },
+    {
+      "name": "vs2022-clangcl-x64-avx2-diagnostics",
+      "inherits": ["vs2022-clangcl-x64-avx2-qa-flags"],
+      "displayName": "Windows ClangCL (VS2022) AVX2 diagnostics",
+      "description": "Enables AVX2 CLUT dispatch and timing tracepoints for source-level debugging. Do not use this preset for throughput benchmarks.",
+      "cacheVariables": {
+        "ICC_AVX2_CLUT_DEBUG": "ON"
+      }
+    },
+    {
+      "name": "vs2022-clangcl-x64-avx512-qa-flags",
+      "inherits": ["vs2022-clangcl-x64-avx2-qa-flags"],
+      "displayName": "Windows ClangCL (VS2022) AVX-512 QA flags",
+      "cacheVariables": {
+        "ICCDEV_ENABLE_AVX512": "ON"
+      }
+    },
+    {
       "name": "mingw-ucrt64-base",
       "inherits": "default-base",
       "hidden": true,
@@ -137,6 +170,34 @@
       "name": "linux-clang-qa-flags",
       "inherits": ["linux-clang", "qa-flags-base"],
       "displayName": "Linux Clang QA flags"
+    },
+    {
+      "name": "linux-clang-clut-baseline-qa-flags",
+      "inherits": ["linux-clang-qa-flags"],
+      "displayName": "Linux Clang CLUT baseline QA flags",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "ENABLE_WXWIDGETS": "OFF",
+        "ICCDEV_ENABLE_AVX2": "OFF",
+        "ICCDEV_ENABLE_AVX512": "OFF",
+        "ICC_AVX2_CLUT_DEBUG": "OFF"
+      }
+    },
+    {
+      "name": "linux-clang-clut-avx2-qa-flags",
+      "inherits": ["linux-clang-clut-baseline-qa-flags"],
+      "displayName": "Linux Clang CLUT AVX2 QA flags",
+      "cacheVariables": {
+        "ICCDEV_ENABLE_AVX2": "ON"
+      }
+    },
+    {
+      "name": "linux-clang-clut-avx512-qa-flags",
+      "inherits": ["linux-clang-clut-avx2-qa-flags"],
+      "displayName": "Linux Clang CLUT AVX-512 QA flags",
+      "cacheVariables": {
+        "ICCDEV_ENABLE_AVX512": "ON"
+      }
     },
     {
       "name": "linux-gcc-asan",

--- a/Build/Cmake/IccProfLib/CMakeLists.txt
+++ b/Build/Cmake/IccProfLib/CMakeLists.txt
@@ -60,6 +60,77 @@ SET( CFILES
     ${SRC_PATH}/IccProfLib/IccWrapper.cpp
    )
 
+function(iccdev_check_cxx_compiler_flag FLAG RESULT_VAR)
+  include(CheckCXXCompilerFlag)
+  set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+  check_cxx_compiler_flag("${FLAG}" "${RESULT_VAR}")
+endfunction()
+
+set(ICCDEV_AVX2_SOURCE "${SRC_PATH}/IccProfLib/IccTagLutAvx2.cpp")
+set(ICCDEV_AVX2_ENABLED OFF)
+if(ICCDEV_ENABLE_AVX2)
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _iccdev_processor)
+  if(MSVC AND NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    message(STATUS
+      "[SKIP] ICCDEV_ENABLE_AVX2 is disabled for native MSVC because measured CLUT throughput is slower than the SSE2 fallback; use ClangCL")
+  elseif(CMAKE_SIZEOF_VOID_P EQUAL 8
+      AND _iccdev_processor MATCHES "^(amd64|x86_64|x64)$")
+    if(MSVC)
+      set(_iccdev_avx2_flag "/arch:AVX2")
+    else()
+      set(_iccdev_avx2_flag "-mavx2")
+    endif()
+    iccdev_check_cxx_compiler_flag(
+      "${_iccdev_avx2_flag}" ICCDEV_COMPILER_SUPPORTS_AVX2)
+    if(ICCDEV_COMPILER_SUPPORTS_AVX2)
+      list(APPEND CFILES "${ICCDEV_AVX2_SOURCE}")
+      set_source_files_properties("${ICCDEV_AVX2_SOURCE}"
+        PROPERTIES COMPILE_OPTIONS "${_iccdev_avx2_flag}")
+      set(ICCDEV_AVX2_ENABLED ON)
+      message(STATUS "AVX2 CLUT interpolation enabled with ${_iccdev_avx2_flag}")
+    else()
+      message(WARNING
+        "ICCDEV_ENABLE_AVX2 was requested, but ${CMAKE_CXX_COMPILER} does not support ${_iccdev_avx2_flag}")
+    endif()
+  else()
+    message(WARNING
+      "ICCDEV_ENABLE_AVX2 was requested for unsupported target architecture '${CMAKE_SYSTEM_PROCESSOR}'")
+  endif()
+endif()
+set(ICCDEV_AVX2_EFFECTIVE "${ICCDEV_AVX2_ENABLED}" CACHE INTERNAL
+  "Whether the AVX2 CLUT implementation is compiled" FORCE)
+
+set(ICCDEV_AVX512_SOURCE "${SRC_PATH}/IccProfLib/IccTagLutAvx512.cpp")
+set(ICCDEV_AVX512_ENABLED OFF)
+if(ICCDEV_ENABLE_AVX512)
+  string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _iccdev_processor)
+  if(CMAKE_SIZEOF_VOID_P EQUAL 8
+      AND _iccdev_processor MATCHES "^(amd64|x86_64|x64)$")
+    if(MSVC)
+      set(_iccdev_avx512_flag "/arch:AVX512")
+    else()
+      set(_iccdev_avx512_flag "-mavx512f")
+    endif()
+    iccdev_check_cxx_compiler_flag(
+      "${_iccdev_avx512_flag}" ICCDEV_COMPILER_SUPPORTS_AVX512)
+    if(ICCDEV_COMPILER_SUPPORTS_AVX512)
+      list(APPEND CFILES "${ICCDEV_AVX512_SOURCE}")
+      set_source_files_properties("${ICCDEV_AVX512_SOURCE}"
+        PROPERTIES COMPILE_OPTIONS "${_iccdev_avx512_flag}")
+      set(ICCDEV_AVX512_ENABLED ON)
+      message(STATUS "AVX-512 CLUT interpolation enabled with ${_iccdev_avx512_flag}")
+    else()
+      message(WARNING
+        "ICCDEV_ENABLE_AVX512 was requested, but ${CMAKE_CXX_COMPILER} does not support ${_iccdev_avx512_flag}")
+    endif()
+  else()
+    message(WARNING
+      "ICCDEV_ENABLE_AVX512 was requested for unsupported target architecture '${CMAKE_SYSTEM_PROCESSOR}'")
+  endif()
+endif()
+set(ICCDEV_AVX512_EFFECTIVE "${ICCDEV_AVX512_ENABLED}" CACHE INTERNAL
+  "Whether the AVX-512 CLUT implementation is compiled" FORCE)
+
 # Public headers - defined unconditionally for target_sources / install
 SET( HEADERS_PUBLIC
   ${SRC_PATH}/IccProfLib/IccApplyBPC.h
@@ -214,6 +285,15 @@ IF(ENABLE_SHARED_LIBS)
 
   # Enforce C++17 standard per-target
   target_compile_features(${TARGET_NAME} PUBLIC cxx_std_17)
+  if(ICCDEV_AVX2_ENABLED)
+    target_compile_definitions(${TARGET_NAME} PRIVATE ICC_USE_AVX2=1)
+  endif()
+  if(ICC_AVX2_CLUT_DEBUG)
+    target_compile_definitions(${TARGET_NAME} PRIVATE ICC_AVX2_CLUT_DEBUG=1)
+  endif()
+  if(ICCDEV_AVX512_ENABLED)
+    target_compile_definitions(${TARGET_NAME} PRIVATE ICC_USE_AVX512=1)
+  endif()
 
   # PUBLIC include dirs - propagate to consumers via target_link_libraries()
   # Build dir FIRST so generated IccProfLibVer.h (with git hash) wins over source tree copy
@@ -248,6 +328,15 @@ IF(ENABLE_STATIC_LIBS)
 
   # Enforce C++17 standard per-target
   target_compile_features(${TARGET_NAME}-static PUBLIC cxx_std_17)
+  if(ICCDEV_AVX2_ENABLED)
+    target_compile_definitions(${TARGET_NAME}-static PRIVATE ICC_USE_AVX2=1)
+  endif()
+  if(ICC_AVX2_CLUT_DEBUG)
+    target_compile_definitions(${TARGET_NAME}-static PRIVATE ICC_AVX2_CLUT_DEBUG=1)
+  endif()
+  if(ICCDEV_AVX512_ENABLED)
+    target_compile_definitions(${TARGET_NAME}-static PRIVATE ICC_USE_AVX512=1)
+  endif()
   if(ICC_USE_ZLIB)
     target_compile_definitions(${TARGET_NAME}-static PUBLIC ICC_USE_ZLIB=1)
   endif()

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -63,12 +63,11 @@ endfunction()
 add_custom_target(check-fast
   COMMAND "${CMAKE_CTEST_COMMAND}"
           ${ICCDEV_CTEST_CONFIG_ARGS}
-          --label-exclude slow
-          --label-exclude known-red
+          --label-exclude "slow|known-red"
           --output-on-failure
           --no-tests=error
   WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-  COMMENT "Run iccDEV CTest suite excluding slow tests"
+  COMMENT "Run iccDEV CTest suite excluding slow and known-red tests"
   VERBATIM
 )
 add_dependencies(check-fast build-test-binaries)
@@ -5184,6 +5183,45 @@ if(WIN32)
   iccdev_add_windows_iccdevcmm_smoke_test()
   iccdev_add_zip_utf8_text_zlib_test()
 
+  if(TARGET iccFromXml AND TARGET iccDumpProfile AND TARGET iccApplyNamedCmm)
+    add_test(
+      NAME iccdev.clut-eight-output-regression
+      COMMAND
+        "${CMAKE_COMMAND}"
+        "-DICCDEV_TEST_OUTDIR=${ICCDEV_TEST_OUTDIR}/iccdev-clut-eight-output-regression"
+        "-DICCDEV_FROM_XML=$<TARGET_FILE:iccFromXml>"
+        "-DICCDEV_DUMP_PROFILE=$<TARGET_FILE:iccDumpProfile>"
+        "-DICCDEV_APPLY_NAMED_CMM=$<TARGET_FILE:iccApplyNamedCmm>"
+        "-DICCDEV_FIXTURE_XML_8=${ICCDEV_TESTING_DIR}/CLUT/avx2-3d-8-output.xml"
+        "-DICCDEV_FIXTURE_XML_9=${ICCDEV_TESTING_DIR}/CLUT/avx2-3d-9-output.xml"
+        "-DICCDEV_FIXTURE_XML_11=${ICCDEV_TESTING_DIR}/CLUT/avx2-3d-11-output.xml"
+        "-DICCDEV_FIXTURE_XML_14=${ICCDEV_TESTING_DIR}/CLUT/avx2-3d-14-output.xml"
+        "-DICCDEV_FIXTURE_XML_15=${ICCDEV_TESTING_DIR}/CLUT/avx2-3d-15-output.xml"
+        "-DICCDEV_FIXTURE_INPUT=${ICCDEV_TESTING_DIR}/CLUT/avx2-3d-8-output.txt"
+        -P "${CMAKE_CURRENT_LIST_DIR}/RunClutEightOutputRegression.cmake"
+    )
+    set_tests_properties(iccdev.clut-eight-output-regression PROPERTIES
+      WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+      TIMEOUT 60
+      LABELS "iccdev;clut;high-channel;regression"
+    )
+    if(WIN32)
+      set(_clut_windows_env_mods
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccFromXml>"
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccDumpProfile>"
+        "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccApplyNamedCmm>"
+      )
+      foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+        list(APPEND _clut_windows_env_mods
+          "PATH=path_list_prepend:${_runtime_path}")
+      endforeach()
+      set_tests_properties(iccdev.clut-eight-output-regression PROPERTIES
+        ENVIRONMENT_MODIFICATION "${_clut_windows_env_mods}"
+      )
+    endif()
+    add_dependencies(check iccFromXml iccDumpProfile iccApplyNamedCmm)
+  endif()
+
   return()
 endif()
 
@@ -5485,6 +5523,16 @@ function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
     LABELS "${LABELS}"
   )
 endfunction()
+
+if(TARGET iccFromXml AND TARGET iccDumpProfile AND TARGET iccApplyNamedCmm)
+  iccdev_add_script_test(
+    iccdev.clut-eight-output-regression
+    60
+    "iccdev;clut;high-channel;regression;sanitizer"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-clut-eight-output-regression-tests.sh"
+  )
+endif()
 
 iccdev_add_script_test(
   iccdev.create-profiles

--- a/Build/Cmake/Testing/RunClutEightOutputRegression.cmake
+++ b/Build/Cmake/Testing/RunClutEightOutputRegression.cmake
@@ -1,0 +1,119 @@
+#################################################################################
+# Native high-output 3D CLUT regression
+# Copyright (c) 2026 The International Color Consortium.
+#                                        All rights reserved.
+#################################################################################
+
+set(_required_vars
+  ICCDEV_TEST_OUTDIR
+  ICCDEV_FROM_XML
+  ICCDEV_DUMP_PROFILE
+  ICCDEV_APPLY_NAMED_CMM
+  ICCDEV_FIXTURE_XML_8
+  ICCDEV_FIXTURE_XML_9
+  ICCDEV_FIXTURE_XML_11
+  ICCDEV_FIXTURE_XML_14
+  ICCDEV_FIXTURE_XML_15
+  ICCDEV_FIXTURE_INPUT
+)
+
+foreach(_required_var IN LISTS _required_vars)
+  if(NOT DEFINED ${_required_var} OR "${${_required_var}}" STREQUAL "")
+    message(FATAL_ERROR "${_required_var} is required")
+  endif()
+endforeach()
+
+foreach(_required_file IN ITEMS
+    "${ICCDEV_FROM_XML}"
+    "${ICCDEV_DUMP_PROFILE}"
+    "${ICCDEV_APPLY_NAMED_CMM}"
+    "${ICCDEV_FIXTURE_XML_8}"
+    "${ICCDEV_FIXTURE_XML_9}"
+    "${ICCDEV_FIXTURE_XML_11}"
+    "${ICCDEV_FIXTURE_XML_14}"
+    "${ICCDEV_FIXTURE_XML_15}"
+    "${ICCDEV_FIXTURE_INPUT}")
+  if(NOT EXISTS "${_required_file}")
+    message(FATAL_ERROR "required file not found: ${_required_file}")
+  endif()
+endforeach()
+
+file(REMOVE_RECURSE "${ICCDEV_TEST_OUTDIR}")
+file(MAKE_DIRECTORY "${ICCDEV_TEST_OUTDIR}")
+
+function(iccdev_run_clut_case NAME FIXTURE_XML EXPECTED_OUTPUT)
+  set(_fixture_icc "${ICCDEV_TEST_OUTDIR}/${NAME}.icc")
+
+  execute_process(
+    COMMAND "${ICCDEV_FROM_XML}" "${FIXTURE_XML}" "${_fixture_icc}"
+    RESULT_VARIABLE _from_xml_result
+    OUTPUT_VARIABLE _from_xml_stdout
+    ERROR_VARIABLE _from_xml_stderr
+  )
+  if(NOT _from_xml_result EQUAL 0)
+    message(FATAL_ERROR
+      "iccFromXml failed for ${NAME} (${_from_xml_result})\n${_from_xml_stdout}${_from_xml_stderr}")
+  endif()
+
+  execute_process(
+    COMMAND "${ICCDEV_DUMP_PROFILE}" -v 100 "${_fixture_icc}"
+    RESULT_VARIABLE _dump_result
+    OUTPUT_VARIABLE _dump_stdout
+    ERROR_VARIABLE _dump_stderr
+  )
+  if(NOT _dump_result EQUAL 0)
+    message(FATAL_ERROR
+      "iccDumpProfile failed for ${NAME} (${_dump_result})\n${_dump_stdout}${_dump_stderr}")
+  endif()
+  if(NOT "${_dump_stdout}${_dump_stderr}" MATCHES "Profile is valid for version 5\\.10")
+    message(FATAL_ERROR
+      "converted ${NAME} fixture is not ICC-valid\n${_dump_stdout}${_dump_stderr}")
+  endif()
+
+  execute_process(
+    COMMAND
+      "${ICCDEV_APPLY_NAMED_CMM}"
+      "${ICCDEV_FIXTURE_INPUT}" 3 0 "${_fixture_icc}" 0
+    RESULT_VARIABLE _apply_result
+    OUTPUT_VARIABLE _apply_stdout
+    ERROR_VARIABLE _apply_stderr
+  )
+  if(NOT _apply_result EQUAL 0)
+    message(FATAL_ERROR
+      "iccApplyNamedCmm failed for ${NAME} (${_apply_result})\n${_apply_stdout}${_apply_stderr}")
+  endif()
+
+  set(_apply_output "${_apply_stdout}${_apply_stderr}")
+  if(NOT _apply_output MATCHES "${EXPECTED_OUTPUT}")
+    message(FATAL_ERROR
+      "${NAME} CLUT output differs from the expected vector\n${_apply_output}")
+  endif()
+endfunction()
+
+iccdev_run_clut_case(
+  avx2-3d-8-output
+  "${ICCDEV_FIXTURE_XML_8}"
+  "0\\.2200[ \t]+0\\.2300[ \t]+0\\.2400[ \t]+0\\.2500[ \t]+0\\.2600[ \t]+0\\.2700[ \t]+0\\.2800[ \t]+0\\.2900"
+)
+iccdev_run_clut_case(
+  avx2-3d-9-output
+  "${ICCDEV_FIXTURE_XML_9}"
+  "0\\.2200[ \t]+0\\.2300[ \t]+0\\.2400[ \t]+0\\.2500[ \t]+0\\.2600[ \t]+0\\.2700[ \t]+0\\.2800[ \t]+0\\.2900[ \t]+0\\.3000"
+)
+iccdev_run_clut_case(
+  avx2-3d-11-output
+  "${ICCDEV_FIXTURE_XML_11}"
+  "0\\.2200[ \t]+0\\.2300[ \t]+0\\.2400[ \t]+0\\.2500[ \t]+0\\.2600[ \t]+0\\.2700[ \t]+0\\.2800[ \t]+0\\.2900[ \t]+0\\.3000[ \t]+0\\.3100[ \t]+0\\.3200"
+)
+iccdev_run_clut_case(
+  avx2-3d-14-output
+  "${ICCDEV_FIXTURE_XML_14}"
+  "0\\.2200[ \t]+0\\.2300[ \t]+0\\.2400[ \t]+0\\.2500[ \t]+0\\.2600[ \t]+0\\.2700[ \t]+0\\.2800[ \t]+0\\.2900[ \t]+0\\.3000[ \t]+0\\.3100[ \t]+0\\.3200[ \t]+0\\.3300[ \t]+0\\.3400[ \t]+0\\.3500"
+)
+iccdev_run_clut_case(
+  avx2-3d-15-output
+  "${ICCDEV_FIXTURE_XML_15}"
+  "0\\.2200[ \t]+0\\.2300[ \t]+0\\.2400[ \t]+0\\.2500[ \t]+0\\.2600[ \t]+0\\.2700[ \t]+0\\.2800[ \t]+0\\.2900[ \t]+0\\.3000[ \t]+0\\.3100[ \t]+0\\.3200[ \t]+0\\.3300[ \t]+0\\.3400[ \t]+0\\.3500[ \t]+0\\.3600"
+)
+
+message(STATUS "[PASS] clut-eight-output-regression")

--- a/IccProfLib/IccCmmThread.cpp
+++ b/IccProfLib/IccCmmThread.cpp
@@ -59,12 +59,17 @@
 
 #include "IccCmmThread.h"
 #include <algorithm>
-#include <future>
+#include <condition_variable>
+#include <mutex>
 #include <new>
+#include <system_error>
 #include <thread>
 
 
 static const int kIccMaxCmmThreads = 256;
+static const icUInt32Number kIccSmallApplyPixels = 1024;
+static const icUInt32Number kIccSmallApplyPixelsPerThread = 256;
+static const icUInt32Number kIccBulkApplyPixelsPerThread = 128;
 
 static int icResolveCmmThreadCount(int nThreads)
 {
@@ -77,6 +82,165 @@ static int icResolveCmmThreadCount(int nThreads)
 
   return std::min(nActual, kIccMaxCmmThreads);
 }
+
+struct CIccApplyThreadedCmmTask
+{
+  CIccApplyCmm *m_worker;
+  icFloatNumber *m_dst;
+  const icFloatNumber *m_src;
+  icUInt32Number m_count;
+  icStatusCMM m_status;
+};
+
+class CIccApplyThreadedCmmPool
+{
+public:
+  CIccApplyThreadedCmmPool()
+  {
+    m_jobHead = 0;
+    m_jobCount = 0;
+    m_pending = 0;
+    m_stop = false;
+  }
+
+  ~CIccApplyThreadedCmmPool()
+  {
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      m_stop = true;
+    }
+    m_jobReady.notify_all();
+
+    for (std::thread &worker : m_threads) {
+      if (worker.joinable())
+        worker.join();
+    }
+  }
+
+  bool Init(int nThreads)
+  {
+    try {
+      m_tasks.resize((size_t)std::max(0, nThreads - 1));
+      m_jobs.resize(m_tasks.size());
+      m_threads.reserve((size_t)std::max(0, nThreads - 1));
+    }
+    catch (const std::bad_alloc &) {
+      return false;
+    }
+
+    return true;
+  }
+
+  icStatusCMM Apply(std::vector<CIccApplyCmm*> &workers,
+                    icFloatNumber *dstPixel, const icFloatNumber *srcPixel,
+                    icUInt32Number nPixels, int nActive,
+                    int nSrcSamples, int nDstSamples)
+  {
+    if (!EnsureWorkerThreads(nActive - 1))
+      return icCmmStatAllocErr;
+
+    icUInt32Number base = nPixels / (icUInt32Number)nActive;
+    icUInt32Number extra = nPixels % (icUInt32Number)nActive;
+    icUInt32Number offset = 0;
+
+    for (int t = 0; t < nActive - 1; t++) {
+      icUInt32Number count = base + (t < (int)extra ? 1u : 0u);
+      CIccApplyThreadedCmmTask &task = m_tasks[(size_t)t];
+      task.m_worker = workers[(size_t)t];
+      task.m_dst = dstPixel + offset * nDstSamples;
+      task.m_src = srcPixel + offset * nSrcSamples;
+      task.m_count = count;
+      task.m_status = icCmmStatOk;
+      offset += count;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      m_jobHead = 0;
+      m_jobCount = (size_t)nActive - 1;
+      m_pending = m_jobCount;
+      for (size_t i = 0; i < m_jobCount; i++)
+        m_jobs[i] = i;
+    }
+
+    for (int i = 0; i < nActive - 1; i++)
+      m_jobReady.notify_one();
+
+    icStatusCMM rv = workers[(size_t)nActive - 1]->Apply(
+      dstPixel + offset * nDstSamples,
+      srcPixel + offset * nSrcSamples,
+      nPixels - offset);
+
+    {
+      std::unique_lock<std::mutex> lock(m_mutex);
+      m_jobDone.wait(lock, [this]() { return m_pending == 0; });
+    }
+
+    for (int i = 0; i < nActive - 1; i++) {
+      const CIccApplyThreadedCmmTask &task = m_tasks[(size_t)i];
+      if (rv == icCmmStatOk && task.m_status != icCmmStatOk)
+        rv = task.m_status;
+    }
+
+    return rv;
+  }
+
+private:
+  bool EnsureWorkerThreads(int nThreads)
+  {
+    try {
+      while ((int)m_threads.size() < nThreads)
+        m_threads.push_back(std::thread(&CIccApplyThreadedCmmPool::WorkerLoop, this));
+    }
+    catch (const std::system_error &) {
+      return false;
+    }
+
+    return true;
+  }
+
+  void WorkerLoop()
+  {
+    while (true) {
+      size_t job = 0;
+      CIccApplyThreadedCmmTask *task = NULL;
+
+      {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_jobReady.wait(lock, [this]() { return m_stop || m_jobCount != 0; });
+        if (m_stop)
+          return;
+
+        job = m_jobs[m_jobHead];
+        m_jobHead++;
+        m_jobCount--;
+        task = &m_tasks[job];
+      }
+
+      icStatusCMM status = task->m_worker->Apply(task->m_dst, task->m_src,
+                                                 task->m_count);
+
+      {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        task->m_status = status;
+        m_pending--;
+        if (!m_pending)
+          m_jobDone.notify_one();
+      }
+    }
+  }
+
+  std::vector<std::thread> m_threads;
+  std::vector<CIccApplyThreadedCmmTask> m_tasks;
+  std::vector<size_t> m_jobs;
+  size_t m_jobHead;
+  size_t m_jobCount;
+  size_t m_pending;
+  bool m_stop;
+  std::mutex m_mutex;
+  std::condition_variable m_jobReady;
+  std::condition_variable m_jobDone;
+};
 
 
 //===========================================================================
@@ -92,6 +256,8 @@ static int icResolveCmmThreadCount(int nThreads)
  */
 CIccApplyThreadedCmm::CIccApplyThreadedCmm(CIccCmm *pCmm) : CIccApplyCmm(pCmm)
 {
+  m_pool = NULL;
+  m_baseCmm = NULL;
   m_nThreads = 1;
 }
 
@@ -103,6 +269,8 @@ CIccApplyThreadedCmm::CIccApplyThreadedCmm(CIccCmm *pCmm) : CIccApplyCmm(pCmm)
  */
 CIccApplyThreadedCmm::~CIccApplyThreadedCmm()
 {
+  delete m_pool;
+
   for (CIccApplyCmm *p : m_workers)
     delete p;
 }
@@ -128,18 +296,40 @@ bool CIccApplyThreadedCmm::Init(CIccCmm *pCmm, int nThreads)
     return false;
   }
 
-  m_workers.clear();
-  m_workers.reserve((size_t)m_nThreads);
+  m_baseCmm = pCmm;
+  try {
+    m_workers.clear();
+    m_workers.reserve((size_t)m_nThreads);
+  }
+  catch (const std::bad_alloc &) {
+    return false;
+  }
 
-  for (int i = 0; i < m_nThreads; i++) {
+  if (!EnsureWorkers(1))
+    return false;
+
+  m_pool = new (std::nothrow) CIccApplyThreadedCmmPool();
+  if (!m_pool || !m_pool->Init(m_nThreads)) {
+    delete m_pool;
+    m_pool = NULL;
+    return false;
+  }
+
+  return true;
+}
+
+bool CIccApplyThreadedCmm::EnsureWorkers(int nWorkers)
+{
+  while ((int)m_workers.size() < nWorkers) {
     icStatusCMM status;
-    CIccApplyCmm* pWorker = pCmm->GetNewApplyCmm(status);
-    if (!pWorker || status != icCmmStatOk) {
-      delete pWorker;
+    CIccApplyCmm *worker = m_baseCmm->GetNewApplyCmm(status);
+    if (!worker || status != icCmmStatOk) {
+      delete worker;
       return false;
     }
-    m_workers.push_back(pWorker);
+    m_workers.push_back(worker);
   }
+
   return true;
 }
 
@@ -162,12 +352,11 @@ icStatusCMM CIccApplyThreadedCmm::Apply(icFloatNumber *DstPixel, const icFloatNu
  * Name: CIccApplyThreadedCmm::Apply (multi-pixel)
  *
  * Purpose:
- *  Partitions nPixels into up to m_nThreads contiguous strips and
- *  processes each strip on a separate thread.  The final strip is run on
- *  the calling thread to overlap its work with the async launches.
+ *  Partitions nPixels into contiguous strips and processes them through
+ *  persistent worker threads. The final strip runs on the calling thread.
  *
- *  Strips differ in size by at most one pixel (remainder pixels are
- *  distributed one each to the first strips).
+ *  The requested thread count is a maximum. Short calls use coarser strips
+ *  than bulk calls so synchronization does not overwhelm transform work.
  *
  * Args:
  *  DstPixel - output buffer (must be large enough for nPixels * dstSamples)
@@ -184,48 +373,22 @@ icStatusCMM CIccApplyThreadedCmm::Apply(icFloatNumber *DstPixel, const icFloatNu
   int nSrcSamples = m_pCmm->GetSourceSamples();
   int nDstSamples = m_pCmm->GetDestSamples();
 
-  // Cap active thread count to actual pixel count
-  int nActive = std::min((int)nPixels, m_nThreads);
+  icUInt32Number pixelsPerThread = nPixels < kIccSmallApplyPixels
+                                    ? kIccSmallApplyPixelsPerThread
+                                    : kIccBulkApplyPixelsPerThread;
+  icUInt32Number usefulThreads = nPixels / pixelsPerThread;
+  if (nPixels % pixelsPerThread)
+    usefulThreads++;
+  int nActive = std::min(m_nThreads, (int)usefulThreads);
 
   if (nActive <= 1)
     return m_workers[0]->Apply(DstPixel, SrcPixel, nPixels);
 
-  icUInt32Number base  = nPixels / nActive;
-  icUInt32Number extra = nPixels % nActive;  // first `extra` strips get one more pixel
+  if (!EnsureWorkers(nActive))
+    return icCmmStatAllocErr;
 
-  // Launch nActive-1 async strips; the last strip runs on the calling thread.
-  std::vector<std::future<icStatusCMM>> futures;
-  futures.reserve(nActive - 1);
-
-  icUInt32Number offset = 0;
-  for (int t = 0; t < nActive - 1; t++) {
-    icUInt32Number count      = base + (t < (int)extra ? 1u : 0u);
-    icFloatNumber *pDst       = DstPixel + offset * nDstSamples;
-    const icFloatNumber *pSrc = SrcPixel + offset * nSrcSamples;
-    CIccApplyCmm *pWorker     = m_workers[t];
-
-    futures.push_back(std::async(std::launch::async,
-      [pWorker, pDst, pSrc, count]() {
-        return pWorker->Apply(pDst, pSrc, count);
-      }));
-
-    offset += count;
-  }
-
-  // Last strip on calling thread using workers[nActive-1]
-  icStatusCMM rv = m_workers[nActive - 1]->Apply(
-    DstPixel + offset * nDstSamples,
-    SrcPixel + offset * nSrcSamples,
-    nPixels - offset);
-
-  // Collect async results; preserve first non-OK status
-  for (auto &f : futures) {
-    icStatusCMM r = f.get();
-    if (rv == icCmmStatOk && r != icCmmStatOk)
-      rv = r;
-  }
-
-  return rv;
+  return m_pool->Apply(m_workers, DstPixel, SrcPixel, nPixels, nActive,
+                       nSrcSamples, nDstSamples);
 }
 
 

--- a/IccProfLib/IccCmmThread.h
+++ b/IccProfLib/IccCmmThread.h
@@ -74,6 +74,7 @@
 
 // Forward reference
 class CIccThreadedCmm;
+class CIccApplyThreadedCmmPool;
 
 /**
  **************************************************************************
@@ -104,8 +105,11 @@ public:
 protected:
   CIccApplyThreadedCmm(CIccCmm *pCmm);
   bool Init(CIccCmm *pCmm, int nThreads);
+  bool EnsureWorkers(int nWorkers);
 
   std::vector<CIccApplyCmm*> m_workers;
+  CIccApplyThreadedCmmPool *m_pool;
+  CIccCmm *m_baseCmm;
   int m_nThreads;
 };
 

--- a/IccProfLib/IccSignatureUtils.h
+++ b/IccProfLib/IccSignatureUtils.h
@@ -90,6 +90,9 @@ Copyright:  (c) see Software License
 #include <cstdint>
 #include <cstdio>
 #include <cmath>
+#ifdef ICC_AVX2_CLUT_DEBUG
+  #include <chrono>
+#endif
 
 
 #ifndef icSigSpectralPcsData
@@ -237,9 +240,86 @@ inline bool IsSpaceSpectralPCS(icColorSpaceSignature sig)
   #define ICC_LOG_SAFE_VAL(name, idx, basePtr, limit) ((void)0)
 #endif
 
+  // -----------------------------------------------------------------------------
+  // AVX2 CLUT DEBUG TRACEPOINTS
+  //
+  // Define ICC_AVX2_CLUT_DEBUG to log dispatch decisions and per-kernel timing.
+  // IccTraceAvx2ClutDispatch() and IccTraceAvx2ClutKernel() are intentional
+  // source-level breakpoints for inspecting the CLUT's offsets and weights.
+  // The helpers and all call sites compile out in normal builds.
+  // -----------------------------------------------------------------------------
 
-///////////////////////////////////////////////////////////////////////////////
-// FUNCTION: ColorSpaceSignatureToStr
+  #ifdef ICC_AVX2_CLUT_DEBUG
+  struct IccAvx2ClutTraceData {
+    bool cpuSupportsAvx2;
+    bool selected;
+    int outputChannels;
+    const void *data;
+    const icUInt32Number *offsets;
+    const icFloatNumber *weights;
+  };
+
+  inline void IccTraceAvx2ClutDispatch(const IccAvx2ClutTraceData &trace)
+  {
+    ICC_LOG_INFO(
+      "AVX2 CLUT dispatch: selected=%d cpu=%d outputs=%d data=%p offsets=[%u,%u,%u,%u,%u,%u,%u,%u]",
+      trace.selected, trace.cpuSupportsAvx2, trace.outputChannels, trace.data,
+      trace.offsets ? trace.offsets[0] : 0, trace.offsets ? trace.offsets[1] : 0,
+      trace.offsets ? trace.offsets[2] : 0, trace.offsets ? trace.offsets[3] : 0,
+      trace.offsets ? trace.offsets[4] : 0, trace.offsets ? trace.offsets[5] : 0,
+      trace.offsets ? trace.offsets[6] : 0, trace.offsets ? trace.offsets[7] : 0);
+  }
+
+  inline void IccTraceAvx2ClutKernel(const IccAvx2ClutTraceData &trace,
+                                     long long elapsedNanoseconds)
+  {
+    const int vectorOutputs = (trace.outputChannels / 8) * 8;
+    const int maskedOutputs = trace.outputChannels - vectorOutputs;
+    ICC_LOG_INFO(
+      "AVX2 CLUT kernel: outputs=%d vector_outputs=%d masked_outputs=%d elapsed_ns=%lld weights=[%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g,%.8g]",
+      trace.outputChannels, vectorOutputs, maskedOutputs,
+      elapsedNanoseconds, trace.weights[0], trace.weights[1], trace.weights[2],
+      trace.weights[3], trace.weights[4], trace.weights[5], trace.weights[6],
+      trace.weights[7]);
+  }
+
+  class IccAvx2ClutTimer {
+  public:
+    explicit IccAvx2ClutTimer(const IccAvx2ClutTraceData &trace)
+      : m_trace(trace), m_start(std::chrono::steady_clock::now())
+    {
+    }
+
+    ~IccAvx2ClutTimer()
+    {
+      const long long elapsedNanoseconds =
+        std::chrono::duration_cast<std::chrono::nanoseconds>(
+          std::chrono::steady_clock::now() - m_start).count();
+      IccTraceAvx2ClutKernel(m_trace, elapsedNanoseconds);
+    }
+
+  private:
+    const IccAvx2ClutTraceData &m_trace;
+    std::chrono::steady_clock::time_point m_start;
+  };
+
+  #define ICC_AVX2_CLUT_TRACE_DISPATCH(cpuSupportsAvx2, selected, outputChannels, data, offsets, weights) \
+    do { \
+      const IccAvx2ClutTraceData trace = {cpuSupportsAvx2, selected, outputChannels, data, offsets, weights}; \
+      IccTraceAvx2ClutDispatch(trace); \
+    } while(0)
+
+  #define ICC_AVX2_CLUT_TRACE_KERNEL(outputChannels, data, offsets, weights) \
+    const IccAvx2ClutTraceData iccAvx2ClutTrace = {true, true, outputChannels, data, offsets, weights}; \
+    IccAvx2ClutTimer iccAvx2ClutTimer(iccAvx2ClutTrace)
+  #else
+  #define ICC_AVX2_CLUT_TRACE_DISPATCH(cpuSupportsAvx2, selected, outputChannels, data, offsets, weights) ((void)0)
+  #define ICC_AVX2_CLUT_TRACE_KERNEL(outputChannels, data, offsets, weights) ((void)0)
+  #endif
+
+
+  ///////////////////////////////////////////////////////////////////////////////
+  // FUNCTION: ColorSpaceSignatureToStr
 //
 // PURPOSE:
 //   Converts a 32-bit ICC color space signature (icUInt32Number) into a

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -84,6 +84,16 @@
 #ifdef ICC_USE_SSE2
   #include <emmintrin.h>
 #endif
+#if (defined(ICC_USE_AVX2) || defined(ICC_USE_AVX512)) && defined(_MSC_VER)
+  #include <intrin.h>
+#endif
+#ifdef ICC_USE_AVX512
+  #include "IccTagLutAvx512.h"
+#endif
+#ifdef ICC_USE_AVX2
+  #include "IccTagLutAvx2.h"
+#endif
+#include "IccSignatureUtils.h"
 #include "IccTag.h"
 #include "IccUtil.h"
 #include "IccProfile.h"
@@ -91,6 +101,59 @@
 
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
+#endif
+
+#ifdef ICC_USE_AVX2
+static inline bool iccUseAvx2ClutOutput(int outputChannels)
+{
+  return outputChannels == 15;
+}
+
+#if defined(_MSC_VER)
+  #define ICC_CLUT_NOINLINE __declspec(noinline)
+#else
+  #define ICC_CLUT_NOINLINE __attribute__((noinline))
+#endif
+
+static ICC_CLUT_NOINLINE bool iccTryInterp3dAvx2(
+  icFloatNumber *destPixel, const icFloatNumber *data,
+  const icUInt32Number offsets[8], const icFloatNumber weights[8],
+  int outputChannels)
+{
+  static const bool hasAvx2 = []() {
+#if defined(_MSC_VER)
+    int cpuid[4];
+    __cpuidex(cpuid, 0, 0);
+    if (cpuid[0] < 7)
+      return false;
+
+    __cpuidex(cpuid, 1, 0);
+    if (!(cpuid[2] & (1 << 27)) || !(cpuid[2] & (1 << 28)))
+      return false;
+    if ((_xgetbv(0) & 0x6) != 0x6)
+      return false;
+
+    __cpuidex(cpuid, 7, 0);
+    return (cpuid[1] & (1 << 5)) != 0;
+#elif defined(__i386__) || defined(__x86_64__)
+    __builtin_cpu_init();
+    return __builtin_cpu_supports("avx2");
+#else
+    return false;
+#endif
+  }();
+
+  ICC_AVX2_CLUT_TRACE_DISPATCH(
+    hasAvx2, hasAvx2, outputChannels, data,
+    hasAvx2 ? offsets : NULL, hasAvx2 ? weights : NULL);
+  if (!hasAvx2)
+    return false;
+
+  iccCLUTInterp3dAvx2(destPixel, data, offsets, weights, outputChannels);
+  return true;
+}
+
+#undef ICC_CLUT_NOINLINE
 #endif
 
 /**
@@ -2933,6 +2996,50 @@ void CIccCLUT::Interp3d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
   dF5 =  s* nt*  u;
   dF6 =  s*  t* nu;
   dF7 =  s*  t*  u;
+
+#ifdef ICC_USE_AVX512
+  static const bool hasAvx512 = []() {
+#if defined(_MSC_VER)
+    int cpuid[4];
+    __cpuidex(cpuid, 0, 0);
+    if (cpuid[0] < 7)
+      return false;
+
+    __cpuidex(cpuid, 1, 0);
+    if (!(cpuid[2] & (1 << 27)) || !(cpuid[2] & (1 << 28)))
+      return false;
+    if ((_xgetbv(0) & 0xe6) != 0xe6)
+      return false;
+
+    __cpuidex(cpuid, 7, 0);
+    return (cpuid[1] & (1 << 16)) != 0;
+#elif defined(__i386__) || defined(__x86_64__)
+    __builtin_cpu_init();
+    return __builtin_cpu_supports("avx512f");
+#else
+    return false;
+#endif
+  }();
+
+  if (hasAvx512 && m_nOutput >= 8 && m_nOutput <= 16) {
+    const icUInt32Number offsets[] = {n000, n001, n010, n011,
+                                      n100, n101, n110, n111};
+    const icFloatNumber weights[] = {dF0, dF1, dF2, dF3, dF4, dF5, dF6, dF7};
+    iccCLUTInterp3dAvx512(destPixel, p, offsets, weights, (int)m_nOutput);
+    return;
+  }
+#endif
+
+#ifdef ICC_USE_AVX2
+  if (iccUseAvx2ClutOutput((int)m_nOutput)) {
+    const icUInt32Number offsets[] = {n000, n001, n010, n011,
+                                      n100, n101, n110, n111};
+    const icFloatNumber weights[] = {dF0, dF1, dF2, dF3, dF4, dF5, dF6, dF7};
+    if (iccTryInterp3dAvx2(
+          destPixel, p, offsets, weights, (int)m_nOutput))
+      return;
+  }
+#endif
 
 #ifdef ICC_USE_SSE2
   const int nOutputLimit = (int)m_nOutput;

--- a/IccProfLib/IccTagLutAvx2.cpp
+++ b/IccProfLib/IccTagLutAvx2.cpp
@@ -1,0 +1,98 @@
+/** @file
+    File:       IccTagLutAvx2.cpp
+
+    Contains:   AVX2 implementation of 3D CLUT interpolation
+*/
+
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and
+ *    "International Color Consortium" must not be used to imply that the
+ *    International Color Consortium endorses or promotes products derived
+ *    from this software.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR ITS CONTRIBUTING
+ * MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <immintrin.h>
+
+#include "IccTagLutAvx2.h"
+#include "IccSignatureUtils.h"
+
+#ifdef USEICCDEVNAMESPACE
+namespace iccDEV {
+#endif
+
+void iccCLUTInterp3dAvx2(icFloatNumber *destPixel, const icFloatNumber *data,
+                          const icUInt32Number offsets[8], const icFloatNumber weights[8],
+                          int nOutput)
+{
+  ICC_AVX2_CLUT_TRACE_KERNEL(nOutput, data, offsets, weights);
+
+  const __m256 weight0 = _mm256_set1_ps(weights[0]);
+  const __m256 weight1 = _mm256_set1_ps(weights[1]);
+  const __m256 weight2 = _mm256_set1_ps(weights[2]);
+  const __m256 weight3 = _mm256_set1_ps(weights[3]);
+  const __m256 weight4 = _mm256_set1_ps(weights[4]);
+  const __m256 weight5 = _mm256_set1_ps(weights[5]);
+  const __m256 weight6 = _mm256_set1_ps(weights[6]);
+  const __m256 weight7 = _mm256_set1_ps(weights[7]);
+
+  int i = 0;
+  for (; i <= nOutput - 8; i += 8, data += 8) {
+    __m256 value = _mm256_mul_ps(_mm256_loadu_ps(data + offsets[0]), weight0);
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_loadu_ps(data + offsets[1]), weight1));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_loadu_ps(data + offsets[2]), weight2));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_loadu_ps(data + offsets[3]), weight3));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_loadu_ps(data + offsets[4]), weight4));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_loadu_ps(data + offsets[5]), weight5));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_loadu_ps(data + offsets[6]), weight6));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_loadu_ps(data + offsets[7]), weight7));
+    _mm256_storeu_ps(destPixel + i, value);
+  }
+
+  const int remaining = nOutput - i;
+  if (remaining) {
+    const __m256i mask = _mm256_setr_epi32(
+      remaining > 0 ? -1 : 0, remaining > 1 ? -1 : 0,
+      remaining > 2 ? -1 : 0, remaining > 3 ? -1 : 0,
+      remaining > 4 ? -1 : 0, remaining > 5 ? -1 : 0,
+      remaining > 6 ? -1 : 0, 0);
+    __m256 value = _mm256_mul_ps(_mm256_maskload_ps(data + offsets[0], mask), weight0);
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_maskload_ps(data + offsets[1], mask), weight1));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_maskload_ps(data + offsets[2], mask), weight2));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_maskload_ps(data + offsets[3], mask), weight3));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_maskload_ps(data + offsets[4], mask), weight4));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_maskload_ps(data + offsets[5], mask), weight5));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_maskload_ps(data + offsets[6], mask), weight6));
+    value = _mm256_add_ps(value, _mm256_mul_ps(_mm256_maskload_ps(data + offsets[7], mask), weight7));
+    _mm256_maskstore_ps(destPixel + i, mask, value);
+  }
+}
+
+#ifdef USEICCDEVNAMESPACE
+}
+#endif

--- a/IccProfLib/IccTagLutAvx2.h
+++ b/IccProfLib/IccTagLutAvx2.h
@@ -1,0 +1,57 @@
+/** @file
+    File:       IccTagLutAvx2.h
+
+    Contains:   Internal AVX2 helpers for CLUT interpolation
+*/
+
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and
+ *    "International Color Consortium" must not be used to imply that the
+ *    International Color Consortium endorses or promotes products derived
+ *    from this software.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR ITS CONTRIBUTING
+ * MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ICCTAGLUTAVX2_H
+#define _ICCTAGLUTAVX2_H
+
+#include "IccDefs.h"
+
+#ifdef USEICCDEVNAMESPACE
+namespace iccDEV {
+#endif
+
+void iccCLUTInterp3dAvx2(icFloatNumber *destPixel, const icFloatNumber *data,
+                          const icUInt32Number offsets[8], const icFloatNumber weights[8],
+                          int nOutput);
+
+#ifdef USEICCDEVNAMESPACE
+}
+#endif
+
+#endif

--- a/IccProfLib/IccTagLutAvx512.cpp
+++ b/IccProfLib/IccTagLutAvx512.cpp
@@ -1,0 +1,75 @@
+/** @file
+    File:       IccTagLutAvx512.cpp
+
+    Contains:   AVX-512 implementation of 3D CLUT interpolation
+*/
+
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and
+ *    "International Color Consortium" must not be used to imply that the
+ *    International Color Consortium endorses or promotes products derived
+ *    from this software.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR ITS CONTRIBUTING
+ * MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <immintrin.h>
+
+#include "IccTagLutAvx512.h"
+
+#ifdef USEICCDEVNAMESPACE
+namespace iccDEV {
+#endif
+
+void iccCLUTInterp3dAvx512(icFloatNumber *destPixel, const icFloatNumber *data,
+                           const icUInt32Number offsets[8], const icFloatNumber weights[8],
+                           int nOutput)
+{
+  const __mmask16 outputMask = (__mmask16)((1u << nOutput) - 1u);
+  const __m512 weight0 = _mm512_set1_ps(weights[0]);
+  const __m512 weight1 = _mm512_set1_ps(weights[1]);
+  const __m512 weight2 = _mm512_set1_ps(weights[2]);
+  const __m512 weight3 = _mm512_set1_ps(weights[3]);
+  const __m512 weight4 = _mm512_set1_ps(weights[4]);
+  const __m512 weight5 = _mm512_set1_ps(weights[5]);
+  const __m512 weight6 = _mm512_set1_ps(weights[6]);
+  const __m512 weight7 = _mm512_set1_ps(weights[7]);
+
+  __m512 value = _mm512_mul_ps(_mm512_maskz_loadu_ps(outputMask, data + offsets[0]), weight0);
+  value = _mm512_add_ps(value, _mm512_mul_ps(_mm512_maskz_loadu_ps(outputMask, data + offsets[1]), weight1));
+  value = _mm512_add_ps(value, _mm512_mul_ps(_mm512_maskz_loadu_ps(outputMask, data + offsets[2]), weight2));
+  value = _mm512_add_ps(value, _mm512_mul_ps(_mm512_maskz_loadu_ps(outputMask, data + offsets[3]), weight3));
+  value = _mm512_add_ps(value, _mm512_mul_ps(_mm512_maskz_loadu_ps(outputMask, data + offsets[4]), weight4));
+  value = _mm512_add_ps(value, _mm512_mul_ps(_mm512_maskz_loadu_ps(outputMask, data + offsets[5]), weight5));
+  value = _mm512_add_ps(value, _mm512_mul_ps(_mm512_maskz_loadu_ps(outputMask, data + offsets[6]), weight6));
+  value = _mm512_add_ps(value, _mm512_mul_ps(_mm512_maskz_loadu_ps(outputMask, data + offsets[7]), weight7));
+  _mm512_mask_storeu_ps(destPixel, outputMask, value);
+}
+
+#ifdef USEICCDEVNAMESPACE
+}
+#endif

--- a/IccProfLib/IccTagLutAvx512.h
+++ b/IccProfLib/IccTagLutAvx512.h
@@ -1,0 +1,57 @@
+/** @file
+    File:       IccTagLutAvx512.h
+
+    Contains:   Internal AVX-512 helpers for CLUT interpolation
+*/
+
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and
+ *    "International Color Consortium" must not be used to imply that the
+ *    International Color Consortium endorses or promotes products derived
+ *    from this software.
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+ * IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR ITS CONTRIBUTING
+ * MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _ICCTAGLUTAVX512_H
+#define _ICCTAGLUTAVX512_H
+
+#include "IccDefs.h"
+
+#ifdef USEICCDEVNAMESPACE
+namespace iccDEV {
+#endif
+
+void iccCLUTInterp3dAvx512(icFloatNumber *destPixel, const icFloatNumber *data,
+                           const icUInt32Number offsets[8], const icFloatNumber weights[8],
+                           int nOutput);
+
+#ifdef USEICCDEVNAMESPACE
+}
+#endif
+
+#endif

--- a/Testing/CLUT/avx2-3d-11-output.xml
+++ b/Testing/CLUT/avx2-3d-11-output.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType></PreferredCMMType>
+    <ProfileVersion>5.10</ProfileVersion>
+    <ProfileDeviceClass>link</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>BCLR</PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.9642" Y="1.0000" Z="0.8249"/>
+    </PCSIlluminant>
+    <ProfileCreator>ICC </ProfileCreator>
+  </Header>
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[AVX2 3D CLUT eleven-output regression fixture]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <colorantTableOutTag>
+      <colorantTableType>
+        <ColorantTable>
+          <Colorant Name="Channel1" Channel1="0.1" Channel2="0.1" Channel3="0.1"/>
+          <Colorant Name="Channel2" Channel1="0.2" Channel2="0.2" Channel3="0.2"/>
+          <Colorant Name="Channel3" Channel1="0.3" Channel2="0.3" Channel3="0.3"/>
+          <Colorant Name="Channel4" Channel1="0.4" Channel2="0.4" Channel3="0.4"/>
+          <Colorant Name="Channel5" Channel1="0.5" Channel2="0.5" Channel3="0.5"/>
+          <Colorant Name="Channel6" Channel1="0.6" Channel2="0.6" Channel3="0.6"/>
+          <Colorant Name="Channel7" Channel1="0.7" Channel2="0.7" Channel3="0.7"/>
+          <Colorant Name="Channel8" Channel1="0.8" Channel2="0.8" Channel3="0.8"/>
+          <Colorant Name="Channel9" Channel1="0.9" Channel2="0.9" Channel3="0.9"/>
+          <Colorant Name="Channel10" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel11" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+        </ColorantTable>
+      </colorantTableType>
+    </colorantTableOutTag>
+    <multiProcessElementType>
+      <TagSignature>A2B0</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="11">
+        <CLutElement InputChannels="3" OutputChannels="11">
+          <GridPoints>2 2 2</GridPoints>
+          <TableData>
+            0.00 0.01 0.02 0.03 0.04 0.05 0.06 0.07 0.08 0.09 0.10
+            0.08 0.09 0.10 0.11 0.12 0.13 0.14 0.15 0.16 0.17 0.18
+            0.16 0.17 0.18 0.19 0.20 0.21 0.22 0.23 0.24 0.25 0.26
+            0.24 0.25 0.26 0.27 0.28 0.29 0.30 0.31 0.32 0.33 0.34
+            0.32 0.33 0.34 0.35 0.36 0.37 0.38 0.39 0.40 0.41 0.42
+            0.40 0.41 0.42 0.43 0.44 0.45 0.46 0.47 0.48 0.49 0.50
+            0.48 0.49 0.50 0.51 0.52 0.53 0.54 0.55 0.56 0.57 0.58
+            0.56 0.57 0.58 0.59 0.60 0.61 0.62 0.63 0.64 0.65 0.66
+          </TableData>
+        </CLutElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/Testing/CLUT/avx2-3d-14-output.xml
+++ b/Testing/CLUT/avx2-3d-14-output.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType></PreferredCMMType>
+    <ProfileVersion>5.10</ProfileVersion>
+    <ProfileDeviceClass>link</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>ECLR</PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.9642" Y="1.0000" Z="0.8249"/>
+    </PCSIlluminant>
+    <ProfileCreator>ICC </ProfileCreator>
+  </Header>
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[AVX2 3D CLUT fourteen-output regression fixture]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <colorantTableOutTag>
+      <colorantTableType>
+        <ColorantTable>
+          <Colorant Name="Channel1" Channel1="0.1" Channel2="0.1" Channel3="0.1"/>
+          <Colorant Name="Channel2" Channel1="0.2" Channel2="0.2" Channel3="0.2"/>
+          <Colorant Name="Channel3" Channel1="0.3" Channel2="0.3" Channel3="0.3"/>
+          <Colorant Name="Channel4" Channel1="0.4" Channel2="0.4" Channel3="0.4"/>
+          <Colorant Name="Channel5" Channel1="0.5" Channel2="0.5" Channel3="0.5"/>
+          <Colorant Name="Channel6" Channel1="0.6" Channel2="0.6" Channel3="0.6"/>
+          <Colorant Name="Channel7" Channel1="0.7" Channel2="0.7" Channel3="0.7"/>
+          <Colorant Name="Channel8" Channel1="0.8" Channel2="0.8" Channel3="0.8"/>
+          <Colorant Name="Channel9" Channel1="0.9" Channel2="0.9" Channel3="0.9"/>
+          <Colorant Name="Channel10" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel11" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel12" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel13" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel14" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+        </ColorantTable>
+      </colorantTableType>
+    </colorantTableOutTag>
+    <multiProcessElementType>
+      <TagSignature>A2B0</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="14">
+        <CLutElement InputChannels="3" OutputChannels="14">
+          <GridPoints>2 2 2</GridPoints>
+          <TableData>
+            0.00 0.01 0.02 0.03 0.04 0.05 0.06 0.07 0.08 0.09 0.10 0.11 0.12 0.13
+            0.08 0.09 0.10 0.11 0.12 0.13 0.14 0.15 0.16 0.17 0.18 0.19 0.20 0.21
+            0.16 0.17 0.18 0.19 0.20 0.21 0.22 0.23 0.24 0.25 0.26 0.27 0.28 0.29
+            0.24 0.25 0.26 0.27 0.28 0.29 0.30 0.31 0.32 0.33 0.34 0.35 0.36 0.37
+            0.32 0.33 0.34 0.35 0.36 0.37 0.38 0.39 0.40 0.41 0.42 0.43 0.44 0.45
+            0.40 0.41 0.42 0.43 0.44 0.45 0.46 0.47 0.48 0.49 0.50 0.51 0.52 0.53
+            0.48 0.49 0.50 0.51 0.52 0.53 0.54 0.55 0.56 0.57 0.58 0.59 0.60 0.61
+            0.56 0.57 0.58 0.59 0.60 0.61 0.62 0.63 0.64 0.65 0.66 0.67 0.68 0.69
+          </TableData>
+        </CLutElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/Testing/CLUT/avx2-3d-15-output.xml
+++ b/Testing/CLUT/avx2-3d-15-output.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType></PreferredCMMType>
+    <ProfileVersion>5.10</ProfileVersion>
+    <ProfileDeviceClass>link</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>FCLR</PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.9642" Y="1.0000" Z="0.8249"/>
+    </PCSIlluminant>
+    <ProfileCreator>ICC </ProfileCreator>
+  </Header>
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[AVX2 3D CLUT fifteen-output regression fixture]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <colorantTableOutTag>
+      <colorantTableType>
+        <ColorantTable>
+          <Colorant Name="Channel1" Channel1="0.1" Channel2="0.1" Channel3="0.1"/>
+          <Colorant Name="Channel2" Channel1="0.2" Channel2="0.2" Channel3="0.2"/>
+          <Colorant Name="Channel3" Channel1="0.3" Channel2="0.3" Channel3="0.3"/>
+          <Colorant Name="Channel4" Channel1="0.4" Channel2="0.4" Channel3="0.4"/>
+          <Colorant Name="Channel5" Channel1="0.5" Channel2="0.5" Channel3="0.5"/>
+          <Colorant Name="Channel6" Channel1="0.6" Channel2="0.6" Channel3="0.6"/>
+          <Colorant Name="Channel7" Channel1="0.7" Channel2="0.7" Channel3="0.7"/>
+          <Colorant Name="Channel8" Channel1="0.8" Channel2="0.8" Channel3="0.8"/>
+          <Colorant Name="Channel9" Channel1="0.9" Channel2="0.9" Channel3="0.9"/>
+          <Colorant Name="Channel10" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel11" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel12" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel13" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel14" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+          <Colorant Name="Channel15" Channel1="1.0" Channel2="1.0" Channel3="1.0"/>
+        </ColorantTable>
+      </colorantTableType>
+    </colorantTableOutTag>
+    <multiProcessElementType>
+      <TagSignature>A2B0</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="15">
+        <CLutElement InputChannels="3" OutputChannels="15">
+          <GridPoints>2 2 2</GridPoints>
+          <TableData>
+            0.00 0.01 0.02 0.03 0.04 0.05 0.06 0.07 0.08 0.09 0.10 0.11 0.12 0.13 0.14
+            0.08 0.09 0.10 0.11 0.12 0.13 0.14 0.15 0.16 0.17 0.18 0.19 0.20 0.21 0.22
+            0.16 0.17 0.18 0.19 0.20 0.21 0.22 0.23 0.24 0.25 0.26 0.27 0.28 0.29 0.30
+            0.24 0.25 0.26 0.27 0.28 0.29 0.30 0.31 0.32 0.33 0.34 0.35 0.36 0.37 0.38
+            0.32 0.33 0.34 0.35 0.36 0.37 0.38 0.39 0.40 0.41 0.42 0.43 0.44 0.45 0.46
+            0.40 0.41 0.42 0.43 0.44 0.45 0.46 0.47 0.48 0.49 0.50 0.51 0.52 0.53 0.54
+            0.48 0.49 0.50 0.51 0.52 0.53 0.54 0.55 0.56 0.57 0.58 0.59 0.60 0.61 0.62
+            0.56 0.57 0.58 0.59 0.60 0.61 0.62 0.63 0.64 0.65 0.66 0.67 0.68 0.69 0.70
+          </TableData>
+        </CLutElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/Testing/CLUT/avx2-3d-8-output.txt
+++ b/Testing/CLUT/avx2-3d-8-output.txt
@@ -1,0 +1,4 @@
+'RGB ' ; Data Format
+icEncodeFloat ; Encoding
+
+0.25 0.50 0.75

--- a/Testing/CLUT/avx2-3d-8-output.xml
+++ b/Testing/CLUT/avx2-3d-8-output.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType></PreferredCMMType>
+    <ProfileVersion>5.10</ProfileVersion>
+    <ProfileDeviceClass>link</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>8CLR</PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.9642" Y="1.0000" Z="0.8249"/>
+    </PCSIlluminant>
+    <ProfileCreator>ICC </ProfileCreator>
+  </Header>
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[AVX2 3D CLUT eight-output regression fixture]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <colorantTableOutTag>
+      <colorantTableType>
+        <ColorantTable>
+          <Colorant Name="Channel1" Channel1="0.1" Channel2="0.1" Channel3="0.1"/>
+          <Colorant Name="Channel2" Channel1="0.2" Channel2="0.2" Channel3="0.2"/>
+          <Colorant Name="Channel3" Channel1="0.3" Channel2="0.3" Channel3="0.3"/>
+          <Colorant Name="Channel4" Channel1="0.4" Channel2="0.4" Channel3="0.4"/>
+          <Colorant Name="Channel5" Channel1="0.5" Channel2="0.5" Channel3="0.5"/>
+          <Colorant Name="Channel6" Channel1="0.6" Channel2="0.6" Channel3="0.6"/>
+          <Colorant Name="Channel7" Channel1="0.7" Channel2="0.7" Channel3="0.7"/>
+          <Colorant Name="Channel8" Channel1="0.8" Channel2="0.8" Channel3="0.8"/>
+        </ColorantTable>
+      </colorantTableType>
+    </colorantTableOutTag>
+    <multiProcessElementType>
+      <TagSignature>A2B0</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="8">
+        <CLutElement InputChannels="3" OutputChannels="8">
+          <GridPoints>2 2 2</GridPoints>
+          <TableData>
+            0.00 0.01 0.02 0.03 0.04 0.05 0.06 0.07
+            0.08 0.09 0.10 0.11 0.12 0.13 0.14 0.15
+            0.16 0.17 0.18 0.19 0.20 0.21 0.22 0.23
+            0.24 0.25 0.26 0.27 0.28 0.29 0.30 0.31
+            0.32 0.33 0.34 0.35 0.36 0.37 0.38 0.39
+            0.40 0.41 0.42 0.43 0.44 0.45 0.46 0.47
+            0.48 0.49 0.50 0.51 0.52 0.53 0.54 0.55
+            0.56 0.57 0.58 0.59 0.60 0.61 0.62 0.63
+          </TableData>
+        </CLutElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/Testing/CLUT/avx2-3d-9-output.xml
+++ b/Testing/CLUT/avx2-3d-9-output.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType></PreferredCMMType>
+    <ProfileVersion>5.10</ProfileVersion>
+    <ProfileDeviceClass>link</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>9CLR</PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.9642" Y="1.0000" Z="0.8249"/>
+    </PCSIlluminant>
+    <ProfileCreator>ICC </ProfileCreator>
+  </Header>
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[AVX2 3D CLUT nine-output regression fixture]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <colorantTableOutTag>
+      <colorantTableType>
+        <ColorantTable>
+          <Colorant Name="Channel1" Channel1="0.1" Channel2="0.1" Channel3="0.1"/>
+          <Colorant Name="Channel2" Channel1="0.2" Channel2="0.2" Channel3="0.2"/>
+          <Colorant Name="Channel3" Channel1="0.3" Channel2="0.3" Channel3="0.3"/>
+          <Colorant Name="Channel4" Channel1="0.4" Channel2="0.4" Channel3="0.4"/>
+          <Colorant Name="Channel5" Channel1="0.5" Channel2="0.5" Channel3="0.5"/>
+          <Colorant Name="Channel6" Channel1="0.6" Channel2="0.6" Channel3="0.6"/>
+          <Colorant Name="Channel7" Channel1="0.7" Channel2="0.7" Channel3="0.7"/>
+          <Colorant Name="Channel8" Channel1="0.8" Channel2="0.8" Channel3="0.8"/>
+          <Colorant Name="Channel9" Channel1="0.9" Channel2="0.9" Channel3="0.9"/>
+        </ColorantTable>
+      </colorantTableType>
+    </colorantTableOutTag>
+    <multiProcessElementType>
+      <TagSignature>A2B0</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="9">
+        <CLutElement InputChannels="3" OutputChannels="9">
+          <GridPoints>2 2 2</GridPoints>
+          <TableData>
+            0.00 0.01 0.02 0.03 0.04 0.05 0.06 0.07 0.08
+            0.08 0.09 0.10 0.11 0.12 0.13 0.14 0.15 0.16
+            0.16 0.17 0.18 0.19 0.20 0.21 0.22 0.23 0.24
+            0.24 0.25 0.26 0.27 0.28 0.29 0.30 0.31 0.32
+            0.32 0.33 0.34 0.35 0.36 0.37 0.38 0.39 0.40
+            0.40 0.41 0.42 0.43 0.44 0.45 0.46 0.47 0.48
+            0.48 0.49 0.50 0.51 0.52 0.53 0.54 0.55 0.56
+            0.56 0.57 0.58 0.59 0.60 0.61 0.62 0.63 0.64
+          </TableData>
+        </CLutElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+  </Tags>
+</IccProfile>

--- a/docs/avx2-clut-diagnostics.md
+++ b/docs/avx2-clut-diagnostics.md
@@ -1,0 +1,181 @@
+# AVX2 CLUT Diagnostics and Optimization Handoff
+
+## Purpose
+
+The AVX2 3D CLUT implementation is runtime-dispatched from
+`CIccCLUT::Interp3d()`. `IccSignatureUtils.h` provides opt-in tracepoints for
+examining that decision and the kernel inputs without affecting normal builds.
+
+## Diagnostic Configuration
+
+Use the Windows ClangCL diagnostics preset:
+
+```cmd
+cmake --preset vs2022-clangcl-x64-avx2-diagnostics -S Build/Cmake -B out/vs2022-clangcl-x64-avx2-diagnostics
+cmake --build out/vs2022-clangcl-x64-avx2-diagnostics --config Debug -- /m /maxcpucount
+ctest --test-dir out/vs2022-clangcl-x64-avx2-diagnostics -C Debug --output-on-failure --no-tests=error -R "^iccdev\.clut-eight-output-regression$"
+```
+
+The preset enables `ICCDEV_ENABLE_AVX2=ON` and
+`ICC_AVX2_CLUT_DEBUG=ON`. The latter is compiled into IccProfLib only and must
+remain disabled for release builds and throughput measurements.
+
+## CI Coverage
+
+`ci-regression-checks` does not set `ICCDEV_ENABLE_AVX2`; its default build
+therefore validates the scalar/SSE fallback and the portable high-output
+fixtures, not the AVX2 kernel. The Windows PR workflow enables AVX2 in its
+ClangCL lane. Run an explicit AVX2-enabled diagnostic build and the focused
+CTest when source-level dispatch evidence is required.
+
+## Local ISA Coverage and Timing Matrix
+
+Build portable, AVX2, and (where the host supports it) AVX-512 variants in
+separate directories. The Linux Clang presets keep the compiler, Release
+configuration, QA flags, dependencies, and disabled diagnostics identical
+across the comparison.
+
+```bash
+cmake --preset linux-clang-clut-baseline-qa-flags \
+  -S Build/Cmake -B out/clut-portable
+cmake --preset linux-clang-clut-avx2-qa-flags \
+  -S Build/Cmake -B out/clut-avx2
+cmake --preset linux-clang-clut-avx512-qa-flags \
+  -S Build/Cmake -B out/clut-avx512
+cmake --build out/clut-portable --parallel "$(nproc)"
+cmake --build out/clut-avx2 --parallel "$(nproc)"
+cmake --build out/clut-avx512 --parallel "$(nproc)"
+ICCDEV_CLUT_ISA_AFFINITY=0-3 \
+  ./.github/scripts/iccdev-clut-isa-local-report.sh out/clut-report \
+  out/clut-portable out/clut-avx2 out/clut-avx512
+```
+
+The generated `report.md` records build options, host information, focused test
+coverage, individual samples, and median end-to-end timings. It is not a
+kernel-only benchmark: profile conversion, validation, CMM setup, and process
+startup are included. Use a diagnostic build to prove dispatch, and establish
+an isolated kernel benchmark before claiming an ISA throughput improvement.
+
+### Cascade Lake Linux Validation
+
+The Linux matrix was run on an Intel Xeon Silver 4216 (Cascade Lake), which
+provides AVX2 and AVX-512F/BW/DQ/VL, with Clang 21.1.8 and CMake 4.2.3. All
+three Release variants passed `iccdev.clut-eight-output-regression`:
+
+| Variant | Median end-to-end time (s) |
+|---|---:|
+| Portable | 0.18 |
+| AVX2 | 0.15 |
+| AVX-512 | 0.17 |
+
+The separate Debug AVX2 trace confirmed that the fifteen-output fixture
+selects AVX2 with eight vector lanes and a seven-output masked tail. Keep the
+current runtime dispatch: these process-level timings are not an isolated
+kernel benchmark and do not justify preferring AVX2 over AVX-512 for this CPU.
+
+### Capture Dispatch Evidence
+
+Timing builds must leave diagnostics disabled. Build a separate Debug AVX2
+configuration with `-DICC_AVX2_CLUT_DEBUG=ON`, then use the checked-in fixtures
+to capture dispatch and lane evidence:
+
+```bash
+iccFromXml Testing/CLUT/avx2-3d-15-output.xml /tmp/clut-fifteen.icc
+iccApplyNamedCmm Testing/CLUT/avx2-3d-8-output.txt 3 0 /tmp/clut-fifteen.icc 0 \
+  > /tmp/clut-fifteen.log 2>&1
+grep 'AVX2 CLUT' /tmp/clut-fifteen.log
+```
+
+An AVX2-capable host reports `selected=1`, `vector_outputs=8`, and
+`masked_outputs=7` for the fifteen-output fixture. The eight-, nine-, eleven-,
+and fourteen-output fixtures confirm SSE2 fallback without entering the AVX2
+trace helper. This demonstrates dispatch selection and lane coverage; the
+logged nanoseconds are diagnostic evidence only and must not be presented as
+throughput.
+ICC profile fixtures support up to 15 output channels, so a 16-lane AVX-512
+case requires an in-memory test surface rather than a serializable profile.
+
+## Tracepoints
+
+Set source breakpoints in these functions:
+
+| Function | Evidence |
+|----------|----------|
+| `IccTraceAvx2ClutDispatch()` | CPU AVX2 availability, output count, selected path, CLUT data pointer, and corner offsets |
+| `IccTraceAvx2ClutKernel()` | Full-vector and masked-tail output counts, elapsed nanoseconds, and interpolation weights |
+
+The fifteen-output fixture exercises eight full-vector outputs and seven masked
+outputs. All other serializable output counts retain SSE2 after sustained-load
+measurements failed to show a repeatable AVX2 benefit.
+
+## Optimization Protocol
+
+1. Use diagnostics to establish the selected path and inputs.
+2. Rebuild with `ICC_AVX2_CLUT_DEBUG=OFF` before collecting measurements.
+3. Keep the AVX2 compiler flag scoped to `IccTagLutAvx2.cpp`.
+4. Preserve the CPUID and XGETBV runtime checks in `CIccCLUT::Interp3d()`.
+5. Run `iccdev.clut-eight-output-regression` after every implementation change.
+6. Compare output values against the scalar/SSE fallback before accepting any optimization.
+7. Run the interleaved native benchmark across all output counts from 8 to 16.
+8. Require bit-exact output-vector parity for every lane; a rounded aggregate
+   checksum can hide lane swaps and canceling errors.
+
+```powershell
+.github\scripts\iccdev-windows-clut-avx2-benchmark.ps1 `
+  -BaselineBuildDir C:\path\to\baseline-build `
+  -Avx2BuildDir C:\path\to\avx2-build `
+  -Iterations 20000000 -Repetitions 11 `
+  -AffinityCpu 30 `
+  -OutputPath out\clut-avx2-benchmark.tsv
+```
+
+Every result row must report `output_vector_match=True`.
+
+Configure the Windows comparison with the same ClangCL QA preset family so
+the optional AVX2 implementation is the only intentional build difference:
+
+```powershell
+$env:VCPKG_ROOT = 'C:\Program Files\Microsoft Visual Studio\2022\Community\VC\vcpkg'
+cmake --preset vs2022-clangcl-x64-clut-baseline-qa-flags `
+  -S Build\Cmake -B out\clut-baseline
+cmake --preset vs2022-clangcl-x64-avx2-qa-flags `
+  -S Build\Cmake -B out\clut-avx2
+cmake --build out\clut-baseline --config Release `
+  --target IccProfLib2 -- /m /maxcpucount
+cmake --build out\clut-avx2 --config Release `
+  --target IccProfLib2 -- /m /maxcpucount
+```
+
+The Visual Studio presets run vcpkg manifest installation during CMake
+configuration. A separate `vcpkg integrate install` or `vcpkg install` step is
+not required. Do not compare the native MSVC preset against the ClangCL AVX2
+preset when attributing a performance difference to AVX2; that also changes
+the compiler. The dedicated baseline and AVX presets suppress only the
+repository's existing Microsoft CRT compatibility deprecations so benchmark
+build output remains actionable; normal build presets retain those warnings.
+
+The AVX2 kernel uses full vectors plus masked loads and stores for the remaining
+one through seven outputs. Dispatch is limited to 15 outputs.
+Native MSVC is intentionally left on the SSE2 path:
+the August 2026 Windows measurements found its AVX2 code slower. Use ClangCL
+for the Windows AVX2 preset. Do not introduce FMA or a wider ISA requirement
+without separate compiler flags and corresponding runtime capability checks.
+
+## Handoff Record
+
+Record the following with each optimization attempt:
+
+| Item | Record |
+|------|--------|
+| Revision | Branch and commit SHA |
+| Environment | Windows version, CPU model, compiler, and preset |
+| Diagnostics | Dispatch decision, output count, vector/tail split, and trace summary |
+| Correctness | Focused CTest command and scalar/SSE comparison |
+| Measurement | Release command, workload, iteration count, and results |
+| Decision | Accepted change, rejected experiment, or pending investigation |
+
+The reference Windows investigation is recorded in
+`avx2-clut-windows-performance.md`.
+
+Use `.github/prompts/avx2-clut-diagnostics.prompt.md` for one-off work and
+`.github/skills/avx2-clut-diagnostics/SKILL.md` for the repeatable workflow.

--- a/docs/avx2-clut-windows-performance.md
+++ b/docs/avx2-clut-windows-performance.md
@@ -1,0 +1,70 @@
+# Windows AVX2 CLUT Performance Report
+
+## Scope
+
+This report records the native Windows comparison for the opt-in 3D CLUT AVX2
+path on branch `ci-qa-simd-issue-2142`, based on master `281ca19` and the
+follow-up masked-tail optimization.
+
+Environment:
+
+- CPU: Intel Xeon w5-2465X, 16 cores / 32 logical processors
+- MSVC: 19.44.35207
+- ClangCL: 19.1.5
+- CMake: 3.31.6
+- Generator: Visual Studio 17 2022, x64
+- Baseline: merge base `d529ece`
+
+## Native Build and Correctness Matrix
+
+The baseline and AVX2 builds used the same QA presets and the native
+`RunClutEightOutputRegression.cmake` runner.
+
+| Compiler | Mode | Baseline | AVX2 | Warnings |
+|----------|------|----------|------|----------|
+| MSVC | Release | PASS | PASS, SSE2 retained | 0 |
+| MSVC | Debug | PASS | PASS, SSE2 retained | 0 |
+| ClangCL | Release | PASS | PASS | 0 |
+| ClangCL | Debug | PASS | PASS | 0 |
+| MSVC ASan | Debug | PASS | PASS, SSE2 retained | 29 pre-existing deprecation warnings |
+| ClangCL ASan | Debug | Runtime unsupported on this host | Runtime unsupported on this host | ASan interception failure before profile parsing |
+
+ClangCL ASan failed with `interception_win: unhandled instruction` in the
+runtime before `iccFromXml` parsed the fixture. This is a Windows sanitizer
+runtime limitation on the tested host, not an iccDEV profile-processing
+finding. Native MSVC ASan completed with no sanitizer finding.
+
+## Release Throughput
+
+The checked-in benchmark pins one thread to a configurable high-numbered
+logical processor, alternates baseline and AVX2 process order, takes the median
+of 11 samples, and verifies bit-exact parity for every output lane. Each sample
+performs 20,000,000 in-process `CIccCLUT::Interp3d()` calls.
+
+| Outputs | CPU 28 improvement | CPU 30 improvement | Dispatch |
+|---------|-------------------:|-------------------:|----------|
+| 8 | -20.27% | -20.32% | SSE2 fallback |
+| 9 | -16.45% | -18.08% | SSE2 fallback |
+| 10 | -16.69% | -11.88% | SSE2 fallback |
+| 11 | -13.45% | -13.66% | SSE2 fallback |
+| 12 | -15.50% | -20.26% | SSE2 fallback |
+| 13 | -12.11% | -12.02% | SSE2 fallback |
+| 14 | -10.89% | -13.45% | SSE2 fallback |
+| 15 | 10.43% | 6.97% | AVX2 |
+| 16 | -13.65% | -14.01% | SSE2 fallback |
+
+Local revalidation at commit `94c0dc5` found that only 15 outputs improved on
+both tested logical processors. Runtime AVX2 dispatch is therefore limited to
+15 outputs. The opt-in
+build still pays a per-call dispatch check on fallback counts; this is recorded
+as a known cost rather than presenting those rows as AVX2 kernel results.
+
+## Decision
+
+- Use full AVX2 vectors plus masked AVX2 loads/stores for the final 1-7 outputs.
+- Keep CPUID and XGETBV runtime checks.
+- Keep AVX2 compiler flags scoped to `IccTagLutAvx2.cpp`.
+- Dispatch AVX2 only for 15 outputs.
+- Enable the Windows AVX2 implementation for ClangCL.
+- Skip native MSVC AVX2 at configure time and retain its faster SSE2 path.
+- Preserve the benchmark helper for future compiler, CPU, and kernel changes.

--- a/docs/build.md
+++ b/docs/build.md
@@ -306,6 +306,121 @@ cmake --preset vs2022-clangcl-x64-qa-flags -S Build/Cmake -B out/vs2022-clangcl-
 cmake --preset mingw-x64-qa-flags -S Build/Cmake -B out/mingw-x64-qa-flags
 ```
 
+### Linux AVX2 and AVX-512 CLUT build
+
+Linux and WSL2 can use paired Clang presets for portable, AVX2, and AVX-512
+CLUT comparisons. The presets hold the compiler, Release configuration, QA
+flags, enabled tools and tests, disabled wxWidgets UI, and disabled AVX2
+diagnostics constant:
+
+```bash
+cmake --preset linux-clang-clut-baseline-qa-flags \
+  -S Build/Cmake -B out/clut-baseline
+cmake --preset linux-clang-clut-avx2-qa-flags \
+  -S Build/Cmake -B out/clut-avx2
+cmake --preset linux-clang-clut-avx512-qa-flags \
+  -S Build/Cmake -B out/clut-avx512
+
+cmake --build out/clut-baseline --parallel "$(nproc)"
+cmake --build out/clut-avx2 --parallel "$(nproc)"
+cmake --build out/clut-avx512 --parallel "$(nproc)"
+```
+
+The AVX-512 preset inherits the AVX2 preset so AVX2 remains the intermediate
+runtime fallback. The focused CLUT test uses distinct values at every grid
+point so its expected output checks both corner selection and interpolation
+weights. Its eight-, nine-, eleven-, and fourteen-output fixtures validate
+fallback behavior, while the fifteen-output fixture covers a full AVX2 vector
+plus a masked tail and the corresponding AVX-512 path.
+
+To inspect AVX2 dispatch or set source breakpoints, add
+`-DICC_AVX2_CLUT_DEBUG=ON`. This emits the CPU decision, output channel count,
+corner offsets, interpolation weights, and per-kernel elapsed nanoseconds
+through `IccSignatureUtils.h`. It is intentionally diagnostic-only: trace
+logging and timing are compiled out when the option is `OFF`, so do not use a
+debug-trace build for throughput benchmarks.
+
+### Windows AVX2 CLUT build
+
+`vs2022-clangcl-x64-avx2-qa-flags` enables the optional AVX2 3D CLUT
+interpolation implementation. It compiles the AVX2 code in a separate
+translation unit and dispatches only after CPUID and XGETBV verify OS AVX
+state, so the resulting binary retains the scalar/SSE fallback on other x64
+CPUs.
+
+```cmd
+set VCPKG_ROOT=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\vcpkg
+cmake --preset vs2022-clangcl-x64-clut-baseline-qa-flags -S Build/Cmake -B out/vs2022-clangcl-x64-clut-baseline-qa-flags
+cmake --preset vs2022-clangcl-x64-avx2-qa-flags -S Build/Cmake -B out/vs2022-clangcl-x64-avx2-qa-flags
+cmake --build out/vs2022-clangcl-x64-clut-baseline-qa-flags --config Release --target IccProfLib2 -- /m /maxcpucount
+cmake --build out/vs2022-clangcl-x64-avx2-qa-flags --config Release -- /m /maxcpucount
+ctest --test-dir out/vs2022-clangcl-x64-avx2-qa-flags -C Release --output-on-failure --no-tests=error -R "^iccdev\.clut-eight-output-regression$"
+ctest --test-dir out/vs2022-clangcl-x64-avx2-qa-flags -C Release --output-on-failure --no-tests=error
+```
+
+The Visual Studio presets run vcpkg manifest installation during
+configuration, so separate `vcpkg integrate install` and `vcpkg install`
+commands are not required. The dedicated CLUT comparison presets suppress the
+repository's existing Microsoft CRT compatibility deprecations; other Windows
+presets continue to report them.
+
+The preset is intentionally opt-in. Enable `ICCDEV_ENABLE_AVX2=ON` only for
+x86-64 compiler targets that accept the required ISA flag; CMake validates the
+compiler flag during configuration. Native MSVC reports an explicit skip and
+keeps SSE2 because its measured AVX2 path was slower; use ClangCL on Windows.
+The focused regression converts valid 3D
+RGB-to-8CLR, RGB-to-9CLR, RGB-to-BCLR, RGB-to-ECLR, and RGB-to-FCLR ICC v5
+fixtures and verifies their expected CLUT outputs. On an AVX2-capable x86-64
+host, the fifteen-output fixture enters the AVX2 helper; eight, nine, eleven,
+and fourteen outputs validate SSE2 fallback.
+
+For an interleaved Release comparison across every supported output count:
+
+```powershell
+.github\scripts\iccdev-windows-clut-avx2-benchmark.ps1 `
+  -BaselineBuildDir out\vs2022-clangcl-x64-clut-baseline-qa-flags `
+  -Avx2BuildDir out\vs2022-clangcl-x64-avx2-qa-flags `
+  -Iterations 20000000 -Repetitions 11 `
+  -AffinityCpu 30 `
+  -OutputPath out\clut-avx2-benchmark.tsv
+```
+
+Every result row must report `output_vector_match=True`. The helper compares
+the raw float bits for each output lane; a rounded aggregate checksum is not a
+sufficient correctness check. Keep both benchmark builds on ClangCL; comparing
+native MSVC against ClangCL also measures a compiler change.
+
+For a Windows debugging session, use the dedicated diagnostics preset:
+
+```cmd
+cmake --preset vs2022-clangcl-x64-avx2-diagnostics -S Build/Cmake -B out/vs2022-clangcl-x64-avx2-diagnostics
+cmake --build out/vs2022-clangcl-x64-avx2-diagnostics --config Debug -- /m /maxcpucount
+ctest --test-dir out/vs2022-clangcl-x64-avx2-diagnostics -C Debug --output-on-failure --no-tests=error -R "^iccdev\.clut-eight-output-regression$"
+```
+
+Set source breakpoints in
+`IccTraceAvx2ClutDispatch()` or `IccTraceAvx2ClutKernel()` in
+`IccSignatureUtils.h` to inspect the selected path and kernel inputs.
+
+### Windows AVX-512 CLUT build
+
+`vs2022-clangcl-x64-avx512-qa-flags` adds the experimental AVX-512
+implementation while retaining AVX2 and scalar/SSE fallbacks. The AVX-512
+translation unit is compiled separately, and runtime dispatch requires CPUID
+AVX-512F support plus XGETBV confirmation that XMM, YMM, opmask, and ZMM state
+are enabled by the operating system.
+
+```cmd
+cmake --preset vs2022-clangcl-x64-avx512-qa-flags -S Build/Cmake -B out/vs2022-clangcl-x64-avx512-qa-flags
+cmake --build out/vs2022-clangcl-x64-avx512-qa-flags --config Release -- /m /maxcpucount
+ctest --test-dir out/vs2022-clangcl-x64-avx512-qa-flags -C Release --output-on-failure --no-tests=error -R "^iccdev\.clut-eight-output-regression$"
+ctest --test-dir out/vs2022-clangcl-x64-avx512-qa-flags -C Release --output-on-failure --no-tests=error
+```
+
+`ICCDEV_ENABLE_AVX512=ON` is independently opt-in and defaults to `OFF`.
+The Windows preset also enables AVX2 so AVX2-capable systems retain that
+intermediate fallback when AVX-512 is unavailable.
+
 ## Runtime packaging
 
 Top-level CMake builds can also emit runtime packages with CPack without changing
@@ -332,7 +447,7 @@ smoke and uploads the `reficcmax-runtime-packages-linux` artifact.
 rather than from `__declspec` annotations: MSVC is deliberately excluded from the
 `ICCPROFLIBDLL_EXPORTS` definition in `Build/Cmake/IccProfLib/CMakeLists.txt`.
 That arrangement dates from #764, and the same file records why hidden visibility
-is not used on GCC/Clang — `ICCPROFLIB_API` annotations are incomplete
+is not used on GCC/Clang -- `ICCPROFLIB_API` annotations are incomplete
 (~308 partial uses across 43 headers) and `IccXML` has none at all.
 
 ### Exported global data (#1888, fixed in #2219)

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -199,7 +199,8 @@ appearance state regressions without committing generated profiles.
 integration test as a separate `slow` CTest label. The maintainer `check` target
 runs the full suite, including `slow`. Routine CI tool sweeps use the fast lane
 with `--label-exclude slow --label-exclude calculator`, and the `check-fast`
-target runs with `--label-exclude slow`; run full CTest or the hybrid gate
+target excludes `slow` and `known-red` with one label regular expression. Run
+full CTest or the hybrid gate
 explicitly when the slow and calculator suites are in scope:
 `ctest --test-dir build -R '^iccdev\.hybrid-pipeline$' --output-on-failure`.
 

--- a/docs/icc-cmm-threading.md
+++ b/docs/icc-cmm-threading.md
@@ -2,7 +2,7 @@
 
 `CIccThreadedCmm` is a decorator over an existing `CIccCmm` that runs
 multi-pixel `Apply()` calls in parallel by splitting the pixel buffer into
-contiguous strips and processing each strip on its own worker. It lives in
+contiguous strips and processing them through persistent workers. It lives in
 [IccProfLib/IccCmmThread.h](../IccProfLib/IccCmmThread.h) and is part of
 `IccProfLib2`.
 
@@ -16,8 +16,10 @@ internal.
 - The wrapped CMM has already been fully configured (`AddXform` + `Begin()`).
 - Single-pixel `Apply()` does not benefit; it is forwarded to one worker.
 
-Threading is unhelpful (and skipped automatically) when `nPixels` is smaller
-than the requested thread count.
+The requested thread count is a maximum. Calls below 1024 pixels use no more
+than one active worker per 256 pixels; larger calls use one per 128 pixels.
+This keeps short TIFF rows from paying more synchronization overhead than
+transform work while retaining host-wide parallelism for wide rows.
 
 ## Construction Model
 
@@ -56,11 +58,12 @@ delete tcmm;   // deletes the wrapped cmm when bDeleteCmm=true
 
 `CIccApplyThreadedCmm::Apply(dst, src, nPixels)` does the following:
 
-1. Caps the active worker count at `min(nPixels, nThreads)`.
+1. Caps active workers by call size: one per 256 pixels below 1024 pixels,
+   otherwise one per 128 pixels, never exceeding `nThreads`.
 2. Splits the buffer into `nActive` contiguous strips, with the first
    `nPixels % nActive` strips receiving one extra pixel.
-3. Launches `nActive - 1` strips via `std::async(std::launch::async)`; runs
-   the final strip on the calling thread to overlap with the launches.
+3. Queues `nActive - 1` strips to persistent worker threads; runs the final
+   strip on the calling thread.
 4. Collects results and returns the first non-OK status, if any.
 
 `Apply(dst, src)` (single pixel) is forwarded to worker `[0]` without any
@@ -102,9 +105,26 @@ iccApplyProfiles -threads N -cfg config.json
 | omitted | Defaults to `nThreads = 1` (no wrapper; underlying CMM is used directly). |
 | `-threads 0` | Use `std::thread::hardware_concurrency()`, capped at `CIccThreadedCmm::GetMaxThreads()`. |
 | `-threads 1` | No threaded wrapper. |
-| `-threads N` (N > 1) | Use exactly `N` workers, up to `CIccThreadedCmm::GetMaxThreads()`. |
+| `-threads N` (N > 1) | Allow up to `N` workers, subject to the per-call workload cap. |
 
 The flag is parsed before `-cfg`, so it must come first.
+
+## TIFF Performance Benchmark
+
+Use the cross-platform benchmark helper to compare `-threads 1`, `2`, and `0`
+with interleaved runs and bit-identical output checks:
+
+```bash
+python3 .github/scripts/iccdev-iccapplyprofiles-threading-benchmark.py \
+  --build-dir out/clut-portable \
+  --output out/iccapplyprofiles-threading.tsv
+```
+
+On Windows, pass a Release Visual Studio build directory such as
+`out/windows-thread-baseline`. Keep the build type, compiler, profile chain,
+storage location, and image sizes identical when comparing revisions. TIFF
+decode and encode remain serial, so report results by image size rather than
+assuming that host-max threads must win every workload.
 
 ## Failure Modes
 


### PR DESCRIPTION
Synchronizes the AVX2 CLUT work with the persistent threaded-CMM apply pool.\n\nValidation: focused AVX2, threaded-CMM, and TIFF CTests; matched 1024x1024 TIFF timing comparison.\n\nRelated branch: ci-qa-avx-instructions now points to the same commit.