### PR TITLE
fix(#2248): restore the documented verbosity default on iccDumpProfile's reject path

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5288,6 +5288,145 @@ if(TARGET iccBenchApply)
 endif()
 
 
+# #2248: iccDumpProfile's verbosity default, on both argument paths.
+#
+# The usage text says the integer parameter is optional with "default=100", and
+# verbosity is initialised to 100 -- but both branches then run strtol() over the
+# next argument to support a profile whose name starts with a digit ("123.icc"),
+# and assign the result unconditionally. When that token is NOT a verbosity
+# argument the parsed value was left in place, so the default never held:
+#
+#   iccDumpProfile profile.icc     verbosity 0        (strtol returns 0)
+#   iccDumpProfile 123.icc         verbosity 123      (outside the documented 1-100)
+#   iccDumpProfile 50test.icc      verbosity 50
+#
+# The -v branch carried a partial recovery, `else if (argv[nArg] == endptr)`, which
+# only fired when strtol consumed nothing at all -- so `-v 123.icc` was wrong there
+# too, and mirroring that branch into the other one would have fixed the first case
+# and left the other two. The fix restores the default across the whole reject path,
+# in both branches, which is what these four tests pin.
+#
+# Like the iccBenchApply block above, this MUST stay above the if(WIN32) branch
+# that follows: that branch return()s, so a registration placed after it never
+# reaches a Windows leg. This is #2237 verbatim, and the argv handling under test
+# is exactly the kind of thing that platform would be expected to cover.
+#
+# These run from a directory holding copies of a corpus profile under digit-led
+# names, because the defect is a property of the ARGUMENT text: an absolute path
+# begins with '/', strtol consumes nothing, and the interesting cases cannot arise.
+if(TARGET iccDumpProfile)
+  set(_dumpcli_dir "${CMAKE_CURRENT_BINARY_DIR}/dumpprofile-cli")
+  file(MAKE_DIRECTORY "${_dumpcli_dir}")
+  foreach(_dumpcli_name "123.icc" "50test.icc" "plain.icc")
+    configure_file(
+      "${ICCDEV_REPO_ROOT}/Testing/sRGB_v4_ICC_preference.icc"
+      "${_dumpcli_dir}/${_dumpcli_name}"
+      COPYONLY
+    )
+  endforeach()
+
+  # The filed defect: an ordinary filename, no -v, no integer.
+  add_test(
+    NAME iccdev.dumpprofile-verbosity-default
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccDumpProfile>"
+      "-DTOOL_ARGS=--diag;plain.icc"
+      "-DWORKDIR=${_dumpcli_dir}"
+      "-DEXPECT_MATCH=Verbosity: 100[^0-9]"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunDumpProfileCliTest.cmake"
+  )
+
+  # A name that merely STARTS with digits. strtol consumes "123" and stops at '.',
+  # so the -v branch's endptr test never fired: this is the case that separates
+  # restoring the reject path from mirroring that branch, and it is the documented
+  # "123.icc" support case the code comment exists for.
+  add_test(
+    NAME iccdev.dumpprofile-verbosity-digit-filename
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccDumpProfile>"
+      "-DTOOL_ARGS=--diag;123.icc"
+      "-DWORKDIR=${_dumpcli_dir}"
+      "-DEXPECT_MATCH=Verbosity: 100[^0-9]"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunDumpProfileCliTest.cmake"
+  )
+
+  # The same shape on the validation branch, the one that had the partial recovery.
+  add_test(
+    NAME iccdev.dumpprofile-verbosity-digit-filename-validate
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccDumpProfile>"
+      "-DTOOL_ARGS=--diag;-v;50test.icc"
+      "-DWORKDIR=${_dumpcli_dir}"
+      "-DEXPECT_MATCH=Verbosity: 100[^0-9]"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunDumpProfileCliTest.cmake"
+  )
+
+  # The controls that keep the three above honest. Restoring the default must not
+  # become "always 100": an explicit integer still has to win, so these go red
+  # against a fix that hardcodes the default instead of restoring it only when the
+  # token was rejected.
+  #
+  # There are two of them because there are two accept paths, and a control on one
+  # says nothing about the other. Measured: hardcoding `verbosity = 100` in the -v
+  # branch's accept path leaves all four of the other tests green while
+  # `iccDumpProfile -v 7 profile.icc` silently runs at 100. That is the same
+  # per-branch reasoning the fix itself rests on, applied to the tests.
+  add_test(
+    NAME iccdev.dumpprofile-verbosity-explicit-wins
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccDumpProfile>"
+      "-DTOOL_ARGS=--diag;7;plain.icc"
+      "-DWORKDIR=${_dumpcli_dir}"
+      "-DEXPECT_MATCH=Verbosity: 7[^0-9]"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunDumpProfileCliTest.cmake"
+  )
+
+  add_test(
+    NAME iccdev.dumpprofile-verbosity-explicit-wins-validate
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccDumpProfile>"
+      "-DTOOL_ARGS=--diag;-v;7;plain.icc"
+      "-DWORKDIR=${_dumpcli_dir}"
+      "-DEXPECT_MATCH=Verbosity: 7[^0-9]"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunDumpProfileCliTest.cmake"
+  )
+
+  set(_dumpcli_tests
+    iccdev.dumpprofile-verbosity-default
+    iccdev.dumpprofile-verbosity-digit-filename
+    iccdev.dumpprofile-verbosity-digit-filename-validate
+    iccdev.dumpprofile-verbosity-explicit-wins
+    iccdev.dumpprofile-verbosity-explicit-wins-validate)
+
+  foreach(_dumpcli_test IN LISTS _dumpcli_tests)
+    set_tests_properties(${_dumpcli_test} PROPERTIES
+      TIMEOUT 120
+      LABELS "iccdev;tools;dumpprofile;cli;issue-2248;regression"
+    )
+  endforeach()
+
+  if(WIN32)
+    # Same reasoning as the iccBenchApply CLI tests above: the tool is reached
+    # through cmake -P, so it needs the runtime paths on PATH or it dies for want
+    # of IccProfLib2.dll. These all assert exit 0, so a missing DLL turns them red
+    # rather than green -- but red for the loader, not for the verbosity contract.
+    set(_dumpcli_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccDumpProfile>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _dumpcli_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    foreach(_dumpcli_test IN LISTS _dumpcli_tests)
+      set_tests_properties(${_dumpcli_test} PROPERTIES
+        ENVIRONMENT_MODIFICATION "${_dumpcli_windows_env_mods}"
+      )
+    endforeach()
+  endif()
+endif()
+
+
 if(WIN32)
   function(iccdev_add_windows_batch_test NAME TIMEOUT LABELS SCRIPT)
     set(_one_value_args

--- a/Build/Cmake/Testing/RunDumpProfileCliTest.cmake
+++ b/Build/Cmake/Testing/RunDumpProfileCliTest.cmake
@@ -1,0 +1,91 @@
+#################################################################################
+# iccDumpProfile command-line contract driver for #2248
+# Copyright (c) 2026 The International Color Consortium.
+#                                        All rights reserved.
+#################################################################################
+
+# RunDumpProfileCliTest.cmake - runs iccDumpProfile once and asserts BOTH the exit
+# status and what the tool reported.
+#
+# The oracle for #2248 is the verbosity iccDumpProfile says it is using, read from
+# its own --diag line, rather than the size of the dump. Line counts were the
+# obvious choice and are the wrong one: they are a proxy that depends on which
+# profile is passed, and most tag dumps are byte-identical across the whole
+# verbosity range -- 'desc' is 49 lines at both 0 and 100 -- so a count-based
+# assertion would silently pass on the majority of fixtures while claiming to pin
+# the default. --diag reports the parsed value directly, so the assertion fails
+# for exactly one reason.
+#
+# Asserting the status alone would not do either: the defect being pinned never
+# changed the exit code. Every invocation below exited 0 both before and after the
+# fix, and printed a profile either way. Only the value differed.
+#
+# Required -D args:
+#   TOOL         - path to the iccDumpProfile executable
+#   EXPECT_MATCH - regex that must appear in stdout or stderr
+# Optional -D args:
+#   TOOL_ARGS    - ';'-separated argument list passed to the tool
+#   WORKDIR      - directory to run the tool from (default: current directory)
+
+cmake_minimum_required(VERSION 3.18...3.29)
+
+foreach(_required TOOL EXPECT_MATCH)
+  if(NOT DEFINED ${_required} OR "${${_required}}" STREQUAL "")
+    message(FATAL_ERROR "[dumpprofile-cli] ${_required} not set")
+  endif()
+endforeach()
+
+if(NOT EXISTS "${TOOL}")
+  message(FATAL_ERROR "[dumpprofile-cli] tool not found: ${TOOL}")
+endif()
+
+set(_workdir_arg)
+if(DEFINED WORKDIR AND NOT "${WORKDIR}" STREQUAL "")
+  if(NOT IS_DIRECTORY "${WORKDIR}")
+    message(FATAL_ERROR "[dumpprofile-cli] WORKDIR not a directory: ${WORKDIR}")
+  endif()
+  set(_workdir_arg WORKING_DIRECTORY "${WORKDIR}")
+endif()
+
+execute_process(
+  COMMAND "${TOOL}" ${TOOL_ARGS}
+  ${_workdir_arg}
+  RESULT_VARIABLE _result
+  OUTPUT_VARIABLE _stdout
+  ERROR_VARIABLE  _stderr
+)
+
+set(_output "${_stdout}${_stderr}")
+
+message(STATUS "[dumpprofile-cli] ${TOOL} ${TOOL_ARGS}")
+message(STATUS "[dumpprofile-cli] exit=${_result}")
+message(STATUS "[dumpprofile-cli] output:\n${_output}")
+
+# A non-numeric RESULT_VARIABLE means the process never started; execute_process
+# reports that as a string rather than a status. Checked separately so a
+# failure-to-launch is not read as an exit code.
+if(NOT _result MATCHES "^-?[0-9]+$")
+  message(FATAL_ERROR "[dumpprofile-cli] tool did not run: ${_result}")
+endif()
+
+# Every case here is a successful dump, so the status is pinned to 0 outright.
+#
+# Do NOT read that check as the guard against a missing or truncated fixture: it
+# is not one. iccDumpProfile returns 0 whether or not the profile parsed --
+# nValid stays 0 unless -v was given -- so `iccDumpProfile --diag nosuch.icc`
+# prints "Unable to parse ... as ICC profile!" and still exits 0, and three of
+# the four registered cases take that no--v path. What actually catches a bad
+# fixture is EXPECT_MATCH: the "Verbosity:" line is emitted only on the branch
+# where the profile opened, so a fixture that failed to copy takes the match from
+# present to absent. The status check is retained for the -v case and as a cheap
+# guard against a crash or a signal, not as fixture validation.
+if(NOT _result EQUAL 0)
+  message(FATAL_ERROR "[dumpprofile-cli] expected success, got exit ${_result}")
+endif()
+
+if(NOT _output MATCHES "${EXPECT_MATCH}")
+  message(FATAL_ERROR
+    "[dumpprofile-cli] output did not match '${EXPECT_MATCH}'")
+endif()
+
+message(STATUS "[dumpprofile-cli] OK")

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -632,8 +632,17 @@ int main(int argc, char* argv[])
         return -1;
       }
     }
-    else if (argv[nArg] == endptr) {
-        verbosity = 100;
+    else {
+      // The token was not accepted as a verbosity argument, so it is the profile
+      // filename and the documented default (usage text: "default=100") applies.
+      //
+      // Restoring here rather than under the old `argv[nArg] == endptr` test matters
+      // because strtol() has ALREADY overwritten verbosity by this point. That test
+      // only fired when strtol consumed nothing at all, so a filename that merely
+      // starts with digits kept the parsed value: "123.icc" -- the very case the
+      // comment above exists to support -- left verbosity at 123, outside the
+      // documented 1-100 range, and "50test.icc" left it at 50.
+      verbosity = 100;
     }
 
     pIcc = ValidateIccProfile(argv[nArg], sReport, nStatus);
@@ -654,6 +663,26 @@ int main(int argc, char* argv[])
         printUsage();
         return -1;
       }
+    }
+    else {
+      // #2248: this branch had no counterpart to the -v branch's recovery, so an
+      // ordinary filename left verbosity at whatever strtol() returned -- 0 for a
+      // name with no leading digit. The documented default is 100, so every plain
+      // `iccDumpProfile <file>` ran at minimum verbosity instead of maximum, and the
+      // two branches disagreed about what "no integer given" means. Same restoration
+      // as above, for the same reason.
+      //
+      // This is the branch that carries the output-volume change, and it is large:
+      // the gates that newly open are the `nVerboseness > 50` / `> 75` CLUT and
+      // curve dumps in IccTagLut.cpp, IccTagMPE.cpp and IccMpeACS.cpp. Measured
+      // across Testing/, `<file> ALL` grows about 6x in total bytes; the worst
+      // single profile, Testing/hybrid/ICC/CMYK_Hybrid_Profile.icc, goes from 133
+      // lines / 0.02 s to 517455 lines / 0.53 s. That is the documented behaviour
+      // rather than a regression, but the callers that pipe `ALL` through a
+      // per-profile `timeout` -- _build-test-unix.yml and iccdev-fuzz-triage.sh,
+      // at 30 s and 20 s -- lost roughly an order of magnitude of headroom, so a
+      // future profile larger than that one is where this would first bite.
+      verbosity = 100;
     }
 
     pIcc = bUseRead ? ReadIccProfile(argv[nArg]) : OpenIccProfile(argv[nArg]);


