### PR TITLE
fix(bpc): estimate black through the tag family the xform actually uses

### DIFF
--- a/.github/ci/regression/bpc-d2b-tag-family.cpp
+++ b/.github/ci/regression/bpc-d2b-tag-family.cpp
@@ -1,0 +1,314 @@
+/*
+    File:       bpc-d2b-tag-family.cpp
+
+    Contains:   CTest helper pinning that CIccApplyBPC estimates the black
+                point through the same tag family the xform being adjusted was
+                built from.
+
+    CIccXform::Create() picks between the AToBx/BToAx colorimetric tags and the
+    DToBx/BToDx MPE tags, and a caller can force the colorimetric ones by
+    passing bUseD2BxB2DxTags=false to AddXform().  CIccApplyBPC rebuilds its own
+    cmm objects to find black, and it used to hardcode that choice as
+    "version >= V5 ? colorimetric : MPE" instead of asking the xform.  For a v4
+    profile carrying both families that is backwards: the transform applies
+    BToAx while black is measured through BToDx, so the scale and offset BPC
+    installs come from a pipeline that is never applied.
+
+    Only the B-side is affected.  Create()'s input branch gates its DToBx lookup
+    on spectralPCS or version >= V5, so a plain v4 profile resolves device->PCS
+    through AToBx whatever the flag says; the output branch has no such gate and
+    follows the flag alone.
+
+    The fixture below is a v4.3 CMYK output profile whose BToA0 and BToD0 tags
+    return deliberately different inks, and whose AToB0 turns those inks into
+    different L* values.  Applying a pixel with BPC enabled must therefore
+    depend on bUseD2BxB2DxTags.  Before the fix both settings produced identical
+    output because the flag never reached CIccApplyBPC.
+*/
+
+#include "IccCmm.h"
+#include "IccDefs.h"
+#include "IccProfile.h"
+#include "IccTag.h"
+#include "IccTagBasic.h"
+#include "IccTagLut.h"
+#include "IccTagMPE.h"
+#include "IccMpeBasic.h"
+#include "IccApplyBPC.h"
+
+#include <cmath>
+#include <cstdio>
+
+static int g_failures = 0;
+
+static void check(bool cond, const char* msg)
+{
+  if (cond) {
+    std::printf("ok:   %s\n", msg);
+  }
+  else {
+    std::printf("FAIL: %s\n", msg);
+    ++g_failures;
+  }
+}
+
+// The two B-side tags hand back these cyan values.  The AToB0 ramp below turns
+// them into L* 40 and L* 5, so both survive calcSrcBlackPoint()'s L*<=50 clip
+// as distinct numbers -- a pair that both clipped would make the test toothless.
+static const icFloatNumber kCyanFromBToA0 = 0.60f;
+static const icFloatNumber kCyanFromBToD0 = 0.95f;
+
+static void fill_identity_curves(LPIccCurve* curves, int n)
+{
+  for (int i = 0; i < n; i++) {
+    CIccTagCurve* c = new CIccTagCurve();
+    c->SetSize(2, icInitIdentity);
+    curves[i] = c;
+  }
+}
+
+// CIccTagLut16 keeps the matrix on the input side of the CLUT, so NewCurvesB()
+// sizes to the input channels and NewCurvesA() to the output channels.
+static bool fill_mbb_curves(CIccTagLut16* pLut, int nIn, int nOut)
+{
+  LPIccCurve* aCurves = pLut->NewCurvesA();
+  LPIccCurve* bCurves = pLut->NewCurvesB();
+  if (!aCurves || !bCurves)
+    return false;
+
+  fill_identity_curves(bCurves, nIn);
+  fill_identity_curves(aCurves, nOut);
+  return true;
+}
+
+// CMYK -> Lab.  L* falls from 100 at cyan 0 to 0 at cyan 1, so a black point
+// measured through a B-side tag returning more cyan lands at a lower L*.
+// a* and b* are held at the 0 encoding.
+static CIccTagLut16* make_atob0()
+{
+  CIccTagLut16* pLut = new CIccTagLut16;
+  pLut->Init(4, 3);
+  pLut->SetColorSpaces(icSigCmykData, icSigLabData);
+
+  if (!fill_mbb_curves(pLut, 4, 3)) {
+    delete pLut;
+    return NULL;
+  }
+
+  icUInt8Number grid[4] = {2, 2, 2, 2};
+  if (!pLut->NewCLUT(grid, 2)) {
+    delete pLut;
+    return NULL;
+  }
+
+  CIccCLUT* clut = pLut->GetCLUT();
+  icFloatNumber* data = clut->GetData(0);
+  const icUInt32Number nNodes = clut->NumPoints();
+  for (icUInt32Number n = 0; n < nNodes; n++) {
+    // The first channel varies slowest over the 2x2x2x2 grid.
+    const icFloatNumber cyan = (n & 0x8) ? 1.0f : 0.0f;
+    data[n * 3 + 0] = 1.0f - cyan;          // L* encoded 0..1 for 0..100
+    data[n * 3 + 1] = 128.0f / 255.0f;      // a* == 0
+    data[n * 3 + 2] = 128.0f / 255.0f;      // b* == 0
+  }
+
+  return pLut;
+}
+
+// Lab -> CMYK returning a constant ink, for the legacy BToA0 tag.
+static CIccTagLut16* make_btoa0(icFloatNumber cyan)
+{
+  CIccTagLut16* pLut = new CIccTagLut16;
+  pLut->Init(3, 4);
+  pLut->SetColorSpaces(icSigLabData, icSigCmykData);
+
+  if (!fill_mbb_curves(pLut, 3, 4)) {
+    delete pLut;
+    return NULL;
+  }
+
+  icUInt8Number grid[3] = {2, 2, 2};
+  if (!pLut->NewCLUT(grid, 2)) {
+    delete pLut;
+    return NULL;
+  }
+
+  CIccCLUT* clut = pLut->GetCLUT();
+  icFloatNumber* data = clut->GetData(0);
+  const icUInt32Number nNodes = clut->NumPoints();
+  for (icUInt32Number n = 0; n < nNodes; n++) {
+    data[n * 4 + 0] = cyan;
+    data[n * 4 + 1] = 0.0f;
+    data[n * 4 + 2] = 0.0f;
+    data[n * 4 + 3] = 0.0f;
+  }
+
+  return pLut;
+}
+
+// Lab -> CMYK as an MPE tag, returning a different constant ink.  A 3->4 matrix
+// with zero coefficients and a constant column is the smallest element that
+// changes the channel count and ignores its input.
+static CIccTagMultiProcessElement* make_btod0(icFloatNumber cyan)
+{
+  CIccTagMultiProcessElement* pTag = new CIccTagMultiProcessElement;
+  pTag->SetChannels(3, 4);
+
+  CIccMpeMatrix* pMtx = new CIccMpeMatrix;
+  if (!pMtx->SetSize(3, 4, true)) {
+    delete pMtx;
+    delete pTag;
+    return NULL;
+  }
+
+  icFloatNumber* m = pMtx->GetMatrix();
+  for (int i = 0; i < 3 * 4; i++)
+    m[i] = 0.0f;
+
+  icFloatNumber* k = pMtx->GetConstants();
+  k[0] = cyan;
+  k[1] = 0.0f;
+  k[2] = 0.0f;
+  k[3] = 0.0f;
+
+  pTag->Attach(pMtx);
+  return pTag;
+}
+
+static void add_text(CIccProfile& p, icSignature sig, const char* text)
+{
+  CIccTagMultiLocalizedUnicode* m = new CIccTagMultiLocalizedUnicode();
+  m->SetText(text);
+  p.AttachTag(sig, m);
+}
+
+// v4.3 CMYK printer profile carrying both B-side families.  bWithBToD0 drops
+// the MPE tag so the test can compute a colorimetric-only reference.
+static bool build_profile(CIccProfile& p, bool bWithBToD0)
+{
+  p.InitHeader();
+  p.m_Header.deviceClass = icSigOutputClass;
+  p.m_Header.colorSpace = icSigCmykData;
+  p.m_Header.pcs = icSigLabData;
+  p.m_Header.version = icVersionNumberV4_3;
+
+  CIccTagXYZ* wtpt = new CIccTagXYZ;
+  (*wtpt)[0].X = icDtoF(0.9642);
+  (*wtpt)[0].Y = icDtoF(1.0);
+  (*wtpt)[0].Z = icDtoF(0.8249);
+  p.AttachTag(icSigMediaWhitePointTag, wtpt);
+
+  CIccTagLut16* pAToB0 = make_atob0();
+  CIccTagLut16* pBToA0 = make_btoa0(kCyanFromBToA0);
+  if (!pAToB0 || !pBToA0) {
+    delete pAToB0;
+    delete pBToA0;
+    return false;
+  }
+  p.AttachTag(icSigAToB0Tag, pAToB0);
+  p.AttachTag(icSigBToA0Tag, pBToA0);
+
+  if (bWithBToD0) {
+    CIccTagMultiProcessElement* pBToD0 = make_btod0(kCyanFromBToD0);
+    if (!pBToD0)
+      return false;
+    p.AttachTag(icSigBToD0Tag, pBToD0);
+  }
+
+  add_text(p, icSigProfileDescriptionTag, "bpc-d2b-tag-family test");
+  add_text(p, icSigCopyrightTag, "bpc-d2b-tag-family test");
+  return true;
+}
+
+// Runs one CMYK pixel through the profile used as a source, with BPC enabled.
+static bool apply_with_bpc(bool bWithBToD0, bool bUseD2BxB2DxTags, icFloatNumber out[3])
+{
+  CIccProfile* pICC = new CIccProfile;
+  if (!build_profile(*pICC, bWithBToD0)) {
+    delete pICC;
+    return false;
+  }
+
+  CIccCreateXformHintManager hint;
+  hint.AddHint(new CIccApplyBPCHint());
+
+  CIccCmm cmm(icSigCmykData, icSigLabData, true);
+  if (cmm.AddXform(pICC, icPerceptual, icInterpTetrahedral, NULL,
+                   icXformLutColor, bUseD2BxB2DxTags, &hint) != icCmmStatOk)
+    return false;
+  if (cmm.Begin() != icCmmStatOk)
+    return false;
+
+  const icFloatNumber in[4] = {0.5f, 0.0f, 0.0f, 0.0f};
+  return cmm.Apply(out, in) == icCmmStatOk;
+}
+
+static bool same(const icFloatNumber a[3], const icFloatNumber b[3])
+{
+  for (int i = 0; i < 3; i++) {
+    if (std::fabs(a[i] - b[i]) > 1e-5)
+      return false;
+  }
+  return true;
+}
+
+static void show(const char* label, const icFloatNumber v[3])
+{
+  std::printf("      %-28s (%.6f %.6f %.6f)\n", label, v[0], v[1], v[2]);
+}
+
+int main()
+{
+  // 1. The xform must record which family Create() resolved it through.
+  for (int i = 0; i < 2; i++) {
+    const bool bUseD2B = (i != 0);
+    CIccProfile* pICC = new CIccProfile;
+    if (!build_profile(*pICC, true)) {
+      delete pICC;
+      check(false, "fixture profile builds");
+      return 1;
+    }
+    // bInput false: the B-side direction, where the flag selects the family.
+    CIccXform* pXform = CIccXform::Create(pICC, false, icPerceptual,
+                                          icInterpTetrahedral, NULL,
+                                          icXformLutColor, bUseD2B);
+    check(pXform != NULL, bUseD2B ? "B-side xform builds with MPE tags allowed"
+                                  : "B-side xform builds with MPE tags refused");
+    if (pXform) {
+      check(pXform->UseD2BTags() == bUseD2B,
+            bUseD2B ? "UseD2BTags() reports the MPE family"
+                    : "UseD2BTags() reports the colorimetric family");
+      delete pXform;
+    }
+  }
+
+  // 2. With both families present, BPC output must follow the flag.
+  icFloatNumber withMpe[3] = {0, 0, 0};
+  icFloatNumber withoutMpe[3] = {0, 0, 0};
+  icFloatNumber colorimetricOnly[3] = {0, 0, 0};
+
+  check(apply_with_bpc(true, true, withMpe),
+        "BPC applies with MPE tags allowed");
+  check(apply_with_bpc(true, false, withoutMpe),
+        "BPC applies with MPE tags refused");
+  // Same profile minus BToD0: the only black available is the colorimetric one.
+  check(apply_with_bpc(false, true, colorimetricOnly),
+        "BPC applies on the colorimetric-only reference profile");
+
+  show("BToD0 present, flag true:", withMpe);
+  show("BToD0 present, flag false:", withoutMpe);
+  show("BToD0 absent (reference):", colorimetricOnly);
+
+  check(!same(withMpe, withoutMpe),
+        "bUseD2BxB2DxTags must change the BPC result when both families exist");
+  check(same(withoutMpe, colorimetricOnly),
+        "refusing the MPE tags must measure black through BToA0");
+
+  if (g_failures) {
+    std::printf("\n%d check(s) FAILED\n", g_failures);
+    return 1;
+  }
+
+  std::printf("\nall checks passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1354,6 +1354,48 @@ function(iccdev_add_xform_create_tag_ownership_test)
   endif()
 endfunction()
 
+# CIccApplyBPC rebuilds its own cmm objects to find the black point, and used to
+# choose the tag family by profile version instead of asking the xform it is
+# adjusting.  A v4 profile carrying both BToA0 and BToD0 therefore had black
+# measured through the MPE tag even when the caller passed
+# bUseD2BxB2DxTags=false, so the scale and offset came from a pipeline the
+# transform never applies.  Only the B-side is affected -- Create()'s input
+# branch gates DToBx on spectralPCS or v5.  Header + IccProfLib only.
+function(iccdev_add_bpc_d2b_tag_family_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccBpcD2bTagFamilyTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/bpc-d2b-tag-family.cpp"
+  )
+  target_link_libraries(iccBpcD2bTagFamilyTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccBpcD2bTagFamilyTest)
+
+  add_test(
+    NAME iccdev.bpc-d2b-tag-family
+    COMMAND "$<TARGET_FILE:iccBpcD2bTagFamilyTest>"
+  )
+  set_tests_properties(iccdev.bpc-d2b-tag-family PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;cmm;xform;bpc;regression"
+  )
+  if(WIN32)
+    set(_bpc_d2b_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccBpcD2bTagFamilyTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _bpc_d2b_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.bpc-d2b-tag-family PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_bpc_d2b_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_xform_abstorel_adjust_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -6247,6 +6289,7 @@ if(WIN32)
   iccdev_add_cmmsearch_namedcolor_ownership_test()
   iccdev_add_xform_create_tag_ownership_test()
   iccdev_add_xform_abstorel_adjust_test()
+  iccdev_add_bpc_d2b_tag_family_test()
   iccdev_add_reflectance_observer_illum_range_test()
   iccdev_add_colorimetry_methods_test()
   iccdev_add_getvalues_nstart_test()
@@ -6596,6 +6639,7 @@ iccdev_add_sparsematrix_set_roundtrip_test()
 iccdev_add_cmmsearch_namedcolor_ownership_test()
 iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_xform_abstorel_adjust_test()
+iccdev_add_bpc_d2b_tag_family_test()
 iccdev_add_reflectance_observer_illum_range_test()
 iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()

--- a/IccProfLib/IccApplyBPC.cpp
+++ b/IccProfLib/IccApplyBPC.cpp
@@ -307,7 +307,7 @@ bool CIccApplyBPC::calcSrcBlackPoint(const CIccProfile* pProfile, const CIccXfor
 		lab2pcs(XYZb, pProfile);
 
 		//convert the PCS value to CMYK
-		if (!pixelXfm(Pixel, XYZb, pProfile->m_Header.pcs, icPerceptual, pProfile)) {
+		if (!pixelXfm(Pixel, XYZb, pProfile->m_Header.pcs, icPerceptual, pProfile, pXform->UseD2BTags())) {
 			return false;
 		}
 	}
@@ -353,7 +353,7 @@ bool CIccApplyBPC::calcSrcBlackPoint(const CIccProfile* pProfile, const CIccXfor
 	}
 
 	// convert the device value to PCS
-	if (!pixelXfm(XYZb, Pixel, pProfile->m_Header.colorSpace, pXform->GetIntent(), pProfile)) {
+	if (!pixelXfm(XYZb, Pixel, pProfile->m_Header.colorSpace, pXform->GetIntent(), pProfile, pXform->UseD2BTags())) {
 		return false;
 	}
 
@@ -396,7 +396,7 @@ bool CIccApplyBPC::calcDstBlackPoint(const CIccProfile* pProfile, const CIccXfor
 	{ // do the complicated and lengthy black point estimation
 
 		// get the black transform
-		CIccCmm* pCmm = getBlackXfm(nIntent, pProfile);
+		CIccCmm* pCmm = getBlackXfm(nIntent, pProfile, pXform->UseD2BTags());
 		if (!pCmm) {
 			return false;
 		}
@@ -558,7 +558,7 @@ bool CIccApplyBPC::calcDstBlackPoint(const CIccProfile* pProfile, const CIccXfor
 **************************************************************************
 */
 bool CIccApplyBPC::pixelXfm(icFloatNumber *DstPixel, icFloatNumber *SrcPixel, icColorSpaceSignature SrcSpace, 
-														icRenderingIntent nIntent, const CIccProfile *pProfile) const
+														icRenderingIntent nIntent, const CIccProfile *pProfile, bool bUseD2BTags) const
 {
 	// create the cmm object
 	CIccCmm cmm(SrcSpace, icSigUnknownData, !IsSpacePCS(SrcSpace));
@@ -568,7 +568,8 @@ bool CIccApplyBPC::pixelXfm(icFloatNumber *DstPixel, icFloatNumber *SrcPixel, ic
 	if (!pICC) return false;
 
 	// add the xform
-	if (cmm.AddXform(pICC, nIntent, icInterpTetrahedral, NULL, icXformLutColorimetric, pICC->m_Header.version >= icVersionNumberV5 ? false : true)!=icCmmStatOk) {
+	if (cmm.AddXform(pICC, nIntent, icInterpTetrahedral, NULL, icXformLutColorimetric,
+									 pICC->m_Header.version >= icVersionNumberV5 ? false : bUseD2BTags)!=icCmmStatOk) {
 		return false;
 	}
 
@@ -594,7 +595,7 @@ bool CIccApplyBPC::pixelXfm(icFloatNumber *DstPixel, icFloatNumber *SrcPixel, ic
 * 
 **************************************************************************
 */
-CIccCmm* CIccApplyBPC::getBlackXfm(icRenderingIntent nIntent, const CIccProfile *pProfile) const
+CIccCmm* CIccApplyBPC::getBlackXfm(icRenderingIntent nIntent, const CIccProfile *pProfile, bool bUseD2BTags) const
 {
 	// create the cmm object
 	CIccCmm* pCmm = new (std::nothrow) CIccCmm(pProfile->m_Header.pcs, icSigUnknownData, false);
@@ -608,7 +609,8 @@ CIccCmm* CIccApplyBPC::getBlackXfm(icRenderingIntent nIntent, const CIccProfile 
 	}
 
 	// add the xform
-	if (pCmm->AddXform(pICC1, nIntent, icInterpTetrahedral, NULL, icXformLutColor, pICC1->m_Header.version >= icVersionNumberV5 ? false : true)!=icCmmStatOk) {
+	if (pCmm->AddXform(pICC1, nIntent, icInterpTetrahedral, NULL, icXformLutColor,
+										 pICC1->m_Header.version >= icVersionNumberV5 ? false : bUseD2BTags)!=icCmmStatOk) {
 		delete pCmm;
 		return NULL;
 	}
@@ -621,7 +623,8 @@ CIccCmm* CIccApplyBPC::getBlackXfm(icRenderingIntent nIntent, const CIccProfile 
 	}
 
 	// add the xform
-	if (pCmm->AddXform(pICC2, icRelativeColorimetric, icInterpTetrahedral, NULL, icXformLutColor, pICC2->m_Header.version >= icVersionNumberV5 ? false : true)!=icCmmStatOk) { // uses the relative intent on the device to Lab side
+	if (pCmm->AddXform(pICC2, icRelativeColorimetric, icInterpTetrahedral, NULL, icXformLutColor,
+										 pICC2->m_Header.version >= icVersionNumberV5 ? false : bUseD2BTags)!=icCmmStatOk) { // uses the relative intent on the device to Lab side
 		delete pCmm;
 		return NULL;
 	}

--- a/IccProfLib/IccApplyBPC.h
+++ b/IccProfLib/IccApplyBPC.h
@@ -116,11 +116,14 @@ private:
 	bool calcSrcBlackPoint(const CIccProfile* pProfile, const CIccXform* pXform, icFloatNumber* XYZb) const;
 	bool calcDstBlackPoint(const CIccProfile* pProfile, const CIccXform* pXform, icFloatNumber* XYZb) const;
 
+	// bUseD2BTags selects the same tag family the xform being adjusted was built
+	// from (CIccXform::UseD2BTags()).  Estimating black through the other family
+	// yields a black point from a pipeline the transform never applies.
 	bool pixelXfm(icFloatNumber *DstPixel, icFloatNumber *SrcPixel, icColorSpaceSignature SrcSpace, 
-								icRenderingIntent nIntent, const CIccProfile *pProfile) const;
+								icRenderingIntent nIntent, const CIccProfile *pProfile, bool bUseD2BTags) const;
 
 	// PCS -> PCS round trip transform, always uses relative intent on the device -> pcs transform
-	CIccCmm* getBlackXfm(icRenderingIntent nIntent, const CIccProfile *pProfile) const;
+	CIccCmm* getBlackXfm(icRenderingIntent nIntent, const CIccProfile *pProfile, bool bUseD2BTags) const;
 };
 
 #ifdef USEICCDEVNAMESPACE

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -1262,6 +1262,13 @@ CIccXform *CIccXform::Create(CIccProfile *pProfile,
 
     rv->SetParams(pProfile, bInput, nIntent, nTagIntent, bUseSpectralPCS, nInterp, pHintManager, bAbsToRel, nMCS);
 
+    // Record the flag as it stands *here*, after the icXformLutSpectral and
+    // icXformLutColorimetric adjustments above rewrote it, so it names the tag
+    // family the selection code actually walked rather than what the caller
+    // asked for.  CIccApplyBPC reads it back to build its black-point
+    // transforms from the same family.
+    rv->SetUseD2BTags(bUseD2BTags);
+
     // The icXformLutGamut case above forced bInput false to walk the gamt tag
     // in its stored B-to-A direction.  Record that this is a gamut xform so the
     // reported destination stays icSigGamutData rather than the device space.
@@ -1402,6 +1409,11 @@ CIccXform *CIccXform::Create(CIccProfile *pProfile,
       rv->m_pConnectionConditions = pProfile;
 
     rv->SetParams(pProfile, bInput, nIntent, nTagIntent, bUseSpectralPCS, nInterp, pHintManager, bAbsToRel, nMCS);
+
+    // No SetUseD2BTags() here: this overload is handed the tag outright, so
+    // there is no tag-family selection to record and no way for CIccApplyBPC
+    // to reproduce the caller's choice by rebuilding a cmm from the profile.
+    // m_bUseD2BTags keeps its constructor default of false.
   }
   else if (bOwnsProfile) {
     // No xform was built for this profile/tag combination; pProfile never
@@ -8279,6 +8291,10 @@ CIccXform *CIccXformMpe::Create(CIccProfile *pProfile, bool bInput/* =true */, i
 
   if (rv) {
     rv->SetParams(pProfile, bInput, nIntent, nTagIntent, bUseSpectralPCS, nInterp, pHintManager, bAbsToRel);
+
+    // bUseDToB is this overload's equivalent of CIccXform::Create()'s
+    // bUseD2BTags; record it for the same reason.
+    rv->SetUseD2BTags(bUseDToB);
 
     // Same reasoning as the icXformLutGamut case in CIccXform::Create(): this
     // overload has no in-tree caller, but it is public API and its gamut case

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -441,6 +441,10 @@ public:
   /// flag the !m_bInput branches of GetDstSpace()/GetNumDstSamples() would
   /// report the profile's device space instead of the single gamut channel.
   void SetGamutXform() { m_bGamutXform = true; }
+  /// Records which tag family Create() resolved this xform through: true for
+  /// the DToBx/BToDx MPE tags, false for the AToBx/BToAx colorimetric ones.
+  /// Only Create() should call this.
+  void SetUseD2BTags(bool bUseD2BTags) { m_bUseD2BTags = bUseD2BTags; }
 
   virtual icStatusCMM Begin();
 
@@ -467,6 +471,13 @@ public:
   
   ///Checks if the profile is to be used as input profile
   bool IsInput() const { return m_bInput; }
+
+  /// True when this xform was resolved through the DToBx/BToDx MPE tags rather
+  /// than the AToBx/BToAx colorimetric ones.  CIccApplyBPC needs it so its
+  /// black-point transforms select the same tag family the xform itself uses;
+  /// a caller that opts out of the MPE tags for the xform but computes black
+  /// through them gets a black point from a pipeline it never applies.
+  bool UseD2BTags() const { return m_bUseD2BTags; }
 
   virtual bool IsLateBinding() const { return false; }
   virtual IIccProfileConnectionConditions *GetProfileCC() const { return m_pProfile; }


### PR DESCRIPTION
## Problem

`CIccXform::Create()` chooses between the `AToBx`/`BToAx` colorimetric tags and the `DToBx`/`BToDx` MPE tags, and a caller forces the colorimetric ones by passing `bUseD2BxB2DxTags=false` to `AddXform()`.

`CIccApplyBPC` rebuilds its own cmm objects to find the black point, and hardcoded that choice as `version >= V5 ? colorimetric : MPE` instead of asking the xform it is adjusting:

```cpp
pICC->m_Header.version >= icVersionNumberV5 ? false : true
```

For a v4 profile carrying both families this is backwards. The transform applies `BToAx` while black is measured through `BToDx`, so the scale and offset BPC installs come from a pipeline that is never applied. These are exactly the profiles where the two pipelines are known to differ — that is *why* a caller opts out — so the error is not marginal, and it is silent.

**Only the B-side is affected.** `Create()`'s input branch gates its `DToBx` lookup on `spectralPCS || version >= V5`, so a plain v4 profile resolves device→PCS through `AToBx` whatever the flag says. The output branch has no such gate and follows the flag alone.

## Fix

`m_bUseD2BTags` already existed on `CIccXform` but was dead — set `false` in the constructor and never written since.

- Record it at the `SetParams()` sites in `CIccXform::Create()` and `CIccXformMpe::Create()`, *after* the `icXformLutSpectral` and `icXformLutColorimetric` adjustments have rewritten it, so it names the family the selection code actually walked rather than what the caller asked for.
- Expose `UseD2BTags()` / `SetUseD2BTags()` as inline accessors — no layout or vtable change, so ABI is unaffected.
- `CalcFactors()` already receives the xform, so only `pixelXfm()` and `getBlackXfm()` gain a parameter.

The `Create()` overload that is handed a tag outright keeps the constructor default, with a comment saying why: there is no selection to record, and no way for `CIccApplyBPC` to reproduce the caller's choice by rebuilding from the profile.

## Blast radius

The V5 arm of the ternary is preserved, so **only the explicit opt-out changes behaviour** and the default path is byte-identical. The CLI tools cannot reach the changed configuration — `iccApplyToLink` decodes intent `10 +` (no D2Bx) and `40 +` (BPC) as mutually exclusive `switch` cases, so BPC there always implies `bUseD2BxB2DxTags=true`. No existing end-to-end baseline can shift; this is a library-API-only change.

## Regression coverage

`iccdev.bpc-d2b-tag-family` builds a v4.3 CMYK printer profile in code whose `BToA0` and `BToD0` return different inks (cyan 0.60 vs 0.95) and whose `AToB0` turns those into L\* 40 and L\* 5 — both clearing `calcSrcBlackPoint()`'s L\*≤50 clip as distinct values, since a pair that both clipped would leave the test toothless.

Applying one CMYK pixel with BPC enabled:

| | flag `true` | flag `false` | `BToD0` absent (reference) |
|---|---|---|---|
| before | 0.499921 | **0.499921** | 0.349680 |
| after | 0.499921 | **0.349680** | 0.349680 |

Before the change the flag was inert and black came from `BToD0` either way. After, `false` matches the `BToA0`-only reference exactly. The test exits 1 before and 0 after.

## Verification performed

Configured and built with the repo's own `vs2022-x64` preset (VS2022 Professional, MSVC x64 Release, vcpkg toolchain) and exercised through CTest:

- `iccdev.bpc-d2b-tag-family` registers as test #67 with labels `bpc cmm iccdev regression xform`, builds, and **passes**.
- Reverting only the three ternaries and rebuilding makes it **fail** under the same toolchain, so the test is a genuine pin on MSVC and not an artefact of one compiler.
- `ctest -L "cmm|xform"` — 16/16 pass.
- `ctest -L regression` — 95/95 pass.
- Full non-slow suite — 101/101 pass.

Re-verified after the branch was rebased onto current master (53 newer commits, including the apply-path guard retirement #2307 and the CLUT channel-count bounds #2306): full reconfigure and rebuild, test #90 passes with byte-identical output, and the full non-slow suite is 133/133.

Also cross-checked earlier with g++ against a hand-built `IccProfLib`, producing byte-identical numbers to the MSVC run.

## Left open

Two pre-existing gaps outside this fix's scope:

- `pixelXfm()` still hardcodes `icXformLutColorimetric`, which closes the `DToBx` path on the input side for *any* profile. Moot for v4 non-spectral, but it means a v5 MPE-only profile cannot resolve a source black point at all.
- The tag-passing `Create()` overload records nothing, so BPC on an xform built that way still assumes the colorimetric family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


