### PR TITLE
fix(#2237): register two platform-agnostic CTests outside the WIN32 branch

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5308,6 +5308,13 @@ if(NOT BASH_EXECUTABLE)
   return()
 endif()
 
+# Registered here as well as inside the if(WIN32) branch above.  That branch ends in
+# return(), so its call list and this one are mutually exclusive rather than duplicated:
+# a function called only up there runs on Windows and nowhere else (#2237).  Nothing in
+# iccdev_add_applytolink_invalid_arg_test() is Windows-specific -- it drives the same
+# iccApplyToLink binary as the v4_missing_desc sibling directly below, which has always
+# been called from both places.
+iccdev_add_applytolink_invalid_arg_test()
 iccdev_add_applytolink_v4_missing_desc_test()
 
 set(ICCDEV_TIMEOUT_COMPAT_DIR "")
@@ -5542,6 +5549,11 @@ iccdev_add_tag_layout_shared_data_test()
 iccdev_add_pawg_q2_tonecurves_test()
 iccdev_add_pawg_q4_characterization_test()
 iccdev_add_pawg_q4_xyz_pcs_decode_test()
+# Same single-call-site omission as iccdev_add_applytolink_invalid_arg_test() above: this
+# was reachable only through the if(WIN32) branch, so the platform-agnostic encoding
+# round trip it pins never ran on Linux or macOS (#2237).  The function already does its
+# own if(WIN32) PATH handling, so calling it unconditionally is safe on every platform.
+iccdev_add_tointernal_fixedint_roundtrip_test()
 iccdev_add_pawg_q1q3_relative_intent_test()
 iccdev_add_cmm_registry_allowlist_test()
 iccdev_add_mpecalc_matrix_overflow_test()


### PR DESCRIPTION
Fixes #2237

## The mechanism

`Build/Cmake/Testing/CMakeLists.txt` has two test-registration call lists: one inside `if(WIN32)` and one after it. The WIN32 branch ends in `return()` before the unconditional tail, so the two lists are **mutually exclusive rather than duplicated** — a function called only from inside that branch registers on Windows and nowhere else.

`iccdev_add_tointernal_fixedint_roundtrip_test()` has exactly that shape (single call site, line 5260, inside the branch). The `ToInternalEncoding`/`FromInternalEncoding` fixed-integer round trip landed for #1935 has therefore never run on Linux or macOS.

## A second instance, found by set-diffing the two lists

Rather than patch the one name in the issue, I diffed the call lists to find out whether the omission was a one-off. Three functions are registered only under WIN32:

| function | verdict |
|---|---|
| `iccdev_add_tointernal_fixedint_roundtrip_test()` | **omission** — the issue |
| `iccdev_add_applytolink_invalid_arg_test()` | **omission** — its immediate sibling `iccdev_add_applytolink_v4_missing_desc_test()` is identically shaped and *is* called from both places |
| `iccdev_add_windows_iccdevcmm_smoke_test()` | **correct** — carries its own `if(NOT WIN32) return()` guard and links `Mscms.lib`; left alone |

So the family is two, not one, and now provably complete. Both new calls sit **after** the WIN32 `endif()` (lines 5317 and 5556 vs `endif()` at 5304), so the Windows leg is unchanged and nothing registers twice.

## Red / green

Release, Unix Makefiles, on `9b16db6f`:

| | tests | `tointernal-fixedint-roundtrip` | `applytolink-invalid-decoded-intent` |
|---|---|---|---|
| before | 197 | absent | absent |
| after | 199 | Test #63, Passed | Test #3, Passed |

Positive controls on the red side: the calls immediately adjacent in the WIN32 list — `pawg-q4-xyz-pcs-decode` and `applytolink-v4-missing-device-descriptions` — were both registered, so the absence is specific to these two names and not a configure-wide miss.

## Anti-vacuity

A newly-registered test that asserts nothing is worse than no test, so both were checked for bite:

- **`iccdev.tointernal-fixedint-roundtrip`** — perturbing one decoded channel by `0.25` inside the helper turns it red: exit 1 with six named divergences (`FAIL RGB/8Bit ch0: encoded 0.000 -> internal 0.250000 -> re-encoded 64.000`, …). The round-trip comparison bites. Source restored before commit; the diff is CMake-only.
- **`iccdev.applytolink-invalid-decoded-intent`** — this one is `WILL_FAIL TRUE`, which passes on *any* nonzero exit, including a missing file. Run by hand it exits 1 on `Invalid rendering intent '9': decoded intent is out of range`, and the identical invocation with intent `0` exits 0 and writes the LUT. It fails for the intent, not for plumbing.

## Other pre-flight

- **clang Debug ASAN+UBSAN**, `-Wall -Wextra -Wpedantic -Werror`: both targets build with **0 warnings** (CI's `grep -cE 'warning:'` gate) and both tests pass.
- **Full suite**, Release: 198/199. The one failure is `iccdev.spectral-tiff-preview`, which dies on `ModuleNotFoundError: No module named 'imagecodecs'` — a local environment gap; `_build-test-unix.yml:95` pip-installs that module in CI. Unrelated to this change.
- **`-DENABLE_TOOLS=OFF`** degrades correctly: `tointernal` still registers (it only needs `IccProfLib`), `applytolink-invalid` drops out through its `if(NOT TARGET iccApplyToLink)` guard, configure returns 0.
- Not exercised locally: **macOS**. Both tests are platform-agnostic (one drives `IccProfLib` directly, the other runs a checked-in profile through `iccApplyToLink`), but I can only reason about that leg, not measure it.

Cost: both tests run in ~0.01 s.

## Dispatched CI

Pre-PR dispatch `ci_scope=source`, run [32520313271](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32520313271): **8 success / 3 skipped**.

The point of this PR is that the two tests run where they previously did not, so the evidence is the test numbers and runtimes, not the green tick:

- **GCC Strict ASAN+UBSAN (Debug)** — `4/195 Test #3: iccdev.applytolink-invalid-decoded-intent ... Passed 0.03 sec` and `63/195 Test #62: iccdev.tointernal-fixedint-roundtrip ... Passed 0.03 sec`. Both are new to this leg.
- **Windows MSVC + ClangCL** — `66/105` and `101/105`, both Passed; **MinGW UCRT64** — `64/106` and `102/106`, both Passed. Unchanged from before, as intended.

No duplicate registration on any platform: each name resolves to a single test number in every job, and `add_test` would have failed configure outright otherwise.
