### PR TITLE
test(#2154): cover the installed find_package surface, and fix what it found

### DIFF
--- a/Build/Cmake/Modules/FindRefIccMAX.cmake
+++ b/Build/Cmake/Modules/FindRefIccMAX.cmake
@@ -29,9 +29,42 @@
 # ----- Phase 1: Try CONFIG mode (preferred) -----
 find_package(RefIccMAX CONFIG QUIET)
 
-if(RefIccMAX_FOUND)
+# Accept CONFIG mode only if it actually produced the imported target this
+# module documents. RefIccMAX_FOUND on its own is not that proof: CMake sets it
+# for any RefIccMAXConfig.cmake it loads, and every iccDEV before #712
+# (2026-03-24) shipped a config that predates the target-based package -- it
+# sets REFICCMAX_* variables and defines no RefIccMAX::* targets at all. A 2.3.1
+# install of exactly that shape is what turned this up. One of those left on the search path
+# (a stale system or package-manager prefix) wins Phase 1 over a correct newer
+# install, and returning on the flag alone then hands the caller a "found"
+# package whose every documented target_link_libraries(RefIccMAX::IccProfLib2)
+# line fails at configure time. Fall through to the manual search instead,
+# which builds the targets itself. examples/hello-iccdev/CMakeLists.txt already
+# works around this downstream; the module has to do it too (#2154).
+if(RefIccMAX_FOUND AND (TARGET RefIccMAX::IccProfLib2 OR
+                        TARGET RefIccMAX::IccProfLib2-static))
   # CONFIG already created targets and set variables - nothing more to do
   return()
+endif()
+
+if(RefIccMAX_FOUND)
+  message(STATUS
+    "FindRefIccMAX: ignoring CONFIG package at ${RefIccMAX_DIR} -- it defines "
+    "no RefIccMAX::IccProfLib2 target; falling back to manual discovery")
+  # RefIccMAX_DIR is deliberately left alone. Clearing it would not blacklist
+  # anything -- the next find_package(... CONFIG) just re-runs the search and
+  # finds the same config again -- while it WOULD discard a hint the user set
+  # with -DRefIccMAX_DIR=..., which Phase 2 reads below and which would then be
+  # gone from the cache on every later configure.
+  set(RefIccMAX_FOUND FALSE)
+  set(REFICCMAX_FOUND FALSE)
+  # The rejected config's variables are still live in this scope. REFICCMAX_
+  # INCLUDE_DIRS and REFICCMAX_LIBRARIES are rebuilt unconditionally further
+  # down, but REFICCMAX_VERSION is only overwritten if IccProfLibVer.h is found
+  # and parses -- otherwise find_package_handle_standard_args would report the
+  # DISCARDED package's version for the manually discovered install, and a
+  # find_package(RefIccMAX 2.4 MODULE) would fail against a stale 2.3.1.
+  unset(REFICCMAX_VERSION)
 endif()
 
 # ----- Phase 2: Manual search fallback -----
@@ -66,28 +99,34 @@ find_path(REFICCMAX_ICCXML_INCLUDE_DIR
     IccXML/IccLibXML
 )
 
-# Find shared libraries
+# Find shared libraries.
+#
+# The "d"-suffixed spellings are the same libraries from a Debug install:
+# Build/Cmake/CMakeLists.txt sets CMAKE_DEBUG_POSTFIX "d", so a Debug build
+# installs IccProfLib2d.lib / libIccProfLib2d.so and this module found NOTHING
+# against it -- on every platform, not just Windows. Release names are listed
+# first so a prefix carrying both still resolves to the release library.
 find_library(REFICCMAX_ICCPROFLIB_LIBRARY
-  NAMES IccProfLib2
+  NAMES IccProfLib2 IccProfLib2d
   HINTS ${_hints}
   PATH_SUFFIXES lib lib64
 )
 
 find_library(REFICCMAX_ICCXML_LIBRARY
-  NAMES IccXML2
+  NAMES IccXML2 IccXML2d
   HINTS ${_hints}
   PATH_SUFFIXES lib lib64
 )
 
 # Find static libraries
 find_library(REFICCMAX_ICCPROFLIB_STATIC_LIBRARY
-  NAMES IccProfLib2-static
+  NAMES IccProfLib2-static IccProfLib2-staticd
   HINTS ${_hints}
   PATH_SUFFIXES lib lib64
 )
 
 find_library(REFICCMAX_ICCXML_STATIC_LIBRARY
-  NAMES IccXML2-static
+  NAMES IccXML2-static IccXML2-staticd
   HINTS ${_hints}
   PATH_SUFFIXES lib lib64
 )
@@ -103,7 +142,23 @@ if(REFICCMAX_ICCPROFLIB_INCLUDE_DIR)
   endif()
 endif()
 
-# Standard find_package handling
+# Standard find_package handling.
+#
+# REFICCMAX_ICCPROFLIB_LIBRARY is the SHARED library on purpose: this module
+# reports not-found for a static-only install rather than half-supporting one.
+# A static archive exports none of its own dependencies, so the consumer has to
+# repeat them -- ICC_USE_ZLIB decides whether zlib is among them, ENABLE_ICCXML
+# decides libxml2, and a hand-written find module cannot see which options the
+# install was built with. Accepting the static archive here gets as far as a
+# "DSO missing from command line" link failure on zlib instead of a clean
+# not-found. Consume a static-only install through CONFIG mode, whose exported
+# targets are generated from the build that produced them and carry exactly the
+# right dependencies; that is the path ports/iccdev takes (#176, #2154).
+#
+# The -static targets below are still created whenever the archives sit next to
+# the shared libraries. It is only the "Static-only installs still need generic
+# target names" fallback that this makes unreachable: reaching it requires
+# RefIccMAX::IccProfLib2 to be absent, and FPHSA has already failed by then.
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(RefIccMAX
   REQUIRED_VARS REFICCMAX_ICCPROFLIB_INCLUDE_DIR REFICCMAX_ICCPROFLIB_LIBRARY
@@ -120,6 +175,20 @@ if(RefIccMAX_FOUND)
   # IccXML2 needs libxml2 for transitive linking
   find_package(LibXml2 QUIET)
   find_package(Threads REQUIRED)
+
+  # Prefer the imported target over ${LIBXML2_LIBRARIES}. The installed
+  # IccProfileXml.h includes <libxml/parser.h>, so the dependency has to carry
+  # libxml2's INCLUDE directories as well as its link line -- and a raw library
+  # path carries none. LibXml2::LibXml2 does (FindLibXml2 has defined it since
+  # CMake 3.12); without it every consumer reaching IccXML2 through this module
+  # fails to compile on the first IccXML header, while the CONFIG-mode package
+  # builds fine because its exported target links LibXml2::LibXml2 (#2154).
+  set(_reficcmax_libxml2 "")
+  if(TARGET LibXml2::LibXml2)
+    set(_reficcmax_libxml2 LibXml2::LibXml2)
+  elseif(LIBXML2_LIBRARIES)
+    set(_reficcmax_libxml2 ${LIBXML2_LIBRARIES})
+  endif()
 
   # ---- Create IMPORTED targets ----
 
@@ -163,12 +232,16 @@ if(RefIccMAX_FOUND)
     if(TARGET RefIccMAX::IccProfLib2)
       list(APPEND _xml_deps RefIccMAX::IccProfLib2)
     endif()
-    if(LIBXML2_LIBRARIES)
-      list(APPEND _xml_deps ${LIBXML2_LIBRARIES})
+    if(_reficcmax_libxml2)
+      list(APPEND _xml_deps ${_reficcmax_libxml2})
+    endif()
+    set(_xml_incs "${REFICCMAX_ICCXML_INCLUDE_DIR}")
+    if(NOT TARGET LibXml2::LibXml2 AND LIBXML2_INCLUDE_DIR)
+      list(APPEND _xml_incs "${LIBXML2_INCLUDE_DIR}")
     endif()
     set_target_properties(RefIccMAX::IccXML2 PROPERTIES
       IMPORTED_LOCATION "${REFICCMAX_ICCXML_LIBRARY}"
-      INTERFACE_INCLUDE_DIRECTORIES "${REFICCMAX_ICCXML_INCLUDE_DIR}"
+      INTERFACE_INCLUDE_DIRECTORIES "${_xml_incs}"
       INTERFACE_LINK_LIBRARIES "${_xml_deps}"
       INTERFACE_COMPILE_FEATURES "cxx_std_17"
     )
@@ -183,12 +256,16 @@ if(RefIccMAX_FOUND)
     elseif(TARGET RefIccMAX::IccProfLib2)
       list(APPEND _xml_static_deps RefIccMAX::IccProfLib2)
     endif()
-    if(LIBXML2_LIBRARIES)
-      list(APPEND _xml_static_deps ${LIBXML2_LIBRARIES})
+    if(_reficcmax_libxml2)
+      list(APPEND _xml_static_deps ${_reficcmax_libxml2})
+    endif()
+    set(_xml_static_incs "${REFICCMAX_ICCXML_INCLUDE_DIR}")
+    if(NOT TARGET LibXml2::LibXml2 AND LIBXML2_INCLUDE_DIR)
+      list(APPEND _xml_static_incs "${LIBXML2_INCLUDE_DIR}")
     endif()
     set_target_properties(RefIccMAX::IccXML2-static PROPERTIES
       IMPORTED_LOCATION "${REFICCMAX_ICCXML_STATIC_LIBRARY}"
-      INTERFACE_INCLUDE_DIRECTORIES "${REFICCMAX_ICCXML_INCLUDE_DIR}"
+      INTERFACE_INCLUDE_DIRECTORIES "${_xml_static_incs}"
       INTERFACE_LINK_LIBRARIES "${_xml_static_deps}"
       INTERFACE_COMPILE_FEATURES "cxx_std_17"
     )

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4120,6 +4120,121 @@ function(iccdev_add_proflib_exported_global_definitions_test)
   )
 endfunction()
 
+# #2154 item 3: the installed find_package() surface, exercised by real consumers.
+#
+# Nothing in CI ran `cmake --install` before this test, and nothing built
+# examples/hello-iccdev at all -- the only find_package(RefIccMAX) in CI is
+# ci-vcpkg-ports.yml, CONFIG mode against a port that forces
+# -DENABLE_SHARED_LIBS=OFF. Every consumer path onto a SHARED install was
+# therefore unguarded, which is how two FindRefIccMAX.cmake defects survived:
+# neither is reachable from inside the build tree, only from a consumer of the
+# installed prefix.
+#
+# Runs everywhere rather than being gated to one platform. The staged prefix is
+# the same on all of them, and the Windows leg additionally covers the dllimport
+# annotation the package has to carry INTERFACE for the eight
+# ICCPROFLIB_DATA_API globals (#1888) -- the module-mode half of which is
+# invisible off Windows, since IccProfLibConf.h's non-PC branch never reads the
+# macro. The check target gains the library targets because the test stages the
+# install from their build artefacts; it deliberately does NOT depend on the
+# command-line tools, and stages by component so a tool that was never built
+# cannot be reported as a broken package.
+function(iccdev_add_installed_package_consumer_test)
+  if(NOT ENABLE_INSTALL_RIM)
+    message(STATUS
+      "ENABLE_INSTALL_RIM is off - skipping iccdev.installed-package-consumer")
+    return()
+  endif()
+
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
+    message(STATUS
+      "IccProfLib/IccXML not both built - skipping iccdev.installed-package-consumer")
+    return()
+  endif()
+
+  # The consumers are configured and compiled out of tree at test time, so they
+  # carry none of this build's sanitizer flags. Linking a clean executable
+  # against an instrumented shared library is not merely unmeasured, it aborts:
+  # ASan refuses to start unless its runtime comes first in the initial library
+  # list. Reproducing the parent's full sanitizer configuration inside a nested
+  # configure would be its own source of false reds, and nothing about package
+  # consumability is sanitizer-specific -- the ordinary legs cover it.
+  # Every option that feeds SANITIZER_LIST, not just the well-known five:
+  # ENABLE_INTEGER_SANITIZER alone leaves the libraries built with
+  # -fno-sanitize-recover=integer, so an unsigned overflow inside library code
+  # aborts the uninstrumented consumer and reports as a packaging failure.
+  if(ENABLE_SANITIZERS OR ENABLE_ASAN OR ENABLE_UBSAN OR ENABLE_TSAN OR
+     ENABLE_MSAN OR ENABLE_LSAN OR ENABLE_FUZZING OR
+     ENABLE_INTEGER_SANITIZER OR ENABLE_FLOAT_SANITIZER)
+    message(STATUS
+      "sanitizer build - skipping iccdev.installed-package-consumer "
+      "(out-of-tree consumers are not instrumented)")
+    return()
+  endif()
+
+  # Library directories whose runtime component the test stages. Tools are
+  # excluded on purpose; see the comment above.
+  set(_lib_subdirs IccProfLib IccXML)
+  if(TARGET "${TARGET_LIB_ICCJSON}")
+    list(APPEND _lib_subdirs IccJSON)
+  endif()
+  if(TARGET "${TARGET_LIB_ICCCONNECT}")
+    list(APPEND _lib_subdirs IccConnect)
+  endif()
+
+  # Everything the "dev" and "runtime" component installs read, so that
+  # `cmake --build . --target check` produces a stageable tree. The static
+  # archives are in the dev component, so they are needed even though the
+  # consumers link the shared libraries.
+  foreach(_dep IccProfLib2 IccProfLib2-static IccXML2 IccXML2-static
+                IccJSON2 IccJSON2-static IccConnect2 IccConnect2-static)
+    if(TARGET ${_dep})
+      # A static-only configuration aliases IccProfLib2 onto IccProfLib2-static,
+      # and add_dependencies() on an ALIAS is a hard CMake error, so resolve
+      # through the alias rather than trusting the name.
+      get_target_property(_dep_alias ${_dep} ALIASED_TARGET)
+      if(_dep_alias)
+        add_dependencies(check ${_dep_alias})
+      else()
+        add_dependencies(check ${_dep})
+      endif()
+    endif()
+  endforeach()
+
+  add_test(
+    NAME iccdev.installed-package-consumer
+    COMMAND "${CMAKE_COMMAND}"
+      "-DICCDEV_TEST_NAME=iccdev.installed-package-consumer"
+      "-DICCDEV_TEST_OUTDIR=${ICCDEV_TEST_OUTDIR}/iccdev-installed-package-consumer"
+      "-DICCDEV_REPO_ROOT=${ICCDEV_REPO_ROOT}"
+      "-DICCDEV_BUILD_DIR=${CMAKE_BINARY_DIR}"
+      "-DICCDEV_CONFIG=$<CONFIG>"
+      "-DICCDEV_GENERATOR=${CMAKE_GENERATOR}"
+      "-DICCDEV_GENERATOR_PLATFORM=${CMAKE_GENERATOR_PLATFORM}"
+      # Without the toolset the ClangCL leg would configure its consumer against
+      # the default v143 while passing it a clang-cl CMAKE_CXX_COMPILER, so the
+      # consumer and the libraries it links come from different compilers.
+      "-DICCDEV_GENERATOR_TOOLSET=${CMAKE_GENERATOR_TOOLSET}"
+      "-DICCDEV_CXX_COMPILER=${CMAKE_CXX_COMPILER}"
+      "-DICCDEV_MSVC_RUNTIME_LIBRARY=${CMAKE_MSVC_RUNTIME_LIBRARY}"
+      "-DICCDEV_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}"
+      "-DICCDEV_VCPKG_TRIPLET=${VCPKG_TARGET_TRIPLET}"
+      "-DICCDEV_LIB_SUBDIRS=${_lib_subdirs}"
+      "-DICCDEV_HAVE_SHARED=${ENABLE_SHARED_LIBS}"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunInstalledPackageConsumerTest.cmake"
+  )
+  # Generous because the test performs three nested configure+build cycles on
+  # top of staging two prefixes; a cold MSVC configure alone can take a minute.
+  set_tests_properties(iccdev.installed-package-consumer PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 900
+    # Four nested configure+build cycles; running them against a runner already
+    # saturated by ctest -j is the likeliest way to spend that timeout.
+    RUN_SERIAL TRUE
+    LABELS "iccdev;install;package;find-package;consumer;issue-2154;regression"
+  )
+endfunction()
+
 # #1830: the JSON BCD version parser used atoi() per component, which accepts a
 # leading '-'; "-1" produced 0xFFFFFFFF and wrapped both the "<< 8" in
 # icJsonParseBCDVersionStr and the caller's "<< 16" (UBSan: "left shift of
@@ -5126,6 +5241,7 @@ if(WIN32)
   iccdev_add_calc_envsig_sign_extension_test()
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_proflib_exported_global_definitions_test()
+  iccdev_add_installed_package_consumer_test()
   iccdev_add_json_bcd_version_test()
   iccdev_add_json_writer_move_test()
   iccdev_add_json_fixednum_size_cap_test()
@@ -5410,6 +5526,7 @@ iccdev_add_mpexml_unknown_reserved_test()
 iccdev_add_calc_envsig_sign_extension_test()
 iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_proflib_exported_global_definitions_test()
+iccdev_add_installed_package_consumer_test()
 iccdev_add_json_bcd_version_test()
 iccdev_add_json_writer_move_test()
 iccdev_add_json_fixednum_size_cap_test()

--- a/Build/Cmake/Testing/RunInstalledPackageConsumerTest.cmake
+++ b/Build/Cmake/Testing/RunInstalledPackageConsumerTest.cmake
@@ -1,0 +1,773 @@
+#################################################################################
+# Installed-package consumer regression for the iccDEV find_package() surface
+# Copyright (c) 2026 The International Color Consortium.
+#                                        All rights reserved.
+#################################################################################
+#
+# #2154 item 3 -- "does the installed surface CONSUME?"
+#
+# Before this test nothing in CI ran `cmake --install` at all, and no workflow
+# or CTest built examples/hello-iccdev. The only find_package(RefIccMAX) in CI
+# was ci-vcpkg-ports.yml, CONFIG mode against a port that forces
+# -DENABLE_SHARED_LIBS=OFF. So every consumer path that reaches a SHARED
+# install -- CONFIG mode, MODULE mode via Build/Cmake/Modules/FindRefIccMAX.cmake,
+# and the example itself -- was uncovered, which is how the two Find-module
+# defects fixed alongside this test survived: neither is visible from inside the
+# build tree, only to a consumer of the installed prefix.
+#
+# The test stages a real install into a temporary prefix and then builds and
+# RUNS consumers against it -- four arms over three separate consumer projects. Building out of tree at test time is
+# the only shape that works here for the same reason it was in
+# RunWindowsExportedDataLinkageTest.cmake: a consumer that fails to configure or
+# link inside the main tree takes the BUILD down, so it could never be expressed
+# as a failing CTest.
+#
+# Arms:
+#   1. CONFIG mode  -- find_package(RefIccMAX CONFIG) against the staged prefix.
+#   2. MODULE mode  -- find_package(RefIccMAX MODULE) against a SECOND prefix
+#                      staged without the CMake package files, so
+#                      FindRefIccMAX.cmake's manual-discovery phase is the code
+#                      under test. Pointing MODULE mode at a prefix that has a
+#                      working RefIccMAXConfig.cmake is vacuous: the module
+#                      returns at its CONFIG phase and never runs the manual
+#                      search that builds the imported targets by hand.
+#   2b. MODULE mode again, with a target-less RefIccMAXConfig.cmake planted
+#                      earlier on CMAKE_PREFIX_PATH -- the shape a pre-2.3.2
+#                      install has. Planted rather than assumed so the arm is
+#                      red on a clean runner too.
+#   3. examples/hello-iccdev -- the documented example, built as shipped.
+#
+# Each arm pins the library it resolved back to this test's own staged prefix.
+# Without that pin a machine with iccDEV installed system-wide would quietly
+# test the system copy and pass no matter what this build tree contains.
+
+# The tree's own collector for Windows runtime dependency directories. It reads
+# the parent CMakeCache.txt for CMAKE_PREFIX_PATH, the vcpkg installed triplet,
+# the compiler/CRT directories and the prefixes behind LIBXML2_LIBRARY /
+# ZLIB_LIBRARY and friends. Reusing it rather than hand-rolling a PATH is what
+# three sibling Windows tests already do -- and hand-rolling is precisely how
+# this test first failed on Windows with 0xc0000135 (STATUS_DLL_NOT_FOUND): the
+# staged prefix carries the iccDEV DLLs but nothing tells the loader where
+# libxml2/iconv/zlib live, which under a vcpkg debug build is
+# <installed>/<triplet>/debug/bin.
+include("${CMAKE_CURRENT_LIST_DIR}/WindowsRuntimePaths.cmake")
+
+set(_required_vars
+  ICCDEV_TEST_NAME
+  ICCDEV_TEST_OUTDIR
+  ICCDEV_REPO_ROOT
+  ICCDEV_BUILD_DIR
+  ICCDEV_CONFIG
+  ICCDEV_GENERATOR
+  ICCDEV_LIB_SUBDIRS
+)
+
+foreach(_required_var IN LISTS _required_vars)
+  if(NOT DEFINED ${_required_var} OR "${${_required_var}}" STREQUAL "")
+    message(FATAL_ERROR "${_required_var} is required")
+  endif()
+endforeach()
+
+file(REMOVE_RECURSE "${ICCDEV_TEST_OUTDIR}")
+file(MAKE_DIRECTORY "${ICCDEV_TEST_OUTDIR}")
+set(_log_file "${ICCDEV_TEST_OUTDIR}/output.log")
+set(_log "")
+
+# A function, NOT a macro. Macro arguments are substituted textually and the
+# result is re-parsed, so feeding raw compiler/linker output through one both
+# expands any ${...} it contains and trips "Invalid escape sequence \U" on the
+# backslash paths every Windows tool prints -- which silently discards the
+# accumulated log this test's only diagnostic depends on.
+function(_note _text)
+  set(_log "${_log}${_text}\n" PARENT_SCOPE)
+endfunction()
+
+# Same %TEMP% relocation and path-digest rationale as
+# RunWindowsExportedDataLinkageTest.cmake: the staged prefix plus a nested
+# configure pushes several levels deeper than the build tree and Windows still
+# enforces 260 characters, and the digest keeps two build trees at one
+# configuration from clearing each other's work.
+set(_work_root "${ICCDEV_TEST_OUTDIR}/work")
+if(DEFINED ENV{TEMP} AND NOT "$ENV{TEMP}" STREQUAL "")
+  string(SHA256 _work_hash "${ICCDEV_BUILD_DIR}|${ICCDEV_TEST_NAME}|${ICCDEV_CONFIG}")
+  string(SUBSTRING "${_work_hash}" 0 12 _work_hash)
+  set(_work_root "$ENV{TEMP}/iccdev-inst-${_work_hash}")
+endif()
+file(REMOVE_RECURSE "${_work_root}")
+file(MAKE_DIRECTORY "${_work_root}")
+# Canonicalise once, after the directory exists. On a Windows runner $ENV{TEMP}
+# is the 8.3 short form (C:\Users\RUNNER~1\...) while CMake reports discovered
+# paths in the long form (C:/Users/runneradmin/...). Both name the same
+# directory, so leaving the two spellings in play makes every later path
+# comparison a coin flip.
+get_filename_component(_work_root "${_work_root}" REALPATH)
+
+set(_prefix_config "${_work_root}/prefix-config")
+set(_prefix_module "${_work_root}/prefix-module")
+
+# ---------------------------------------------------------------------------
+# Stage the install
+# ---------------------------------------------------------------------------
+#
+# Deliberately NOT a whole-tree `cmake --install`. That runs every install rule
+# in the tree, including the command-line tools, so it fails outright unless
+# every tool target happens to have been built -- which would make this test
+# report a missing tool as a broken package. The two steps below install exactly
+# what a library consumer resolves:
+#
+#   * component "dev"      -- public headers (including the generated
+#                             IccProfLibVer.h), the static archives, the Windows
+#                             import libraries, and the CMake package files that
+#                             install(EXPORT) generates.
+#   * component "runtime", -- the shared libraries. Run per library directory
+#     per directory          rather than tree-wide because the tools default to
+#                            this component too.
+function(_stage_prefix _prefix _with_package_files)
+  set(_stage_log "")
+
+  # --config is required, not decorative: without it a multi-config generator
+  # installs whatever configuration was baked in at generate time, and
+  # Build/Cmake/CMakeLists.txt force-sets CMAKE_BUILD_TYPE to Release whenever
+  # it is unset -- which every Visual Studio and Xcode preset leaves unset. A
+  # Debug ctest run would then stage Release artefacts and fail on a missing
+  # .lib for reasons having nothing to do with package consumability.
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" --install "${ICCDEV_BUILD_DIR}"
+            --prefix "${_prefix}" --component dev --config "${ICCDEV_CONFIG}"
+    RESULT_VARIABLE _dev_result
+    OUTPUT_VARIABLE _dev_stdout
+    ERROR_VARIABLE _dev_stderr
+  )
+  set(_stage_log "${_stage_log}----- install dev stdout -----\n${_dev_stdout}\n")
+  set(_stage_log "${_stage_log}----- install dev stderr -----\n${_dev_stderr}\n")
+
+  if(NOT _dev_result EQUAL 0)
+    set(_stage_error
+      "Staging the dev component into ${_prefix} failed with ${_dev_result}. This is \
+the install(FILES)/install(TARGETS ... ARCHIVE)/install(EXPORT) surface; a \
+missing static archive here means the library targets were not all built."
+      PARENT_SCOPE)
+    set(_stage_log "${_stage_log}" PARENT_SCOPE)
+    return()
+  endif()
+
+  foreach(_subdir IN LISTS ICCDEV_LIB_SUBDIRS)
+    set(_subdir_script "${ICCDEV_BUILD_DIR}/${_subdir}/cmake_install.cmake")
+    if(NOT EXISTS "${_subdir_script}")
+      set(_stage_error "Install script not found: ${_subdir_script}" PARENT_SCOPE)
+      set(_stage_log "${_stage_log}" PARENT_SCOPE)
+      return()
+    endif()
+    execute_process(
+      COMMAND "${CMAKE_COMMAND}"
+              "-DCMAKE_INSTALL_PREFIX=${_prefix}"
+              "-DCMAKE_INSTALL_COMPONENT=runtime"
+              "-DCMAKE_INSTALL_CONFIG_NAME=${ICCDEV_CONFIG}"
+              -P "${_subdir_script}"
+      RESULT_VARIABLE _rt_result
+      OUTPUT_VARIABLE _rt_stdout
+      ERROR_VARIABLE _rt_stderr
+    )
+    set(_stage_log "${_stage_log}----- install runtime ${_subdir} -----\n${_rt_stdout}${_rt_stderr}\n")
+    if(NOT _rt_result EQUAL 0)
+      set(_stage_error
+        "Staging the runtime component of ${_subdir} into ${_prefix} failed with ${_rt_result}."
+        PARENT_SCOPE)
+      set(_stage_log "${_stage_log}" PARENT_SCOPE)
+      return()
+    endif()
+  endforeach()
+
+  # The MODULE-mode prefix must not carry package files; see the header comment.
+  #
+  # Found by searching for the files themselves rather than by globbing a
+  # hardcoded lib/ lib64/ share/ list. The package lands in
+  # ${CMAKE_INSTALL_LIBDIR}/cmake/reficcmax, and CMAKE_INSTALL_LIBDIR comes from
+  # GNUInstallDirs and is a settable cache variable besides -- anything other
+  # than plain lib or lib64 would leave the config in place, FindRefIccMAX.cmake
+  # would return at its CONFIG phase, and arm 2 would silently stop testing the
+  # manual-discovery path it exists for while still passing.
+  if(NOT _with_package_files)
+    file(GLOB_RECURSE _pkg_files "${_prefix}/RefIccMAXConfig.cmake")
+    foreach(_pkg_file IN LISTS _pkg_files)
+      get_filename_component(_pkg_dir "${_pkg_file}" DIRECTORY)
+      file(REMOVE_RECURSE "${_pkg_dir}")
+    endforeach()
+    # Assert the scrub worked rather than trusting it; a surviving config makes
+    # the whole arm vacuous.
+    file(GLOB_RECURSE _pkg_left "${_prefix}/RefIccMAXConfig.cmake")
+    if(_pkg_left)
+      set(_stage_error
+        "Could not strip the CMake package files from ${_prefix}; ${_pkg_left} survived, which would make the MODULE-mode arm vacuous."
+        PARENT_SCOPE)
+      set(_stage_log "${_stage_log}" PARENT_SCOPE)
+      return()
+    endif()
+  endif()
+
+  set(_stage_error "" PARENT_SCOPE)
+  set(_stage_log "${_stage_log}" PARENT_SCOPE)
+endfunction()
+
+_stage_prefix("${_prefix_config}" TRUE)
+_note("${_stage_log}")
+set(_stage_failure "${_stage_error}")
+
+if(NOT _stage_failure)
+  _stage_prefix("${_prefix_module}" FALSE)
+  _note("${_stage_log}")
+  set(_stage_failure "${_stage_error}")
+endif()
+
+function(_fail _message)
+  file(WRITE "${_log_file}" "CTest test: ${ICCDEV_TEST_NAME}\n"
+       "Configuration: ${ICCDEV_CONFIG}\n"
+       "Staged prefix (CONFIG): ${_prefix_config}\n"
+       "Staged prefix (MODULE): ${_prefix_module}\n\n${_log}")
+  # Inline the tail of the log into the CTest output as well as writing the
+  # file. On a CI runner the file is unreachable -- the log path in a failure
+  # message is only useful to someone sitting on the machine -- so without this
+  # a red leg says which arm failed and nothing about why. The tail is where the
+  # failing arm's own stdout/stderr has just been appended; bounded so a long
+  # compiler transcript cannot bury the message it is attached to.
+  set(_tail "${_log}")
+  string(LENGTH "${_tail}" _tail_len)
+  if(_tail_len GREATER 4000)
+    math(EXPR _tail_start "${_tail_len} - 4000")
+    string(SUBSTRING "${_tail}" ${_tail_start} -1 _tail)
+    set(_tail "...(truncated; full log in the file below)...\n${_tail}")
+  endif()
+  message(FATAL_ERROR
+    "${_message}\n\n----- tail of ${ICCDEV_TEST_NAME} log -----\n${_tail}\n"
+    "----- end of tail -----\nFull log: ${_log_file}")
+endfunction()
+
+if(_stage_failure)
+  _fail("${_stage_failure}")
+endif()
+
+# ---------------------------------------------------------------------------
+# The installed surface itself
+# ---------------------------------------------------------------------------
+#
+# Checked before any consumer runs so that a missing header is reported as a
+# missing header rather than as a compile error three layers down.
+set(_incdir "${_prefix_config}/include/RefIccMAX/IccProfLib2")
+set(_required_files
+  "${_incdir}/IccProfile.h"
+  "${_incdir}/IccUtil.h"
+  "${_incdir}/IccProfLibConf.h"
+  # Generated at build time from the version + git hash (#823), so its absence
+  # means the generated-header install rule regressed, not the static list.
+  "${_incdir}/IccProfLibVer.h"
+  # Relocated out of Tools/CmdLine by #2154. It is header-only and has no
+  # exported symbol, so an install-rule omission would be invisible to every
+  # in-tree consumer -- this is the only thing that would notice.
+  "${_incdir}/IccCmdLineUtil.h"
+)
+foreach(_required_file IN LISTS _required_files)
+  if(NOT EXISTS "${_required_file}")
+    _fail("Installed package is missing ${_required_file}")
+  endif()
+endforeach()
+
+file(GLOB_RECURSE _config_files "${_prefix_config}/*RefIccMAXConfig.cmake")
+file(GLOB_RECURSE _targets_files "${_prefix_config}/*RefIccMAXTargets.cmake")
+if(NOT _config_files)
+  _fail("Installed package has no RefIccMAXConfig.cmake under ${_prefix_config}")
+endif()
+if(NOT _targets_files)
+  _fail("Installed package has no RefIccMAXTargets.cmake under ${_prefix_config} -- install(EXPORT RefIccMAXTargets) did not run")
+endif()
+list(GET _config_files 0 _config_file)
+get_filename_component(_package_dir "${_config_file}" DIRECTORY)
+_note("Resolved package dir: ${_package_dir}")
+
+# ---------------------------------------------------------------------------
+# Consumer arms
+# ---------------------------------------------------------------------------
+set(_common_args
+  -G "${ICCDEV_GENERATOR}"
+  -Wno-dev
+)
+if(DEFINED ICCDEV_GENERATOR_PLATFORM AND NOT "${ICCDEV_GENERATOR_PLATFORM}" STREQUAL "")
+  list(APPEND _common_args -A "${ICCDEV_GENERATOR_PLATFORM}")
+endif()
+# Matters on the ClangCL leg: the parent's CMAKE_CXX_COMPILER is clang-cl, so
+# leaving the nested configure on the default v143 toolset would build the
+# consumer with a different compiler than the libraries it links.
+if(DEFINED ICCDEV_GENERATOR_TOOLSET AND NOT "${ICCDEV_GENERATOR_TOOLSET}" STREQUAL "")
+  list(APPEND _common_args -T "${ICCDEV_GENERATOR_TOOLSET}")
+endif()
+if(DEFINED ICCDEV_CXX_COMPILER AND NOT "${ICCDEV_CXX_COMPILER}" STREQUAL "")
+  list(APPEND _common_args "-DCMAKE_CXX_COMPILER=${ICCDEV_CXX_COMPILER}")
+endif()
+# Forwarded so the nested configure resolves LibXml2/nlohmann_json the same way
+# the parent did. On the Windows legs those come from vcpkg, and without the
+# toolchain the consumer's find_dependency(LibXml2) fails for a reason that has
+# nothing to do with the iccDEV package under test.
+if(DEFINED ICCDEV_TOOLCHAIN_FILE AND NOT "${ICCDEV_TOOLCHAIN_FILE}" STREQUAL "")
+  list(APPEND _common_args "-DCMAKE_TOOLCHAIN_FILE=${ICCDEV_TOOLCHAIN_FILE}")
+  # examples/hello-iccdev ships a vcpkg.json. Under a vcpkg toolchain that puts
+  # the nested configure into manifest mode, which would try to resolve and
+  # build that manifest -- a network fetch inside a CTest. The consumer needs
+  # the dependencies the PARENT build already resolved, so classic mode against
+  # the installed tree is both faster and what is actually under test.
+  list(APPEND _common_args "-DVCPKG_MANIFEST_MODE=OFF")
+endif()
+if(DEFINED ICCDEV_VCPKG_TRIPLET AND NOT "${ICCDEV_VCPKG_TRIPLET}" STREQUAL "")
+  list(APPEND _common_args "-DVCPKG_TARGET_TRIPLET=${ICCDEV_VCPKG_TRIPLET}")
+endif()
+if(DEFINED ICCDEV_MSVC_RUNTIME_LIBRARY AND NOT "${ICCDEV_MSVC_RUNTIME_LIBRARY}" STREQUAL "")
+  list(APPEND _common_args "-DCMAKE_MSVC_RUNTIME_LIBRARY=${ICCDEV_MSVC_RUNTIME_LIBRARY}")
+endif()
+if(NOT ICCDEV_GENERATOR MATCHES "Visual Studio|Xcode|Multi-Config")
+  list(APPEND _common_args "-DCMAKE_BUILD_TYPE=${ICCDEV_CONFIG}")
+endif()
+
+# The consumer source is shared by all three CMake-side arms. It touches one
+# ICCPROFLIB_DATA_API global and one plain exported function, includes the
+# relocated IccCmdLineUtil.h, and drives IccXML so the libxml2 include path has
+# to have propagated -- that last one is what the MODULE-mode arm regression
+# tests, since a raw library path carries no include directories.
+set(_consumer_source "\
+#include \"IccProfile.h\"\n\
+#include \"IccUtil.h\"\n\
+#include \"IccCmdLineUtil.h\"\n\
+#include \"IccProfileXml.h\"\n\
+\n\
+#include <cmath>\n\
+#include <cstdio>\n\
+#include <cstring>\n\
+#include <string>\n\
+\n\
+int main()\n\
+{\n\
+  int failures = 0;\n\
+\n\
+  // An ICCPROFLIB_DATA_API global: exported data, which is what needs the\n\
+  // dllimport annotation the package has to carry INTERFACE on Windows.\n\
+  if (std::fabs(icD50XYZ[1] - 1.0) > 1e-6) {\n\
+    std::fprintf(stderr, \"FAIL icD50XYZ[1]=%f\\n\", icD50XYZ[1]);\n\
+    ++failures;\n\
+  }\n\
+  if (!icMsgValidateWarning || std::strcmp(icMsgValidateWarning, \"Warning! - \") != 0) {\n\
+    std::fprintf(stderr, \"FAIL icMsgValidateWarning\\n\");\n\
+    ++failures;\n\
+  }\n\
+\n\
+  // A plain exported function, to tell a data-export failure apart from the\n\
+  // package being unusable altogether.\n\
+  CIccInfo info;\n\
+  if (!info.GetColorSpaceSigName(icSigRgbData)) {\n\
+    std::fprintf(stderr, \"FAIL GetColorSpaceSigName\\n\");\n\
+    ++failures;\n\
+  }\n\
+\n\
+  // Reaches IccXML, whose installed header includes <libxml/parser.h>. The\n\
+  // assertion is that the CALL SUCCEEDS, deliberately not that it produces\n\
+  // bytes: examples/hello-iccdev treats empty output from a bare header as an\n\
+  // expected outcome, so requiring content here would assert something the\n\
+  // tree itself documents as not guaranteed. What this arm needs to establish\n\
+  // is that IccXML2 resolved, loaded and ran from the installed package.\n\
+  CIccProfileXml profile;\n\
+  profile.InitHeader();\n\
+  profile.m_Header.colorSpace = icSigRgbData;\n\
+  profile.m_Header.pcs = icSigLabData;\n\
+  profile.m_Header.deviceClass = icSigDisplayClass;\n\
+  std::string xml;\n\
+  if (!profile.ToXml(xml)) {\n\
+    std::fprintf(stderr, \"FAIL ToXml returned false\\n\");\n\
+    ++failures;\n\
+  }\n\
+\n\
+  if (failures) {\n\
+    std::fprintf(stderr, \"installed-consumer: %d failure(s)\\n\", failures);\n\
+    return 1;\n\
+  }\n\
+  std::printf(\"installed-consumer: OK xml=%zu\\n\", xml.size());\n\
+  return 0;\n\
+}\n")
+
+# Runs one consumer: configure, build, then execute with the staged shared
+# libraries reachable.
+function(_run_consumer _label _src_dir _build_dir _prefix _extra_args _out_ok)
+  set(_arm_log "===== arm: ${_label} =====\n")
+  set(_arm_stdout "" PARENT_SCOPE)
+  set(_arm_run_stdout "" PARENT_SCOPE)
+
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" -S "${_src_dir}" -B "${_build_dir}"
+            ${_common_args} ${_extra_args}
+    RESULT_VARIABLE _cfg_result
+    OUTPUT_VARIABLE _cfg_stdout
+    ERROR_VARIABLE _cfg_stderr
+  )
+  set(_arm_log "${_arm_log}----- configure stdout -----\n${_cfg_stdout}\n")
+  set(_arm_log "${_arm_log}----- configure stderr -----\n${_cfg_stderr}\n")
+  if(NOT _cfg_result EQUAL 0)
+    set(${_out_ok} "configure failed with ${_cfg_result}" PARENT_SCOPE)
+    set(_arm_log "${_arm_log}" PARENT_SCOPE)
+    set(_arm_stdout "${_cfg_stdout}" PARENT_SCOPE)
+    return()
+  endif()
+
+  execute_process(
+    # No --parallel: each consumer is one or two translation units, so an
+    # unbounded job count buys nothing and only competes with the other tests
+    # CTest may be running alongside this one.
+    COMMAND "${CMAKE_COMMAND}" --build "${_build_dir}" --config "${ICCDEV_CONFIG}"
+    RESULT_VARIABLE _bld_result
+    OUTPUT_VARIABLE _bld_stdout
+    ERROR_VARIABLE _bld_stderr
+  )
+  set(_arm_log "${_arm_log}----- build stdout -----\n${_bld_stdout}\n")
+  set(_arm_log "${_arm_log}----- build stderr -----\n${_bld_stderr}\n")
+  if(NOT _bld_result EQUAL 0)
+    set(${_out_ok} "build failed with ${_bld_result}" PARENT_SCOPE)
+    set(_arm_log "${_arm_log}" PARENT_SCOPE)
+    set(_arm_stdout "${_cfg_stdout}" PARENT_SCOPE)
+    return()
+  endif()
+
+  # Locate the executable across single- and multi-config generators.
+  set(_exe "")
+  file(GLOB_RECURSE _candidates
+    "${_build_dir}/iccdev-installed-consumer"
+    "${_build_dir}/iccdev-installed-consumer.exe"
+    "${_build_dir}/hello-iccdev"
+    "${_build_dir}/hello-iccdev.exe")
+  foreach(_candidate IN LISTS _candidates)
+    if(NOT IS_DIRECTORY "${_candidate}")
+      set(_exe "${_candidate}")
+      break()
+    endif()
+  endforeach()
+  if(NOT _exe)
+    set(${_out_ok} "consumer executable not found under ${_build_dir}" PARENT_SCOPE)
+    set(_arm_log "${_arm_log}" PARENT_SCOPE)
+    set(_arm_stdout "${_cfg_stdout}" PARENT_SCOPE)
+    return()
+  endif()
+  set(_arm_log "${_arm_log}executable: ${_exe}\n")
+
+  # The staged prefix is not on any default loader path, so point the loader at
+  # it explicitly: bin/ for Windows DLLs, lib/ elsewhere.
+  if(WIN32)
+    # Staged prefix first (the package under test), then everything the parent
+    # build resolved its own dependencies from.
+    set(_win_path "${_prefix}/bin;${_prefix}/lib")
+    iccdev_collect_cache_runtime_path_entries(_runtime_entries "${ICCDEV_BUILD_DIR}")
+
+    # vcpkg keeps per-configuration DLLs in SEPARATE trees -- release in
+    # <installed>/<triplet>/bin, debug in <installed>/<triplet>/debug/bin -- and
+    # the shared collector only knows the release one. In-tree Windows tests do
+    # not notice, because StageWindowsRuntime.cmake copies the dependency DLLs
+    # next to the binaries it stages; an out-of-tree consumer gets no such copy
+    # and fails to LOAD with 0xc0000135 (STATUS_DLL_NOT_FOUND) on a Debug leg.
+    # The collector's ZLIB_LIBRARY/LIBXML2_LIBRARY fallback cannot cover it
+    # either: under a multi-config generator those cache values are the list
+    # "optimized;<path>;debug;<path>", which no EXISTS test matches.
+    foreach(_vcpkg_cache_name VCPKG_INSTALLED_DIR _VCPKG_INSTALLED_DIR)
+      iccdev_read_cache_value(_vcpkg_installed "${ICCDEV_BUILD_DIR}" "${_vcpkg_cache_name}")
+      if(NOT "${_vcpkg_installed}" STREQUAL "")
+        break()
+      endif()
+    endforeach()
+    iccdev_read_cache_value(_vcpkg_triplet "${ICCDEV_BUILD_DIR}" VCPKG_TARGET_TRIPLET)
+    if(NOT "${_vcpkg_installed}" STREQUAL "" AND NOT "${_vcpkg_triplet}" STREQUAL "")
+      set(_vcpkg_root "${_vcpkg_installed}/${_vcpkg_triplet}")
+      if(ICCDEV_CONFIG MATCHES "[Dd]ebug")
+        iccdev_add_existing_path_entry(_runtime_entries "${_vcpkg_root}/debug/bin")
+      endif()
+      iccdev_add_existing_path_entry(_runtime_entries "${_vcpkg_root}/bin")
+    endif()
+
+    # Last resort, and independent of any cache spelling: any <...>/debug/lib or
+    # <...>/lib directory the parent linked against has its DLLs in the sibling
+    # bin/. Derived from the per-configuration halves of the library cache
+    # entries, so the "optimized;...;debug;..." form is handled.
+    foreach(_lib_cache_name LIBXML2_LIBRARY ZLIB_LIBRARY TIFF_LIBRARY
+                            PNG_LIBRARY JPEG_LIBRARY)
+      iccdev_read_cache_value(_lib_value "${ICCDEV_BUILD_DIR}" "${_lib_cache_name}")
+      foreach(_lib_entry IN LISTS _lib_value)
+        if(EXISTS "${_lib_entry}" AND NOT IS_DIRECTORY "${_lib_entry}")
+          get_filename_component(_lib_dir "${_lib_entry}" DIRECTORY)
+          get_filename_component(_lib_prefix "${_lib_dir}/.." ABSOLUTE)
+          iccdev_add_existing_path_entry(_runtime_entries "${_lib_prefix}/bin")
+        endif()
+      endforeach()
+    endforeach()
+
+    foreach(_entry IN LISTS _runtime_entries)
+      set(_win_path "${_win_path};${_entry}")
+    endforeach()
+    set(_env_args "PATH=${_win_path};$ENV{PATH}")
+    # Logged because a load failure names no DLL: 0xc0000135 tells you something
+    # was missing and nothing about what, so the search path and what the
+    # package actually staged are the only evidence a CI run can leave behind.
+    set(_arm_log "${_arm_log}----- runtime PATH -----\n${_win_path}\n")
+    file(GLOB _staged_bin "${_prefix}/bin/*" "${_prefix}/lib/*.dll")
+    set(_arm_log "${_arm_log}----- staged binaries -----\n")
+    foreach(_staged IN LISTS _staged_bin)
+      set(_arm_log "${_arm_log}  ${_staged}\n")
+    endforeach()
+  elseif(APPLE)
+    set(_env_args "DYLD_LIBRARY_PATH=${_prefix}/lib:$ENV{DYLD_LIBRARY_PATH}")
+  else()
+    set(_env_args "LD_LIBRARY_PATH=${_prefix}/lib:${_prefix}/lib64:$ENV{LD_LIBRARY_PATH}")
+  endif()
+
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}" -E env "${_env_args}" "${_exe}"
+    RESULT_VARIABLE _run_result
+    OUTPUT_VARIABLE _run_stdout
+    ERROR_VARIABLE _run_stderr
+  )
+  set(_arm_log "${_arm_log}----- run stdout -----\n${_run_stdout}\n")
+  set(_arm_log "${_arm_log}----- run stderr -----\n${_run_stderr}\n")
+  if(NOT _run_result EQUAL 0)
+    set(${_out_ok} "consumer exited with ${_run_result}" PARENT_SCOPE)
+    set(_arm_log "${_arm_log}" PARENT_SCOPE)
+    set(_arm_stdout "${_cfg_stdout}" PARENT_SCOPE)
+    return()
+  endif()
+
+  set(${_out_ok} "" PARENT_SCOPE)
+  set(_arm_log "${_arm_log}" PARENT_SCOPE)
+  set(_arm_stdout "${_cfg_stdout}" PARENT_SCOPE)
+  set(_arm_run_stdout "${_run_stdout}" PARENT_SCOPE)
+endfunction()
+
+# --- Anti-vacuity: both arms must have resolved THIS test's staged prefix -----
+#
+# Not packed into a list and looped: configure output routinely contains
+# semicolons, and list(GET) over that would silently read the wrong field.
+function(_assert_resolved_under _arm_name _arm_out _arm_prefix)
+  if(NOT _arm_out MATCHES "ICCDEV_RESOLVED_LIB=([^\n\r]+)")
+    _fail("${_arm_name}-mode arm did not report the library it resolved")
+  endif()
+  set(_resolved "${CMAKE_MATCH_1}")
+  string(STRIP "${_resolved}" _resolved)
+  file(TO_CMAKE_PATH "${_resolved}" _resolved)
+  file(TO_CMAKE_PATH "${_arm_prefix}" _expected_prefix)
+  # Compare canonical forms, not the spellings each side happened to print.
+  get_filename_component(_resolved_real "${_resolved}" REALPATH)
+  get_filename_component(_expected_real "${_expected_prefix}" REALPATH)
+  if(WIN32)
+    # NTFS is case-insensitive, and the two sides reach this point from
+    # different APIs, so a case difference here is not a real mismatch.
+    string(TOLOWER "${_resolved_real}" _resolved_real)
+    string(TOLOWER "${_expected_real}" _expected_real)
+  endif()
+  # Compare against the prefix WITH a trailing separator, so the match is on a
+  # path boundary rather than on a string prefix: without it a sibling directory
+  # whose name merely starts with the prefix -- "<root>/prefix-config-elsewhere"
+  # against "<root>/prefix-config" -- satisfies the check, which is exactly the
+  # false accept this assertion exists to prevent.
+  string(FIND "${_resolved_real}/" "${_expected_real}/" _prefix_pos)
+  if(NOT _prefix_pos EQUAL 0)
+    _fail("${_arm_name}-mode arm resolved ${_resolved}, which is outside this test's staged prefix ${_expected_prefix}. The arm tested some other iccDEV installation and proves nothing about this build tree.\nCanonicalised comparison was:\n  resolved: ${_resolved_real}\n  expected: ${_expected_real}")
+  endif()
+  message(STATUS "${_arm_name} arm resolved ${_resolved}")
+endfunction()
+
+# --- Arm 1: CONFIG mode ------------------------------------------------------
+set(_config_src "${_work_root}/consumer-config")
+file(MAKE_DIRECTORY "${_config_src}")
+file(WRITE "${_config_src}/consumer.cpp" "${_consumer_source}")
+# RefIccMAX_DIR is set explicitly rather than left to CMAKE_PREFIX_PATH so the
+# arm cannot drift onto an unrelated iccDEV installed elsewhere on the machine.
+file(WRITE "${_config_src}/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.16...3.29)
+project(IccDevInstalledConfigConsumer LANGUAGES CXX)
+find_package(RefIccMAX CONFIG REQUIRED)
+# A static-only install exports only RefIccMAX::IccProfLib2-static, and
+# RefIccMAXConfig.cmake then synthesises the generic name as an INTERFACE
+# IMPORTED wrapper that has neither IMPORTED_LOCATION nor
+# IMPORTED_CONFIGURATIONS. Resolve through to whichever target actually names a
+# file, or the anti-vacuity pin fails every static-only build.
+function(_iccdev_imported_location _target _out)
+  set(_result "")
+  if(TARGET ${_target})
+    get_target_property(_result ${_target} IMPORTED_LOCATION)
+    if(NOT _result)
+      get_target_property(_cfgs ${_target} IMPORTED_CONFIGURATIONS)
+      foreach(_cfg IN LISTS _cfgs)
+        get_target_property(_candidate ${_target} IMPORTED_LOCATION_${_cfg})
+        if(_candidate)
+          set(_result "${_candidate}")
+          break()
+        endif()
+      endforeach()
+    endif()
+  endif()
+  if(NOT _result)
+    set(_result "")
+  endif()
+  set(${_out} "${_result}" PARENT_SCOPE)
+endfunction()
+
+_iccdev_imported_location(RefIccMAX::IccProfLib2 _loc)
+if(NOT _loc)
+  _iccdev_imported_location(RefIccMAX::IccProfLib2-static _loc)
+endif()
+message(STATUS "ICCDEV_RESOLVED_LIB=${_loc}")
+add_executable(iccdev-installed-consumer consumer.cpp)
+target_compile_features(iccdev-installed-consumer PRIVATE cxx_std_17)
+target_link_libraries(iccdev-installed-consumer PRIVATE
+  RefIccMAX::IccProfLib2 RefIccMAX::IccXML2)
+]=])
+
+_run_consumer("CONFIG mode" "${_config_src}" "${_work_root}/build-config"
+  "${_prefix_config}" "-DRefIccMAX_DIR=${_package_dir}" _config_error)
+_note("${_arm_log}")
+set(_config_cfg_stdout "${_arm_stdout}")
+set(_config_run_stdout "${_arm_run_stdout}")
+
+if(_config_error)
+  _fail("CONFIG-mode consumer: ${_config_error}.\nfind_package(RefIccMAX CONFIG) against the staged prefix must configure, link and run -- this is the install(EXPORT) surface.")
+endif()
+if(NOT _config_run_stdout MATCHES "installed-consumer: OK")
+  _fail("CONFIG-mode consumer did not report success")
+endif()
+_assert_resolved_under("CONFIG" "${_config_cfg_stdout}" "${_prefix_config}")
+
+# --- Arms 2 and 2b: MODULE mode ---------------------------------------------
+#
+# Skipped, loudly, on a static-only build. FindRefIccMAX.cmake reports
+# not-found for a static-only install by design -- see the REQUIRED_VARS comment
+# there -- so these arms would be testing that documented refusal, not the
+# manual-discovery path they exist for. The CONFIG and hello-iccdev arms still
+# run and still cover a static-only package.
+if(NOT ICCDEV_HAVE_SHARED)
+  message(STATUS
+    "${ICCDEV_TEST_NAME}: static-only build -- MODULE-mode arms skipped "
+    "(FindRefIccMAX.cmake requires a shared IccProfLib2); CONFIG and "
+    "hello-iccdev arms still run")
+  _note("SKIPPED: MODULE-mode arms (static-only build)")
+else()
+
+# --- Arm 2: MODULE mode ------------------------------------------------------
+set(_module_src "${_work_root}/consumer-module")
+file(MAKE_DIRECTORY "${_module_src}")
+file(WRITE "${_module_src}/consumer.cpp" "${_consumer_source}")
+file(WRITE "${_module_src}/CMakeLists.txt" [=[
+cmake_minimum_required(VERSION 3.16...3.29)
+project(IccDevInstalledModuleConsumer LANGUAGES CXX)
+list(APPEND CMAKE_MODULE_PATH "${ICCDEV_MODULE_PATH}")
+find_package(RefIccMAX MODULE REQUIRED)
+get_target_property(_loc RefIccMAX::IccProfLib2 IMPORTED_LOCATION)
+message(STATUS "ICCDEV_RESOLVED_LIB=${_loc}")
+get_target_property(_defs RefIccMAX::IccProfLib2 INTERFACE_COMPILE_DEFINITIONS)
+message(STATUS "ICCDEV_MODULE_DEFS=${_defs}")
+add_executable(iccdev-installed-consumer consumer.cpp)
+target_compile_features(iccdev-installed-consumer PRIVATE cxx_std_17)
+target_link_libraries(iccdev-installed-consumer PRIVATE
+  RefIccMAX::IccProfLib2 RefIccMAX::IccXML2)
+]=])
+
+_run_consumer("MODULE mode" "${_module_src}" "${_work_root}/build-module"
+  "${_prefix_module}"
+  "-DICCDEV_MODULE_PATH=${ICCDEV_REPO_ROOT}/Build/Cmake/Modules;-DCMAKE_PREFIX_PATH=${_prefix_module}"
+  _module_error)
+_note("${_arm_log}")
+set(_module_cfg_stdout "${_arm_stdout}")
+set(_module_run_stdout "${_arm_run_stdout}")
+
+if(_module_error)
+  _fail("MODULE-mode consumer: ${_module_error}.\nThis arm is FindRefIccMAX.cmake's manual-discovery phase. A configure failure on a non-existent RefIccMAX::IccProfLib2 means the module returned a package with no imported targets; a compile failure on <libxml/parser.h> means the IccXML2 target lost libxml2's include directories (#2154).")
+endif()
+if(NOT _module_run_stdout MATCHES "installed-consumer: OK")
+  _fail("MODULE-mode consumer did not report success")
+endif()
+
+# The module must hand a Windows consumer the same dllimport annotation the
+# CONFIG package carries INTERFACE. This is a configure-time property check
+# because off Windows the macro is inert -- IccProfLibConf.h's non-PC branch
+# does not read it -- so nothing at compile or link time would notice its loss
+# on the platforms where this test usually runs (#2154, from #1888).
+if(NOT _module_cfg_stdout MATCHES "ICCDEV_MODULE_DEFS=[^\n]*ICCPROFLIBDLL_DATA_IMPORTS")
+  _fail("FindRefIccMAX.cmake's RefIccMAX::IccProfLib2 lost ICCPROFLIBDLL_DATA_IMPORTS from INTERFACE_COMPILE_DEFINITIONS. A Windows consumer reaching iccDEV through the module would get LNK2019 on the eight ICCPROFLIB_DATA_API globals.")
+endif()
+
+# --- Arm 2b: MODULE mode with a target-less config shadowing the prefix ------
+#
+# The regression test for FindRefIccMAX.cmake's CONFIG phase, made independent
+# of what happens to be installed on the machine running it.
+#
+# iccDEV <= 2.3.1 shipped a RefIccMAXConfig.cmake that only sets REFICCMAX_*
+# variables and defines no RefIccMAX::* targets. CMake still reports the package
+# as found when it loads one, so a module that returns on RefIccMAX_FOUND alone
+# hands the caller a package with no imported targets and every documented
+# target_link_libraries(RefIccMAX::IccProfLib2) then fails at configure time --
+# and it does so in preference to a perfectly good newer install further along
+# the search path. The stub below reproduces exactly that layout, so the arm
+# fails on a clean runner rather than only where a stale install happens to sit.
+set(_legacy_prefix "${_work_root}/legacy-prefix")
+file(WRITE "${_legacy_prefix}/lib/cmake/reficcmax/RefIccMAXConfig.cmake" [=[
+# Stands in for the pre-2.3.2 package: variables only, no imported targets.
+set(REFICCMAX_VERSION "2.3.1")
+set(REFICCMAX_INCLUDE_DIRS "")
+set(REFICCMAX_LIBRARIES "")
+]=])
+
+_run_consumer("MODULE mode (legacy config shadowed)" "${_module_src}"
+  "${_work_root}/build-module-legacy" "${_prefix_module}"
+  # The two prefixes are ONE CMAKE_PREFIX_PATH value, so the separator between
+  # them is an escaped semicolon; an unescaped one would split _extra_args into
+  # separate arguments and drop the real prefix off the search path.
+  "-DICCDEV_MODULE_PATH=${ICCDEV_REPO_ROOT}/Build/Cmake/Modules;-DCMAKE_PREFIX_PATH=${_legacy_prefix}\;${_prefix_module}"
+  _legacy_error)
+_note("${_arm_log}")
+set(_legacy_cfg_stdout "${_arm_stdout}")
+set(_legacy_run_stdout "${_arm_run_stdout}")
+
+if(_legacy_error)
+  _fail("MODULE mode with a target-less RefIccMAXConfig.cmake earlier on CMAKE_PREFIX_PATH: ${_legacy_error}.\nFindRefIccMAX.cmake must not return at its CONFIG phase on RefIccMAX_FOUND alone -- it has to confirm CONFIG mode actually created RefIccMAX::IccProfLib2, and fall through to manual discovery when it did not (#2154).")
+endif()
+if(NOT _legacy_run_stdout MATCHES "installed-consumer: OK")
+  _fail("MODULE-mode (legacy config shadowed) consumer did not report success")
+endif()
+
+_assert_resolved_under("MODULE" "${_module_cfg_stdout}" "${_prefix_module}")
+_assert_resolved_under("MODULE-legacy" "${_legacy_cfg_stdout}" "${_prefix_module}")
+
+endif()
+
+# --- Arm 3: examples/hello-iccdev -------------------------------------------
+#
+# Built exactly as shipped, so the example in the tree is covered rather than a
+# copy of it. RefIccMAX_DIR pins its first discovery path to the staged prefix;
+# ICCDEV_BUILD_DIR is pointed at a directory that does not exist so a stale
+# build tree cannot satisfy it instead.
+set(_hello_src "${ICCDEV_REPO_ROOT}/examples/hello-iccdev")
+if(NOT EXISTS "${_hello_src}/CMakeLists.txt")
+  _fail("examples/hello-iccdev not found at ${_hello_src}")
+endif()
+
+_run_consumer("hello-iccdev" "${_hello_src}" "${_work_root}/build-hello"
+  "${_prefix_config}"
+  "-DRefIccMAX_DIR=${_package_dir};-DICCDEV_BUILD_DIR=${_work_root}/no-such-build-dir"
+  _hello_error)
+_note("${_arm_log}")
+set(_hello_cfg_stdout "${_arm_stdout}")
+set(_hello_run_stdout "${_arm_run_stdout}")
+
+if(_hello_error)
+  _fail("examples/hello-iccdev: ${_hello_error}.\nThe documented example must build and run against an installed package.")
+endif()
+if(NOT _hello_cfg_stdout MATCHES "hello-iccdev: using installed RefIccMAX package")
+  _fail("examples/hello-iccdev did not take its installed-package discovery path; it fell back to a build tree and did not test the install.")
+endif()
+if(NOT _hello_run_stdout MATCHES "Hello, iccDEV!")
+  _fail("examples/hello-iccdev ran but did not produce its expected output")
+endif()
+
+file(WRITE "${_log_file}" "CTest test: ${ICCDEV_TEST_NAME}\n"
+     "Configuration: ${ICCDEV_CONFIG}\n"
+     "Staged prefix (CONFIG): ${_prefix_config}\n"
+     "Staged prefix (MODULE): ${_prefix_module}\n\n${_log}")
+message(STATUS "Wrote ${ICCDEV_TEST_NAME} log to ${_log_file}")
+message(STATUS "${ICCDEV_TEST_NAME}: CONFIG, MODULE and hello-iccdev consumers "
+               "all built and ran against the staged install")

