### PR TITLE
fix(#2357,#2358,#2359): drop the intent lower-bound test that #2261 made dead

### DIFF
--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -1149,8 +1149,13 @@ int CIccCfgProfileSequence::fromArgs(const char** args, int nArg, bool bReset)
         break;
       }
       
-      // pin decoded values to valid range
-      if (nIntent < (int)icPerceptual || nIntent > (int)icAbsoluteColorimetric)
+      // Pin the decoded values to their valid range.  Only the upper bound can
+      // fire here: a negative code is refused at the top of this decode (#2190),
+      // and the lower half never covered that case in the first place -- by the
+      // time it runs "% 10" has dropped the sign, which is exactly how "-110"
+      // reached this point as 0.  Testing it left a comparison that is always
+      // false (CodeQL cpp/constant-comparison #2359).
+      if (nIntent > (int)icAbsoluteColorimetric)
         return 0;
       
       if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
@@ -1414,8 +1419,13 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
         nType = icXformLutColor;
       }
       
-      // pin decoded values to valid range
-      if (nIntent < (int)icPerceptual || nIntent > (int)icAbsoluteColorimetric)
+      // Pin the decoded values to their valid range.  Only the upper bound can
+      // fire here: a negative code is refused at the top of this decode (#2190),
+      // and the lower half never covered that case in the first place -- by the
+      // time it runs "% 10" has dropped the sign, which is exactly how "-110"
+      // reached this point as 0.  Testing it left a comparison that is always
+      // false (CodeQL cpp/constant-comparison #2357).
+      if (nIntent > (int)icAbsoluteColorimetric)
         return 0;
       
       if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
@@ -1484,8 +1494,13 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
       nType = icXformLutColor;
     }
       
-    // pin decoded values to valid range
-    if (nIntent < (int)icPerceptual || nIntent > (int)icAbsoluteColorimetric)
+    // Pin the decoded values to their valid range.  Only the upper bound can
+    // fire here: a negative code is refused at the top of this decode (#2190),
+    // and the lower half never covered that case in the first place -- by the
+    // time it runs "% 10" has dropped the sign, which is exactly how "-110"
+    // reached this point as 0.  Testing it left a comparison that is always
+    // false (CodeQL cpp/constant-comparison #2358).
+    if (nIntent > (int)icAbsoluteColorimetric)
       return 0;
       
     if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)


### PR DESCRIPTION
Closes CodeQL alerts #2357, #2358, #2359 (`cpp/constant-comparison`, "Comparison
is always false because nIntent >= 0") at `IccCmmConfig.cpp:1153`, `:1418`, `:1488`.

## Why they appeared

They are a consequence of my own PR #2261 (`a77dbc28`), which added
`if (nIntent < 0) return 0;` to all three decimal-coded intent decodes. That guard
exists because the sign was lost before the older range test could see it: `% 10`
leaves 0 for any negative code whose units digit is zero, which is how `-110`
decoded exactly like `110` (#2190). With the sign refused up front, the
`nIntent < (int)icPerceptual` half of the later test can no longer fire.

Before #2261 it could — `-3 % 10` is `-3` — so this is code that *became* dead, not
code that always was.

## Fixed, not dismissed

The lower half never covered the negative case it appears to guard; that was the
finding of #2190. So it protects nothing and leaves a comparison that is always false.

This differs from alerts #2297/#2298 (`iccApplyToLink.cpp:833`), which I dismissed
as won't-fix: there the redundancy rests on a remote premise (parameter types) that
a future signature change could invalidate. Here the premise is an explicit guard
twelve lines above in the same function.

Between each guard and each comparison `nIntent` is only reassigned by `%` against
positive constants, which preserve non-negativity, so `nIntent` is in `[0,9]` at the
test. **The upper bound is untouched and still live: codes 4-9 are rejected.**

## Verification

Behaviour-preserving, measured rather than argued:

| Check | Result |
|---|---|
| Firing probe at all 3 sites, 13,622 invocations of `iccApplyNamedCmm` + `iccApplySearch` (exhaustive `-1200..1200` plus a structured sweep of the overprint/HToS/V5/luminance/type columns, both signs) | never fired |
| Positive control — same probe, site-1 guard disabled | fired **1,584** times, so the null result is not vacuous |
| A/B of exit status + output hash over the same 13,622 runs | byte-identical |
| Oracle sensitivity — a mutant dropping the *upper* bound instead | changed **1,056** runs, so the A/B can see a change of this shape |
| ctest before/after | identical pass/fail set |

The existing negative-code coverage stays non-vacuous: the `-110` assertions in
`iccdev-applysearch-cli-args-regression.sh` use `assert_rejected_sequence`, which pins
the parse-time diagnostic, and they are answered by the untouched guards rather than
by the removed operand.

## Pre-flight

CI's own gate (`grep -cE 'warning:'` on the build log) = **0** on both:

- GCC 15.2.0 in the CI regression container, `-Wall -Wextra -Wpedantic -Werror` + LTO;
  configure reports `Linux: strict warnings ENABLED`
- clang-18, same flags; likewise ENABLED

Pre-PR dispatch per the suggested workflow: `ci_scope=source`, run
**32656333914** — 11 success / 3 skipped, including Windows MSVC + ClangCL,
GCC 15.2 Strict Release LTO, Tool Smoke Tests ASAN+UBSAN and both macOS configs.

`/code-review high` and `/security-review` both returned no findings.

## Adjacent, deliberately not in this PR

`Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp:1076` runs the structurally identical
range test with **no** preceding `nIntent < 0` guard, so the #2190 negative-code defect
is still live there: on master `-10` and `-110` exit 0 and produce byte-identical device
links to `10` and `110`. CodeQL cannot see it — the check is genuinely live at that site,
which is why only a set-diff found it. Left out because this PR's argument is "remove
provably dead code" and that is a live behavioural fix. Note `iccBenchApply.cpp:144`'s
`DecodeIntent()` documents itself as matching `iccApplyToLink` exactly, so a guard there
has to move with it. Happy to file it separately or fold it into #2262 — your call.

Also left alone: the `nType < (int)icXformLutMinimum` test one line below each site is
dead by the same argument (`abs()` makes it non-negative), but CodeQL is `abs()`-blind so
it is unflagged, and it was already dead before #2261.
