### PR TITLE
fix(#2154): order both vcpkg configuration trees in the shared Windows runtime path collector

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4235,6 +4235,32 @@ function(iccdev_add_installed_package_consumer_test)
   )
 endfunction()
 
+# #2154: coverage for the collector behind every Windows runtime PATH in this
+# tree, Build/Cmake/Testing/WindowsRuntimePaths.cmake, which had none.
+#
+# It is registered on EVERY platform, not behind if(WIN32). The two defects it
+# pins only bite on Windows -- an out-of-tree consumer that finds no libxml2 or
+# zlib dies at load with 0xc0000135, STATUS_DLL_NOT_FOUND, which names no DLL --
+# but their cause is CMakeCache.txt parsing, so a synthetic cache reproduces
+# them anywhere. Discovering a cache-parsing bug on the Windows Debug leg costs
+# a full CI round trip per attempt; discovering it here costs under a second.
+# The test needs no targets, no build products and no bash: it writes its own
+# cache fixtures and calls the collector directly.
+function(iccdev_add_windows_runtime_paths_test)
+  add_test(
+    NAME iccdev.windows-runtime-paths
+    COMMAND "${CMAKE_COMMAND}"
+      "-DICCDEV_TEST_NAME=iccdev.windows-runtime-paths"
+      "-DICCDEV_TEST_OUTDIR=${ICCDEV_TEST_OUTDIR}/iccdev-windows-runtime-paths"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunWindowsRuntimePathsTest.cmake"
+  )
+  set_tests_properties(iccdev.windows-runtime-paths PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;cmake;windows;runtime-path;issue-2154;regression"
+  )
+endfunction()
+
 # #1830: the JSON BCD version parser used atoi() per component, which accepts a
 # leading '-'; "-1" produced 0xFFFFFFFF and wrapped both the "<< 8" in
 # icJsonParseBCDVersionStr and the caller's "<< 16" (UBSan: "left shift of
@@ -5242,6 +5268,7 @@ if(WIN32)
   iccdev_add_proflib_exported_data_linkage_test()
   iccdev_add_proflib_exported_global_definitions_test()
   iccdev_add_installed_package_consumer_test()
+  iccdev_add_windows_runtime_paths_test()
   iccdev_add_json_bcd_version_test()
   iccdev_add_json_writer_move_test()
   iccdev_add_json_fixednum_size_cap_test()
@@ -5302,6 +5329,11 @@ if(WIN32)
 
   return()
 endif()
+
+# Registered above the bash gate on purpose. This test runs cmake -P against
+# synthetic CMakeCache.txt fixtures -- no bash, no tools, no build products --
+# and the collector it covers is used by builds that have no bash either.
+iccdev_add_windows_runtime_paths_test()
 
 if(NOT BASH_EXECUTABLE)
   message(WARNING "bash not found; iccDEV CTest script tests are disabled.")

--- a/Build/Cmake/Testing/RunInstalledPackageConsumerTest.cmake
+++ b/Build/Cmake/Testing/RunInstalledPackageConsumerTest.cmake
@@ -42,11 +42,12 @@
 # test the system copy and pass no matter what this build tree contains.
 
 # The tree's own collector for Windows runtime dependency directories. It reads
-# the parent CMakeCache.txt for CMAKE_PREFIX_PATH, the vcpkg installed triplet,
-# the compiler/CRT directories and the prefixes behind LIBXML2_LIBRARY /
-# ZLIB_LIBRARY and friends. Reusing it rather than hand-rolling a PATH is what
-# three sibling Windows tests already do -- and hand-rolling is precisely how
-# this test first failed on Windows with 0xc0000135 (STATUS_DLL_NOT_FOUND): the
+# the parent CMakeCache.txt for CMAKE_PREFIX_PATH, both of vcpkg's
+# per-configuration installed trees, the compiler/CRT directories and the
+# prefixes behind LIBXML2_LIBRARY / ZLIB_LIBRARY and friends. Reusing it rather
+# than hand-rolling a PATH is what three sibling Windows tests already do -- and
+# hand-rolling is precisely how this test first failed on Windows with
+# 0xc0000135 (STATUS_DLL_NOT_FOUND): the
 # staged prefix carries the iccDEV DLLs but nothing tells the loader where
 # libxml2/iconv/zlib live, which under a vcpkg debug build is
 # <installed>/<triplet>/debug/bin.
@@ -457,47 +458,11 @@ function(_run_consumer _label _src_dir _build_dir _prefix _extra_args _out_ok)
     # Staged prefix first (the package under test), then everything the parent
     # build resolved its own dependencies from.
     set(_win_path "${_prefix}/bin;${_prefix}/lib")
+    # The collector reads ICCDEV_CONFIG from this script's scope, so the vcpkg
+    # debug tree that an out-of-tree consumer needs on the Debug leg is ordered
+    # ahead of the release one. This test used to carry its own copy of that
+    # logic; the shared helper owns it now.
     iccdev_collect_cache_runtime_path_entries(_runtime_entries "${ICCDEV_BUILD_DIR}")
