### PR TITLE
fix: bound CLUT channel counts at every parser, and let Begin() refuse

### DIFF
--- a/.github/ci/regression/clut-apply-guard-retirement.cpp
+++ b/.github/ci/regression/clut-apply-guard-retirement.cpp
@@ -1,0 +1,247 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression for the per-pixel bounds checks removed from the apply path once
+// CIccCLUT::Begin() was made able to refuse.
+//
+// Three guards were retired. Two were redundant; one was a defect. This file
+// pins the behaviour that justifies each removal, so none of them is restored
+// on the strength of a plausible-looking argument -- which has happened twice
+// already to the InterpND pair, in both directions.
+//
+// 1. Interp3dTetra's "if (m_nOutput > 16) return;" -- A DEFECT, not redundancy.
+//
+//    It was described as bounding the destPixel write loop because "valid LUT
+//    profiles cap output channels at <=16". They do not. m_nOutput is an
+//    icUInt16Number precisely because MPE CLUT elements need more:
+//    CIccMpeCLUT::Read bounds m_nInputChannels at 16 and deliberately leaves
+//    m_nOutputChannels unbounded, and a spectral CLUT's output count is its
+//    spectral step count. Interp1d/2d/3d/4d/5d/6d all write m_nOutput values
+//    with no such bound -- Interp3dTetra was the only one that believed the
+//    cap, and for a legal 3-input CLUT with >=17 outputs it returned without
+//    writing anything, leaving destPixel holding whatever the caller had in it.
+//    Same CLUT through Interp3d under icElemInterpLinear: correct values.
+//
+//    testTetraMatchesTrilinearAtGridPoints() drives both routines over the same
+//    CLUT at grid points, where tetrahedral and trilinear interpolation must
+//    agree exactly, and compares them across output counts spanning the old
+//    threshold. On master it fails at 17 and 20 with the tetra destination
+//    untouched.
+//
+// 2. InterpND's "if (m_nInput > 16) return;" and "if (m_nNodes > 65536)
+//    return;" -- redundant, and already unreachable before Begin() could
+//    refuse.
+//
+//    Init() rejects an m_nInput outside 1..16 and leaves m_pData NULL, and the
+//    element readers turn that into a failed Read() through their GetData(0)
+//    checks, so no profile ever presented InterpND with an out-of-range count.
+//    Now Begin() refuses such a CLUT outright and every caller acts on the
+//    result, so the invariant is established once instead of per pixel.
+//    testBeginRefusesWhatTheGuardsCaught() pins that Begin() is the thing doing
+//    the refusing, and testNDInterpolatesAcrossTheOldThreshold() pins that the
+//    N-D path still computes correctly either side of it.
+//
+// Deliberately NOT covered here: CIccXformNDLut's two per-pixel min-with-16
+// clamps. Those are finding A3 on the perf/hoist-hardening-guards branch, which
+// tightens the same Begin() bound from 256 to 16 and removes them with A/B
+// measurements behind it. That work predates this file and keeps ownership;
+// duplicating it here would have put the same change on two branches.
+// CIccXformNDLut::Begin()'s contract belongs to ndlut-input-channel-mismatch.cpp
+// either way.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccTagLut.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[clut-apply-guards] FAIL: %s\n", what);
+  }
+}
+
+// Build a CLUT of nIn dimensions and nOut output channels on a 2-point grid,
+// filled with a deterministic ramp so a dropped write is distinguishable from a
+// correct one that happens to be zero.
+CIccCLUT *buildCLUT(icUInt8Number nIn, icUInt16Number nOut)
+{
+  CIccCLUT *pCLUT = new CIccCLUT(nIn, nOut, 4);
+  if (!pCLUT->Init((icUInt8Number)2)) {
+    delete pCLUT;
+    return NULL;
+  }
+
+  icFloatNumber *pData = pCLUT->GetData(0);
+  const icUInt32Number nValues = pCLUT->NumPoints() * nOut;
+  for (icUInt32Number i = 0; i < nValues; i++)
+    pData[i] = (icFloatNumber)((i % 97) / 97.0);
+
+  pCLUT->Begin();
+  return pCLUT;
+}
+
+// At an exact grid corner every interpolation scheme must return the stored
+// node, so tetrahedral and trilinear agree bit-for-bit and the comparison needs
+// no tolerance argument. This is what makes a silently skipped write visible.
+void testTetraMatchesTrilinearAtGridPoints(icUInt16Number nOut)
+{
+  CIccCLUT *pCLUT = buildCLUT(3, nOut);
+  char msg[160];
+
+  std::snprintf(msg, sizeof(msg), "3x%u CLUT initializes", (unsigned)nOut);
+  check(pCLUT != NULL, msg);
+  if (!pCLUT)
+    return;
+
+  // Two opposite corners plus an interior point.
+  const icFloatNumber probes[3][3] = {
+    { 0.0f, 0.0f, 0.0f },
+    { 1.0f, 1.0f, 1.0f },
+    { 0.5f, 0.25f, 0.75f },
+  };
+
+  const icFloatNumber kSentinel = -12345.0f;
+  std::vector<icFloatNumber> tetra(nOut), tri(nOut);
+
+  for (int p = 0; p < 3; p++) {
+    for (icUInt16Number i = 0; i < nOut; i++)
+      tetra[i] = tri[i] = kSentinel;
+
+    pCLUT->Interp3dTetra(&tetra[0], probes[p]);
+    pCLUT->Interp3d(&tri[0], probes[p]);
+
+    bool bTetraWrote = true;
+    for (icUInt16Number i = 0; i < nOut; i++) {
+      if (tetra[i] == kSentinel) { bTetraWrote = false; break; }
+    }
+
+    std::snprintf(msg, sizeof(msg),
+                  "Interp3dTetra writes all %u output channels (probe %d)",
+                  (unsigned)nOut, p);
+    check(bTetraWrote, msg);
+
+    // At the two corners the schemes must agree exactly; at the interior point
+    // they may legitimately differ, so only the corners are compared. Both are
+    // still checked for having been written at all.
+    if (p < 2 && bTetraWrote) {
+      bool bMatch = true;
+      for (icUInt16Number i = 0; i < nOut; i++) {
+        if (std::fabs((double)tetra[i] - (double)tri[i]) > 1e-6) {
+          bMatch = false;
+          break;
+        }
+      }
+      std::snprintf(msg, sizeof(msg),
+                    "Interp3dTetra == Interp3d at grid corner (nOut=%u, probe %d)",
+                    (unsigned)nOut, p);
+      check(bMatch, msg);
+    }
+  }
+
+  delete pCLUT;
+}
+
+// The N-D path either side of the retired threshold. 6 dimensions routes to
+// Interp6d; 7 is the smallest count that actually reaches InterpND.
+void testNDInterpolatesAcrossTheOldThreshold()
+{
+  for (icUInt8Number nIn = 6; nIn <= 8; nIn++) {
+    CIccCLUT *pCLUT = buildCLUT(nIn, 3);
+    char msg[160];
+
+    std::snprintf(msg, sizeof(msg), "%u-input CLUT initializes", (unsigned)nIn);
+    check(pCLUT != NULL, msg);
+    if (!pCLUT)
+      continue;
+
+    CIccApplyCLUT *pApply = pCLUT->GetNewApply();
+    std::snprintf(msg, sizeof(msg), "%u-input CLUT yields an apply object",
+                  (unsigned)nIn);
+    check(pApply != NULL, msg);
+
+    if (pApply) {
+      std::vector<icFloatNumber> src(nIn, 0.0f);
+      icFloatNumber dst[3] = { -12345.0f, -12345.0f, -12345.0f };
+
+      pCLUT->InterpND(dst, &src[0], pApply);
+
+      // All-zero input is grid node 0, whose stored value is the ramp's start.
+      std::snprintf(msg, sizeof(msg),
+                    "InterpND writes node 0 for a %u-input CLUT", (unsigned)nIn);
+      check(dst[0] != -12345.0f, msg);
+
+      std::snprintf(msg, sizeof(msg),
+                    "InterpND returns the stored node 0 value (%u inputs)",
+                    (unsigned)nIn);
+      check(std::fabs((double)dst[0] - 0.0) < 1e-6, msg);
+
+      delete pApply;
+    }
+    delete pCLUT;
+  }
+}
+
+// The invariants the InterpND guards used to re-test are now Begin()'s to
+// establish. Pin that Begin() is what refuses, so the guards are not restored
+// on the belief that nothing else covers this.
+void testBeginRefusesWhatTheGuardsCaught()
+{
+  // Above the 16-input maximum: Init() refuses, so Begin() must too.
+  {
+    CIccCLUT clut((icUInt8Number)17, (icUInt16Number)3, 4);
+    check(!clut.Init((icUInt8Number)2), "Init() refuses 17 input channels");
+    check(!clut.Begin(), "Begin() refuses a 17-input CLUT");
+  }
+
+  // Init() never called at all -- the state a caller of the public API reaches,
+  // and the one no per-pixel channel-count check ever detected.
+  {
+    CIccCLUT clut((icUInt8Number)3, (icUInt16Number)3, 4);
+    check(!clut.Begin(), "Begin() refuses a CLUT that was never Init()ed");
+  }
+
+  // A well-formed CLUT must still begin, or the assertions above prove nothing.
+  {
+    CIccCLUT clut((icUInt8Number)3, (icUInt16Number)3, 4);
+    check(clut.Init((icUInt8Number)2), "Init() accepts a 3-input CLUT");
+    check(clut.Begin(), "Begin() accepts a well-formed CLUT");
+  }
+}
+
+} // namespace
+
+int main()
+{
+  // Spanning the retired m_nOutput > 16 threshold. 16 is the control: it passed
+  // before the removal too, so a failure there means the removal broke something
+  // rather than fixed it.
+  testTetraMatchesTrilinearAtGridPoints(3);
+  testTetraMatchesTrilinearAtGridPoints(16);
+  testTetraMatchesTrilinearAtGridPoints(17);
+  testTetraMatchesTrilinearAtGridPoints(20);
+
+  testNDInterpolatesAcrossTheOldThreshold();
+  testBeginRefusesWhatTheGuardsCaught();
+
+  if (g_fail) {
+    std::fprintf(stderr, "[clut-apply-guards] %d assertion(s) failed\n", g_fail);
+    return g_fail;
+  }
+  std::printf("[clut-apply-guards] all assertions passed\n");
+  return 0;
+}

--- a/.github/ci/regression/clut-apply-guard-retirement.cpp
+++ b/.github/ci/regression/clut-apply-guard-retirement.cpp
@@ -42,6 +42,13 @@
 //    the refusing, and testNDInterpolatesAcrossTheOldThreshold() pins that the
 //    N-D path still computes correctly either side of it.
 //
+// 3. CIccMBB::Init()/Cleanup() -- the same shape one level up. Cleanup()
+//    clamped its delete loops at 16 to stop a "corrupted channel count" walking
+//    past the curve-pointer arrays, but NewCurvesA/B/M allocate those arrays to
+//    the very counts being clamped, so the clamp could only leak. Init() now
+//    bounds both counts and Cleanup() frees what was allocated. See
+//    testMBBInitBoundsItsChannelCounts().
+//
 // Deliberately NOT covered here: CIccXformNDLut's two per-pixel min-with-16
 // clamps. Those are finding A3 on the perf/hoist-hardening-guards branch, which
 // tightens the same Begin() bound from 256 to 16 and removes them with A/B
@@ -223,6 +230,52 @@ void testBeginRefusesWhatTheGuardsCaught()
   }
 }
 
