### PR TITLE
fix(#2254): correct the iccBenchApply CLI contract and the profile-root resolution that made its benchmark vacuous on Windows

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4973,9 +4973,17 @@ endif()
 #
 # Records; never asserts a timing threshold. Shared CI runners vary 20-30%
 # between runs on the same commit, so a threshold would flake without catching
-# anything a local run would not. The test passes when every case either
-# measured or reported SKIP, and fails only on a real defect: a checksum that
-# moved between thread counts, or a second Begin() that changed the output.
+# anything a local run would not. The test fails on a real defect: a checksum
+# that moved between thread counts, a second Begin() that changed the output,
+# or -- since #2254 -- a run in which no case was measured at all.
+#
+# That last clause is the anti-vacuity guard, and it is not theoretical. Before
+# #2254 the tool exited 0 after printing "0 case(s) measured, 9 skipped", so
+# this test passed unchanged against a build whose profile fixture produced
+# nothing. iccdev.bench-apply-empty-suite below is its negative control: it
+# points the roots at a directory with no Testing/ tree and requires the
+# failure, so a regression that restores the old exit status turns that test
+# red rather than quietly re-hollowing this one.
 #
 # The 'slow' label puts it on the existing opt-out path rather than inventing
 # one: check-fast excludes 'slow' while check excludes only 'known-red', so the
@@ -4985,31 +4993,62 @@ endif()
 # generated profiles into the source tree while iccdev.windows-create-profiles
 # writes them into the build tree, and the tool resolves against both rather
 # than assuming a platform.
+#
+# #2254 corrected the second root. It was ${CMAKE_BINARY_DIR}, which resolved
+# nothing on any platform: iccdev.windows-create-profiles does not generate into
+# <build>/Testing -- that is the CTest scratch directory -- but into
+# ${ICCDEV_TEST_OUTDIR}/windows-testing, a copy of the source Testing/ tree that
+# it then fills with 135 profiles (see the WIN32 branch below and
+# RunWindowsBatchTest.cmake:184-194). All nine cases open a generated profile
+# first -- the table's one tracked profile is never the first in its chain -- so
+# on Windows every case SKIPped and this test passed in 0.01
+# seconds without measuring anything -- visible in run 32563985818, where the
+# fixture that produced the profiles it never found took 6.62 seconds. That
+# directory is already a Testing tree rather than a directory containing one,
+# which is why icBenchResolveProfile now tries each root both ways.
+#
+# On POSIX the new value simply does not exist and the source root answers, as
+# it always did.
+#
+# #2254: the two tests that DRIVE the suite are gated on iccFromXml, because
+# without it there is no corpus and no fixture to build one. The Windows
+# fixture is registered only inside if(TARGET iccFromXml) (see
+# iccdev.windows-create-profiles below), and every one of the nine cases opens a
+# generated profile first, so on a configuration such as the mingw-core-x64
+# preset -- ENABLE_ICCXML=OFF with ENABLE_TESTS=ON and ENABLE_TOOLS=ON -- the
+# suite can only ever measure zero. Before this change that was a silent pass;
+# with the exit status corrected it would be a red leg reporting a configuration
+# choice as a defect. Not registering a test that cannot measure is the honest
+# reading of both. The argument-handling tests below are NOT gated: they exit
+# before a profile is opened, and iccdev.bench-apply-empty-suite asserts the
+# absence of a corpus, so it needs one least of all.
 if(TARGET iccBenchApply)
   add_dependencies(build-test-binaries iccBenchApply)
 
-  if(WIN32)
-    add_test(
-      NAME iccdev.apply-throughput
-      COMMAND "$<TARGET_FILE:iccBenchApply>" -suite -csv -pixels 65536 -repeats 3
-    )
-  else()
-    add_test(
-      NAME iccdev.apply-throughput
-      COMMAND
-        "${CMAKE_COMMAND}" -E env
-        ${ICCDEV_TEST_ENV}
-        "$<TARGET_FILE:iccBenchApply>" -suite -csv -pixels 65536 -repeats 3
+  if(TARGET iccFromXml)
+    if(WIN32)
+      add_test(
+        NAME iccdev.apply-throughput
+        COMMAND "$<TARGET_FILE:iccBenchApply>" -suite -csv -pixels 65536 -repeats 3
+      )
+    else()
+      add_test(
+        NAME iccdev.apply-throughput
+        COMMAND
+          "${CMAKE_COMMAND}" -E env
+          ${ICCDEV_TEST_ENV}
+          "$<TARGET_FILE:iccBenchApply>" -suite -csv -pixels 65536 -repeats 3
+      )
+    endif()
+
+    set_tests_properties(iccdev.apply-throughput PROPERTIES
+      WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+      TIMEOUT 300
+      LABELS "iccdev;iccprofLib;benchmark;throughput;slow"
+      FIXTURES_REQUIRED iccdev_profiles
+      ENVIRONMENT "ICCDEV_BENCH_SOURCE_ROOT=${ICCDEV_REPO_ROOT};ICCDEV_BENCH_BUILD_ROOT=${ICCDEV_TEST_OUTDIR}/windows-testing"
     )
   endif()
-
-  set_tests_properties(iccdev.apply-throughput PROPERTIES
-    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
-    TIMEOUT 300
-    LABELS "iccdev;iccprofLib;benchmark;throughput;slow"
-    FIXTURES_REQUIRED iccdev_profiles
-    ENVIRONMENT "ICCDEV_BENCH_SOURCE_ROOT=${ICCDEV_REPO_ROOT};ICCDEV_BENCH_BUILD_ROOT=${CMAKE_BINARY_DIR}"
-  )
 
   # #2250: iccBenchApply read the -PCC profile and never deleted it. The CMM does
   # not take ownership -- CIccXform::Create stores it as the bare
@@ -5065,6 +5104,149 @@ if(TARGET iccBenchApply)
     LABELS "iccdev;iccprofLib;benchmark;throughput;pcc;leak;issue-2250;regression"
   )
 
+  # -------------------------------------------------------------------------
+  # #2254: the iccBenchApply command-line contract.
+  #
+  # A QA pass over the tool's invocations found three ways to ask for something
+  # and be told nothing, plus the exit status that made the benchmark above
+  # vacuous. Each of the four tests below pins one of them, and each fails
+  # against the tool as it stood at 0964739d:
+  #
+  #   arity-floor           an argc floor of 3 rejected every two-argument
+  #                         invocation, including `iccBenchApply -suite` -- the
+  #                         spelling the Readme and docs/tools-cli-reference.md
+  #                         both give as the way to run the table. Callers
+  #                         padded it with a stray trailing token, which is how
+  #                         the next defect went unnoticed.
+  #
+  #                         This is asserted through `iccBenchApply 1` rather
+  #                         than through `-suite` itself, for a reason worth
+  #                         stating: the floor is an argc test, so any
+  #                         two-argument form exercises the same branch, and
+  #                         `-suite` on its own has no way to be made cheap. It
+  #                         takes the default 1048576-pixel, 7-repeat budget,
+  #                         which on the slow build that prompted #2254 ran for
+  #                         over 25 minutes in a single case. Registering that
+  #                         as a CTest would import the exact runtime this issue
+  #                         is about. `1` reaches the floor in microseconds and
+  #                         discriminates on the message: before the fix the
+  #                         tool printed the usage text, after it the chain
+  #                         error the argument actually earns.
+  #   suite-rejects-chain   `-suite 1 <profile> 10002` ran the built-in table,
+  #                         silently discarded the profile and the intent, and
+  #                         exited 0.
+  #   suite-rejects-perxform  RunSuite reads neither g_bPerXform nor g_bLeaf, so
+  #                         both options were accepted and dropped.
+  #   empty-suite           every case SKIPping still exited 0. This is the
+  #                         negative control for iccdev.apply-throughput: it
+  #                         gives the tool roots with no Testing/ tree, so all
+  #                         nine cases must SKIP and the run must fail.
+  #
+  # These are argument-handling assertions, not benchmarks. Three of the four
+  # exit before any profile is opened, so they need no fixture and no timing
+  # budget; only suite-standalone measures, and it does so at 4096 pixels and a
+  # single repeat.
+  file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/bench-empty-root")
+
+  add_test(
+    NAME iccdev.bench-apply-arity-floor
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=1"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=No profiles given"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-arity-floor PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;issue-2254;regression"
+  )
+
+  add_test(
+    NAME iccdev.bench-apply-suite-rejects-chain
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;-suite;1;Testing/sRGB_v4_ICC_preference.icc;10002"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=takes no chain"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-suite-rejects-chain PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;issue-2254;regression"
+  )
+
+  add_test(
+    NAME iccdev.bench-apply-suite-rejects-perxform
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;-perxform;-suite"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=has no effect with -suite"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-suite-rejects-perxform PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;issue-2254;regression"
+  )
+
+  # The positive counterpart to iccdev.bench-apply-empty-suite below, and the
+  # regression test for the resolver change: run from inside a Testing tree with
+  # no ICCDEV_BENCH_* set at all, so both roots default to "." and only the
+  # direct form can resolve anything. Before #2254 this measured zero cases --
+  # it is the invocation from the QA report, `cd Testing && iccBenchApply
+  # -suite` -- and it is the same code path that makes the Windows profile tree
+  # reachable, so the two platforms pin each other here rather than each relying
+  # on a leg the other does not run.
+  # Gated with iccdev.apply-throughput, and for a second reason as well: on
+  # Windows this working directory is created by iccdev.windows-create-profiles,
+  # which is itself inside if(TARGET iccFromXml). Registered unconditionally,
+  # the test would fail with "Unable to find working directory" on a no-XML
+  # Windows configure -- a message about the fixture, not about the CLI contract
+  # the test exists to pin.
+  if(TARGET iccFromXml)
+    if(WIN32)
+      set(_bench_testing_cwd "${ICCDEV_TEST_OUTDIR}/windows-testing")
+    else()
+      set(_bench_testing_cwd "${ICCDEV_REPO_ROOT}/Testing")
+    endif()
+
+    add_test(
+      NAME iccdev.bench-apply-testing-cwd
+      COMMAND "${CMAKE_COMMAND}"
+        "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+        "-DTOOL_ARGS=-pixels;4096;-repeats;1;-suite"
+        "-DEXPECT_EXIT=zero"
+        "-DEXPECT_MATCH=[1-9][0-9]* case\\(s\\) measured"
+        -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+    )
+    set_tests_properties(iccdev.bench-apply-testing-cwd PROPERTIES
+      WORKING_DIRECTORY "${_bench_testing_cwd}"
+      TIMEOUT 300
+      LABELS "iccdev;iccprofLib;benchmark;cli;issue-2254;regression"
+      FIXTURES_REQUIRED iccdev_profiles
+    )
+  endif()
+
+  add_test(
+    NAME iccdev.bench-apply-empty-suite
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;-suite"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=no benchmark cases were measured"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-empty-suite PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;issue-2254;regression"
+    ENVIRONMENT "ICCDEV_BENCH_SOURCE_ROOT=${CMAKE_CURRENT_BINARY_DIR}/bench-empty-root;ICCDEV_BENCH_BUILD_ROOT=${CMAKE_CURRENT_BINARY_DIR}/bench-empty-root"
+  )
+
   if(WIN32)
     set(_bench_windows_env_mods
       "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccBenchApply>"
@@ -5074,12 +5256,34 @@ if(TARGET iccBenchApply)
       list(APPEND _bench_windows_env_mods
         "PATH=path_list_prepend:${_runtime_path}")
     endforeach()
-    set_tests_properties(iccdev.apply-throughput PROPERTIES
-      ENVIRONMENT_MODIFICATION "${_bench_windows_env_mods}"
-    )
-    set_tests_properties(iccdev.apply-throughput-pcc PROPERTIES
-      ENVIRONMENT_MODIFICATION "${_bench_windows_env_mods}"
-    )
+    # Only the tests that were actually registered: set_tests_properties on an
+    # unknown name is a hard configure error, and the two suite-driving tests
+    # are gated on iccFromXml above.
+    set(_bench_env_mod_tests
+      iccdev.apply-throughput-pcc
+      iccdev.bench-apply-arity-floor
+      iccdev.bench-apply-suite-rejects-chain
+      iccdev.bench-apply-suite-rejects-perxform
+      iccdev.bench-apply-empty-suite)
+    if(TARGET iccFromXml)
+      list(APPEND _bench_env_mod_tests
+        iccdev.apply-throughput
+        iccdev.bench-apply-testing-cwd)
+    endif()
+    # #2254: the CLI-contract tests reach the tool through cmake -P, and a child
+    # process inherits the PATH the test process was given, so they need the
+    # same runtime paths. Without this they would fail on Windows for want of
+    # IccProfLib2.dll, and the three that assert a nonzero exit would have
+    # passed for exactly that wrong reason -- STATUS_DLL_NOT_FOUND is an
+    # ordinary nonzero status, not a launch failure the wrapper can spot. What
+    # keeps that honest is the wrapper's mandatory EXPECT_MATCH on every
+    # negative test; the paths are what make the tests measure the tool rather
+    # than the loader.
+    foreach(_bench_cli_test IN LISTS _bench_env_mod_tests)
+      set_tests_properties(${_bench_cli_test} PROPERTIES
+        ENVIRONMENT_MODIFICATION "${_bench_windows_env_mods}"
+      )
+    endforeach()
   endif()
 endif()
 

--- a/Build/Cmake/Testing/RunBenchApplyCliTest.cmake
+++ b/Build/Cmake/Testing/RunBenchApplyCliTest.cmake
@@ -1,0 +1,101 @@
+#################################################################################
+# iccBenchApply command-line contract driver for #2254
+# Copyright (c) 2026 The International Color Consortium.
+#                                        All rights reserved.
+#################################################################################
+
+# RunBenchApplyCliTest.cmake - runs iccBenchApply once and asserts BOTH halves of
+# the outcome: the exit status and what the tool said.
+#
+# #2254 exists because every defect it collects was an exit status that agreed
+# with a wrong outcome. `-suite` with a chain ran the built-in table, ignored the
+# profile the caller named, and exited 0. `-suite` alone was rejected outright.
+# A run whose nine cases all SKIPped reported success, which is what made
+# iccdev.apply-throughput vacuous.
+#
+# CTest cannot express "nonzero AND this message" on its own: WILL_FAIL passes on
+# any nonzero exit -- including a crash, a usage error, or a missing shared
+# library -- and PASS_REGULAR_EXPRESSION makes CTest ignore the return code
+# entirely. Either one alone would pass against a tool that failed for the wrong
+# reason, which is the same class of defect this file is testing for. Asserting
+# both here is the only way to keep the assertion honest.
+#
+# Required -D args:
+#   TOOL         - path to the iccBenchApply executable
+#   EXPECT_EXIT  - "zero" or "nonzero"
+# Optional -D args:
+#   TOOL_ARGS    - ';'-separated argument list passed to the tool
+#   EXPECT_MATCH - regex that must appear in stdout or stderr
+
+cmake_minimum_required(VERSION 3.18...3.29)
+
+foreach(_required TOOL EXPECT_EXIT)
+  if(NOT DEFINED ${_required} OR "${${_required}}" STREQUAL "")
+    message(FATAL_ERROR "[bench-apply-cli] ${_required} not set")
+  endif()
+endforeach()
+
+if(NOT EXISTS "${TOOL}")
+  message(FATAL_ERROR "[bench-apply-cli] tool not found: ${TOOL}")
+endif()
+
+if(NOT EXPECT_EXIT STREQUAL "zero" AND NOT EXPECT_EXIT STREQUAL "nonzero")
+  message(FATAL_ERROR
+    "[bench-apply-cli] EXPECT_EXIT must be 'zero' or 'nonzero', got '${EXPECT_EXIT}'")
+endif()
+
+# EXPECT_MATCH is mandatory for a negative test, enforced rather than advised.
+# "nonzero" on its own is satisfied by any failure, and the ones most likely to
+# occur are not the one being tested: on Windows a missing IccProfLib2.dll exits
+# -1073741515, which is a perfectly ordinary nonzero status. A negative test
+# without a message assertion would then pass on every Windows leg while proving
+# nothing, which is the exact shape of defect #2254 collects. Making it a
+# configuration error means the next such test cannot be written vacuously.
+if(EXPECT_EXIT STREQUAL "nonzero"
+   AND (NOT DEFINED EXPECT_MATCH OR "${EXPECT_MATCH}" STREQUAL ""))
+  message(FATAL_ERROR
+    "[bench-apply-cli] EXPECT_EXIT=nonzero requires EXPECT_MATCH: a bare"
+    " nonzero exit does not distinguish the refusal under test from a crash"
+    " or a missing runtime library")
+endif()
+
+execute_process(
+  COMMAND "${TOOL}" ${TOOL_ARGS}
+  RESULT_VARIABLE _result
+  OUTPUT_VARIABLE _stdout
+  ERROR_VARIABLE  _stderr
+)
+
+set(_output "${_stdout}${_stderr}")
+
+message(STATUS "[bench-apply-cli] ${TOOL} ${TOOL_ARGS}")
+message(STATUS "[bench-apply-cli] exit=${_result}")
+message(STATUS "[bench-apply-cli] output:\n${_output}")
+
+# A non-numeric RESULT_VARIABLE means the process could not be started at all --
+# execute_process reports the reason as a string rather than a status. That is a
+# narrower case than it looks: a process that starts and then dies for a missing
+# DLL still yields a number. The EXPECT_MATCH requirement above is what covers
+# that; this check only keeps a failure-to-launch from being read as a status.
+if(NOT _result MATCHES "^-?[0-9]+$")
+  message(FATAL_ERROR "[bench-apply-cli] tool did not run: ${_result}")
+endif()
+
+if(EXPECT_EXIT STREQUAL "zero" AND NOT _result EQUAL 0)
+  message(FATAL_ERROR
+    "[bench-apply-cli] expected success, got exit ${_result}")
+endif()
+
+if(EXPECT_EXIT STREQUAL "nonzero" AND _result EQUAL 0)
+  message(FATAL_ERROR
+    "[bench-apply-cli] expected a nonzero exit, got 0")
+endif()
+
+if(DEFINED EXPECT_MATCH AND NOT "${EXPECT_MATCH}" STREQUAL "")
+  if(NOT _output MATCHES "${EXPECT_MATCH}")
+    message(FATAL_ERROR
+      "[bench-apply-cli] output did not match '${EXPECT_MATCH}'")
+  endif()
+endif()
+
+message(STATUS "[bench-apply-cli] OK")

--- a/Tools/CmdLine/IccBenchApply/BenchCases.cpp
+++ b/Tools/CmdLine/IccBenchApply/BenchCases.cpp
@@ -161,6 +161,28 @@ static void EnsureRoots()
 // source tree on POSIX and iccdev.windows-create-profiles writes them into the
 // build tree (see the note at Build/Cmake/Testing/CMakeLists.txt:1746), so a
 // single hardcoded root works on exactly one platform.
+// #2254: each root is tried two ways -- as a directory that CONTAINS Testing/,
+// and as a Testing tree itself. One hardcoded "/Testing/" segment was wrong for
+// both platforms in different ways.
+//
+// On Windows the generated profiles do not live under <build>/Testing at all.
+// iccdev.windows-create-profiles copies the source Testing/ tree to
+// ${ICCDEV_TEST_OUTDIR}/windows-testing and generates its 135 profiles there
+// (Build/Cmake/Testing/CMakeLists.txt:5238, RunWindowsBatchTest.cmake:184-194),
+// so with ICCDEV_BENCH_BUILD_ROOT=${CMAKE_BINARY_DIR} the probe looked in
+// <build>/Testing -- the CTest scratch directory -- and missed all nine cases.
+// iccdev.apply-throughput has therefore been passing on every Windows leg
+// without measuring anything: 0.01s on run 32563985818, against 6.62s for the
+// fixture that generated the profiles it never found. A directory that is
+// already a Testing tree can now be named directly.
+//
+// On POSIX the same second form fixes the other reported case: running the tool
+// from inside Testing/, where the default root of "." made every path resolve
+// as ./Testing/Testing/<rel> and all nine cases SKIP.
+//
+// The forms are ordered containing-root first so that a repository root keeps
+// resolving exactly as it did; the direct form is only reached when the first
+// misses.
 bool icBenchResolveProfile(const std::string &rel, std::string &abs)
 {
   EnsureRoots();
@@ -169,12 +191,16 @@ bool icBenchResolveProfile(const std::string &rel, std::string &abs)
   for (int i = 0; i < 2; i++) {
     if (roots[i]->empty())
       continue;
-    std::string cand = *roots[i] + "/Testing/" + rel;
-    FILE *f = fopen(cand.c_str(), "rb");
-    if (f) {
-      fclose(f);
-      abs = cand;
-      return true;
+
+    const std::string cands[2] = { *roots[i] + "/Testing/" + rel,
+                                   *roots[i] + "/" + rel };
+    for (int j = 0; j < 2; j++) {
+      FILE *f = fopen(cands[j].c_str(), "rb");
+      if (f) {
+        fclose(f);
+        abs = cands[j];
+        return true;
+      }
     }
   }
   return false;

--- a/Tools/CmdLine/IccBenchApply/Readme.md
+++ b/Tools/CmdLine/IccBenchApply/Readme.md
@@ -27,7 +27,7 @@ way.
 | `-threads L` | comma list of thread counts, e.g. `1,2,8` (default `1`) |
 | `-perxform` | per-xform breakdown, including PCS steps |
 | `-leaf` | isolated hot leaf functions |
-| `-suite` | run the built-in case table, ignoring any chain arguments |
+| `-suite` | run the built-in case table; takes no chain arguments |
 | `-csv` | machine-readable output |
 
 Examples:
@@ -36,9 +36,20 @@ Examples:
 # one chain, per-xform breakdown
 iccBenchApply -perxform 1 Testing/V2/v2RgbLut8.icc 1 Testing/V2/v2CmykLut16.icc 1
 
+# the built-in table
+iccBenchApply -suite
+
 # the built-in table at three thread counts, as CSV
 iccBenchApply -suite -csv -threads 1,2,8
+
+# the built-in table, bounded for a quick check
+iccBenchApply -suite -pixels 65536 -repeats 3
 ```
+
+`-suite` and a chain are alternatives, not a chain with a default. Passing both
+is refused rather than silently resolved in favour of the table, and `-perxform`
+and `-leaf` are refused with `-suite` because the table reports whole-chain
+throughput only. Anything the tool will not act on, it says so about.
 
 The chain is a repeating trailing group, which is what makes non-round-tripping
 profiles usable: an input-only profile such as `SpecRef/SixChanCameraRef.icc` or
@@ -130,9 +141,48 @@ and NaN — because several of the clamp and non-finite paths worth measuring wo
 otherwise never execute, and a happy-path-only buffer would let an incorrect
 change pass the checksum oracle unnoticed.
 
+## Runtime, and what looks like a hang
+
+The suite gives every case the same pixel budget, and the cases do not cost the
+same per pixel. On one Release host the spread across the table was `monochrome`
+at 33.77 Mpx/s against `mpe-calc` at 0.18 -- a factor of about 190 -- so at the
+default 1048576 pixels and 7 repeats, `mpe-calc` alone accounts for most of the
+run. On a debug or sanitizer build, where every case is slower again by an order
+of magnitude, that single case can run for tens of minutes.
+
+That is slow, not stuck. Each row's case name and thread count are printed and
+flushed before the measurement starts, so the case in progress is always the one
+named last. Under `-csv` that notice goes to stderr instead -- `running <case>
+t=<n>` -- because a record stream cannot carry a half-written row; stdout stays
+exactly the CSV a parser expects. Use `-pixels` to bound a run; the registered
+`iccdev.apply-throughput` test uses `-pixels 65536 -repeats 3`.
+
+## Exit status
+
+Zero when every measured case agreed with itself across thread counts and across
+a second `Begin()`. Nonzero on a checksum that moved, on an argument the tool
+will not act on, and -- since #2254 -- when the run measured no cases at all.
+Individual `SKIP`s are tolerated, because a case that cannot resolve on one
+platform is expected; nine of nine is not a benchmark, it is a misconfiguration,
+and it used to exit zero.
+
 ## Profile path resolution
 
 `-suite` resolves each Testing-relative path against two roots, in order:
 `ICCDEV_BENCH_SOURCE_ROOT` then `ICCDEV_BENCH_BUILD_ROOT`, defaulting to `.`.
 Both are needed because the POSIX profile fixture writes generated profiles into
-the source tree while the Windows fixture writes them into the build tree.
+the source tree while the Windows fixture writes them into its own work
+directory.
+
+Each root is tried two ways -- as a directory that *contains* `Testing/`, and as
+a `Testing` tree itself -- so `iccBenchApply -suite` works from the repository
+root and from inside `Testing/`, and a fixture directory that is already a
+Testing tree can be named directly. The containing form is tried first, so a
+repository root resolves exactly as it always did.
+
+Note that all nine cases open a *generated* profile first. The one tracked
+profile in the table, `ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc`, is never
+first in its chain, so without the `create-profiles` fixture having run every
+case reports `SKIP` and the run fails; see **Exit status** above. The two
+registered tests that drive the suite are therefore only registered where a
+profile-generating target exists.

--- a/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
+++ b/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
@@ -111,7 +111,7 @@ static void Usage()
   printf("  -perxform          per-xform breakdown, including PCS steps\n");
   printf("  -leaf              isolated hot leaf functions\n");
   printf("  -threads L         comma list of thread counts, e.g. 1,2,8\n");
-  printf("  -suite             run the built-in case table, ignoring any chain\n");
+  printf("  -suite             run the built-in case table; takes no chain\n");
   printf("  -csv               machine-readable output\n");
   printf("\nNo timing threshold is ever asserted. This tool records.\n");
 }
@@ -225,6 +225,30 @@ static bool RunThreadSweep(CIccCmm &cmm, const std::vector<int> &threads,
     BenchStats st;
     icUInt32Number sum;
 
+    // #2254: emit the row's identity BEFORE the measurement, not after it. The
+    // suite's per-case cost spans two orders of magnitude at a fixed pixel
+    // budget -- 33.77 Mpx/s for monochrome against 0.18 for mpe-calc on the same
+    // host -- so on a slow or instrumented build one case can run for tens of
+    // minutes. With nothing on stdout until it finished, that was reported as a
+    // hang: the last line printed was the previous case, and the running one was
+    // invisible. The completed row is byte-identical to before; only the moment
+    // the first half of it appears has changed. CSV is untouched, since a
+    // half-written record is not a record.
+    if (g_bCsv) {
+      // CSV cannot carry a half-written row, so the progress goes to stderr --
+      // the same channel the empty-suite diagnostic uses, and for the same
+      // reason. CI drives the suite with -csv, which is precisely where a case
+      // that runs for tens of minutes is least visible, so gating the progress
+      // on !g_bCsv would have left the reported symptom in place exactly where
+      // it was reported from.
+      fprintf(stderr, "running %s t=%d\n", szCaseName, n);
+      fflush(stderr);
+    }
+    else {
+      printf("  %-16s t=%-4d ", i ? "" : szCaseName, n);
+      fflush(stdout);
+    }
+
     if (n == 1) {
       st = icBenchRun(
         [&]() { cmm.Apply(dst.data(), src.data(), g_nPixels); },
@@ -238,8 +262,15 @@ static bool RunThreadSweep(CIccCmm &cmm, const std::vector<int> &threads,
       // after the first threaded iteration and the next one would use freed
       // memory.
       CIccThreadedCmm *pT = CIccThreadedCmm::Attach(&cmm, n, false);
+      // The CSV arm is new with #2254. This branch used to print the human row
+      // unconditionally, so an Attach failure under -csv injected a padded text
+      // line into the middle of the record stream. Reporting it as a record
+      // keeps the file parseable and keeps the failure visible.
       if (!pT) {
-        printf("  %-16s t=%-4d  (Attach failed; skipped)\n", szCaseName, n);
+        if (g_bCsv)
+          printf("%s,%d,,,,,attach-failed\n", szCaseName, n);
+        else
+          printf(" (Attach failed; skipped)\n");
         continue;
       }
       st = icBenchRun(
@@ -265,8 +296,7 @@ static bool RunThreadSweep(CIccCmm &cmm, const std::vector<int> &threads,
              st.maxMpxPerSec, sum, bMatch ? "ok" : "checksum-mismatch");
     }
     else {
-      printf("  %-16s t=%-4d %9.2f %7.2fx  0x%08x  %s\n",
-             i ? "" : szCaseName, n, st.medianMpxPerSec,
+      printf("%9.2f %7.2fx  0x%08x  %s\n", st.medianMpxPerSec,
              rateFirst > 0.0 ? st.medianMpxPerSec / rateFirst : 0.0,
              sum, bMatch ? "OK" : "CHECKSUM MISMATCH");
     }
@@ -380,10 +410,19 @@ static void RunLeaf(const char *szProfilePath)
 
 // Runs the built-in table.
 //
-// A case whose profile is missing is a SKIP with a reason, not a failure: a build
-// configured without ENABLE_ICCXML never generates most of the corpus, and the
-// cases whose profiles are tracked should still run there. An explicit chain on
-// the command line is held to a stricter standard and fails loudly instead.
+// A case whose profile is missing is a SKIP with a reason, not a failure, so a
+// corpus that is short one profile still measures the rest. #2254 corrected the
+// scope of that tolerance: it used to extend to a run in which NOTHING
+// measured, and the original note here claimed "the cases whose profiles are
+// tracked should still run" on a build configured without ENABLE_ICCXML. That
+// set is empty. All nine cases open a generated profile FIRST -- the only
+// tracked profile in the table, ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc,
+// is never first -- so without the corpus generator the suite measures zero
+// cases, every time. Tolerating that made the exit status say "pass" for a run
+// that did nothing. Zero measured is now a failure, and the CTests that drive
+// the suite are registered only where a profile-generating target exists. An
+// explicit chain on the command line is held to a stricter standard still, and
+// fails loudly on the first profile it cannot open.
 static int RunSuite()
 {
   const std::vector<BenchCase> &cases = icBenchBuiltinCases();
@@ -513,12 +552,51 @@ static int RunSuite()
     printf("\n  %d case(s) measured, %d skipped.%s\n", nRan, nSkipped,
            bAllOk ? "" : "  SOME CASES FAILED.");
 
+  // #2254: measuring nothing is a failure, not a pass. Every case SKIPs when the
+  // profile roots are wrong -- running from Testing/ is enough, because the
+  // roots default to "." and the tool then looks for ./Testing/Testing/... -- and
+  // the old exit status made that indistinguishable from a clean run. That also
+  // made iccdev.apply-throughput vacuous: it drives this function and asserts
+  // only the exit code, so a build whose profile fixture produced nothing still
+  // reported a passing benchmark. Individual SKIPs stay tolerated; a case that
+  // cannot resolve on one platform is expected. Zero of nine is not.
+  if (!nRan) {
+    // stderr, unlike every other diagnostic in this file, because this one is
+    // the only one that can be reached with -csv in effect: stdout is then a
+    // record stream and a paragraph of prose in the middle of it is not
+    // parseable. Flush stdout first so the two streams keep the order they were
+    // written in when both land in one log.
+    fflush(stdout);
+    fprintf(stderr,
+            "FAIL: no benchmark cases were measured. All %d were skipped.\n"
+            "      Each of ICCDEV_BENCH_SOURCE_ROOT and ICCDEV_BENCH_BUILD_ROOT\n"
+            "      (both defaulting to \".\") is tried as a directory holding a\n"
+            "      Testing/ tree and as a Testing tree itself, so run this from\n"
+            "      the repository root or from Testing/, or set those roots.\n"
+            "      Generated profiles come from the create-profiles fixture.\n",
+            nSkipped);
+    return 1;
+  }
+
   return bAllOk ? 0 : 1;
 }
 
 int main(int argc, const char *argv[])
 {
-  if (argc < 3) {
+  // #2254: this floor was 3, which rejected every two-argument invocation --
+  // `iccBenchApply -suite` among them, the shortest and most obvious way to ask
+  // for the built-in table. The chain needs two arguments and -suite needs
+  // none, so an argc floor cannot express the requirement for both; the real
+  // per-mode checks are below, where the mode is known. An invocation with no
+  // arguments at all is still just the usage text.
+  //
+  // Worth being exact about what this did and did not break: the Readme's
+  // examples all carried enough options to clear the floor, so nothing
+  // documented was failing. The cost was that the natural spelling did not
+  // work, and callers padded it with a stray trailing token instead -- which is
+  // how the silent chain-discard below went unnoticed. The bare form is now an
+  // example, because it now runs.
+  if (argc < 2) {
     Usage();
     return 1;
   }
@@ -597,7 +675,29 @@ int main(int argc, const char *argv[])
   if (g_threads.empty())
     g_threads.push_back(1);
 
-  // -suite ignores any chain arguments, as documented: the table is the input.
+  // #2254: -suite used to ignore trailing arguments outright, which is how a QA
+  // run of `iccBenchApply -suite 1 sRGB_v4_ICC_preference.icc 10002` produced
+  // the built-in table and never touched that profile or that intent. Silently
+  // discarding a chain the caller spelled out in full is worse than refusing it,
+  // so refuse it and name what was dropped. Now that the argc floor above lets
+  // `-suite` stand alone, there is a correct spelling to point at.
+  if (g_bSuite && nArg < argc) {
+    printf("-suite runs the built-in case table and takes no chain;"
+           " '%s' and everything after it would be ignored.\n"
+           "Drop them, or drop -suite to benchmark that chain.\n", argv[nArg]);
+    return 1;
+  }
+
+  // Same reason, different argument: RunSuite reads neither g_bPerXform nor
+  // g_bLeaf, so both were accepted and dropped. A caller who asked for a
+  // breakdown and got a plain table has no way to tell it was refused.
+  if (g_bSuite && (g_bPerXform || g_bLeaf)) {
+    printf("%s has no effect with -suite: the built-in table reports"
+           " whole-chain throughput only.\n",
+           g_bPerXform ? "-perxform" : "-leaf");
+    return 1;
+  }
+
   if (g_bSuite)
     return RunSuite();
 


### PR DESCRIPTION
Closes #2254.

## What the QA report found, and what it turned out to be

The report is four invocations of `iccBenchApply` and a 28-minute hang. Every one
of them had an exit status that agreed with the wrong outcome, which is why none
had ever shown up in CI.

| QA sample | Behaviour on `0964739d` | Now |
|---|---|---|
| `cd Testing && iccBenchApply -suite  1 sRGB…icc 10002` | 9 SKIP, **exit 0** | 9 measured, exit 0 |
| `iccBenchApply -suite 1` | table runs, `1` silently discarded | refused, naming what was dropped |
| `iccBenchApply -suite 0` | identical output to `-suite 1` | refused likewise |
| `iccBenchApply -suite` | usage text, **exit 1** | runs the table |
| `-suite` stops after `mono-lab` for 28 min | no output while a case runs | case name flushed before the measurement |

The hang is not a stall. At a fixed pixel budget the table spans about **190×**
between the cheapest and dearest case — `monochrome` 33.77 Mpx/s against
`mpe-calc` 0.18 on one Release host — so `mpe-calc` alone accounts for most of a
run, and more than that on a debug or instrumented build. Nothing reached stdout
until a case *finished*, so the case in progress was invisible and the last line
printed was the previous one.

## The defect underneath the first sample

`icBenchResolveProfile` built exactly one candidate, `<root>/Testing/<rel>`. That
single hardcoded segment was wrong on both platforms:

* **POSIX** — run from inside `Testing/`, the default root of `"."` makes every
  path resolve as `./Testing/Testing/<rel>`. All nine cases SKIP.
* **Windows** — `iccdev.windows-create-profiles` generates its 135 profiles into
  `${ICCDEV_TEST_OUTDIR}/windows-testing`, a copy of the source `Testing/` tree,
  **not** into `<build>/Testing`, which is the CTest scratch directory. With
  `ICCDEV_BENCH_BUILD_ROOT=${CMAKE_BINARY_DIR}` the probe looked somewhere the
  profiles have never been.

All nine cases open a *generated* profile first — the table's one tracked
profile, `ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc`, is never first in its
chain — so on Windows every case SKIPped and `iccdev.apply-throughput` reported a
passing benchmark having measured nothing.

**That is visible in this repository's own CI.** Run `32563985818`, the Windows
MSVC + ClangCL leg of the previous iccBenchApply PR:

```
2/108 Test #4: iccdev.windows-create-profiles ...... Passed  6.62 sec
3/108 Test #2: iccdev.apply-throughput ............. Passed  0.01 sec
```

6.62 seconds to generate the profiles; 0.01 seconds to "benchmark" nine cases at
65536 pixels × 3 repeats. The same suite takes 1.85s on a fast Linux host and 46s
under ASan. The test has been vacuous on every Windows leg for its whole life.

Each root is now tried two ways — as a directory *containing* `Testing/`, and as
a `Testing` tree itself — containing form first, so a repository root resolves
exactly as it always did.

## Reproducing the Windows result without Windows

`windows-testing` is a Testing tree with no `Testing/` child. Building a
directory with that shape locally reproduces the leg exactly:

```sh
# after ctest -R iccdev.create-profiles, build a tree with the same shape:
mkdir -p /tmp/win-shape
tar -C Testing -cf - V2 Calc Display SpecRef ApplyDataFiles | tar -C /tmp/win-shape -xf -
test ! -d /tmp/win-shape/Testing   # a Testing tree with no Testing/ child

cd / && ICCDEV_BENCH_SOURCE_ROOT=/nonexistent ICCDEV_BENCH_BUILD_ROOT=/tmp/win-shape \
  iccBenchApply -pixels 4096 -repeats 1 -suite
```

```
0964739d:     0 case(s) measured, 9 skipped.   exit=0
this branch:  9 case(s) measured, 0 skipped.   exit=0
```

## Where the corpus does not exist

Because all nine cases need generated profiles, the two CTests that *drive* the
suite are registered only where a profile-generating target exists. The
`mingw-core-x64` preset is `ENABLE_ICCXML=OFF` with `ENABLE_TESTS=ON` and
`ENABLE_TOOLS=ON`, and `iccdev.windows-create-profiles` sits inside
`if(TARGET iccFromXml)` — so the suite there can only ever measure zero, and the
corrected exit status would report a configuration choice as a defect. Verified
by configuring that shape:

```
$ cmake -S Build/Cmake -B build-noxml -DENABLE_ICCXML=OFF -DENABLE_TESTS=ON -DENABLE_TOOLS=ON
$ ctest -N -R 'bench-apply|apply-throughput'
  iccdev.apply-throughput-pcc              # tracked profile only
  iccdev.bench-apply-arity-floor           # exits before opening a profile
  iccdev.bench-apply-suite-rejects-chain
  iccdev.bench-apply-suite-rejects-perxform
  iccdev.bench-apply-empty-suite           # asserts the ABSENCE of a corpus
```

The argument-handling tests are deliberately not gated.

## Tests

Five, each **red against `0964739d` for its own distinct reason**:

| test | red because |
|---|---|
| `iccdev.bench-apply-arity-floor` | old tool prints the usage text, not `No profiles given` |
| `iccdev.bench-apply-suite-rejects-chain` | old tool exits 0 |
| `iccdev.bench-apply-suite-rejects-perxform` | old tool exits 0 |
| `iccdev.bench-apply-testing-cwd` | old tool measures 0 cases from inside `Testing/` |
| `iccdev.bench-apply-empty-suite` | old tool exits 0 with nothing measured |

The last two are each other's controls: one must *measure* with only the direct
root form available, the other must *fail* with neither form resolving. And
`-testing-cwd` exercises on POSIX the same code path that makes the Windows
profile tree reachable, so neither platform relies on a leg the other does not
run.

`RunBenchApplyCliTest.cmake` asserts exit status **and** message together, which
neither `WILL_FAIL` (passes on any nonzero exit) nor `PASS_REGULAR_EXPRESSION`
(ignores the return code) can do alone. It also **refuses to run** a
`EXPECT_EXIT=nonzero` test that carries no message assertion: on Windows a
missing `IccProfLib2.dll` exits `-1073741515`, an ordinary nonzero status that
would satisfy such a test while proving nothing.

## Compatibility

Completed output rows are byte-identical — only the moment the first half of a
row appears has changed. Under `-csv` the progress notice goes to stderr, so
stdout stays exactly the record stream a parser expects; `ci-afl-regression-repro.yml`
pipes stdout only, and its 27-record / 9-case `awk` contract is unaffected. An
`Attach` failure under `-csv` previously injected a padded text line into the
middle of the record stream and now emits a record.

No tracked invocation passes a chain to `-suite`; `docs/tools-cli-reference.md`
and the Readme both use option-only forms.

## Pre-flight

| lane | result |
|---|---|
| clang 21.1.3 `-Wall -Wextra -Wpedantic -Werror`, strict ENABLED | 0 warnings |
| GCC 15.2.0 Release + LTO, CI's own container, `-Werror` | 0 warnings |
| clang 22.1.2 ASAN+UBSAN Debug, CI's container, `-Werror` | 0 warnings |
| full `ctest` in CI's container | **207/207 passed** |
| `iccBenchApply` under ASan+UBSan, `detect_leaks=1`, both cwds | clean |

Dispatched pre-PR per the suggested workflow: `ci_scope=source`, run
`32589818957` — 8 jobs green (GCC 15.2 Strict Release LTO, Tool Smoke Tests
ASAN+UBSAN Debug, Windows MSVC + ClangCL, MinGW UCRT64 smoke, macOS Debug and
Release LTO).

## The Windows leg, measured on that run

This is the part that could only be verified on CI, and it is the clearest
statement of what the PR does:

```
run 32563985818 (master):     iccdev.apply-throughput ... Passed   0.01 sec
run 32589818957 (this branch): iccdev.apply-throughput ... Passed  14.88 sec
                               iccdev.apply-throughput ... Passed  28.54 sec
```

Same test, same command, same nine cases. It is measuring for the first time.
`iccdev.bench-apply-testing-cwd` takes 0.50s / 0.94s there, confirming the
`windows-testing` tree resolves, and all five new tests pass on Windows. The
28.54s worst case sits inside the existing 300s `TIMEOUT` with 10x margin.
