### PR TITLE
test(#2240): fix five defects in the SpecSep QA harness

### DIFF
--- a/.github/scripts/iccdev-registry-profile-qa.sh
+++ b/.github/scripts/iccdev-registry-profile-qa.sh
@@ -145,7 +145,11 @@ run_scan pawg "$SCRIPT_DIR/icc-pawg-qa-scan.sh" text || status=1
 run_scan dumpprofile "$SCRIPT_DIR/icc-dumpprofile-qa-scan.sh" validate-all || status=1
 run_scan roundtrip "$SCRIPT_DIR/icc-roundtrip-qa-scan.sh" intent-1 || status=1
 
-specsep_args=(--profile-dir "$PROFILE_DIR")
+# --fail-on, like run_scan above: this corpus deliberately contains malformed
+# profiles, and CI runs the whole job with --fail-on CRASH,TIMEOUT.  Without
+# forwarding it, an ordinary validation rejection in this lane failed a job the
+# other three lanes were told to tolerate.
+specsep_args=(--profile-dir "$PROFILE_DIR" --fail-on "$FAIL_ON")
 if [[ "$MAX_PROFILES" -gt 0 ]]; then
   specsep_args+=(--max-profiles "$MAX_PROFILES")
 fi

--- a/.github/scripts/iccdev-specsep-profile-sweep.sh
+++ b/.github/scripts/iccdev-specsep-profile-sweep.sh
@@ -56,9 +56,16 @@ MAX_PROFILES=0
 # accept path at all: the checked-in .icc corpus is 1/3/4-channel, so the
 # default 8 can only ever produce rejections.
 CHANNELS=8
+# Statuses that make this script exit nonzero.  Strict by default: the
+# registered CTests run against checked-in, known-good corpora where any
+# unexpected result is a regression.  iccdev-registry-profile-qa.sh forwards
+# its own --fail-on here, because that corpus deliberately contains malformed
+# profiles and CI runs it with a narrower policy.
+FAIL_ON="ALL"
 
 usage() {
-  echo "Usage: $0 [--profile-dir DIR] [--max-profiles N] [--channels N]"
+  echo "Usage: $0 [--profile-dir DIR] [--max-profiles N] [--channels N] [--fail-on LIST]"
+  echo "  --fail-on: ALL (default), or a comma-separated subset of CRASH,TIMEOUT,QA-ISSUE"
 }
 
 while [ "$#" -gt 0 ]; do
@@ -76,6 +83,11 @@ while [ "$#" -gt 0 ]; do
     --channels)
       [ "$#" -ge 2 ] || { echo "Missing value for --channels" >&2; exit 2; }
       CHANNELS="$2"
+      shift 2
+      ;;
+    --fail-on)
+      [ "$#" -ge 2 ] || { echo "Missing value for --fail-on" >&2; exit 2; }
+      FAIL_ON="$2"
       shift 2
       ;;
     -h|--help)
@@ -141,11 +153,36 @@ if [ "${#PROFILES[@]}" -eq 0 ]; then
   exit 2
 fi
 
+status_is_fail_on() {
+  local status="$1" item
+  [ "$FAIL_ON" = "ALL" ] && return 0
+  IFS=',' read -r -a _fail_on_items <<<"$FAIL_ON"
+  for item in "${_fail_on_items[@]}"; do
+    [ "$item" = "$status" ] && return 0
+  done
+  return 1
+}
+
+# The tool escapes every byte >= 0x7f as \xNN before echoing a path
+# (icSanitizeConsoleText), so requiring the raw path in the log turns a perfectly
+# clean rejection into a FAIL for any profile whose path is not pure ASCII --
+# and arbitrary downloaded corpora are this sweep's headline use.  Only apply
+# that clause when the path can actually appear verbatim.
+path_is_printable_ascii() {
+  case "$1" in
+    *[!\ -~]*) return 1 ;;
+    *) return 0 ;;
+  esac
+}
+
 total=0
 accepted=0
 expected_reject=0
 failed=0
 sanitizer=0
+crash=0
+timeout_count=0
+qa_issue=0
 
 for profile in "${PROFILES[@]}"; do
   if [ "$MAX_PROFILES" -gt 0 ] && [ "$total" -ge "$MAX_PROFILES" ]; then
@@ -165,31 +202,55 @@ for profile in "${PROFILES[@]}"; do
 
   sed "s|^|[$profile_name] |" "$log"
 
