### PR TITLE
fix(#1982): honour the D2B/B2D opt-out for dual-PCS profiles

### DIFF
--- a/.github/scripts/iccdev-issue-1982-dual-pcs-selection-regression.sh
+++ b/.github/scripts/iccdev-issue-1982-dual-pcs-selection-regression.sh
@@ -1,0 +1,228 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 International Color Consortium
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+###############################################################################
+# Guards CIccXform::Create's DToBx/BToDx tag selection for dual-PCS profiles
+# (#1982).
+#
+# ICC.2:2023 lets a profile encode an independent colorimetric PCS and spectral
+# PCS.  iccApplyToLink's intent codes 11/13 decode to icXformLutColor with
+# bUseD2BxB2DxTags cleared, i.e. an explicit opt-out of D2B/B2D selection, and
+# CIccCmm::AddXform honours it (its space selection reads
+# "bUseD2BxB2DxTags || !m_Header.pcs").  CIccXform::Create used to test the bare
+# spectralPCS field instead, so it handed back a spectral transform while the CMM
+# had recorded the colorimetric connection space.
+#
+# Two directions, because they fail differently and one hides the other:
+#
+#   Part 1 (source profile).  SixChanInputRef has AToB3 6->3 and DToB3 6->36 and
+#   no reverse tags.  Before the fix the 6->36 DToB3 was selected against a
+#   3-sample XYZ connection space and CIccCmm::Begin() rejected the chain
+#   outright, so a plain exit-status check is enough: measured on master
+#   f78e915a the tool exits 255 with "status 2: Invalid space link".
+#
+#   Part 2 (destination profile).  SixChanCameraRef carries all four of AToB3,
+#   BToA3, DToB3 and BToD3.  Here an exit status proves nothing -- the source and
+#   destination mis-selections cancel out, so before the fix the chain builds a
+#   link happily, just the wrong one.  The discriminator has to be relative:
+#   build the same two-profile chain twice, once with both ends opting out
+#   (11,11) and once with both opting in (1,1), and require the two links to
+#   DIFFER.  Both arms succeed in both builds -- what changes is the route -- so
+#   this is an assertion about tag selection and not an exit-status accident.
+#   Measured on master f78e915a the two links are byte-identical once the
+#   volatile header fields are stripped, which is precisely the bug: the opt-out
+#   changed nothing.  Note the two ends have to move together; opting out at the
+#   source while opting in at the destination is a genuine PCS mismatch once the
+#   fix lands, and the tool correctly refuses it.
+#
+# Exit codes:
+#   0  - pass
+#   2  - regression
+#   77 - skipped because a required tool is not built (SKIP_RETURN_CODE)
+###############################################################################
+
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+tools_dir="${ICCDEV_TOOLS_DIR:-$repo_root/Build/Tools}"
+outdir="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-1982}"
+
+find_tool()
+{
+  find "$tools_dir" -maxdepth 2 -type f -name "$1" 2>/dev/null | head -n 1
+}
+
+fail()
+{
+  echo "[FAIL] $1"
+  exit 2
+}
+
+# Missing tools are a SKIP, not a FAIL: this test is registered unconditionally,
+# so a build configured without ENABLE_ICCXML must not turn it red.  Exit 77
+# rather than the siblings' 0 so SKIP_RETURN_CODE turns it into a ctest "Skipped"
+# -- an exit 0 here would report a green pass for a run that asserted nothing.
+skip()
+{
+  echo "[SKIP] $1"
+  exit 77
+}
+
+mkdir -p "$outdir" || fail "cannot create output directory $outdir"
+
+from_xml="$(find_tool iccFromXml)"
+apply_to_link="$(find_tool iccApplyToLink)"
+dump_profile="$(find_tool iccDumpProfile)"
+
+for tool in "$from_xml" "$apply_to_link" "$dump_profile"; do
+  if [ -z "$tool" ] || [ ! -x "$tool" ]; then
+    skip "required tool not found under $tools_dir"
+  fi
+done
+
+sanitizer_check()
+{
+  # $1 = log file, $2 = context for the failure message
+  if grep -Eq "AddressSanitizer:|runtime error:|UndefinedBehaviorSanitizer" "$1"; then
+    fail "sanitizer finding $2; see $1"
+  fi
+}
+
+# No ASAN_OPTIONS/UBSAN_OPTIONS override here on purpose.  ICCDEV_TEST_ENV
+# already sets halt_on_error=0 for both, which is what keeps sanitizer_check()
+# reachable: with halt_on_error=1 a report aborts the tool, the "|| fail" on the
+# invocation fires first, and the finding is reported as a tool failure instead.
+
+###############################################################################
+# Part 1 -- dual-PCS source profile keeps its colorimetric AToBx transform
+###############################################################################
+
+src_xml="$repo_root/Testing/SpecRef/SixChanInputRef.xml"
+src_icc="$outdir/SixChanInputRef.icc"
+[ -f "$src_xml" ] || fail "missing fixture: $src_xml"
+
+"$from_xml" "$src_xml" "$src_icc" >"$outdir/fromxml-input.log" 2>&1 ||
+  fail "iccFromXml failed on $src_xml; see $outdir/fromxml-input.log"
+"$dump_profile" -v 100 "$src_icc" ALL >"$outdir/input.log" 2>&1
+
+# Anti-vacuity pins: if the fixture ever loses the dual PCS or either transform
+# the assertions below would still "pass" while testing nothing.
+grep -Eq "PCS Color Space:[[:space:]]+XYZData" "$outdir/input.log" ||
+  fail "fixture no longer exposes an XYZ PCS"
+grep -Eq "Spectral PCS:[[:space:]]+0x0024ChannelReflectanceData" "$outdir/input.log" ||
+  fail "fixture no longer exposes a 36-channel spectral PCS"
+# Anchored: "6->3" is a prefix of "6->36", so an unanchored AToB pin is satisfied
+# by the DToB line and can never detect the fixture change it names.
+grep -Eq "Matrix Element \\('matf' = 6D617466\\) 6->3$" "$outdir/input.log" ||
+  fail "fixture no longer has a 6-to-3 AToB transform"
+grep -Eq "Matrix Element \\('matf' = 6D617466\\) 6->36$" "$outdir/input.log" ||
+  fail "fixture no longer has a 6-to-36 DToB transform"
+
+for intent in 11 13; do
+  link_icc="$outdir/link-$intent.icc"
+  log="$outdir/applytolink-$intent.log"
+  rm -f "$link_icc"
+
+  "$apply_to_link" "$link_icc" 0 2 1 Issue1982 0 1 1 0 \
+      "$src_icc" "$intent" >"$log" 2>&1 ||
+    fail "iccApplyToLink failed for source intent $intent; see $log"
+
+  sanitizer_check "$log" "for source intent $intent"
+
+  "$dump_profile" -v 100 "$link_icc" ALL >"$outdir/link-$intent.log" 2>&1
+  grep -Eq "PCS Color Space:[[:space:]]+XYZData" "$outdir/link-$intent.log" ||
+    fail "source intent $intent did not produce XYZ PCS output"
+  grep -Eq "MPE Element Chain: 1 elements, 6->3 channels" "$outdir/link-$intent.log" ||
+    fail "source intent $intent did not produce a 6-to-3 colorimetric link"
+done
+
+echo "[ok] part 1: dual-PCS D2B opt-out retained 6-to-3 XYZ links"
+
+###############################################################################
+# Part 2 -- dual-PCS destination profile honours the same opt-out
+###############################################################################
+
+dst_xml="$repo_root/Testing/SpecRef/SixChanCameraRef.xml"
+dst_icc="$outdir/SixChanCameraRef.icc"
+[ -f "$dst_xml" ] || fail "missing fixture: $dst_xml"
+
+"$from_xml" "$dst_xml" "$dst_icc" >"$outdir/fromxml-dest.log" 2>&1 ||
+  fail "iccFromXml failed on $dst_xml; see $outdir/fromxml-dest.log"
+"$dump_profile" -v 100 "$dst_icc" ALL >"$outdir/dest.log" 2>&1
+
+# The whole point of this fixture is that BOTH reverse tags exist, so the
+# colorimetric route is available and the choice between them is real.
+grep -Eq "PCS Color Space:[[:space:]]+XYZData" "$outdir/dest.log" ||
+  fail "destination fixture no longer exposes an XYZ PCS"
+grep -Eq "Spectral PCS:[[:space:]]+0x0024ChannelReflectanceData" "$outdir/dest.log" ||
+  fail "destination fixture no longer exposes a 36-channel spectral PCS"
+for tag in BToA3Tag BToD3Tag; do
+  grep -Eq "$tag" "$outdir/dest.log" ||
+    fail "destination fixture no longer carries $tag"
+done
+
+# Strip the fields that differ between two runs of the same tool (creation time,
+# profile ID/MD5, the dump banner and the file name/size) so the comparison is
+# about the transform that was selected and nothing else.
+normalize()
+{
+  grep -Ev "Creation Date|Profile ID|^Size:|^Profile:|^Built with" "$1" > "$2"
+}
+
+for intent in 11 1; do
+  link_icc="$outdir/chain-link-$intent.icc"
+  log="$outdir/applytolink-chain-$intent.log"
+  rm -f "$link_icc" "$outdir/chain-link-$intent.norm"
+
+  "$apply_to_link" "$link_icc" 0 3 1 Issue1982 0 1 1 0 \
+      "$src_icc" "$intent" "$dst_icc" "$intent" >"$log" 2>&1 ||
+    fail "iccApplyToLink failed for chain intent $intent; see $log"
+
+  sanitizer_check "$log" "for chain intent $intent"
+
+  # Both arms must actually have produced a link.  Without this the comparison
+  # below would "differ" simply because one dump is an open failure message,
+  # and the test would pass against an unfixed library.
+  [ -f "$link_icc" ] || fail "chain intent $intent wrote no device link"
+
+  "$dump_profile" -v 100 "$link_icc" ALL >"$outdir/chain-link-$intent.log" 2>&1
+  normalize "$outdir/chain-link-$intent.log" "$outdir/chain-link-$intent.norm"
+  grep -Eq "MPE Element Chain" "$outdir/chain-link-$intent.norm" ||
+    fail "chain intent $intent produced a dump with no transform chain in it"
+done
+
+if cmp -s "$outdir/chain-link-11.norm" "$outdir/chain-link-1.norm"; then
+  fail "the D2B/B2D opt-out (11) and opt-in (1) produced identical links: the spectral tags were selected either way"
+fi
+
+echo "[ok] part 2: dual-PCS B2D opt-out selected a different link from the opt-in"
+echo "[PASS] dual-PCS transform selection honours the D2B/B2D opt-out in both directions"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -6793,6 +6793,26 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1337-checkpcsconnections-regression.sh"
 )
 
