### PR TITLE
fix(#2211): keep the Heidelberg licence banner out of Doxygen's Markdown scanner

### DIFF
--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -112,7 +112,10 @@ bgCurve->curve[i] = 255 - (icUInt16Number)i;
  */
 
 
-/***************************************************************** 
+/* Opens with a space before its asterisk run on purpose: Doxygen 1.15 and later
+   would otherwise read the TeX-style double-backtick quoting in the licence text
+   below as a Markdown code span that never closes. Wording unchanged (#2211). */
+/* ****************************************************************
  Copyright (c) 2002  Heidelberger Druckmaschinen AG 
 
  * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED


### PR DESCRIPTION
Fixes #2211.

## Root cause

Both reported warnings come from one cause. `IccProfLib/icProfileHeader.h:118` sits inside a licence banner that opens with `/***`. Doxygen 1.15 and later treat that as a doxygen-style opener and scan the block for Markdown code spans, so the TeX-style double-backtick quoting in ``` ``AS IS'' ``` opens a code span. Nothing closes it, the scanner runs to end of file, and both messages fall out of that one unterminated span:

```
IccProfLib/icProfileHeader.h:2189: warning: Reached end of file while still searching closing '``' of a verbatim block starting at line 118
IccProfLib/icProfileHeader.h:2189: warning: Reached end of file while still inside a (nested) comment. Nesting level 1 (possible line reference(s): 115)
```

The mechanism is `commentcnv.l`: the opener rule for `` ` ``{1,2} fires only inside a doxygen-style comment, and the close for a `` `` `` span is `''` — but only when `MARKDOWN_STRICT` is `NO`, and `YES` is the default.

## Why only this file

A plain `/*` block is not scanned; a `/**` doc comment or a `/***` banner is. Across the **170 occurrences** of this disclaimer in **169 C/C++ files**, this is the **only** one whose enclosing comment opens with `/**` rather than a plain `/*`. After the change there are none. The sibling SunSoft banner below still opens with `/***` but contains no backticks, so it is correctly left alone.

## The fix

One space before the banner's asterisk run, demoting it to a plain comment. **The licence wording is untouched** and the opener keeps its original 67-column width. A short note above records why, so a later reformatter does not close the gap back up.

## Evidence

Measured with `.github/ci/doxygen/Doxyfile` on a **clean worktree** (no untracked files):

| Doxygen | before | after |
|---|---|---|
| 1.9.8 — what CI installs | 4 warnings, none in this file | 4 |
| 1.11.0, 1.13.2, 1.14.0 | none in this file | none |
| 1.15.0, 1.16.1, 1.18.0 | 8, of which **2** are this file | **6** |

Symbols extracted from the header: **238 before, 238 after** — no documentation content is lost either way. The damage is the warning, not the output.

Also verified: strict Clang lane (`strict warnings ENABLED (Clang 21.1.3)`, `-Wall -Wextra -Wpedantic -Werror`) builds with **0 warnings** across 149 objects → 23 executables and 4 shared libraries, with the edited header in the dependency set of 134 translation units; `-Wcomment` clean on both `g++` and `clang++`; under CI's 1.9.8 the generated XML is unchanged apart from the source listing of the edited lines themselves.

## Two notes for the reviewer

**CI cannot currently see this defect.** The `ci-latest-release` Doxygen job installs the distro package on `ubuntu-24.04`, which is 1.9.8, and that binary does not contain the warning string at all. So CI neither reproduced the warning before this change nor can it prove the fix — it was verified against local 1.15.0 / 1.16.1 / 1.18.0 builds. It is still a live break rather than a cosmetic one: the warnings do reach `WARN_LOGFILE`, and the job fails on a non-empty log, so it breaks the moment that runner's Doxygen passes 1.14.

**No CTest accompanies this, deliberately.** Any test driven by CI's Doxygen 1.9.8 would pass vacuously. The durable guard is bumping the Doxygen that job installs. That looks viable but I have not fully proven it: after this fix the only residual warnings under 1.18.0 are four `\dotfile` lines that are an artefact of the local `HAVE_DOT=NO` override, and CI sets `HAVE_DOT=YES` with graphviz installed — which I cannot reproduce locally, so I have not confirmed the count is zero under CI's real configuration. One cosmetic point if it is taken up: `DOT_MULTI_TARGETS` at `.github/ci/doxygen/Doxyfile:141` is obsolete in 1.18, though it prints to stderr only and does not reach `WARN_LOGFILE`, so it would not fail the gate. Happy to raise this separately against #2209 rather than widen this PR.

## Rejected alternative

`MARKDOWN_STRICT = NO` is Doxygen's own carve-out for exactly this ``` ``text'' ``` construct, and on the single file it looks like a clean one-line Doxyfile fix. Across the repository it is strictly worse: it clears these two warnings but introduces **eight new end-of-file warnings, every one in a tracked Markdown file** (`docs/ctest.md`, `docs/regression-container.md`, `docs/regression-workflow-governance.md`, `docs/tools-cli-reference.md`, `docs/matlab-bindings.md`, `docs/superpowers/plans/2026-08-20-apply-throughput-harness.md`, `Tools/CmdLine/IccPawgReport/registry/GOVERNANCE_SUBMISSIONS.md`, `.../PERMISSIVENESS_DELTAS.md`) and changes 17 generated outputs.
