### PR TITLE
docs(#2234): add the specsep-qa agent surface and document the QA harness

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -142,6 +142,7 @@ Key safety rules:
 |------|-------|
 | Documentation maintenance | `.github/skills/docs-maintenance/SKILL.md` |
 | Sanitizer reproduction | `.github/skills/sanitizer-repro/SKILL.md` |
+| iccSpecSepToTiff QA | `.github/skills/specsep-qa/SKILL.md` |
 | JSON/config regressions | `.github/skills/json-config-regression/SKILL.md` |
 | Regression workflow governance | `.github/skills/regression-workflow-governance/SKILL.md` |
 | Regression container maintainer | `.github/skills/regression-container-maintainer/SKILL.md` |

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -71,6 +71,7 @@ Use `.github/ci/regression/README.md` as the canonical catalog and naming guide.
 
 Script-based gates live in `.github/scripts/`, including:
 
+- `iccdev-specsep-qa.sh` (runs the complete SpecSep script suite)
 - `iccdev-json-parser-regression-tests.sh`
 - `iccdev-json-cfg-tests.sh`
 - `iccdev-stdobserver-regression-tests.sh`
@@ -88,6 +89,13 @@ Script-based gates live in `.github/scripts/`, including:
 
 When adding a new regression input, add the matching script or workflow assertion
 in the same change.
+
+The SpecSep wrapper preflights the checked-in sequences under
+`.github/ci/test-data/spectral/`, `.github/ci/test-data/specsep-harvest/`, and
+`.github/ci/test-data/specsep-truncated/`, then runs the CLI argument, TIFF
+geometry, usage/metadata, and numbered-fixture matrix suites plus both
+optional-profile sweeps. It is independent of the caller's current directory;
+set `ICCDEV_TOOLS_DIR` when the build is not under `Build/Tools`.
 
 ## Test Profile Directories
 

--- a/.github/prompts/specsep-qa.prompt.md
+++ b/.github/prompts/specsep-qa.prompt.md
@@ -1,0 +1,39 @@
+# iccSpecSepToTiff QA
+
+Use this prompt to validate or diagnose `iccSpecSepToTiff` behavior with the
+repository-owned fixtures and scripts.
+
+## Inputs
+
+- Branch or worktree:
+- Build directory:
+- Failure or behavior to prove:
+- Sanitizer configuration, if any:
+
+## Procedure
+
+1. Confirm the worktree and tool build match the target commit.
+2. Read `Tools/CmdLine/IccSpecSepToTiff/Readme.md` for the current CLI contract.
+3. Run `.github/scripts/iccdev-specsep-qa.sh` with `ICCDEV_TOOLS_DIR` set to the
+   matching `Build/Tools` directory.
+4. Rerun only the failing child suite while diagnosing it.
+5. When optional-profile coverage is relevant, run
+   `.github/scripts/iccdev-specsep-profile-sweep.sh --profile-dir DIR` against
+   the downloaded or external corpus, with `--channels N` set to a sample count
+   that corpus can actually match -- a mismatched value makes every profile an
+   expected rejection and the sweep passes without embedding anything. Classify
+   clean profile incompatibility separately from crashes, timeouts, sanitizer
+   findings, partial output, and unexplained exits.
+6. For registered-test changes, run
+   `ctest --test-dir Build -R '^iccdev\.specsep-' --output-on-failure --no-tests=error`.
+7. Report the command, exit status, per-suite totals, sanitizer findings, and
+   any missing fixture or tool identified by preflight.
+
+For a timed option/output review, run
+`.github/scripts/iccdev-specsep-campaign.sh --seconds N`. Review
+`matrix-summary.txt`, the exact generated TIFF paths, and the representative
+`iccTiffDump` and `tiffinfo` reports. Distinguish exact pixel equality from
+metadata/specification conformance and report any divergence separately.
+
+Keep outputs under `ICCDEV_TEST_OUTDIR`. Do not depend on `~/scripts`, private
+scratch paths, or untracked fixtures.

--- a/.github/skills/README.md
+++ b/.github/skills/README.md
@@ -10,6 +10,7 @@ long command references.
 | `docs-maintenance` | Reducing documentation noise or reorganizing docs. |
 | `pre-pr-security-cycle` | Running the maintainer pre-PR secure loop: code, build/test, SAST/CodeQL, sanitizer/DAST-style checks, fix, repeat, handoff. |
 | `sanitizer-repro` | Reproducing ASAN/UBSAN findings or security advisories. |
+| `specsep-qa` | Running or diagnosing the repository-owned `iccSpecSepToTiff` QA suites and fixtures. |
 | `json-config-regression` | Editing JSON/profile config parsing or tests. |
 | `maintainer-ci-ctest` | Updating maintainer-owned CI, CTest, CPack, sanitizer, workflow, or release gates. |
 | `maintainer-label-system` | Maintaining label taxonomy, path labeler rules, issue triage, PR status labels, and CodeQL label routing. |

--- a/.github/skills/specsep-qa/SKILL.md
+++ b/.github/skills/specsep-qa/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: specsep-qa
+description: >
+  Build, run, or diagnose the repository-owned iccSpecSepToTiff QA suites and
+  their checked-in spectral TIFF fixtures.
+allowed-tools:
+  - bash
+  - read
+  - grep
+  - glob
+  - shell(git:*)
+---
+
+# iccSpecSepToTiff QA
+
+Use this skill for `iccSpecSepToTiff` CLI contract, TIFF geometry, profile
+alignment, output cleanup, or fixture work.
+
+## Workflow
+
+1. Read `../../../Tools/CmdLine/IccSpecSepToTiff/Readme.md` for the command
+   contract and limits.
+2. Build `iccSpecSepToTiff`, `iccTiffDump`, and `iccFromXml` in the same tree.
+3. Run the repository wrapper from any directory:
+
+```bash
+ICCDEV_TOOLS_DIR=/path/to/iccDEV/Build/Tools \
+  /path/to/iccDEV/.github/scripts/iccdev-specsep-qa.sh
+```
+
+4. For a focused failure, rerun the named child script shown by the wrapper.
+5. Keep durable fixtures under `.github/ci/test-data/`; keep generated TIFFs
+   and logs under `ICCDEV_TEST_OUTDIR`.
+
+For a bounded option/output campaign with exact pixel and TIFF-tag validation,
+run:
+
+```bash
+ICCDEV_TOOLS_DIR=/path/to/iccDEV/Build/Tools \
+  /path/to/iccDEV/.github/scripts/iccdev-specsep-campaign.sh --seconds 300
+```
+
+The numbered-fixture child suite runs every checked-in valid TIFF as a
+single-channel input with all four compression and planar combinations.
+
+The profile sweep runs twice, because a profile is accepted only when its sample
+count matches the generated TIFF: once at the default eight channels across
+`Testing/CalcTest`, which can only produce rejections, and once at
+`--channels 3` across `Testing/`, whose single depth-1 profile is the 3-channel
+sRGB v4 preference. A run that accepts nothing says so, so a rejection-only
+corpus cannot look like full coverage. For a local registry download, rerun with
+`--profile-dir /path/to/profiles` and a `--channels` value the corpus can match;
+accepted profiles must be embedded, while profile-specific clean rejections are
+expected.
+
+The extended campaign requires Python `numpy`, `tifffile`, and `imagecodecs` --
+tifffile defers LZW decoding to imagecodecs and half the matrix writes LZW. It
+preserves a
+machine-readable text summary, representative `iccTiffDump`/`tiffinfo`
+inspections, generated inputs, and output TIFFs under `ICCDEV_TEST_OUTDIR`.
+It exits nonzero for either a functional failure or a specification-audit
+finding; review both categories in `matrix-summary.txt`.
+
+## Fixture Rules
+
+- `spectral/spec_1` through `spec_10` are the tiny normal conversion sequence.
+- `specsep-harvest/gray300/spec_1` through `spec_8` cover larger grayscale
+  input.
+- `specsep-truncated/spec_1` is the late-read-failure cleanup fixture.
+- Do not replace these with local scratch paths or generated build artifacts.
+
+## Validation
+
+Run the wrapper, then the six registered CTests when CTest integration is in
+scope:
+
+```bash
+ctest --test-dir Build -R '^iccdev\.specsep-' --output-on-failure --no-tests=error
+```
+
+Verify changed text files are ASCII and run `git diff --check`.
+
+## References
+
+- `../../prompts/specsep-qa.prompt.md`
+- `../../../docs/ctest.md`
+- `../../instructions/testing.instructions.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ shares one source of truth. Update rules here, not in the mirrors.
 | Regression container prompt | `.github/prompts/regression-container-maintainer.prompt.md` |
 | Maintainer CTest selection and CI budget | `.github/skills/maintainer-ci-ctest/SKILL.md` |
 | Security repro | `.github/prompts/reproduce-security-issue.prompt.md` |
+| iccSpecSepToTiff QA | `.github/skills/specsep-qa/SKILL.md` |
 | Issue filing format | `.github/prompts/file-security-issue.prompt.md` |
 | Library hardening | `.github/instructions/icc-library-code.instructions.md` |
 | Workflow hardening | `.github/instructions/workflow-governance.instructions.md` |

--- a/Tools/CmdLine/IccSpecSepToTiff/Readme.md
+++ b/Tools/CmdLine/IccSpecSepToTiff/Readme.md
@@ -117,6 +117,52 @@ There is no additional tool-specific cap on image dimensions, total pixels, or
 prefix length. Allocation failures and arithmetic overflow fail the conversion
 instead of producing a partial output.
 
+## Maintainer QA
+
+After building the tools, run the complete checked-in QA surface from any
+directory:
+
+```sh
+ICCDEV_TOOLS_DIR=/path/to/iccDEV/Build/Tools \
+  /path/to/iccDEV/.github/scripts/iccdev-specsep-qa.sh
+```
+
+The wrapper verifies the repository fixtures and runs the CLI argument, TIFF
+geometry, usage/metadata, and numbered-fixture matrix suites plus both
+optional-profile sweeps. Generated TIFFs and logs stay outside the source tree
+under `ICCDEV_TEST_OUTDIR`.
+
+To exercise the optional `profile` argument against an external or downloaded
+profile directory:
+
+```sh
+ICCDEV_TOOLS_DIR=/path/to/iccDEV/Build/Tools \
+  /path/to/iccDEV/.github/scripts/iccdev-specsep-profile-sweep.sh \
+  --profile-dir /path/to/profiles --channels 3
+```
+
+A profile is embedded only when its sample count equals `--channels`, so set
+that to a value the corpus carries; otherwise every profile is a clean rejection
+and the sweep reports that it accepted nothing. Compatible profiles must be
+embedded in a nonempty TIFF; incompatible or non-conformant profiles must be
+rejected with a profile diagnostic and no partial output.
+
+For a bounded matrix covering compression, planar layout, range order, bit
+depth, photometric conversion, optional profile embedding, rejection paths, and
+exact output pixels and tags:
+
+```sh
+ICCDEV_TOOLS_DIR=/path/to/iccDEV/Build/Tools \
+  /path/to/iccDEV/.github/scripts/iccdev-specsep-campaign.sh --seconds 300
+```
+
+The campaign requires Python `numpy`, `tifffile`, and `imagecodecs`. Its
+`--seconds` value buys repetition rather than coverage: the case set is
+deterministic, so a longer run is a soak that surfaces nondeterminism, not a
+wider matrix. It keeps its summary, generated inputs and TIFFs, and independent
+`iccTiffDump`/`tiffinfo` inspections under `ICCDEV_TEST_OUTDIR`. Functional
+failures and specification-audit findings both produce a nonzero exit.
+
 ## See Also
 
 - [CLI tool reference](../../../docs/tools-cli-reference.md)

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -136,6 +136,11 @@ before running the suite.
 | `iccdev.specsep-tiff-geometry-regression` | `.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh` |
 | `iccdev.tiff-resolution-unit-regression` | `.github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh` |
 | `iccdev.tiff-separated-strips` | `.github/ci/regression/tiff-separated-strips.cpp` |
+| `iccdev.specsep-usage-exit-code-regression` | `.github/scripts/iccdev-issue-1514-specsep-usage-exit-code-regression-tests.sh` |
+| `iccdev.specsep-cli-args-regression` | `.github/scripts/iccdev-specsep-cli-args-regression-tests.sh` |
+| `iccdev.specsep-corpus-matrix` | `.github/scripts/iccdev-specsep-corpus-matrix.sh` |
+| `iccdev.specsep-profile-sweep` | `.github/scripts/iccdev-specsep-profile-sweep.sh` |
+| `iccdev.specsep-profile-sweep-accept` | `.github/scripts/iccdev-specsep-profile-sweep.sh` (`--channels 3`) |
 | `iccdev.dump-profile-header-regression` | `.github/scripts/iccdev-dump-profile-header-regression-tests.sh` |
 | `iccdev.basic-string-regressions` | `.github/scripts/iccdev-basic-string-regression-tests.sh` |
 | `iccdev.pawg-report-regressions` | `.github/scripts/iccdev-pawg-report-regression-tests.sh` |

--- a/docs/maintainer-qa-scans.md
+++ b/docs/maintainer-qa-scans.md
@@ -16,7 +16,7 @@ profile compatibility reporting.
 | `.github/scripts/icc-pawg-qa-scan.sh` | `iccPawgReport` | text, JSON, eager-read, JSON eager-read |
 | `.github/scripts/icc-dumpprofile-qa-scan.sh` | `iccDumpProfile` | basic, validate, verbosity, tag, `ALL`, read, diagnostic read |
 | `.github/scripts/icc-roundtrip-qa-scan.sh` | `iccRoundTrip` | intents 0-3 with LUT and MPE modes |
-| `.github/scripts/iccdev-registry-profile-qa.sh` | registry runner | PAWG text, dump validate-all, roundtrip intent 1 |
+| `.github/scripts/iccdev-registry-profile-qa.sh` | registry runner | PAWG text, dump validate-all, roundtrip intent 1, SpecSep optional-profile sweep |
 
 Each tool scanner writes:
 
@@ -142,8 +142,14 @@ Run the default CI-sized sweep:
 
 This downloads the listed ICC registry and malformed-security profiles, records
 `download-manifest.tsv`, scans `.icc` files, and writes a top-level
-`summary.md`. The APTEC characterization `.txt` sidecar is downloaded and hashed
-for provenance, but the ICC command-line tools scan only `.icc` files.
+`summary.md`. The SpecSep lane exercises the optional profile argument against
+fixed checked-in inputs. It runs at the sweep's default eight channels, so a
+profile is embedded only when its sample count is eight; anything else is a
+clean rejection with no partial TIFF, and the sweep says so when it accepted
+nothing. This runner does not expose the sweep's `--channels`, so to aim the
+sample count at a particular corpus run
+`.github/scripts/iccdev-specsep-profile-sweep.sh` directly. The APTEC characterization `.txt` sidecar is downloaded and
+hashed for provenance, but the ICC command-line tools scan only `.icc` files.
 
 Use a bounded smoke test during workflow bring-up:
 
@@ -164,8 +170,9 @@ Use a previously downloaded directory for no-network reruns:
 ```
 
 Use `--full-matrix` only for scheduled or manual jobs. It multiplies each ICC
-file by every tool variant and can be much slower than the default CI smoke
-matrix.
+file by every PAWG, DumpProfile, and RoundTrip variant and can be much slower
+than the default CI smoke matrix. The SpecSep lane always runs one fixed-input
+case per selected profile.
 
 ## CI wiring
 

--- a/docs/tools-cli-reference.md
+++ b/docs/tools-cli-reference.md
@@ -57,6 +57,21 @@ non-spectral profiles must have a data color-space sample count equal to
 `SamplesPerPixel`. Non-ICC bytes, empty files, non-compliant profiles, and
 sample-count mismatches are rejected.
 
+Sweep the optional profile argument across a directory while holding the
+checked-in separation inputs constant:
+
+```bash
+ICCDEV_TOOLS_DIR="$PWD/Build/Tools" \
+  .github/scripts/iccdev-specsep-profile-sweep.sh \
+  --profile-dir /path/to/profiles --channels 3
+```
+
+`--channels` sets how many inputs are combined, and therefore the sample count a
+profile must match to be embedded; it defaults to 8. An incompatible profile is
+an expected rejection only when the tool emits a profile diagnostic and leaves no
+output TIFF. Timeouts, sanitizer findings, unexplained exits, and incomplete
+successes fail the sweep.
+
 ## Text Data Encoding Values
 
 These values are used by `iccApplyNamedCmm` and `iccApplySearch`.


### PR DESCRIPTION
Part of #2234 — item (3), and the last of the three-way split confirmed on #2227. The tool landed as #2233 (`cb66b77b`), the harness as #2238 (`b6f6e3f5`); this is the skill, prompt, and documentation that make them findable.

Docs and agent surface only: 10 files, +215/−6, no code.

## What lands

`.github/skills/specsep-qa/SKILL.md` and `.github/prompts/specsep-qa.prompt.md`, indexed from `AGENTS.md`, `.github/copilot-instructions.md`, and `.github/skills/README.md`. The six registered `iccdev.specsep-*` CTests in `docs/ctest.md`; the SpecSep lane of the registry runner in `docs/maintainer-qa-scans.md`; the sweep in `docs/tools-cli-reference.md` and `testing.instructions.md`; and a **Maintainer QA** section in the tool Readme — the section held back from #2233 because it described scripts that did not exist yet.

## Corrected against what shipped, not what the branch assumed

- The campaign needs `numpy`, `tifffile` **and `imagecodecs`** — tifffile defers LZW decoding and half the matrix writes LZW.
- Five registered CTests became six.
- The sweep is described as the two registrations it now has, and **`--channels` is named everywhere the sweep is**. A profile is embedded only when its sample count matches the generated TIFF, so a corpus aimed at the wrong channel count passes while never accepting anything. That is the most misleading property of this harness, and every doc that mentions the sweep now says so.
- `--seconds` on the campaign is documented as repetition, not coverage: the case set is deterministic, so a longer run is a soak, not a wider matrix.
- The registry runner builds its sweep arguments from `--profile-dir` and `--max-profiles` only, so the docs point at running the sweep directly rather than implying a `--channels` that invocation does not accept.

## Two traps in the source branch, both from it predating #2231

1. Its `docs/ctest.md` hunk **deleted** the `iccdev.tiff-separated-strips` row. Kept, with the new rows added around it.
2. Its `docs/maintainer-qa-scans.md` hunk rewrote three unrelated em-dashes to hyphens. Dropped; only the substantive edits are taken.

## Evidence

- Pre-PR dispatch `ci_scope=auto`, run **32511851563 — success**. Path scoping skipped the build and test lanes, which is correct for a docs-only change.
- **Every command in the new docs was run.** The skill's `ctest -R '^iccdev\.specsep-'` selector resolves to exactly the six tests; the sweep invocation with `--channels 3` accepts the sRGB v4 preference profile.
- `preflight-safety-checks.sh`: 0 failures.

## Note

`docs/ctest.md` is CRLF and the added rows match it, so `git diff --check` reports trailing whitespace on them. That is the file's own convention — normalising it to LF turns a five-line change into a whole-file diff. Pre-flight passes.

## Follow-up already identified

`/code-review` on this branch surfaced five defects in the **merged** harness from #2238, which I will raise separately against #2234. The sharpest: `iccdev_specsep_matrix.py`'s `resolution-unit` and `orientation` checks are written `tag is None or value == expected`, so they pass when the tag is **absent** — and an absent `ResolutionUnit` is precisely the #2220 defect that `TiffImg.cpp:367` now writes unconditionally to prevent. The `rows-per-strip` check two lines below uses `is not None and ...`, which is what all three should be.