+  names_the_profile=1
+  if path_is_printable_ascii "$profile"; then
+    grep -Fq "$profile" "$log" || names_the_profile=0
+  fi
+
+  status=""
+  detail=""
   if grep -Eq \
     'ERROR: AddressSanitizer|LeakSanitizer: detected memory leaks|runtime error:' \
     "$log"; then
     sanitizer=$((sanitizer + 1))
-    failed=$((failed + 1))
-    echo "[$profile_name] FAIL: sanitizer diagnostic"
+    status="CRASH"
+    detail="sanitizer diagnostic"
+  elif [ "$rc" -eq 124 ]; then
+    status="TIMEOUT"
+    detail="timeout after $TIMEOUT_SECONDS seconds"
+  elif [ "$rc" -ge 128 ] && [ "$rc" -le 192 ]; then
+    status="CRASH"
+    detail="died from signal $((rc - 128))"
   elif [ "$rc" -eq 0 ]; then
     if [ -s "$output" ] && grep -Eq '^Profile:[[:space:]]+embedded$' "$log"; then
       accepted=$((accepted + 1))
       echo "[$profile_name] ACCEPT"
     else
-      failed=$((failed + 1))
-      echo "[$profile_name] FAIL: success did not produce an embedded-profile TIFF"
+      status="QA-ISSUE"
+      detail="success did not produce an embedded-profile TIFF"
     fi
   elif { [ "$rc" -eq 1 ] || [ "$rc" -eq 255 ]; } && \
-       grep -Eqi 'profile' "$log" && grep -Fq "$profile" "$log" && \
+       grep -Eqi 'profile' "$log" && [ "$names_the_profile" -eq 1 ] && \
        [ ! -e "$output" ]; then
     expected_reject=$((expected_reject + 1))
     echo "[$profile_name] EXPECTED_REJECT"
-  elif [ "$rc" -eq 124 ]; then
-    failed=$((failed + 1))
-    echo "[$profile_name] FAIL: timeout after $TIMEOUT_SECONDS seconds"
   else
-    failed=$((failed + 1))
-    echo "[$profile_name] FAIL: exit=$rc output_exists=$(test -e "$output" && echo yes || echo no)"
+    status="QA-ISSUE"
+    detail="exit=$rc output_exists=$(test -e "$output" && echo yes || echo no)"
+  fi
+
+  if [ -n "$status" ]; then
+    case "$status" in
+      CRASH) crash=$((crash + 1)) ;;
+      TIMEOUT) timeout_count=$((timeout_count + 1)) ;;
+      QA-ISSUE) qa_issue=$((qa_issue + 1)) ;;
+    esac
+    if status_is_fail_on "$status"; then
+      failed=$((failed + 1))
+      echo "[$profile_name] FAIL($status): $detail"
+    else
+      echo "[$profile_name] $status (tolerated by --fail-on $FAIL_ON): $detail"
+    fi
   fi
 done
 
@@ -203,6 +264,8 @@ fi
 
 printf 'SpecSep profile sweep: %d profiles, %d accepted, %d expected rejects, %d failed, %d sanitizer findings\n' \
   "$total" "$accepted" "$expected_reject" "$failed" "$sanitizer"
+printf 'SpecSep profile sweep statuses: CRASH=%d TIMEOUT=%d QA-ISSUE=%d fail_on=%s\n' \
+  "$crash" "$timeout_count" "$qa_issue" "$FAIL_ON"
 printf 'Generated TIFFs and logs: %s\n' "$OUTDIR"
 
 if [ "$failed" -ne 0 ]; then