+# Guards dual-PCS transform selection in CIccXform::Create (#1982).  The D2B/B2D
+# opt-out intents must select the colorimetric AToBx/BToAx transforms rather than
+# the fixture's spectral DToBx/BToDx ones.  Covers both directions: the source
+# side is checked by exit status and link shape, the destination side by
+# requiring the opt-out and opt-in links to differ (they are byte-identical when
+# the opt-out is ignored, so an exit-status check alone would be vacuous there).
+iccdev_add_script_test(
+  iccdev.issue-1982-dual-pcs-selection-regression
+  120
+  "iccdev;tools;cmm;applytolink;issue-1982;regression;asan"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-1982-dual-pcs-selection-regression.sh"
+)
+# The script exits 77 when iccFromXml/iccApplyToLink/iccDumpProfile are absent
+# (a build without ENABLE_ICCXML, or a Windows checkout where the tools are
+# .exe).  Without this the skip would be reported as a green pass.
+set_tests_properties(iccdev.issue-1982-dual-pcs-selection-regression PROPERTIES
+  SKIP_RETURN_CODE 77
+)
+
 # CI debug helper for the NaN/SixChanInputRef iccApplyToLink PoC.  It preserves
 # the original master heap-buffer-overflow replay with extra signature/register
 # logging and now expects the NaN range to fail closed before CMM/LUT generation.

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -597,7 +597,18 @@ CIccXform *CIccXform::Create(CIccProfile *pProfile,
         // lives in DToBx tags regardless of how the caller set bUseD2BTags. Opening
         // that path here lets icXformLutColor + a spectral source profile resolve
         // without the caller having to set useD2BxB2Dx explicitly.
-        if (bUseD2BTags || pProfile->m_Header.spectralPCS) {
+        //
+        // "Spectral-only" is the !pcs test, not the bare spectralPCS test that
+        // stood here: ICC.2:2023 lets a profile carry an independent colorimetric
+        // PCS as well, and for those the caller's opt-out has to be honoured.
+        // CIccCmm::AddXform already draws the line that way -- its nDstSpace
+        // selection reads (bUseD2BxB2DxTags || !m_Header.pcs) -- so without this
+        // term the two disagree: AddXform records the 3-sample XYZ connection
+        // while Create hands back a DToBx transform emitting spectralPCS samples,
+        // and CIccCmm::Begin() then rejects the chain with icCmmStatBadSpaceLink.
+        // Measured on SixChanInputRef (AToB3 6->3, DToB3 6->36) with the D2B
+        // opt-out intents 11 and 13 (#1982).
+        if (bUseD2BTags || (pProfile->m_Header.spectralPCS && !pProfile->m_Header.pcs)) {
           if (nLutType != icXformLutColorimetric &&
               (pProfile->m_Header.spectralPCS || pProfile->m_Header.version >= icVersionNumberV5)) {
             pTag = pProfile->FindTag(icSigDToB0Tag + nTagIntent);
@@ -736,7 +747,16 @@ CIccXform *CIccXform::Create(CIccProfile *pProfile,
 
         // Spectral-only destination profiles only carry BToDx tags; let icXformLutColor
         // resolve them without requiring the caller to set useD2BxB2Dx.
-        if (bUseD2BTags || (nLutType != icXformLutColorimetric && pProfile->m_Header.spectralPCS)) {
+        //
+        // Same !pcs correction as the bInput branch above, and it has to land in
+        // the same commit: the two mis-selections currently cancel out.  A chain
+        // whose source and destination are both dual-PCS resolves today because
+        // both ends silently take the spectral route, so fixing only the input
+        // side leaves the destination on BToDx and turns a working link into
+        // icCmmStatUnsupportedPcsLink.  Measured with SixChanInputRef into
+        // SixChanCameraRef under the opt-out intents (#1982).
+        if (bUseD2BTags || (nLutType != icXformLutColorimetric &&
+                            pProfile->m_Header.spectralPCS && !pProfile->m_Header.pcs)) {
           pTag = pProfile->FindTag(icSigBToD0Tag + nTagIntent);
 
           //Additional precedence not prescribed by the v4 ICC Specification


### PR DESCRIPTION
## Summary

Harvests the `CIccXform::Create` half of `ci-qa-issue-1982` (`ea41af37`, @xsscx) and adds
a two-direction regression CTest. Part of #1982 — items 1 and 2; item 3 is already
implemented, and one behaviour question is left open for a maintainer (both below).
Deliberately not a closing keyword.

`CIccXform::Create` selected a spectral `DToBx`/`BToDx` transform whenever the profile
carried a `spectralPCS`, ignoring the caller's `bUseD2BTags` opt-out. Every other
space-selection site already tests `!pcs` as well — `CIccCmm::AddXform` at
`IccCmm.cpp:9093`/`:9112` and `CIccNamedColorCmm::AddXform` at `:11718`/`:11796`/`:11813`
all read `(bUseD2BxB2DxTags || !m_Header.pcs)`. For a profile carrying both a colorimetric
and a spectral PCS the sites disagreed: `AddXform` recorded the 3-sample XYZ connection
while `Create` returned a transform emitting 36 spectral samples, and `CIccCmm::Begin()`
rejected the chain.

Both `Create` lines were introduced together in `92ffea98` (#1018, hybrid spectral
profiles). The `AddXform` half already carried the `!pcs` term; the two `Create` sites did
not. With this change all seven sites agree.

## Measured

Clang 21.1.3 Release, master `f78e915a`, `Testing/SpecRef/SixChanInputRef.xml`
(`AToB3` 6→3, `DToB3` 6→36, `PCS=XYZ`, `SpectralPCS=rs0024`):

```
iccApplyToLink link.icc 0 2 1 T 0 1 1 0 SixChanInputRef.icc 11
  before: exit 255, "status 2: Invalid space link"
  after:  exit 0,   PCS XYZData, "MPE Element Chain: 1 elements, 6->3 channels"
```

Same for intent 13. Both decode to `icXformLutColor` with `bUseD2BxB2DxTags` cleared.

Instrumented master, whole 222-test suite, one probe per decision site:

```
IN_FLIP tagIntent=1 lut=0            <- SixChanInputRef @ 11
ADDXFORM_MISMATCH src=6/6 dst=36/3   <- xform emits 36, CMM recorded 3
```

## Why both sites in one commit

The two mis-selections cancel out. A chain whose source *and* destination are dual-PCS
resolves today because both ends silently take the spectral route. With only the input
site corrected:

```
SixChanInputRef 11 -> SixChanCameraRef 11
  master:          exit 0
  input site only: exit 255, "status 13: Unsupported PCS Link used"
```

## #1018 is not regressed

`CMYK_Hybrid_Profile`'s spectral sub-profile has an empty `<PCS>`, so `!pcs` holds and its
`DToBx` path stays open. `iccdev.hybrid-pipeline` passes: 43s Release, 494s ASan+UBSan.

## The test

`iccdev.issue-1982-dual-pcs-selection-regression`, both directions.

Part 1 (source) asserts exit status and link shape. Part 2 (destination) cannot: the
chain builds a link either way, just the wrong one, so an exit-status check would be
vacuous. It builds the same chain twice — both ends opting out `(11,11)` and both opting
in `(1,1)` — and requires the two links to differ. On master they are byte-identical once
`Creation Date` / `Profile ID` / size / banner are stripped. Both arms succeed in both
builds, so this asserts the route and not an error.

Red/green:

| tree | result |
|---|---|
| master `f78e915a` | FAIL (part 1) |
| input site only | FAIL (part 2) |
| both sites | PASS |

**No pre-existing test exercised the opt-out path at all.** The only other script using a
tens-digit-1 intent code is `iccdev-applytolink-nan-sixchan-debug.sh`, and it feeds `nan`
as the range so it fails before `AddXform`. A green suite is therefore not the evidence
here — the three-way red/green above is. The test exits 77 with `SKIP_RETURN_CODE` when
the tools are absent, so a build that cannot run it reports `Skipped` rather than a green
pass.

## Pre-flight

Base `d1a7d42a`.  Dispatched `ci-pr-action` with `ci_scope=source` before opening this PR
per the suggested workflow: run
[32743042807](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/32743042807),
**success**, 12 jobs green / 3 skipped by scope — GCC 15.2 Strict Release LTO, Windows
MSVC + ClangCL, MinGW UCRT64, macOS Release + Debug, Tool Smoke Tests ASAN+UBSAN.  On the
ASAN leg the new test ran as `149/220 Test #150 ... Passed 0.54 sec` (`100% tests passed,
0 failed out of 220`); script CTests are not registered on the Windows leg, which
nonetheless configured the new registration under MSVC (129 tests, 100%).

Local lanes:

| lane | result |
|---|---|
| Clang 21.1.3 Release, `-Wall -Wextra -Wpedantic -Werror`, strict warnings ENABLED | **0 warnings**, ctest 223/224 |
| GCC 15.2.0 in `ghcr.io/internationalcolorconsortium/iccdev-ci-regression:latest`, same flags + LTO, strict warnings ENABLED | **0 warnings**, build and `build-test-binaries` both rc=0 |
| Clang ASan+UBSan Debug | ctest 222/223, new test passes in 0.34s |
| `detect_leaks=1` over the six affected `iccApplyToLink` paths, including the newly reachable `ProfileMissingTag` refusal | no leaks, no findings (LeakSanitizer confirmed live against a deliberately leaky control) |
| `shellcheck` 0.9.0 | rc=0 |

The one ctest failure in each run is `iccdev.spectral-tiff-preview`, which needs the
`imagecodecs` Python module and fails identically on pristine master.

## One behaviour change worth a maintainer's eye

`Testing/Calc/CameraModel.xml` is dual-PCS with `A2B3` + `B2D3` and **no `B2A3`**. As a
destination under the opt-out it now returns `icCmmStatProfileMissingTag` where master
silently used the spectral `B2D3`. A sweep of all 221 tracked XML found only three
dual-PCS profiles carrying `B2D` tags, and CameraModel is used only for XML→ICC, dump and
writer-failure tests — never as a CMM destination — so nothing in the suite covers it
either way. Whether an opt-out should fall back to the spectral tag when no colorimetric
tag exists in that direction is a spec call, raised on #1982 rather than decided here.

## Not harvested: the branch's third change

`ci-qa-issue-1982` also adds a sample-count guard in `CIccCmm::AddXform` (issue item 3).
Left out, measured against the branch applied verbatim:

1. **`CIccCmm::Begin()` already does it.** Its two `GetNumSrcSamples()`/`GetNumDstSamples()`
   comparisons against the CMM's counts carry the comment *"Otherwise we'll have a heap
   overflow during Apply."* That is exactly why the unfixed dual-PCS case fails closed with
   `icCmmStatBadSpaceLink` rather than overflowing.

2. **It fires twice in the 222-test suite and both tests still print PASS.**

   | test | master | with the guard |
   |---|---|---|
   | `iccdev.issue-1336-applytolink-pcc-regression` | fails on the **second** profile (`fuzz-abst-a044ff69.icc`, status 2) | fails on the **first** (`fuzz-mntr-ef352586.icc`, status 4) |
   | `iccdev.issue-1985-encoding-lumamtx-uaf` | status 2 | status 4 |

   #1336 exists to prove a `-PCC` profile is released on the `AddXform` error path. Moving
   the failure to the first profile means that path is never reached, so the test goes
   vacuous while still reporting `[PASS]` — it only greps for a LeakSanitizer report. #1985's
   own header documents the expected outcome as *"the ordinary 'invalid space link'
   rejection"*, which the guard changes.

3. **It is not a channel-count check in practice.** `icGetSpaceSamples()` returns `0` for any
   signature it does not map, so the guard is really "reject any profile whose PCS signature
   is unrecognised or zero". Both firings were `.../0` cases — `nDstSpace=00000000`, and
   `nSrcSpace=F6BD2F3E` from the fuzzed abstract profile — not genuine disagreements.

Reproduce: apply the guard and run `ctest -R 'issue-1336|issue-1985'`.

## Checklist

- [X] Built locally with the documented build flow in `docs/build.md`
- [X] Ran relevant CTest/profile tests from `docs/ctest.md`
- [X] Added or updated regression coverage for behavior changes
- [X] Checked sanitizer coverage for memory-safety or parser changes
- [ ] Updated documentation for user-visible behavior changes
- [X] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [X] New source files include the ICC copyright and BSD 3-Clause license header
- [X] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