-
-    # vcpkg keeps per-configuration DLLs in SEPARATE trees -- release in
-    # <installed>/<triplet>/bin, debug in <installed>/<triplet>/debug/bin -- and
-    # the shared collector only knows the release one. In-tree Windows tests do
-    # not notice, because StageWindowsRuntime.cmake copies the dependency DLLs
-    # next to the binaries it stages; an out-of-tree consumer gets no such copy
-    # and fails to LOAD with 0xc0000135 (STATUS_DLL_NOT_FOUND) on a Debug leg.
-    # The collector's ZLIB_LIBRARY/LIBXML2_LIBRARY fallback cannot cover it
-    # either: under a multi-config generator those cache values are the list
-    # "optimized;<path>;debug;<path>", which no EXISTS test matches.
-    foreach(_vcpkg_cache_name VCPKG_INSTALLED_DIR _VCPKG_INSTALLED_DIR)
-      iccdev_read_cache_value(_vcpkg_installed "${ICCDEV_BUILD_DIR}" "${_vcpkg_cache_name}")
-      if(NOT "${_vcpkg_installed}" STREQUAL "")
-        break()
-      endif()
-    endforeach()
-    iccdev_read_cache_value(_vcpkg_triplet "${ICCDEV_BUILD_DIR}" VCPKG_TARGET_TRIPLET)
-    if(NOT "${_vcpkg_installed}" STREQUAL "" AND NOT "${_vcpkg_triplet}" STREQUAL "")
-      set(_vcpkg_root "${_vcpkg_installed}/${_vcpkg_triplet}")
-      if(ICCDEV_CONFIG MATCHES "[Dd]ebug")
-        iccdev_add_existing_path_entry(_runtime_entries "${_vcpkg_root}/debug/bin")
-      endif()
-      iccdev_add_existing_path_entry(_runtime_entries "${_vcpkg_root}/bin")
-    endif()
-
-    # Last resort, and independent of any cache spelling: any <...>/debug/lib or
-    # <...>/lib directory the parent linked against has its DLLs in the sibling
-    # bin/. Derived from the per-configuration halves of the library cache
-    # entries, so the "optimized;...;debug;..." form is handled.
-    foreach(_lib_cache_name LIBXML2_LIBRARY ZLIB_LIBRARY TIFF_LIBRARY
-                            PNG_LIBRARY JPEG_LIBRARY)
-      iccdev_read_cache_value(_lib_value "${ICCDEV_BUILD_DIR}" "${_lib_cache_name}")
-      foreach(_lib_entry IN LISTS _lib_value)
-        if(EXISTS "${_lib_entry}" AND NOT IS_DIRECTORY "${_lib_entry}")
-          get_filename_component(_lib_dir "${_lib_entry}" DIRECTORY)
-          get_filename_component(_lib_prefix "${_lib_dir}/.." ABSOLUTE)
-          iccdev_add_existing_path_entry(_runtime_entries "${_lib_prefix}/bin")
-        endif()
-      endforeach()
-    endforeach()
 
     foreach(_entry IN LISTS _runtime_entries)
       set(_win_path "${_win_path};${_entry}")

