### PR TITLE
fix(#2265): restore the rotl/rotr operand and drop the manifest lines it hid

### DIFF
--- a/.github/ci/regression/mpecalc-rotate-operand-roundtrip.cpp
+++ b/.github/ci/regression/mpecalc-rotate-operand-roundtrip.cpp
@@ -1,0 +1,94 @@
+// Regression test for the rotl/rotr operand that SIccCalcOp::Describe dropped
+// (#2265), IccProfLib/IccMpeCalc.cpp.
+//
+// The icSigRotateLeftOp/icSigRotateRightOp arm formatted its selectors into the
+// scratch buffer and then fell straight to `break` without the `desc += buf;`
+// every neighbouring arm ends with, so rotl and rotr always described themselves
+// bare.  Reading that text back gives CIccFuncTokenizer::GetIndex() no operand,
+// so it keeps the (1,1) initV1/initV2 it is called with for these ops and then
+// subtracts them off again -- landing both selectors on 0.  CIccOpDefRotateLeft
+// ::Exec uses v1 as the rotate count (nCopy = v1+1) and v2 as the offset
+// (nPos = v2+1), so an iccToXml -> iccFromXml round trip silently rewrote
+// rotl(3,2) as rotl(1,1) and changed the transform.  Where the original count
+// exceeded the available stack the round trip also erased the underflow, turning
+// an invalid profile into a valid one: Testing/CalcTest/calcUnderStack_rotl.icc
+// and _rotr.icc reconstructed clean while their 72 siblings still rejected.
+//
+// The fix emits both selectors biased by the same one GetIndex() removes, and
+// keeps the copy/posdup convention of omitting what the defaults already supply
+// so ops written without an index are unchanged.
+//
+// Describe() composed with SetFunction() must be the identity on the op text.
+// The two unindexed cases are the control: they are stable both pre- and
+// post-fix, so a run that reports only those as OK has not silently passed.
+//
+// Exit code 0 = pass, 1 = an operand was lost in the round trip.
+
+#include "IccMpeCalc.h"
+
+#include <cstdio>
+#include <string>
+
+static int g_failures = 0;
+
+// Collapse runs of whitespace so the comparison tracks the op text, not the
+// blanks Describe() lays out.
+static std::string squeeze(const std::string &s)
+{
+  std::string out;
+  bool pending = false;
+  for (std::string::const_iterator i = s.begin(); i != s.end(); ++i) {
+    const char c = *i;
+    if (c == ' ' || c == '\t' || c == '\n' || c == '\r') { pending = true; continue; }
+    if (pending && !out.empty()) out += ' ';
+    pending = false;
+    out += c;
+  }
+  return out;
+}
+
+static void checkRoundTrip(const char *szFuncDef)
+{
+  CIccCalculatorFunc fn(NULL);
+  std::string sReport;
+
+  if (fn.SetFunction(szFuncDef, sReport) != icFuncParseNoError) {
+    std::printf("FAIL: %s did not parse (%s)\n", szFuncDef, sReport.c_str());
+    ++g_failures;
+    return;
+  }
+
+  std::string sDescribed;
+  fn.Describe(sDescribed, 100, 0);
+
+  const std::string sWanted = squeeze(szFuncDef);
+  const std::string sGot = squeeze(sDescribed);
+
+  if (sWanted == sGot) {
+    std::printf("ok:   %s\n", sWanted.c_str());
+  }
+  else {
+    std::printf("FAIL: %s described back as %s\n", sWanted.c_str(), sGot.c_str());
+    ++g_failures;
+  }
+}
+
+int main()
+{
+  // Controls: no operand to lose, identical before and after the fix.
+  checkRoundTrip("{ 1 2 3 4 5 6 7 8 rotl }");
+  checkRoundTrip("{ 1 2 3 4 5 6 7 8 rotr }");
+
+  // The regression: pre-fix every one of these described back bare.
+  checkRoundTrip("{ 1 2 3 4 5 6 7 8 rotl(3) }");
+  checkRoundTrip("{ 1 2 3 4 5 6 7 8 rotl(3,2) }");
+  checkRoundTrip("{ 1 2 3 4 5 6 7 8 rotr(4) }");
+  checkRoundTrip("{ 1 2 3 4 5 6 7 8 rotr(4,3) }");
+
+  if (g_failures) {
+    std::printf("\n%d operand round trip(s) FAILED\n", g_failures);
+    return 1;
+  }
+  std::printf("\nall checks passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -995,6 +995,48 @@ function(iccdev_add_pawg_q1q3_relative_intent_test)
   endif()
 endfunction()
 
+# Guards the rotl/rotr operand that SIccCalcOp::Describe dropped (#2265):
+# the icSigRotateLeftOp/icSigRotateRightOp arm formatted its selectors and then
+# broke without appending them, so the ops described themselves bare and a
+# re-read fell back on GetIndex()'s (1,1) defaults -- zeroing the rotate count
+# and offset.  An iccToXml -> iccFromXml round trip therefore rewrote the
+# transform, and erased the stack underflow that made calcUnderStack_rotl.icc
+# and _rotr.icc invalid.  The test asserts Describe(SetFunction(text)) == text.
+function(iccdev_add_mpecalc_rotate_operand_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccMpeCalcRotateOperandTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/mpecalc-rotate-operand-roundtrip.cpp"
+  )
+  target_link_libraries(iccMpeCalcRotateOperandTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccMpeCalcRotateOperandTest)
+
+  add_test(
+    NAME iccdev.mpecalc-rotate-operand-roundtrip
+    COMMAND "$<TARGET_FILE:iccMpeCalcRotateOperandTest>"
+  )
+  set_tests_properties(iccdev.mpecalc-rotate-operand-roundtrip PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 25
+    LABELS "iccdev;mpe;calc;xml;regression"
+  )
+  if(WIN32)
+    set(_mpecalc_rotate_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccMpeCalcRotateOperandTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _mpecalc_rotate_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.mpecalc-rotate-operand-roundtrip PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_mpecalc_rotate_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # Guards the calc-element matrix-size integer overflow (#1447 Solve / #1448
 # Transpose): CIccOpDefTranspose/Solve::Exec computed `int nSize = r*c` with r,c
 # each up to 65536, overflowing int and slipping past the size guard into a bad
@@ -5940,6 +5982,7 @@ if(WIN32)
   iccdev_add_pawg_q1q3_relative_intent_test()
   iccdev_add_cmm_registry_allowlist_test()
   iccdev_add_mpecalc_matrix_overflow_test()
+  iccdev_add_mpecalc_rotate_operand_test()
   iccdev_add_sparsematrix_set_roundtrip_test()
   iccdev_add_cmmsearch_namedcolor_ownership_test()
   iccdev_add_xform_create_tag_ownership_test()
@@ -6284,6 +6327,7 @@ iccdev_add_tointernal_fixedint_roundtrip_test()
 iccdev_add_pawg_q1q3_relative_intent_test()
 iccdev_add_cmm_registry_allowlist_test()
 iccdev_add_mpecalc_matrix_overflow_test()
+iccdev_add_mpecalc_rotate_operand_test()
 iccdev_add_sparsematrix_set_roundtrip_test()
 iccdev_add_cmmsearch_namedcolor_ownership_test()
 iccdev_add_xform_create_tag_ownership_test()

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -1963,7 +1963,25 @@ void SIccCalcOp::Describe(std::string &desc, int /* nVerboseness */)
 
     case icSigRotateLeftOp:       
     case icSigRotateRightOp:
-      snprintf(buf, bufSize, "(%d,%d)", data.select.v1, data.select.v2);
+      // The formatted operand was never appended, so rotl/rotr described
+      // themselves bare no matter what they held.  Re-reading that text gives
+      // GetIndex() nothing to parse, so it applies the (1,1) defaults it then
+      // subtracts back off and both selectors land on 0 -- silently rewriting
+      // rotl(3,2) as rotl(1,1).  Exec() uses v1 as the rotate count and v2 as
+      // the offset, so that changes the transform; where the original count
+      // exceeded the stack it also erased the underflow that made the profile
+      // invalid.  Emit both selectors biased by the same one GetIndex() removes,
+      // and omit what the defaults already supply so unindexed ops are unchanged.
+      if (!data.select.v2) {
+        if (data.select.v1) {
+          snprintf(buf, bufSize, "(%d)", data.select.v1+1);
+          desc += buf;
+        }
+      }
+      else {
+        snprintf(buf, bufSize, "(%d,%d)", data.select.v1+1, data.select.v2+1);
+        desc += buf;
+      }
       break;
 
     case icSigCopyOp:             

--- a/Testing/expected-invalid-fromxml.tsv
+++ b/Testing/expected-invalid-fromxml.tsv
@@ -5,22 +5,12 @@
 #
 # Keep this manifest narrow. New diagnostics should fail CI until a maintainer
 # either fixes the fixture/tool behavior or classifies the profile here.
+#
+# Narrow means every entry earns its place: the glob has to match a profile the
+# ubuntu-latest sweep actually produces (that is the only leg with
+# run-full-tests), and the fragment has to be text IccProfLib can emit -- the
+# classifier greps for it literally. An entry that fails either test silently
+# pre-approves its whole glob for a regression it can never match.
 calcUnderStack_*	parse-fail	Unable to parse element of type CIccMpeXmlCalculator	calculator under-stack negative profiles intentionally reject invalid stack operations
 uio-CIccCalculatorFunc-CheckUnderflowOverflow-IccMpeCalc_cpp-Line4238	parse-fail	Unable to Parse	calculator underflow/overflow fixture intentionally emits malformed unknown-element XML
 calcOverMem_*	invalid-saved	accesses illegal temporary channels	calculator over-memory negative profiles intentionally validate illegal temporary channel access
-Spec*	invalid-saved	Invalid pcs color space	iccMAX spectral fixtures round-trip with NULL PCS and missing colorimetric critical tags
-Ref*	invalid-saved	Invalid pcs color space	iccMAX spectral reference fixtures round-trip with NULL PCS diagnostics
-argbRef	invalid-saved	Invalid pcs color space	iccMAX spectral reference fixture round-trips with NULL PCS diagnostics
-srgbRef	invalid-saved	Invalid pcs color space	iccMAX spectral reference fixture round-trips with NULL PCS diagnostics
-MultSpectralRGB	invalid-saved	Invalid pcs color space	multispectral RGB fixture round-trips with NULL PCS diagnostics
-CMYK_Hybrid_Profile	invalid-saved	Media white point tag missing	hybrid spectral fixture is tracked as expected-invalid after XML reconstruction
-ElevenChanKubelkaMunk	invalid-saved	Invalid pcs color space	spectral calculator fixture round-trips with NULL PCS diagnostics
-FluorescentNamedColor	invalid-saved	Unknown color space	named-color spectral fixture round-trips with NULL PCS diagnostics
-NamedColor	invalid-saved	Unknown color space	named-color spectral fixture round-trips with NULL PCS diagnostics
-SparseMatrixNamedColor	invalid-saved	Unknown color space	named-color sparse matrix fixture round-trips with NULL PCS diagnostics
-*SelectMID	invalid-saved	Invalid PCS designator for MultiplexIdentificationClass	MCS multiplex identification fixtures are tracked negative conformance vectors
-*Select-MID	invalid-saved	Invalid PCS designator for MultiplexIdentificationClass	MCS multiplex identification fixtures are tracked negative conformance vectors
-*-Mid_Overprint	invalid-saved	Invalid PCS designator for MultiplexIdentificationClass	overprint multiplex identification fixtures are tracked negative conformance vectors
-ISO22028-Encoded*	invalid-saved	Encoding Class has non-zero Header	encoding-class fixtures preserve non-zero reserved header diagnostics
-sRgbEncoding*	invalid-saved	Encoding Class has non-zero Header	encoding-class fixtures preserve non-zero reserved header diagnostics
-LCDDisplayCat8Obs	invalid-saved	Negative Z value	display category-eight observer fixture has tracked red colorant diagnostics


### PR DESCRIPTION
Part of #2265.

`Testing/expected-invalid-fromxml.tsv` asked a maintainer to *either* fix the fixture/tool
behavior *or* classify the profile. Doing both meant first measuring which entries were real.

## What the manifest actually covered

The lane is an ICC -> XML -> ICC round trip: `iccToXml` over every `Testing/**/*.icc`
(tracked plus `CreateAllProfiles.sh` output), then `iccFromXml`, then
`.github/scripts/iccdev-classify-fromxml-logs.sh` against this manifest. It runs on
**ubuntu-latest only** — `_build-matrix.yml:67` passes `run-full-tests` for that OS alone —
so that corpus is authoritative. Reproduced locally: 215 profiles, 214 XML.

Of the 19 entries, **3 were live and 16 matched nothing**:

| entry | profiles matched | status now |
|---|---|---|
| `calcUnderStack_*` | 74 | live (72 parse-fail; the other 2 are the defect below) |
| `calcOverMem_*` | 3 | live, `invalid-saved` |
| `uio-...-Line4238` | 1 | live, `parse-fail` |
| `Spec*` | 61 | all `valid-saved` |
| `Ref*` / `argbRef` / `srgbRef` | 3 / 1 / 1 | all `valid-saved` |
| `ElevenChanKubelkaMunk`, `FluorescentNamedColor`, `NamedColor`, `SparseMatrixNamedColor` | 1 each | all `valid-saved` |
| `*SelectMID` / `*Select-MID` | 4 / 3 | all `valid-saved` |
| `ISO22028-Encoded*` / `sRgbEncoding*` | 2 / 2 | all `valid-saved` |
| `MultSpectralRGB`, `CMYK_Hybrid_Profile`, `*-Mid_Overprint`, `LCDDisplayCat8Obs` | **0** | not in the corpus at all |

The last four name `Testing/hybrid` artifacts. `hybrid/BuildAndTest.sh` writes them to
`ICC/` and `Results/`, `hybrid/.gitignore` ignores `ICC/*.icc`, and `CreateAllProfiles.sh`
never enters that directory — so CI has never seen them. Built by hand, all six round-trip
`valid-saved` too.

**Nine of the stale entries could not have matched under any circumstances.** They grep for
`Invalid pcs color space` / `Unknown color space`, but IccProfLib writes *colour*
(`" - %s: Invalid pcs colour space!\n"`), and `matches_manifest` uses `grep -Fq`. Control:
a `Spec*` profile mutated to `<PCS>bogs</PCS>` really does emit
`Invalid pcs colour space` and round-trips `invalid-saved` — the **old** manifest reports it
`[UNCLASSIFIED_INVALID]` and fails the lane, exactly as the pruned one does. Removing those
lines costs no coverage.

## The two exceptions were a real defect

`calcUnderStack_rotl` and `_rotr` round-tripped **valid** while their 72 siblings rejected.
`SIccCalcOp::Describe`, `IccMpeCalc.cpp:1964`:

```c
case icSigRotateLeftOp:
case icSigRotateRightOp:
  snprintf(buf, bufSize, "(%d,%d)", data.select.v1, data.select.v2);
  break;                     // every neighbouring arm ends `desc += buf;`
```

The operand is formatted and discarded, so rotl/rotr always describe themselves bare.
Re-reading leaves `CIccFuncTokenizer::GetIndex()` nothing to parse, so it keeps the `(1,1)`
`initV1/initV2` these ops pass and then subtracts them off — landing both selectors on 0.
`CIccOpDefRotateLeft::Exec` uses v1 as the rotate count (`nCopy = v1+1`) and v2 as the offset
(`nPos = v2+1`), so this is not cosmetic:

* **Valid profiles are silently corrupted.** A profile holding `rotl` with `v1=2, v2=0`
  round-trips to `v1=0, v2=0` — 2 bytes changed at the op, profile still reports valid,
  transform different.
* **Invalid profiles become valid.** `calcUnderStack_rotl.icc` validates with
  `Stack underflow at operation "rotl"`; its reconstruction validates clean.

Appending `buf` alone is **not** the fix — built and measured: it emits `rotl(2,0)`, and
`GetIndex` rejects a value below `initV2`, so the profile then fails to parse entirely.
Both selectors need the same `+1` bias, and the fix keeps the `copy`/`posdup` convention of
omitting what the defaults already supply, so ops written without an index are unchanged.

## Verification

* Sweep, pristine corpus, after the fix: **214 logs, 136 valid-saved, 3 expected-invalid,
  75 expected-parse-fail, 0 unclassified, 0 hard-fail.** Exactly two profiles change verdict
  (`rotl`, `rotr`, now `EXPECTED_PARSE_FAIL` like their siblings); no other profile moves.
* Old manifest vs pruned manifest on the fixed tree: **identical counts**.
* New CTest `iccdev.mpecalc-rotate-operand-roundtrip` asserts
  `Describe(SetFunction(text)) == text`. Against the unfixed library it **fails 4 of 6**
  cases while the two unindexed controls still pass, so it is not vacuous.
* Clean under ASAN+UBSAN with `detect_leaks=1` (verified the leak detector was armed with a
  deliberate-leak control).
* Strict Clang 21.1.3 (`strict warnings ENABLED`) and the GCC 15.2.0 CI container
  (`ghcr.io/.../iccdev-ci-regression:latest`, `-Wall -Wextra -Wpedantic -Werror`, LTO):
  **`grep -cE 'warning:'` = 0** in both, including `build-test-binaries`.
* `ctest`: 221 tests, 1 failure — `iccdev.spectral-tiff-preview`, verified pre-existing on
  the unmodified tree.
* `Testing/CalcTest/runtests.sh` (load-bearing since #2266) exits 0.
* Dispatched `ci_scope=source` run
  [32666534356](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32666534356):
  all lanes green (GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL, MinGW UCRT64,
  macOS Debug + Release LTO, Tool Smoke ASAN+UBSAN).
* The CTest is confirmed to actually **run on Windows**, not merely to configure there:
  `85/127 Test #85: iccdev.mpecalc-rotate-operand-roundtrip ... Passed 0.01 sec`, and the
  Windows total moved 126 -> 127. The first dispatch
  ([32665656197](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32665656197))
  was green with 126 and *without* this test: registering it only from the later of the two
  call lists in `Build/Cmake/Testing/CMakeLists.txt` covers Linux and macOS but not Windows.
  It is now called from both, matching `mpecalc-matrix-size-overflow` and
  `calc-envsig-sign-extension`; Linux still registers it exactly once.

## Deliberately not changed

* **`v1`/`v2` = `0xffff` describes as `(65536)`, which `GetIndex` then rejects.** Real, but
  pre-existing and shared: `copy`, `posdup`, `solve` and `transpose` all emit the same
  unreadable text on master today. Making rotate the one op that deviates would be worse
  than the hole; the representability limit belongs in `GetIndex`/the grammar and should be
  fixed for all six together. No profile in `Testing/` reaches it.
* **`Testing/CalcTest/report.txt`** still shows the old bare `rotl`. Regenerating it is a
  2124-line diff — the committed copy was built with `IccProfLib 2.3.1.7+d377cb6` and
  predates the iccMAX summary block and the `ColorSpaceClass` -> `ColorSpace` rename. The 4
  rotl/rotr lines are 4 of 2124 already-stale lines, so refreshing it is separate
  housekeeping, not this change.

## Separately reported

`find Testing -name '*.icc'` keys the sweep by `basename`, so 215 profiles produce 214 XML
files: `Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc` (tracked, 24712 B) and
`Testing/Display/sRGB_D65_MAT.icc` (generated, 24708 B) are different profiles, the
generated one wins, and the tracked one is never round-trip tested.
