### PR TITLE
perf(apply): retire per-pixel guards Begin() already establishes, and record what the review measured

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,7 @@ RUN apt-get update \
     libtiff-tools=4.7.0-3ubuntu5 \
     liblzma-dev=5.8.3-1 \
     libpng-dev=1.6.57-1 \
-    libssl-dev=3.5.5-1ubuntu3.3 \
+    libssl-dev=3.5.5-1ubuntu3.4 \
     libtiff-dev=4.7.0-3ubuntu5 \
     libwxgtk3.2-dev=3.2.9+dfsg-1 \
     zlib1g=1:1.3.dfsg+really1.3.1-1ubuntu3 \
@@ -69,7 +69,7 @@ RUN apt-get update \
     make=4.4.1-3 \
     nano=8.7.1-1ubuntu0.1 \
     nlohmann-json3-dev=3.12.0.really.3.12.0.really.3.11.3-3build1 \
-    openssl-provider-legacy=3.5.5-1ubuntu3.3 \
+    openssl-provider-legacy=3.5.5-1ubuntu3.4 \
     pkg-config=2.5.1-4 \
     python3=3.14.3-0ubuntu2 \
     python3-dev=3.14.3-0ubuntu2 \

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -7139,8 +7139,20 @@ icStatusCMM CIccXformNDLut::Begin()
   // m_nInput/m_nOutput). Assert that bound explicitly and reject an out-of-range
   // count as an invalid LUT so the per-channel curve walks can never be driven past
   // those arrays even if the count reached this object corrupted.
-  const int kMaxLutInputChannels = 256;
-  if (m_nNumInput < 0 || m_nNumInput >= kMaxLutInputChannels)
+  // Bound is 16, not 256. Apply() copies the source into a fixed icFloatNumber
+  // Pixel[16], so a tag declaring more input channels than that cannot be applied
+  // correctly no matter what: the previous 256 bound let such a tag through and
+  // Apply() then clamped the count to 16 per pixel, silently truncating the
+  // transform rather than reporting it. Refusing it here removes both per-pixel
+  // clamps and turns quiet wrong colour into icCmmStatInvalidLut.
+  //
+  // 16 is also the ceiling the format allows: icMaxChannels, which CIccCLUT::Init
+  // enforces on load (see the CWE-674 note at IccTagLut.cpp:2182).
+  const int kMaxLutInputChannels = 16;
+  if (m_nNumInput < 0 || m_nNumInput > kMaxLutInputChannels)
+    return icCmmStatInvalidLut;
+
+  if (m_pTag->m_nOutput > kMaxLutInputChannels)
     return icCmmStatInvalidLut;
 
   m_ApplyCurvePtrA = m_ApplyCurvePtrB = m_ApplyCurvePtrM = NULL;
@@ -7343,8 +7355,8 @@ void CIccXformNDLut::Apply(CIccApplyXform* pApply, icFloatNumber *DstPixel, cons
   if (m_bSrcPcsConversion)
     SrcPixel = CheckSrcAbs(pApply, SrcPixel);
 
-  // Prevent array bounds overflow - Pixel has 16 elements
-  int nInput = (m_nNumInput > 16) ? 16 : m_nNumInput;
+  // No clamp: Begin() refuses m_nNumInput above 16, which is what Pixel[] holds.
+  const int nInput = m_nNumInput;
 
   for (i=0; i<nInput; i++)
     Pixel[i] = SrcPixel[i];
@@ -7420,7 +7432,8 @@ void CIccXformNDLut::Apply(CIccApplyXform* pApply, icFloatNumber *DstPixel, cons
     }
   }
 
-  int nOutput = (m_pTag->m_nOutput > 16) ? 16 : m_pTag->m_nOutput;
+  // No clamp: Begin() refuses m_pTag->m_nOutput above 16 for the same reason.
+  const int nOutput = m_pTag->m_nOutput;
   for (i=0; i<nOutput; i++) {
     DstPixel[i] = Pixel[i];
   }

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -6455,6 +6455,11 @@ CIccXform3DLut::~CIccXform3DLut()
     }
   }
 
+  // Apply() zero-fills its scratch pixel above channel 3 only when nothing
+  // downstream will write those channels. Interp3d and Interp3dTetra write all
+  // m_nOutput channels on every path, so with a CLUT present the fill is dead.
+  m_bNeedScratchInit = (m_pTag->m_CLUT == NULL);
+
   return icCmmStatOk;
 }
 