--- a/.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh
+++ b/.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh
@@ -232,6 +232,12 @@ run_specsep_resolution_unit_preserve() {
   TOTAL=$((TOTAL + 1))
   rm -f "$LOGFILE" "$OUTPUT_TIFF"
 
+  if [ ! -x "$SPECSEP" ]; then
+    fail_case "$name" "missing executable: $SPECSEP"
+    return
+  fi
+
+
   if ! generate_centimeter_inputs; then
     fail_case "$name" "centimeter TIFF generation failed"
     return
@@ -289,6 +295,11 @@ run_specsep_checked_in_truncated_reject() {
 
   TOTAL=$((TOTAL + 1))
   rm -f "$LOGFILE" "$OUTPUT_TIFF"
+
+  if [ ! -x "$SPECSEP" ]; then
+    fail_case "$name" "missing executable: $SPECSEP"
+    return
+  fi
 
   if [ ! -s "$fixture_dir/spec_1" ]; then
     fail_case "$name" "missing checked-in fixture: $fixture_dir/spec_1"

--- a/.github/scripts/iccdev_specsep_matrix.py
+++ b/.github/scripts/iccdev_specsep_matrix.py
@@ -281,9 +281,15 @@ class Campaign:
                 and all(int(value) == 0 for value in page.extrasamples),
                 "x-resolution": abs(float(x_resolution) - 144.0) < 0.001,
                 "y-resolution": abs(float(y_resolution) - 96.0) < 0.001,
-                "resolution-unit": resolution_unit is None
-                or int(resolution_unit.value) == 2,
-                "orientation": orientation is None or int(orientation.value) == 1,
+                # `is not None and`, not `is None or`: TiffImg.cpp writes both
+                # tags unconditionally, and an absent ResolutionUnit is exactly
+                # the #2220 defect this check exists to catch -- the tolerant
+                # form passed in precisely that case.  Matches the
+                # rows-per-strip check below.
+                "resolution-unit": resolution_unit is not None
+                and int(resolution_unit.value) == 2,
+                "orientation": orientation is not None
+                and int(orientation.value) == 1,
                 "rows-per-strip": rows_per_strip is not None
                 and int(rows_per_strip.value) == 1,
                 "predictor": (int(predictor.value) if predictor else 1)
@@ -350,9 +356,13 @@ class Campaign:
 
     def run_reject(self, name, arguments, expected):
         output = pathlib.Path(arguments[0]) if arguments else None
-        preexisting = output is not None and (output.exists() or output.is_symlink())
         if output and output.exists() and output.is_file() and not output.is_symlink():
             output.unlink()
+        # Probed after the unlink, not before: a reject that wrongly left a file
+        # behind would otherwise mark itself "preexisting" on the next soak
+        # iteration and disable the no-output assertion for the rest of the run.
+        # A directory target is preexisting by nature and never removable here.
+        preexisting = output is not None and (output.exists() or output.is_symlink())
         result, sanitizer = self.command(arguments)
         passed = (
             sanitizer is None

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5709,38 +5709,45 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-cli-args-regression-tests.sh"
 )
 
-iccdev_add_script_test(
-  iccdev.specsep-corpus-matrix
-  180
-  "iccdev;specsep;tiff;corpus;matrix;regression;asan"
-  "${ICCDEV_REPO_ROOT}"
-  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-corpus-matrix.sh"
-)
+# Guarded on the target, like iccdev.tiff-resolution-unit-regression below.
+# Both scripts exit 2 when iccSpecSepToTiff is missing rather than skipping the
+# way the older sibling suites do, so an unguarded registration turns a
+# tools-off configure red instead of simply not offering the tests.
+if(TARGET iccSpecSepToTiff)
+  iccdev_add_script_test(
+    iccdev.specsep-corpus-matrix
+    180
+    "iccdev;specsep;tiff;corpus;matrix;regression;asan"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-corpus-matrix.sh"
+  )
 
-# The sweep only reaches its accept path when a profile's sample count matches
-# the generated TIFF, so it is registered twice rather than once.  CalcTest is 80
-# deliberately broken profiles at the default 8 channels -- rejection only -- and
-# a single run against it would be green while never once embedding a profile.
-# Testing/ holds exactly one .icc at depth 1, the 3-channel sRGB v4 preference
-# profile, so the second registration covers acceptance for the cost of one file.
-iccdev_add_script_test(
-  iccdev.specsep-profile-sweep
-  300
-  "iccdev;specsep;tiff;profile;sweep;regression;asan"
-  "${ICCDEV_REPO_ROOT}"
-  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-profile-sweep.sh"
-  --profile-dir "${ICCDEV_REPO_ROOT}/Testing/CalcTest"
-)
+  # The sweep only reaches its accept path when a profile's sample count matches
+  # the generated TIFF, so it is registered twice rather than once.  CalcTest is
+  # 80 deliberately broken profiles at the default 8 channels -- rejection only
+  # -- and a single run against it would be green while never once embedding a
+  # profile.  Testing/ holds exactly one .icc at depth 1, the 3-channel sRGB v4
+  # preference profile, so the second registration covers acceptance for the
+  # cost of one file.
+  iccdev_add_script_test(
+    iccdev.specsep-profile-sweep
+    300
+    "iccdev;specsep;tiff;profile;sweep;regression;asan"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-profile-sweep.sh"
+    --profile-dir "${ICCDEV_REPO_ROOT}/Testing/CalcTest"
+  )
 
-iccdev_add_script_test(
-  iccdev.specsep-profile-sweep-accept
-  120
-  "iccdev;specsep;tiff;profile;sweep;regression;asan"
-  "${ICCDEV_REPO_ROOT}"
-  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-profile-sweep.sh"
-  --profile-dir "${ICCDEV_REPO_ROOT}/Testing"
-  --channels 3
-)
+  iccdev_add_script_test(
+    iccdev.specsep-profile-sweep-accept
+    120
+    "iccdev;specsep;tiff;profile;sweep;regression;asan"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-profile-sweep.sh"
+    --profile-dir "${ICCDEV_REPO_ROOT}/Testing"
+    --channels 3
+  )
+endif()
 
 # TIFFTAG_RESOLUTIONUNIT lives in shared CTiffImg code, so it is covered per caller:
 # iccSpecSepToTiff and iccApplyProfiles both write through the same Create(), and


### PR DESCRIPTION
Fixes #2240.

Post-merge follow-ups to #2238, all found by reviewing the harness as code rather than as tests. Every one of them was green before it was measured.

## 1. The matrix could not detect the defect it was written for

`iccdev_specsep_matrix.py`'s `resolution-unit` and `orientation` checks read `tag is None or value == expected`, so an **absent** tag passed — and an absent `ResolutionUnit` is exactly the #2220 defect that `TiffImg.cpp:367` now writes unconditionally to prevent. Both become `is not None and`, matching the `rows-per-strip` check two lines below that already had it right.

Isolated red/green on a pre-#2226 output (tag 296 genuinely absent):

| | tag present | tag absent |
|---|---|---|
| shipped `is None or` | `True` | **`True`** ← passes in the case it exists to catch |
| this PR `is not None and` | `True` | `False` |

## 2. A soak assertion that disarmed itself

`preexisting` was probed **before** the stale-output unlink, so a reject that wrongly left a file behind was recorded once and then marked preexisting on every later iteration, disabling the "rejection left no output" clause for the rest of the run. Probed after the unlink instead.

## 3. Clean rejections misclassified under any non-ASCII path

The sweep required the raw profile path in the log, but the tool prints `icSanitizeConsoleText()`, which rewrites every byte ≥ 0x7f as `\xNN`. The sweep's headline use is arbitrary downloaded corpora, so a profile under a non-ASCII path produced a perfectly clean rejection classified `FAIL`. The clause now applies only when the path can appear verbatim.

## 4. The registry lane ignored `--fail-on`

The other three scanners get it through `run_scan`, and CI runs the job with `CRASH,TIMEOUT`. So an ordinary validation rejection in this lane failed a job the other lanes were explicitly told to tolerate — against a corpus that deliberately contains malformed-security profiles.

The sweep gains `--fail-on` using the shared status vocabulary (`CRASH`, `TIMEOUT`, `QA-ISSUE`) and the runner forwards `$FAIL_ON`. It stays **strict by default**, because the registered CTests run against known-good checked-in corpora where anything unexpected is a regression; only the registry runner relaxes it.

Verified to change the verdict, same corpus and same binary:

```
--fail-on ALL (default)   FAIL(QA-ISSUE): success did not produce an embedded-profile TIFF   rc=1
--fail-on CRASH,TIMEOUT   QA-ISSUE (tolerated by --fail-on CRASH,TIMEOUT): ...               rc=0
```

## 5. Three CTest registrations turned a tools-off configure red

`iccdev.specsep-corpus-matrix` and both profile sweeps were registered unconditionally, but their scripts `exit 2` when `iccSpecSepToTiff` is missing rather than skipping the way the older sibling suites do. Guarded on `TARGET iccSpecSepToTiff`, like `iccdev.tiff-resolution-unit-regression` below them. Verified with `-DENABLE_TOOLS=OFF`: the three no longer register at all (6 tests → 3) instead of failing.

## Also

The two geometry cases added in #2238 lacked the missing-executable guard every pre-existing case in that file uses. Both run first, so on a tree where the tool was not built the suite led with "expected graceful reject exit=255, got exit=127" instead of the file's own diagnostic.

## Evidence

- Pre-PR dispatch `ci_scope=source`, run **32512471092 — 10 success / 2 skipped**. The six CTests **actually ran** in the ASAN+UBSAN leg: `#106` 1.41s, `#107` 0.67s, `#108` 2.64s, `#109` 8.40s, `#110` 9.05s, `#111` 0.14s.
- Locally: all six CTests pass; the QA wrapper's six suites pass plain and under ASan/UBSan; the matrix is 1931/1931 on the current tool.
- `preflight-safety-checks.sh`: 0 failures. `shellcheck` clean on every changed script.

I cancelled an earlier dispatch (32512415428) rather than leave it testing a stale base after #2239 merged; 32512471092 is the run for this content.