--- a/Build/Cmake/Testing/RunWindowsRuntimePathsTest.cmake
+++ b/Build/Cmake/Testing/RunWindowsRuntimePathsTest.cmake
@@ -1,0 +1,227 @@
+#################################################################################
+# Windows runtime dependency path collector regression
+# Copyright (c) 2026 The International Color Consortium.
+#                                        All rights reserved.
+#################################################################################
+# Regression coverage for Build/Cmake/Testing/WindowsRuntimePaths.cmake, the
+# tree's shared collector of Windows runtime dependency directories.
+#
+# The two defects this pins are Windows-only in EFFECT -- an out-of-tree
+# consumer dies at load with 0xc0000135 (STATUS_DLL_NOT_FOUND, which names no
+# DLL) -- but their CAUSE is pure CMakeCache.txt parsing, so they reproduce on
+# any platform against a synthetic cache. That is why this test is registered
+# everywhere rather than behind if(WIN32): the collector had no coverage at all,
+# and the Windows Debug leg is an expensive place to discover a parsing bug.
+#
+#   1. vcpkg splits DLLs by configuration -- release in <installed>/<triplet>/bin
+#      and debug in <installed>/<triplet>/debug/bin. The collector added only the
+#      release tree, so a Debug consumer found nothing.
+#   2. Under a multi-config generator LIBXML2_LIBRARY / ZLIB_LIBRARY and friends
+#      hold the list "optimized;<path>;debug;<path>". EXISTS on that whole string
+#      is false, so those entries contributed nothing at all.
+
+set(_required_vars
+  ICCDEV_TEST_NAME
+  ICCDEV_TEST_OUTDIR
+)
+
+foreach(_required_var IN LISTS _required_vars)
+  if(NOT DEFINED ${_required_var} OR "${${_required_var}}" STREQUAL "")
+    message(FATAL_ERROR "${_required_var} is required")
+  endif()
+endforeach()
+
+include("${CMAKE_CURRENT_LIST_DIR}/WindowsRuntimePaths.cmake")
+
+set(_fixture_root "${ICCDEV_TEST_OUTDIR}/fixture")
+file(REMOVE_RECURSE "${_fixture_root}")
+
+# A stand-in vcpkg installed tree and a stand-in dependency prefix, both with
+# populated release and debug halves. The directories must really exist: every
+# entry the collector emits has passed an EXISTS test.
+set(_vcpkg_root "${_fixture_root}/vcpkg")
+set(_triplet x64-windows)
+set(_dep_root "${_fixture_root}/dep")
+foreach(_dir
+    "${_vcpkg_root}/${_triplet}/bin"
+    "${_vcpkg_root}/${_triplet}/debug/bin"
+    "${_dep_root}/bin"
+    "${_dep_root}/lib"
+    "${_dep_root}/debug/bin"
+    "${_dep_root}/debug/lib")
+  file(MAKE_DIRECTORY "${_dir}")
+endforeach()
+file(TOUCH "${_dep_root}/lib/zlib.lib")
+file(TOUCH "${_dep_root}/debug/lib/zlibd.lib")
+
+# The collector emits every entry through file(TO_CMAKE_PATH), so normalise the
+# expectations the same way. On Windows ICCDEV_TEST_OUTDIR can still reach this
+# script with backslashes, and a raw string compare would then miss on spelling
+# alone -- a false red that says nothing about the collector.
+foreach(_expect_pair
+    "_expect_vcpkg_release;${_vcpkg_root}/${_triplet}/bin"
+    "_expect_vcpkg_debug;${_vcpkg_root}/${_triplet}/debug/bin"
+    "_expect_dep_release;${_dep_root}/bin"
+    "_expect_dep_debug;${_dep_root}/debug/bin")
+  list(GET _expect_pair 0 _expect_name)
+  list(GET _expect_pair 1 _expect_raw)
+  file(TO_CMAKE_PATH "${_expect_raw}" ${_expect_name})
+endforeach()
+
+# Writes a synthetic CMakeCache.txt and returns the directory holding it. BODY
+# is one quoted string whose lines are separated by "|", NOT a varargs list: the
+# whole point of these fixtures is cache values that themselves contain ";", and
+# ARGN would silently split those across lines.
+function(iccdev_write_fixture_cache OUT_DIR NAME BODY)
+  set(_dir "${_fixture_root}/${NAME}")
+  file(MAKE_DIRECTORY "${_dir}")
+  string(REPLACE "|" "\n" _body "${BODY}")
+  file(WRITE "${_dir}/CMakeCache.txt" "${_body}\n")
+  set(${OUT_DIR} "${_dir}" PARENT_SCOPE)
+endfunction()
+
+# Calls the collector with ICCDEV_CONFIG shadowed to CONFIG for this scope only,
+# which is exactly how the CTest wrappers reach it.
+function(iccdev_probe_entries OUT_VAR CACHE_DIR CONFIG)
+  set(ICCDEV_CONFIG "${CONFIG}")
+  iccdev_collect_cache_runtime_path_entries(_entries "${CACHE_DIR}")
+  set(${OUT_VAR} "${_entries}" PARENT_SCOPE)
+endfunction()
+
+set(_failures)
+
+# The collected list is reported on every failure: a runtime PATH defect leaves
+# no other evidence behind, so guessing from a bare "expected X" is how #2236
+# spent three blind CI cycles.
+function(iccdev_expect_entry ARM ENTRIES WANTED)
+  list(FIND ENTRIES "${WANTED}" _index)
+  if(_index LESS 0)
+    string(REPLACE ";" "\n    " _pretty "${ENTRIES}")
+    set(_failures_local "${_failures}")
+    list(APPEND _failures_local "${ARM}: missing ${WANTED}\n  collected:\n    ${_pretty}")
+    set(_failures "${_failures_local}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+function(iccdev_expect_order ARM ENTRIES FIRST SECOND)
+  list(FIND ENTRIES "${FIRST}" _first_index)
+  list(FIND ENTRIES "${SECOND}" _second_index)
+  if(_first_index LESS 0 OR _second_index LESS 0 OR NOT _first_index LESS _second_index)
+    string(REPLACE ";" "\n    " _pretty "${ENTRIES}")
+    set(_failures_local "${_failures}")
+    list(APPEND _failures_local
+      "${ARM}: expected ${FIRST} ahead of ${SECOND}\n  collected:\n    ${_pretty}")
+    set(_failures "${_failures_local}" PARENT_SCOPE)
+  endif()
+endfunction()
+
+# ---------------------------------------------------------------------------
+# Arm 1: multi-config generator. No CMAKE_BUILD_TYPE in the cache and no
+# ICCDEV_CONFIG, and the library cache entry is the "optimized;...;debug;..."
+# list that used to defeat EXISTS outright.
+# ---------------------------------------------------------------------------
+iccdev_write_fixture_cache(_multi_config_dir multi-config
+  "VCPKG_INSTALLED_DIR:PATH=${_vcpkg_root}|VCPKG_TARGET_TRIPLET:STRING=${_triplet}|ZLIB_LIBRARY:STRING=optimized;${_dep_root}/lib/zlib.lib;debug;${_dep_root}/debug/lib/zlibd.lib")
+
+iccdev_probe_entries(_multi_config_entries "${_multi_config_dir}" "")
+foreach(_wanted "${_expect_vcpkg_release}" "${_expect_vcpkg_debug}"
+                "${_expect_dep_release}" "${_expect_dep_debug}")
+  iccdev_expect_entry("multi-config" "${_multi_config_entries}" "${_wanted}")
+endforeach()
+# With no configuration to go on, the release tree keeps the position it had
+# before the collector knew about debug trees.
+iccdev_expect_order("multi-config" "${_multi_config_entries}"
+  "${_expect_vcpkg_release}" "${_expect_vcpkg_debug}")
+
+# ---------------------------------------------------------------------------
+# Arm 2: the Windows Debug leg. ICCDEV_CONFIG must put the debug tree ahead of
+# the release one, because the loader takes the first match on PATH.
+# ---------------------------------------------------------------------------
+iccdev_probe_entries(_debug_entries "${_multi_config_dir}" "Debug")
+foreach(_wanted "${_expect_vcpkg_release}" "${_expect_vcpkg_debug}"
+                "${_expect_dep_release}" "${_expect_dep_debug}")
+  iccdev_expect_entry("config-debug" "${_debug_entries}" "${_wanted}")
+endforeach()
+iccdev_expect_order("config-debug" "${_debug_entries}"
+  "${_expect_vcpkg_debug}" "${_expect_vcpkg_release}")
+
+# ---------------------------------------------------------------------------
+# Arm 3: single-config build tree with no ICCDEV_CONFIG passed. The cache's own
+# CMAKE_BUILD_TYPE is the fallback and must produce the same debug ordering.
+# ---------------------------------------------------------------------------
+iccdev_write_fixture_cache(_cache_debug_dir cache-debug
+  "CMAKE_BUILD_TYPE:STRING=Debug|VCPKG_INSTALLED_DIR:PATH=${_vcpkg_root}|VCPKG_TARGET_TRIPLET:STRING=${_triplet}")
+
+iccdev_probe_entries(_cache_debug_entries "${_cache_debug_dir}" "")
+iccdev_expect_order("cache-debug" "${_cache_debug_entries}"
+  "${_expect_vcpkg_debug}" "${_expect_vcpkg_release}")
+
+# ---------------------------------------------------------------------------
+# Arm 4: some vcpkg toolchain versions publish only the internal spelling
+# _VCPKG_INSTALLED_DIR. Reading just VCPKG_INSTALLED_DIR finds no tree at all.
+# ---------------------------------------------------------------------------
+iccdev_write_fixture_cache(_vcpkg_internal_dir vcpkg-internal
+  "_VCPKG_INSTALLED_DIR:PATH=${_vcpkg_root}|VCPKG_TARGET_TRIPLET:STRING=${_triplet}")
+
+iccdev_probe_entries(_vcpkg_internal_entries "${_vcpkg_internal_dir}" "Debug")
+iccdev_expect_entry("vcpkg-internal-spelling" "${_vcpkg_internal_entries}"
+  "${_expect_vcpkg_debug}")
+
+# ---------------------------------------------------------------------------
+# Arm 5: CMAKE_PREFIX_PATH names the same triplet directory the vcpkg variables
+# do. The prefix loop runs first and iccdev_add_existing_path_entry keeps an
+# entry's FIRST position, so ordering the vcpkg block alone was not enough --
+# the release tree got pinned ahead of the debug one regardless.
+# ---------------------------------------------------------------------------
+iccdev_write_fixture_cache(_prefix_path_dir prefix-path
+  "CMAKE_PREFIX_PATH:STRING=${_vcpkg_root}/${_triplet}|VCPKG_INSTALLED_DIR:PATH=${_vcpkg_root}|VCPKG_TARGET_TRIPLET:STRING=${_triplet}")
+
+iccdev_probe_entries(_prefix_path_entries "${_prefix_path_dir}" "Debug")
+iccdev_expect_order("prefix-path-debug" "${_prefix_path_entries}"
+  "${_expect_vcpkg_debug}" "${_expect_vcpkg_release}")
+
+# ---------------------------------------------------------------------------
+# Arm 6: no vcpkg variables at all, only the per-configuration library cache
+# spellings select_library_configurations() writes. This is the shape the
+# _VCPKG_INSTALLED_DIR fallback exists to rescue, and the debug prefix must
+# still come first -- both trees spell the DLL identically, so second place
+# means the release DLL binds into a Debug consumer.
+# ---------------------------------------------------------------------------
+iccdev_write_fixture_cache(_library_only_dir library-only
+  "ZLIB_LIBRARY_RELEASE:FILEPATH=${_dep_root}/lib/zlib.lib|ZLIB_LIBRARY_DEBUG:FILEPATH=${_dep_root}/debug/lib/zlibd.lib")
+
+iccdev_probe_entries(_library_only_debug "${_library_only_dir}" "Debug")
+iccdev_expect_order("library-only-debug" "${_library_only_debug}"
+  "${_expect_dep_debug}" "${_expect_dep_release}")
+
+# The release build must keep the mirror-image order, so the arm above cannot
+# pass by the collector simply always emitting debug first.
+iccdev_probe_entries(_library_only_release "${_library_only_dir}" "Release")
+iccdev_expect_order("library-only-release" "${_library_only_release}"
+  "${_expect_dep_release}" "${_expect_dep_debug}")
+
+# ---------------------------------------------------------------------------
+# Anti-vacuity: a cache naming trees that do not exist must yield none of them.
+# Without this, a collector that appended candidates unconditionally would pass
+# every assertion above while emitting directories the loader cannot use.
+# ---------------------------------------------------------------------------
+iccdev_write_fixture_cache(_absent_dir absent
+  "VCPKG_INSTALLED_DIR:PATH=${_fixture_root}/no-such-vcpkg|VCPKG_TARGET_TRIPLET:STRING=${_triplet}")
+
+iccdev_probe_entries(_absent_entries "${_absent_dir}" "Debug")
+foreach(_entry IN LISTS _absent_entries)
+  if(_entry MATCHES "no-such-vcpkg")
+    list(APPEND _failures "absent-tree: collector emitted nonexistent ${_entry}")
+  endif()
+endforeach()
+
+if(_failures)
+  set(_report "")
+  foreach(_failure IN LISTS _failures)
+    set(_report "${_report}\n- ${_failure}")
+  endforeach()
+  message(FATAL_ERROR "${ICCDEV_TEST_NAME} failed:${_report}")
+endif()
+
+message(STATUS "${ICCDEV_TEST_NAME}: collector covers both vcpkg configuration trees "
+               "and per-configuration library cache lists")

--- a/Build/Cmake/Testing/WindowsRuntimePaths.cmake
+++ b/Build/Cmake/Testing/WindowsRuntimePaths.cmake
@@ -12,6 +12,29 @@ function(iccdev_add_existing_path_entry OUT_VAR CANDIDATE)
   endif()
 endfunction()
 
+# Adds one dependency prefix's runtime directories in the order the loader must
+# see them. Every prefix this file deals with has the same two-tree shape --
+# <prefix>/bin holds release DLLs, <prefix>/debug/bin holds debug ones -- and
+# both trees spell the DLL identically (libxml2.dll either way), so whichever
+# lands on PATH first is the one that binds.
+#
+# This is done per prefix rather than once for vcpkg because the ordering is
+# otherwise trivially defeated: CMAKE_PREFIX_PATH is read before the vcpkg block
+# below, and list(REMOVE_DUPLICATES) keeps an entry's FIRST position, so a prefix
+# path naming the same triplet directory would pin the release tree ahead of the
+# debug one no matter what the vcpkg block did afterwards.
+function(iccdev_add_prefix_runtime_entries OUT_VAR PREFIX CONFIG)
+  set(_prefix_entries_local "${${OUT_VAR}}")
+  if(CONFIG MATCHES "^[Dd][Ee][Bb][Uu][Gg]$")
+    iccdev_add_existing_path_entry(_prefix_entries_local "${PREFIX}/debug/bin")
+    iccdev_add_existing_path_entry(_prefix_entries_local "${PREFIX}/bin")
+  else()
+    iccdev_add_existing_path_entry(_prefix_entries_local "${PREFIX}/bin")
+    iccdev_add_existing_path_entry(_prefix_entries_local "${PREFIX}/debug/bin")
+  endif()
+  set(${OUT_VAR} "${_prefix_entries_local}" PARENT_SCOPE)
+endfunction()
+
 function(iccdev_read_cache_value OUT_VAR BUILD_DIR CACHE_NAME)
   set(${OUT_VAR} "" PARENT_SCOPE)
   set(_cache_file "${BUILD_DIR}/CMakeCache.txt")
@@ -32,18 +55,48 @@ endfunction()
 function(iccdev_collect_cache_runtime_path_entries OUT_VAR BUILD_DIR)
   set(_runtime_path_entries)
 
+  # Resolved first, because every prefix added below is ordered by it.
+  # ICCDEV_CONFIG is set by StageWindowsRuntime.cmake, RunWindowsBatchTest.cmake
+  # and RunInstalledPackageConsumerTest.cmake; RunWindowsDumpProfileSmokeTest and
+  # RunWindowsPawgReportSmokeTest do not set it, and a multi-config generator
+  # leaves the cache's CMAKE_BUILD_TYPE empty too. Those callers get the
+  # release-first order, which is what every caller got before this helper knew
+  # about debug trees at all -- in-tree tests are unaffected either way because
+  # StageWindowsRuntime.cmake copies dependency DLLs next to the staged binaries.
+  set(_runtime_config "")
+  if(DEFINED ICCDEV_CONFIG)
+    set(_runtime_config "${ICCDEV_CONFIG}")
+  endif()
+  if("${_runtime_config}" STREQUAL "")
+    iccdev_read_cache_value(_runtime_config "${BUILD_DIR}" CMAKE_BUILD_TYPE)
+  endif()
+
   iccdev_read_cache_value(_cmake_prefix_path "${BUILD_DIR}" CMAKE_PREFIX_PATH)
   foreach(_prefix IN LISTS _cmake_prefix_path)
-    iccdev_add_existing_path_entry(_runtime_path_entries "${_prefix}/bin")
+    iccdev_add_prefix_runtime_entries(_runtime_path_entries "${_prefix}" "${_runtime_config}")
   endforeach()
 
-  iccdev_read_cache_value(_vcpkg_installed_dir "${BUILD_DIR}" VCPKG_INSTALLED_DIR)
+  # vcpkg splits DLLs by configuration: release in <installed>/<triplet>/bin and
+  # debug in <installed>/<triplet>/debug/bin. Adding only the release tree is
+  # why an out-of-tree consumer on the Windows Debug leg dies at load with
+  # 0xc0000135 (STATUS_DLL_NOT_FOUND, which names no DLL). In-tree tests never
+  # notice, because StageWindowsRuntime.cmake copies the dependency DLLs next to
+  # the binaries it stages. `_VCPKG_INSTALLED_DIR` is the vcpkg toolchain's own
+  # internal spelling and is the only one present in some vcpkg versions.
+  set(_vcpkg_installed_dir "")
+  foreach(_vcpkg_cache_name VCPKG_INSTALLED_DIR _VCPKG_INSTALLED_DIR)
+    iccdev_read_cache_value(_vcpkg_installed_dir "${BUILD_DIR}" "${_vcpkg_cache_name}")
+    if(NOT "${_vcpkg_installed_dir}" STREQUAL "")
+      break()
+    endif()
+  endforeach()
   iccdev_read_cache_value(_vcpkg_target_triplet "${BUILD_DIR}" VCPKG_TARGET_TRIPLET)
   if(NOT "${_vcpkg_installed_dir}" STREQUAL ""
       AND NOT "${_vcpkg_target_triplet}" STREQUAL "")
-    iccdev_add_existing_path_entry(
+    iccdev_add_prefix_runtime_entries(
       _runtime_path_entries
-      "${_vcpkg_installed_dir}/${_vcpkg_target_triplet}/bin")
+      "${_vcpkg_installed_dir}/${_vcpkg_target_triplet}"
+      "${_runtime_config}")
   endif()
 
   foreach(_compiler_cache_name CMAKE_C_COMPILER CMAKE_CXX_COMPILER)
@@ -84,23 +137,40 @@ function(iccdev_collect_cache_runtime_path_entries OUT_VAR BUILD_DIR)
     endif()
   endforeach()
 
-  foreach(_library_cache_name
-      LIBXML2_LIBRARY
-      PNG_LIBRARY
-      PNG_LIBRARY_RELEASE
-      JPEG_LIBRARY
-      JPEG_LIBRARY_RELEASE
-      TIFF_LIBRARY
-      TIFF_LIBRARY_RELEASE
-      ZLIB_LIBRARY
-      ZLIB_LIBRARY_RELEASE
-  )
-    iccdev_read_cache_value(_library_path "${BUILD_DIR}" "${_library_cache_name}")
-    if(NOT "${_library_path}" STREQUAL "" AND EXISTS "${_library_path}")
-      get_filename_component(_library_dir "${_library_path}" DIRECTORY)
-      get_filename_component(_library_prefix "${_library_dir}/.." ABSOLUTE)
-      iccdev_add_existing_path_entry(_runtime_path_entries "${_library_prefix}/bin")
+  # select_library_configurations() sets the singular <LIB>_LIBRARY_RELEASE and
+  # <LIB>_LIBRARY_DEBUG alongside the combined <LIB>_LIBRARY, so reading the
+  # configuration-matching spelling FIRST is what gives these prefixes the same
+  # debug-first ordering the vcpkg tree gets. Without it a Debug consumer whose
+  # cache carries no vcpkg variables -- the case the _VCPKG_INSTALLED_DIR
+  # fallback above exists for -- would still bind the release DLL.
+  set(_library_cache_names)
+  foreach(_library_stem LIBXML2 PNG JPEG TIFF ZLIB)
+    if(_runtime_config MATCHES "^[Dd][Ee][Bb][Uu][Gg]$")
+      list(APPEND _library_cache_names
+        "${_library_stem}_LIBRARY_DEBUG" "${_library_stem}_LIBRARY_RELEASE")
+    else()
+      list(APPEND _library_cache_names
+        "${_library_stem}_LIBRARY_RELEASE" "${_library_stem}_LIBRARY_DEBUG")
     endif()
+    # The combined value last: it is the fallback for a cache that carries no
+    # per-configuration spelling at all, and it cannot express an order.
+    list(APPEND _library_cache_names "${_library_stem}_LIBRARY")
+  endforeach()
+
+  foreach(_library_cache_name IN LISTS _library_cache_names)
+    iccdev_read_cache_value(_library_value "${BUILD_DIR}" "${_library_cache_name}")
+    # Under a multi-config generator these cache entries are the per-config list
+    # "optimized;<release path>;debug;<debug path>", so an EXISTS test on the
+    # whole string is false and the entry used to contribute nothing at all.
+    # Iterating the halves covers both spellings; the "optimized"/"debug"/
+    # "general" keywords are not paths and drop out of the EXISTS test below.
+    foreach(_library_path IN LISTS _library_value)
+      if(EXISTS "${_library_path}" AND NOT IS_DIRECTORY "${_library_path}")
+        get_filename_component(_library_dir "${_library_path}" DIRECTORY)
+        get_filename_component(_library_prefix "${_library_dir}/.." ABSOLUTE)
+        iccdev_add_existing_path_entry(_runtime_path_entries "${_library_prefix}/bin")
+      endif()
+    endforeach()
   endforeach()
 
   iccdev_add_existing_path_entry(_runtime_path_entries "$ENV{SystemRoot}/System32")

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -259,7 +259,17 @@ unified `bin` runtime directory and falls back to the older per-tool
 Windows CTest wrappers collect build-tree DLL directories plus runtime
 dependency directories from `CMakeCache.txt`, including `CMAKE_PREFIX_PATH`,
 vcpkg installed triplets, compiler `bin` directories, and common dependency
-library prefixes. MSVC builds also add the matching Debug CRT redistributable
+library prefixes. Per-configuration trees are covered on both counts: vcpkg
+keeps release DLLs in `<installed>/<triplet>/bin` and debug DLLs in
+`<installed>/<triplet>/debug/bin`, and the collector adds both, ordering the one
+matching `ICCDEV_CONFIG` (or the cache's `CMAKE_BUILD_TYPE`) first. That ordering
+is applied per prefix -- to `CMAKE_PREFIX_PATH` entries and dependency library
+prefixes as well as to the vcpkg tree -- because the first matching directory on
+`PATH` is the one the loader binds, and both trees spell the DLL identically. Dependency
+library cache entries are read per configuration too, so the
+`optimized;<path>;debug;<path>` form a multi-config generator stores in
+`LIBXML2_LIBRARY` or `ZLIB_LIBRARY` contributes its `bin` prefixes instead of
+being discarded whole. MSVC builds also add the matching Debug CRT redistributable
 directory when it is present, so Debug helper binaries and DLLs can run on CI
 machines that do not have `msvcp140d.dll` or `vcruntime140d.dll` on the system
 `PATH`. This keeps CTest execution independent of a developer's interactive
@@ -268,6 +278,15 @@ Debug CRT by building a bounded runtime `PATH` from tool, DLL, vcpkg, MSVC CRT,
 and Windows system directories.
 MinGW builds still need the UCRT64 `bin` directory on the invoking shell `PATH`
 because GCC launches runtime-dependent compiler subprocesses during the build.
+
+`iccdev.windows-runtime-paths`
+(`Build/Cmake/Testing/RunWindowsRuntimePathsTest.cmake`) covers that collector
+against synthetic `CMakeCache.txt` fixtures, asserting both vcpkg configuration
+trees, the per-configuration ordering, and the `optimized;...;debug;...`
+library-cache form. It is registered on every platform rather than only on
+Windows: the effect of a miss is Windows-only -- an out-of-tree consumer fails
+to load with `0xc0000135`, `STATUS_DLL_NOT_FOUND`, which names no DLL -- but the
+cause is cache parsing, so it reproduces anywhere and needs no build products.
 
 Windows MSVC AddressSanitizer uses comma-separated `ASAN_OPTIONS`
 (`detect_leaks=0,halt_on_error=1`) and does not support LeakSanitizer


### PR DESCRIPTION
## What

`Build/Cmake/Testing/WindowsRuntimePaths.cmake` is this tree's single collector of Windows
runtime dependency directories — five call sites depend on it, and it had **no test coverage
of any kind**. PR #2236 hit two defects in it and worked around both *locally* inside
`RunInstalledPackageConsumerTest.cmake` rather than fixing the source, so the next
out-of-tree consumer test would have hit the identical wall.

**Defect 1 — vcpkg's per-configuration debug tree was never added.** vcpkg keeps release DLLs
in `<installed>/<triplet>/bin` and debug DLLs in `<installed>/<triplet>/debug/bin`. The
collector added only the release tree. The Windows CI leg builds Debug, so a consumer needing
libxml2 / zlib / iconv found nothing and died at load with `0xc0000135`
(`STATUS_DLL_NOT_FOUND`) — which names no DLL. This cost #2236 three blind CI cycles.

**Defect 2 — `EXISTS` was applied to a multi-config LIST.** Under a multi-config generator
`LIBXML2_LIBRARY` / `ZLIB_LIBRARY` and friends hold `optimized;<path>;debug;<path>`. `EXISTS`
on that whole string is false, so those entries contributed **nothing at all** — the fallback
that was supposed to cover defect 1 could not.

## How

Both trees are collected, and the one matching `ICCDEV_CONFIG` (or the cache's
`CMAKE_BUILD_TYPE`) is ordered first. Ordering is applied **per prefix**, in
`iccdev_add_prefix_runtime_entries()`, rather than once inside the vcpkg block — a single
ordered block does not survive contact with the rest of the collector:

- `CMAKE_PREFIX_PATH` is read *first*, and `iccdev_add_existing_path_entry()` keeps an entry's
  **first** position, so a prefix naming the same triplet directory pinned the release tree
  ahead of the debug one regardless of what the vcpkg block did afterwards.
- Library-derived prefixes got no ordering at all — exactly the case the `_VCPKG_INSTALLED_DIR`
  fallback exists to rescue.

Order matters because both trees spell the DLL identically (`libxml2.dll` either way), so
second place means the **release** DLL binds into a Debug process.

Also read now: the `_VCPKG_INSTALLED_DIR` spelling (the vcpkg toolchain's internal one, the
only one some vcpkg versions publish), and the per-configuration `*_LIBRARY_RELEASE` /
`*_LIBRARY_DEBUG` names that `select_library_configurations()` writes. The generated cache-name
list is a strict superset of the nine names read before.

The duplicate in `RunInstalledPackageConsumerTest.cmake` is deleted — one implementation, not
two.

## Test

`iccdev.windows-runtime-paths` is the collector's first coverage of any kind. It drives
`cmake -P` against synthetic `CMakeCache.txt` fixtures, so it is registered on **every**
platform and **above the bash gate**: it needs no bash, no targets and no build products. The
effect of a miss is Windows-only, but the cause is cache parsing, so it reproduces anywhere in
~0.04s instead of costing a Windows Debug CI round trip per attempt.

Seven arms, all of which **fail against `origin/master`**:

| Arm | Pins |
|---|---|
| `multi-config` | both vcpkg trees + both library-derived prefixes present; release-first when no config is known |
| `config-debug` | `ICCDEV_CONFIG=Debug` orders the vcpkg debug tree first |
| `cache-debug` | the cache's `CMAKE_BUILD_TYPE` is an equivalent fallback |
| `vcpkg-internal-spelling` | `_VCPKG_INSTALLED_DIR` alone still resolves the tree |
| `prefix-path-debug` | a `CMAKE_PREFIX_PATH` entry shadowing the triplet dir does not defeat the ordering |
| `library-only-debug` | debug-first with no vcpkg cache variables at all |
| `library-only-release` | the Release mirror, so the ordering arms cannot pass by always emitting debug first |

Plus an anti-vacuity arm pinning that nonexistent directories are still never emitted.

Failure output prints the whole collected list, because a runtime PATH defect leaves no other
evidence behind.

## Deliberately not changed

**`StageWindowsRuntime.cmake`.** It does not call the collector; it already adds the vcpkg
debug tree behind an `ICCDEV_CONFIG` gate; and it enumerates the singular
`*_LIBRARY_RELEASE` / `*_LIBRARY_DEBUG` names, which `select_library_configurations()` sets to
single `FILEPATH` values (confirmed against a real cache), so defect 2 cannot reach it. It also
*copies* DLLs rather than building a PATH, where adding both configuration trees would put
debug and release DLLs in one directory.

**`RunWindowsDumpProfileSmokeTest` / `RunWindowsPawgReportSmokeTest`** still pass no
`ICCDEV_CONFIG`, so they keep the release-first order. That is benign and unchanged from
before — `StageWindowsRuntime.cmake` copies dependency DLLs next to the binaries those in-tree
tests stage. The collector comment says so rather than claiming a guarantee it does not have.

## Validation

- Red/green: all seven arms fail against `origin/master`, pass on this branch. Re-verified
  after the rebase onto `9b16db6f`.
- Build clean, CI's own gate: `grep -cE 'warning:' build.log` = **0**. No C/C++ file is touched
  by this diff, so the compile-warning gate is not perturbed.
- `ctest`: 197/198. The single failure, `iccdev.spectral-tiff-preview`, is
  `ModuleNotFoundError: No module named 'imagecodecs'` — a missing Python module in the local
  environment, present identically before this change.
- Configures clean in both a strict Release profile (`-Wall -Wextra -Wpedantic -Werror`) and a
  **Debug** profile; both gaps are Debug-only in effect, so Debug is a distinct pre-flight lane.
- Registration verified structurally for Windows: the `if(WIN32)` branch spans L5005–L5331 and
  `return()`s at L5330, so the unconditional call at L5336 is unreachable there — exactly one
  `add_test` per platform, no duplicate-name configure error.

`docs/ctest.md` updated per the CTest-infra doc requirement.

## CI

Dispatched **before** opening this PR per the suggested workflow, so it did not contend with
the PR's own run: `ci_scope=source` → run
[32522295845](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32522295845),
**all lanes green** (GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL, MinGW UCRT64, Tool
Smoke Tests ASAN+UBSAN Debug; Docker and the manual thread-linkage job skipped).

The new test is confirmed to have *executed* on every leg, not merely to have ridden a green
check:

| Leg | Test | Result |
|---|---|---|
| Windows MSVC + ClangCL | #49 of 106 | Passed 0.04s / 0.03s (both configs) |
| MinGW UCRT64 | #47 of 107 | Passed 0.05s |
| GCC Strict ASAN+UBSAN Debug | #3 of 194 | Passed |

`source` was chosen over `full` as the narrowest scope that still covers the change: it buys
Windows plus the whole CTest set, and Windows is the only place this defect's effect is
observable.

Part of #2154


