### PR TITLE
fix(#2242): refuse symlinked TIFF output destinations at the shared CTiffImg::Create()

### DIFF
--- a/.github/ci/regression/tiff-create-bytesperline-overflow.cpp
+++ b/.github/ci/regression/tiff-create-bytesperline-overflow.cpp
@@ -46,6 +46,14 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 namespace {
 
@@ -60,10 +68,65 @@ void check(bool ok, const char *what)
 }
 
 const char *kOutPath = "tiff-create-overflow-should-not-exist.tif";
+const char *kSymlinkPath = "tiff-create-symlink-output.tif";
+const char *kSymlinkTarget = "tiff-create-symlink-target.txt";
 
 void cleanup()
 {
   std::remove(kOutPath);
+}
+
+void cleanupSymlinkTest()
+{
+  std::remove(kSymlinkPath);
+  std::remove(kSymlinkTarget);
+}
+
+bool createOutputSymlink()
+{
+#if defined(_WIN32)
+  return CreateSymbolicLinkA(kSymlinkPath, kSymlinkTarget, 0) != 0;
+#else
+  return symlink(kSymlinkTarget, kSymlinkPath) == 0;
+#endif
+}
+
+bool outputIsSymlink()
+{
+#if defined(_WIN32)
+  DWORD attributes = GetFileAttributesA(kSymlinkPath);
+  return attributes != INVALID_FILE_ATTRIBUTES &&
+         (attributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0;
+#else
+  struct stat st;
+  return lstat(kSymlinkPath, &st) == 0 && S_ISLNK(st.st_mode);
+#endif
+}
+
+bool targetContentIsOriginal()
+{
+  char content[64] = {};
+  std::FILE *file = std::fopen(kSymlinkTarget, "rb");
+  if (!file)
+    return false;
+
+  size_t count = std::fread(content, 1, sizeof(content) - 1, file);
+  std::fclose(file);
+  return count == std::strlen("IMPORTANT ORIGINAL CONTENT\n") &&
+         std::strcmp(content, "IMPORTANT ORIGINAL CONTENT\n") == 0;
+}
+
+bool writeOriginalTarget()
+{
+  std::FILE *file = std::fopen(kSymlinkTarget, "wb");
+  if (!file)
+    return false;
+
+  const char *content = "IMPORTANT ORIGINAL CONTENT\n";
+  bool ok = std::fwrite(content, 1, std::strlen(content), file) ==
+            std::strlen(content);
+  std::fclose(file);
+  return ok;
 }
 
 // Create() with parameters whose bytes-per-line overflows unsigned int must fail.
@@ -217,6 +280,64 @@ int main()
       }
     }
     cleanup();
+  }
+
+  // --- 8. CTiffImg is shared by iccSpecSepToTiff and iccApplyProfiles. A
+  // symlink destination must be rejected before TIFFOpen("w") follows it and
+  // truncates its target. Keep the check here at the shared Create() boundary
+  // rather than duplicating it in either caller.
+  //
+  // Red/green: against the pre-fix TiffImg.cpp two of the three assertions
+  // below fail -- Create() returns true and the target comes back holding a
+  // TIFF header instead of its original bytes. The third ("leaves the rejected
+  // symlink intact") passes either way, because the pre-fix path wrote through
+  // the link rather than unlinking it; it is here to pin that refusing the
+  // destination stays non-destructive, not to detect the original defect.
+  {
+    cleanupSymlinkTest();
+    check(writeOriginalTarget(), "created the symlink regression target");
+    if (createOutputSymlink()) {
+      CTiffImg img;
+      const bool ok = img.Create(kSymlinkPath, 64u, 4u, 8u, PHOTO_MINISBLACK,
+                                 3u, 0u, 72.0f, 72.0f);
+      check(!ok, "Create() rejects a symlink output destination");
+      img.Close();
+      check(outputIsSymlink(), "Create() leaves the rejected symlink intact");
+      check(targetContentIsOriginal(),
+            "Create() leaves the rejected symlink target unchanged");
+    }
+    else {
+      std::printf("[tiff-create-overflow] SKIP: cannot create file symlink\n");
+    }
+    cleanupSymlinkTest();
+  }
+
+  // --- 9. A device is not a regular output destination.
+  //
+  // The POSIX arm of this case passes against the pre-fix TiffImg.cpp too --
+  // stat() already reported /dev/null as non-regular, so this is regression
+  // coverage for behaviour that must survive the lstat() switch, not evidence
+  // of the defect. The genuinely new coverage is the Windows arm: "NUL" and
+  // "NUL.tif" are reserved DOS device names that GetFileAttributesA() reports
+  // as INVALID_FILE_ATTRIBUTES, which the old `return true;` Windows stub
+  // accepted outright.
+  {
+#if defined(_WIN32)
+    // "C:NUL" is drive-relative and resolves to the null device just as "NUL"
+    // does; it is listed because the basename scan stops at ':' and an earlier
+    // revision of the name check therefore missed it. "CONIN$" matches neither
+    // the 3- nor the 4-character reserved-name form.
+    const char *devicePaths[] = { "NUL", "NUL.tif", "C:NUL", "CONIN$" };
+#else
+    const char *devicePaths[] = { "/dev/null" };
+#endif
+    for (const char *devicePath : devicePaths) {
+      CTiffImg img;
+      const bool ok = img.Create(devicePath, 64u, 4u, 8u, PHOTO_MINISBLACK,
+                                 3u, 0u, 72.0f, 72.0f);
+      check(!ok, "Create() rejects a device output destination");
+      img.Close();
+    }
   }
 
   if (g_fail)

