### PR TITLE
fix(#2190): treat the decimal-coded intent columns as independent fields

### DIFF
--- a/.github/scripts/iccdev-applynamedcmm-cli-args-regression.sh
+++ b/.github/scripts/iccdev-applynamedcmm-cli-args-regression.sh
@@ -248,5 +248,127 @@ run_expect_reject enc-percent-lab-src "$APPLY" "$LABSRC" 3 0 "$SRGB" 1
 grep -Fq "Invalid source data encoding" "$OUTDIR/enc-percent-lab-src.log" ||
   fail "enc-percent-lab-src did not report the source encoding rejection"
 
+
+###############################################################################
+# #2190: the decimal-coded intent columns are independent fields, and
+# CIccCfgProfile::fromArgs() did not treat them that way
+#
+# Three separate silences, all on the same decode:
+#
+#   1. +100000 (HToS) forced +10000 (V5 sub-profile) on with it. The V5 digit
+#      is read as "nIntent / 10000" and the HToS column had not been stripped
+#      first, so every code >= 100000 divides to >= 10 and set the flag. No
+#      argument existed that asked for HToS alone. The -INIT decode in the same
+#      file already stripped at this width, which is what makes this a slip
+#      rather than a contract.
+#   2. The millions column accepted any value: only 1 and 2 were decoded and
+#      everything else fell through to the default over-white. "3000000" -- the
+#      form in the issue, from a caller trying to combine over-black and
+#      over-gray, which are mutually exclusive array members -- ran a plain
+#      over-white transform and exited 0.
+#   3. A negative code was accepted whenever its units digit was zero: the type
+#      digit takes abs() and the intent digit does not, so "-110" decoded
+#      exactly like "110" and the sign silently discarded the overprint field
+#      along the way (-1000110 / 1000000 is -1, matching neither variant).
+#
+# The flag half is asserted through -exportcfg, not through exit status. Exit
+# status cannot see it: every invocation below exited 0 before the fix, which
+# is precisely the defect. The decoded configuration is the only place a wrong
+# flag is observable, so that read-back is the assertion.
+###############################################################################
+
+assert_cfg_has() {
+  grep -Fq "$2" "$1" || fail "$3"
+}
+
+assert_cfg_lacks() {
+  if grep -Fq "$2" "$1"; then
+    fail "$3"
+  fi
+}
+
+# useHToS is asserted as a decode result only. Nothing downstream consumes it
+# (AddXform takes no HToS argument and CheckPCSRangeConversions injects the
+# transform unconditionally), so these cases pin which columns the parser reads
+# -- they are not evidence that the HToS selector does anything at apply time.
+#
+# The two flags are a crossing pair, for the same reason the encoding cases
+# above are: asserting only that +100000 sets HToS would still pass with the
+# columns fused, and asserting only that it leaves V5 clear would pass if the
+# export had silently stopped emitting either field. Each arm has to show one
+# flag present and the other absent, and the third arm has to show both, before
+# "independent" is pinned rather than merely "not always equal".
+HTOS_CFG="$OUTDIR/intent-htos-only.cfg.json"
+rm -f "$HTOS_CFG"
+run_expect_success intent-htos-only "$APPLY" -exportcfg "$HTOS_CFG" "$DATA" 0 1 "$SRGB" 100000
+assert_cfg_has   "$HTOS_CFG" '"useHToS": true' \
+  "intent-htos-only did not set useHToS for +100000"
+assert_cfg_lacks "$HTOS_CFG" '"useV5SubProfile": true' \
+  "intent-htos-only set useV5SubProfile: the HToS column is bleeding into the V5 column"
+
+V5_CFG="$OUTDIR/intent-v5-only.cfg.json"
+rm -f "$V5_CFG"
+run_expect_success intent-v5-only "$APPLY" -exportcfg "$V5_CFG" "$DATA" 0 1 "$SRGB" 10000
+assert_cfg_has   "$V5_CFG" '"useV5SubProfile": true' \
+  "intent-v5-only did not set useV5SubProfile for +10000"
+assert_cfg_lacks "$V5_CFG" '"useHToS": true' \
+  "intent-v5-only set useHToS for a code that does not carry it"
+
+BOTH_CFG="$OUTDIR/intent-htos-and-v5.cfg.json"
+rm -f "$BOTH_CFG"
+run_expect_success intent-htos-and-v5 "$APPLY" -exportcfg "$BOTH_CFG" "$DATA" 0 1 "$SRGB" 110000
+assert_cfg_has "$BOTH_CFG" '"useHToS": true' \
+  "intent-htos-and-v5 did not set useHToS for +110000"
+assert_cfg_has "$BOTH_CFG" '"useV5SubProfile": true' \
+  "intent-htos-and-v5 did not set useV5SubProfile for +110000"
+
+# Overprint: the two documented codes have to keep decoding to their own
+# variants, or the rejections below would pass against a parser that had simply
+# stopped reading the millions column at all. The transform name is the
+# read-back that carries the overprint -- it is only rendered for a named
+# transform, hence the "110" (namedColorimetric) type digit on every arm here.
+BLACK_CFG="$OUTDIR/intent-over-black.cfg.json"
+rm -f "$BLACK_CFG"
+run_expect_success intent-over-black "$APPLY" -exportcfg "$BLACK_CFG" "$DATA" 0 1 "$SRGB" 1000110
+assert_cfg_has "$BLACK_CFG" '"transform": "namedColorimetricOnBlack"' \
+  "intent-over-black did not decode +1000000 to the over-black variant"
+
+GRAY_CFG="$OUTDIR/intent-over-gray.cfg.json"
+rm -f "$GRAY_CFG"
+run_expect_success intent-over-gray "$APPLY" -exportcfg "$GRAY_CFG" "$DATA" 0 1 "$SRGB" 2000110
+assert_cfg_has "$GRAY_CFG" '"transform": "namedColorimetricOnGray"' \
+  "intent-over-gray did not decode +2000000 to the over-gray variant"
+
+# ...and an unrecognised millions column is refused rather than answered with
+# over-white. 3000000 and 3111003 are the exact codes reported in #2190.
+assert_rejected_sequence() {
+  grep -Fqx "Unable to parse profile sequence arguments" "$OUTDIR/$1.log" ||
+    fail "$1 was refused, but not by the profile-sequence parser"
+}
+
+run_expect_reject intent-overprint-3 "$APPLY" "$DATA" 0 1 "$SRGB" 3000000
+assert_rejected_sequence intent-overprint-3
+run_expect_reject intent-overprint-3-flags "$APPLY" "$DATA" 0 1 "$SRGB" 3111003
+assert_rejected_sequence intent-overprint-3-flags
+run_expect_reject intent-overprint-9 "$APPLY" "$DATA" 0 1 "$SRGB" 9000110
+assert_rejected_sequence intent-overprint-9
+run_expect_reject intent-overprint-12 "$APPLY" "$DATA" 0 1 "$SRGB" 12000110
+assert_rejected_sequence intent-overprint-12
+
+# Negative codes. Paired with the positive form of the same value so the
+# rejection cannot be credited to the type digit or to the profile: 110 is
+# asserted to succeed immediately above as intent-over-black's base, and -110
+# used to reach the identical decode.
+run_expect_reject intent-negative "$APPLY" "$DATA" 0 1 "$SRGB" -110
+assert_rejected_sequence intent-negative
+run_expect_reject intent-negative-overprint "$APPLY" "$DATA" 0 1 "$SRGB" -1000110
+assert_rejected_sequence intent-negative-overprint
+POS_CFG="$OUTDIR/intent-pos.cfg.json"
+rm -f "$POS_CFG"
+run_expect_success intent-negative-control "$APPLY" -exportcfg "$POS_CFG" \
+  "$DATA" 0 1 "$SRGB" 110
+assert_cfg_has "$POS_CFG" '"transform": "namedColorimetric"' \
+  "intent-negative-control did not accept the positive form of the rejected code"
+
 echo "  [PASS] iccApplyNamedCmm-cli-args"
 exit 0

--- a/.github/scripts/iccdev-applysearch-cli-args-regression.sh
+++ b/.github/scripts/iccdev-applysearch-cli-args-regression.sh
@@ -156,5 +156,63 @@ run_expect_reject init-missing-value "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -I
 run_expect_reject legacy-extra "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT 1 ignored-extra
 run_expect_reject env-short-name "$APPLY" "$DATA" 0 0 -ENV:abc 1 "$SRGB" 1 "$SRGB" 1 -INIT 1
 
+
+###############################################################################
+# #2190: the intent-code columns, in both positions iccApplySearch offers
+#
+# iccApplySearch is the only tool that reaches CIccCfgSearchApply::fromArgs and
+# the -INIT initializer, so it is the only place the two decodes can be pinned
+# against each other. They must answer the same code the same way: while the
+# profile decode refused an unrecognised overprint column and -INIT masked it
+# off, "3000000" was rejected in one position and silently accepted in the
+# other within a single command line.
+#
+# -INIT has no overprint and no HToS field, so any code reaching those columns
+# is refused there rather than truncated to the part it can represent.
+###############################################################################
+
+assert_rejected_sequence() {
+  grep -Fqx "Unable to parse profile sequence arguments" "$OUTDIR/$1.log" ||
+    fail "$1 was refused, but not by the profile-sequence parser"
+}
+
+# Same value, both positions, same verdict -- the pairing is the assertion.
+run_expect_reject intent-overprint-3-profile \
+  "$APPLY" "$DATA" 0 0 "$SRGB" 3000000 "$SRGB" 1 -INIT 1
+assert_rejected_sequence intent-overprint-3-profile
+run_expect_reject intent-overprint-3-init \
+  "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT 3000000
+assert_rejected_sequence intent-overprint-3-init
+run_expect_reject intent-overprint-9-init \
+  "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT 9000000
+assert_rejected_sequence intent-overprint-9-init
+run_expect_reject intent-htos-init \
+  "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT 100000
+assert_rejected_sequence intent-htos-init
+
+# Negative codes, both positions. "-110" used to decode exactly like "110"
+# because the type digit takes abs() and the intent digit does not.
+#
+# These two need the diagnostic asserted, not just a non-zero exit. Before the
+# fix "-110" was accepted by the parser and the run died later in Begin() with
+# "Invalid Look-Up Table type" -- also a non-zero exit, so run_expect_reject
+# alone passes against the defect and pins nothing. The parse-time message is
+# what separates "refused the argument" from "ran with it and failed downstream".
+run_expect_reject intent-negative-profile \
+  "$APPLY" "$DATA" 0 0 "$SRGB" -110 "$SRGB" 1 -INIT 1
+assert_rejected_sequence intent-negative-profile
+run_expect_reject intent-negative-init \
+  "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT -110
+assert_rejected_sequence intent-negative-init
+
+# Controls. Without these the rejections above would also be satisfied by a
+# decode that had stopped accepting the columns altogether: +1000000 is a valid
+# overprint in the profile position, and +10000 is the widest column -INIT can
+# still represent, so both must continue to run.
+run_expect_success intent-overprint-1-profile \
+  "$APPLY" "$DATA" 0 0 "$SRGB" 1000000 "$SRGB" 1 -INIT 1
+run_expect_success intent-v5-init \
+  "$APPLY" "$DATA" 0 0 "$SRGB" 1 "$SRGB" 1 -INIT 10000
+
 echo "  [PASS] iccApplySearch-cli-args"
 exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7280,10 +7280,16 @@ if(TARGET iccApplyNamedCmm)
   # other. Both profiles it uses are tracked, so this still needs no fixture
   # dependency and the timeout is unchanged -- the added cases run the same
   # 16-row rgb8bit.txt transform the existing ones already do.
+  #
+  # #2190 adds the intent-code half. Its flag cases assert the decoded
+  # configuration through -exportcfg instead of the exit status, because the
+  # defects they pin all exited 0: +100000 silently forced the V5 sub-profile
+  # flag on with HToS, and an unrecognised overprint column silently decoded as
+  # over-white. Exit status is only load-bearing for the rejection cases.
   iccdev_add_script_test(
     iccdev.applynamedcmm-cli-args
     120
-    "iccdev;cmm;config;cli;security;issue-1674;issue-2124;regression"
+    "iccdev;cmm;config;cli;security;issue-1674;issue-2124;issue-2190;regression"
     "${ICCDEV_REPO_ROOT}"
     "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-applynamedcmm-cli-args-regression.sh"
    )
@@ -7298,7 +7304,7 @@ if(TARGET iccApplySearch)
   iccdev_add_script_test(
     iccdev.applysearch-cli-args
     120
-    "iccdev;cmm;config;cli;security;issue-1674;issue-1853;regression"
+    "iccdev;cmm;config;cli;security;issue-1674;issue-1853;issue-2190;regression"
     "${ICCDEV_REPO_ROOT}"
     "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-applysearch-cli-args-regression.sh"
    )

--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -1078,24 +1078,54 @@ int CIccCfgProfileSequence::fromArgs(const char** args, int nArg, bool bReset)
       if (!icParseIntArg(args[1], nIntent) || nIntent == INT_MIN)
         return 0;
 
+      // A negative code is not a documented form, but it was accepted whenever
+      // the units digit was zero: nType takes abs() while the intent digit does
+      // not, and -110 % 10 is 0, so "-110" decoded exactly like "110" -- and the
+      // sign silently took the overprint field with it, because -1000110 / 1000000
+      // is -1, which matched neither over-black nor over-gray.  #1400 added the
+      // range checks below to reject invalid codes; this is the case they cannot
+      // see, because by the time they run the value has already lost the sign
+      // (#2190).
+      if (nIntent < 0)
+        return 0;
+
       pProf->m_useD2BxB2Dx = true;
       // Overprint variant for NamedColor xforms is encoded as the millions
       // digit of the intent code:
       //   +1000000 -> icNamedColorOverBlack (spcb)
       //   +2000000 -> icNamedColorOverGray  (spcg)
-      // Anything else leaves the default icNamedColorOverWhite (spec).
+      // Any other value in that column is refused rather than decoded as the
+      // default icNamedColorOverWhite (spec).  The two array members are
+      // mutually exclusive, so "+3000000" cannot mean both; answering it with
+      // neither handed a caller who asked for an overprint a plain over-white
+      // transform and exit 0, and the same silence swallowed "+9000000" and
+      // every larger typo (#2190).
       // Strip the field before the existing decimal-coded flags are read.
       {
         int overprintCode = nIntent / 1000000;
-        if (overprintCode == 1)
+        if (overprintCode == 0)
+          pProf->m_nOverprint = icNamedColorOverWhite;
+        else if (overprintCode == 1)
           pProf->m_nOverprint = icNamedColorOverBlack;
         else if (overprintCode == 2)
           pProf->m_nOverprint = icNamedColorOverGray;
         else
-          pProf->m_nOverprint = icNamedColorOverWhite;
+          return 0;
         nIntent = nIntent % 1000000;
       }
+      // Recorded, but nothing downstream consumes it: m_useHToS reaches only
+      // toJson(), CIccCmm::AddXform() has no HToS parameter, and
+      // CheckPCSRangeConversions() injects the HToS transform whenever the tag
+      // is present regardless of any flag.  Left as-is here -- wiring it
+      // through is a library API change, not part of this decode fix (#2190).
       pProf->m_useHToS = (nIntent / 100000) != 0;
+      // Strip the HToS digit before the V5 sub-profile digit is read.  Without
+      // this the "/ 10000" below still sees the hundred-thousands column, so any
+      // code carrying +100000 forced m_useV5SubProfile true as well and there was
+      // no way to ask for HToS alone -- the two flags are documented as
+      // independent.  The -INIT decode further down already strips at this width
+      // for exactly this reason (#2190).
+      nIntent = nIntent % 100000;
       pProf->m_useV5SubProfile = (nIntent / 10000) != 0;
       nIntent = nIntent % 10000;
       pProf->m_adjustPcsLuminance = nIntent / 1000 != 0;
@@ -1320,24 +1350,54 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
       if (!icParseIntArg(args[1], nIntent) || nIntent == INT_MIN)
         return 0;
 
+      // A negative code is not a documented form, but it was accepted whenever
+      // the units digit was zero: nType takes abs() while the intent digit does
+      // not, and -110 % 10 is 0, so "-110" decoded exactly like "110" -- and the
+      // sign silently took the overprint field with it, because -1000110 / 1000000
+      // is -1, which matched neither over-black nor over-gray.  #1400 added the
+      // range checks below to reject invalid codes; this is the case they cannot
+      // see, because by the time they run the value has already lost the sign
+      // (#2190).
+      if (nIntent < 0)
+        return 0;
+
       pProf->m_useD2BxB2Dx = true;
       // Overprint variant for NamedColor xforms is encoded as the millions
       // digit of the intent code:
       //   +1000000 -> icNamedColorOverBlack (spcb)
       //   +2000000 -> icNamedColorOverGray  (spcg)
-      // Anything else leaves the default icNamedColorOverWhite (spec).
+      // Any other value in that column is refused rather than decoded as the
+      // default icNamedColorOverWhite (spec).  The two array members are
+      // mutually exclusive, so "+3000000" cannot mean both; answering it with
+      // neither handed a caller who asked for an overprint a plain over-white
+      // transform and exit 0, and the same silence swallowed "+9000000" and
+      // every larger typo (#2190).
       // Strip the field before the existing decimal-coded flags are read.
       {
         int overprintCode = nIntent / 1000000;
-        if (overprintCode == 1)
+        if (overprintCode == 0)
+          pProf->m_nOverprint = icNamedColorOverWhite;
+        else if (overprintCode == 1)
           pProf->m_nOverprint = icNamedColorOverBlack;
         else if (overprintCode == 2)
           pProf->m_nOverprint = icNamedColorOverGray;
         else
-          pProf->m_nOverprint = icNamedColorOverWhite;
+          return 0;
         nIntent = nIntent % 1000000;
       }
+      // Recorded, but nothing downstream consumes it: m_useHToS reaches only
+      // toJson(), CIccCmm::AddXform() has no HToS parameter, and
+      // CheckPCSRangeConversions() injects the HToS transform whenever the tag
+      // is present regardless of any flag.  Left as-is here -- wiring it
+      // through is a library API change, not part of this decode fix (#2190).
       pProf->m_useHToS = (nIntent / 100000) != 0;
+      // Strip the HToS digit before the V5 sub-profile digit is read.  Without
+      // this the "/ 10000" below still sees the hundred-thousands column, so any
+      // code carrying +100000 forced m_useV5SubProfile true as well and there was
+      // no way to ask for HToS alone -- the two flags are documented as
+      // independent.  The -INIT decode further down already strips at this width
+      // for exactly this reason (#2190).
+      nIntent = nIntent % 100000;
       pProf->m_useV5SubProfile = (nIntent / 10000) != 0;
       nIntent = nIntent % 10000;
       pProf->m_adjustPcsLuminance = nIntent / 1000 != 0;
@@ -1391,10 +1451,24 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
     if (!icParseIntArg(args[1], nIntent) || nIntent == INT_MIN)
       return 0;
 
+    // Same sign gap as the two profile decodes above: abs() on the type digit
+    // let a negative code through whenever the units digit was zero (#2190).
+    if (nIntent < 0)
+      return 0;
+
     m_bInitialized = true;
 
     m_useD2BxB2DxInitial = true;
-    nIntent = nIntent % 100000;
+    // -INIT carries no overprint and no HToS field -- there is no
+    // m_nOverprintInitial or m_useHToSInitial for them to land in -- so a code
+    // reaching into those columns is refused rather than masked off.  Masking
+    // is what "% 100000" used to do here, and once the two profile decodes
+    // above started refusing an unrecognised overprint column it left the same
+    // value answered two different ways inside one command line: "<profile>
+    // 3000000" was rejected while "-INIT 3000000" silently ran a plain
+    // perceptual initial transform and exited 0 (#2190).
+    if (nIntent >= 100000)
+      return 0;
     m_useV5SubProfileInitial = (nIntent / 10000) != 0;
     nIntent = nIntent % 10000;
     m_adjustPcsLuminanceInitial = nIntent / 1000 != 0;

--- a/Tools/CmdLine/IccApplyNamedCmm/Readme.md
+++ b/Tools/CmdLine/IccApplyNamedCmm/Readme.md
@@ -86,6 +86,11 @@ named color, differing in PCS-side stem:
 iccApplyNamedCmm <data> 0 1 Named/NamedColor.icc 1000003
 ```
 
+The two overprint codes are alternatives, not bits: over-black and
+over-gray name mutually exclusive array members, so `+3000000` is
+refused rather than treated as a request for both (it used to decode
+as plain over-white and exit 0 -- #2190).
+
 If the profile lacks the requested array member for any named color the
 apply hits, `Apply` fails with `icCmmStatBadTintXform` rather than
 silently falling back to a different member; this surfaces the

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -263,6 +263,11 @@ void Usage()
   printf("  +100000 - Use HToS tag if present\n");
   printf(" +1000000 - NamedColor over black (icSigNmclSpectralOverBlackMbr 'spcb')\n");
   printf(" +2000000 - NamedColor over gray  (icSigNmclSpectralOverGrayMbr 'spcg')\n");
+  // The two overprint codes read as additive flags, and #2190 was filed by a
+  // caller who combined them. They select mutually exclusive array members, so
+  // say here that only one may be given rather than let "+3000000" look legal.
+  printf("            (over black and over gray are alternatives, not flags:\n");
+  printf("             only one of +1000000 / +2000000 may be given)\n");
 }
 
 static std::string GetProfileId(const char* profilePath)

--- a/docs/icc-connect.md
+++ b/docs/icc-connect.md
@@ -161,7 +161,12 @@ The two axes combine into the following set of JSON `transform` values:
 The legacy argv form (`CIccCfgProfileSequence::fromArgs`) carries only
 the overprint axis, in the millions digit of the intent code:
 `intent + 1000000` -> over-black; `intent + 2000000` -> over-gray;
-anything else stays at over-white. The output-side axis is JSON-only.
+absent -> over-white. Any other value in that column is refused --
+over-black and over-gray name mutually exclusive array members, so
+`+3000000` cannot request both, and decoding it as over-white answered
+a caller who asked for an overprint with a transform that had none
+(#2190). The intent code must also be non-negative. The output-side
+axis is JSON-only.
 
 If the profile lacks the requested array member for any named color
 encountered during apply (output-side stem or overprint suffix), `Apply`

--- a/docs/tools-cli-reference.md
+++ b/docs/tools-cli-reference.md
@@ -111,6 +111,18 @@ parsed by the shared `CIccCfgProfile::fromArgs` is:
 | `+1000000` | NamedColor over-black (`icSigNmclSpectralOverBlackMbr`, `'spcb'`) |
 | `+2000000` | NamedColor over-gray (`icSigNmclSpectralOverGrayMbr`, `'spcg'`) |
 
+Each column is an independent field: `+100000` no longer implies `+10000`, and
+`+10000` never implied `+100000`. The millions column accepts only the two
+overprint values above -- the members are mutually exclusive, so a combined
+`+3000000` is refused rather than decoded as over-white -- and the whole code
+must be non-negative (#2190).
+
+`+100000` is currently recorded in the configuration but not acted on: no
+`AddXform` overload takes an HToS argument, and `CheckPCSRangeConversions()`
+injects the HToS transform whenever the tag is present, regardless of the flag.
+It is accepted and round-trips through the JSON config, but selects nothing
+(#2190).
+
 The over-black / over-gray flags only affect chains that include a v5
 NamedColor profile. JSON callers prefer the `transform` field values,
 which combine an output-side stem (`named` / `namedColorimetric` /


### PR DESCRIPTION
Part of #2190.

`CIccCfgProfile::fromArgs()` decodes the legacy intent argument as a stack of decimal
columns. Four of them were not isolated from each other. **Every case below exited 0
before this change** — which is why none of them ever showed up as a failure.

## What was wrong

| # | code | master | now |
|---|---|---|---|
| 1 | `100000` (HToS) | `useHToS` **and `useV5SubProfile`** | `useHToS` only |
| 2 | `3000000` / `9000000` / `3111003` | accepted, silently **over-white** | rejected |
| 3 | `-110` | accepted, decodes as `110` | rejected |
| 4 | `-INIT 3000000` | accepted, masked to `0` | rejected |

1. **HToS forced V5.** The V5 digit is read as `nIntent / 10000` and the HToS column
   had not been stripped first, so every code `>= 100000` divides to `>= 10` and set
   the flag. No argument existed that selected HToS alone, though the two are
   documented as independent.
2. **The millions column decoded only 1 and 2**; anything else fell through to the
   default over-white. `3000000` — the form in the issue, from a caller trying to
   combine over-black and over-gray — ran a plain over-white transform and exited 0.
   The two values name *mutually exclusive* array members, so a combined request
   cannot be honoured; it is refused rather than answered with neither.
3. **Negative codes** were accepted whenever the units digit was zero: the type digit
   takes `abs()` and the intent digit does not, so `-110 % 10 == 0` and `-110` decoded
   exactly like `110`. `-1000110 / 1000000` is `-1`, so the sign also discarded the
   overprint field. #1400 added the range checks that bound this argument; this is the
   case they cannot see, because the value has lost its sign before they run.
4. **`-INIT` masked the columns it cannot represent.** It has no overprint and no HToS
   field, and `% 100000` truncated them away. Fixing (2) at the two profile decodes
   *without* this would have left one value answered two different ways inside a single
   command line: `<profile> 3000000` refused while `-INIT 3000000` silently ran a plain
   perceptual initial transform and exited 0.

## Scope

Three decode sites (`CIccCfgProfileSequence::fromArgs`, `CIccCfgSearchApply::fromArgs`,
the `-INIT` initializer), verified through **each of the three tools that reach them** —
`iccApplyNamedCmm`, `iccApplyProfiles`, `iccApplySearch` — rather than at the shared
function alone.

## Evidence

**A/B over 57 intent codes** against `origin/master` `80194ac0`, decode read back through
`-exportcfg`. **10 arms change**, all named in the issue or a direct consequence. The
other **47 decode byte-identically** — every documented form, including `0`-`3`, the
`+10`/`+20`/`+30`/`+40`/`+90`/`+100` type digits, `+1000`, `+10000`, `+1000000`,
`+2000000`.

**Red/green.** Every new assertion was checked individually red against a pristine
`origin/master` binary and green against the fix. Controls (`+10000`, `+110000`,
`+1000000`, `+2000000`, `110`, `-INIT 10000`) pass on both.

**The flag cases assert the decoded configuration through `-exportcfg`, not exit status** —
exit status cannot see defects that exited 0. The HToS/V5 arms are a crossing pair, so
neither a fused decode nor an export that stopped emitting the fields can satisfy them;
each `lacks` assertion is paired with a `has` on the same file, and both were confirmed
to fail on a stripped and on a missing read-back.

**The `iccApplySearch` rejections assert the parse-time diagnostic, not a non-zero exit.**
That tool's chain check already failed `-110` downstream in `Begin()` on master, so
`run_expect_reject` alone passed against the defect and pinned nothing. Caught by
per-caller red/green; the same arm in `iccApplyNamedCmm` exits 0 and did discriminate.

## Pre-flight

| lane | result |
|---|---|
| clang 21.1.3 strict `-Wall -Wextra -Wpedantic -Werror` Release | **0 warnings**, 0 errors |
| GCC **15.2.0** strict + LTO, in `iccdev-ci-regression:latest` | **0 warnings**, 0 errors |
| clang Debug ASAN+UBSAN, `detect_leaks=1` | clean on all reject paths |
| GCC Release | both scripts pass |
| full `ctest` (212) | 211 pass; `spectral-tiff-preview` fails on a missing local `imagecodecs` module, unrelated |
| `shellcheck` 0.9.0 (CI's exact version) | rc=0 on both changed scripts |

`ctest -R 'applynamedcmm-cli-args|applysearch-cli-args'`

Dispatched pre-PR: `ci_scope=source` run
[32609087567](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32609087567).

## Docs

`docs/icc-connect.md` documented the over-white fallback explicitly ("anything else stays
at over-white"), so **this changes a stated contract**, not just behaviour. That text is
updated alongside the flag table in `docs/tools-cli-reference.md`, the tool Readme, and
`Usage()` — the `+` notation is what invited the combined code in the first place.

## Deliberately not changed (reported on the issue instead)

- **`m_useHToS` is inert.** Written by this decode, read only by `toJson()`, and no
  further: no `AddXform` overload takes an HToS argument, and `CheckPCSRangeConversions()`
  injects the HToS transform whenever the tag is present regardless of any flag. So
  `+100000` round-trips through the JSON config but selects nothing — before this change
  it at least turned V5 on, which was the bug. Wiring it through is a library API change.
  The docs and test comments now say the column is *recorded*, not honoured.
- **`51/61/71/81` are not bogus** (refutes Finding 2). The units digit indexes real tags:
  `icSigBrdfSpectralParameter0Tag + nTagIntent` (`IccCmm.cpp:957`), `icSigBRDFDToB0Tag`
  (`:1001`), `icSigBRDFMToS0Tag` (`:1058`), `icSigMToS0Tag` (`:1151`), with `nTagIntent`
  being the CLI digit at `:540`. Rejecting them would remove reachable function. The gap
  is in `Usage()`, which prints `50 - BDRF Model` where it prints `20 + Intent - Preview`
  for the structurally identical Preview case — left for maintainer ruling.
- **`31`/`32`** likewise: gamut always reads `icSigGamutTag` (`:929`, no `nTagIntent`) and
  only absolute is special-cased (`:1535`), so `30`/`31`/`32` are genuinely identical and
  `33` differs — exactly what the two documented lines say.
