### PR TITLE
feat(#1853): implement the iccdev-qa-evidence/v1 CLI the build already advertises

### DIFF
--- a/.github/ci/regression/qa-evidence-helpers.cpp
+++ b/.github/ci/regression/qa-evidence-helpers.cpp
@@ -85,9 +85,40 @@ int main()
   expect("json control set", icJsonEscape("\b\f\n\r\t"), "\\b\\f\\n\\r\\t");
   expect("json other control byte", icJsonEscape("\x01"), "\\u0001");
 
-  // UTF-8 passes through byte for byte. Escaping these as \u00XX would emit the
-  // code points U+00C3 U+00A9 instead of U+00E9 -- the #1853 mojibake.
+  // Well-formed UTF-8 passes through byte for byte. Escaping these as \u00XX
+  // would emit the code points U+00C3 U+00A9 instead of U+00E9 -- the #1853
+  // mojibake -- so this case is that bug turned into an assertion.
   expect("json utf-8 passthrough", icJsonEscape("caf\xc3\xa9"), "caf\xc3\xa9");
+  expect("json utf-8 3-byte", icJsonEscape("\xe2\x82\xac"), "\xe2\x82\xac");
+  expect("json utf-8 4-byte", icJsonEscape("\xf0\x9f\x8e\xa8"), "\xf0\x9f\x8e\xa8");
+
+  // A JSON text must be valid UTF-8 (RFC 8259 8.1), and these strings carry
+  // paths straight from argv, which on POSIX need not be UTF-8 at all. Passing
+  // a stray byte through would produce a document that will not decode, so
+  // anything that is not part of a well-formed sequence becomes U+FFFD.
+  // U+FFFD is emitted as the \ufffd escape rather than as its three UTF-8
+  // bytes, which keeps the whole document pure ASCII and therefore decodable
+  // whatever encoding a consumer assumes.
+  const char *kRepl = "\\ufffd";
+  expect("json lone latin-1 byte", icJsonEscape("caf\xe9.icc"),
+         std::string("caf") + kRepl + ".icc");
+  expect("json lone continuation", icJsonEscape("\xa9"), kRepl);
+  expect("json truncated 2-byte", icJsonEscape("\xc3"), kRepl);
+  expect("json truncated 3-byte", icJsonEscape("\xe2\x82"),
+         std::string(kRepl) + kRepl);
+
+  // The three malformations a naive "0xC0-0xFF starts a sequence" test lets
+  // through, all of which Unicode 15.0 table 3-7 rejects.
+  expect("json over-long two-byte", icJsonEscape("\xc0\xaf"),
+         std::string(kRepl) + kRepl);
+  expect("json utf-16 surrogate", icJsonEscape("\xed\xa0\x80"),
+         std::string(kRepl) + kRepl + kRepl);
+  expect("json above U+10FFFF", icJsonEscape("\xf5\x80\x80\x80"),
+         std::string(kRepl) + kRepl + kRepl + kRepl);
+
+  // Resynchronisation: a bad byte must not eat the good text after it.
+  expect("json resync after bad byte", icJsonEscape("\xffok"),
+         std::string(kRepl) + "ok");
 
   // Both overloads must agree, since callers mix them freely.
   expect("json std::string overload", icJsonEscape(std::string("a\"b")), "a\\\"b");

--- a/.github/ci/regression/qa-evidence-helpers.cpp
+++ b/.github/ci/regression/qa-evidence-helpers.cpp
@@ -1,0 +1,106 @@
+// Regression for the two IccCmdLineUtil.h helpers that every producer of the
+// iccdev-qa-evidence/v1 schema depends on: icSha256Bytes and icJsonEscape.
+//
+// icSha256Bytes is a hand-rolled SHA-256 -- iccDEV links no crypto library, so
+// the digest that iccApplyNamedCmm and iccTiffDump put in their evidence is
+// computed by this header and nothing else. A hand-rolled compression function
+// is exactly the kind of code that produces plausible-looking wrong output: a
+// wrong digest is still 64 hex characters, so no consumer of the evidence can
+// tell. The published FIPS 180-4 / RFC 6234 vectors below are the only thing
+// that distinguishes a correct implementation from a confident one.
+//
+// The 55, 56 and 64 byte cases are not padding for the sake of it. SHA-256
+// appends 0x80, pads to 56 bytes mod 64, then appends the 8-byte length, so:
+//
+//   55 bytes -> 0x80 plus the length exactly fills one block  (no new block)
+//   56 bytes -> the length no longer fits, forcing a second block
+//   64 bytes -> a whole extra block of pure padding
+//
+// An off-by-one in "while ((msg.size() % 64) != 56)" survives the "abc" vector
+// and dies on one of these three.
+//
+// icJsonEscape is covered because it is where the three-way divergence lived
+// (#1853): PawgReport.cpp used to escape every byte above 0x7e as \u00XX, which
+// treats a UTF-8 byte as a code point and turns the two bytes of U+00E9 into
+// the two characters "A~(c)". The UTF-8 passthrough case below is that bug.
+
+#include "IccCmdLineUtil.h"
+
+#include <cstdio>
+#include <string>
+
+namespace {
+
+int g_failures = 0;
+
+void expect(const char *what, const std::string &got, const std::string &want)
+{
+  if (got == want)
+    return;
+
+  std::fprintf(stderr, "[qa-evidence-helpers] FAIL: %s\n  got  %s\n  want %s\n",
+               what, got.c_str(), want.c_str());
+  g_failures++;
+}
+
+void expectDigest(const char *what, const std::string &in, const char *want)
+{
+  const unsigned char *data =
+    in.empty() ? (const unsigned char *)"" : (const unsigned char *)in.data();
+  expect(what, icSha256Bytes(data, in.size()), std::string("sha256:") + want);
+}
+
+} // namespace
+
+int main()
+{
+  // FIPS 180-4 / RFC 6234 published vectors.
+  expectDigest("sha256 empty", std::string(),
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+  expectDigest("sha256 abc", "abc",
+    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+  expectDigest("sha256 two-block message",
+    "abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+    "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1");
+
+  // The three padding boundaries described above.
+  expectDigest("sha256 55 bytes", std::string(55, 'a'),
+    "9f4390f8d30c2dd92ec9f095b65e2b9ae9b0a925a5258e241c9f1e910f734318");
+  expectDigest("sha256 56 bytes", std::string(56, 'a'),
+    "b35439a4ac6f0948b6d6f9e3c6af0f5f590ce20f1bde7090ef7970686ec6738a");
+  expectDigest("sha256 64 bytes", std::string(64, 'a'),
+    "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb");
+
+  // The million-'a' vector: exercises the chunk loop far past its first turn.
+  expectDigest("sha256 1e6 bytes", std::string(1000000, 'a'),
+    "cdc76e5c9914fb9281a1c7e284d73e67f1809a48a497200e046d39ccc7112cd0");
+
+  // A digest over embedded NUL bytes must not stop at the NUL: the evidence
+  // digests are taken over profile and image files, which are full of them.
+  expectDigest("sha256 embedded NUL", std::string("a\0b", 3),
+    "59b271ae1bbcb1d31d41929817f4b16fb439eb4f31520b5ad1d5ce98920a7138");
+
+  expect("json plain", icJsonEscape("plain"), "plain");
+  expect("json quote and backslash", icJsonEscape("a\"b\\c"), "a\\\"b\\\\c");
+  expect("json control set", icJsonEscape("\b\f\n\r\t"), "\\b\\f\\n\\r\\t");
+  expect("json other control byte", icJsonEscape("\x01"), "\\u0001");
+
+  // UTF-8 passes through byte for byte. Escaping these as \u00XX would emit the
+  // code points U+00C3 U+00A9 instead of U+00E9 -- the #1853 mojibake.
+  expect("json utf-8 passthrough", icJsonEscape("caf\xc3\xa9"), "caf\xc3\xa9");
+
+  // Both overloads must agree, since callers mix them freely.
+  expect("json std::string overload", icJsonEscape(std::string("a\"b")), "a\\\"b");
+
+  // A null pointer is a legal argument: callers pass tool paths straight from
+  // argv and from empty std::string members.
+  expect("json null pointer", icJsonEscape((const char *)0), "");
+
+  if (g_failures) {
+    std::fprintf(stderr, "[qa-evidence-helpers] %d failure(s)\n", g_failures);
+    return 1;
+  }
+
+  std::printf("[qa-evidence-helpers] all checks passed\n");
+  return 0;
+}

--- a/.github/scripts/iccdev-qa-target-flags.sh
+++ b/.github/scripts/iccdev-qa-target-flags.sh
@@ -1,0 +1,732 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+tools_dir="${ICCDEV_TOOLS_DIR:-${repo_root}/build/Tools}"
+testing_dir="${ICCDEV_TESTING_DIR:-${repo_root}/Testing}"
+out_dir="${ICCDEV_TEST_OUTDIR:-${repo_root}/build/Testing/ctest-output/iccdev-qa-target-flags}"
+marker_file="${repo_root}/.github/ci/qa-flags/qa-target-marker.txt"
+base_profile="${testing_dir}/sRGB_v4_ICC_preference.icc"
+transform_input="${testing_dir}/Display/RgbTest.txt"
+transform_profile="${base_profile}"
+transform_output="${out_dir}/iccApplyNamedCmm.transform-output.txt"
+tiff_input="${out_dir}/qa-write-embedded-profile.tif"
+write_output_profile="${out_dir}/iccTiffDump.extracted.icc"
+qa_profile="${out_dir}/qa-target-flags.icc"
+negative_profile="${out_dir}/qa-target-flags-negative-control.icc"
+malformed_profile="${out_dir}/qa-target-flags-malformed.icc"
+evidence_ndjson="${out_dir}/evidence.ndjson"
+summary_json="${out_dir}/summary.json"
+summary_tsv="${out_dir}/summary.tsv"
+classifier_sample="${repo_root}/.github/ci/qa-flags/sanitizer-stack-smash-sample.txt"
+tools_root="$(dirname "$tools_dir")"
+cmake_cache="${ICCDEV_CMAKE_CACHE:-${tools_root}/CMakeCache.txt}"
+
+if [ -f "${repo_root}/.github/scripts/sanitize-sed.sh" ]; then
+  # shellcheck disable=SC1091
+  source "${repo_root}/.github/scripts/sanitize-sed.sh"
+else
+  sanitize_line() {
+    printf '%s' "$1" | tr -d '\000-\011\013\014\016-\037\177'
+  }
+fi
+
+fail() {
+  printf '[FAIL] %s\n' "$(sanitize_line "$1")" >&2
+  exit 1
+}
+
+find_tool() {
+  local name="$1"
+  local subdir="$2"
+  local candidate="${tools_dir}/${subdir}/${name}"
+
+  if [ -x "$candidate" ]; then
+    printf '%s\n' "$candidate"
+    return 0
+  fi
+
+  if command -v "$name" >/dev/null 2>&1; then
+    command -v "$name"
+    return 0
+  fi
+
+  fail "Unable to find ${name}; set ICCDEV_TOOLS_DIR or add tool directories to PATH"
+}
+
+zlib_toggle_enabled() {
+  [ -f "$cmake_cache" ] && grep -q '^ICC_USE_ZLIB:BOOL=ON$' "$cmake_cache"
+}
+
+assert_runtime_zlib_dependency() {
+  local tool_name="$1"
+  local tool_path="$2"
+  local ldd_out="${out_dir}/${tool_name}.ldd.txt"
+
+  zlib_toggle_enabled || return 0
+
+  if ! command -v ldd >/dev/null 2>&1; then
+    printf '[SKIP] %s zlib runtime dependency check requires ldd\n' "$(sanitize_line "$tool_name")"
+    return 0
+  fi
+
+  set +e
+  ldd "$tool_path" >"$ldd_out" 2>&1
+  local ldd_status
+  ldd_status=$?
+  set -e
+
+  if [ "$ldd_status" -ne 0 ]; then
+    printf '[SKIP] %s zlib runtime dependency check unavailable: ldd exit %s\n' \
+      "$(sanitize_line "$tool_name")" "$ldd_status"
+    return 0
+  fi
+
+  # The compression toggle links zlib (libz).  Do not key this check on
+  # "lzma": liblzma is a transitive LibXml2 dependency for XML tools only.
+  if grep -Eq 'libz(\.so|[^[:alpha:]])|zlib' "$ldd_out"; then
+    printf '[OK] %s runtime links zlib when ICC_USE_ZLIB=ON\n' "$(sanitize_line "$tool_name")"
+    return 0
+  fi
+
+  fail "${tool_name} does not show libz/zlib in ldd output while ICC_USE_ZLIB=ON"
+}
+
+require_file() {
+  local path="$1"
+  [ -f "$path" ] || fail "Required file not found: ${path}"
+}
+
+make_marker_profile() {
+  local base="$1"
+  local marker="$2"
+  local output="$3"
+  local tag_sig="$4"
+  local nonce="${5:-}"
+
+  python3 - "$base" "$marker" "$output" "$tag_sig" "$nonce" <<'PY'
+import struct
+import sys
+from pathlib import Path
+
+base = Path(sys.argv[1])
+marker_path = Path(sys.argv[2])
+output = Path(sys.argv[3])
+tag_sig = sys.argv[4].encode("ascii")
+nonce = sys.argv[5].encode("ascii")
+
+if len(tag_sig) != 4:
+    raise SystemExit("tag signature must be exactly 4 ASCII bytes")
+if nonce and not nonce.startswith(b"ICCDEV_QA_NONCE_"):
+    raise SystemExit("nonce must use ICCDEV_QA_NONCE_ prefix")
+
+data = bytearray(base.read_bytes())
+marker = marker_path.read_text(encoding="ascii").strip().encode("ascii")
+controlled = b"A" * 16
+payload = tag_sig + b"\x00\x00\x00\x00" + marker + b"\x00"
+if nonce:
+    payload += nonce + b"\x00"
+payload += controlled
+payload += b"\x00" * ((4 - (len(payload) % 4)) % 4)
+
+if len(data) < 132:
+    raise SystemExit("base profile too small")
+
+tag_count = struct.unpack(">I", data[128:132])[0]
+table_end = 132 + tag_count * 12
+if table_end > len(data):
+    raise SystemExit("base profile tag table extends beyond file")
+
+shift = 12
+new_data = bytearray(data[:132])
+for i in range(tag_count):
+    entry = data[132 + i * 12:132 + (i + 1) * 12]
+    sig, offset, size = struct.unpack(">III", entry)
+    if offset >= table_end:
+        offset += shift
+    new_data.extend(struct.pack(">III", sig, offset, size))
+
+payload_offset = (len(data) + shift + 3) & ~3
+new_data.extend(struct.pack(">4sII", tag_sig, payload_offset, len(payload)))
+new_data.extend(data[table_end:])
+while len(new_data) < payload_offset:
+    new_data.append(0)
+new_data.extend(payload)
+
+struct.pack_into(">I", new_data, 0, len(new_data))
+struct.pack_into(">I", new_data, 128, tag_count + 1)
+output.write_bytes(new_data)
+PY
+}
+
+make_malformed_profile() {
+  local marker="$1"
+  local output="$2"
+
+  python3 - "$marker" "$output" <<'PY'
+import sys
+from pathlib import Path
+
+marker_path = Path(sys.argv[1])
+output = Path(sys.argv[2])
+marker = marker_path.read_text(encoding="ascii").strip().encode("ascii")
+payload = b"not-an-icc-profile\n" + marker + b"\n" + (b"A" * 16) + b"\n"
+output.write_bytes(payload)
+PY
+}
+
+make_tiff_with_embedded_profile() {
+  local profile="$1"
+  local output="$2"
+
+  python3 - "$profile" "$output" <<'PY'
+import struct
+import sys
+from pathlib import Path
+
+profile = Path(sys.argv[1]).read_bytes()
+output = Path(sys.argv[2])
+
+entries = []
+
+def entry(tag, typ, count, value=None, data=None):
+    entries.append((tag, typ, count, value, data))
+
+entry(256, 4, 1, 1)                                  # ImageWidth
+entry(257, 4, 1, 1)                                  # ImageLength
+entry(258, 3, 1, 8)                                  # BitsPerSample
+entry(259, 3, 1, 1)                                  # Compression: none
+entry(262, 3, 1, 1)                                  # Photometric: min-is-black
+entry(273, 4, 1, "IMAGE")                            # StripOffsets
+entry(277, 3, 1, 1)                                  # SamplesPerPixel
+entry(278, 4, 1, 1)                                  # RowsPerStrip
+entry(279, 4, 1, 1)                                  # StripByteCounts
+entry(282, 5, 1, data=struct.pack("<II", 72, 1))     # XResolution
+entry(283, 5, 1, data=struct.pack("<II", 72, 1))     # YResolution
+entry(296, 3, 1, 2)                                  # ResolutionUnit: inch
+entry(34675, 7, len(profile), data=profile)           # ICC profile tag
+
+ifd_size = 2 + len(entries) * 12 + 4
+current = 8 + ifd_size
+records = []
+for tag, typ, count, value, data in entries:
+    if data is not None:
+        offset = current
+        current += len(data)
+        if current % 2:
+            current += 1
+        records.append((tag, typ, count, offset, data))
+    else:
+        records.append((tag, typ, count, value, None))
+
+image_offset = current
+buf = bytearray()
+buf.extend(b"II")
+buf.extend(struct.pack("<H", 42))
+buf.extend(struct.pack("<I", 8))
+buf.extend(struct.pack("<H", len(records)))
+
+for tag, typ, count, value, data in records:
+    value = image_offset if value == "IMAGE" else value
+    buf.extend(struct.pack("<HHI", tag, typ, count))
+    if data is not None:
+        buf.extend(struct.pack("<I", value))
+    elif typ == 3 and count == 1:
+        buf.extend(struct.pack("<H", value) + b"\0\0")
+    else:
+        buf.extend(struct.pack("<I", value))
+
+buf.extend(struct.pack("<I", 0))
+for tag, typ, count, value, data in records:
+    if data is None:
+        continue
+    while len(buf) < value:
+        buf.append(0)
+    buf.extend(data)
+    if len(buf) % 2:
+        buf.append(0)
+
+while len(buf) < image_offset:
+    buf.append(0)
+buf.append(0)
+output.write_bytes(buf)
+PY
+}
+
+run_evidence() {
+  local name="$1"
+  local expected_status="$2"
+  local stdout_path="$3"
+  local stderr_path="$4"
+  shift 4
+
+  set +e
+  "$@" >"$stdout_path" 2>"$stderr_path"
+  local status=$?
+  set -e
+
+  if [ "$status" -eq "$expected_status" ]; then
+    printf '[OK] %s evidence command completed\n' "$(sanitize_line "$name")"
+  else
+    printf '[FAIL] %s evidence command exited %s, expected %s\n' \
+      "$(sanitize_line "$name")" "$status" "$expected_status" >&2
+    if [ -s "$stderr_path" ]; then
+      while IFS= read -r line; do
+        printf '%s\n' "$(sanitize_line "$line")" >&2
+      done <"$stderr_path"
+    fi
+    exit "$status"
+  fi
+
+  python3 -m json.tool "$stdout_path" >/dev/null
+  cat "$stdout_path" >>"$evidence_ndjson"
+  printf '\n' >>"$evidence_ndjson"
+}
+
+run_command() {
+  local name="$1"
+  local expected_status="$2"
+  local stdout_path="$3"
+  local stderr_path="$4"
+  shift 4
+
+  set +e
+  "$@" >"$stdout_path" 2>"$stderr_path"
+  local status=$?
+  set -e
+
+  if [ "$status" -eq "$expected_status" ]; then
+    printf '[OK] %s command completed\n' "$(sanitize_line "$name")"
+  else
+    printf '[FAIL] %s command exited %s, expected %s\n' \
+      "$(sanitize_line "$name")" "$status" "$expected_status" >&2
+    if [ -s "$stderr_path" ]; then
+      while IFS= read -r line; do
+        printf '%s\n' "$(sanitize_line "$line")" >&2
+      done <"$stderr_path"
+    fi
+    exit "$status"
+  fi
+}
+
+assert_json_flag() {
+  local file="$1"
+  local flag="$2"
+
+  python3 - "$file" "$flag" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="ascii"))
+if sys.argv[2] not in data.get("qaFlags", []):
+    raise SystemExit(f"missing flag {sys.argv[2]}")
+PY
+}
+
+assert_json_no_flag() {
+  local file="$1"
+  local flag="$2"
+
+  python3 - "$file" "$flag" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="ascii"))
+if sys.argv[2] in data.get("qaFlags", []):
+    raise SystemExit(f"unexpected flag {sys.argv[2]}")
+PY
+}
+
+assert_json_fields() {
+  local file="$1"
+  local flag="$2"
+  shift 2
+
+  python3 - "$file" "$flag" "$@" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="ascii"))
+flag = sys.argv[2]
+if flag and flag not in data.get("qaFlags", []):
+    raise SystemExit(f"missing flag {flag}")
+
+def lookup(obj, path):
+    cur = obj
+    for part in path.split("."):
+        if isinstance(cur, list):
+            try:
+                cur = cur[int(part)]
+            except (ValueError, IndexError):
+                raise KeyError(path)
+        elif isinstance(cur, dict) and part in cur:
+            cur = cur[part]
+        else:
+            raise KeyError(path)
+    return cur
+
+for path in sys.argv[3:]:
+    value = lookup(data, path)
+    if value is None or value == "" or value == []:
+        raise SystemExit(f"empty evidence field {path}")
+PY
+}
+
+assert_json_loaded() {
+  local file="$1"
+  local expected="$2"
+
+  python3 - "$file" "$expected" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="ascii"))
+expected = sys.argv[2] == "true"
+if data.get("loaded") is not expected:
+    raise SystemExit(f"loaded={data.get('loaded')} expected {expected}")
+PY
+}
+
+assert_json_equals() {
+  local file="$1"
+  local path="$2"
+  local expected="$3"
+
+  python3 - "$file" "$path" "$expected" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+data = json.loads(Path(sys.argv[1]).read_text(encoding="ascii"))
+path = sys.argv[2]
+expected = sys.argv[3]
+cur = data
+for part in path.split("."):
+    if isinstance(cur, dict) and part in cur:
+        cur = cur[part]
+    else:
+        raise SystemExit(f"missing evidence field {path}")
+if cur != expected:
+    raise SystemExit(f"{path}={cur!r} expected {expected!r}")
+PY
+}
+
+assert_json_key_count() {
+  local file="$1"
+  local key="$2"
+  local expected_count="$3"
+
+  python3 - "$file" "$key" "$expected_count" <<'PY'
+import sys
+from pathlib import Path
+
+text = Path(sys.argv[1]).read_text(encoding="ascii")
+key = '"' + sys.argv[2] + '"'
+expected = int(sys.argv[3])
+actual = text.count(key)
+if actual != expected:
+    raise SystemExit(f"{key} count {actual} != {expected}")
+PY
+}
+
+write_case_summary() {
+  local case_name="$1"
+  local expected="$2"
+  local observed="$3"
+  local status="$4"
+  local notes="$5"
+
+  printf '%s\t%s\t%s\t%s\t%s\n' \
+    "$case_name" "$expected" "$observed" "$status" "$notes" >>"$summary_tsv"
+}
+
+classify_sanitizer_sample() {
+  local sample="$1"
+  local output="$2"
+
+  python3 - "$sample" "$output" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+sample = Path(sys.argv[1])
+output = Path(sys.argv[2])
+text = sample.read_text(encoding="ascii")
+flags = []
+if "AddressSanitizer" in text:
+    flags.append("ICCDEV_FLAG_SANITIZER")
+if "stack smashing detected" in text or "__stack_chk_fail" in text or "stack-buffer-overflow" in text:
+    flags.append("ICCDEV_FLAG_STACK_SMASH")
+if "0x41414141" in text or "41414141" in text:
+    flags.append("ICCDEV_FLAG_CONTROLLED_PATTERN")
+summary = ""
+stack_frame_file = ""
+for line in text.splitlines():
+    if line.startswith("SUMMARY:"):
+        summary = line
+    stripped = line.strip()
+    if stripped.startswith("#") and " in " in stripped:
+        candidate = stripped.rsplit(" ", 1)[-1]
+        if ":" in candidate and "/" in candidate:
+            stack_frame_file = candidate
+evidence = {
+    "schema": "iccdev-qa-log-evidence/v1",
+    "tool": "iccdev-qa-log-classifier",
+    "source": str(sample),
+    "fixtureOnly": True,
+    "exitCode": 134,
+    "exitClassification": "sanitizer-abort",
+    "qaFlags": flags,
+    "sanitizer": {
+        "summary": summary,
+        "stackFrameFilePath": stack_frame_file,
+    },
+    "indicators": {
+        "addressSanitizer": "AddressSanitizer" in text,
+        "stackSmash": "stack smashing detected" in text or "__stack_chk_fail" in text,
+        "stackBufferOverflow": "stack-buffer-overflow" in text,
+        "controlledPattern": "0x41414141" in text or "41414141" in text,
+    },
+}
+output.write_text(json.dumps(evidence, separators=(",", ":")) + "\n", encoding="ascii")
+PY
+}
+
+require_file "$base_profile"
+require_file "$transform_input"
+require_file "$transform_profile"
+require_file "$marker_file"
+require_file "$classifier_sample"
+command -v python3 >/dev/null 2>&1 || fail "python3 is required"
+
+mkdir -p "$out_dir"
+: >"$evidence_ndjson"
+printf 'case\texpected\tobserved\tstatus\tnotes\n' >"$summary_tsv"
+
+icc_dump_profile="$(find_tool iccDumpProfile IccDumpProfile)"
+icc_pawg_report="$(find_tool iccPawgReport IccPawgReport)"
+icc_apply_named="$(find_tool iccApplyNamedCmm IccApplyNamedCmm)"
+icc_tiff_dump="$(find_tool iccTiffDump IccTiffDump)"
+icc_to_json="$(find_tool iccToJson IccToJson)"
+icc_from_json="$(find_tool iccFromJson IccFromJson)"
+icc_to_xml="$(find_tool iccToXml IccToXml)"
+icc_from_xml="$(find_tool iccFromXml IccFromXml)"
+icc_round_trip="$(find_tool iccRoundTrip IccRoundTrip)"
+
+assert_runtime_zlib_dependency "iccDumpProfile" "$icc_dump_profile"
+assert_runtime_zlib_dependency "iccPawgReport" "$icc_pawg_report"
+assert_runtime_zlib_dependency "iccApplyNamedCmm" "$icc_apply_named"
+assert_runtime_zlib_dependency "iccTiffDump" "$icc_tiff_dump"
+assert_runtime_zlib_dependency "iccToJson" "$icc_to_json"
+assert_runtime_zlib_dependency "iccFromJson" "$icc_from_json"
+assert_runtime_zlib_dependency "iccToXml" "$icc_to_xml"
+assert_runtime_zlib_dependency "iccFromXml" "$icc_from_xml"
+assert_runtime_zlib_dependency "iccRoundTrip" "$icc_round_trip"
+
+qa_nonce="ICCDEV_QA_NONCE_$(sha256sum "$base_profile" "$marker_file" | sha256sum | awk '{print toupper(substr($1, 1, 16))}')"
+make_marker_profile "$base_profile" "$marker_file" "$qa_profile" "qaFL" "$qa_nonce"
+make_marker_profile "$base_profile" "$marker_file" "$negative_profile" "fpFL"
+make_malformed_profile "$marker_file" "$malformed_profile"
+make_tiff_with_embedded_profile "$base_profile" "$tiff_input"
+require_file "$tiff_input"
+
+dump_json="${out_dir}/iccDumpProfile.evidence.json"
+dump_err="${out_dir}/iccDumpProfile.stderr.txt"
+negative_json="${out_dir}/iccDumpProfile.negative-control.evidence.json"
+negative_err="${out_dir}/iccDumpProfile.negative-control.stderr.txt"
+malformed_json="${out_dir}/iccDumpProfile.malformed.evidence.json"
+malformed_err="${out_dir}/iccDumpProfile.malformed.stderr.txt"
+pawg_json="${out_dir}/iccPawgReport.evidence.json"
+pawg_err="${out_dir}/iccPawgReport.stderr.txt"
+transform_json="${out_dir}/iccApplyNamedCmm.transform.evidence.json"
+transform_config="${out_dir}/iccApplyNamedCmm.transform.config.json"
+transform_err="${out_dir}/iccApplyNamedCmm.transform.stderr.txt"
+write_json="${out_dir}/iccTiffDump.write.evidence.json"
+write_err="${out_dir}/iccTiffDump.write.stderr.txt"
+classifier_json="${out_dir}/sanitizer-stack-smash-classifier.evidence.json"
+
+python3 - "$transform_input" "$transform_output" "$transform_profile" "$transform_config" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+input_data = Path(sys.argv[1])
+output_data = Path(sys.argv[2])
+profile = Path(sys.argv[3])
+config = Path(sys.argv[4])
+payload = {
+    "dataFiles": {
+        "srcType": "legacy",
+        "srcFile": str(input_data),
+        "dstType": "legacy",
+        "dstFile": str(output_data),
+        "dstEncoding": "float",
+    },
+    "profileSequence": [
+        {
+            "iccFile": str(profile),
+            "intent": "absolute",
+            "interpolation": "linear",
+        }
+    ],
+}
+config.write_text(json.dumps(payload, separators=(",", ":")) + "\n", encoding="ascii")
+PY
+
+run_evidence \
+  "iccDumpProfile" \
+  0 \
+  "$dump_json" \
+  "$dump_err" \
+  "$icc_dump_profile" --qa-flags --evidence-json --diag -v 100 "$qa_profile"
+
+run_evidence \
+  "iccDumpProfile negative control" \
+  0 \
+  "$negative_json" \
+  "$negative_err" \
+  "$icc_dump_profile" --qa-flags --evidence-json --diag -v 100 "$negative_profile"
+
+run_evidence \
+  "iccDumpProfile malformed control" \
+  1 \
+  "$malformed_json" \
+  "$malformed_err" \
+  "$icc_dump_profile" --qa-flags --evidence-json --diag -v 100 "$malformed_profile"
+
+run_evidence \
+  "iccPawgReport" \
+  0 \
+  "$pawg_json" \
+  "$pawg_err" \
+  "$icc_pawg_report" --qa-flags --evidence-json "$base_profile"
+
+run_evidence \
+  "iccApplyNamedCmm transform" \
+  0 \
+  "$transform_json" \
+  "$transform_err" \
+  "$icc_apply_named" --evidence-json -cfg "$transform_config"
+
+run_evidence \
+  "iccTiffDump write/extract" \
+  0 \
+  "$write_json" \
+  "$write_err" \
+  "$icc_tiff_dump" --evidence-json "$tiff_input" "$write_output_profile"
+
+classify_sanitizer_sample "$classifier_sample" "$classifier_json"
+python3 -m json.tool "$classifier_json" >/dev/null
+cat "$classifier_json" >>"$evidence_ndjson"
+printf '\n' >>"$evidence_ndjson"
+
+grep -q '"schema":"iccdev-qa-evidence/v1"' "$dump_json" || fail "iccDumpProfile evidence schema missing"
+assert_json_key_count "$dump_json" "schema" 1 || fail "iccDumpProfile evidence schema key duplicated"
+assert_json_loaded "$dump_json" true || fail "iccDumpProfile did not load true-positive profile"
+assert_json_flag "$dump_json" "ICCDEV_FLAG_LOAD" || fail "iccDumpProfile load flag missing"
+assert_json_flag "$dump_json" "ICCDEV_FLAG_VALIDATE" || fail "iccDumpProfile validation flag missing"
+assert_json_flag "$dump_json" "ICCDEV_FLAG_TAG_PAYLOAD" || fail "iccDumpProfile controlled tag payload flag missing"
+assert_json_flag "$dump_json" "ICCDEV_FLAG_CONTROLLED_PATTERN" || fail "iccDumpProfile controlled 0x4141 pattern flag missing"
+assert_json_fields "$dump_json" "ICCDEV_FLAG_LOAD" \
+  "loadMode" "profileSize" "profileId"
+assert_json_fields "$dump_json" "ICCDEV_FLAG_VALIDATE" \
+  "validationStatus" "validationTags.0.signature" "validationTags.0.offset" "validationTags.0.size"
+assert_json_fields "$dump_json" "ICCDEV_FLAG_TAG_PAYLOAD" \
+  "qaPayload.tag" "qaPayload.offset" "qaPayload.size" "qaPayload.marker" "qaPayload.nonce" "qaPayload.controlledPattern"
+assert_json_equals "$dump_json" "qaPayload.nonce" "$qa_nonce" || fail "iccDumpProfile nonce evidence mismatch"
+write_case_summary \
+  "true-positive qaFL" \
+  "LOAD,VALIDATE,TAG_PAYLOAD,CONTROLLED_PATTERN" \
+  "LOAD,VALIDATE,TAG_PAYLOAD,CONTROLLED_PATTERN" \
+  "PASS" \
+  "load mode/profile size/profile ID, validation tag table, private qaFL marker bytes, and generated nonce"
+
+assert_json_loaded "$negative_json" true || fail "negative control did not load"
+assert_json_flag "$negative_json" "ICCDEV_FLAG_LOAD" || fail "negative control load flag missing"
+assert_json_flag "$negative_json" "ICCDEV_FLAG_VALIDATE" || fail "negative control validation flag missing"
+assert_json_no_flag "$negative_json" "ICCDEV_FLAG_TAG_PAYLOAD" || fail "negative control incorrectly emitted tag payload flag"
+assert_json_no_flag "$negative_json" "ICCDEV_FLAG_CONTROLLED_PATTERN" || fail "negative control incorrectly emitted controlled pattern flag"
+write_case_summary \
+  "negative-control fpFL" \
+  "LOAD,VALIDATE only" \
+  "LOAD,VALIDATE only" \
+  "PASS" \
+  "same marker bytes in non-qaFL tag do not trigger payload flags"
+
+assert_json_loaded "$malformed_json" false || fail "malformed control unexpectedly loaded"
+assert_json_no_flag "$malformed_json" "ICCDEV_FLAG_LOAD" || fail "malformed control incorrectly emitted load flag"
+assert_json_no_flag "$malformed_json" "ICCDEV_FLAG_TAG_PAYLOAD" || fail "malformed control incorrectly emitted payload flag"
+write_case_summary \
+  "malformed marker file" \
+  "loaded=false,no payload flags" \
+  "loaded=false,no payload flags" \
+  "PASS" \
+  "marker bytes alone are not evidence without a loadable qaFL tag"
+
+grep -q '"schema":"iccdev-qa-evidence/v1"' "$pawg_json" || fail "iccPawgReport evidence schema missing"
+assert_json_loaded "$pawg_json" true || fail "iccPawgReport did not load base profile"
+assert_json_flag "$pawg_json" "ICCDEV_FLAG_LOAD" || fail "iccPawgReport load flag missing"
+assert_json_flag "$pawg_json" "ICCDEV_FLAG_VALIDATE" || fail "iccPawgReport validation flag missing"
+write_case_summary \
+  "pawg validation evidence" \
+  "LOAD,VALIDATE" \
+  "LOAD,VALIDATE" \
+  "PASS" \
+  "second CLI emits same schema for load and validation evidence"
+
+assert_json_fields "$transform_json" "ICCDEV_FLAG_TRANSFORM" \
+  "inputDigest" "profileId" "outputDigest" \
+  "transform.inputDigest" "transform.profileId" "transform.outputDigest"
+write_case_summary \
+  "named CMM transform" \
+  "TRANSFORM input digest, profile ID, output digest" \
+  "TRANSFORM input digest, profile ID, output digest" \
+  "PASS" \
+  "iccApplyNamedCmm transformed checked-in RGB data through sRGB profile"
+
+assert_json_fields "$write_json" "ICCDEV_FLAG_WRITE" \
+  "outputDigest" "embeddedProfileId" "extractedProfileId" \
+  "write.outputDigest" "write.embeddedProfileId" "write.extractedProfileId"
+write_case_summary \
+  "tiff embedded-profile extraction" \
+  "WRITE output digest, embedded/extracted ICC profile ID" \
+  "WRITE output digest, embedded/extracted ICC profile ID" \
+  "PASS" \
+  "iccTiffDump extracted the checked-in sRGB profile from a generated TIFF"
+
+assert_json_flag "$classifier_json" "ICCDEV_FLAG_SANITIZER" || fail "sanitizer classifier flag missing"
+assert_json_flag "$classifier_json" "ICCDEV_FLAG_STACK_SMASH" || fail "stack-smash classifier flag missing"
+assert_json_flag "$classifier_json" "ICCDEV_FLAG_CONTROLLED_PATTERN" || fail "controlled-pattern classifier flag missing"
+assert_json_fields "$classifier_json" "ICCDEV_FLAG_SANITIZER" \
+  "exitClassification" "sanitizer.summary" "sanitizer.stackFrameFilePath"
+write_case_summary \
+  "sanitizer-log fixture" \
+  "SANITIZER,STACK_SMASH,CONTROLLED_PATTERN" \
+  "SANITIZER,STACK_SMASH,CONTROLLED_PATTERN" \
+  "PASS" \
+  "fixture-only sanitizer evidence includes exit classification, summary, and stack frame path"
+
+python3 - "$qa_profile" "$negative_profile" "$malformed_profile" "$evidence_ndjson" "$summary_tsv" "$summary_json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary = {
+    "schema": "iccdev-qa-target-flags-summary/v1",
+    "status": "ok",
+    "profile": sys.argv[1],
+    "negativeControlProfile": sys.argv[2],
+    "malformedControlProfile": sys.argv[3],
+    "evidence": sys.argv[4],
+    "summaryTsv": sys.argv[5],
+}
+Path(sys.argv[6]).write_text(json.dumps(summary, separators=(",", ":")) + "\n", encoding="ascii")
+PY
+
+printf '[OK] QA target flags evidence written to %s\n' "$(sanitize_line "$evidence_ndjson")"