### PR DESCRIPTION
## Summary

Closes #2248 by taking **(a')** rather than the (a)/(b) offered on the issue: restore the documented verbosity default across the whole *reject* path, in both argument branches, instead of mirroring the `-v` branch's partial recovery.

`iccDumpProfile`'s usage text says the integer parameter is optional with `default=100`, and `verbosity` is initialised to 100. Both branches then run `strtol()` over the next token to support a profile whose name starts with a digit (`123.icc`) and assign the result unconditionally. When that token is *not* a verbosity argument the parsed value was left in place, unrestored and unclamped, so the documented default never held.

## Why not (a)

(a) was to mirror the `-v` branch's `else if (argv[nArg] == endptr) verbosity = 100;` into the other branch. **That branch is itself wrong**, so copying it propagates the defect: the test only fires when `strtol` consumed *nothing*, and a filename that merely starts with digits keeps the parsed value.

Measured with `--diag`, which reports the parsed verbosity directly, across three built trees:

| argument | master `56f01b2e` | option (a) | option (a') |
|---|---|---|---|
| ordinary filename | 0 | 100 | 100 |
| `123.icc` | 123 | **123** | 100 |
| `50test.icc` | 50 | **50** | 100 |
| `-v 50test.icc` | 50 | **50** | 100 |
| `999999.icc` | 999999 | **999999** | 100 |
| `7 <profile>` | 7 | 7 | 7 |
| `150 <profile>` | 100 | 100 | 100 |

`123.icc` is the exact case the surrounding code comment exists to support, and it ran at verbosity 123 -- outside the documented 1-100 range entirely, because clamping happens only on the accept path. Against the CTests below, option (a) built as a variant goes from 3 red to 2 red; (a') to 0.

(b), documenting the current behaviour, would have written down something the tool's own usage string contradicts. With (a') no documentation changes, because the code now does what the usage text already said.

## Blast radius

This was the open question on the issue, and it is the reason (a) was not taken outright. Surveyed and measured rather than estimated:

- **22 call sites** pass neither `-v` nor an explicit integer, across 10 scripts and `_build-test-unix.yml`.
- Verbosity-100 output is a **strict superset** of verbosity-0 -- zero lines lost in every case tested -- so every presence-grep still matches. Most tag dumps are byte-identical anyway (`desc` is 49 lines at both).
- Every `! grep -q` among them is a *negated presence* check, not an absence assertion. The one true absence assertion, `iccdev-tool-coverage-baseline.sh:1046` (ESC characters), is 0 at both verbosities.
- **Volume does grow.** `<file> ALL` is ~6x more bytes across `Testing/`; the worst single profile, `Testing/hybrid/ICC/CMYK_Hybrid_Profile.icc`, goes from 133 lines / 0.02 s to 517455 lines / 0.53 s as the `nVerboseness > 50` / `> 75` CLUT and curve dumps open. No consumer breaks, but the two callers piping `ALL` through a per-profile `timeout` (`_build-test-unix.yml`, `iccdev-fuzz-triage.sh`, at 30 s and 20 s) lose about an order of magnitude of headroom. Recorded at the call site so it is not rediscovered.

The CTests for all 22 sites pass with **zero skips**, which confirms the survey empirically rather than by prediction.

## Tests

Five CTests, `ctest -R dumpprofile-verbosity`. **Three are red against `56f01b2e`.**

They build their own fixtures by copying a tracked corpus profile under digit-led names, because the defect is a property of the *argument text*: an absolute path begins with `/`, `strtol` consumes nothing, and the interesting cases cannot arise. The oracle is the verbosity reported via `--diag`, not the size of the dump -- a line-count assertion would pass vacuously on the majority of fixtures, since most tags are identical across the verbosity range.

Two of the five are **controls that pass both before and after by design**, one per accept path. There are two because a control on one branch says nothing about the other: hardcoding `verbosity = 100` in the `-v` accept path leaves the other four green while `iccDumpProfile -v 7 <profile>` silently runs at 100. Verified by mutation.

Registered **above** the `if(WIN32)` branch that `return()`s, so they reach the Windows legs -- the #2237 defect, which this first reproduced before it was caught.

## Pre-flight

- Strict Clang 18.1.3, `-Wall -Wextra -Wpedantic -Werror`, configure reports `strict warnings ENABLED`: **0 warnings, 0 errors**.
- Full build: 0 warnings.
- Full local suite: **211/212**. The single failure, `iccdev.spectral-tiff-preview`, is a missing `imagecodecs` Python module in this environment and is unrelated to argv handling.
- Pre-PR dispatch `ci_scope=source`, **run 32602852142: success**, 9 jobs green / 4 skipped -- GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL, MinGW UCRT64 smoke, macOS Clang Debug and Release LTO, Tool Smoke Tests ASAN+UBSAN.
- **The five CTests are confirmed to have run on Windows**, not merely registered there: the MSVC + ClangCL job log shows `Test #9`-`#13` executing at 0.02 s each in both configurations, 118/118 passing. That is the check the placement exists for -- a green Windows leg alone would not have proved it, which is how #2154 went wrong.

## Review

`/code-review high` raised three findings, all confirmed by measurement and all fixed here: a backwards rationale in the test driver's comment (`iccDumpProfile --diag nosuch.icc` exits **0**, so `EXPECT_MATCH` rather than the status check is what guards a bad fixture); a one-sided control, which is why there are now five tests and not four; and an unrecorded output-volume change, now measured and documented above.