--- a/docs/build.md
+++ b/docs/build.md
@@ -390,6 +390,22 @@ platforms) pins the linkage and the literal values, while
 **out of tree** at test time and reports a lost annotation as a single failing
 test with the `LNK2019` in its log.
 
+A third test, `iccdev.installed-package-consumer`, covers the same annotation
+one step further out — on the *installed* package rather than the build tree.
+It stages an install into a temporary prefix and then builds and runs three
+consumers against it: `find_package(RefIccMAX CONFIG)`, `find_package(RefIccMAX
+MODULE)` through `FindRefIccMAX.cmake`, and `examples/hello-iccdev` itself. A
+fourth arm repeats MODULE mode with a target-less `RefIccMAXConfig.cmake`
+planted earlier on `CMAKE_PREFIX_PATH`, the shape every install before #712 has.
+Each
+arm pins the library it resolved back to the staged prefix, so a machine with
+iccDEV installed system-wide cannot quietly satisfy the test with that copy
+instead. The MODULE arm additionally asserts the imported target still carries
+`ICCPROFLIBDLL_DATA_IMPORTS`, which no compile or link step would notice off
+Windows because `IccProfLibConf.h`'s non-PC branch never reads the macro. The
+arms are skipped, with a logged reason, on sanitizer builds (the out-of-tree
+consumers are not instrumented) and the MODULE arms on static-only builds.
+
 `IccUtil.h` also declared `icInfo` until #1897, but that one had no definition
 anywhere in the tree and so failed to link on every platform — a dangling
 declaration rather than an export problem. It is gone; construct a `CIccInfo`