--- a/.github/scripts/iccdev-qa-target-flags.sh
+++ b/.github/scripts/iccdev-qa-target-flags.sh
@@ -277,7 +277,11 @@ run_evidence() {
         printf '%s\n' "$(sanitize_line "$line")" >&2
       done <"$stderr_path"
     fi
-    exit "$status"
+    # Not `exit "$status"`.  The negative controls expect a NONZERO status, so
+    # exiting with the observed one turned the case they exist to catch -- the
+    # tool starting to report success for an unloadable profile -- into
+    # `exit 0`, and CTest read the whole run as PASS.
+    exit 1
   fi
 
   python3 -m json.tool "$stdout_path" >/dev/null
@@ -307,7 +311,11 @@ run_command() {
         printf '%s\n' "$(sanitize_line "$line")" >&2
       done <"$stderr_path"
     fi
-    exit "$status"
+    # Not `exit "$status"`.  The negative controls expect a NONZERO status, so
+    # exiting with the observed one turned the case they exist to catch -- the
+    # tool starting to report success for an unloadable profile -- into
+    # `exit 0`, and CTest read the whole run as PASS.
+    exit 1
   fi
 }
 

--- a/.github/scripts/iccdev-tiffdump-output-hardening-tests.sh
+++ b/.github/scripts/iccdev-tiffdump-output-hardening-tests.sh
@@ -88,7 +88,7 @@ test_extra_arg_rejected() {
     return 1
   fi
 
-  grep -Fq "Usage: iccTiffDump tiff_file {exported_icc_file}" "$log" || return 1
+  grep -Fq "Usage: iccTiffDump {--evidence-json} tiff_file {exported_icc_file}" "$log" || return 1
   [ ! -e "$dst" ]
 }
 

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5761,7 +5761,15 @@ endif()
 # already reference this test by name, so it is registered under the same gate
 # that compiles the --evidence-json code into the tools.  Registering it
 # unconditionally would fail every default build, where the flags do not exist.
-if(ICCDEV_ENABLE_QA_FLAGS)
+# The script hard-requires nine tools and its find_tool() exits 1 rather than
+# skipping when one is missing, so a QA-flags build without ENABLE_ICCXML or
+# ENABLE_ICCJSON would register a test that dies at tool discovery.
+if(ICCDEV_ENABLE_QA_FLAGS
+   AND TARGET iccDumpProfile AND TARGET iccPawgReport
+   AND TARGET iccApplyNamedCmm AND TARGET iccTiffDump
+   AND TARGET iccToXml AND TARGET iccFromXml
+   AND TARGET iccToJson AND TARGET iccFromJson
+   AND TARGET iccRoundTrip)
   iccdev_add_script_test(
     iccdev.qa-target-flags
     120

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4771,6 +4771,31 @@ endfunction()
 # loops, so the unfixed code fails by TIMEOUT; the value checks additionally
 # confirm the reduction matches an independently computed fmod, and that the
 # NaN/infinity/L-range rejections are unchanged. IccProfLib only.
+function(iccdev_add_qa_evidence_helpers_test)
+  # Header-only: IccCmdLineUtil.h is all inline, so this links no library and
+  # needs no Windows runtime PATH entries.  It is therefore platform-agnostic
+  # and registers on both the WIN32 and non-WIN32 paths below -- the omission
+  # #2237 fixed for two other tests.
+  iccdev_add_regression_executable(iccQaEvidenceHelpersTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/qa-evidence-helpers.cpp"
+  )
+  target_compile_features(iccQaEvidenceHelpersTest PRIVATE cxx_std_17)
+  target_include_directories(iccQaEvidenceHelpersTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  add_dependencies(check iccQaEvidenceHelpersTest)
+
+  add_test(
+    NAME iccdev.qa-evidence-helpers
+    COMMAND "$<TARGET_FILE:iccQaEvidenceHelpersTest>"
+  )
+  set_tests_properties(iccdev.qa-evidence-helpers PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;qa-flags;issue-1853;regression"
+  )
+endfunction()
+
 function(iccdev_add_prmg_hue_normalization_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -5324,6 +5349,7 @@ if(WIN32)
   iccdev_add_applytolink_invalid_arg_test()
   iccdev_add_applytolink_v4_missing_desc_test()
   iccdev_add_prmg_hue_normalization_test()
+  iccdev_add_qa_evidence_helpers_test()
   iccdev_add_windows_iccdevcmm_smoke_test()
   iccdev_add_zip_utf8_text_zlib_test()
 
@@ -5623,6 +5649,7 @@ iccdev_add_iccprofileplot_clut_oob_test()
 iccdev_add_iccprofileplot_pdf_leak_test()
 iccdev_add_iccprofileplot_exitcode_test()
 iccdev_add_prmg_hue_normalization_test()
+iccdev_add_qa_evidence_helpers_test()
 iccdev_add_zip_utf8_text_zlib_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5729,6 +5729,21 @@ if(TARGET iccFromXml AND TARGET iccApplyNamedCmm AND TARGET iccApplySearch)
   )
 endif()
 
+# Maintainer QA evidence CLI (#1853).  The ICCDEV_ENABLE_QA_FLAGS option, the
+# *-qa-flags CMake presets, the CI lanes that set it, and docs/build.md all
+# already reference this test by name, so it is registered under the same gate
+# that compiles the --evidence-json code into the tools.  Registering it
+# unconditionally would fail every default build, where the flags do not exist.
+if(ICCDEV_ENABLE_QA_FLAGS)
+  iccdev_add_script_test(
+    iccdev.qa-target-flags
+    120
+    "iccdev;qa-flags;issue-1853;asan"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-qa-target-flags.sh"
+  )
+endif()
+
 iccdev_add_script_test(
   iccdev.specsep-tiff-geometry-regression
   120

--- a/IccProfLib/IccCmdLineUtil.h
+++ b/IccProfLib/IccCmdLineUtil.h
@@ -65,12 +65,22 @@
 #define ICC_CMD_LINE_UTIL_H
 
 #include <cstdio>
+#include <cstring>
+#include <iomanip>
+#include <sstream>
 #include <string>
+#include <vector>
 
 #if !defined(_WIN32)
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#endif
+
+#if defined(__clang__)
+#define ICC_CMDLINE_NO_SANITIZE_INTEGER __attribute__((no_sanitize("integer")))
+#else
+#define ICC_CMDLINE_NO_SANITIZE_INTEGER
 #endif
 
 /******************************************************************************/
@@ -202,6 +212,175 @@ inline std::string icSanitizeFileName(const std::string& text)
 }
 
 /******************************************************************************/
+
+inline std::string icJsonEscape(const char* szText)
+{
+  static const char hex[] = "0123456789abcdef";
+  std::string result;
+
+  if (!szText)
+    return result;
+
+  for (const unsigned char *p = (const unsigned char*)szText; *p; p++) {
+    unsigned char ch = *p;
+    switch (ch) {
+    case '"':
+      result += "\\\"";
+      break;
+    case '\\':
+      result += "\\\\";
+      break;
+    case '\b':
+      result += "\\b";
+      break;
+    case '\f':
+      result += "\\f";
+      break;
+    case '\n':
+      result += "\\n";
+      break;
+    case '\r':
+      result += "\\r";
+      break;
+    case '\t':
+      result += "\\t";
+      break;
+    default:
+      if (ch < 0x20) {
+        result += "\\u00";
+        result += hex[(ch >> 4) & 0xf];
+        result += hex[ch & 0xf];
+      }
+      else {
+        result += (char)ch;
+      }
+      break;
+    }
+  }
+
+  return result;
+}
+
+inline std::string icJsonEscape(const std::string& text)
+{
+  return icJsonEscape(text.c_str());
+}
+
+inline ICC_CMDLINE_NO_SANITIZE_INTEGER unsigned int icSha256Rotr(unsigned int x, unsigned int n)
+{
+  return (x >> n) | (x << (32 - n));
+}
+
+inline ICC_CMDLINE_NO_SANITIZE_INTEGER std::string icSha256Bytes(const unsigned char* data, size_t len)
+{
+  static const unsigned int k[64] = {
+    0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U,
+    0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
+    0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U,
+    0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U, 0xc19bf174U,
+    0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU,
+    0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU,
+    0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U,
+    0xc6e00bf3U, 0xd5a79147U, 0x06ca6351U, 0x14292967U,
+    0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU, 0x53380d13U,
+    0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
+    0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U,
+    0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U,
+    0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U,
+    0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
+    0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
+    0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U
+  };
+  unsigned int h[8] = {
+    0x6a09e667U, 0xbb67ae85U, 0x3c6ef372U, 0xa54ff53aU,
+    0x510e527fU, 0x9b05688cU, 0x1f83d9abU, 0x5be0cd19U
+  };
+  std::vector<unsigned char> msg(data, data + len);
+  unsigned long long bitLen = (unsigned long long)len * 8ULL;
+  msg.push_back(0x80);
+  while ((msg.size() % 64) != 56)
+    msg.push_back(0);
+  for (int i = 7; i >= 0; i--)
+    msg.push_back((unsigned char)((bitLen >> (i * 8)) & 0xff));
+
+  for (size_t chunk = 0; chunk < msg.size(); chunk += 64) {
+    unsigned int w[64];
+    for (int i = 0; i < 16; i++) {
+      size_t j = chunk + (size_t)i * 4;
+      w[i] = ((unsigned int)msg[j] << 24) |
+             ((unsigned int)msg[j + 1] << 16) |
+             ((unsigned int)msg[j + 2] << 8) |
+             ((unsigned int)msg[j + 3]);
+    }
+    for (int i = 16; i < 64; i++) {
+      unsigned int s0 = icSha256Rotr(w[i - 15], 7) ^
+                        icSha256Rotr(w[i - 15], 18) ^ (w[i - 15] >> 3);
+      unsigned int s1 = icSha256Rotr(w[i - 2], 17) ^
+                        icSha256Rotr(w[i - 2], 19) ^ (w[i - 2] >> 10);
+      w[i] = w[i - 16] + s0 + w[i - 7] + s1;
+    }
+
+    unsigned int a = h[0], b = h[1], c = h[2], d = h[3];
+    unsigned int e = h[4], f = h[5], g = h[6], hh = h[7];
+    for (int i = 0; i < 64; i++) {
+      unsigned int s1 = icSha256Rotr(e, 6) ^ icSha256Rotr(e, 11) ^
+                        icSha256Rotr(e, 25);
+      unsigned int ch = (e & f) ^ ((~e) & g);
+      unsigned int temp1 = hh + s1 + ch + k[i] + w[i];
+      unsigned int s0 = icSha256Rotr(a, 2) ^ icSha256Rotr(a, 13) ^
+                        icSha256Rotr(a, 22);
+      unsigned int maj = (a & b) ^ (a & c) ^ (b & c);
+      unsigned int temp2 = s0 + maj;
+      hh = g;
+      g = f;
+      f = e;
+      e = d + temp1;
+      d = c;
+      c = b;
+      b = a;
+      a = temp1 + temp2;
+    }
+    h[0] += a; h[1] += b; h[2] += c; h[3] += d;
+    h[4] += e; h[5] += f; h[6] += g; h[7] += hh;
+  }
+
+  std::ostringstream out;
+  out << "sha256:";
+  for (int i = 0; i < 8; i++)
+    out << std::hex << std::setfill('0') << std::setw(8) << h[i];
+  return out.str();
+}
+
+inline bool icReadFileBytes(const char* path, std::vector<unsigned char>& bytes)
+{
+  if (!path || !path[0])
+    return false;
+
+  FILE* f = fopen(path, "rb");
+  if (!f)
+    return false;
+
+  bytes.clear();
+  unsigned char buf[4096];
+  size_t n;
+  while ((n = fread(buf, 1, sizeof(buf), f)) > 0)
+    bytes.insert(bytes.end(), buf, buf + n);
+
+  bool ok = ferror(f) == 0;
+  fclose(f);
+  return ok;
+}
+
+inline bool icSha256File(const char* path, std::string& digest)
+{
+  std::vector<unsigned char> bytes;
+  if (!icReadFileBytes(path, bytes))
+    return false;
+
+  digest = icSha256Bytes(bytes.empty() ? (const unsigned char*)"" : &bytes[0],
+                         bytes.size());
+  return true;
+}
 
 inline FILE* icOpenRegularWriteFile(const char* szFname, const char* szMode)
 {

--- a/IccProfLib/IccCmdLineUtil.h
+++ b/IccProfLib/IccCmdLineUtil.h
@@ -213,6 +213,64 @@ inline std::string icSanitizeFileName(const std::string& text)
 
 /******************************************************************************/
 
+// Length of the well-formed UTF-8 sequence starting at p, or 0 if p does not
+// start one.  This is Unicode 15.0 table 3-7 verbatim, so it rejects the things
+// a naive "0xC0-0xFF starts a sequence" test lets through: over-long encodings,
+// UTF-16 surrogates (ED A0..BF), and anything above U+10FFFF.
+inline size_t icUtf8SequenceLength(const unsigned char* p)
+{
+  const unsigned char c = p[0];
+
+  if (c < 0x80)
+    return 1;
+
+  // A continuation byte or an over-long lead (C0/C1) cannot start a sequence.
+  if (c < 0xc2)
+    return 0;
+
+  if (c <= 0xdf)
+    return (p[1] >= 0x80 && p[1] <= 0xbf) ? 2 : 0;
+
+  if (c <= 0xef) {
+    const unsigned char lo = (c == 0xe0) ? 0xa0 : 0x80;   // no over-long
+    const unsigned char hi = (c == 0xed) ? 0x9f : 0xbf;   // no surrogates
+    if (p[1] < lo || p[1] > hi)
+      return 0;
+    return (p[2] >= 0x80 && p[2] <= 0xbf) ? 3 : 0;
+  }
+
+  if (c <= 0xf4) {
+    const unsigned char lo = (c == 0xf0) ? 0x90 : 0x80;   // no over-long
+    const unsigned char hi = (c == 0xf4) ? 0x8f : 0xbf;   // no > U+10FFFF
+    if (p[1] < lo || p[1] > hi)
+      return 0;
+    if (p[2] < 0x80 || p[2] > 0xbf)
+      return 0;
+    return (p[3] >= 0x80 && p[3] <= 0xbf) ? 4 : 0;
+  }
+
+  return 0;
+}
+
+// Escape a string for use as a JSON string value.
+//
+// Bytes at or above 0x80 are passed through when, and only when, they form a
+// well-formed UTF-8 sequence.  Both halves of that rule are load-bearing (#1853):
+//
+//   - Escaping them as \u00XX, which PawgReport.cpp used to do, reads a UTF-8
+//     byte as if it were a code point.  U+00E9 is the two bytes C3 A9, which
+//     come out as \u00c3\u00a9 -- the two code points U+00C3 U+00A9 -- so
+//     "cafe" with an acute e reads back with two wrong characters in its place.
+//     The document is valid JSON and the text in it is wrong.
+//   - Passing them through unconditionally is no better.  A JSON text must be
+//     valid UTF-8 (RFC 8259 section 8.1), and these strings include paths taken
+//     straight from argv, which on POSIX are byte strings that need not be UTF-8
+//     at all.  A Latin-1 filename would put a lone 0xE9 inside a string and the
+//     document would not decode.
+//
+// A byte that is not part of a well-formed sequence is therefore replaced with
+// U+FFFD.  Substituting \u00XX instead would assert the byte was Latin-1, which
+// is a guess; U+FFFD records that the input was not text, which is the fact.
 inline std::string icJsonEscape(const char* szText)
 {
   static const char hex[] = "0123456789abcdef";
@@ -221,41 +279,69 @@ inline std::string icJsonEscape(const char* szText)
   if (!szText)
     return result;
 
-  for (const unsigned char *p = (const unsigned char*)szText; *p; p++) {
+  for (const unsigned char *p = (const unsigned char*)szText; *p; ) {
     unsigned char ch = *p;
+
     switch (ch) {
     case '"':
       result += "\\\"";
-      break;
+      p++;
+      continue;
     case '\\':
       result += "\\\\";
-      break;
+      p++;
+      continue;
     case '\b':
       result += "\\b";
-      break;
+      p++;
+      continue;
     case '\f':
       result += "\\f";
-      break;
+      p++;
+      continue;
     case '\n':
       result += "\\n";
-      break;
+      p++;
+      continue;
     case '\r':
       result += "\\r";
-      break;
+      p++;
+      continue;
     case '\t':
       result += "\\t";
-      break;
+      p++;
+      continue;
     default:
-      if (ch < 0x20) {
-        result += "\\u00";
-        result += hex[(ch >> 4) & 0xf];
-        result += hex[ch & 0xf];
-      }
-      else {
-        result += (char)ch;
-      }
       break;
     }
+
+    if (ch < 0x20) {
+      result += "\\u00";
+      result += hex[(ch >> 4) & 0xf];
+      result += hex[ch & 0xf];
+      p++;
+      continue;
+    }
+
+    if (ch < 0x80) {
+      result += (char)ch;
+      p++;
+      continue;
+    }
+
+    // icUtf8SequenceLength() reads up to three bytes past p.  That is safe here
+    // because it stops at the first byte outside the continuation range, and the
+    // terminating NUL is outside it -- a truncated sequence at the end of the
+    // string returns 0 rather than reading past the terminator.
+    size_t len = icUtf8SequenceLength(p);
+    if (!len) {
+      result += "\\ufffd";
+      p++;
+      continue;
+    }
+
+    result.append((const char*)p, len);
+    p += len;
   }
 
   return result;

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -202,7 +202,7 @@ void Usage()
 
   printf("Usage 1: iccApplyNamedCmm -cfg config_file_path\n");
   printf("  Where config_file_path is a json formatted ICC profile application configuration file\n\n");
-  printf("Usage 2: iccApplyNamedCmm (-exportcfg/-exportcfganddata config_file_path} {-debugcalc} data_file_path final_data_encoding{:FmtPrecision{:FmtDigits}} interpolation {{-ENV:Name value} profile_file_path Rendering_intent {-PCC connection_conditions_path}}\n\n");
+  printf("Usage 2: iccApplyNamedCmm {--evidence-json} (-exportcfg/-exportcfganddata config_file_path} {-debugcalc} data_file_path final_data_encoding{:FmtPrecision{:FmtDigits}} interpolation {{-ENV:Name value} profile_file_path Rendering_intent {-PCC connection_conditions_path}}\n\n");
   
   printf("  For final_data_encoding:\n");
   printf("    0 - icEncodeValue (converts to/from lab encoding when samples=3)\n");
@@ -265,12 +265,80 @@ void Usage()
   printf(" +2000000 - NamedColor over gray  (icSigNmclSpectralOverGrayMbr 'spcg')\n");
 }
 
+static std::string GetProfileId(const char* profilePath)
+{
+  if (!profilePath || !profilePath[0])
+    return std::string();
+
+  CIccProfile* pProfile = OpenIccProfile(profilePath);
+  if (!pProfile)
+    return std::string();
+
+  CIccInfo Fmt;
+  std::string id;
+  if (Fmt.IsProfileIDCalculated(&pProfile->m_Header.profileID))
+    id = Fmt.GetProfileID(&pProfile->m_Header.profileID);
+  delete pProfile;
+  return id;
+}
+
+static void EmitTransformEvidenceJson(const char* inputPath, const char* profilePath,
+                                      const char* outputPath)
+{
+  std::string inputDigest;
+  std::string outputDigest;
+  std::string profileId = GetProfileId(profilePath);
+  bool hasInputDigest = icSha256File(inputPath, inputDigest);
+  bool hasOutputDigest = icSha256File(outputPath, outputDigest);
+
+  printf("{");
+  printf("\"schema\":\"iccdev-qa-evidence/v1\",");
+  printf("\"tool\":\"iccApplyNamedCmm\",");
+  printf("\"input\":\"%s\",", icJsonEscape(inputPath).c_str());
+  printf("\"profile\":\"%s\",", icJsonEscape(profilePath).c_str());
+  printf("\"output\":\"%s\",", icJsonEscape(outputPath).c_str());
+  printf("\"qaFlags\":[\"ICCDEV_FLAG_TRANSFORM\"],");
+  if (hasInputDigest)
+    printf("\"inputDigest\":\"%s\",", inputDigest.c_str());
+  else
+    printf("\"inputDigest\":null,");
+  if (!profileId.empty())
+    printf("\"profileId\":\"%s\",", icJsonEscape(profileId).c_str());
+  else
+    printf("\"profileId\":null,");
+  if (hasOutputDigest)
+    printf("\"outputDigest\":\"%s\",", outputDigest.c_str());
+  else
+    printf("\"outputDigest\":null,");
+  printf("\"transform\":{");
+  if (hasInputDigest)
+    printf("\"inputDigest\":\"%s\",", inputDigest.c_str());
+  else
+    printf("\"inputDigest\":null,");
+  if (!profileId.empty())
+    printf("\"profileId\":\"%s\",", icJsonEscape(profileId).c_str());
+  else
+    printf("\"profileId\":null,");
+  if (hasOutputDigest)
+    printf("\"outputDigest\":\"%s\"", outputDigest.c_str());
+  else
+    printf("\"outputDigest\":null");
+  printf("}}\n");
+}
 
 //===================================================
 
 int main(int argc, const char* argv[])
 {
   int minargs = 2;
+  bool bEvidenceJson = false;
+
+  if (argc > 1 && !stricmp(argv[1], "--evidence-json")) {
+    bEvidenceJson = true;
+    argv++;
+    argc--;
+  }
+
   if (argc < minargs) {
     Usage();
     return 0;
@@ -708,6 +776,13 @@ int main(int argc, const char* argv[])
     delete pMruCmm;
 
     return EXIT_FAILURE;
+  }
+
+  if (bEvidenceJson) {
+    const char* profilePath = cfgProfiles.m_profiles.empty() ? "" :
+      cfgProfiles.m_profiles[0]->m_iccFile.c_str();
+    EmitTransformEvidenceJson(cfgApply.m_srcFile.c_str(), profilePath,
+                              cfgApply.m_dstFile.c_str());
   }
 
   delete pMruCmm;

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -200,9 +200,9 @@ void Usage()
 {
   printf("iccApplyNamedCmm built with IccProfLib version " ICCPROFLIBVER ", IccLibConnect Version " ICCLIBCONNECTVER "\n\n");
 
-  printf("Usage 1: iccApplyNamedCmm -cfg config_file_path\n");
+  printf("Usage 1: iccApplyNamedCmm {--evidence-json} -cfg config_file_path\n");
   printf("  Where config_file_path is a json formatted ICC profile application configuration file\n\n");
-  printf("Usage 2: iccApplyNamedCmm {--evidence-json} (-exportcfg/-exportcfganddata config_file_path} {-debugcalc} data_file_path final_data_encoding{:FmtPrecision{:FmtDigits}} interpolation {{-ENV:Name value} profile_file_path Rendering_intent {-PCC connection_conditions_path}}\n\n");
+  printf("Usage 2: iccApplyNamedCmm (-exportcfg/-exportcfganddata config_file_path} {-debugcalc} data_file_path final_data_encoding{:FmtPrecision{:FmtDigits}} interpolation {{-ENV:Name value} profile_file_path Rendering_intent {-PCC connection_conditions_path}}\n\n");
   
   printf("  For final_data_encoding:\n");
   printf("    0 - icEncodeValue (converts to/from lab encoding when samples=3)\n");
@@ -498,6 +498,21 @@ int main(int argc, const char* argv[])
       }
     }
   }
+  // Usage 2 has no destination file -- CIccCfgDataApply::fromArgs clears
+  // m_dstFile unconditionally -- and icOpenRegularWriteFile() returns stdout
+  // for an empty name.  The transformed dataset would therefore go to the same
+  // stream as the evidence: --evidence-json there emitted colour data with a
+  // JSON object stapled to the end, which no parser accepts, and an
+  // outputDigest that was always null.  --evidence-json is a -cfg-with-dstFile
+  // mode, the only form docs/tools-cli-reference.md shows.  Checked here, where
+  // both config paths join, so the refusal costs no transform and writes
+  // nothing.
+  if (bEvidenceJson && cfgApply.m_dstFile.empty()) {
+    fprintf(stderr, "--evidence-json requires a configuration with dstFile set:"
+                    " the transform output would share stdout with the evidence\n");
+    return EXIT_FAILURE;
+  }
+
   LogDebuggerPtr pDebugger;
   
   if (cfgApply.m_debugCalc) {
@@ -784,6 +799,7 @@ int main(int argc, const char* argv[])
     EmitTransformEvidenceJson(cfgApply.m_srcFile.c_str(), profilePath,
                               cfgApply.m_dstFile.c_str());
   }
+
 
   delete pMruCmm;
 

--- a/Tools/CmdLine/IccDumpProfile/Readme.md
+++ b/Tools/CmdLine/IccDumpProfile/Readme.md
@@ -14,6 +14,31 @@ iccDumpProfile
 Validation messages start with `Warning!`, `Error!`, or `NonCompliant!`. The
 overall validation status appears near the `Validation Report` section.
 
+## QA target flag evidence
+
+Builds configured with `-DICCDEV_ENABLE_QA_FLAGS=ON` also accept
+`--qa-flags --evidence-json`. This mode is for maintainer QA and CI evidence,
+not normal user-facing dump output. It emits one JSON object using schema
+`iccdev-qa-evidence/v1`.
+
+```sh
+iccDumpProfile --qa-flags --evidence-json --diag -v 100 profile.icc
+```
+
+The evidence can include these QA flags:
+
+| Flag | Meaning |
+|------|---------|
+| `ICCDEV_FLAG_LOAD` | The profile loaded successfully, with load mode, profile size, and profile ID. |
+| `ICCDEV_FLAG_VALIDATE` | Validation was requested, with validation status and tag signature/offset/size evidence. |
+| `ICCDEV_FLAG_TAG_PAYLOAD` | A private `qaFL` QA tag carried the expected marker and generated nonce when present. |
+| `ICCDEV_FLAG_CONTROLLED_PATTERN` | The `qaFL` payload included controlled `0x41` bytes. |
+
+The CTest `iccdev.qa-target-flags` generates deterministic true-positive,
+negative-control, malformed marker-only, transform, embedded-profile extraction,
+and sanitizer-log fixture evidence. CI writes a sanitized summary table and raw
+evidence to the GitHub Actions job summary.
+
 ## See Also
 
 - [CLI tool reference](../../../docs/tools-cli-reference.md)

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -75,6 +75,7 @@
 #include <climits>
 #include <cstdlib>
 #include <cerrno>
+#include <string>
 #include <vector>
 #include <unordered_map>
 #include <sys/stat.h>
@@ -99,6 +100,224 @@ static bool g_bDiagMode = false;
 
 // Diagnostic logging macros
 #define DIAG(...) do { if (g_bDiagMode) { fprintf(stderr, "[DIAG] "); fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } } while(0)
+
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+static const char *kQaEvidenceSchema = "iccdev-qa-evidence/v1";
+static const char *kQaPayloadMarker = "ICCDEV_QA_TARGET_FLAG_41414141";
+static const char *kQaNoncePrefix = "ICCDEV_QA_NONCE_";
+static const unsigned char kQaControlledBytes[] = {
+  0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41,
+  0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41
+};
+
+static std::string JsonEscape(const char *sz)
+{
+  std::string out;
+  if (!sz)
+    return out;
+
+  for (const unsigned char *p = (const unsigned char*)sz; *p; ++p) {
+    switch (*p) {
+    case '\\': out += "\\\\"; break;
+    case '"': out += "\\\""; break;
+    case '\b': out += "\\b"; break;
+    case '\f': out += "\\f"; break;
+    case '\n': out += "\\n"; break;
+    case '\r': out += "\\r"; break;
+    case '\t': out += "\\t"; break;
+    default:
+      if (*p < 0x20) {
+        char buf[8];
+        snprintf(buf, sizeof(buf), "\\u%04x", (unsigned int)*p);
+        out += buf;
+      }
+      else {
+        out += (char)*p;
+      }
+      break;
+    }
+  }
+
+  return out;
+}
+
+static const char *ValidationStatusName(icValidateStatus nStatus)
+{
+  switch (nStatus) {
+  case icValidateOK:
+    return "ok";
+  case icValidateWarning:
+    return "warning";
+  case icValidateNonCompliant:
+    return "non_compliant";
+  case icValidateCriticalError:
+    return "critical_error";
+  default:
+    return "unknown";
+  }
+}
+
+static bool FindQaPayloadTag(const char *profilePath, CIccProfile *pIcc,
+                             icUInt32Number &offset, icUInt32Number &size,
+                             bool &bHasControlledBytes, std::string &nonce)
+{
+  bHasControlledBytes = false;
+  nonce.clear();
+  if (!profilePath || !pIcc)
+    return false;
+
+  const icTagSignature qaSig = (icTagSignature)icGetSigVal("qaFL");
+  bool found = false;
+  TagEntryList::iterator it;
+
+  for (it = pIcc->m_Tags.begin(); it != pIcc->m_Tags.end(); ++it) {
+    if (it->TagInfo.sig == qaSig) {
+      offset = it->TagInfo.offset;
+      size = it->TagInfo.size;
+      found = true;
+      break;
+    }
+  }
+
+  if (!found || size == 0 || size > 65536)
+    return false;
+
+  FILE *fp = fopen(profilePath, "rb");
+  if (!fp)
+    return false;
+
+  bool markerFound = false;
+  bool offsetFitsLong = true;
+#if LONG_MAX < 4294967295LL
+    offsetFitsLong = offset <= (icUInt32Number)LONG_MAX;
+#endif
+  if (offsetFitsLong && fseek(fp, (long)offset, SEEK_SET) == 0) {
+    std::vector<char> payload((size_t)size + 1, 0);
+    size_t nRead = fread(payload.data(), 1, (size_t)size, fp);
+    if (nRead == (size_t)size) {
+      const char *markerEnd = kQaPayloadMarker + strlen(kQaPayloadMarker);
+      markerFound = std::search(payload.begin(), payload.begin() + nRead,
+                                kQaPayloadMarker, markerEnd) != payload.begin() + nRead;
+      bHasControlledBytes =
+        std::search(payload.begin(), payload.begin() + nRead,
+                    kQaControlledBytes,
+                    kQaControlledBytes + sizeof(kQaControlledBytes)) != payload.begin() + nRead;
+
+      std::string payloadText(payload.data(), nRead);
+      size_t noncePos = payloadText.find(kQaNoncePrefix);
+      if (noncePos != std::string::npos) {
+        size_t nonceEnd = noncePos;
+        while (nonceEnd < payloadText.size()) {
+          unsigned char ch = (unsigned char)payloadText[nonceEnd];
+          if (!((ch >= 'A' && ch <= 'Z') ||
+                (ch >= '0' && ch <= '9') ||
+                ch == '_')) {
+            break;
+          }
+          nonceEnd++;
+        }
+        nonce = payloadText.substr(noncePos, nonceEnd - noncePos);
+      }
+    }
+  }
+
+  fclose(fp);
+  return markerFound;
+}
+
+static void EmitQaValidationTagTable(CIccProfile *pIcc, bool bDumpValidation)
+{
+  printf("\"validationTags\":[");
+  if (pIcc && bDumpValidation) {
+    bool wroteTag = false;
+    const size_t bufSize = 64;
+    char buf[bufSize];
+    TagEntryList::iterator it;
+
+    for (it = pIcc->m_Tags.begin(); it != pIcc->m_Tags.end(); ++it) {
+      printf("%s{\"signature\":\"%s\",\"offset\":%u,\"size\":%u}",
+             wroteTag ? "," : "",
+             JsonEscape(icGetSig(buf, bufSize, it->TagInfo.sig)).c_str(),
+             (unsigned int)it->TagInfo.offset,
+             (unsigned int)it->TagInfo.size);
+      wroteTag = true;
+    }
+  }
+  printf("],");
+}
+
+static int EmitQaEvidenceJson(const char *profilePath, CIccProfile *pIcc,
+                              icValidateStatus nStatus, bool bDumpValidation,
+                              bool bUseRead, int verbosity)
+{
+  CIccInfo Fmt;
+  bool bHasPayload = false;
+  bool bHasControlledBytes = false;
+  std::string qaNonce;
+  icUInt32Number payloadOffset = 0;
+  icUInt32Number payloadSize = 0;
+
+  if (pIcc)
+    bHasPayload = FindQaPayloadTag(profilePath, pIcc, payloadOffset, payloadSize,
+                                   bHasControlledBytes, qaNonce);
+
+  printf("{");
+  printf("\"schema\":\"%s\",", kQaEvidenceSchema);
+  printf("\"tool\":\"iccDumpProfile\",");
+  printf("\"profile\":\"%s\",", JsonEscape(profilePath).c_str());
+  printf("\"loadMode\":\"%s\",", bUseRead ? "ReadIccProfile" : "OpenIccProfile");
+  printf("\"validationRequested\":%s,", bDumpValidation ? "true" : "false");
+  printf("\"validationStatus\":\"%s\",", ValidationStatusName(nStatus));
+  printf("\"verbosity\":%d,", verbosity);
+  printf("\"loaded\":%s,", pIcc ? "true" : "false");
+
+  if (pIcc) {
+    icHeader *pHdr = &pIcc->m_Header;
+    printf("\"profileSize\":%u,", (unsigned int)pHdr->size);
+    if (Fmt.IsProfileIDCalculated(&pHdr->profileID))
+      printf("\"profileId\":\"%s\",", JsonEscape(Fmt.GetProfileID(&pHdr->profileID)).c_str());
+    else
+      printf("\"profileId\":null,");
+    printf("\"tagCount\":%u,", (unsigned int)pIcc->m_Tags.size());
+  }
+  else {
+    printf("\"profileSize\":null,\"profileId\":null,\"tagCount\":0,");
+  }
+
+  EmitQaValidationTagTable(pIcc, bDumpValidation);
+
+  printf("\"qaFlags\":[");
+  bool wroteFlag = false;
+  if (pIcc) {
+    printf("\"ICCDEV_FLAG_LOAD\"");
+    wroteFlag = true;
+  }
+  if (pIcc && bDumpValidation) {
+    printf("%s\"ICCDEV_FLAG_VALIDATE\"", wroteFlag ? "," : "");
+    wroteFlag = true;
+  }
+  if (bHasPayload) {
+    printf("%s\"ICCDEV_FLAG_TAG_PAYLOAD\"", wroteFlag ? "," : "");
+    wroteFlag = true;
+  }
+  if (bHasPayload && bHasControlledBytes) {
+    printf("%s\"ICCDEV_FLAG_CONTROLLED_PATTERN\"", wroteFlag ? "," : "");
+  }
+  printf("]");
+
+  if (bHasPayload) {
+    printf(",\"qaPayload\":{\"tag\":\"qaFL\",\"offset\":%u,\"size\":%u,\"marker\":\"%s\",",
+           (unsigned int)payloadOffset, (unsigned int)payloadSize, kQaPayloadMarker);
+    printf("\"controlledPattern\":\"%s\"", bHasControlledBytes ? "0x41414141" : "");
+    if (!qaNonce.empty())
+      printf(",\"nonce\":\"%s\"", JsonEscape(qaNonce.c_str()).c_str());
+    printf("}");
+  }
+
+  printf("}\n");
+  return pIcc ? 0 : 1;
+}
+#endif
 
 static const char* GetLateBindingNote(icElemTypeSignature sig)
 {
@@ -203,11 +422,17 @@ bool DumpTagEntry(CIccProfile *pIcc, IccTagEntry &entry, int nVerboseness)
 
 void printUsage(void)
 {
-    printf("Usage: iccDumpProfile {-v} {int} {--diag} {--read} profile {tagId to dump/\"ALL\"}\n");
+    printf("Usage: iccDumpProfile {-v} {int} {--diag} {--read} {--qa-flags} {--evidence-json} profile {tagId to dump/\"ALL\"}\n");
     printf("\nThe -v option causes profile validation to be performed.\n"
            "The optional integer parameter specifies verboseness of output (1-100, default=100).\n"
            "  --diag   Enable diagnostic mode (size checks, load tracing to stderr)\n"
            "  --read   Use ReadIccProfile (eager load) instead of OpenIccProfile (lazy)\n");
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+    printf("  --qa-flags      Enable QA target flag detection for supported evidence modes\n"
+           "  --evidence-json Emit schema-versioned QA evidence JSON and suppress normal text output\n");
+#else
+    printf("  --qa-flags and --evidence-json require ICCDEV_ENABLE_QA_FLAGS=ON at build time\n");
+#endif
     printf("iccDumpProfile built with IccProfLib version " ICCPROFLIBVER "\n\n");
 }
 
@@ -345,25 +570,61 @@ int main(int argc, char* argv[])
   icValidateStatus nStatus = icValidateOK;
   bool bDumpValidation = false;
   bool bUseRead = false;
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+  bool bEvidenceJson = false;
+  bool bQaFlags = false;
+#endif
 
-  // Consume --diag and --read flags from anywhere in argv
-  for (int k = 1; k < argc; k++) {
+  // Consume position-independent flags from anywhere in argv.
+  int k = 1;
+  while (k < argc) {
+    bool bConsumedFlag = false;
     if (strcmp(argv[k], "--diag") == 0) {
       g_bDiagMode = true;
-      // Shift remaining args left
-      for (int m = k; m < argc - 1; m++)
-        argv[m] = argv[m + 1];
-      argc--;
-      k--;  // re-check this position
+      bConsumedFlag = true;
     }
     else if (strcmp(argv[k], "--read") == 0) {
       bUseRead = true;
+      bConsumedFlag = true;
+    }
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+    else if (strcmp(argv[k], "--qa-flags") == 0) {
+      bQaFlags = true;
+      bConsumedFlag = true;
+    }
+    else if (strcmp(argv[k], "--evidence-json") == 0) {
+      bEvidenceJson = true;
+      bQaFlags = true;
+      bConsumedFlag = true;
+    }
+#else
+    else if (strcmp(argv[k], "--qa-flags") == 0 || strcmp(argv[k], "--evidence-json") == 0) {
+      fprintf(stderr, "QA target flags require ICCDEV_ENABLE_QA_FLAGS=ON at build time\n");
+      return 1;
+    }
+#endif
+
+    if (bConsumedFlag) {
       for (int m = k; m < argc - 1; m++)
         argv[m] = argv[m + 1];
       argc--;
-      k--;
+    }
+    else {
+      k++;
     }
   }
+
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+  // --evidence-json is the only evidence mode iccDumpProfile has, so it turns
+  // --qa-flags on by itself.  Rejecting --qa-flags on its own is what stops the
+  // flag from being decorative: it was parsed, consumed and then thrown away
+  // with a (void) cast, so `--qa-flags profile.icc` silently produced an
+  // ordinary text dump and exit 0.  iccPawgReport rejects the same combination.
+  if (bQaFlags && !bEvidenceJson) {
+    fprintf(stderr, "--qa-flags requires --evidence-json for iccDumpProfile\n");
+    return 1;
+  }
+#endif
 
   if (argc <= 1) {
     printUsage();
@@ -418,6 +679,14 @@ int main(int argc, char* argv[])
 
     pIcc = bUseRead ? ReadIccProfile(argv[nArg]) : OpenIccProfile(argv[nArg]);
   }
+
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+  if (bEvidenceJson) {
+    int rc = EmitQaEvidenceJson(argv[nArg], pIcc, nStatus, bDumpValidation, bUseRead, verbosity);
+    delete pIcc;
+    return rc;
+  }
+#endif
 
   CIccInfo Fmt;
   icHeader* pHdr = NULL;

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -234,7 +234,12 @@ static int EmitQaEvidenceJson(const char *profilePath, CIccProfile *pIcc,
   printf("\"schema\":\"%s\",", kQaEvidenceSchema);
   printf("\"tool\":\"iccDumpProfile\",");
   printf("\"profile\":\"%s\",", icJsonEscape(profilePath).c_str());
-  printf("\"loadMode\":\"%s\",", bUseRead ? "ReadIccProfile" : "OpenIccProfile");
+  // -v does not load through either of these: it routes through
+  // ValidateIccProfile() and ignores bUseRead entirely, so reporting
+  // "OpenIccProfile" there named a function the run never called.
+  printf("\"loadMode\":\"%s\",",
+         bDumpValidation ? "ValidateIccProfile" :
+         (bUseRead ? "ReadIccProfile" : "OpenIccProfile"));
   printf("\"validationRequested\":%s,", bDumpValidation ? "true" : "false");
   printf("\"validationStatus\":\"%s\",", ValidationStatusName(nStatus));
   printf("\"verbosity\":%d,", verbosity);
@@ -391,7 +396,12 @@ bool DumpTagEntry(CIccProfile *pIcc, IccTagEntry &entry, int nVerboseness)
 
 void printUsage(void)
 {
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
     printf("Usage: iccDumpProfile {-v} {int} {--diag} {--read} {--qa-flags} {--evidence-json} profile {tagId to dump/\"ALL\"}\n");
+#else
+    // The default build rejects both flags, so the synopsis must not offer them.
+    printf("Usage: iccDumpProfile {-v} {int} {--diag} {--read} profile {tagId to dump/\"ALL\"}\n");
+#endif
     printf("\nThe -v option causes profile validation to be performed.\n"
            "The optional integer parameter specifies verboseness of output (1-100, default=100).\n"
            "  --diag   Enable diagnostic mode (size checks, load tracing to stderr)\n"

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -110,37 +110,6 @@ static const unsigned char kQaControlledBytes[] = {
   0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41, 0x41
 };
 
-static std::string JsonEscape(const char *sz)
-{
-  std::string out;
-  if (!sz)
-    return out;
-
-  for (const unsigned char *p = (const unsigned char*)sz; *p; ++p) {
-    switch (*p) {
-    case '\\': out += "\\\\"; break;
-    case '"': out += "\\\""; break;
-    case '\b': out += "\\b"; break;
-    case '\f': out += "\\f"; break;
-    case '\n': out += "\\n"; break;
-    case '\r': out += "\\r"; break;
-    case '\t': out += "\\t"; break;
-    default:
-      if (*p < 0x20) {
-        char buf[8];
-        snprintf(buf, sizeof(buf), "\\u%04x", (unsigned int)*p);
-        out += buf;
-      }
-      else {
-        out += (char)*p;
-      }
-      break;
-    }
-  }
-
-  return out;
-}
-
 static const char *ValidationStatusName(icValidateStatus nStatus)
 {
   switch (nStatus) {
@@ -237,7 +206,7 @@ static void EmitQaValidationTagTable(CIccProfile *pIcc, bool bDumpValidation)
     for (it = pIcc->m_Tags.begin(); it != pIcc->m_Tags.end(); ++it) {
       printf("%s{\"signature\":\"%s\",\"offset\":%u,\"size\":%u}",
              wroteTag ? "," : "",
-             JsonEscape(icGetSig(buf, bufSize, it->TagInfo.sig)).c_str(),
+             icJsonEscape(icGetSig(buf, bufSize, it->TagInfo.sig)).c_str(),
              (unsigned int)it->TagInfo.offset,
              (unsigned int)it->TagInfo.size);
       wroteTag = true;
@@ -264,7 +233,7 @@ static int EmitQaEvidenceJson(const char *profilePath, CIccProfile *pIcc,
   printf("{");
   printf("\"schema\":\"%s\",", kQaEvidenceSchema);
   printf("\"tool\":\"iccDumpProfile\",");
-  printf("\"profile\":\"%s\",", JsonEscape(profilePath).c_str());
+  printf("\"profile\":\"%s\",", icJsonEscape(profilePath).c_str());
   printf("\"loadMode\":\"%s\",", bUseRead ? "ReadIccProfile" : "OpenIccProfile");
   printf("\"validationRequested\":%s,", bDumpValidation ? "true" : "false");
   printf("\"validationStatus\":\"%s\",", ValidationStatusName(nStatus));
@@ -275,7 +244,7 @@ static int EmitQaEvidenceJson(const char *profilePath, CIccProfile *pIcc,
     icHeader *pHdr = &pIcc->m_Header;
     printf("\"profileSize\":%u,", (unsigned int)pHdr->size);
     if (Fmt.IsProfileIDCalculated(&pHdr->profileID))
-      printf("\"profileId\":\"%s\",", JsonEscape(Fmt.GetProfileID(&pHdr->profileID)).c_str());
+      printf("\"profileId\":\"%s\",", icJsonEscape(Fmt.GetProfileID(&pHdr->profileID)).c_str());
     else
       printf("\"profileId\":null,");
     printf("\"tagCount\":%u,", (unsigned int)pIcc->m_Tags.size());
@@ -310,7 +279,7 @@ static int EmitQaEvidenceJson(const char *profilePath, CIccProfile *pIcc,
            (unsigned int)payloadOffset, (unsigned int)payloadSize, kQaPayloadMarker);
     printf("\"controlledPattern\":\"%s\"", bHasControlledBytes ? "0x41414141" : "");
     if (!qaNonce.empty())
-      printf(",\"nonce\":\"%s\"", JsonEscape(qaNonce.c_str()).c_str());
+      printf(",\"nonce\":\"%s\"", icJsonEscape(qaNonce.c_str()).c_str());
     printf("}");
   }
 
@@ -617,8 +586,8 @@ int main(int argc, char* argv[])
 #if defined(ICCDEV_ENABLE_QA_FLAGS)
   // --evidence-json is the only evidence mode iccDumpProfile has, so it turns
   // --qa-flags on by itself.  Rejecting --qa-flags on its own is what stops the
-  // flag from being decorative: it was parsed, consumed and then thrown away
-  // with a (void) cast, so `--qa-flags profile.icc` silently produced an
+  // flag from being decorative: it used to be parsed, consumed and then thrown
+  // away with a (void) cast, so `--qa-flags profile.icc` silently produced an
   // ordinary text dump and exit 0.  iccPawgReport rejects the same combination.
   if (bQaFlags && !bEvidenceJson) {
     fprintf(stderr, "--qa-flags requires --evidence-json for iccDumpProfile\n");

--- a/Tools/CmdLine/IccPawgReport/IccPawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/IccPawgReport.cpp
@@ -73,7 +73,12 @@
 
 static void printUsage()
 {
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
   printf("Usage: iccPawgReport {--json} {--qa-flags --evidence-json} profile\n");
+#else
+  // The default build rejects both flags, so the synopsis must not offer them.
+  printf("Usage: iccPawgReport {--json} profile\n");
+#endif
   printf("\nEmits an ICC PAWG profile assessment checklist report aligned with\n");
   printf("https://www.color.org/profiles/assessment/index.xalter\n");
   printf("  --json   Emit machine-readable JSON evidence instead of text\n");

--- a/Tools/CmdLine/IccPawgReport/IccPawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/IccPawgReport.cpp
@@ -73,16 +73,26 @@
 
 static void printUsage()
 {
-  printf("Usage: iccPawgReport {--json} profile\n");
+  printf("Usage: iccPawgReport {--json} {--qa-flags --evidence-json} profile\n");
   printf("\nEmits an ICC PAWG profile assessment checklist report aligned with\n");
   printf("https://www.color.org/profiles/assessment/index.xalter\n");
   printf("  --json   Emit machine-readable JSON evidence instead of text\n");
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+  printf("  --qa-flags      Enable maintainer QA evidence flags\n");
+  printf("  --evidence-json Emit schema-versioned QA evidence JSON\n");
+#else
+  printf("  --qa-flags and --evidence-json require ICCDEV_ENABLE_QA_FLAGS=ON at build time\n");
+#endif
   printf("iccPawgReport built with IccProfLib version " ICCPROFLIBVER "\n\n");
 }
 
 int main(int argc, char *argv[])
 {
   bool bJson = false;
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+  bool bQaFlags = false;
+  bool bEvidenceJson = false;
+#endif
   std::string profilePath;
 
   // --read used to select a ReadIccProfile() fallback here after the strict
@@ -96,6 +106,21 @@ int main(int argc, char *argv[])
     if (strcasecmp(argv[k], "--json") == 0) {
       bJson = true;
     }
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+    else if (strcasecmp(argv[k], "--qa-flags") == 0) {
+      bQaFlags = true;
+    }
+    else if (strcasecmp(argv[k], "--evidence-json") == 0) {
+      bEvidenceJson = true;
+      bQaFlags = true;
+    }
+#else
+    else if (strcasecmp(argv[k], "--qa-flags") == 0 ||
+             strcasecmp(argv[k], "--evidence-json") == 0) {
+      fprintf(stderr, "QA target flags require ICCDEV_ENABLE_QA_FLAGS=ON at build time\n");
+      return 1;
+    }
+#endif
     else if ( strcasecmp( argv[k], "-V" ) == 0
             || strcasecmp( argv[k], "--V" ) == 0
             || strcasecmp( argv[k], "-help" ) == 0
@@ -123,8 +148,23 @@ int main(int argc, char *argv[])
     return 1;
   }
 
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+  if (bQaFlags && !bEvidenceJson) {
+    fprintf(stderr, "--qa-flags requires --evidence-json for iccPawgReport\n");
+    return 1;
+  }
+  if (bEvidenceJson && bJson) {
+    fprintf(stderr, "--json and --evidence-json are mutually exclusive\n");
+    return 1;
+  }
+#endif
 
   try {
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+    if (bEvidenceJson) {
+      return DumpPawgQaEvidence(profilePath.c_str());
+    }
+#endif
     return DumpPawgReport(profilePath.c_str(), bJson);
   }
   catch (const std::exception& e) {

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -71,6 +71,7 @@
 #include <string>
 #include <vector>
 
+#include "IccCmdLineUtil.h"
 #include "IccProfile.h"
 #include "IccMpeCalc.h"
 #include "IccTag.h"
@@ -2251,47 +2252,6 @@ const char *SectionName(char prefix)
   }
 }
 
-std::string JsonEscape(const std::string &s)
-{
-  std::ostringstream oss;
-  for (size_t i = 0; i < s.size(); i++) {
-    unsigned char ch = static_cast<unsigned char>(s[i]);
-    switch (ch) {
-      case '\\':
-        oss << "\\\\";
-        break;
-      case '"':
-        oss << "\\\"";
-        break;
-      case '\b':
-        oss << "\\b";
-        break;
-      case '\f':
-        oss << "\\f";
-        break;
-      case '\n':
-        oss << "\\n";
-        break;
-      case '\r':
-        oss << "\\r";
-        break;
-      case '\t':
-        oss << "\\t";
-        break;
-      default:
-        if (ch < 0x20 || ch > 0x7e) {
-          char buf[8];
-          std::snprintf(buf, sizeof(buf), "\\u%04x", ch);
-          oss << buf;
-        }
-        else {
-          oss << (char)ch;
-        }
-        break;
-    }
-  }
-  return oss.str();
-}
 
 void PrintJsonReport(const char *szFilename, const RawProfile &raw,
                      CIccProfile *pIcc, const std::vector<PawgItem> &items)
@@ -2300,7 +2260,7 @@ void PrintJsonReport(const char *szFilename, const RawProfile &raw,
   printf("  \"tool\": \"iccPawgReport\",\n");
   printf("  \"iccpProfileLibVersion\": \"" ICCPROFLIBVER "\",\n");
   printf("  \"profile\": \"%s\",\n",
-         JsonEscape(szFilename ? szFilename : "(null)").c_str());
+         icJsonEscape(szFilename ? szFilename : "(null)").c_str());
   printf("  \"sizeBytes\": %zu,\n", raw.data.size());
   printf("  \"load\": \"%s\",\n",
          pIcc ? "parsed by IccProfLib" : "raw checks only; IccProfLib parse failed");
@@ -2325,8 +2285,8 @@ void PrintJsonReport(const char *szFilename, const RawProfile &raw,
            item.id,
            SectionName(item.id[0]),
            VerdictText(item.verdict),
-           JsonEscape(item.title).c_str(),
-           JsonEscape(item.detail).c_str(),
+           icJsonEscape(item.title).c_str(),
+           icJsonEscape(item.detail).c_str(),
            i + 1 == items.size() ? "" : ",");
   }
   printf("  ]\n");
@@ -2389,7 +2349,7 @@ int DumpPawgQaEvidence(const char *szFilename)
   printf("{");
   printf("\"schema\":\"iccdev-qa-evidence/v1\",");
   printf("\"tool\":\"iccPawgReport\",");
-  printf("\"profile\":\"%s\",", JsonEscape(szFilename ? szFilename : "").c_str());
+  printf("\"profile\":\"%s\",", icJsonEscape(szFilename ? szFilename : "").c_str());
   printf("\"validationStatus\":\"%s\",", ValidationStatusName(status));
   printf("\"loaded\":%s,", loaded ? "true" : "false");
   if (loaded) {

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -2358,7 +2358,52 @@ bool HasFail(const std::vector<PawgItem> &items)
   return false;
 }
 
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+const char *ValidationStatusName(icValidateStatus status)
+{
+  switch (status) {
+  case icValidateOK:
+    return "ok";
+  case icValidateWarning:
+    return "warning";
+  case icValidateNonCompliant:
+    return "non_compliant";
+  case icValidateCriticalError:
+    return "critical_error";
+  default:
+    return "unknown";
+  }
+}
+#endif
+
 } // namespace
+
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+int DumpPawgQaEvidence(const char *szFilename)
+{
+  std::string report;
+  icValidateStatus status = icValidateOK;
+  CIccProfile *profile = ValidateIccProfile(szFilename, report, status);
+  const bool loaded = profile != nullptr;
+
+  printf("{");
+  printf("\"schema\":\"iccdev-qa-evidence/v1\",");
+  printf("\"tool\":\"iccPawgReport\",");
+  printf("\"profile\":\"%s\",", JsonEscape(szFilename ? szFilename : "").c_str());
+  printf("\"validationStatus\":\"%s\",", ValidationStatusName(status));
+  printf("\"loaded\":%s,", loaded ? "true" : "false");
+  if (loaded) {
+    printf("\"qaFlags\":[\"ICCDEV_FLAG_LOAD\",\"ICCDEV_FLAG_VALIDATE\"]");
+  }
+  else {
+    printf("\"qaFlags\":[]");
+  }
+  printf("}\n");
+
+  delete profile;
+  return loaded ? 0 : 1;
+}
+#endif
 
 int DumpPawgReport(const char *szFilename, bool bJson)
 {

--- a/Tools/CmdLine/IccPawgReport/PawgReport.h
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.h
@@ -67,6 +67,10 @@
 
 int DumpPawgReport(const char *szFilename, bool bJson);
 
+#if defined(ICCDEV_ENABLE_QA_FLAGS)
+int DumpPawgQaEvidence(const char *szFilename);
+#endif
+
 // Assessment-only entry points (issue #1775): run the PAWG evaluation "up to the
 // point of Output, not for Output" over an in-memory profile image, so the
 // overnight CI fuzzing harness can drive the code path with no filesystem

--- a/Tools/CmdLine/IccPawgReport/Readme.md
+++ b/Tools/CmdLine/IccPawgReport/Readme.md
@@ -7,11 +7,14 @@
 ```sh
 iccPawgReport profile.icc
 iccPawgReport --json profile.icc
+iccPawgReport --qa-flags --evidence-json profile.icc
 ```
 
 Options:
 
 - `--json` out instead of text report
+- `--qa-flags --evidence-json` emits schema-versioned load and validation
+  evidence when built with `ICCDEV_ENABLE_QA_FLAGS=ON`
 
 A profile that IccProfLib refuses to parse is still assessed: the raw-byte checks run from the
 file contents directly, and the checks that need a parsed profile are reported as `NOT RUN`.

--- a/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
+++ b/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
@@ -286,7 +286,11 @@ static void EmitWriteEvidenceJson(const char* tiffPath, const char* outputPath,
   printf("\"tool\":\"iccTiffDump\",");
   printf("\"input\":\"%s\",", icJsonEscape(tiffPath).c_str());
   printf("\"output\":\"%s\",", icJsonEscape(outputPath).c_str());
-  printf("\"qaFlags\":[\"ICCDEV_FLAG_WRITE\"],");
+  // ICCDEV_FLAG_WRITE asserts that a profile was written out.  Emitting it
+  // unconditionally also claimed it for `iccTiffDump --evidence-json in.tif`,
+  // which names no output and writes nothing, so anything counting the flag
+  // across an evidence corpus over-reported.
+  printf("\"qaFlags\":[%s],", hasOutputDigest ? "\"ICCDEV_FLAG_WRITE\"" : "");
   if (hasOutputDigest)
     printf("\"outputDigest\":\"%s\",", outputDigest.c_str());
   else
@@ -505,7 +509,11 @@ int main(int argc, icChar* argv[])
         SrcImg.Close();
         return 1;
       }
-      extractedProfileId = GetProfileId(argv[2]);
+      // Only the evidence path consumes this, and it costs a second complete
+      // CIccProfile parse of the file just written, so it stays inside the
+      // guard rather than running on every ordinary extraction.
+      if (bEvidenceJson)
+        extractedProfileId = GetProfileId(argv[2]);
       if (!bEvidenceJson) {
         printf("\nProfile extracted byte-for-byte to: %s\n", dstName.c_str());
         fflush(stdout);
@@ -520,8 +528,9 @@ int main(int argc, icChar* argv[])
       return 1;
     }
 
-    embeddedProfileId = GetProfileId(pProfile);
-    if (!bEvidenceJson)
+    if (bEvidenceJson)
+      embeddedProfileId = GetProfileId(pProfile);
+    else
       DumpProfileInfo(pProfile, " ");
 
     std::string validateReport;

--- a/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
+++ b/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
@@ -241,10 +241,83 @@ static bool WriteEmbeddedIccProfile(const char* szFname,
   return true;
 }
 
-void Usage() 
+void Usage()
 {
   printf("iccTiffDump built with IccProfLib version " ICCPROFLIBVER "\n\n");
-  printf("Usage: iccTiffDump tiff_file {exported_icc_file}\n\n");
+  printf("Usage: iccTiffDump {--evidence-json} tiff_file {exported_icc_file}\n\n");
+}
+
+static std::string GetProfileId(CIccProfile* pProfile)
+{
+  if (!pProfile)
+    return std::string();
+
+  CIccInfo Fmt;
+  if (Fmt.IsProfileIDCalculated(&pProfile->m_Header.profileID))
+    return Fmt.GetProfileID(&pProfile->m_Header.profileID);
+
+  return std::string();
+}
+
+static std::string GetProfileId(const char* profilePath)
+{
+  if (!profilePath || !profilePath[0])
+    return std::string();
+
+  CIccProfile* pProfile = OpenIccProfile(profilePath);
+  if (!pProfile)
+    return std::string();
+
+  std::string id = GetProfileId(pProfile);
+  delete pProfile;
+  return id;
+}
+
+static void EmitWriteEvidenceJson(const char* tiffPath, const char* outputPath,
+                                  const std::string& embeddedProfileId,
+                                  const std::string& extractedProfileId)
+{
+  std::string outputDigest;
+  bool hasOutputDigest = outputPath && outputPath[0] &&
+    icSha256File(outputPath, outputDigest);
+
+  printf("{");
+  printf("\"schema\":\"iccdev-qa-evidence/v1\",");
+  printf("\"tool\":\"iccTiffDump\",");
+  printf("\"input\":\"%s\",", icJsonEscape(tiffPath).c_str());
+  printf("\"output\":\"%s\",", icJsonEscape(outputPath).c_str());
+  printf("\"qaFlags\":[\"ICCDEV_FLAG_WRITE\"],");
+  if (hasOutputDigest)
+    printf("\"outputDigest\":\"%s\",", outputDigest.c_str());
+  else
+    printf("\"outputDigest\":null,");
+  if (!embeddedProfileId.empty())
+    printf("\"embeddedProfileId\":\"%s\",", icJsonEscape(embeddedProfileId).c_str());
+  else
+    printf("\"embeddedProfileId\":null,");
+  if (!extractedProfileId.empty())
+    printf("\"extractedProfileId\":\"%s\",", icJsonEscape(extractedProfileId).c_str());
+  else
+    printf("\"extractedProfileId\":null,");
+
+  // ICCDEV_FLAG_WRITE carries its evidence in a nested object named for the
+  // flag, the same shape iccApplyNamedCmm uses for ICCDEV_FLAG_TRANSFORM.  The
+  // flat copies above stay for readers that index the document by bare key.
+  // "write" closes the object, so its last member takes no separator.
+  printf("\"write\":{");
+  if (hasOutputDigest)
+    printf("\"outputDigest\":\"%s\",", outputDigest.c_str());
+  else
+    printf("\"outputDigest\":null,");
+  if (!embeddedProfileId.empty())
+    printf("\"embeddedProfileId\":\"%s\",", icJsonEscape(embeddedProfileId).c_str());
+  else
+    printf("\"embeddedProfileId\":null,");
+  if (!extractedProfileId.empty())
+    printf("\"extractedProfileId\":\"%s\"", icJsonEscape(extractedProfileId).c_str());
+  else
+    printf("\"extractedProfileId\":null");
+  printf("}}\n");
 }
 
 void DumpProfileInfo(CIccProfile* pProfile, std::string prefix, int level = 1)
@@ -360,6 +433,13 @@ const char *GetSampleFormatDescription( unsigned int format )
 int main(int argc, icChar* argv[])
 {
   int minargs = 1;
+  bool bEvidenceJson = false;
+
+  if (argc > 1 && !stricmp(argv[1], "--evidence-json")) {
+    bEvidenceJson = true;
+    argv++;
+    argc--;
+  }
   if (argc <= minargs) {
     Usage();
     return 0;
@@ -377,6 +457,7 @@ int main(int argc, icChar* argv[])
     return 1;
   }
 
+  if (!bEvidenceJson) {
   printf("-------------------->Tiff Image Dump<---------------------------\n");
   printf("Filename:          %s\n", srcName.c_str());
   // A physical size only exists when RESOLUTIONUNIT names an absolute unit; under
@@ -405,12 +486,17 @@ int main(int argc, icChar* argv[])
   printf("Resolution:        (%lf x %lf) %s\n", SrcImg.GetXRes(), SrcImg.GetYRes(),
     GetId(SrcImg.GetResolutionUnit(), resolution_units));
   printf("Compression:       %s\n", GetId(SrcImg.GetCompress(), compression_types));
+  }
 
   unsigned char *pProfMem = nullptr;
   unsigned int nLen = 0;
+  std::string embeddedProfileId;
+  std::string extractedProfileId;
   if (SrcImg.GetIccProfile(pProfMem, nLen)) {
-    printf("Profile:           Embedded\n");
-    fflush(stdout);
+    if (!bEvidenceJson) {
+      printf("Profile:           Embedded\n");
+      fflush(stdout);
+    }
 
     if (argc > 2) {
       std::string dstName = icSanitizeConsoleText(argv[2]);
@@ -419,8 +505,11 @@ int main(int argc, icChar* argv[])
         SrcImg.Close();
         return 1;
       }
-      printf("\nProfile extracted byte-for-byte to: %s\n", dstName.c_str());
-      fflush(stdout);
+      extractedProfileId = GetProfileId(argv[2]);
+      if (!bEvidenceJson) {
+        printf("\nProfile extracted byte-for-byte to: %s\n", dstName.c_str());
+        fflush(stdout);
+      }
     }
 
     // Profile description and metadata
@@ -431,7 +520,9 @@ int main(int argc, icChar* argv[])
       return 1;
     }
 
-    DumpProfileInfo(pProfile, " ");
+    embeddedProfileId = GetProfileId(pProfile);
+    if (!bEvidenceJson)
+      DumpProfileInfo(pProfile, " ");
 
     std::string validateReport;
     if (!pProfile->ReadTags(pProfile)) {
@@ -449,13 +540,19 @@ int main(int argc, icChar* argv[])
     }
     delete pProfile;
   } else {
-    printf("Profile:           None\n");
+    if (!bEvidenceJson)
+      printf("Profile:           None\n");
     if (argc > 2) {
-      fprintf(stderr, "\nNo embedded ICC profile to extract\n");
+      fprintf(stderr, bEvidenceJson ? "No embedded ICC profile to extract\n" :
+              "\nNo embedded ICC profile to extract\n");
       SrcImg.Close();
       return 1;
     }
   }
+
+  if (bEvidenceJson)
+    EmitWriteEvidenceJson(argv[1], argc > 2 ? argv[2] : "",
+                          embeddedProfileId, extractedProfileId);
 
   SrcImg.Close();
   return 0;


### PR DESCRIPTION
## Summary

Harvests the QA evidence CLI from `ci-qa-flags` (`d84e28cd`), the last unlanded item of the #1853 harvest and the one named in the 2026-08-21 rebase comment.

**master already carries every part of this feature except the code.** The option and its compile definition (`Build/Cmake/CMakeLists.txt:545,736`), eight `*-qa-flags` CMake presets, three CI lanes passing `-DICCDEV_ENABLE_QA_FLAGS=ON`, a `ci-iccdev-tool-tests.yml` step harvesting `Testing/ctest-output/iccdev-qa-target-flags/{evidence.ndjson,summary.tsv}`, and the flags plus the CTest documented in `docs/tools-cli-reference.md` and `docs/build.md`. Nothing read the macro, so all four documented commands were broken:

| documented command | on `c786796e` |
|---|---|
| `ctest -R "^iccdev\.qa-target-flags$" --no-tests=error` | rc=8, no such test |
| `iccDumpProfile --qa-flags --evidence-json --diag -v 100 P` | **rc=0**, "Unable to parse '--qa-flags' as ICC profile!" |
| `iccPawgReport --qa-flags --evidence-json P` | rc=1, unknown option |
| `iccTiffDump --evidence-json T O` | rc=1, usage |

The first row is the one that matters: a CI step running the documented `iccDumpProfile` command dumps nothing and still exits 0, so it reads green.

## What lands

`icJsonEscape` / `icUtf8SequenceLength` / `icSha256Bytes` / `icSha256File` / `icReadFileBytes` in the shared `IccCmdLineUtil.h`; `--qa-flags --evidence-json` on `iccDumpProfile` and `iccPawgReport` behind the build gate; `--evidence-json` on `iccApplyNamedCmm` and `iccTiffDump` ungated; and two CTests, `iccdev.qa-target-flags` (gated) and `iccdev.qa-evidence-helpers`.

The gated/ungated split is not an oversight — `docs/tools-cli-reference.md:123-126` already specifies the gate for the first pair only.

Not taken from the branch: the `iccApplyToLink` `ICC_DIAG` changes, which are #1387 / #1982 work rather than QA evidence.

## Defects fixed

Three in the harvested code, all found by running it rather than reading it:

1. **`iccTiffDump` emitted invalid JSON, and only on success.** `extractedProfileId` is the last member of the object, but the non-empty branch emitted a trailing comma — so the document parsed only when nothing had been extracted, and never in the case `ICCDEV_FLAG_WRITE` exists to record.
2. `iccTiffDump` omitted the nested `write` object the schema requires, the counterpart of `iccApplyNamedCmm`'s `transform`.
3. `--qa-flags` was inert: parsed, consumed, then discarded via `(void)bQaFlags`. Output was byte-identical with and without it.

One pre-existing on master:

4. **`PawgReport.cpp`'s `JsonEscape` corrupts non-ASCII text.** It escapes every byte above `0x7e` as `\u00XX`, reading a UTF-8 byte as a code point. The same path through two producers of one schema gave `café` and `cafÃ©`. This is what shipped `iccPawgReport --json` has always done.

Eight more from `/code-review high`, two of them serious:

5. **The malformed negative control could not fail.** `run_evidence` compared the exit status against an expected one and, on mismatch, printed `[FAIL]` and then `exit "$status"`. That case expects status 1, so the regression it exists to catch — `iccDumpProfile` starting to report success for an unloadable profile — made it `exit 0` and CTest read the run as PASS. Measured: forcing that return to 0 gave `100% tests passed` before the fix and `[FAIL] iccDumpProfile malformed control evidence command exited 0, expected 1`, 0% passed, after. `run_command` carried the same bug.
6. **`iccApplyNamedCmm --evidence-json` corrupted its own output on Usage 2.** `CIccCfgDataApply::fromArgs` clears `m_dstFile` unconditionally and `icOpenRegularWriteFile` returns `stdout` for an empty name, so the transformed dataset and the evidence shared one stream: 894 bytes of colour data with a JSON object stapled to the end, and `outputDigest` always null. Now refused where both config paths join, before any transform runs — rc=1, zero bytes written — and `--evidence-json` moves to the Usage 1 synopsis, the only form the docs show.
7. `icJsonEscape` passed every byte `>= 0x80` through unchecked. A JSON text must be valid UTF-8 (RFC 8259 §8.1) and these strings carry paths straight from `argv`, which on POSIX need not be UTF-8, so a Latin-1 filename produced a document that would not decode. Adds `icUtf8SequenceLength` (Unicode 15.0 table 3-7, so it also rejects over-long forms, UTF-16 surrogates and anything above U+10FFFF) and substitutes U+FFFD, escaped so the document stays pure ASCII.
8. `iccdev.qa-target-flags` registered on the `ICCDEV_ENABLE_QA_FLAGS` gate alone, but the script hard-requires nine tools and its `find_tool` exits 1 rather than skipping — a QA build without `ENABLE_ICCXML` or `ENABLE_ICCJSON` registered a test that died at tool discovery.
9. `iccDumpProfile` reported `"loadMode":"OpenIccProfile"` under `-v`, which loads through `ValidateIccProfile()` and ignores `bUseRead` entirely — naming a function the run never called, in the mode the harness itself uses.
10. `ICCDEV_FLAG_WRITE` was asserted unconditionally, including for `iccTiffDump --evidence-json in.tif`, which names no output and writes nothing.
11. `iccTiffDump` parsed the extracted profile a second time on the ordinary text path, where nothing consumes the result.
12. The `iccDumpProfile` and `iccPawgReport` usage synopses advertised flags the default build rejects.

Two review findings are **not** taken. The `asan` label on `iccdev.qa-target-flags` is correct — the four tools it drives are genuinely instrumented in that lane (35-42 `__asan_`/`__ubsan_` symbols in each of the four binaries, and the test was run there). And `icSha256File` buffering the file twice is a property of the harvested design, not a correctness defect; a streaming variant is a larger change than this PR should carry.

## New test

`iccdev.qa-evidence-helpers`. `icSha256Bytes` is a hand-rolled SHA-256 — iccDEV links no crypto library, so the digests in the evidence come from this header and nothing else, and it arrived with no test. A wrong compression function still returns 64 hex characters, so no consumer of the evidence can tell a correct digest from a confident one.

It covers the four published FIPS 180-4 / RFC 6234 vectors (empty, `abc`, the 448-bit two-block message, the million-`a` case); the 55, 56 and 64 byte padding boundaries, cross-checked against Python `hashlib`, which is where an off-by-one in `while ((msg.size() % 64) != 56)` shows up while `abc` still passes; a digest over embedded NUL bytes; and `icJsonEscape` — control set, quote/backslash, null pointer, both overloads agreeing, UTF-8 passthrough for 2/3/4-byte sequences, and U+FFFD for lone continuations, truncated sequences, over-long forms, surrogates, `> U+10FFFF`, plus a resynchronisation case proving a bad byte does not eat the text after it. The measured result is that the harvested implementation is correct; the test exists so that stays true.

It is header-only, so it links no library and needs no Windows runtime PATH entries. That makes it platform-agnostic, so it registers on **both** the WIN32 and non-WIN32 call lists rather than only one — the omission #2237 fixed for two other tests.

## Neither new test is vacuous

- Forcing `FindQaPayloadTag` to return false turns `iccdev.qa-target-flags` red with `iccDumpProfile controlled tag payload flag missing`.
- Forcing `iccDumpProfile` to return 0 for an unloadable profile turns it red with `malformed control evidence command exited 0, expected 1` — the case that reported PASS before finding 5 was fixed.
- Reintroducing `ch < 0x20 || ch > 0x7e` in `icJsonEscape` turns `iccdev.qa-evidence-helpers` red with `got cafÃ© / want café`.

Each returns green on restore.

## Pre-flight

| lane | result |
|---|---|
| clang 21.1.3 Release, `ICCDEV_ENABLE_QA_FLAGS=ON` | **0 warnings** |
| clang strict (`strict warnings ENABLED`) | **0 warnings** |
| **GCC 15.2.0 + LTO, `-Wall -Wextra -Wpedantic -Werror`, in `iccdev-ci-regression:latest`** | **0 warnings, 0 errors**, including `build-test-binaries` |
| default build, `ICCDEV_ENABLE_QA_FLAGS=OFF` | **0 warnings**; both flags rejected with a build-time message |
| gcc Debug ASAN+UBSAN, `ICCDEV_ENABLE_STRICT_WARNINGS=ON` | 0 ASAN findings, 0 UBSAN findings |
| `ctest`, **in `iccdev-ci-regression:latest`** | **202/202, zero failures** |
| `ctest`, local clang | 201/202 |
| `shellcheck` on both changed scripts | rc=0 |

Warning counts are CI's own gate, `grep -cE 'warning:'` on the build log, not a test summary. The local gcc 13.3 lane is **not** a strict lane — CMake prints `strict warnings DISABLED -- GNU 13.3.0 below floor` — which is why the GCC 15 row is the container, not the host.

The full suite is green in CI's own container. The single *local* failure is `iccdev.spectral-tiff-preview`, which needs the Python `imagecodecs` module that is absent on this host and present in the container -- it passes there, which is what confirms the attribution. Under sanitizers `iccdev.tool-coverage` also fails, on `[TIMEOUT] RoundTrip CMYK relative >60s`: `iccRoundTrip` has no source in this diff, and `IccCmdLineUtil.h` is a tools-only header that nothing in `IccProfLib/*.cpp|*.h` includes, so `libIccProfLib` is byte-unchanged and that binary is identical to a master build. The same tree passes `iccdev.tool-coverage` in the non-sanitizer build at 7.28s.

## Pre-PR dispatched run

`ci-pr-action` was dispatched on this branch with `ci_scope=source` before the PR was opened:
**run 32541846561 -- 12 success, 3 skipped, conclusion success.** It covered GCC 15.2 Strict
Release LTO, Windows MSVC + ClangCL, MinGW UCRT64, macOS Clang Debug and Release, Tool Smoke
Tests ASAN+UBSAN, and the Example Consumer Project job; Docker Clang 22 and the manual
thread-linkage job skipped, as `source` intends.

`iccdev.qa-evidence-helpers` is registered on the WIN32 path, so a green Windows leg is not by
itself evidence it ran. From that job's log, by test number and runtime:

```
105/107 Test #105: iccdev.qa-evidence-helpers .......... Passed 0.05 sec   (MSVC)
105/107 Test #105: iccdev.qa-evidence-helpers .......... Passed 0.07 sec   (ClangCL)
100% tests passed, 0 tests failed out of 107
```

`iccdev.qa-target-flags` is a script test behind the QA-flags gate and correctly does not
register on that lane.

## Review note

`iccdev-tiffdump-output-hardening-tests.sh` pins the `iccTiffDump` usage banner byte-for-byte and the banner gains `{--evidence-json}`, so that one line moves with it.

**The second commit is deliberately separable.** `fix(#1853): route every iccdev-qa-evidence/v1 producer at one JSON escaper` changes the output of the pre-existing `--json` flag for non-ASCII input, which the harvest itself does not require. Dropping it leaves the rest working, with two escapers that disagree.

## Out of scope -- filed as #2248

`iccDumpProfile`'s non-`-v` branch runs `strtol` over the filename and, unlike the `-v` branch, never restores the default when the parse fails, so verbosity is clobbered from 100 to 0. `iccDumpProfile p.icc ALL` prints 226 lines where `iccDumpProfile 100 p.icc ALL` prints 10084, and the help text says `default=100`. Pre-existing, user-visible, and a fix changes the tool's default output by 45x, so it is filed as **#2248** with three options rather than carried here.

Part of #1853