@@ -6482,10 +6487,15 @@ void CIccXform3DLut::Apply(CIccApplyXform* pApply, icFloatNumber *DstPixel, cons
   Pixel[0] = SrcPixel[0];
   Pixel[1] = SrcPixel[1];
   Pixel[2] = SrcPixel[2];
-  
-  // make sure all output pixel values are initialized, just in case
-  for (i = 3; i < m_pTag->m_nOutput; ++i) {
-     Pixel[i] = 0.0;
+
+  // Only when nothing downstream will write these channels. With a CLUT present
+  // Interp3d/Interp3dTetra write all m_nOutput channels on every path, so this
+  // fill is dead -- and it ran unconditionally, on every pixel. Decided in
+  // Begin(); the original comment was "just in case", which is the case.
+  if (m_bNeedScratchInit) {
+    for (i = 3; i < m_pTag->m_nOutput; ++i) {
+      Pixel[i] = 0.0;
+    }
   }
 
   if (m_pTag->m_bInputMatrix) {

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -1356,6 +1356,11 @@ public:
   virtual LPIccCurve* ExtractInputCurves();
   virtual LPIccCurve* ExtractOutputCurves();
 protected:
+  /// Whether Apply() must zero its scratch pixel above channel 3. Set by Begin().
+  /// When a CLUT is present, Interp3d/Interp3dTetra write all m_nOutput channels
+  /// on every path, so the fill is dead; Apply() ran it unconditionally.
+  bool m_bNeedScratchInit;
+
 
   const CIccMBB *m_pTag;
 

--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -1216,8 +1216,11 @@ icFloatNumber CIccSampledCurveSegment::Apply(icFloatNumber v) const
   else if (v>m_endPoint)
     v=m_endPoint;
 
+  // No isfinite guard: v is clamped into [m_startPoint, m_endPoint] above, and
+  // Begin() refuses a zero span (m_endPoint-m_startPoint == 0.0 returns false),
+  // so pos cannot be non-finite. The clamps stay -- they bound the index.
   icFloatNumber pos = (v-m_startPoint)/m_range * m_last;
-  if (!std::isfinite(pos) || pos<0.0f)
+  if (pos<0.0f)
     pos=0.0f;
   else if (pos>m_last)
     pos=m_last;
@@ -1843,8 +1846,10 @@ icFloatNumber CIccSingleSampledCurve::Apply(icFloatNumber v) const
     return m_hiSlope * v + m_hiIntercept;
   }
 
+  // No isfinite guard: v is inside [m_firstEntry, m_lastEntry] on this path, and
+  // Begin() refuses m_range == 0 and m_last == 0, so pos cannot be non-finite.
   icFloatNumber pos = (v-m_firstEntry)/m_range * m_last;
-  if (!std::isfinite(pos) || pos<0.0f)
+  if (pos<0.0f)
     pos=0.0f;
   else if (pos>m_last)
     pos=m_last;
@@ -2487,8 +2492,10 @@ icFloatNumber CIccSampledCalculatorCurve::Apply(icFloatNumber v) const
     return m_hiSlope * v + m_hiIntercept;
   }
 
+  // No isfinite guard: same argument as CIccSingleSampledCurve::Apply -- v is
+  // inside the sampled range here and Begin() refuses a zero range.
   icFloatNumber pos = (v - m_firstEntry) / m_range * m_last;
-  if (!std::isfinite(pos) || pos<0.0f)
+  if (pos<0.0f)
     pos=0.0f;
   else if (pos>m_last)
     pos=m_last;
@@ -4217,11 +4224,11 @@ bool CIccToneMapFunc::Begin()
 
 icFloatNumber CIccToneMapFunc::Apply(icFloatNumber lumValue, icFloatNumber pixelValue) const
 {
-  if (!m_nFunctionType && m_params) {
-    return m_params[0] * lumValue * (pixelValue + m_params[1]) + m_params[2];
-  }
-
-  return 0;
+  // No function-type or null-parameter test: Begin() returns false unless
+  // m_nFunctionType is 0 and m_params is non-null with at least NumArgs()
+  // entries, and a tone map whose Begin() failed is never applied. This ran once
+  // per output channel per pixel to re-establish both.
+  return m_params[0] * lumValue * (pixelValue + m_params[1]) + m_params[2];
 }
 
 icValidateStatus CIccToneMapFunc::Validate(std::string& sReport, int /* nVerboseness */) const
@@ -6400,11 +6407,18 @@ bool CIccMpeCAM::Write(CIccIO *pIO)
 
 bool CIccMpeCAM::Begin(icElemInterp /* nInterp */, CIccTagMultiProcessElement * /* pMPE */ )
 {
-  if (m_pCAM) {
-    icFloatNumber surround = m_pCAM->GetParameter_C();
-    return std::isfinite((double)surround) && surround >= 0.0f && surround <= 1.0f;
-  }
-  return false;
+  if (!m_pCAM)
+    return false;
+
+  // Moved here from CIccMpeJabToXYZ::Apply and CIccMpeXYZToJab::Apply, which each
+  // re-tested it on every pixel. Both convert through a three-component CAM, so
+  // any other channel count is an element this class cannot apply; refusing it
+  // here is what lets Apply() run unguarded.
+  if (m_nInputChannels != 3 || m_nOutputChannels != 3)
+    return false;
+
+  icFloatNumber surround = m_pCAM->GetParameter_C();
+  return std::isfinite((double)surround) && surround >= 0.0f && surround <= 1.0f;
 }
 
 void CIccMpeCAM::SetCAM(CIccCamConverter *pCAM)
@@ -6532,16 +6546,10 @@ CIccMpeJabToXYZ::~CIccMpeJabToXYZ()
 
 void CIccMpeJabToXYZ::Apply(CIccApplyMpe * /* pApply */, icFloatNumber *dstPixel, const icFloatNumber *srcPixel) const
 {
-  if (!dstPixel || !srcPixel)
-    return;
-
-  if (!m_pCAM || m_nInputChannels != 3 || m_nOutputChannels != 3) {
-    if (m_nOutputChannels > 0 && m_nOutputChannels <= 3) {
-      memset(dstPixel, 0, m_nOutputChannels * sizeof(icFloatNumber));
-    }
-    return;
-  }
-
+  // No guards: CIccMpeCAM::Begin() refuses a null m_pCAM and a channel count
+  // other than 3, and an element whose Begin() failed is never applied. The
+  // buffers come from the caller's own storage, so they cannot be null. All of
+  // this was re-established on every pixel.
   m_pCAM->JabToXYZ(srcPixel, dstPixel, 1);
 }
 
@@ -6598,16 +6606,10 @@ CIccMpeXYZToJab::~CIccMpeXYZToJab()
 
 void CIccMpeXYZToJab::Apply(CIccApplyMpe * /* pApply */, icFloatNumber *dstPixel, const icFloatNumber *srcPixel) const
 {
-  if (!dstPixel || !srcPixel)
-    return;
-
-  if (!m_pCAM || m_nInputChannels != 3 || m_nOutputChannels != 3) {
-    if (m_nOutputChannels > 0 && m_nOutputChannels <= 3) {
-      memset(dstPixel, 0, m_nOutputChannels * sizeof(icFloatNumber));
-    }
-    return;
-  }
-
+  // No guards: CIccMpeCAM::Begin() refuses a null m_pCAM and a channel count
+  // other than 3, and an element whose Begin() failed is never applied. The
+  // buffers come from the caller's own storage, so they cannot be null. All of
+  // this was re-established on every pixel.
   m_pCAM->XYZToJab(srcPixel, dstPixel, 1);
 }
 

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -3842,19 +3842,27 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
   os.pixel = pApply->GetInput();
   os.output = pApply->GetOutput();
   os.nOps = nOps;
-  
-  // Defensive measure - this happens only in overflow/underflow situations.
-  // But it can happen from multiple calling locations, and it isn't easy to check them all.
-  if (nOps > 0x80000000UL)
-    return false;
+
+  // Read the debugger hook once. It is a file-static pointer, so the compiler
+  // must otherwise reload it after every Exec() that might have stored to it --
+  // twice per opcode per pixel, in the tightest loop in the library. It cannot
+  // legitimately change mid-apply: IIccCalcDebugger::SetDebugger is a setup call.
+  IIccCalcDebugger * const pDebugger = g_pDebugger;
+
+  // The former "if (nOps > 0x80000000UL) return false;" guard is gone. Read()
+  // rejects m_nOps at or above MAX_CALC_ELEMENTS (65536, IccMpeCalc.h:107) and
+  // sizes m_Op[] to the accepted count, and every recursive call below passes a
+  // sub-range of that, so the bound was unreachable by four orders of magnitude.
+  // It also fired once per recursion, not once per apply, so nested conditionals
+  // multiplied it.
 
   icUInt32Number pc = 0;
   while (pc < os.nOps) {
     os.idx = pc;
     op = &ops[os.idx];
 
-    if (g_pDebugger)
-      g_pDebugger->BeforeOp(op, os, ops);
+    if (pDebugger)
+      pDebugger->BeforeOp(op, os, ops);
 
     if (op->sig==icSigIfOp) {
       icFloatNumber a1;
@@ -3994,12 +4002,14 @@ bool CIccCalculatorFunc::ApplySequence(CIccApplyMpeCalculator *pApply, icUInt32N
         return false;
     }
 
-    if (g_pDebugger) {
-      g_pDebugger->AfterOp(op, os, ops);
+    if (pDebugger) {
+      pDebugger->AfterOp(op, os, ops);
     }
 
-    if (!icCalcAddUInt32(os.idx, 1, pc))
-      return false;
+    // Plain increment: os.idx is bounded by nOps, which Read() caps at
+    // MAX_CALC_ELEMENTS, so the checked add could not overflow. It ran once per
+    // opcode per pixel to prove that.
+    pc = os.idx + 1;
   }
   return true;
 }

--- a/IccProfLib/IccMpeSpectral.cpp
+++ b/IccProfLib/IccMpeSpectral.cpp
@@ -678,17 +678,13 @@ bool CIccMpeEmissionMatrix::Begin(icElemInterp /* nInterp */, CIccTagMultiProces
  ******************************************************************************/
 void CIccMpeEmissionMatrix::Apply(CIccApplyMpe * /* pApply */, icFloatNumber *dstPixel, const icFloatNumber *srcPixel) const
 {
-  if (m_pApplyMtx) {
-    m_pApplyMtx->VectorMult(dstPixel, srcPixel);
-    dstPixel[0] += m_xyzOffset[0];
-    dstPixel[1] += m_xyzOffset[1];
-    dstPixel[2] += m_xyzOffset[2];
-  }
-  else {
-    dstPixel[0] = 0;
-    dstPixel[1] = 0;
-    dstPixel[2] = 0;
-  }
+  // No null test: Begin() returns false when m_pApplyMtx could not be built, and
+  // an element whose Begin() failed is never applied. The former else branch
+  // zeroed the output for a state that cannot reach here.
+  m_pApplyMtx->VectorMult(dstPixel, srcPixel);
+  dstPixel[0] += m_xyzOffset[0];
+  dstPixel[1] += m_xyzOffset[1];
+  dstPixel[2] += m_xyzOffset[2];
 }
 
 
@@ -761,18 +757,12 @@ bool CIccMpeInvEmissionMatrix::Begin(icElemInterp /* nInterp */, CIccTagMultiPro
  ******************************************************************************/
 void CIccMpeInvEmissionMatrix::Apply(CIccApplyMpe * /* pApply */, icFloatNumber *dstPixel, const icFloatNumber *srcPixel) const
 {
-  if (m_pApplyMtx) {
-    icFloatNumber xyz[3];
-    xyz[0] = srcPixel[0] - m_xyzOffset[0];
-    xyz[1] = srcPixel[1] - m_xyzOffset[1];
-    xyz[2] = srcPixel[2] - m_xyzOffset[2];
-    m_pApplyMtx->VectorMult(dstPixel, xyz);
-  }
-  else {
-    dstPixel[0] = 0;
-    dstPixel[1] = 0;
-    dstPixel[2] = 0;
-  }
+  // No null test, for the same reason as CIccMpeEmissionMatrix::Apply above.
+  icFloatNumber xyz[3];
+  xyz[0] = srcPixel[0] - m_xyzOffset[0];
+  xyz[1] = srcPixel[1] - m_xyzOffset[1];
+  xyz[2] = srcPixel[2] - m_xyzOffset[2];
+  m_pApplyMtx->VectorMult(dstPixel, xyz);
 }
 
 /**

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -709,6 +709,27 @@ bool CIccTagCurve::IsIdentity()
 *  
 *****************************************************************************
 */
+/**
+****************************************************************************
+* Name: CIccTagCurve::Begin
+*
+* Purpose: Precomputes what Apply() would otherwise rederive per call.
+*
+*  m_nMaxIndex is the table's top index. m_fGamma decodes the single-entry form,
+*  where m_Curve[0] is a u8Fixed8Number holding the gamma: Apply() used to redo
+*  that decode on every call before handing the result to pow().
+*****************************************************************************
+*/
+void CIccTagCurve::Begin()
+{
+  m_nMaxIndex = m_nSize ? (icUInt16Number)(m_nSize - 1) : 0;
+
+  //Convert 0.0 to 1.0 float to 16bit and then convert from u8Fixed8Number
+  m_fGamma = (m_nSize == 1 && m_Curve)
+               ? (icFloatNumber)(m_Curve[0] * 65535.0 / 256.0)
+               : (icFloatNumber)1.0;
+}
+
 icFloatNumber CIccTagCurve::Apply(icFloatNumber v) const
 {
   if (std::isnan(v))
@@ -718,16 +739,19 @@ icFloatNumber CIccTagCurve::Apply(icFloatNumber v) const
   else if(v<0.0) v = 0.0;
   else if(v>1.0) v = 1.0;
 
-  icUInt32Number nIndex = static_cast<icUInt32Number>(v * m_nMaxIndex);
-
+  // The two degenerate table sizes are tested before nIndex is computed. They
+  // were tested after, so every call through a gamma curve or an empty curve
+  // paid a multiply and a cast whose result it then discarded.
   if (!m_nSize) {
     return v;
   }
   if (m_nSize==1) {
-    //Convert 0.0 to 1.0 float to 16bit and then convert from u8Fixed8Number
-    icFloatNumber dGamma = (icFloatNumber)(m_Curve[0] * 65535.0 / 256.0);
-    return (icFloatNumber)pow(v, dGamma);
+    // Gamma decoded once in Begin(); this rebuilt it from m_Curve[0] per call.
+    return (icFloatNumber)pow(v, m_fGamma);
   }
+
+  icUInt32Number nIndex = static_cast<icUInt32Number>(v * m_nMaxIndex);
+
   if (nIndex == m_nMaxIndex) {
     return m_Curve[nIndex];
   }
@@ -1925,6 +1949,7 @@ CIccCLUT::CIccCLUT(icUInt8Number nInputChannels, icUInt16Number nOutputChannels,
   memset(&m_nReserved2, 0 , sizeof(m_nReserved2));
 
   m_UnitClipFunc = ClutUnitClip;
+  m_nMaxDataOffset2d = 0;   // set by Begin() for the 2-input case
 }
 
 
@@ -1960,6 +1985,7 @@ CIccCLUT::CIccCLUT(const CIccCLUT &ICLUT)
   memcpy(m_pData, ICLUT.m_pData, num*sizeof(icFloatNumber));
 
   m_UnitClipFunc = ICLUT.m_UnitClipFunc;
+  m_nMaxDataOffset2d = ICLUT.m_nMaxDataOffset2d;
 }
 
 
@@ -1998,6 +2024,7 @@ CIccCLUT &CIccCLUT::operator=(const CIccCLUT &CLUTTag)
   memcpy(m_pData, CLUTTag.m_pData, num*sizeof(icFloatNumber));
 
   m_UnitClipFunc = CLUTTag.m_UnitClipFunc;
+  m_nMaxDataOffset2d = CLUTTag.m_nMaxDataOffset2d;
 
   return *this;
 }
@@ -2580,6 +2607,10 @@ bool CIccCLUT::Begin()
     m_nOffset[1] = n001 = m_DimSize[0];
     m_nOffset[2] = n010 = m_DimSize[1];
     m_nOffset[3] = n011 = n001 + n010;
+
+    // Ceiling for Interp2d's offset clamp; see there. Depends only on values
+    // fixed by this point, so Interp2d no longer recomputes it per pixel.
+    m_nMaxDataOffset2d = (int)NumPoints()*(int)m_nOutput - ((int)m_nOutput + (int)n011);
   }
   else if (m_nInput==3) {
     m_nOffset[0] = n000 = 0;

--- a/IccProfLib/IccTagLut.h
+++ b/IccProfLib/IccTagLut.h
@@ -159,7 +159,7 @@ public:
   bool SetSize(icUInt32Number nSize, icTagCurveSizeInit nSizeOpt=icInitZero);
   bool SetGamma(icFloatNumber gamma);
 
-  virtual void Begin() {m_nMaxIndex = m_nSize ? (icUInt16Number)(m_nSize - 1) : 0;}
+  virtual void Begin();
   virtual icFloatNumber Apply(icFloatNumber v) const;
   virtual icValidateStatus Validate(std::string sigPath, std::string &sReport, const CIccProfile* pProfile=NULL) const;
   virtual bool IsIdentity();
@@ -168,6 +168,10 @@ protected:
   icFloatNumber *m_Curve;
   icUInt32Number m_nSize;
   icUInt16Number m_nMaxIndex;
+
+  /// Gamma for the single-entry form, decoded once by Begin(). Apply() rebuilt it
+  /// from m_Curve[0] on every call before handing it to pow().
+  icFloatNumber m_fGamma;
 };
 
 /**
@@ -419,6 +423,11 @@ protected:
   void SubIterate(IIccCLUTExec* pExec, icUInt8Number nIndex, icUInt32Number nPos);
 
   icCLUTCLIPFUNC m_UnitClipFunc;
+
+  /// Ceiling for Interp2d's offset clamp, computed in Begin() from values fixed
+  /// by then. Interp2d recomputed it from NumPoints(), m_nOutput and n011 on
+  /// every pixel.
+  int m_nMaxDataOffset2d;
 
   icUInt8Number m_nReserved2[3];
   

--- a/docs/superpowers/results/2026-08-20-tier-ab-results.md
+++ b/docs/superpowers/results/2026-08-20-tier-ab-results.md
@@ -61,36 +61,61 @@ those fixtures use `curveType` with a single u8Fixed8 entry, so every call took
 the gamma path that was re-decoding `m_Curve[0]` *and* computing an `nIndex` it
 then discarded. Nothing else on this branch is individually resolvable.
 
-## A1 and A2 were not done, and must not be
+## A1 and A2 were not done, and were correct not to be here
 
-An earlier draft of this document described these as bounds "duplicated from
-`Begin()`", and justified leaving them on cost grounds: removing them needs
-`CIccCLUT::Begin()` to be able to refuse, it returns `void`, and widening it to
-`bool` means touching ten call sites of a public API for two comparisons that
-tier C showed measure nothing.
+Two drafts of this section have now been wrong in opposite directions, and the
+reason is worth recording, because both errors came from reasoning about
+reachability without measuring it.
 
-**That framing is wrong. They are not duplicates -- they are the only guard that
-works,** and removing them would open a hole rather than tidy one. The chain
-above them leaks at every step:
+The first draft called these bounds "duplicated from `Begin()`" and justified
+leaving them on cost grounds. The second called them **"the only guard that
+works"** on the strength of a chain of unchecked returns leading from
+`CIccMpeSpectralCLUT::Read` down to the interpolators.
 
-- `CIccMpeSpectralCLUT::Read` reads `m_nInputChannels` as a 16-bit value from the
-  profile and validates only `< 1`. There is no upper bound, and the value is then
-  narrowed to `icUInt8Number` when the CLUT is constructed, so a declared 17 stays
-  17 and a declared 256 becomes 0. `CIccMpeCLUT::Read` in `IccMpeBasic.cpp` does
-  bound it; the spectral path appears not to.
-- `CIccCLUT::Init` rejects `m_nInput > 16` and returns false, but six of its eight
-  call sites discard the return. Only the two lut8/lut16 read paths check it.
-- `CIccCLUT::Begin` bails with a bare `return;` on the same condition, before
-  filling `m_MaxGridPoint`, setting `m_nNodes`, or allocating `m_nOffset`, leaving
-  the object unusable with no way for any of its nine callers to know.
+The chain was real, and every link in it was described accurately. Its
+*conclusion* was not. That was established by probing the library rather than
+reading it, in the branch that fixed the underlying defect
+(`fix/clut-channel-count-validation`):
 
-So the per-pixel `if (m_nInput > 16) return;` in `InterpND`, and the matching
-`m_nOutput` guard in `Interp3dTetra`, are what actually stop a malformed CLUT
-reaching the interpolation. They are load-bearing.
+- **`m_nInput > 16` never reached a CLUT through any read path.** Both element
+  readers follow the discarded `Init()` with `pData = m_pCLUT->GetData(0); if
+  (!pData) return false;`. `Init()` returns before the `delete[]`/reallocation
+  when it refuses, the constructor had already set `m_pData` to NULL, and
+  `GetData(0)` is `&m_pData[0]`. So the dropped return was caught by accident.
+  Declared counts of 17, 255, 256 and 272 all made `Read()` return false.
+- Which means the per-pixel `if (m_nInput > 16) return;` in `InterpND` and the
+  `m_nOutput` guard in `Interp3dTetra` were **not reachable from a malformed
+  profile either**. They were neither duplicates nor load-bearing. They were
+  unreachable, and the honest reason to leave them alone was that no one had
+  established which.
+- The defect that *was* reachable is the narrowing cast's **truncation**, not its
+  overflow: a declared 257 became a one-dimensional CLUT under an element still
+  reporting 257 input channels, and 259/260/272 did the same onto 3, 4 and 16.
+- `CIccCLUT::Init` had six of **ten** call sites discarding its return, not six of
+  eight. `CIccMpeExtCLUT::Read` and `CIccCLUT::Read` check it too.
 
-They can only be retired after the read-path bound and the discarded `Init()`
-returns are fixed, and that is a correctness change that does not belong in a
-performance branch. It is being handled separately.
+The fix landed on that branch: the count is bounded before the cast in every
+parser (`Read`, `icCLutFromXml`, `icCLUTFromJson`), all ten `Init()` returns are
+acted on, `CIccCLUT::Begin()` returns `bool` and refuses a CLUT that `Init()`
+never made usable, and the MPE `Begin()` overrides check the element's declared
+count against its CLUT's dimensionality.
+
+**With that in place the per-pixel guards became retireable** -- not because they
+were duplicates, but because the invariant they were the last expression of is
+now established once, at `Begin()`, on every construction path. They have since
+been retired there, as a correctness change rather than a performance one: tier C
+measured them at nothing, and one of the two turned out to be a defect. The
+`m_nOutput > 16` test in `Interp3dTetra` was justified on the claim that "valid
+LUT profiles cap output channels at <=16", which is false -- `m_nOutput` is an
+`icUInt16Number` precisely because MPE CLUT elements need more, and every sibling
+interpolator writes `m_nOutput` values unbounded. For a legal 3-input CLUT with
+>=17 outputs it returned without writing anything at all.
+
+The lasting point for this document: A1/A2 were correctly left out of a
+performance branch, but the reasoning offered for that in both earlier drafts was
+guesswork. "This guard is load-bearing" and "this guard is redundant" are the
+same claim about reachability, and neither is knowable by reading the call chain
+alone.
 
 ## Tier B has essentially nothing to offer
 

--- a/docs/superpowers/results/2026-08-20-tier-ab-results.md
+++ b/docs/superpowers/results/2026-08-20-tier-ab-results.md
@@ -1,0 +1,146 @@
+# Tier A/B results: retiring the hardening-era per-pixel guards
+
+Date: 2026-08-20
+Branch: `perf/hoist-hardening-guards`
+Audit: the 15 tier-A and tier-B findings
+Prior results: `2026-08-20-tier-c-results.md`
+
+This is the branch that answers the original question directly: **did the
+stability and vulnerability work cost measurable throughput?**
+
+## Answer
+
+**Almost none of it did.** Of the guards the hardening commits added to per-pixel
+code, the measurable cost is close to zero. The wins on this branch come from two
+things that are not guards at all: a gamma decode that was being redone per call,
+and a zero-fill that was mostly dead.
+
+That is worth stating plainly because it was the premise of the whole review. The
+guards are individually a compare against a member or a null test, and on this
+hardware those do not show up.
+
+## Results
+
+| finding | what it was | outcome |
+|---|---|---|
+| A3 | NDLut per-pixel min-with-16 clamps | done, also a correctness fix |
+| A4 | three unreachable `isfinite(pos)` guards | done |
+| A5 | `Interp2d` offset ceiling recomputed per pixel | done |
+| A6 | `CIccTagCurve::Apply` ordering + gamma decode | **done, the win** |
+| A7 | `CIccToneMapFunc::Apply` re-testing `Begin()`'s contract | done |
+| A8 | CAM elements re-testing pointers and channel counts | done, check moved to `Begin()` |
+| A9 | emission matrices re-testing an allocation | done |
+| A10 | `CIccXform3DLut` scratch zero-fill | done, gated |
+| A1, A2 | `Interp3dTetra` / `InterpND` channel bounds | **not done, and must not be** |
+| B2, B3, B4 | interpreter loop overhead | done, measured nothing |
+| B1 | Calc if/select offset re-validation | **not done** |
+| B5 | Calc operand stack representation | **not done** |
+
+### Measured
+
+Two runs of best-of-8 interleaved A/B (method in the tier-C results):
+
+| case | run 1 | run 2 | re-verified | why |
+|---|---|---|---|---|
+| `monochrome` | +6.2% | +16.6% | **+10.5%** | single-entry gamma curve |
+| `mono-lab` | +3.1% | +9.9% | **+11.1%** | same, plus a CLUT |
+| `matrix-trc` | +3.6% | +4.4% | **+3.0%** | TRC curves |
+| all others | within noise | | within noise | |
+
+The third column is a re-measurement taken after this work was rebased onto a
+master roughly forty commits newer, against a reference built from that same
+master. It matters because the harness had a defect in the interval --
+`iccBenchApply`'s profile-root resolution was fixed in #2256, which had made the
+benchmark vacuous on Windows, the platform all of these numbers were taken on.
+The re-measurement was done specifically to check whether that invalidated them.
+It did not: the same three cases move, in the same direction, by comparable
+amounts, and every checksum is identical to the master reference.
+
+The wins land exactly on the curve-dominated cases, which is what A6 predicts:
+those fixtures use `curveType` with a single u8Fixed8 entry, so every call took
+the gamma path that was re-decoding `m_Curve[0]` *and* computing an `nIndex` it
+then discarded. Nothing else on this branch is individually resolvable.
+
+## A1 and A2 were not done, and must not be
+
+An earlier draft of this document described these as bounds "duplicated from
+`Begin()`", and justified leaving them on cost grounds: removing them needs
+`CIccCLUT::Begin()` to be able to refuse, it returns `void`, and widening it to
+`bool` means touching ten call sites of a public API for two comparisons that
+tier C showed measure nothing.
+
+**That framing is wrong. They are not duplicates -- they are the only guard that
+works,** and removing them would open a hole rather than tidy one. The chain
+above them leaks at every step:
+
+- `CIccMpeSpectralCLUT::Read` reads `m_nInputChannels` as a 16-bit value from the
+  profile and validates only `< 1`. There is no upper bound, and the value is then
+  narrowed to `icUInt8Number` when the CLUT is constructed, so a declared 17 stays
+  17 and a declared 256 becomes 0. `CIccMpeCLUT::Read` in `IccMpeBasic.cpp` does
+  bound it; the spectral path appears not to.
+- `CIccCLUT::Init` rejects `m_nInput > 16` and returns false, but six of its eight
+  call sites discard the return. Only the two lut8/lut16 read paths check it.
+- `CIccCLUT::Begin` bails with a bare `return;` on the same condition, before
+  filling `m_MaxGridPoint`, setting `m_nNodes`, or allocating `m_nOffset`, leaving
+  the object unusable with no way for any of its nine callers to know.
+
+So the per-pixel `if (m_nInput > 16) return;` in `InterpND`, and the matching
+`m_nOutput` guard in `Interp3dTetra`, are what actually stop a malformed CLUT
+reaching the interpolation. They are load-bearing.
+
+They can only be retired after the read-path bound and the discarded `Init()`
+returns are fixed, and that is a correctness change that does not belong in a
+performance branch. It is being handled separately.
+
+## Tier B has essentially nothing to offer
+
+B2/B3/B4 were done: the debugger hook is read once instead of twice per opcode
+(it is a file-static, so the compiler had to reload it after every `Exec`), and
+two unreachable arithmetic guards are gone. **`mpe-calc` moved −1.4%** -- nothing,
+on the case wholly dominated by that loop.
+
+Attribution explains why, and retires B1 and B5 with it:
+
+- The first `Mpe` is **98%** of the `mpe-calc` chain.
+- That calculator has **zero branch ops**. B1 -- re-validating if/select offsets
+  per pixel, which the audit called the highest-value target in tier B -- has
+  nothing to act on.
+- Its sub-elements are CurveSets of FormulaSegments with exponents 1.0 and 2.4,
+  so `CIccFormulaCurveSegment::Apply` calls `pow()` per channel per pixel. At
+  0.14 Mpx/s the cost is irreducible transcendental math.
+
+That also explains a result from the previous branch: the CLUT clamp work moved
+`mpe-calc` 0.0%. It is not CLUT-bound or interpreter-bound. It is `pow`-bound.
+
+B5's operand-stack traffic is noise beside that, and replacing `std::vector` with
+a raw buffer would mean removing underflow checks that a security reviewer would
+reasonably want kept, for no measurable return.
+
+**The audit called tier B the highest-value target in the review. That was wrong,
+and it was wrong for a measurable reason: it counted checked-arithmetic calls
+without asking what fraction of the runtime they represent.**
+
+## A3 is also a correctness fix
+
+`CIccXformNDLut::Begin()` bounded the input channel count at 256 while `Apply()`
+copies into a fixed `Pixel[16]`, so a tag declaring 17 to 255 channels was
+admitted and then silently truncated -- quietly wrong colour rather than an error.
+The bound is now 16, with a matching output check, which also lets both per-pixel
+clamps go.
+
+Nothing in the corpus is affected: the 11-, 17- and 18-channel profiles all
+resolve to `Mpe` xforms. `CIccXformNDLut` appears unreachable from the corpus
+entirely, so the clamp removal is unmeasured and the correctness change untested.
+
+## Process note: rebuild everything after a header change
+
+Adding a member to `CIccCLUT` changes `sizeof`, and building only the
+`iccBenchApply` target left sixty-odd regression binaries with object code
+compiled against the old header but linking the new DLL. The result was
+**16 failures, mostly SEGFAULTs and one heap corruption, across unrelated tests**
+-- and a wasted bisect concluding that A3 was at fault when it was not. A full
+rebuild gave 102/102 with the identical source.
+
+The failure mode is bad in both directions: it can invent failures, and it can
+just as easily hide real ones behind a spurious pass. Any CTest run that follows
+a header change and a partial build is not evidence of anything.


### PR DESCRIPTION
## Summary

The tier-A/B half of the apply-path performance review, plus the results document that answers the question the review was set up to ask: **did the stability and vulnerability hardening cost measurable throughput?**

Almost none of it did. The guards the hardening commits added to per-pixel code are individually a compare against a member or a null test, and on this hardware they do not show up at all. The wins on this branch come from two things that are **not** guards — a gamma decode being redone on every call to the library's hottest function, and a zero-fill that was dead whenever a CLUT was present.

## Measured

Two runs of best-of-8 interleaved A/B, re-verified after rebasing onto a master roughly forty commits newer:

| case | run 1 | run 2 | re-verified | why |
|---|---|---|---|---|
| `monochrome` | +6.2% | +16.6% | **+10.5%** | single-entry gamma curve |
| `mono-lab` | +3.1% | +9.9% | **+11.1%** | same, plus a CLUT |
| `matrix-trc` | +3.6% | +4.4% | **+3.0%** | TRC curves |
| all others | within noise | | within noise | |

The re-measurement matters because `iccBenchApply`'s profile-root resolution was fixed in #2256 during the interval, which had made the benchmark vacuous on Windows — the platform all these numbers were taken on. It did not invalidate them: the same three cases move, in the same direction, by comparable amounts, and every checksum is identical to the master reference.

The wins land exactly on the curve-dominated cases, which is what the `CIccTagCurve::Apply` change predicts — those fixtures use `curveType` with a single u8Fixed8 entry, so every call took the gamma path that was re-decoding `m_Curve[0]` *and* computing an `nIndex` it then discarded.

## What changed

- **A6, `CIccTagCurve::Apply`** — the hottest function in the library. Degenerate table sizes are tested before `nIndex` is computed rather than after, and the single-entry gamma is decoded once in `Begin()` instead of being rebuilt from `m_Curve[0]` on every call before going to `pow()`.
- **A4**, three sampled-curve `Apply`s: the `isfinite(pos)` guard is unreachable — `v` is already clamped into the sampled range and each class's `Begin()` refuses a zero span. The range clamps stay; they bound the index.
- **A7**, `CIccToneMapFunc::Apply`: `Begin()` already refuses unless the function type is 0 with enough params.
- **A8**, the two CAM elements: the channel-count check **moves to** `CIccMpeCAM::Begin()` rather than going away — `Begin()` previously refused only a null `m_pCAM`.
- **A9**, the two spectral emission matrices: `Begin()` returns false when the matrix could not be allocated and `CIccTagMultiProcessElement::Begin()` propagates that, so the null test and its zero-fill else branch were dead.
- **A5**, `Interp2d`'s offset ceiling, computed in `CIccCLUT::Begin()` from values fixed by then instead of two multiplies and two subtractions per pixel.
- **A3**, `CIccXformNDLut`: the `Begin()` bound tightens from 256 to 16 and gains an output check, which lets both per-pixel min-with-16 clamps go. Also a correctness fix — `Apply()` copies into a fixed `Pixel[16]`, so the old 256 bound admitted tags it could not apply and then silently truncated the transform.
- **B2/B3/B4**, the calculator: the debugger hook is read once instead of twice per opcode (it is a file-static, so the compiler had to reload it after every `Exec`), and two unreachable arithmetic guards are gone.

Every removal carries a comment saying whether its condition was decided by `Begin()` or was unreachable, so the argument can be re-derived rather than taken on trust.

## What was deliberately not done, and why

- **B1/B5.** `mpe-calc` moved −1.4% — nothing, on the case wholly dominated by that loop. Attribution explains it: the first `Mpe` is **98%** of the chain, that calculator has **zero branch ops** (so B1 has nothing to act on), and its sub-elements are CurveSets of FormulaSegments with exponents 1.0 and 2.4 — so `pow()` per channel per pixel. At 0.14 Mpx/s the cost is irreducible transcendental math, not interpreter overhead. That also explains why the previous branch's CLUT work moved `mpe-calc` 0.0%. **The audit called tier B the highest-value target in the review. That was wrong**, and wrong for a measurable reason: it counted checked-arithmetic call sites without asking what share of runtime they were.
- **A1/A2**, the per-pixel bounds in `InterpND` and `Interp3dTetra`. These need `CIccCLUT::Begin()` to be able to refuse, and it returned `void`. That prerequisite is supplied by **#2306**, which also retires them — as a correctness change rather than a performance one, since tier C measured them at nothing and one of the two turned out to be a defect.

## The results document

`docs/superpowers/results/2026-08-20-tier-ab-results.md` records the above, and also two things worth not repeating.

**A reasoning failure.** Two drafts of the A1/A2 section were wrong in opposite directions — the bounds were called "duplicated from `Begin()`", then "the only guard that works". Both were reasoning about reachability from the call chain rather than measuring it, and neither was true. Probing the library (during #2306) showed `m_nInput > 16` never reached a CLUT through any read path: the element readers turn a failed `Init()` into a failed `Read()` via their `GetData(0)` NULL checks. The guards were unreachable, not load-bearing. The final commit here corrects that section with the measured evidence.

**A process failure.** Adding a member to `CIccCLUT` changes `sizeof`, and building only the benchmark target left sixty-odd regression binaries compiled against the old header but linked against the new DLL. That produced 16 failures — mostly SEGFAULTs plus one heap corruption — across unrelated tests, and a bisect that wrongly blamed A3. A full rebuild gave a clean suite on identical source. The failure mode invents failures and can equally hide real ones.

## Verification

`ctest --label-exclude known-red`: **129/129**, from a clean worktree on current master. All nine benchmark checksums identical to the master reference.

## Merge order

Conflicts with **#2306** in `IccTagLut.{cpp,h}`, `IccCmm.cpp`, `IccMpeBasic.cpp` and `IccMpeSpectral.cpp`. **#2306 should land first** — it makes `CIccCLUT::Begin()` return `bool`, which is the prerequisite this branch recorded as blocking A1/A2. Rebasing this branch afterwards resolves those hunks toward the version #2306 establishes, and lets the A1/A2 deferral be dropped rather than carried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