+// CIccMBB::Init() is the same shape of contract one level up: it sets the two
+// counts everything else in the object is sized from, so it is where their bound
+// belongs.
+//
+// Cleanup() used to clamp its delete loops to 16 "so a corrupted channel count
+// can never walk past the allocation". That reasoning is inverted -- the arrays
+// are allocated to those very counts by NewCurvesA/B/M, so a count above 16 does
+// not overrun anything; the clamp leaked entries 16..n-1, silently, from a
+// destructor. Init() now refuses counts outside 1..16 and Cleanup() frees exactly
+// what was allocated.
+//
+// The refusal is the testable half. The leak itself is not directly observable
+// without a sanitizer, but it is unreachable once Init() cannot record an
+// out-of-range count in the first place -- which is the point of fixing it there
+// rather than in the loop.
+void testMBBInitBoundsItsChannelCounts()
+{
+  // Above the bound: refused, and the object is left untouched rather than
+  // half-torn-down, because Init() checks before it calls Cleanup().
+  {
+    CIccTagLutAtoB lut;
+    check(lut.Init(3, 3), "CIccMBB::Init accepts 3x3");
+    check(lut.NewCurvesA() != NULL, "3x3 MBB allocates A curves");
+
+    check(!lut.Init(17, 3), "CIccMBB::Init refuses 17 input channels");
+    check(!lut.Init(3, 17), "CIccMBB::Init refuses 17 output channels");
+    check(!lut.Init(0, 3), "CIccMBB::Init refuses 0 input channels");
+    check(!lut.Init(3, 0), "CIccMBB::Init refuses 0 output channels");
+
+    check(lut.InputChannels() == 3 && lut.OutputChannels() == 3,
+          "a refused CIccMBB::Init leaves the counts unchanged");
+    check(lut.GetCurvesA() != NULL,
+          "a refused CIccMBB::Init does not tear down the object");
+  }
+
+  // At the bound: 16 is accepted, so the check is a bound and not an off-by-one.
+  {
+    CIccTagLutAtoB lut;
+    check(lut.Init(16, 16), "CIccMBB::Init accepts 16x16");
+    check(lut.NewCurvesA() != NULL, "16x16 MBB allocates A curves");
+    check(lut.NewCurvesB() != NULL, "16x16 MBB allocates B curves");
+    check(lut.NewCurvesM() != NULL, "16x16 MBB allocates M curves");
+    // Destruction here exercises Cleanup() over the full 16 without the clamp.
+  }
+}
+
 } // namespace
 
 int main()
@@ -237,6 +290,7 @@ int main()
 
   testNDInterpolatesAcrossTheOldThreshold();
   testBeginRefusesWhatTheGuardsCaught();
+  testMBBInitBoundsItsChannelCounts();
 
   if (g_fail) {
     std::fprintf(stderr, "[clut-apply-guards] %d assertion(s) failed\n", g_fail);

--- a/.github/ci/regression/spectral-clut-channel-count-bound.cpp
+++ b/.github/ci/regression/spectral-clut-channel-count-bound.cpp
@@ -156,6 +156,38 @@ ReadResult readEmissionCLUT(std::vector<icUInt8Number> &body)
 // A generous payload: 16 grid points ^ a few dims, times steps, times 4 bytes.
 const size_t kBigPayload = 4u * 1024u * 1024u;
 
+// m_nInputChannels is protected on CIccMultiProcessElement. Deriving is how a
+// test reaches it without widening the library's interface for a test's benefit
+// -- the same approach mpexml-unknown-reserved.cpp takes for m_nReserved.
+//
+// This models a state no reader produces any more but that the object model
+// still permits: an element whose declared channel count disagrees with the
+// CLUT behind it. All three parsers that could reach it now bound the count
+// (Read() here, icCLutFromXml() in IccTagXml.cpp, icCLUTFromJson() in
+// IccTagJson.cpp), so the check in Begin() is the backstop for anything that
+// builds an element some other way -- including callers of the public API,
+// which is what IccProfLib exposes these classes as.
+//
+// CIccMpeCLUT is the element used rather than one of the spectral pair, because
+// its Begin() ignores pMPE entirely (the parameter is commented out in the
+// definition) and so returns a verdict on the CLUT alone. The spectral
+// overrides reach for the enclosing tag's applied PCC once their channel checks
+// pass, so removing the guard under test would make them fault on a NULL tag
+// instead of returning -- a failure, but an unreadable one. All three carry the
+// same comparison; this asserts it where the answer is a clean bool.
+class MismatchedCLUT : public CIccMpeCLUT
+{
+public:
+  // Attach a CLUT of one dimensionality while declaring another, exactly as the
+  // narrowing cast used to do on its own. SetCLUT() derives m_nInputChannels
+  // from the CLUT, so the declared count is overwritten afterwards.
+  void setMismatch(CIccCLUT *pCLUT, icUInt16Number nDeclaredInputChannels)
+  {
+    SetCLUT(pCLUT);
+    m_nInputChannels = nDeclaredInputChannels;
+  }
+};
+
 } // namespace
 
 int main()
@@ -287,6 +319,56 @@ int main()
       check(pCLUT->GetData(0) != NULL, "valid NewCLUT() CLUT has storage");
       check(pCLUT->NumPoints() == 9u * 9u * 9u, "valid NewCLUT() CLUT has 9^3 points");
     }