@@ -582,3 +598,11 @@ For a complete consuming-project example, see the
 find_package(RefIccMAX CONFIG REQUIRED)
 target_link_libraries(my_target PRIVATE RefIccMAX::IccProfLib2-static)
 ```
+
+Use `CONFIG` mode for a static-only install, as above.
+`Build/Cmake/Modules/FindRefIccMAX.cmake` reports not-found for one on purpose:
+a static archive carries none of its own dependencies, and which ones the
+consumer has to repeat depends on the options the install was built with
+(`ICC_USE_ZLIB`, `ENABLE_ICCXML`) — something a hand-written find module cannot
+see. The `CONFIG` package is generated from the build that produced it and
+carries them exactly.

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -241,6 +241,7 @@ Windows full tool builds register these tests when all targets are available:
 | `iccdev.windows-pawg-report-smoke` | `Build/Cmake/Testing/RunWindowsPawgReportSmokeTest.cmake` |
 | `iccdev.issue-987-shared-mpe-export` | `Build/Cmake/Testing/RunWindowsSharedExportTest.cmake` |
 | `iccdev.issue-1009-iccjson-profilejson-export` | `Build/Cmake/Testing/RunWindowsIccJsonExportTest.cmake` |
+| `iccdev.installed-package-consumer` | `Build/Cmake/Testing/RunInstalledPackageConsumerTest.cmake` |
 
 The batch-backed Windows tests run through
 `Build/Cmake/Testing/RunWindowsBatchTest.cmake`. The wrapper copies `Testing/`
@@ -299,6 +300,25 @@ through, and deletes a two-profile RGB transform without registering the CMM
 globally. `iccdev.issue-1009-iccjson-profilejson-export` checks that
 `IccJSON2.dll` exports `CIccProfileJson::~CIccProfileJson` for MSVC ABI
 consumers.
+
+`iccdev.installed-package-consumer` runs on every platform and covers the
+*installed* package rather than the build tree. It stages an install into a
+temporary prefix -- component `dev` tree-wide, then component `runtime` per
+library directory, so a command-line tool that was never built cannot be
+reported as a broken package -- checks the installed header and CMake package
+surface, then builds and runs three consumers against it:
+`find_package(RefIccMAX CONFIG)`, `find_package(RefIccMAX MODULE)` through
+`Build/Cmake/Modules/FindRefIccMAX.cmake`, and `examples/hello-iccdev` as
+shipped. A fourth arm repeats MODULE mode with a target-less
+`RefIccMAXConfig.cmake` planted earlier on `CMAKE_PREFIX_PATH`, the shape a
+pre-2.3.2 install has. Each arm pins the library it resolved back to the staged
+prefix, so an iccDEV installed elsewhere on the machine cannot satisfy the test
+in place of this build tree. Unlike the Windows consumers above, this one is
+skipped -- with a logged reason -- on sanitizer builds rather than inheriting
+the parent settings: its consumers are separate CMake projects, and an
+uninstrumented executable cannot load an ASan-instrumented library. The
+MODULE-mode arms are likewise skipped on static-only builds, where
+`FindRefIccMAX.cmake` reports not-found by design.
 
 ## Fixtures and Logs
 


### PR DESCRIPTION
## Summary

Item 3 of the #2154 roadmap asks whether the **installed** surface actually consumes. Nothing answered that, and the gap is measurable rather than theoretical:

```
$ grep -rln "cmake --install\|--target install" .github/workflows/
$            # no hits
$ grep -rn  "hello-iccdev" .github/ **/CMakeLists.txt
$            # only a release-notes string -- no workflow, no CTest
```

The one `find_package(RefIccMAX)` in CI is `ci-vcpkg-ports.yml:399`, CONFIG mode against a port that forces `-DENABLE_SHARED_LIBS=OFF` (`ports/iccdev/portfile.cmake:87`). So every consumer path onto a **shared** install was unguarded.

This adds `iccdev.installed-package-consumer`, which stages a real install into a temporary prefix and then builds **and runs** consumers against it — four arms over three consumer projects:

| arm | covers |
| --- | --- |
| CONFIG | `find_package(RefIccMAX CONFIG)`, i.e. the `install(EXPORT)` surface |
| MODULE | `FindRefIccMAX.cmake`'s manual-discovery phase |
| MODULE + planted legacy config | the pre-#712 package shape, planted so the arm is red on a clean runner |
| `examples/hello-iccdev` | the documented example, built as shipped |

Building out of tree at test time is the only shape that works here, for the same reason it was in `RunWindowsExportedDataLinkageTest.cmake`: a consumer that cannot configure or link inside the main tree takes the **build** down rather than turning one test red.

## Three real defects it surfaced

Neither is reachable from inside the build tree — only from a consumer of the installed prefix, which is exactly why they survived.

**1. `FindRefIccMAX.cmake` returned at its CONFIG phase on `RefIccMAX_FOUND` alone.** CMake sets that flag for *any* `RefIccMAXConfig.cmake` it loads, and every iccDEV before #712 (2026-03-24) shipped one that sets `REFICCMAX_*` variables and defines no `RefIccMAX::*` targets — I verified the pre-#712 template contains zero `RefIccMAX::` and hit a real 2.3.1 install of that shape. Such an install wins Phase 1 over a correct newer one, and the module then reported the package found while creating **no imported targets**:

```
-- REPRO RefIccMAX_FOUND=1
-- REPRO target RefIccMAX::IccProfLib2: ABSENT
```

Every documented `target_link_libraries(RefIccMAX::IccProfLib2)` then fails at configure time. `examples/hello-iccdev` already works around this downstream ("Ignoring incomplete RefIccMAX package at ..."); the module now does too.

**2. The module's `IccXML2` targets linked `${LIBXML2_LIBRARIES}`, a raw library path, which carries no include directories.** The installed `IccProfileXml.h` includes `<libxml/parser.h>`, so every MODULE-mode consumer failed to compile on the first IccXML header:

```
.../include/RefIccMAX/IccXML2/IccProfileXml.h:65:10: fatal error: libxml/parser.h: No such file or directory
```

They now prefer `LibXml2::LibXml2`, as the CONFIG package already did.

**3. The module could not find a Debug install at all — on any platform.** `Build/Cmake/CMakeLists.txt:213` sets `CMAKE_DEBUG_POSTFIX "d"`, so a Debug build installs `IccProfLib2d.lib` / `libIccProfLib2d.so`, and the module's `find_library(NAMES IccProfLib2)` matched none of it:

```
Could NOT find RefIccMAX (missing: REFICCMAX_ICCPROFLIB_LIBRARY)
```

Found by the Windows leg, which builds Debug; then reproduced locally against a Linux Debug install, so it is a general defect rather than a Windows one. Release names are listed first so a prefix carrying both still resolves to the release library.

## One deliberately *not* fixed

MODULE mode rejects static-only installs, which makes its own "Static-only installs still need generic target names" fallback unreachable. I fixed that, then reverted: accepting the archive only gets as far as `undefined reference to 'inflateEnd' ... DSO missing from command line`. A static archive exports none of its own dependencies, and which ones the consumer must repeat depends on `ICC_USE_ZLIB` / `ENABLE_ICCXML` — a hand-written find module cannot see the options the install was built with. CONFIG mode is generated from the build that produced it and carries them exactly; that is the path `ports/iccdev` takes. Documented in the module and in `docs/build.md` rather than half-fixed.

## Red/green

Each defect was isolated, not just observed together:

| module state | result |
| --- | --- |
| master | **RED** at the MODULE arm |
| phase-1 fix only (libxml2 defect left in) | **RED** on `libxml/parser.h` — deterministic, machine-independent |
| phase-1 defect only, legacy config planted | **RED**, no imported targets |
| both fixes | **GREEN** |

The planted-legacy-config arm exists because defect 1 otherwise only reproduces where a stale install happens to sit. Each arm also pins the library it resolved back to this test's own staged prefix — without that, a machine with iccDEV installed system-wide would quietly test that copy and pass regardless of this build tree.

## Verification

| check | result |
| --- | --- |
| shared build, all four arms | green |
| static-only build (CONFIG + hello-iccdev; MODULE skipped, logged) | green |
| Debug build, shared (all four arms) | green; red without the debug-postfix fix |
| sanitizer build | skipped with logged reason |
| full local CTest suite (post-rebase) | 193/194 |
| strict Clang `-Wall -Wextra -Wpedantic -Werror` (`strict warnings ENABLED`) | 0 warnings |

The single suite failure is the pre-existing `iccdev.spectral-tiff-preview`, which needs a Python `imagecodecs` module absent from this machine; it fails identically without this change. No C++ source is modified by this PR, so the compiler-warning surface is unchanged.

**Not exercised locally: Windows.** The Windows-specific handling — `--config` on the dev install, `CMAKE_GENERATOR_TOOLSET` forwarding, `%TEMP%` relocation for `MAX_PATH`, `bin/` on `PATH` for the staged DLLs, and `VCPKG_MANIFEST_MODE=OFF` so `hello-iccdev`'s `vcpkg.json` does not trigger a manifest fetch inside a CTest — is reasoned and reviewed but only CI can confirm it.

## Notes

- Registered at **both** call sites in `Build/Cmake/Testing/CMakeLists.txt`. The `if(WIN32)` block ends with `return()`, so the two sites are mutually exclusive, not duplicated — a single registration would silently cover only one set of platforms.
- Staging is by component (`dev` tree-wide, then `runtime` per library directory) rather than a whole-tree `cmake --install`, so a command-line tool that was never built cannot be reported as a broken package.
- `RUN_SERIAL`, and no `--parallel` on the nested builds: each consumer is one or two translation units, so an unbounded job count only competes with whatever else CTest is running.

## CI

Pre-PR dispatch `ci_scope=source`, run
[32506578831](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32506578831)
— **all green**, including Windows MSVC + ClangCL. `iccdev.installed-package-consumer`
is confirmed to have actually run there rather than merely registering: Test #48,
Passed, 26.80s and 31.09s (the two Windows profiles), suite 105/105.

That run was dispatched on base `c1ddd7ea`; master has since moved to `cb66b77b`
(#2233), which touches only `IccSpecSepToTiff`, one script and an MCP doc — disjoint
from the five files here. The branch is rebased onto `cb66b77b` and `git range-diff`
reports the commit unchanged, so no second dispatch was spent on a content-free rebase.

`source` was chosen over `full` deliberately: it buys Windows plus the complete CTest
set without `full`'s long cycle, which is what a new test target that must configure
*and run* on MSVC needs.

Part of #2154