--- a/.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh
+++ b/.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh
@@ -333,6 +333,84 @@ run_specsep_checked_in_truncated_reject() {
   pass_case "$name" "short strip read rejected and the partial output discarded"
 }
 
+run_specsep_symlink_output_reject() {
+  local name="specsep-symlink-output-reject"
+  local fixture_dir="$REPO_ROOT/.github/ci/test-data/spectral"
+  local target="$OUTDIR/specsep-symlink-target.txt"
+  local link="$OUTDIR/specsep-symlink-output.tif"
+  local expected="IMPORTANT ORIGINAL CONTENT"
+  local exit_code=0
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$target" "$link" "$LOGFILE"
+
+  if [ ! -x "$SPECSEP" ]; then
+    fail_case "$name" "missing executable: $SPECSEP"
+    return
+  fi
+
+  if [ ! -s "$fixture_dir/spec_1" ]; then
+    fail_case "$name" "missing checked-in fixture: $fixture_dir/spec_1"
+    return
+  fi
+
+  if ! ln -s "$target" "$link" 2>/dev/null; then
+    skip_case "$name" "file symlinks are unavailable"
+    return
+  fi
+  printf '%s\n' "$expected" > "$target"
+
+  timeout 60 "$SPECSEP" "$link" 0 0 "$fixture_dir/spec_" 1 3 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  # The reject path still runs the tool, so a recoverable sanitizer report under
+  # halt_on_error=0 would leave exit=255 and the expected diagnostic intact and
+  # the case would pass with a finding sitting in the log.  Match the sibling
+  # reject cases and fail on it.
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 255 ]; then
+    fail_case "$name" "expected symlink rejection exit=255, got exit=$exit_code"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if ! grep -Fq "regular non-symlink file" "$LOGFILE" 2>/dev/null; then
+    fail_case "$name" "missing symlink output diagnostic"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ ! -L "$link" ]; then
+    fail_case "$name" "rejected output symlink was removed"
+    return
+  fi
+
+  if [ "$(cat "$target")" != "$expected" ]; then
+    fail_case "$name" "rejected output symlink target was modified"
+    return
+  fi
+
+  rm -f "$target"
+  exit_code=0
+  timeout 60 "$SPECSEP" "$link" 0 0 "$fixture_dir/spec_" 1 3 1 > "$LOGFILE" 2>&1 || exit_code=$?
+
+  if ! check_sanitizers "$name" "$LOGFILE"; then
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  if [ "$exit_code" -ne 255 ] || [ ! -L "$link" ]; then
+    fail_case "$name" "rejected dangling output symlink was modified or removed"
+    sed -n '1,40p' "$LOGFILE"
+    return
+  fi
+
+  pass_case "$name" "valid and dangling output symlinks were left intact"
+}
+
 run_specsep_geometry_reject() {
   local name="specsep-tiff-geometry-reject"
   local exit_code=0
@@ -870,6 +948,7 @@ run_specsep_create_failure_preserves_existing_output() {
 echo "=== iccSpecSepToTiff malformed TIFF geometry regression ==="
 run_specsep_resolution_unit_preserve
 run_specsep_checked_in_truncated_reject
+run_specsep_symlink_output_reject
 run_specsep_geometry_reject
 run_specsep_packed_bps_reject
 run_specsep_descending_range_accept

--- a/Tools/CmdLine/IccApplyProfiles/Readme.md
+++ b/Tools/CmdLine/IccApplyProfiles/Readme.md
@@ -60,6 +60,22 @@ The destination TIFF carries the source's `XResolution`, `YResolution` and
 `ResolutionUnit`. The unit tag is always written, so the output states its unit
 rather than relying on the reader defaulting an absent tag to inches.
 
+## Output Destination Safety
+
+The destination must be a regular non-symlink file when it already exists.
+Directories, devices, POSIX symlinks, and Windows reparse points are rejected
+before libtiff opens the destination. Naming a symlink as the output is
+therefore an error rather than a write through to its target; point the tool at
+the target path directly.
+
+Two limits are deliberate rather than oversights:
+
+- A **hard** link is accepted. It is another name for the regular file it links
+  to, and nothing in the file's metadata distinguishes it from the original.
+- The destination is checked and then opened, so a path swapped between those
+  two steps is not covered. The check guards against writing through a symlink
+  that is already there, not against a race for the path.
+
 ## See Also
 
 - [CLI tool reference](../../../docs/tools-cli-reference.md)

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -75,7 +75,39 @@
 #include <limits>
 #include "TiffImg.h"
 
-#if !defined(_WIN32)
+// The output-destination check below needs GetFileAttributesA() on Windows and
+// lstat()/errno on POSIX (#2242).  <windows.h> is pulled in here, in the shared
+// TU, rather than in either tool: iccSpecSepToTiff and iccApplyProfiles both
+// reach the destination through this file's CTiffImg::Create(), so a tool-local
+// copy would harden one caller and leave the other.
+//
+// NOMINMAX alone is NOT sufficient here, and getting this wrong breaks the
+// build rather than the behaviour.  <windows.h> defines min()/max() as
+// function-like macros, and this TU already used three names they capture --
+// kMaxTiffSamples and checkedUInt32's std::numeric_limits<>::max() below, and
+// the std::max() in Open()'s strip sizing.  The guard only suppresses them if
+// it is seen before the FIRST inclusion of <windows.h>, and that can arrive
+// transitively through "TiffImg.h" above, at which point the #define lands too
+// late and the include guard makes our own #include a no-op.  MSVC then reports
+// C4003 "not enough arguments for function-like macro invocation 'max'" plus
+// C2589/C2059 at each of the three sites.  Undefining the macros after the
+// include is what actually guarantees it -- the same belt-and-braces pairing
+// used at IccXML/IccLibXML/IccUtilXml.cpp:75-88, which needs it for the same
+// reason.  (IccProfLib/IccTagBasic.cpp:1669 solves the same collision the other
+// way, by writing the call as "(std::numeric_limits<T>::max)()".)
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#ifdef max
+#undef max
+#endif
+#ifdef min
+#undef min
+#endif
+#else
+#include <cerrno>
 #include <sys/stat.h>
 #endif
 
@@ -118,14 +150,127 @@ bool checkedUInt32Product(unsigned int a, unsigned int b, unsigned int &result)
   return checkedUInt32(static_cast<icUInt64Number>(a) * b, result);
 }
 
+#if defined(_WIN32)
+// Win32 resolves the reserved DOS device names (CON, PRN, AUX, NUL, COM1-9,
+// LPT1-9) anywhere on a path, with any extension and with trailing spaces
+// ignored -- "NUL", "NUL.tif" and "dir\\NUL " all open the null device rather
+// than creating a file.  GetFileAttributesA() reports INVALID_FILE_ATTRIBUTES
+// for them, which the caller below would otherwise read as "nothing there yet,
+// go ahead", so the name has to be rejected before the attribute query.  This
+// is the Windows counterpart of the POSIX S_ISREG() arm refusing /dev/null.
+bool isWindowsDevicePath(const char *path)
+{
+  const char *name = path;
+
+  // "C:NUL" is drive-*relative*: it names NUL in the current directory of drive
+  // C:, and Win32 resolves it to the null device just as "NUL" does.  The
+  // basename scan below stops at ':', so with the drive prefix left on, the
+  // scan ends at length 1 and the device name is never compared -- the path
+  // would be approved and written to the null device.  Strip the prefix first.
+  if (name[0] && name[1] == ':' &&
+      ((name[0] >= 'A' && name[0] <= 'Z') || (name[0] >= 'a' && name[0] <= 'z')))
+    name += 2;
+
+  for (const char *p = name; *p; p++) {
+    if (*p == '\\' || *p == '/')
+      name = p + 1;
+  }
+
+  size_t length = 0;
+  while (name[length] && name[length] != '.' && name[length] != ':')
+    length++;
+  while (length && name[length - 1] == ' ')
+    length--;
+
+  switch (length) {
+  case 3:
+    return (_strnicmp(name, "CON", 3) == 0 ||
+            _strnicmp(name, "PRN", 3) == 0 ||
+            _strnicmp(name, "AUX", 3) == 0 ||
+            _strnicmp(name, "NUL", 3) == 0);
+  case 4:
+    return name[3] >= '1' && name[3] <= '9' &&
+           (_strnicmp(name, "COM", 3) == 0 ||
+            _strnicmp(name, "LPT", 3) == 0);
+  // CONIN$/CONOUT$ are reserved console devices too, and match neither of the
+  // length-3/4 forms above.
+  case 6:
+    return _strnicmp(name, "CONIN$", 6) == 0;
+  case 7:
+    return _strnicmp(name, "CONOUT$", 7) == 0;
+  default:
+    return false;
+  }
+}
+#endif
+
+// Decide whether TIFFOpen(szFname, "w") may be allowed to truncate szFname.
+//
+// The check already refused a directory, a FIFO and a device, but it used
+// stat(), which follows symbolic links -- so a destination that was a symlink
+// to a regular file was approved and the *link target* was truncated and
+// rewritten (#2242).  lstat() inspects the link itself, so a symlink is no
+// longer a regular file and is refused, whether or not its target exists.
+//
+// Any stat() failure previously meant "permit".  Only ENOENT means the path is
+// genuinely free, so that is the only failure that still permits; anything else
+// (EACCES, ENOTDIR, ELOOP on an intermediate component) is refused here instead
+// of being handed to TIFFOpen().
+//
+// Scope, measured rather than assumed: relative to the previous behaviour this
+// changes symlink destinations only.  Absent, regular, directory, FIFO and
+// device destinations all resolve exactly as before.  A *hard* link is still
+// accepted -- it is indistinguishable from the regular file it is a name for --
+// and the lstat()/TIFFOpen() pair is still two syscalls, so a destination that
+// is replaced between them is not covered.  Both limits are recorded in the
+// tool Readmes; neither is a regression introduced here.
 bool canCreateRegularOutput(const char* szFname)
 {
+  // TIFFOpen() survives a null path (libtiff reports "Bad address"), so this is
+  // a diagnostic tidy-up rather than a crash fix: it lets the caller fail with
+  // the destination message instead of a libtiff errno string.
+  if (!szFname || !szFname[0])
+    return false;
+
 #if defined(_WIN32)
-  return true;
+  if (isWindowsDevicePath(szFname))
+    return false;
+
+  DWORD attributes = GetFileAttributesA(szFname);
+  if (attributes == INVALID_FILE_ATTRIBUTES) {
+    DWORD error = GetLastError();
+    return error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND;
+  }
+
+  // Refusing every reparse point is too broad.  FILE_ATTRIBUTE_REPARSE_POINT is
+  // also set on OneDrive Files On-Demand placeholders (IO_REPARSE_TAG_CLOUD*),
+  // Windows dedup stubs (IO_REPARSE_TAG_DEDUP) and WOF-compressed files -- all
+  // ordinary files that happen to be backed indirectly, and all of which the
+  // tool wrote to happily before this change.  Only *name surrogates*
+  // (IO_REPARSE_TAG_SYMLINK and IO_REPARSE_TAG_MOUNT_POINT) redirect the write
+  // to another path, which is what #2242 is about, so discriminate on the
+  // reparse tag rather than on the attribute bit.  The tag is only reachable
+  // through FindFirstFileA's dwReserved0; szFname cannot contain a wildcard
+  // here, because GetFileAttributesA above would have failed with
+  // ERROR_INVALID_NAME and returned already.
+  if (attributes & FILE_ATTRIBUTE_REPARSE_POINT) {
+    WIN32_FIND_DATAA findData;
+    HANDLE hFind = FindFirstFileA(szFname, &findData);
+    if (hFind == INVALID_HANDLE_VALUE)
+      return false;
+
+    DWORD reparseTag = findData.dwReserved0;
+    FindClose(hFind);
+
+    if (IsReparseTagNameSurrogate(reparseTag))
+      return false;
+  }
+
+  return (attributes & (FILE_ATTRIBUTE_DEVICE | FILE_ATTRIBUTE_DIRECTORY)) == 0;
 #else
   struct stat st;
-  if (stat(szFname, &st) != 0)
-    return true;
+  if (lstat(szFname, &st) != 0)
+    return errno == ENOENT;
 
   return S_ISREG(st.st_mode);
 #endif
@@ -156,6 +301,7 @@ bool calcBytesPerLine(unsigned int width, unsigned int bitsPerSample,
 CTiffImg::CTiffImg()
   : m_hTif(NULL),
     m_bRead(false),
+    m_bOutputOpened(false),
     m_nWidth(0),
     m_nHeight(0),
     m_nBitsPerSample(0),
@@ -219,6 +365,16 @@ void CTiffImg::Close()
   }
 
   // Reset all remaining members to their ctor-initialized values (ctor order).
+  //
+  // m_bOutputOpened is the one deliberate exception to the #1429 "every member"
+  // rule above, and it is an exception because Create() calls Close() itself:
+  // both of Create()'s post-TIFFOpen failure arms (the EXTRASAMPLES calloc and
+  // the TIFFSetField that follows it) close the handle and return false with a
+  // truncated file already on disk.  Clearing the flag here would therefore
+  // report "we never opened the output" to the caller in precisely the case
+  // where a stub of ours exists to discard.  The flag records the outcome of
+  // the last Create()/Open() call rather than the state of the handle, so it is
+  // reset by those two entry points instead (#2242).
   m_bRead = false;
   m_nWidth = 0;
   m_nHeight = 0;
@@ -253,6 +409,7 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
 {
   Close();
   m_bRead = false;
+  m_bOutputOpened = false;
 
   if (nBPS % 8)
     return false;
@@ -323,9 +480,19 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
   }
 
   if (!canCreateRegularOutput(szFname)) {
-    TIFFError(szFname,"Output image must be a regular file");
+    TIFFError(szFname,"Output image must be a regular non-symlink file");
     return false;
   }
+
+  // Set before the call, not after it: TIFFOpen(..., "w") open()s with
+  // O_CREAT|O_TRUNC and only then builds the TIFF structure, so a failure
+  // inside libtiff (an allocation failure in TIFFClientOpen) returns NULL with
+  // the destination already created and truncated.  Measured with libtiff's
+  // internal allocation forced to fail: "TIFFClientOpenExt: Out of memory
+  // (TIFF structure)", TIFFOpen NULL, and a 0-byte stub left on disk.  Setting
+  // the flag after the null check below would report "we never opened the
+  // output" for exactly that stub and leak it past the caller's cleanup.
+  m_bOutputOpened = true;
 
   m_hTif = TIFFOpen(szFname, "w");
   if (!m_hTif) {
@@ -472,6 +639,7 @@ bool CTiffImg::Open(const char *szFname)
 {
   Close();
   m_bRead = true;
+  m_bOutputOpened = false;
 
   m_hTif = TIFFOpen(szFname, "r");
   if (!m_hTif) {

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.h
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.h
@@ -114,6 +114,14 @@ public:
               float fXRes, float fYRes, bool bCompress=true, bool bSep=false,
               unsigned int nResolutionUnit=RESUNIT_INCH);
   bool Open(const char *szFname);
+  // True once this object's Create() got past TIFFOpen(..., "w") -- i.e. the
+  // destination was actually created or truncated by this run.  A caller that
+  // discards a failed output needs this to tell "Create() refused the path and
+  // touched nothing" from "Create() opened the path and then failed", because
+  // only the second case leaves something of ours to remove (#2242).  Reset by
+  // Create() and Open(), and deliberately NOT cleared by Close(), so it stays
+  // readable on the failure path after Create() has closed the handle.
+  bool WasOutputOpened() const { return m_bOutputOpened; }
 
   bool ReadLine(unsigned char *pBuf);
   bool WriteLine(unsigned char *pBuf);
@@ -169,6 +177,7 @@ protected:
 
   TIFF *m_hTif;
   bool m_bRead;
+  bool m_bOutputOpened;
 
   unsigned int m_nWidth;
   unsigned int m_nHeight;

--- a/Tools/CmdLine/IccSpecSepToTiff/Readme.md
+++ b/Tools/CmdLine/IccSpecSepToTiff/Readme.md
@@ -86,11 +86,14 @@ single-channel TIFF inputs.
 - Output uses explicit `ExtraSamples` metadata for every sample beyond the
   first. Very high channel-count spectral TIFFs can be valid but may exceed
   limits in display tools such as ImageMagick.
-- On POSIX, an existing output destination must be a regular file; a directory
-  or device is rejected before anything is written. If profile embedding,
-  reading, or writing fails after the output was created, the incomplete output
-  is removed, and a failed create removes the stub only when the destination did
-  not already exist.
+- An existing output destination must be a regular non-symlink file. Directories,
+  devices, POSIX symlinks, and Windows reparse points are rejected before
+  anything is written; a hard link is accepted, being another name for a regular
+  file. If profile embedding, reading, or writing fails after the output was
+  created, the incomplete output is removed, and a failed create removes the stub
+  only when the destination did not already exist *and* this run had actually
+  opened it -- a refused destination, including a dangling symlink, is left
+  exactly as it was found.
 - A successful conversion reports the accepted profile, if any, followed by the
   output path, dimensions, bit depth, sample count, planar configuration,
   compression, and embedded-profile state. Nothing is written to standard output

--- a/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
+++ b/Tools/CmdLine/IccSpecSepToTiff/iccSpecSepToTiff.cpp
@@ -660,6 +660,15 @@ int main(int argc, char* argv[]) {
   // regular file).  Removing unconditionally on failure would therefore delete
   // a pre-existing file this run never touched, so only discard an output that
   // did not exist beforehand.
+  //
+  // outputExisted alone is not sufficient once Create() refuses symlinks
+  // (#2242).  A *dangling* symlink reads as "did not exist" here -- the probe
+  // below opens the link's target, which is missing -- so the !outputExisted
+  // arm on its own would remove() the link that Create() had just declined to
+  // touch.  Measured: with the lstat() change but without WasOutputOpened(),
+  // a dangling-symlink destination is correctly refused and then deleted.
+  // Gating on "did TIFFOpen() actually run" is what keeps the refusal
+  // non-destructive, so both halves of this guard are load-bearing.
   bool outputExisted = false;
   {
     // Probed with CIccFileIO to match readValidateProfile() above; a bare
@@ -679,7 +688,7 @@ int main(int argc, char* argv[]) {
                      (unsigned int)nSamples, nExtraSamples, xRes, yRes, bCompress, bSep,
                      f->GetResolutionUnit())) {
     fprintf(stderr, "Unable to create %s\n", icSanitizeConsoleText(argv[1]).c_str());
-    if (!outputExisted)
+    if (!outputExisted && outfile.WasOutputOpened())
       remove(argv[1]);
     return -1;
   }


### PR DESCRIPTION
## Summary

`canCreateRegularOutput()` (`TiffImg.cpp`) used `stat()`, which follows symbolic links. A
destination that was a symlink to a regular file was therefore approved, and
`TIFFOpen(..., "w")` truncated and rewrote the **link target**. The failure path then made it
worse: `discardPartialOutput()`'s `remove()` unlinked the *symlink* rather than the file it had
just damaged, so the link vanished and the target was left holding a partial TIFF.

This takes **Resolution (a)** from the issue — refuse symlinked destinations — which is the
direction @xsscx moved toward on `ci-qa-issue-2242`.

The check lives in the shared `TiffImg.cpp` because `iccSpecSepToTiff` and `iccApplyProfiles`
both reach the destination through the same `CTiffImg::Create()`; a tool-local copy would
harden one caller and leave the other.

Part of #2242.

## Reproduction, on master `1992e16d`

```sh
printf 'IMPORTANT ORIGINAL CONTENT\n' > target.txt
ln -s "$PWD/target.txt" out.tif
iccSpecSepToTiff out.tif 0 0 .github/ci/test-data/spectral/spec_ 1 3 1
```

| | master | this PR |
|---|---|---|
| exit | 0 | 255 |
| `target.txt` | 27 → **336 bytes**, magic `49492a00` | 27 bytes, unchanged |
| `out.tif` | still a symlink | still a symlink |

And the cleanup case, with an input that fails after `Create()` succeeded:

| | master | this PR |
|---|---|---|
| exit | 255 | 255 |
| `target.txt` | **174 bytes of partial TIFF** | 27 bytes, unchanged |
| `out.tif` | **GONE** — the link was removed | still a symlink |

## Why the cleanup gate is not cosmetic

Fixing only `stat()` → `lstat()` is a **regression**. I built that single-change variant to
check:

| variant | dangling-symlink destination | link survives |
|---|---|---|
| master | exit 0, silently creates the target | yes |
| `lstat()` alone | exit 255, refuses | **NO — deleted** |
| this PR | exit 255, refuses | yes |

`outputExisted` is computed by opening the link's *target*, which for a dangling link is
missing — so `!outputExisted` fires `remove()` on the very link `Create()` just declined to
touch. `WasOutputOpened()` exists for that case, and both halves of the guard are load-bearing.

## Scope: what actually changes

Measured at the shared `Create()` boundary, not assumed. Only symlinks move:

| destination | master | this PR |
|---|---|---|
| absent | accept | accept |
| regular file | accept | accept |
| hard link | accept | accept |
| **symlink → file** | **accept** | **refuse** |
| **symlink → dangling** | **accept** | **refuse** |
| directory | refuse | refuse |
| FIFO | refuse | refuse |
| device (`/dev/null`) | refuse | refuse |

A normal regular-file overwrite is byte-identical (336 bytes, same magic) before and after.

Two limits are deliberate and now recorded in both tool Readmes: a **hard link** is still
accepted (it is another name for the regular file it links to, and no metadata separates
them), and the check/open pair is still two syscalls, so this guards against a symlink that is
already there rather than a race for the path.

## `<windows.h>` in this TU breaks the build unless min/max are undefined

⚠️ This is the substantive difference from `ci-qa-issue-2242`, and worth calling out because
the branch's Windows legs are red on it: run
[32519984222](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32519984222)
fails *Windows MSVC + ClangCL build* and *MinGW UCRT64 smoke*.

Pulling `<windows.h>` into `TiffImg.cpp` captures three **pre-existing** names — `kMaxTiffSamples`
and `checkedUInt32()`'s `std::numeric_limits<>::max()`, and the `std::max()` in `Open()`'s
strip sizing. MSVC reports `C4003 not enough arguments for function-like macro invocation
'max'` plus `C2589`/`C2059` at each. `NOMINMAX` alone does not fix it: the guard only suppresses
the macros if it is seen before the **first** inclusion of `<windows.h>`, and that can arrive
transitively via `"TiffImg.h"`, after which the `#define` is too late and the include guard
makes our own `#include` a no-op.

This PR pairs `NOMINMAX` with an explicit `#undef max` / `#undef min`, which is the existing
in-repo idiom at `IccXML/IccLibXML/IccUtilXml.cpp:75-88` — that TU needs it for exactly the same
reason. (`IccProfLib/IccTagBasic.cpp:1669` solves the same collision the other way, by writing
`(std::numeric_limits<T>::max)()`.)

Proven red/green on Linux by reproducing the three expression forms under `windows.h`-style
macros: **6 compile errors** without the `#undef`, **0** with it.

## Windows arm

`_WIN32` was `return true;` — no check at all. It now rejects reserved DOS device names, then
queries attributes:

- **Only *name-surrogate* reparse points are refused**, via the reparse tag rather than the
  attribute bit. `FILE_ATTRIBUTE_REPARSE_POINT` is also set on OneDrive Files On-Demand
  placeholders, dedup stubs and WOF-compressed files — ordinary files the tool wrote to before,
  which a blanket attribute check would start rejecting.
- The device-name check strips a drive prefix first, so drive-relative `C:NUL` is caught; the
  basename scan stops at `':'` and would otherwise compare a 1-character name and approve the
  null device. `CONIN$`/`CONOUT$` are matched too.

A 28-case truth table over the extracted function (including `NUL.tif`, `NUL:`, `C:\NUL`,
`dir/NUL`, `\\?\C:\NUL`, `COM0`, `NULL.tif`, `A:`) passes all 28.

**The Windows arm is unbuildable locally** — it needs the Windows CI legs, which is why this was
dispatched with `ci_scope=source`.

## Tests

Both are new coverage, and both were confirmed to fail against the pre-fix tree rather than
merely passing against the new one:

- `.github/ci/regression/tiff-create-bytesperline-overflow.cpp` — cases 8 and 9 at the shared
  `Create()` boundary. Compiled against pristine master `TiffImg.cpp`: **2 assertions fail**
  (`Create() rejects a symlink output destination`, `...target unchanged`).
- `.github/scripts/iccdev-specsep-tiff-geometry-regression-tests.sh` —
  `specsep-symlink-output-reject`, covering a valid link, a dangling link, and the target
  contents. Against master binaries: **`[FAIL] ... expected symlink rejection exit=255, got
  exit=0`**; against this branch, `11 passed, 0 failed`.

Honest note on case 9: its POSIX `/dev/null` arm **passes against master too** — `stat()`
already reported it non-regular. It is regression coverage for behaviour that must survive the
`lstat()` switch, not evidence of the defect. The genuinely new coverage there is the Windows
arm. This is stated in the test comment so nobody reads it as a red/green assertion.

## Pre-flight

| lane | result |
|---|---|
| clang 18 Release | 0 warnings, 0 errors |
| **GCC 15.2.0 strict, CI container** (`-Wall -Wextra -Wpedantic -Werror`, LTO), full build — configure printed `strict warnings ENABLED (GNU 15.2.0)` | **0 warnings, 0 errors** |
| clang 18 strict (`-Wall -Wextra -Wpedantic -Werror`), `strict warnings ENABLED (Clang 18.1.3)` | **0 warnings, 0 errors** |
| GCC (local) Release | 0 warnings |
| ASAN+UBSAN (666 `__asan` symbols — instrumentation verified, not just the label), incl. `detect_leaks=1` | clean, 0 diagnostics |
| `shellcheck` 0.9.0, bare, on the changed script | rc=0 |
| `ctest -R "tiff\|specsep\|applyprofiles\|applytolink"` | identical to the master baseline |

CTest parity: this branch and master `1992e16d` both report `90% tests passed, 2 tests failed
out of 21`, failing the same two — `iccdev.tiff-separated-strips` (missing file, 0.01s) and
`iccdev.spectral-tiff-preview` (`ModuleNotFoundError: No module named 'imagecodecs'`). Both are
pre-existing environment gaps, unrelated to this change.

## Not in scope — a sibling site

`icOpenRegularWriteFile()` (`IccProfLib/IccCmdLineUtil.h:471`) has the **identical**
symlink-follow: it `stat()`s, then `open()`s without `O_NOFOLLOW`. Measured — it writes through
a symlink and creates a dangling link's target. **8 call sites across 6 tools**: iccProfilePlot,
iccJpegDump, iccPngDump, iccApplyToLink, and both `MiniTIFF.cpp` copies. Left alone here to keep
this PR to the boundary #2242 names; happy to file it separately.

## CI

Dispatched before opening this PR, per the suggested workflow:
[`ci-pr-action` run 32594646054](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32594646054),
`ci_scope=source`, on `24ea9eb1` — **success**. 11 jobs ran, 4 skipped by design (Docker Clang 22,
Example Consumer, the manual thread-linkage job, and the PowerShell audit).

Both legs that are red on `ci-qa-issue-2242` are green here:

| leg | `ci-qa-issue-2242` | this branch |
|---|---|---|
| Windows MSVC + ClangCL build | ❌ failure | ✅ success |
| MinGW UCRT64 smoke | ❌ failure | ✅ success |

Also green: GCC 15.2 Strict Release LTO, macOS clang Debug and Release LTO, Tool Smoke Tests
GCC Strict ASAN+UBSAN Debug.

The new tests are confirmed to have **executed**, not merely ridden a green leg —
`iccdev.specsep-tiff-geometry-regression` #117 in 1.67s and `iccdev.tiff-create-overflow` #46 in
0.04s, with `100% tests passed, 0 tests failed` out of 113 and 203 on the two CTest lanes. The
C++ case's "cannot create file symlink" SKIP path does not appear anywhere in the run log, so the
symlink assertions really did run on every platform that reached them.