+  }
+
+  // ---- Begin() must refuse a count that disagrees with its CLUT -------------
+  //
+  // The backstop for every construction route that is not Read(). Begin() is
+  // what the apply path calls whatever built the element, so a disagreement has
+  // to be caught here if it was not prevented earlier. The XML parser used to
+  // produce exactly this state (see spectral-clut-xml-channel-mismatch.cpp);
+  // now nothing does, which is precisely why the guard needs its own coverage
+  // rather than relying on a parser to reach it.
+  //
+  {
+    // A well-formed 3-dimensional CLUT: 2 grid points per dimension, 3 outputs.
+    CIccCLUT *pCLUT = new CIccCLUT((icUInt8Number)3, (icUInt16Number)3, 4);
+    check(pCLUT->Init((icUInt8Number)2), "helper CLUT initializes");
+
+    MismatchedCLUT elem;
+    elem.setMismatch(pCLUT, /*declared*/259);   // 259 & 0xFF == 3
+
+    check(elem.NumInputChannels() == 259, "helper declares 259 input channels");
+    check(elem.GetCLUT() != NULL && elem.GetCLUT()->GetInputDim() == 3,
+          "helper's CLUT is three-dimensional");
+    check(!elem.Begin(icElemInterpLinear, NULL),
+          "Begin() refuses declared 259 over a three-dimensional CLUT");
+  }
+
+  // The control: an element whose counts agree must still begin. Without it the
+  // assertion above could be satisfied by a Begin() that refuses everything.
+  {
+    CIccCLUT *pCLUT = new CIccCLUT((icUInt8Number)3, (icUInt16Number)3, 4);
+    pCLUT->Init((icUInt8Number)2);
+
+    MismatchedCLUT elem;
+    elem.setMismatch(pCLUT, /*declared*/3);
+
+    check(elem.Begin(icElemInterpLinear, NULL),
+          "Begin() accepts an element whose count matches its CLUT");
+  }
+
+  // And a CLUT that Init() never made usable must be refused by Begin() even
+  // when the counts agree -- this is what CIccCLUT::Begin() returning bool
+  // buys, and the state a caller reaches by skipping Init() altogether.
+  {
+    CIccCLUT *pCLUT = new CIccCLUT((icUInt8Number)3, (icUInt16Number)3, 4);
+    // Deliberately no Init().
+    MismatchedCLUT elem;
+    elem.setMismatch(pCLUT, /*declared*/3);
+
+    check(!elem.Begin(icElemInterpLinear, NULL),
+          "Begin() refuses a CLUT that was never Init()ed");
   }
 
   if (g_fail) {

--- a/.github/ci/regression/spectral-clut-channel-count-bound.cpp
+++ b/.github/ci/regression/spectral-clut-channel-count-bound.cpp
@@ -1,0 +1,298 @@
+// Regression: CIccMpeSpectralCLUT::Read must bound m_nInputChannels before the
+// narrowing cast that constructs its CIccCLUT, and every CIccCLUT::Init() call in
+// IccProfLib must act on the result.
+//
+// Read() takes m_nInputChannels as a 16-bit field straight from the profile and
+// validated only "< 1". It then built the CLUT with
+//
+//   m_pCLUT = new CIccCLUT((icUInt8Number)m_nInputChannels, ...)   // IccMpeSpectral.cpp
+//
+// so the field was narrowed to 8 bits with no upper bound in between.
+// CIccMpeCLUT::Read (IccMpeBasic.cpp) and CIccMpeExtCLUT::Read both bound the same
+// field with "if (m_nInputChannels > 16) return false;" before the equivalent cast;
+// the spectral path did not.
+//
+// What that cast does splits into two cases, and only one of them was actually a
+// hole -- which is the point of the two groups of assertions below.
+//
+// OUT OF RANGE (17, 255, 272 -> 17, 255, 16; and 256 -> 0). Already refused, but
+// not by anything that meant to refuse it. CIccCLUT::Init() rejects m_nInput of 0
+// or > 16 and returns false, and all six IccProfLib call sites that mattered
+// discarded that false. What stopped these was incidental: Init() returns before
+// the "delete[] m_pData; m_pData = NULL;" that would reallocate, the constructor
+// had already set m_pData to NULL, and GetData(0) is "&m_pData[index]" -- NULL for
+// index 0. Read()'s existing "pData = m_pCLUT->GetData(0); if (!pData) return
+// false;" therefore converted the dropped Init() failure into a failed Read().
+// These cases are pinned here precisely because nothing declares that coupling: a
+// future change to GetData() (a NULL check returning a dummy, say) or to the order
+// of Init()'s guards would reopen the hole with no test noticing.
+//
+// TRUNCATING (257 -> 1). This one was live. Read() returned true, and the element
+// reported NumInputChannels() == 257 over a CLUT whose GetInputDim() was 1. Nothing
+// downstream compares the two. It is reachable past the CMM's channel checks
+// because icNumColorSpaceChannels() is defined as the low 16 bits of the colour
+// space signature (icProfileHeader.h), so a header can declare a 257-channel
+// N-channel space, icGetSpaceSamples() returns 257, and the
+//
+//   if (inputSamples != xformInputSamples || ...) return icCmmStatBadXform;
+//
+// equality in CIccXformMpe::Begin() is satisfied. The element then applies: because
+// 257 matches no arm of the switch on m_nInputChannels in
+// CIccMpeEmissionCLUT::Begin(), m_interpType falls to icNdInterp, InterpND() walks
+// the CLUT's own m_nInput of 1, and 256 of the 257 input channels are silently
+// discarded. Not a memory-safety fault -- the CLUT is internally consistent, just
+// not the CLUT the element claims to be -- but a profile that transforms to wrong
+// colour without any diagnostic.
+//
+// The Init() call sites are covered too, via CIccMBB::NewCLUT(). Its documented
+// contract is "Return: Pointer to the CIccCLUT object", and it called Init() and
+// returned the CLUT whether or not Init() had succeeded, so a caller received a
+// CLUT with m_pData NULL and (before #1781's tightening) a committed
+// m_nNumPoints. That is the same defect iccApplyToLink.cpp works around by hand
+// rather than calling NewCLUT() -- see the comment at its CIccTagLutAtoB
+// construction. NewCLUT() now returns NULL on Init() failure, which is what its
+// contract already said it would.
+//
+// Red-green: reverting the "m_nInputChannels > 16" bound in
+// CIccMpeSpectralCLUT::Read makes the 257 assertion fail (Read succeeds and the
+// channel counts disagree). Reverting the NewCLUT() Init() check makes the
+// 17-input NewCLUT assertion fail (a non-NULL CLUT comes back with no storage).
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccTagLut.h"
+#include "IccMpeBasic.h"
+#include "IccMpeSpectral.h"
+#include "IccIO.h"
+#include "IccUtil.h"
+#include "IccDefs.h"
+
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[spectral-clut-channels] FAIL: %s\n", what);
+  }
+}
+
+// Append a value in ICC wire order (big-endian); CIccIO::Read16/Read32 swap to
+// host order on the way in.
+void putBE(std::vector<icUInt8Number> &b, unsigned long long v, int nBytes)
+{
+  for (int i = nBytes - 1; i >= 0; --i)
+    b.push_back((icUInt8Number)((v >> (8 * i)) & 0xff));
+}
+
+// Build an emissionCLUT MPE element body, matching the 40-byte header
+// CIccMpeSpectralCLUT::Read computes: type sig, reserved, input/output channel
+// counts, flags, spectral range (start/end/steps), storage type, 16 grid points.
+// The payload that follows is zero-filled and deliberately generous, so the
+// nMaxSize arms of Init() are never what refuses a case -- only the channel-count
+// guards can be.
+std::vector<icUInt8Number> buildEmissionCLUT(icUInt16Number nInputChannels,
+                                             icUInt16Number nOutputChannels,
+                                             icUInt8Number nGridPoints,
+                                             icUInt16Number nSteps,
+                                             size_t nPayloadBytes)
+{
+  std::vector<icUInt8Number> b;
+  putBE(b, (unsigned long long)icSigEmissionCLUTElemType, 4);
+  putBE(b, 0u, 4);                                  // reserved
+  putBE(b, nInputChannels, 2);
+  putBE(b, nOutputChannels, 2);
+  putBE(b, 0u, 4);                                  // flags
+  putBE(b, 400u, 2);                                // range.start
+  putBE(b, 700u, 2);                                // range.end
+  putBE(b, nSteps, 2);                              // range.steps
+  putBE(b, (unsigned long long)icValueTypeFloat32, 2);
+  for (int i = 0; i < 16; ++i)
+    b.push_back(nGridPoints);
+
+  b.insert(b.end(), nPayloadBytes, (icUInt8Number)0);
+  return b;
+}
+
+// Feed the element body through Read(). On success, reports the element's declared
+// input channel count and the dimensionality of the CLUT actually built.
+struct ReadResult {
+  bool bRead;
+  unsigned nDeclaredInputChannels;
+  unsigned nClutInputDim;
+  bool bHaveClut;
+};
+
+ReadResult readEmissionCLUT(std::vector<icUInt8Number> &body)
+{
+  ReadResult r = { false, 0, 0, false };
+
+  CIccMemIO io;
+  if (!io.Attach(&body[0], body.size()))
+    return r;
+
+  CIccMpeEmissionCLUT elem;
+  r.bRead = elem.Read((icUInt32Number)body.size(), &io);
+  if (r.bRead) {
+    r.nDeclaredInputChannels = (unsigned)elem.NumInputChannels();
+    CIccCLUT *pCLUT = elem.GetCLUT();
+    r.bHaveClut = (pCLUT != NULL);
+    if (pCLUT)
+      r.nClutInputDim = (unsigned)pCLUT->GetInputDim();
+  }
+  return r;
+}
+
+// A generous payload: 16 grid points ^ a few dims, times steps, times 4 bytes.
+const size_t kBigPayload = 4u * 1024u * 1024u;
+
+} // namespace
+
+int main()
+{
+  // ---- The live defect: a truncating channel count ----------------------------
+  //
+  // 257 narrows to 1. Before the fix Read() returned true and the element
+  // advertised 257 input channels over a one-dimensional CLUT. Must be refused.
+  {
+    std::vector<icUInt8Number> b =
+        buildEmissionCLUT(/*in*/257, /*out*/3, /*grid*/4, /*steps*/4, kBigPayload);
+    ReadResult r = readEmissionCLUT(b);
+    check(!r.bRead, "257 input channels (truncates to 1) -> Read() false");
+    if (r.bRead)
+      std::fprintf(stderr,
+                   "[spectral-clut-channels]   declared=%u but CLUT dim=%u\n",
+                   r.nDeclaredInputChannels, r.nClutInputDim);
+  }
+
+  // 259 -> 3 and 260 -> 4 truncate onto counts that are not merely valid but
+  // ordinary, so the resulting element looks entirely well-formed from the CLUT
+  // side. These are the cases least likely to be caught by inspection.
+  {
+    std::vector<icUInt8Number> b =
+        buildEmissionCLUT(/*in*/259, /*out*/3, /*grid*/4, /*steps*/4, kBigPayload);
+    check(!readEmissionCLUT(b).bRead, "259 input channels (truncates to 3) -> Read() false");
+  }
+  {
+    std::vector<icUInt8Number> b =
+        buildEmissionCLUT(/*in*/260, /*out*/3, /*grid*/2, /*steps*/4, kBigPayload);
+    check(!readEmissionCLUT(b).bRead, "260 input channels (truncates to 4) -> Read() false");
+  }
+
+  // 272 -> 16, landing exactly on the supported maximum: the CLUT is built at the
+  // largest dimensionality Init() allows while the element still claims 272.
+  {
+    std::vector<icUInt8Number> b =
+        buildEmissionCLUT(/*in*/272, /*out*/3, /*grid*/2, /*steps*/2, kBigPayload);
+    check(!readEmissionCLUT(b).bRead, "272 input channels (truncates to 16) -> Read() false");
+  }
+
+  // ---- Out of range: refused before the fix, but only incidentally -----------
+  //
+  // These pin the behaviour so the GetData(0)/Init() coupling described at the top
+  // of this file cannot be broken silently.
+  {
+    std::vector<icUInt8Number> b =
+        buildEmissionCLUT(/*in*/17, /*out*/3, /*grid*/2, /*steps*/2, kBigPayload);
+    check(!readEmissionCLUT(b).bRead, "17 input channels (past CIccCLUT max) -> Read() false");
+  }
+  {
+    std::vector<icUInt8Number> b =
+        buildEmissionCLUT(/*in*/255, /*out*/3, /*grid*/2, /*steps*/2, kBigPayload);
+    check(!readEmissionCLUT(b).bRead, "255 input channels -> Read() false");
+  }
+  {
+    std::vector<icUInt8Number> b =
+        buildEmissionCLUT(/*in*/256, /*out*/3, /*grid*/2, /*steps*/2, kBigPayload);
+    check(!readEmissionCLUT(b).bRead, "256 input channels (truncates to 0) -> Read() false");
+  }
+
+  // ---- The invariant, stated positively --------------------------------------
+  //
+  // Whenever Read() succeeds, the count the element reports must be the
+  // dimensionality of the CLUT backing it. This is the assertion that would have
+  // caught the original defect without knowing which values truncate.
+  {
+    const icUInt16Number kValid[] = { 1, 2, 3, 4, 16 };
+    for (size_t i = 0; i < sizeof(kValid) / sizeof(kValid[0]); ++i) {
+      // Keep the grid at 2 for the wide cases so 2^16 nodes stays affordable.
+      icUInt8Number nGrid = (kValid[i] <= 4) ? (icUInt8Number)4 : (icUInt8Number)2;
+      std::vector<icUInt8Number> b =
+          buildEmissionCLUT(kValid[i], /*out*/3, nGrid, /*steps*/2, kBigPayload);
+      ReadResult r = readEmissionCLUT(b);
+
+      char msg[160];
+      std::snprintf(msg, sizeof(msg),
+                    "%u input channels -> Read() true", (unsigned)kValid[i]);
+      check(r.bRead, msg);
+
+      if (r.bRead) {
+        std::snprintf(msg, sizeof(msg),
+                      "%u input channels -> NumInputChannels() == CLUT GetInputDim()",
+                      (unsigned)kValid[i]);
+        check(r.bHaveClut && r.nDeclaredInputChannels == r.nClutInputDim, msg);
+      }
+    }
+  }
+
+  // ---- CIccCLUT::Init()'s result must reach the caller -----------------------
+  //
+  // CIccMBB::NewCLUT() promises a pointer to the CLUT object; on Init() failure it
+  // used to promise one with no storage behind it. A 17-channel CIccMBB is the
+  // shortest route to an Init() that refuses: mAB/lut8/lut16 reads all cap the
+  // channel count at 15, so this state is only reachable through the public
+  // Init(nInput, nOutput) API -- which is exactly the caller NewCLUT() serves.
+  {
+    CIccTagLutAtoB lut;
+    lut.Init(/*nInput*/17, /*nOutput*/3);
+    CIccCLUT *pCLUT = lut.NewCLUT((icUInt8Number)2, 2);
+    check(pCLUT == NULL, "NewCLUT() with 17 input channels -> NULL (Init() refused)");
+    if (pCLUT)
+      std::fprintf(stderr,
+                   "[spectral-clut-channels]   NewCLUT returned %p with GetData(0)=%p\n",
+                   (void *)pCLUT, (void *)pCLUT->GetData(0));
+    // The tag must not be left holding the rejected CLUT either.
+    check(lut.GetCLUT() == NULL, "NewCLUT() failure leaves CIccMBB with no CLUT");
+  }
+
+  // Grid granularity below 2 is the other way Init() refuses, and it reaches
+  // NewCLUT() through the same public API with an otherwise ordinary channel
+  // count -- so it exercises the propagation without relying on the 16-input cap.
+  {
+    CIccTagLutAtoB lut;
+    lut.Init(/*nInput*/3, /*nOutput*/3);
+    CIccCLUT *pCLUT = lut.NewCLUT((icUInt8Number)1, 2);
+    check(pCLUT == NULL, "NewCLUT() with 1 grid point -> NULL (Init() refused)");
+    check(lut.GetCLUT() == NULL, "NewCLUT() grid failure leaves CIccMBB with no CLUT");
+  }
+
+  // A well-formed CIccMBB must still get its CLUT -- the propagation must not
+  // regress the ordinary path.
+  {
+    CIccTagLutAtoB lut;
+    lut.Init(/*nInput*/3, /*nOutput*/3);
+    CIccCLUT *pCLUT = lut.NewCLUT((icUInt8Number)9, 2);
+    check(pCLUT != NULL, "NewCLUT() with a valid 9-point 3x3 grid -> non-NULL");
+    if (pCLUT) {
+      check(pCLUT->GetData(0) != NULL, "valid NewCLUT() CLUT has storage");
+      check(pCLUT->NumPoints() == 9u * 9u * 9u, "valid NewCLUT() CLUT has 9^3 points");
+    }
+  }
+
+  if (g_fail) {
+    std::fprintf(stderr, "[spectral-clut-channels] %d assertion(s) failed\n", g_fail);
+    return g_fail;
+  }
+  std::printf("[spectral-clut-channels] all assertions passed\n");
+  return 0;
+}

