### PR TITLE
fix(#2268): refuse negative rendering-intent codes in iccApplyToLink and iccBenchApply

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2575,6 +2575,130 @@ function(iccdev_add_applytolink_invalid_arg_test)
   endif()
 endfunction()
 
+# #2268: iccApplyToLink accepted a negative rendering-intent code.
+#
+# The decode at iccApplyToLink.cpp splits one integer into decimal columns, and
+# it takes abs() on the transform-type digit but not on the intent digit. A
+# negative code whose units digit is zero therefore survived every check: "-10"
+# and "-110" reached the range test at the bottom carrying an intent of 0, and
+# produced device links byte-identical to "10" and "110". Only a non-zero units
+# digit -- "-3" -- was ever refused, which is why the gap read as covered.
+#
+# The same guard lands in iccBenchApply::DecodeIntent(), whose comment states it
+# decodes "the way iccApplyToLink.cpp does, so a chain given to this tool and the
+# same chain given to that one resolve identically". The pair below and the
+# iccdev.bench-apply-negative-intent-* pair above assert that sentence: same
+# code, both tools, same verdict. Fixing one alone is what would break it.
+#
+# Driven through RunBenchApplyCliTest.cmake rather than WILL_FAIL because a bare
+# nonzero exit does not distinguish this refusal from a crash or a missing
+# runtime library -- the wrapper makes the message assertion mandatory. That
+# matters more here than usual: the sibling iccdev.applytolink-invalid-decoded-intent
+# below is a WILL_FAIL test, so a message-blind assertion is exactly the coverage
+# this family already had and the reason the sign case went unnoticed.
+#
+# iccdev.applytolink-valid-intent-code is the positive control, and it is not
+# optional: a guard that refused every code would satisfy both negative tests.
+function(iccdev_add_applytolink_negative_intent_tests)
+  if(NOT TARGET iccApplyToLink)
+    return()
+  endif()
+
+  add_dependencies(check iccApplyToLink)
+  add_dependencies(check-fast iccApplyToLink)
+
+  set(_applytolink_intent_tests "")
+
+  # "-10" is the pair for "10" and "-110" the pair for "110". On the FIXED tree
+  # the two negatives reach the same branch -- the guard fires immediately after
+  # ParseIntArg, before any % or abs() arithmetic -- so the second is not extra
+  # branch coverage. It is kept because it is a second independent red probe
+  # against the unfixed tool, where the two took genuinely different routes
+  # through the column decode ("-110" also set the luminance flag via
+  # nLuminance = -1) and both still produced output.
+  # Spelled out rather than looped because foreach() flattens a "name;code"
+  # element into two iterations, so the pairing would not survive the loop.
+  add_test(
+    NAME iccdev.applytolink-negative-intent-code
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccApplyToLink>"
+      "-DLABEL=applytolink-cli"
+      "-DTOOL_ARGS=${ICCDEV_TEST_OUTDIR}/applytolink-negative-intent-code.icc;0;2;1;NegativeIntent;0;1;0;0;${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc;-10"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=a negative intent code is not a valid form"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  list(APPEND _applytolink_intent_tests iccdev.applytolink-negative-intent-code)
+
+  add_test(
+    NAME iccdev.applytolink-negative-intent-code-typed
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccApplyToLink>"
+      "-DLABEL=applytolink-cli"
+      "-DTOOL_ARGS=${ICCDEV_TEST_OUTDIR}/applytolink-negative-intent-code-typed.icc;0;2;1;NegativeIntent;0;1;0;0;${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc;-110"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=a negative intent code is not a valid form"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  list(APPEND _applytolink_intent_tests iccdev.applytolink-negative-intent-code-typed)
+
+  # Same command line, same columns, only the sign removed. "LUT successfully
+  # written" is asserted rather than the exit status alone so this stays a
+  # statement about the tool doing the work, not merely about it not failing.
+  add_test(
+    NAME iccdev.applytolink-valid-intent-code
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccApplyToLink>"
+      "-DLABEL=applytolink-cli"
+      "-DTOOL_ARGS=${ICCDEV_TEST_OUTDIR}/applytolink-valid-intent-code.icc;0;2;1;ValidIntent;0;1;0;0;${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc;10"
+      "-DEXPECT_EXIT=zero"
+      "-DEXPECT_MATCH=LUT successfully written"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  list(APPEND _applytolink_intent_tests iccdev.applytolink-valid-intent-code)
+
+  # The second positive control, and it earns its place: with only "10" a guard
+  # mis-written as "nIntent < 0 || nIntent >= 100" would satisfy every other test
+  # here. "110" is the smallest accepted code that reaches past the tens column.
+  add_test(
+    NAME iccdev.applytolink-valid-intent-code-typed
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccApplyToLink>"
+      "-DLABEL=applytolink-cli"
+      "-DTOOL_ARGS=${ICCDEV_TEST_OUTDIR}/applytolink-valid-intent-code-typed.icc;0;2;1;ValidIntent;0;1;0;0;${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc;110"
+      "-DEXPECT_EXIT=zero"
+      "-DEXPECT_MATCH=LUT successfully written"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  list(APPEND _applytolink_intent_tests iccdev.applytolink-valid-intent-code-typed)
+
+  set_tests_properties(${_applytolink_intent_tests} PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;tools;applytolink;cli;exitcode;issue-2268;regression"
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+
+  if(WIN32)
+    # The tool is reached through cmake -P, and the child inherits this test
+    # process's PATH, so it needs the same runtime paths as every other
+    # iccApplyToLink test. Without them the two negative tests would pass on
+    # Windows for want of IccProfLib2.dll -- STATUS_DLL_NOT_FOUND is an ordinary
+    # nonzero exit -- and the positive control is what would catch it.
+    set(_applytolink_intent_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccApplyToLink>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _applytolink_intent_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(${_applytolink_intent_tests} PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_applytolink_intent_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_applytolink_v4_missing_desc_test)
   if(NOT TARGET iccApplyToLink)
     return()
@@ -5247,6 +5371,73 @@ if(TARGET iccBenchApply)
     ENVIRONMENT "ICCDEV_BENCH_SOURCE_ROOT=${CMAKE_CURRENT_BINARY_DIR}/bench-empty-root;ICCDEV_BENCH_BUILD_ROOT=${CMAKE_CURRENT_BINARY_DIR}/bench-empty-root"
   )
 
+  # #2268: the sign column, on the tool that documents itself as decoding the
+  # same way iccApplyToLink does.
+  #
+  # DecodeIntent() takes abs() on the transform-type digit and not on the intent
+  # digit, so "-10" resolved exactly like "10" and ran a full benchmark. "-3" was
+  # refused, which is what made the gap look covered. The guard sits inside
+  # DecodeIntent() rather than at the caller so the built-in -suite table is held
+  # to the same rule as the command line; the table itself carries only :1 and :3
+  # today, so nothing there changes.
+  #
+  # Paired with iccdev.applytolink-negative-intent-code below: the two tools must
+  # answer one code the same way, which is the equivalence DecodeIntent()'s own
+  # comment claims. -pixels/-repeats are pinned low because the positive control
+  # measures for real, and the two negative cases exit before a profile is opened.
+  add_test(
+    NAME iccdev.bench-apply-negative-intent-code
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;-10"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=a negative intent code is not a valid form"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-negative-intent-code PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;issue-2268;regression"
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+
+  # Positive control for the guard above: same command line, sign removed. Without
+  # it a DecodeIntent() that returned false unconditionally would pass the
+  # negative test and prove nothing.
+  add_test(
+    NAME iccdev.bench-apply-valid-intent-code
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;10"
+      "-DEXPECT_EXIT=zero"
+      "-DEXPECT_MATCH=chain: 1 profile"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-valid-intent-code PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;issue-2268;regression"
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+
+  # Same reason as the iccApplyToLink twin: "10" alone cannot tell a correct
+  # guard from one mis-written as "nEncoded < 0 || nEncoded >= 100".
+  add_test(
+    NAME iccdev.bench-apply-valid-intent-code-typed
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;110"
+      "-DEXPECT_EXIT=zero"
+      "-DEXPECT_MATCH=chain: 1 profile"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-valid-intent-code-typed PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;issue-2268;regression"
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+
   if(WIN32)
     set(_bench_windows_env_mods
       "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccBenchApply>"
@@ -5264,7 +5455,10 @@ if(TARGET iccBenchApply)
       iccdev.bench-apply-arity-floor
       iccdev.bench-apply-suite-rejects-chain
       iccdev.bench-apply-suite-rejects-perxform
-      iccdev.bench-apply-empty-suite)
+      iccdev.bench-apply-empty-suite
+      iccdev.bench-apply-negative-intent-code
+      iccdev.bench-apply-valid-intent-code
+      iccdev.bench-apply-valid-intent-code-typed)
     if(TARGET iccFromXml)
       list(APPEND _bench_env_mod_tests
         iccdev.apply-throughput
@@ -5747,6 +5941,7 @@ if(WIN32)
   iccdev_add_iccprofileplot_pdf_leak_test()
   iccdev_add_iccprofileplot_exitcode_test()
   iccdev_add_applytolink_invalid_arg_test()
+  iccdev_add_applytolink_negative_intent_tests()
   iccdev_add_applytolink_v4_missing_desc_test()
   iccdev_add_prmg_hue_normalization_test()
   iccdev_add_qa_evidence_helpers_test()
@@ -5773,6 +5968,7 @@ endif()
 # iccApplyToLink binary as the v4_missing_desc sibling directly below, which has always
 # been called from both places.
 iccdev_add_applytolink_invalid_arg_test()
+iccdev_add_applytolink_negative_intent_tests()
 iccdev_add_applytolink_v4_missing_desc_test()
 
 set(ICCDEV_TIMEOUT_COMPAT_DIR "")

--- a/Build/Cmake/Testing/RunBenchApplyCliTest.cmake
+++ b/Build/Cmake/Testing/RunBenchApplyCliTest.cmake
@@ -1,11 +1,17 @@
 #################################################################################
-# iccBenchApply command-line contract driver for #2254
+# Command-line contract driver, introduced for iccBenchApply by #2254
 # Copyright (c) 2026 The International Color Consortium.
 #                                        All rights reserved.
 #################################################################################
 
-# RunBenchApplyCliTest.cmake - runs iccBenchApply once and asserts BOTH halves of
-# the outcome: the exit status and what the tool said.
+# RunBenchApplyCliTest.cmake - runs one command-line tool once and asserts BOTH
+# halves of the outcome: the exit status and what the tool said.
+#
+# Nothing here is specific to iccBenchApply; the file name records where the
+# pattern started, not what it may drive.  #2268 reuses it for iccApplyToLink,
+# because the defect it pins is that the two tools disagreed about the same
+# intent code and the assertion has to be spelled identically on both to say so.
+# The log label is therefore a parameter (LABEL) rather than a literal.
 #
 # #2254 exists because every defect it collects was an exit status that agreed
 # with a wrong outcome. `-suite` with a chain ran the built-in table, ignored the
@@ -21,27 +27,33 @@
 # both here is the only way to keep the assertion honest.
 #
 # Required -D args:
-#   TOOL         - path to the iccBenchApply executable
+#   TOOL         - path to the executable under test
 #   EXPECT_EXIT  - "zero" or "nonzero"
 # Optional -D args:
 #   TOOL_ARGS    - ';'-separated argument list passed to the tool
 #   EXPECT_MATCH - regex that must appear in stdout or stderr
+#   LABEL        - prefix for this driver's own log lines
+#                  (default: bench-apply-cli, so existing callers are unchanged)
 
 cmake_minimum_required(VERSION 3.18...3.29)
 
+if(NOT DEFINED LABEL OR "${LABEL}" STREQUAL "")
+  set(LABEL "bench-apply-cli")
+endif()
+
 foreach(_required TOOL EXPECT_EXIT)
   if(NOT DEFINED ${_required} OR "${${_required}}" STREQUAL "")
-    message(FATAL_ERROR "[bench-apply-cli] ${_required} not set")
+    message(FATAL_ERROR "[${LABEL}] ${_required} not set")
   endif()
 endforeach()
 
 if(NOT EXISTS "${TOOL}")
-  message(FATAL_ERROR "[bench-apply-cli] tool not found: ${TOOL}")
+  message(FATAL_ERROR "[${LABEL}] tool not found: ${TOOL}")
 endif()
 
 if(NOT EXPECT_EXIT STREQUAL "zero" AND NOT EXPECT_EXIT STREQUAL "nonzero")
   message(FATAL_ERROR
-    "[bench-apply-cli] EXPECT_EXIT must be 'zero' or 'nonzero', got '${EXPECT_EXIT}'")
+    "[${LABEL}] EXPECT_EXIT must be 'zero' or 'nonzero', got '${EXPECT_EXIT}'")
 endif()
 
 # EXPECT_MATCH is mandatory for a negative test, enforced rather than advised.
@@ -54,7 +66,7 @@ endif()
 if(EXPECT_EXIT STREQUAL "nonzero"
    AND (NOT DEFINED EXPECT_MATCH OR "${EXPECT_MATCH}" STREQUAL ""))
   message(FATAL_ERROR
-    "[bench-apply-cli] EXPECT_EXIT=nonzero requires EXPECT_MATCH: a bare"
+    "[${LABEL}] EXPECT_EXIT=nonzero requires EXPECT_MATCH: a bare"
     " nonzero exit does not distinguish the refusal under test from a crash"
     " or a missing runtime library")
 endif()
@@ -68,9 +80,9 @@ execute_process(
 
 set(_output "${_stdout}${_stderr}")
 
-message(STATUS "[bench-apply-cli] ${TOOL} ${TOOL_ARGS}")
-message(STATUS "[bench-apply-cli] exit=${_result}")
-message(STATUS "[bench-apply-cli] output:\n${_output}")
+message(STATUS "[${LABEL}] ${TOOL} ${TOOL_ARGS}")
+message(STATUS "[${LABEL}] exit=${_result}")
+message(STATUS "[${LABEL}] output:\n${_output}")
 
 # A non-numeric RESULT_VARIABLE means the process could not be started at all --
 # execute_process reports the reason as a string rather than a status. That is a
@@ -78,24 +90,24 @@ message(STATUS "[bench-apply-cli] output:\n${_output}")
 # DLL still yields a number. The EXPECT_MATCH requirement above is what covers
 # that; this check only keeps a failure-to-launch from being read as a status.
 if(NOT _result MATCHES "^-?[0-9]+$")
-  message(FATAL_ERROR "[bench-apply-cli] tool did not run: ${_result}")
+  message(FATAL_ERROR "[${LABEL}] tool did not run: ${_result}")
 endif()
 
 if(EXPECT_EXIT STREQUAL "zero" AND NOT _result EQUAL 0)
   message(FATAL_ERROR
-    "[bench-apply-cli] expected success, got exit ${_result}")
+    "[${LABEL}] expected success, got exit ${_result}")
 endif()
 
 if(EXPECT_EXIT STREQUAL "nonzero" AND _result EQUAL 0)
   message(FATAL_ERROR
-    "[bench-apply-cli] expected a nonzero exit, got 0")
+    "[${LABEL}] expected a nonzero exit, got 0")
 endif()
 
 if(DEFINED EXPECT_MATCH AND NOT "${EXPECT_MATCH}" STREQUAL "")
   if(NOT _output MATCHES "${EXPECT_MATCH}")
     message(FATAL_ERROR
-      "[bench-apply-cli] output did not match '${EXPECT_MATCH}'")
+      "[${LABEL}] output did not match '${EXPECT_MATCH}'")
   endif()
 endif()
 
-message(STATUS "[bench-apply-cli] OK")
+message(STATUS "[${LABEL}] OK")

--- a/Tools/CmdLine/IccApplyToLink/Readme.md
+++ b/Tools/CmdLine/IccApplyToLink/Readme.md
@@ -28,6 +28,7 @@ Key arguments:
 | `option` with `link_type=1` | Digits of precision for `.cube` output, from `0` through `20`. |
 | `first_transform` | `0` uses the destination transform from the first profile; `1` uses the source transform from the first profile. |
 | `interp` | `0` linear interpolation; `1` tetrahedral interpolation. |
+| `rendering_intent` | Base intent `0`-`3` plus decimal-coded modifiers, read as independent columns: the tens digit is the transform-lookup type (`icXformLutType`, reachable values `0`-`9`; `+10` drops the D2Bx/B2Dx tags and `+40` adds black-point compensation), `+100` requests luminance matching, and `+1000` uses a V5 sub-profile if present. A negative code is rejected (#2268). |
 
 For a CMYK output profile to RGB color-space profile chain, use the first
 profile as a source transform and write a DeviceLink profile:

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -1050,6 +1050,20 @@ int main(int argc, icChar* argv[])
         releasePccList(pccList);
         return 1;
       }
+      // A negative code is not a documented form, but it was accepted whenever
+      // the units digit was zero: nType below takes abs() while the intent digit
+      // does not, and -110 % 10 is 0, so "-110" decoded exactly like "110" and
+      // wrote a byte-identical device link.  The range test further down cannot
+      // see it -- by the time it runs the value has already lost the sign, which
+      // is why only "-3" and other non-zero units digits were ever refused.
+      // Same gap and same remedy as CIccCfgProfileSequence::fromArgs()
+      // (IccCmmConfig.cpp, #2190); refused here so the two tools agree (#2268).
+      if (nIntent < 0) {
+        printf("Invalid rendering intent '%s': a negative intent code is not a"
+               " valid form\n", argv[nCount+1]);
+        releasePccList(pccList);
+        return 1;
+      }
       bUseSubProfile = (nIntent / 1000) > 0;
       nIntent = nIntent % 1000;
       nLuminance = nIntent / 100;
@@ -1073,7 +1087,14 @@ int main(int argc, icChar* argv[])
         break;
       }
       
-      if (nIntent < (int)icPerceptual || nIntent > (int)icAbsoluteColorimetric) {
+      // Only the upper bound is testable here.  nIntent is "value % 10" of a
+      // value the guard above has already refused if negative, so it is 0..9 --
+      // icPerceptual is 0, and a "nIntent < icPerceptual" term would be
+      // constantly false.  That is the same dead comparison CodeQL raised as
+      // #2357/#2358/#2359 against IccCmmConfig.cpp once #2261 added the sign
+      // guard there, removed in #2267; adding the guard here without removing
+      // this term would file the alert a second time (#2268).
+      if (nIntent > (int)icAbsoluteColorimetric) {
         printf("Invalid rendering intent '%s': decoded intent is out of range\n", argv[nCount+1]);
         releasePccList(pccList);
         return 1;
@@ -1110,7 +1131,11 @@ int main(int argc, icChar* argv[])
 
       //Read profile from path and add it to theCmm
       CIccProfile* pXformProfile = ReadIccProfile(argv[nCount], bUseSubProfile); //We need all tags in profile for providing information to link
-      stat = theCmm.AddXform(pXformProfile, nIntent<0 ? icUnknownIntent : (icRenderingIntent)nIntent, nInterp, pPccProfile,
+      // No negative test here: nIntent reached this point through the sign guard
+      // and the range check above, so it is 0..3 and the icUnknownIntent arm
+      // this used to carry could never be taken.  Kept as a plain cast rather
+      // than a dead ternary for the reason given at the range check (#2268).
+      stat = theCmm.AddXform(pXformProfile, (icRenderingIntent)nIntent, nInterp, pPccProfile,
                               (icXformLutType)nType, bUseD2BxB2DxTags, &Hint);
       if (stat) {
         // AddXform can fail for reasons that have nothing to do with the

--- a/Tools/CmdLine/IccBenchApply/Readme.md
+++ b/Tools/CmdLine/IccBenchApply/Readme.md
@@ -16,9 +16,22 @@ iccBenchApply {options} interpolation {profile_path rendering_intent {-PCC pcc_p
 ```
 
 `interpolation` is `0` for linear or `1` for tetrahedral. `rendering_intent`
-takes `0..3` plus the `+1000` / `+10000` modifiers, decoded exactly as
-`iccApplyToLink` decodes them, so a chain given to either tool resolves the same
-way.
+takes `0..3` plus the `+1000` / `+10000` modifiers, and a negative code is
+rejected here exactly as `iccApplyToLink` rejects it — the column arithmetic
+drops the sign, so `-10` used to resolve as `10` in both tools (#2268).
+
+The decode is **not** otherwise identical to `iccApplyToLink`'s, despite what
+this file said before #2268. Two columns diverge, so a chain given to the two
+tools does not always resolve the same way:
+
+| column | `iccApplyToLink` | `iccBenchApply` |
+|---|---|---|
+| `+100` | read as a luminance-matching request (`CIccLuminanceMatchingHint`) | discarded — the hundreds column is never read |
+| tens digit `4` | mapped to lookup type `0` plus a black-point-compensation hint | passed through as `icXformLutBPC`, which `AddXform` refuses with `Invalid Look-Up Table type` |
+
+So `iccBenchApply … profile.icc 40` fails where `iccApplyToLink … profile.icc 40`
+succeeds. Use this tool to time the plain intent and sub-profile columns; it
+cannot currently time a BPC or luminance-matched chain.
 
 | option | effect |
 |---|---|

--- a/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
+++ b/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
@@ -144,19 +144,50 @@ static bool ParseIntArg(const char *arg, int minValue, int maxValue, int &value)
 static bool DecodeIntent(int nEncoded, int &nIntent, int &nType,
                          bool &bUseSubProfile, bool &bUseD2BxB2DxTags)
 {
+  // Assigned before the guard below so every return path leaves the caller with
+  // defined values.  The early return is new, and both current callers treat
+  // false as fatal without reading these -- but the function used to promise
+  // that all four were written, and a later caller would inherit uninitialised
+  // locals with nothing to warn it (#2268).
+  nIntent = 0;
+  nType = 0;
+  bUseSubProfile = false;
+  bUseD2BxB2DxTags = true;
+
+  // A negative code is not a documented form, and the column arithmetic below
+  // cannot refuse one: nType takes abs() while the intent digit does not, so
+  // -110 % 10 is 0 and "-110" resolved exactly like "110".  The return test at
+  // the bottom runs after the sign is already gone, which is why "-3" was
+  // refused and "-10" was not.  Guarding here rather than at the caller keeps
+  // the built-in -suite table held to the same rule as the command line, and
+  // matches the guard iccApplyToLink grew in the same change (#2268, #2190).
+  //
+  // The sign rule is the only part of this decode that is now known to match
+  // that tool column for column.  Two others do NOT: the hundreds column is
+  // read there as a luminance-matching request and is discarded here, and a
+  // tens digit of 4 selects black-point compensation there while reaching
+  // AddXform() as icXformLutBPC here.  Do not widen the equivalence claim
+  // above without closing those.
+  if (nEncoded < 0)
+    return false;
+
   bUseSubProfile = (nEncoded / 1000) > 0;
   nIntent = nEncoded % 1000;
   nIntent = nIntent % 100;
   nType   = abs(nIntent) / 10;
   nIntent = nIntent % 10;
 
-  bUseD2BxB2DxTags = true;
   if (nType == 1) {
     nType = 0;
     bUseD2BxB2DxTags = false;
   }
 
-  return nIntent >= (int)icPerceptual && nIntent <= (int)icAbsoluteColorimetric;
+  // Only the upper bound is testable.  nIntent is "% 100" then "% 10" of a
+  // value already refused if negative, so it is 0..9 and icPerceptual is 0 --
+  // a ">= icPerceptual" term would be constantly true.  Same dead comparison
+  // CodeQL raised as #2357/#2358/#2359 against IccCmmConfig.cpp once #2261 put
+  // the sign guard in front of it (#2268).
+  return nIntent <= (int)icAbsoluteColorimetric;
 }
 
 // Names for the icXformType values in IccCmm.h:177-187. PCS is named explicitly
@@ -748,8 +779,18 @@ int main(int argc, const char *argv[])
     bool bUseSubProfile, bUseD2BxB2DxTags;
     if (!DecodeIntent(nEncoded, nIntent, nType,
                       bUseSubProfile, bUseD2BxB2DxTags)) {
-      printf("Invalid rendering intent '%s': decoded intent out of range\n",
-             argv[nArg - 1]);
+      // Two distinct rejections share one gate, so name which one fired.  The
+      // sign case is the whole point of the guard: "-10" used to be accepted
+      // and resolve as "10", so reporting it as an out-of-range decoded intent
+      // would describe a digit the caller can see is in range (#2268).
+      if (nEncoded < 0) {
+        printf("Invalid rendering intent '%s': a negative intent code is not a"
+               " valid form\n", argv[nArg - 1]);
+      }
+      else {
+        printf("Invalid rendering intent '%s': decoded intent out of range\n",
+               argv[nArg - 1]);
+      }
       return 1;
     }
 

--- a/docs/tools-cli-reference.md
+++ b/docs/tools-cli-reference.md
@@ -123,6 +123,23 @@ injects the HToS transform whenever the tag is present, regardless of the flag.
 It is accepted and round-trips through the JSON config, but selects nothing
 (#2190).
 
+`iccApplyToLink` and `iccBenchApply` do not reach that shared parser. Each
+carries its own decode of a smaller set of columns, and the weights differ by a
+decade: in `iccApplyToLink` the tens digit is the transform-lookup type, `+100`
+is luminance matching and `+1000` selects the V5 sub-profile.
+
+The non-negative rule above holds in all three decodes, but it reached the two
+tools separately (#2268) -- before that a negative code whose units digit was
+zero, such as `-10`, was accepted by them and produced the same output as its
+positive twin.
+
+The sign rule is the only column the two tools are known to share. `iccBenchApply`
+discards the hundreds column rather than reading it as a luminance request, and
+passes a tens digit of `4` straight through as `icXformLutBPC` instead of mapping
+it to a black-point-compensation hint -- so `iccBenchApply <profile> 40` fails with
+`Invalid Look-Up Table type` where `iccApplyToLink <profile> 40` succeeds. See
+[`Tools/CmdLine/IccBenchApply/Readme.md`](../Tools/CmdLine/IccBenchApply/Readme.md).
+
 The over-black / over-gray flags only affect chains that include a v5
 NamedColor profile. JSON callers prefer the `transform` field values,
 which combine an output-side stem (`named` / `namedColorimetric` /


### PR DESCRIPTION
Closes #2268.

## The defect

`iccApplyToLink` splits one integer into decimal columns and takes `abs()` on the
transform-type digit but not on the intent digit. A negative code whose units digit is
zero therefore survived every check: by the time the range test at
`iccApplyToLink.cpp:1076` runs, `nIntent % 10` has already dropped the sign, so it
cannot see it. Only a non-zero units digit — `-3` — was ever refused, which is why the
gap read as covered.

Measured on `e23426a0`, clang-18 Release:

| intent code | exit | result |
|---|---|---|
| `10` | 0 | link written |
| `-10` | 0 | link written |
| `110` | 0 | link written |
| `-110` | 0 | link written |
| `-3` | 1 | `Invalid rendering intent '-3': decoded intent is out of range` |
| `4` | 1 | `Invalid rendering intent '4': decoded intent is out of range` |

`-10` and `-110` produce device links **byte-identical** to `10` and `110`, compared
after zeroing the two volatile header fields (dateTime `24..35`, profileID `84..99`):

```
link_1         050855ba73b5af43
link_10        e9c6a131041dc066
link_neg10     e9c6a131041dc066     <- identical to 10
link_110       e9c6a131041dc066
link_neg110    e9c6a131041dc066     <- identical to 110
```

`1` differs, so the comparison is not blind.

## Why both tools

This is the defect PR #2261 fixed in `CIccCfgProfileSequence::fromArgs` for
`iccApplyNamedCmm` / `iccApplySearch` (#2190). Set-diffing every decimal-column decode
in the tree — the `abs(nIntent)/10` tell — gives exactly five sites:

| site | status |
|---|---|
| `IccCmmConfig.cpp:1133` (profile sequence) | guarded by #2261 |
| `IccCmmConfig.cpp:1410` (search apply) | guarded by #2261 |
| `IccCmmConfig.cpp:1486` (`-INIT`) | guarded by #2261 |
| `iccApplyToLink.cpp:1057` | **this PR** |
| `iccBenchApply.cpp:150` | **this PR** |

`IccCmmConfig.cpp:785`/`:798` and `IccCmm.cpp:112` are *not* in the family: the first two
range-check a raw JSON number with no column decode, and the third takes an already-decoded
`icRenderingIntent`.

CodeQL does not flag `iccApplyToLink.cpp:1076`, correctly — with no upstream guard the
lower bound is genuinely live there, so only a set-diff finds it.

## The dead bounds the guard creates, removed in the same change

Adding a sign guard makes the lower half of the range test that follows it constantly
false. That is character-for-character the defect CodeQL filed as #2357/#2358/#2359
against `IccCmmConfig.cpp` after #2261 landed, and that #2267 removed three hours ago.
Both `Tools` paths are in `.github/codeql-config.yml`, so shipping the guard alone would
file the same alert a second time. Removed here in the same commit:

| site | dead term | why |
|---|---|---|
| `iccApplyToLink.cpp` range test | `nIntent < (int)icPerceptual` | `nIntent` is `value % 10` of a value already refused if negative, so `0..9`; `icPerceptual` is `0` |
| `iccApplyToLink.cpp` `AddXform` call | `nIntent<0 ? icUnknownIntent :` | true arm unreachable; the tool could never request `icUnknownIntent` |
| `iccBenchApply.cpp` `DecodeIntent` return | `nIntent >= (int)icPerceptual` | same reasoning, always true |

`DecodeIntent()` also now writes its four output parameters before the early return. Both
current callers treat `false` as fatal and read none of them, so this is latent only — but
the function previously promised all four were assigned, and a later caller would have
inherited uninitialised locals with nothing to warn it.

## The equivalence claim was wrong, and this change made it load-bearing

`iccBenchApply::DecodeIntent()` and `Tools/CmdLine/IccBenchApply/Readme.md` both said the
decode matched `iccApplyToLink` column for column, so a chain given to either tool
resolves the same way. It does not, and closing only the sign column would have made that
claim *more* misleading rather than less. Measured:

| column | `iccApplyToLink` | `iccBenchApply` |
|---|---|---|
| `+100` | read as a luminance request (`CIccLuminanceMatchingHint`) | discarded — the hundreds column is never read |
| tens digit `4` | mapped to lookup type `0` plus a BPC hint | passed through as `icXformLutBPC` |

```
$ iccBenchApply -pixels 4096 -repeats 1 1 Testing/sRGB_v4_ICC_preference.icc 40
Unable to add 'Testing/sRGB_v4_ICC_preference.icc' to the chain: Invalid Look-Up Table type

$ iccApplyToLink out.icc 0 2 1 t 0 1 0 0 Testing/sRGB_v4_ICC_preference.icc 40
LUT successfully written to 'out.icc'
```

So `40` fails on one tool and succeeds on the other. Both Readmes and
`docs/tools-cli-reference.md` now say so and scope the equivalence to the sign rule.
(`+100` is a code-level divergence only — on this profile `iccApplyToLink` produced a
link byte-identical to `0`, so no observable difference is claimed for it.)

## Tests

Seven CTests, driven through `RunBenchApplyCliTest.cmake` because it asserts the exit
status **and** the message together. A bare nonzero exit does not separate this refusal
from a crash or a missing runtime library — and on Windows a missing `IccProfLib2.dll`
exits `-1073741515`, an ordinary nonzero status. That matters more than usual here: the
pre-existing `iccdev.applytolink-invalid-decoded-intent` is a `WILL_FAIL` test, which is
exactly the message-blind coverage that let the sign case through.

The driver's log label is now a `LABEL` parameter so one wrapper serves both tools; the
default keeps all five existing callers byte-identical. Nothing in the tree greps the old
`bench-apply-cli` prefix.

Red/green, run against tools built from `e23426a0` and again after the fix:

| test | vs `e23426a0` | vs this branch |
|---|---|---|
| `iccdev.applytolink-negative-intent-code` (`-10`) | **FAIL** | pass |
| `iccdev.applytolink-negative-intent-code-typed` (`-110`) | **FAIL** | pass |
| `iccdev.bench-apply-negative-intent-code` (`-10`) | **FAIL** | pass |
| `iccdev.applytolink-valid-intent-code` (`10`) | pass | pass |
| `iccdev.applytolink-valid-intent-code-typed` (`110`) | pass | pass |
| `iccdev.bench-apply-valid-intent-code` (`10`) | pass | pass |
| `iccdev.bench-apply-valid-intent-code-typed` (`110`) | pass | pass |

The four positive controls pass against **both** builds by design: they are what stops a
guard that refused every code from satisfying the three negative tests. The two `110`
controls are not redundant with the `10` pair — verified against a deliberately
mis-written `nIntent < 0 || nIntent >= 100` guard, which the other five tests all pass
and only the `110` control catches:

```
vs the mis-written guard:   neg-10 PASS   neg-110 PASS   pos-10 PASS   pos-110 FAIL
```

## Pre-flight

| lane | result |
|---|---|
| clang-18 strict Release, `-Wall -Wextra -Wpedantic -Werror` | build OK, **0 warnings** on CI's `grep -cE 'warning:'` gate, tools + `build-test-binaries` |
| GCC 15.2.0 in `iccdev-ci-regression:latest`, strict + `ENABLE_LTO=ON` | build OK, **0 warnings**; configure reports `strict warnings ENABLED (GNU 15.2.0)` |
| full CTest, 219 tests | 218 pass. The one failure is `iccdev.spectral-tiff-preview`, `ModuleNotFoundError: No module named 'imagecodecs'` — a missing local Python module, unrelated |
| ASAN+UBSAN, `detect_leaks=1` | clean on all seven cases; binaries confirmed instrumented (225 sanitizer symbols each) |

## Not changed here

`iccApplyToLink.cpp:1082` tests `nType < icXformLutMinimum || nType > icXformLutMaximum`,
but `nType` is `abs(nIntent % 100) / 10`, so it is always `0..9`: **both** bounds are
unreachable, and `icXformLutSpectral` (0xA) through `icXformLutNamedDevice` (0xD) cannot
be selected from this CLI at all. `140` is accepted and produces output byte-identical to
`40`. This predates the PR and CodeQL does not flag it. Whether those LUT types *should*
be reachable from the command line is a design question rather than a decode bug, so it is
reported rather than changed here — filed separately.