--- a/.github/ci/regression/spectral-clut-xml-channel-mismatch.cpp
+++ b/.github/ci/regression/spectral-clut-xml-channel-mismatch.cpp
@@ -1,0 +1,259 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression: an MPE spectral CLUT element built by the XML parser must not end
+// up declaring more input channels than its CLUT actually has, and the apply
+// path must refuse it if it somehow does.
+//
+// This is the companion to spectral-clut-channel-count-bound.cpp, which pins the
+// same invariant on the binary reader. The two exist separately because the
+// bound the binary reader gained does not cover this route at all, and the first
+// version of that fix assumed it did.
+//
+// CIccMpeSpectralCLUT::Read narrows a 16-bit m_nInputChannels to icUInt8Number
+// when it constructs the CLUT, and now bounds the field at 16 first, so the
+// element's count and the CLUT's dimensionality cannot diverge there. Read() is
+// not the only constructor. CIccMpeXmlEmissionCLUT::ParseXml (IccMpeXml.cpp)
+// sets m_nInputChannels from the InputChannels attribute via
+// icXmlParseChannels, whose cap is kIccXmlMaxChannels == 0xFFFF, and then calls
+//
+//   icCLutFromXml(pNode, m_nInputChannels, m_Range.steps, ...)
+//
+// which performs its own independent narrowing -- "icUInt8Number nInput =
+// (icUInt8Number)nIn;" in IccTagXml.cpp -- to build the CLUT. So InputChannels
+// = "257" leaves a one-dimensional CLUT under an element that still reports 257
+// through NumInputChannels(): exactly the state the binary reader used to
+// produce. icCLutFromXml() does check Init()'s result, which is why the
+// out-of-range counts (17, 255) are refused; the truncating ones are refused by
+// nothing in the parser.
+//
+// The guard therefore belongs where every apply path converges regardless of
+// what built the element. CIccMpeEmissionCLUT::Begin() and
+// CIccMpeReflectanceCLUT::Begin() now compare m_pCLUT->GetInputDim() against
+// m_nInputChannels and refuse a mismatch, CIccMpeCLUT::Begin() carries the same
+// comparison, and CIccCLUT::Begin() returns bool so a CLUT that Init() never
+// made usable can say so rather than leaving itself half-configured.
+//
+// The assertions drive the real libxml2 parser rather than simulating it,
+// because the point in dispute is precisely whether the parser reaches a state
+// the binary reader cannot.
+//
+// Red-green: removing the GetInputDim() != m_nInputChannels check from
+// CIccMpeEmissionCLUT::Begin() makes the 257/259/272 "Begin() false" assertions
+// fail while ParseXml still succeeds -- the whole defect in one line.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccMpeXml.h"
+#include "IccTagMPE.h"
+#include "IccTagLut.h"
+
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+#include <cstdio>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[spectral-clut-xml] FAIL: %s\n", what);
+  }
+}
+
+// Build an EmissionCLutElement document with an attacker-chosen InputChannels.
+//
+// The grid is given as the GridGranularity attribute rather than a GridPoints
+// list, because icCLutFromXml() validates a GridPoints list against the
+// *declared* count ("points.GetSize() < nInput") while GridGranularity reaches
+// CIccCLUT::Init(icUInt8Number) against the *truncated* m_nInput. That
+// asymmetry is itself part of the defect: nothing in the parser ties the count
+// the element records to the CLUT it builds. Both GridGranularity and TableData
+// belong to the element node itself -- icCLutFromXml() is handed the
+// EmissionCLutElement node, and reads the attribute off it and TableData from
+// its children.
+//
+// TableData is mandatory (icCLutFromXml() fails with "Cannot find table data"
+// without it) and its length must equal NumPoints() * GetOutputChannels() of
+// the CLUT actually built -- i.e. sized to the TRUNCATED dimensionality,
+// granularity ^ (declared & 0xFF), times the spectral step count. Sizing it
+// that way is what a hand-written malicious document would do, and it is why
+// this fixture parses at all. When the truncated count is itself out of range
+// (17, 255) Init() refuses before TableData is looked at, so a token table is
+// emitted rather than an astronomically large one.
+std::string buildDoc(unsigned nInputChannels, unsigned nGranularity,
+                     unsigned nSteps)
+{
+  const unsigned nTruncatedDim = nInputChannels & 0xFFu;
+
+  unsigned long long nTableEntries = 4;
+  if (nTruncatedDim >= 1 && nTruncatedDim <= 16) {
+    unsigned long long nPoints = 1;
+    for (unsigned i = 0; i < nTruncatedDim; ++i)
+      nPoints *= nGranularity;
+    nTableEntries = nPoints * nSteps;
+  }
+
+  std::string s;
+  s += "<EmissionCLutElement InputChannels=\"";
+  s += std::to_string(nInputChannels);
+  s += "\" OutputChannels=\"3\" StorageType=\"0\" Flags=\"0\" GridGranularity=\"";
+  s += std::to_string(nGranularity);
+  s += "\">\n";
+  s += "  <Wavelengths start=\"400\" end=\"700\" steps=\"";
+  s += std::to_string(nSteps);
+  s += "\"/>\n";
+  s += "  <WhiteData>\n    ";
+  for (unsigned i = 0; i < nSteps; ++i)
+    s += "1.0 ";
+  s += "\n  </WhiteData>\n";
+  s += "  <TableData>\n    ";
+  for (unsigned long long i = 0; i < nTableEntries; ++i)
+    s += "0.5 ";
+  s += "\n  </TableData>\n";
+  s += "</EmissionCLutElement>\n";
+  return s;
+}
+
+struct ParseOutcome {
+  bool bParsed;
+  bool bBegan;
+  unsigned nDeclared;
+  unsigned nClutDim;
+  bool bHaveClut;
+};
+
+// Parse the document into a real CIccMpeXmlEmissionCLUT, and optionally ask the
+// element to Begin() the way the CMM would.
+//
+// Begin() is passed a NULL pMPE, which is deliberate and is why bCallBegin
+// exists. CIccMpeEmissionCLUT::Begin() needs the enclosing tag only to reach an
+// applied PCC for its observer, and it does so *after* the CLUT and
+// channel-count checks this test is about. So for a mismatched element Begin()
+// must refuse before pMPE is ever touched -- and if a future change reorders
+// those checks, this test crashes rather than passing quietly, which is the
+// signal we want. A well-formed element gets past them and would then
+// dereference the NULL, so the control below parses only.
+ParseOutcome parseAndBegin(const std::string &doc, bool bCallBegin)
+{
+  ParseOutcome r = { false, false, 0, 0, false };
+
+  xmlDoc *pDoc = xmlReadMemory(doc.c_str(), (int)doc.size(), "frag.xml", NULL,
+                               XML_PARSE_NOERROR | XML_PARSE_NOWARNING |
+                               XML_PARSE_HUGE);
+  if (!pDoc) {
+    std::fprintf(stderr, "[spectral-clut-xml] test fixture is not valid XML\n");
+    return r;
+  }
+
+  xmlNode *pRoot = xmlDocGetRootElement(pDoc);
+  if (pRoot) {
+    CIccMpeXmlEmissionCLUT elem;
+    std::string parseStr;
+    r.bParsed = elem.ParseXml(pRoot, parseStr);
+    if (r.bParsed) {
+      r.nDeclared = (unsigned)elem.NumInputChannels();
+      CIccCLUT *pCLUT = elem.GetCLUT();
+      r.bHaveClut = (pCLUT != NULL);
+      if (pCLUT)
+        r.nClutDim = (unsigned)pCLUT->GetInputDim();
+      if (bCallBegin)
+        r.bBegan = elem.Begin(icElemInterpLinear, NULL);
+    }
+    else if (!parseStr.empty()) {
+      std::fprintf(stderr, "[spectral-clut-xml] parse refused: %s",
+                   parseStr.c_str());
+    }
+  }
+
+  xmlFreeDoc(pDoc);
+  return r;
+}
+
+// Assert the contract for a declared count that narrows onto a dimensionality a
+// CIccCLUT can hold.
+//
+// The contract is an either/or, and both halves are real answers: the parser may
+// refuse the document, or it may accept it -- but if it accepts it, the count the
+// element reports MUST equal the dimensionality of the CLUT it built. What must
+// never happen is a parsed element carrying a disagreement, because from that
+// point on nothing in the object records which of the two numbers is the truth.
+//
+// Written this way the assertion does not depend on where the fix lives. It held
+// before icCLutFromXml() gained its bound only if Begin() refused; it holds after
+// because the parser refuses. Either is acceptable; neither being true is not.
+void checkTruncating(unsigned nDeclared, unsigned nGranularity, unsigned nSteps)
+{
+  ParseOutcome r = parseAndBegin(buildDoc(nDeclared, nGranularity, nSteps),
+                                 /*bCallBegin*/false);
+
+  char msg[224];
+  std::snprintf(msg, sizeof(msg),
+                "%u input channels: parser must refuse or stay consistent "
+                "(parsed=%s declared=%u clutDim=%u)",
+                nDeclared, r.bParsed ? "true" : "false",
+                r.nDeclared, r.nClutDim);
+  check(!r.bParsed || (r.bHaveClut && r.nDeclared == r.nClutDim), msg);
+}
+
+} // namespace
+
+int main()
+{
+  // ---- The XML route to the mismatch -----------------------------------------
+  //
+  // 257 narrows to 1, 259 to 3, 272 to 16 -- the last landing exactly on the
+  // supported maximum, so nothing about the resulting CLUT looks wrong in
+  // isolation. A granularity of 2 keeps the 16-dimensional case at 65536 nodes.
+  checkTruncating(/*declared*/257, /*granularity*/2, /*steps*/4);
+  checkTruncating(/*declared*/259, /*granularity*/2, /*steps*/4);
+  checkTruncating(/*declared*/272, /*granularity*/2, /*steps*/2);
+
+  // ---- Out of range: icCLutFromXml() checks Init(), so these are refused -----
+  //
+  // 17 and 255 survive the cast unchanged, Init() rejects them, and
+  // icCLutFromXml() returns NULL. Pinned so the parser's Init() check cannot be
+  // dropped the way the library's own call sites had been.
+  {
+    ParseOutcome r = parseAndBegin(buildDoc(/*declared*/17, /*gran*/2, /*steps*/2), /*bCallBegin*/true);
+    check(!r.bParsed || !r.bBegan, "17 input channels -> not usable");
+  }
+  {
+    ParseOutcome r = parseAndBegin(buildDoc(/*declared*/255, /*gran*/2, /*steps*/2), /*bCallBegin*/true);
+    check(!r.bParsed || !r.bBegan, "255 input channels -> not usable");
+  }
+
+  // ---- Control: an ordinary element must still parse and begin ---------------
+  //
+  // 3 input channels, a 2-point grid per dimension, 4 spectral steps. If this
+  // regresses, the guards above are over-tight. Begin() is not asserted here:
+  // the spectral overrides need an applied PCC from the enclosing MPE tag to
+  // build their observer, which a bare element cannot supply, so the meaningful
+  // control is that the element parses and its counts agree.
+  {
+    ParseOutcome r = parseAndBegin(buildDoc(/*declared*/3, /*gran*/2, /*steps*/4), /*bCallBegin*/false);
+    check(r.bParsed, "valid 3-channel EmissionCLutElement -> ParseXml true");
+    if (r.bParsed) {
+      check(r.bHaveClut, "valid element has a CLUT");
+      check(r.nDeclared == 3, "valid element declares 3 input channels");
+      check(r.nClutDim == 3, "valid element's CLUT is 3-dimensional");
+    }
+  }
+
+  if (g_fail) {
+    std::fprintf(stderr, "[spectral-clut-xml] %d assertion(s) failed\n", g_fail);
+    return g_fail;
+  }
+  std::printf("[spectral-clut-xml] all assertions passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5862,6 +5862,49 @@ function(iccdev_add_spectral_clut_channel_count_test)
   endif()
 endfunction()
 
+function(iccdev_add_spectral_clut_xml_channel_mismatch_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccSpectralClutXmlChannelMismatchTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/spectral-clut-xml-channel-mismatch.cpp"
+  )
+  target_compile_features(iccSpectralClutXmlChannelMismatchTest PRIVATE cxx_std_17)
+  target_include_directories(iccSpectralClutXmlChannelMismatchTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccXML/IccLibXML"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+    ${LIBXML2_INCLUDE_DIR}
+  )
+  target_link_libraries(iccSpectralClutXmlChannelMismatchTest PRIVATE
+    ${TARGET_LIB_ICCXML} ${TARGET_LIB_ICCPROFLIB} ${LIBXML2_LIBRARIES})
+  add_dependencies(check iccSpectralClutXmlChannelMismatchTest)
+
+  add_test(
+    NAME iccdev.spectral-clut-xml-channel-mismatch
+    COMMAND "$<TARGET_FILE:iccSpectralClutXmlChannelMismatchTest>"
+  )
+  set_tests_properties(iccdev.spectral-clut-xml-channel-mismatch PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;xml;mpe;spectral;clut;security;regression"
+  )
+  if(WIN32)
+    set(_spectral_clut_xml_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccSpectralClutXmlChannelMismatchTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCXML}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _spectral_clut_xml_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.spectral-clut-xml-channel-mismatch PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_spectral_clut_xml_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 if(WIN32)
   function(iccdev_add_windows_batch_test NAME TIMEOUT LABELS SCRIPT)
     set(_one_value_args
@@ -6192,6 +6235,7 @@ if(WIN32)
   iccdev_add_windows_iccdevcmm_smoke_test()
   iccdev_add_zip_utf8_text_zlib_test()
   iccdev_add_spectral_clut_channel_count_test()
+  iccdev_add_spectral_clut_xml_channel_mismatch_test()
 
   if(TARGET iccFromXml AND TARGET iccDumpProfile AND TARGET iccApplyNamedCmm)
     add_test(
@@ -6535,6 +6579,7 @@ iccdev_add_prmg_hue_normalization_test()
 iccdev_add_qa_evidence_helpers_test()
 iccdev_add_zip_utf8_text_zlib_test()
 iccdev_add_spectral_clut_channel_count_test()
+iccdev_add_spectral_clut_xml_channel_mismatch_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5862,6 +5862,55 @@ function(iccdev_add_spectral_clut_channel_count_test)
   endif()
 endfunction()
 
+function(iccdev_add_clut_apply_guard_retirement_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccClutApplyGuardRetirementTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/clut-apply-guard-retirement.cpp"
+  )
+  target_link_libraries(iccClutApplyGuardRetirementTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+
+  add_dependencies(check iccClutApplyGuardRetirementTest)
+
+  # No fixture: every CLUT here is built in memory. The output counts that matter
+  # (17, 20) exceed what any tracked profile carries, which is why the defect in
+  # Interp3dTetra survived so long.
+  if(WIN32)
+    add_test(
+      NAME iccdev.clut-apply-guard-retirement
+      COMMAND "$<TARGET_FILE:iccClutApplyGuardRetirementTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.clut-apply-guard-retirement
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccClutApplyGuardRetirementTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.clut-apply-guard-retirement PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;clut;cmm;apply;regression"
+  )
+  if(WIN32)
+    set(_clut_apply_guard_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccClutApplyGuardRetirementTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _clut_apply_guard_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.clut-apply-guard-retirement PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_clut_apply_guard_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_spectral_clut_xml_channel_mismatch_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
     return()
@@ -6236,6 +6285,7 @@ if(WIN32)
   iccdev_add_zip_utf8_text_zlib_test()
   iccdev_add_spectral_clut_channel_count_test()
   iccdev_add_spectral_clut_xml_channel_mismatch_test()
+  iccdev_add_clut_apply_guard_retirement_test()
 
   if(TARGET iccFromXml AND TARGET iccDumpProfile AND TARGET iccApplyNamedCmm)
     add_test(
@@ -6580,6 +6630,7 @@ iccdev_add_qa_evidence_helpers_test()
 iccdev_add_zip_utf8_text_zlib_test()
 iccdev_add_spectral_clut_channel_count_test()
 iccdev_add_spectral_clut_xml_channel_mismatch_test()
+iccdev_add_clut_apply_guard_retirement_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5813,6 +5813,54 @@ if(TARGET iccDumpProfile)
   endif()
 endif()
 
+function(iccdev_add_spectral_clut_channel_count_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccSpectralClutChannelCountTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/spectral-clut-channel-count-bound.cpp"
+  )
+  target_link_libraries(iccSpectralClutChannelCountTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+
+  add_dependencies(check iccSpectralClutChannelCountTest)
+
+  # No fixture argument: the test builds the MPE element bodies in memory. The
+  # channel counts that matter (257, 259, 260, 272) are single 16-bit fields, so a
+  # tracked profile would carry nothing the buffers here do not say more directly.
+  if(WIN32)
+    add_test(
+      NAME iccdev.spectral-clut-channel-count-bound
+      COMMAND "$<TARGET_FILE:iccSpectralClutChannelCountTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.spectral-clut-channel-count-bound
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccSpectralClutChannelCountTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.spectral-clut-channel-count-bound PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;mpe;spectral;clut;security;regression"
+  )
+  if(WIN32)
+    set(_spectral_clut_channel_count_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccSpectralClutChannelCountTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _spectral_clut_channel_count_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.spectral-clut-channel-count-bound PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_spectral_clut_channel_count_windows_env_mods}"
+    )
+  endif()
+endfunction()
 
 if(WIN32)
   function(iccdev_add_windows_batch_test NAME TIMEOUT LABELS SCRIPT)
@@ -6143,6 +6191,7 @@ if(WIN32)
   iccdev_add_qa_evidence_helpers_test()
   iccdev_add_windows_iccdevcmm_smoke_test()
   iccdev_add_zip_utf8_text_zlib_test()
+  iccdev_add_spectral_clut_channel_count_test()
 
   if(TARGET iccFromXml AND TARGET iccDumpProfile AND TARGET iccApplyNamedCmm)
     add_test(
@@ -6485,6 +6534,7 @@ iccdev_add_iccprofileplot_exitcode_test()
 iccdev_add_prmg_hue_normalization_test()
 iccdev_add_qa_evidence_helpers_test()
 iccdev_add_zip_utf8_text_zlib_test()
+iccdev_add_spectral_clut_channel_count_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -2582,7 +2582,13 @@ static bool icMBBFromJson(CIccMBB *pMBB, const IccJson &j, icConvertType nType, 
     parseStr += "Missing or invalid inputChannels/outputChannels in LUT\n";
     return false;
   }
-  pMBB->Init((icUInt8Number)nIn, (icUInt8Number)nOut);
+  // Bounded at 15 by the check above, so this cannot fail today -- checked for
+  // the same reason as the XML parser's equivalent: the bound and the Init() that
+  // relies on it are in different places.
+  if (!pMBB->Init((icUInt8Number)nIn, (icUInt8Number)nOut)) {
+    parseStr += "Invalid inputChannels/outputChannels in LUT\n";
+    return false;
+  }
 
   // aCurves
   if (jsonExistsField(j, "aCurves") && j["aCurves"].is_array()) {

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -6364,7 +6364,10 @@ CIccXform3DLut::~CIccXform3DLut()
     }
 
     if (m_pTag->m_CLUT) {
-      m_pTag->m_CLUT->Begin();
+      // Begin() refuses a CLUT that Init() never made usable -- reachable when
+      // the tag was built by a parser rather than read from a profile.
+      if (!m_pTag->m_CLUT->Begin())
+        return icCmmStatInvalidLut;
     }
 
     if (m_pTag->m_CurvesA) {
@@ -6397,7 +6400,10 @@ CIccXform3DLut::~CIccXform3DLut()
     }
 
     if (m_pTag->m_CLUT) {
-      m_pTag->m_CLUT->Begin();
+      // Begin() refuses a CLUT that Init() never made usable -- reachable when
+      // the tag was built by a parser rather than read from a profile.
+      if (!m_pTag->m_CLUT->Begin())
+        return icCmmStatInvalidLut;
     }
 
     if (m_pTag->m_CurvesM) {
@@ -6732,7 +6738,10 @@ icStatusCMM CIccXform4DLut::Begin()
     }
 
     if (m_pTag->m_CLUT) {
-      m_pTag->m_CLUT->Begin();
+      // Begin() refuses a CLUT that Init() never made usable -- reachable when
+      // the tag was built by a parser rather than read from a profile.
+      if (!m_pTag->m_CLUT->Begin())
+        return icCmmStatInvalidLut;
     }
 
     if (m_pTag->m_CurvesA) {
@@ -6768,7 +6777,10 @@ icStatusCMM CIccXform4DLut::Begin()
     }
 
     if (m_pTag->m_CLUT) {
-      m_pTag->m_CLUT->Begin();
+      // Begin() refuses a CLUT that Init() never made usable -- reachable when
+      // the tag was built by a parser rather than read from a profile.
+      if (!m_pTag->m_CLUT->Begin())
+        return icCmmStatInvalidLut;
     }
 
     if (m_pTag->m_CurvesM) {
@@ -7158,7 +7170,10 @@ icStatusCMM CIccXformNDLut::Begin()
     }
 
     if (m_pTag->m_CLUT) {
-      m_pTag->m_CLUT->Begin();
+      // Begin() refuses a CLUT that Init() never made usable -- reachable when
+      // the tag was built by a parser rather than read from a profile.
+      if (!m_pTag->m_CLUT->Begin())
+        return icCmmStatInvalidLut;
     }
 
     if (m_pTag->m_CurvesA) {
@@ -7202,7 +7217,10 @@ icStatusCMM CIccXformNDLut::Begin()
     }
 
     if (m_pTag->m_CLUT) {
-      m_pTag->m_CLUT->Begin();
+      // Begin() refuses a CLUT that Init() never made usable -- reachable when
+      // the tag was built by a parser rather than read from a profile.
+      if (!m_pTag->m_CLUT->Begin())
+        return icCmmStatInvalidLut;
     }
 
     if (m_pTag->m_CurvesM) {

--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -5793,7 +5793,20 @@ bool CIccMpeCLUT::Begin(icElemInterp nInterp, CIccTagMultiProcessElement * /* pM
   if (!m_pCLUT)
     return false;
 
-  m_pCLUT->Begin();
+  // m_interpType is chosen from m_nInputChannels below, but every interpolator
+  // it selects walks the CLUT's own m_nInput. The two are only guaranteed equal
+  // when the element came from Read(), which bounds the count before narrowing
+  // it to the CLUT's icUInt8Number. An element built by a parser sets
+  // m_nInputChannels from its own source and lets the same narrowing happen
+  // separately when it constructs the CLUT, so a declared 257 could leave a
+  // one-dimensional CLUT under an element claiming 257 channels. Compare them
+  // here, where every apply path passes regardless of how the element was
+  // built.
+  if (m_pCLUT->GetInputDim() != m_nInputChannels)
+    return false;
+
+  if (!m_pCLUT->Begin())
+    return false;
 
   switch (m_nInputChannels) {
   case 1:

--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -5709,7 +5709,12 @@ bool CIccMpeCLUT::Read(icUInt32Number size, CIccIO *pIO)
 
   m_pCLUT->SetClipFunc(NoClip);
 
-  m_pCLUT->Init(gridPoints);
+  // The GetData(0) check below turns a refused Init() into a failed Read() only
+  // because Init() leaves m_pData NULL and GetData(0) is &m_pData[0]. State the
+  // rejection where it happens instead of relying on that; CIccMpeExtCLUT::Read
+  // further down this file already does.
+  if (!m_pCLUT->Init(gridPoints))
+    return false;
 
   icFloatNumber *pData = m_pCLUT->GetData(0);
 

--- a/IccProfLib/IccMpeSpectral.cpp
+++ b/IccProfLib/IccMpeSpectral.cpp
@@ -1470,6 +1470,18 @@ bool CIccMpeEmissionCLUT::Begin(icElemInterp nInterp, CIccTagMultiProcessElement
   if (!m_pCLUT || !m_pWhite || m_pCLUT->GetOutputChannels()!=m_Range.steps || m_nOutputChannels!=3)
     return false;
 
+  // The element's declared input channel count and the dimensionality of the
+  // CLUT backing it must agree. Read() now bounds the count before the narrowing
+  // cast that builds the CLUT, but Read() is not the only constructor: the XML
+  // parser sets m_nInputChannels straight from the InputChannels attribute
+  // (capped at 0xFFFF by icXmlParseChannels) and then lets icCLutFromXml()
+  // narrow the same value to icUInt8Number independently, so a declared 257
+  // yields a one-dimensional CLUT under an element still claiming 257. Checking
+  // it here covers every route in, because Begin() is what the apply path calls
+  // whatever built the object.
+  if (m_pCLUT->GetInputDim() != m_nInputChannels)
+    return false;
+
   switch (m_nInputChannels) {
   case 1:
     m_interpType = ic1dInterp;
@@ -1556,7 +1568,8 @@ bool CIccMpeEmissionCLUT::Begin(icElemInterp nInterp, CIccTagMultiProcessElement
     pDst += m_nOutputChannels;
   }
 
-  m_pApplyCLUT->Begin();
+  if (!m_pApplyCLUT->Begin())
+    return false;
 
   return true;
 }
@@ -1577,6 +1590,18 @@ bool CIccMpeReflectanceCLUT::Begin(icElemInterp nInterp, CIccTagMultiProcessElem
   if (!m_pCLUT || !m_pWhite ||
       m_Range.steps < 2 || m_Range.start >= m_Range.end ||
       m_pCLUT->GetOutputChannels()!=m_Range.steps || m_nOutputChannels!=3)
+    return false;
+
+  // The element's declared input channel count and the dimensionality of the
+  // CLUT backing it must agree. Read() now bounds the count before the narrowing
+  // cast that builds the CLUT, but Read() is not the only constructor: the XML
+  // parser sets m_nInputChannels straight from the InputChannels attribute
+  // (capped at 0xFFFF by icXmlParseChannels) and then lets icCLutFromXml()
+  // narrow the same value to icUInt8Number independently, so a declared 257
+  // yields a one-dimensional CLUT under an element still claiming 257. Checking
+  // it here covers every route in, because Begin() is what the apply path calls
+  // whatever built the object.
+  if (m_pCLUT->GetInputDim() != m_nInputChannels)
     return false;
 
   switch (m_nInputChannels) {
@@ -1736,7 +1761,8 @@ bool CIccMpeReflectanceCLUT::Begin(icElemInterp nInterp, CIccTagMultiProcessElem
   if (pApplyMtx!=&observer)
     delete pApplyMtx;
 
-  m_pApplyCLUT->Begin();
+  if (!m_pApplyCLUT->Begin())
+    return false;
 
   return true;
 }

--- a/IccProfLib/IccMpeSpectral.cpp
+++ b/IccProfLib/IccMpeSpectral.cpp
@@ -1038,6 +1038,26 @@ bool CIccMpeSpectralCLUT::Read(icUInt32Number size, CIccIO *pIO)
   if (m_nInputChannels < 1 || m_nOutputChannels < 1)
     return false;
 
+  // m_nInputChannels is a 16-bit field taken straight from the profile, and it
+  // is narrowed to icUInt8Number when the CLUT is constructed below. The bound
+  // that matters here is therefore not only CIccCLUT's 16-input maximum but the
+  // cast: a declared 256 truncates to 0 and a declared 257 truncates to 1, so
+  // the count this element reports through NumInputChannels() stops describing
+  // the CLUT that backs it. The out-of-range values are already refused, if only
+  // by accident -- Init() below rejects an m_nInput of 0 or >16, leaves m_pData
+  // NULL, and the GetData(0) check that follows turns that into a failed Read.
+  // The truncating ones are not: 257 produces a readable element advertising 257
+  // input channels over a one-dimensional CLUT, and because
+  // icNumColorSpaceChannels() is the low 16 bits of the colour space signature,
+  // a header can declare a 257-channel N-channel space and satisfy the
+  // inputSamples == NumInputChannels() equality in CIccXformMpe::Begin. The
+  // element then applies, reading channel 0 and silently discarding the other
+  // 256. Bound the field before the cast, as CIccMpeCLUT::Read (IccMpeBasic.cpp)
+  // and CIccMpeExtCLUT::Read already do, so the count and the CLUT cannot
+  // disagree.
+  if (m_nInputChannels > 16)
+    return false;
+
   if (!pIO->Read32(&m_flags))
     return false;
 
@@ -1070,7 +1090,13 @@ bool CIccMpeSpectralCLUT::Read(icUInt32Number size, CIccIO *pIO)
   if (!nBytesPerSample)
     return false;
 
-  m_pCLUT->Init(gridPoints, size - headerSize, nBytesPerSample);
+  // The GetData(0) check below has been catching this failure by side effect --
+  // Init() leaves m_pData NULL when it refuses, and GetData(0) is &m_pData[0].
+  // Say it directly, so the rejection does not depend on GetData()'s current
+  // shape, and so the reason a malformed CLUT is refused appears at the point of
+  // refusal. CIccMpeExtCLUT::Read in IccMpeBasic.cpp already reads this way.
+  if (!m_pCLUT->Init(gridPoints, size - headerSize, nBytesPerSample))
+    return false;
 
   icFloatNumber *pData = m_pCLUT->GetData(0);
 
@@ -1493,10 +1519,21 @@ bool CIccMpeEmissionCLUT::Begin(icElemInterp nInterp, CIccTagMultiProcessElement
   }
 
   m_pApplyCLUT->SetClipFunc(NoClip);
-  m_pApplyCLUT->Init(m_pCLUT->GridPointArray());
+
+  // Unlike the Read() path, nothing here checks the pointers Init() is
+  // responsible for: pDst below is used as the destination of the VectorMult()
+  // loop without a NULL test, so a refused Init() writes through NULL on the
+  // first node rather than failing. The apply CLUT is built at the same
+  // dimensionality and grid as m_pCLUT, so an Init() that refuses here means the
+  // two have diverged; refusing Begin() is the only correct answer.
+  if (!m_pApplyCLUT->Init(m_pCLUT->GridPointArray()))
+    return false;
 
   icFloatNumber *pSrc = m_pCLUT->GetData(0);
   icFloatNumber *pDst = m_pApplyCLUT->GetData(0);
+
+  if (!pSrc || !pDst)
+    return false;
 
   icFloatNumber xyzW[3];
   icUInt32Number i;
@@ -1643,10 +1680,24 @@ bool CIccMpeReflectanceCLUT::Begin(icElemInterp nInterp, CIccTagMultiProcessElem
   }
 
   m_pApplyCLUT->SetClipFunc(NoClip);
-  m_pApplyCLUT->Init(m_pCLUT->GridPointArray());
+
+  // As in CIccMpeEmissionCLUT::Begin above: pDst is written through without a
+  // NULL test, so Init()'s refusal has to stop us here. pApplyMtx is this
+  // function's to release on every exit once it is not the stack observer.
+  if (!m_pApplyCLUT->Init(m_pCLUT->GridPointArray())) {
+    if (pApplyMtx!=&observer)
+      delete pApplyMtx;
+    return false;
+  }
 
   icFloatNumber *pSrc = m_pCLUT->GetData(0);
   icFloatNumber *pDst = m_pApplyCLUT->GetData(0);
+
+  if (!pSrc || !pDst) {
+    if (pApplyMtx!=&observer)
+      delete pApplyMtx;
+    return false;
+  }
 
   icFloatNumber xyzW[3];
 

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -2870,11 +2870,32 @@ void CIccCLUT::Interp2d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
  */
 void CIccCLUT::Interp3dTetra(icFloatNumber *destPixel, const icFloatNumber *srcPixel) const
 {
-  // CWE-400/834: m_nOutput controls the destPixel write loop below. Valid LUT
-  // profiles cap output channels at <=16 (the read path rejects larger); guard
-  // locally so the bound is explicit even if the field is corrupted in memory.
-  if (m_nOutput > 16)
-    return;
+  // NOTE FOR ANYONE ADDING A BOUNDS CHECK HERE -- please don't; this one was a
+  // defect.
+  //
+  // "if (m_nOutput > 16) return;" used to stand here, described as bounding the
+  // destPixel write loop below on the grounds that "valid LUT profiles cap
+  // output channels at <=16". They do not, and this was the only interpolator
+  // that believed it. Interp1d, Interp2d, Interp3d, Interp4d, Interp5d and
+  // Interp6d all write m_nOutput values with no such bound, and m_nOutput is an
+  // icUInt16Number precisely because MPE CLUT elements need more than 16 --
+  // CIccMpeCLUT::Read bounds m_nInputChannels at 16 but deliberately leaves
+  // m_nOutputChannels unbounded, and a spectral CLUT's output count is its
+  // spectral step count.
+  //
+  // So for a perfectly legal 3-input CLUT with 17 or more outputs, this returned
+  // without writing anything: destPixel was left holding whatever the caller had
+  // in it, and only when the tetrahedral path was selected. Interp3d, reached
+  // from the same element under icElemInterpLinear, produced correct values for
+  // the identical CLUT. Measured before removal, at 3 inputs and 0.5 in each
+  // channel: nOut=16 gave 0.250 from both routines; nOut=17 and nOut=20 gave
+  // 0.250 from Interp3d and an untouched destination from Interp3dTetra.
+  //
+  // destPixel is sized by the caller from the same channel count this loop
+  // walks -- m_nBufChannels in the MPE pipeline, GetNumDstSamples() for a LUT
+  // xform, both pinned to the tag's output count at Begin() -- so the write is
+  // in bounds for any m_nOutput the object can legitimately carry, exactly as it
+  // is in the six sibling routines.
   icUInt8Number mx = m_MaxGridPoint[0];
   icUInt8Number my = m_MaxGridPoint[1];
   icUInt8Number mz = m_MaxGridPoint[2];
@@ -3486,18 +3507,37 @@ void CIccCLUT::InterpND(icFloatNumber *destPixel, const icFloatNumber *srcPixel,
   icFloatNumber* s = pApply->m_s;
   icUInt32Number* ig = pApply->m_ig;
 
-  // CWE-400/834: m_nInput drives the grid loop below and m_nNodes = (1<<m_nInput)
-  // used for the df[] loop. Input channels are capped at <=16 by Init() on load;
-  // guard locally so both bounds are explicit at point of use.
-  if (m_nInput > 16)
-    return;
-
-  // CWE-400/CWE-834: m_nNodes == (1<<m_nInput) and indexes the fixed df[]/m_nOffset
-  // arrays; assert the derived upper bound (m_nInput<=16 => m_nNodes<=65536) on the
-  // field itself so the node walks below have an explicit limit.
-  const icUInt32Number nMaxNodes = 65536;
-  if (m_nNodes > nMaxNodes)
-    return;
+  // NOTE FOR ANYONE ADDING A BOUNDS CHECK HERE -- please don't; put it in
+  // Begin().
+  //
+  // Two per-pixel guards used to stand at this point: "if (m_nInput > 16)
+  // return;" and "if (m_nNodes > 65536) return;". Both are gone deliberately.
+  //
+  // m_nInput indexes the fixed 16-entry m_GridPoints/m_MaxGridPoint/m_nPower
+  // arrays and drives m_nNodes = (1<<m_nInput), which indexes df[] and
+  // m_nOffset. Those bounds still matter -- they are just no longer this
+  // function's to assert. Begin() establishes both: it refuses an m_nInput
+  // outside 1..16 and refuses a CLUT whose Init() never allocated m_pData, it
+  // returns bool rather than leaving the object half-configured, and all nine of
+  // its callers act on the result up through CIccCmm::Begin(), which aborts the
+  // chain on the first failure. So Apply() cannot be reached with either bound
+  // violated, and re-testing them per pixel could only re-confirm what Begin()
+  // proved.
+  //
+  // The history is worth knowing, because these lines have twice been reasoned
+  // about incorrectly. They were called "duplicated from Begin()" and, later,
+  // "the only guard that works" -- both by tracing the call chain rather than
+  // probing it, and neither was true at the time. Before Begin() could refuse,
+  // m_nInput > 16 was already unreachable here: the element readers turned a
+  // failed Init() into a failed Read() through their GetData(0) NULL checks,
+  // because Init() leaves m_pData NULL when it refuses and GetData(0) is
+  // &m_pData[0]. The guards were unreachable, not load-bearing.
+  //
+  // Note also what they never did: nothing here protected the failure that
+  // actually crashes an un-Begin()'d CLUT, which is a NULL m_nOffset and an
+  // uninitialized m_MaxGridPoint, regardless of the channel count.
+  // Begin()-before-Apply() is the precondition that matters, and it is now a
+  // checked one.
 
   for (i=0; i<m_nInput; i++) {
     // See icClutGridClamp: scales into grid units and clamps, replacing the

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -3841,11 +3841,26 @@ void CIccMBB::Cleanup()
 {
   int i;
 
-  // CWE-400/834: the curve-pointer arrays are allocated to m_nInput/m_nOutput at
-  // load (both capped at <=16 by the lut tag read path). Clamp the delete loops to
-  // the array bound so a corrupted channel count can never walk past the allocation.
-  int nIn  = (m_nInput  > 16) ? 16 : m_nInput;
-  int nOut = (m_nOutput > 16) ? 16 : m_nOutput;
+  // These loops must mirror NewCurvesA/B/M exactly, because those are what
+  // allocated the arrays: A takes !IsInputB() ? m_nInput : m_nOutput, M and B
+  // take IsInputMatrix() ? m_nInput : m_nOutput, and IsInputB() is defined as
+  // IsInputMatrix(), so each branch below frees the same count its allocator
+  // used.
+  //
+  // They used to be clamped to 16 "so a corrupted channel count can never walk
+  // past the allocation". That reasoning is inverted: the arrays are sized by the
+  // very counts being clamped, so a count above 16 does not overrun the
+  // allocation -- clamping *leaks* the entries from 16 upward, silently, in a
+  // destructor. And a count below the allocation cannot happen, because nothing
+  // mutates m_nInput/m_nOutput between NewCurves* and Cleanup() except Init(),
+  // which calls Cleanup() first.
+  //
+  // The bound belongs where the count is established, and now is: Init() refuses
+  // anything outside 1..16, matching CIccCLUT::Init() and the guarantee
+  // CIccCLUT::Begin() relies on. So these loops trust their counts, exactly as
+  // the interpolators trust what Begin() established.
+  int nIn  = m_nInput;
+  int nOut = m_nOutput;
 
   if (IsInputMatrix()) {
     if (m_CurvesB) {
@@ -3918,11 +3933,32 @@ void CIccMBB::Cleanup()
  *  nOutputChannels = number of output channels
  *****************************************************************************
  */
-void CIccMBB::Init(icUInt8Number nInputChannels, icUInt8Number nOutputChannels)
+bool CIccMBB::Init(icUInt8Number nInputChannels, icUInt8Number nOutputChannels)
 {
+  // Establish the bound here, where the counts are set, rather than re-testing it
+  // in the loops that consume them. Everything downstream sizes itself from these
+  // two numbers -- NewCurvesA/B/M allocate arrays of them, Cleanup() frees the
+  // same counts, and SetCLUT() requires a CIccCLUT whose own dimensionality
+  // matches m_nInput, which CIccCLUT::Init() independently caps at 16. Sixteen is
+  // therefore the bound the whole object already depends on; it just was not
+  // stated anywhere, so Cleanup() clamped defensively and leaked instead.
+  //
+  // Nothing loaded from a profile is newly refused: the mAB, lut8 and lut16 read
+  // paths all reject counts above 15 before they get here, and both the XML and
+  // JSON MBB parsers bound theirs at 15 as well. What this catches is a direct
+  // caller of the public API -- the same door CIccCLUT::Init() and
+  // CIccCLUT::Begin() are guarding.
+  //
+  // Checked before Cleanup(), so a refused call leaves the object exactly as it
+  // was rather than half-torn-down.
+  if (nInputChannels < 1 || nInputChannels > 16 ||
+      nOutputChannels < 1 || nOutputChannels > 16)
+    return false;
+
   Cleanup();
   m_nInput = nInputChannels;
   m_nOutput = nOutputChannels;
+  return true;
 }
 
 /**

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -4365,7 +4365,8 @@ CIccMatrix* CIccMBB::NewMatrix()
  * Args:
  *  pGridPoints = number of grid points in the CLUT
  *
- * Return: Pointer to the CIccCLUT object
+ * Return: Pointer to the CIccCLUT object, or NULL if the CLUT could not be
+ *  initialized for this object's channel counts and the requested grid.
  *****************************************************************************
  */
 CIccCLUT* CIccMBB::NewCLUT(icUInt8Number *pGridPoints, icUInt8Number nPrecision/*=2*/)
@@ -4375,7 +4376,19 @@ CIccCLUT* CIccMBB::NewCLUT(icUInt8Number *pGridPoints, icUInt8Number nPrecision/
 
   m_CLUT = new CIccCLUT(m_nInput, m_nOutput, nPrecision);
 
-  m_CLUT->Init(pGridPoints);
+  // Init() refuses an input count outside 1..16, a grid granularity below 2, and
+  // any grid whose node count overflows 32 bits. Its result was dropped here and
+  // the CLUT handed back regardless, so callers received an object with
+  // m_pData NULL that nothing distinguished from a working one -- GetData(0)
+  // returned NULL and was written through (#1781). iccApplyToLink works around
+  // this by constructing the CLUT itself and calling SetCLUT(); it should not
+  // have to. Report the failure the way the return type always implied, and drop
+  // the CLUT rather than leaving the tag owning an unusable one.
+  if (!m_CLUT->Init(pGridPoints)) {
+    delete m_CLUT;
+    m_CLUT = NULL;
+    return NULL;
+  }
 
   return m_CLUT;
 }
@@ -4415,7 +4428,8 @@ CIccCLUT *CIccMBB::SetCLUT(CIccCLUT *clut)
  * Args:
  *  nGridPoints = number of grid points in the CLUT
  *
- * Return: Pointer to the CIccCLUT object
+ * Return: Pointer to the CIccCLUT object, or NULL if the CLUT could not be
+ *  initialized for this object's channel counts and the requested grid.
  *****************************************************************************
  */
 CIccCLUT* CIccMBB::NewCLUT(icUInt8Number nGridPoints, icUInt8Number nPrecision/*=2*/)
@@ -4425,7 +4439,13 @@ CIccCLUT* CIccMBB::NewCLUT(icUInt8Number nGridPoints, icUInt8Number nPrecision/*
 
   m_CLUT = new CIccCLUT(m_nInput, m_nOutput, nPrecision);
 
-  m_CLUT->Init(nGridPoints);
+  // See the pGridPoints overload above: Init()'s refusal was dropped and the
+  // uninitialized CLUT returned as though it were usable.
+  if (!m_CLUT->Init(nGridPoints)) {
+    delete m_CLUT;
+    m_CLUT = NULL;
+    return NULL;
+  }
 
   return m_CLUT;
 }

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -2528,14 +2528,28 @@ void CIccCLUT::DumpLut(IDescribeSink &sink, const icChar *szName,
  *
  *****************************************************************************
  */
-void CIccCLUT::Begin()
+bool CIccCLUT::Begin()
 {
   int i;
-  // CWE-400/834: m_nInput indexes the fixed 16-entry m_GridPoints/m_MaxGridPoint/
-  // m_nPower arrays and drives m_nNodes = (1<<m_nInput). Init() already rejects
-  // m_nInput>16 on load; assert the bound locally so it is explicit at point of use.
-  if (m_nInput > 16)
-    return;
+
+  // Init() is what establishes every quantity below: the grid, the data buffer,
+  // and the input count itself. It refuses an m_nInput outside 1..16, a grid
+  // granularity below 2, and any grid whose size overflows 32 bits, and it
+  // leaves m_pData NULL when it does. That NULL is the one reliable signal that
+  // this object was never made usable, and it is the state a CLUT built outside
+  // the profile reader can be left in -- icCLutFromXml() and icCLUTFromJson()
+  // construct a CIccCLUT directly from a parsed channel count, and the public
+  // constructor plus a skipped or failed Init() reaches it too. Refuse here so
+  // an uninitialized CLUT cannot be handed to the interpolators.
+  if (!m_pData)
+    return false;
+
+  // m_nInput indexes the fixed 16-entry m_GridPoints/m_MaxGridPoint/m_nPower
+  // arrays and drives m_nNodes = (1<<m_nInput) (CWE-400/834). Init() rejects
+  // m_nInput>16, so a CLUT holding data cannot be over the bound; keep the
+  // check so the limit is explicit at the point the arrays are indexed.
+  if (m_nInput < 1 || m_nInput > 16)
+    return false;
   for (i=0; i<m_nInput; i++) {
     m_MaxGridPoint[i] = m_GridPoints[i] - 1;
   }
@@ -2555,7 +2569,7 @@ void CIccCLUT::Begin()
   // bound on the field so the offset-table walks below have an explicit upper limit
   // a corrupted CLUT cannot exceed. Value-preserving: a valid m_nNodes is <= 65536.
   if (m_nNodes > 65536)
-    return;
+    return false;
 
   if (m_nInput==1) {
     m_nOffset[0] = n000 = 0;
@@ -2719,6 +2733,8 @@ void CIccCLUT::Begin()
       }
     }
   }
+
+  return true;
 }
 
 

--- a/IccProfLib/IccTagLut.h
+++ b/IccProfLib/IccTagLut.h
@@ -478,7 +478,12 @@ public:
   bool SwapMBCurves() const { return m_bUseMCurvesAsBCurves; }
 
   void Cleanup();
-  void Init(icUInt8Number nInputChannels, icUInt8Number nOutputChannels);
+
+  //! Set the channel counts everything else in this object is sized from.
+  //! Returns false, changing nothing, if either count is outside 1..16 -- the
+  //! bound CIccCLUT::Init() and the lut read paths already impose. Callers on a
+  //! load or parse path must not proceed when this returns false.
+  bool Init(icUInt8Number nInputChannels, icUInt8Number nOutputChannels);
 
   icUInt8Number InputChannels() const { return m_nInput; }
   icUInt8Number OutputChannels() const { return m_nOutput; }

--- a/IccProfLib/IccTagLut.h
+++ b/IccProfLib/IccTagLut.h
@@ -373,7 +373,11 @@ public:
   icUInt32Number GetOffset(int index) const { return m_nOffset ? m_nOffset[index] : 0; }
 
 
-  void Begin();
+  //! Prepare the CLUT for Apply(). Returns false if the object is not in a
+  //! usable state -- most importantly if Init() was never called or refused,
+  //! which leaves no data behind the grid the interpolators would walk. Callers
+  //! on an apply path must not proceed when this returns false.
+  bool Begin();
 
   CIccApplyCLUT* GetNewApply();
 

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -4134,6 +4134,20 @@ CIccCLUT *icCLutFromXml(xmlNode *pNode, int nIn, int nOut, icConvertType nType, 
   if (nType == icConvert8Bit)
     nPrecision = 1;  
 
+  // nIn arrives as the caller's declared input channel count and is narrowed to
+  // icUInt8Number here. The callers do not bound it to what a CIccCLUT can
+  // hold: icXmlParseChannels caps at kIccXmlMaxChannels (0xFFFF), so a
+  // declared 257 would silently become a one-dimensional CLUT while the element
+  // that asked for it goes on reporting 257 input channels, and 259/272 land on
+  // 3 and 16 the same way. Counts above 16 are refused outright rather than
+  // truncated -- CIccCLUT::Init() would reject them anyway, so nothing valid is
+  // lost, and refusing here keeps the element's count and its CLUT in agreement
+  // instead of leaving the disagreement for the apply path to catch.
+  if (nIn < 1 || nIn > 16 || nOut < 1) {
+    parseStr += "Error! - InputChannels must be between 1 and 16 for a CLUT.\n";
+    return NULL;
+  }
+
   icUInt8Number nInput = (icUInt8Number)nIn;
   icUInt16Number nOutput = (icUInt16Number)nOut;
 

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -4682,7 +4682,14 @@ bool icMBBFromXml(CIccMBB *pMBB, xmlNode *pNode, icConvertType nType, std::strin
   if (nIn < 1 || nOut < 1)
     return false;
 
-  pMBB->Init(nIn, nOut);
+  // The parse above already caps both counts at 15, so this cannot fail today.
+  // Check it anyway: the cap lives in a different function from the Init() that
+  // depends on it, and a future relaxation there should surface here rather than
+  // silently produce an MBB whose curve arrays disagree with its channel counts.
+  if (!pMBB->Init((icUInt8Number)nIn, (icUInt8Number)nOut)) {
+    parseStr += "Error! - Invalid InputChannels or OutputChannels for a LUT tag.\n";
+    return false;
+  }
 
   for (; pNode; pNode = pNode->next) {
     if (pNode->type == XML_ELEMENT_NODE) {

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -572,14 +572,15 @@ public:
       for (icUInt16Number i = 0; i < nDstSamples; i++) {
         pCurves[i] = new CIccTagCurve();
       }
-      // CIccMBB::NewCLUT() calls CIccCLUT::Init() but discards its result and
-      // returns the CLUT either way, so a grid Init refused arrived here as a
+      // CIccMBB::NewCLUT() used to call CIccCLUT::Init() and return the CLUT
+      // whether or not it succeeded, so a grid Init refused arrived here as a
       // CLUT with m_pData NULL and m_nNumPoints already committed: GetData(0)
       // gave a NULL write target that setNextNode()'s countdown guard did not
-      // stop, and the first node memcpy'd to address zero (#1781). Build and
-      // initialize the CLUT explicitly -- as the V5 branch above already does
-      // -- so Init()'s result is visible here, then hand it over with
-      // SetCLUT(), which is what NewCLUT() would have done internally.
+      // stop, and the first node memcpy'd to address zero (#1781). NewCLUT() now
+      // returns NULL in that case, but this branch keeps building and
+      // initializing the CLUT explicitly -- as the V5 branch above already does
+      // -- because that is what lets the failure be reported with the grid size
+      // and channel counts that caused it, rather than as a bare NULL.
       CIccCLUT* pCLUT = new CIccCLUT((icUInt8Number)nSrcSamples, (icUInt8Number)nDstSamples);
       if (!pCLUT->Init(m_grid)) {
         printf("Unable to allocate a %d-point CLUT for %u source and %u destination channels\n",


### PR DESCRIPTION
## Summary

`CIccCLUT`'s channel-count validation had a silent-failure chain: `CIccCLUT::Init()` rejects an input count outside 1..16 and returns `false`, six of its ten call sites in IccProfLib discarded that return, and `CIccCLUT::Begin()` bailed with a bare `return;` on the same condition — leaving the object half-configured with no way for any of its nine callers to know.

The diagnosis changed twice while investigating, so the findings are worth stating up front.

**The out-of-range case was never reachable.** `m_nInput > 16` could not reach a CLUT through any read path. Both element readers follow the discarded `Init()` with `pData = m_pCLUT->GetData(0); if (!pData) return false;`. `Init()` returns before the reallocation when it refuses, the constructor had already set `m_pData` to NULL, and `GetData(0)` is `&m_pData[0]`. Declared counts of 17, 255, 256 and 272 all made `Read()` return false. The dropped return was being caught by accident.

**The reachable defect was truncation, not overflow.** `m_nInputChannels` is a 16-bit field narrowed to `icUInt8Number` when the CLUT is constructed. A declared 257 read clean and produced an element reporting 257 input channels over a **one-dimensional** CLUT; 259, 260 and 272 do the same onto 3, 4 and 16. Nothing downstream compared the two, and it survives the CMM's channel checks — `icNumColorSpaceChannels()` is the low 16 bits of the colour space signature, so a header can declare a 257-channel N-channel space and satisfy the `inputSamples != xformInputSamples` equality in `CIccXformMpe::Begin()`. The element then applies with `m_interpType` falling to `icNdInterp`, `InterpND()` walking the CLUT's own `m_nInput` of 1, and 256 input channels silently discarded. Wrong colour, no diagnostic.

**`Read()` was not the only door.** `CIccMpeXmlEmissionCLUT::ParseXml` never calls `Read()`. It sets `m_nInputChannels` from the `InputChannels` attribute (capped at `kIccXmlMaxChannels` = 0xFFFF) and then calls `icCLutFromXml()`, which does its own independent narrowing to build the CLUT. So the XML path reproduced the identical defect and a bound on `Read()` alone did nothing for it. `icCLUTFromJson()` already bounded `nIn` at 16, so JSON was unaffected.

## The contract

**`Begin()` validates, `Apply()` trusts.** That was always the de facto arrangement — `m_nOffset`, `m_nNodes` and `m_MaxGridPoint` are all `Begin()`'s outputs, and an un-`Begin()`'d CLUT dies on a NULL `m_nOffset` regardless of any channel count. What changes here is that "Begin succeeded" becomes a *checked* precondition instead of an assumption, which is what then lets the per-pixel re-tests go.

## Changes

Bounded at every parser, and enforced once where every apply path converges:

- **`CIccMpeSpectralCLUT::Read`** bounds `m_nInputChannels > 16` before the narrowing cast, matching `CIccMpeCLUT::Read` and `CIccMpeExtCLUT::Read`. The wire format carries a fixed 16-byte `gridPoints` array, so an element declaring more cannot describe its own grid — 16 is provably the right bound and no valid profile is affected.
- **`icCLutFromXml()`** refuses `nIn` outside 1..16 before its cast, so the XML parser can no longer build an element whose count disagrees with its CLUT.
- **All ten `Init()` call sites** act on the result. Four already did. The two in `CIccMpeEmissionCLUT::Begin` / `CIccMpeReflectanceCLUT::Begin` were the dangerous ones — unlike the read paths they had **no** `GetData(0)` NULL check and used the result as the destination of a `VectorMult()` loop.
- **`CIccMBB::NewCLUT()`** (both overloads) returns `NULL` on `Init()` failure instead of a CLUT with `m_pData` NULL — which is what its documented `Return: Pointer to the CIccCLUT object` always implied (#1781). No callers outside the test suite; `iccApplyToLink` builds its CLUT by hand specifically to work around this.
- **`CIccCLUT::Begin()` returns `bool`** and refuses when `m_pData` is NULL — the one reliable signal that `Init()` was never called or refused, and the state reachable through the public API. All nine call sites propagate: six in `IccCmm.cpp` return `icCmmStatInvalidLut`, three in the MPE elements return `false`. `CIccCmm::Begin` already aborts on the first non-Ok xform, so a refused CLUT stops setup before `Apply()` is reached.
- **The MPE `Begin()` overrides** compare `m_pCLUT->GetInputDim()` against `m_nInputChannels` — the check covering construction routes that don't exist yet, and the public API.

### On the `Begin()` signature change

`void` → `bool` on a public, non-virtual method. It is **source-compatible** with every existing caller (a discarded return still compiles). MSVC mangles the return type, so the exported symbol changes from `?Begin@CIccCLUT@@QEAAXXZ` to `?Begin@CIccCLUT@@QEAA_NXZ` — a prebuilt consumer gets a **link error, not silent misbehaviour**.

It is also not separable from the guard retirement below: without a return value `Begin()` cannot report that `Init()` never ran, and once the per-pixel checks come out nothing downstream re-tests it. `CIccMBB::Init()` changes the same way for the same reason.

## Per-pixel guards retired

Two, in `CIccCLUT`'s interpolators. Both removal sites carry a note saying what stood there, why it went, and that `Begin()` is where a bound belongs.

- **`Interp3dTetra`'s `m_nOutput > 16` was a defect, not redundancy.** Justified on the grounds that "valid LUT profiles cap output channels at <=16". They do not — `m_nOutput` is `icUInt16Number` precisely because MPE CLUT elements need more, `CIccMpeCLUT::Read` bounds `m_nInputChannels` at 16 and deliberately leaves `m_nOutputChannels` unbounded, and a spectral CLUT's output count is its spectral step count. Every sibling (`Interp1d`/`2d`/`3d`/`4d`/`5d`/`6d`) writes `m_nOutput` values with no such bound. For a legal 3-input CLUT with ≥17 outputs this returned **without writing anything**, leaving `destPixel` holding whatever the caller had in it, while the same CLUT through `Interp3d` produced correct values:

  ```
  nOut=16   Interp3d[0]=0.250   Interp3dTetra[0]=0.250
  nOut=17   Interp3d[0]=0.250   Interp3dTetra[0]=-1.000  <-- wrote nothing
  nOut=20   Interp3d[0]=0.250   Interp3dTetra[0]=-1.000  <-- wrote nothing
  ```

- **`InterpND`'s `m_nInput > 16` and `m_nNodes > 65536` were redundant**, and had been unreachable even before `Begin()` could refuse.

These are findings **A1 and A2** from the tier-A audit, which `perf/hoist-hardening-guards` deferred precisely because retiring them needs `Begin()` to be able to refuse. This PR supplies that prerequisite.

**A3 on that branch is deliberately not done here.** `CIccXformNDLut`'s two per-pixel clamps and the tightened `Begin()` bound that replaces them were independently re-derived on this branch before the overlap was noticed, and have been dropped again: the perf branch's version predates this work and carries A/B measurements, and the same change should not exist on two branches.

## `CIccMBB::Cleanup()` — the same shape one level up

`Cleanup()` clamped its delete loops to 16 "so a corrupted channel count can never walk past the allocation". The reasoning is inverted: `NewCurvesA/B/M` allocate the curve-pointer arrays to `m_nInput`/`m_nOutput` themselves, so a count above 16 never overran the allocation — the clamp **leaked** entries 16..n-1, silently, from a destructor.

`CIccMBB::Init()` now returns `bool` and refuses either count outside 1..16 — the bound the object already depended on everywhere else, since `SetCLUT()` requires a CLUT whose dimensionality matches `m_nInput` and `CIccCLUT::Init()` caps that at 16. It checks *before* calling `Cleanup()`, so a refused call leaves the object untouched rather than half-torn-down. `Cleanup()` then frees exactly what was allocated, its branches mirroring the allocators' `IsInputMatrix()`/`IsInputB()` selection (the two are the same predicate). Nothing loaded from a profile is newly refused: mAB/lut8/lut16 reads reject above 15, and both the XML and JSON MBB parsers bound theirs at 15 — and now check the result.

## Tests

Three regression binaries under `.github/ci/regression/`, registered above the file-scope `if(WIN32)` block in `Build/Cmake/Testing/CMakeLists.txt`:

- `spectral-clut-channel-count-bound.cpp` — the binary reader and the API. The truncating counts, the out-of-range counts (pinned so the incidental `GetData(0)` coupling cannot be broken silently), the `NewCLUT()` contract, and the `Begin()` checks via `CIccMpeCLUT`, whose `Begin()` ignores `pMPE` and so returns a clean verdict on the CLUT alone.
- `spectral-clut-xml-channel-mismatch.cpp` — drives the real libxml2 parser. Asserts the parser either refuses a truncating count or produces an element whose counts agree, written so it does not depend on which layer holds the line.
- `clut-apply-guard-retirement.cpp` — pins the behaviour justifying each removal. Compares `Interp3dTetra` against `Interp3d` at grid corners (where the two must agree exactly, so a skipped write is unmissable) across output counts spanning the old threshold, exercises `InterpND` either side of it, pins that `Begin()` is now what refuses, and covers the `CIccMBB::Init()` bound.

Red-green verified per guard, each disabled independently:

| Guard disabled | Failing assertion |
|---|---|
| `Read()` `> 16` bound | four truncation assertions |
| `NewCLUT()` `Init()` check | four propagation assertions |
| `icCLutFromXml()` bound | `parsed=true declared=257 clutDim=1` |
| `GetInputDim()` comparison | `Begin() refuses declared 259 over a three-dimensional CLUT` |
| `Init()` skipped entirely | `Begin() refuses a CLUT that was never Init()ed` |
| `Interp3dTetra` guard restored | six assertions at `nOut=17`/`20`, with `nOut=3`/`16` staying green |

`ctest --label-exclude known-red`: **132/132**, three of which are added here. Each commit was built and tested independently, so bisect stays sound.

> Build note: the regression binaries are `EXCLUDE_FROM_ALL` and only build via the `build-test-binaries` target. `cmake --build --config Release` alone leaves them stale, which produces SEGFAULTs and heap corruption in unrelated tests — build both targets, or use `check`.

## Merge order

`#2207` and `#2217` are merged. The one branch still outstanding is `perf/hoist-hardening-guards`, which conflicts here in `IccTagLut.{cpp,h}`, `IccCmm.cpp`, `IccMpeBasic.cpp` and `IccMpeSpectral.cpp` — `CIccCLUT::Begin()`'s signature is the hunk needing care.

**This should land first.** That branch deferred A1/A2 pending exactly the `Begin()` → `bool` change made here, so rebasing it afterwards lets it drop the deferral rather than carry it. A companion commit on that branch corrects its results doc, which described the per-pixel guards as "the only guard that works" on the strength of the same `Read()`-only analysis corrected above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
