### PR TITLE
fix(#2324,#2347): restore the sampled-curve non-finite invariant

### DIFF
--- a/.github/ci/regression/sampled-curve-nonfinite-range.cpp
+++ b/.github/ci/regression/sampled-curve-nonfinite-range.cpp
@@ -1,0 +1,338 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression for the fourth, fifth and sixth per-pixel guards retired alongside
+// the CLUT ones covered by clut-apply-guard-retirement.cpp. Those three were
+// not redundant.
+//
+// Each of the sampled curves computed
+//
+//   pos = (v - first) / m_range * m_last;
+//   if (!std::isfinite(pos) || pos < 0.0f) pos = 0.0f;
+//
+// and the isfinite term was dropped on the argument that "Begin() refuses
+// m_range == 0, so pos cannot be non-finite". That does not follow: m_range is
+// m_lastEntry - m_firstEntry, both endpoints arrive unvalidated from the wire
+// (Read() via ReadFloat32Float, the XML front end via atof, which accepts
+// "nan"), and NaN == 0.0 is false. A NaN endpoint therefore passed every test
+// in Begin(), reached Apply(), and produced a NaN pos that also survived both
+// clamps below -- because NaN compares false against everything -- leaving
+// static_cast<icUInt32Number>(NaN) to index m_pSamples. That cast is undefined
+// (#2324, #2347); under -fno-sanitize-recover=float-cast-overflow it aborts,
+// and in a plain build it yields an implementation-defined index far outside
+// the array.
+//
+// The fix is split, because the three sites do not have the same invariant:
+//
+//   CIccSingleSampledCurve and CIccSampledCalculatorCurve carry a real sampled
+//   domain, so their Begin() now refuses a non-finite m_range and Apply() keeps
+//   the cleared hot path. isfinite() on the span is exactly the right test: a
+//   difference is finite only when both endpoints are finite AND it does not
+//   overflow, so one check covers NaN, infinity, and the +/-FLT_MAX pair.
+//   testSingleSampledBeginRefusesNonFiniteRange() and
+//   testCalculatorCurveBeginRefusesNonFiniteRange() pin that, and the 0..1 rows
+//   in each are the controls -- they passed before the guard was added too, so a
+//   failure there means the new check over-rejects rather than protects.
+//
+//   CIccSampledCurveSegment cannot make that promise from Begin(). The outermost
+//   segments of a segmented curve are constructed with the icMinFloat32Number /
+//   icMaxFloat32Number sentinels (CIccSegmentedCurve::Read), so an infinite
+//   m_range is a legitimate configuration there, and even between finite
+//   endpoints (v - m_startPoint) can overflow to infinity and give inf/inf.
+//   Refusing a non-finite span would reject conforming profiles, so that site
+//   keeps the per-pixel isfinite guard. testSegmentApplyKeepsItsGuard() and
+//   testSegmentApplySurvivesAnInfiniteSpan() pin both halves of that.
+//
+// Note also that CIccSegmentedCurve::Read() push_back()s segments directly
+// rather than going through Insert(), so Insert()'s contiguity test
+// (StartPoint() == previous EndPoint(), which a NaN would fail) never runs on
+// the read path and cannot be relied on to keep NaN out.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccMpeBasic.h"
+#include "IccMpeCalc.h"
+#include "IccTagMPE.h"
+
+#include <cmath>
+#include <cstdio>
+#include <limits>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[sampled-curve-nonfinite] FAIL: %s\n", what);
+  }
+}
+
+const icFloatNumber kNaN = std::numeric_limits<icFloatNumber>::quiet_NaN();
+const icFloatNumber kInf = std::numeric_limits<icFloatNumber>::infinity();
+
+struct RangeCase {
+  icFloatNumber first;
+  icFloatNumber last;
+  bool          expectBegin;   // Begin() must return this
+  const char   *label;
+};
+
+// The +/-FLT_MAX row is the one a NaN-only check would miss: both endpoints are
+// finite, but their difference overflows to infinity in float, and inf in the
+// denominator turns a large numerator into inf/inf == NaN.
+const RangeCase kRanges[] = {
+  { 0.0f,              1.0f,              true,  "0..1 (control)" },
+  { 0.030029f,         4.8046f,           true,  "0.03..4.8 (control, real HLG domain)" },
+  { kNaN,              1.0f,              false, "NaN first entry" },
+  { 0.0f,              kNaN,              false, "NaN last entry" },
+  { kNaN,              kNaN,              false, "NaN both entries" },
+  { -kInf,             1.0f,              false, "-inf first entry" },
+  { 0.0f,              kInf,              false, "+inf last entry" },
+  { icMinFloat32Number, icMaxFloat32Number, false, "+/-FLT_MAX span overflows to inf" },
+};
+
+const size_t kNumRanges = sizeof(kRanges) / sizeof(kRanges[0]);
+
+void testSingleSampledBeginRefusesNonFiniteRange()
+{
+  for (size_t i = 0; i < kNumRanges; i++) {
+    const RangeCase &c = kRanges[i];
+
+    CIccSingleSampledCurve curve(c.first, c.last);
+    check(curve.SetSize(4), "single sampled curve allocates its samples");
+    icFloatNumber *pSamples = curve.GetSamples();
+    if (!pSamples)
+      continue;
+    for (int s = 0; s < 4; s++)
+      pSamples[s] = (icFloatNumber)(s / 3.0);
+
+    const bool began = curve.Begin(icElemInterpLinear, NULL);
+
+    char msg[192];
+    std::snprintf(msg, sizeof(msg), "CIccSingleSampledCurve::Begin(%s) returns %s",
+                  c.label, c.expectBegin ? "true" : "false");
+    check(began == c.expectBegin, msg);
+
+    // Only the accepted rows may be applied; an element whose Begin() failed is
+    // never applied by the CMM, so exercising a refused one here would test a
+    // path the library does not use.
+    if (!began)
+      continue;
+
+    for (int p = 0; p <= 8; p++) {
+      const icFloatNumber v = c.first + (c.last - c.first) * (icFloatNumber)(p / 8.0);
+      const icFloatNumber out = curve.Apply(v);
+      std::snprintf(msg, sizeof(msg),
+                    "CIccSingleSampledCurve::Apply(%s) stays finite and in [0,1]", c.label);
+      check(std::isfinite((double)out) && out >= 0.0f && out <= 1.0f, msg);
+    }
+  }
+}
+
+// A 1-in/1-out identity calculator, the smallest thing that gets past
+// CIccSampledCalculatorCurve::Begin()'s channel-count and null checks so the
+// range test underneath them is actually reached.
+CIccMpeCalculator *newIdentityCalculator()
+{
+  CIccMpeCalculator *pCalc = new CIccMpeCalculator(1, 1);
+  std::string sReport;
+  if (pCalc->SetCalcFunc("{ in(0) out(0) }", sReport) != icFuncParseNoError) {
+    std::fprintf(stderr, "[sampled-curve-nonfinite] calculator setup: %s\n", sReport.c_str());
+    delete pCalc;
+    return NULL;
+  }
+  return pCalc;
+}
+
+void testCalculatorCurveBeginRefusesNonFiniteRange()
+{
+  for (size_t i = 0; i < kNumRanges; i++) {
+    const RangeCase &c = kRanges[i];
+
+    CIccMpeCalculator *pCalc = newIdentityCalculator();
+    check(pCalc != NULL, "identity calculator builds");
+    if (!pCalc)
+      return;
+
+    // A real enclosing element, not NULL: CIccMpeCalculator::Begin() reads
+    // pMPE->GetCmmEnvLookup() without a null test (IccMpeCalc.cpp:5231), so the
+    // NULL that the other two curves in this file accept would crash here
+    // before reaching the range check under test. Declared before the curve so
+    // it outlives it: Begin() parks a pointer into this element inside the
+    // calculator the curve owns and deletes.
+    CIccTagMultiProcessElement mpe(1, 1);
+
+    CIccSampledCalculatorCurve curve(c.first, c.last);
+    check(curve.SetCalculator(pCalc), "sampled calculator curve takes the calculator");
+    check(curve.SetRecommendedSize(16), "sampled calculator curve takes a size");
+
+    const bool began = curve.Begin(icElemInterpLinear, &mpe);
+
+    char msg[192];
+    std::snprintf(msg, sizeof(msg), "CIccSampledCalculatorCurve::Begin(%s) returns %s",
+                  c.label, c.expectBegin ? "true" : "false");
+    check(began == c.expectBegin, msg);
+
+    if (!began)
+      continue;
+
+    for (int p = 0; p <= 8; p++) {
+      const icFloatNumber v = c.first + (c.last - c.first) * (icFloatNumber)(p / 8.0);
+      const icFloatNumber out = curve.Apply(v);
+      std::snprintf(msg, sizeof(msg),
+                    "CIccSampledCalculatorCurve::Apply(%s) stays finite", c.label);
+      check(std::isfinite((double)out), msg);
+    }
+  }
+}
+
+// Build a sampled segment with the given span, preceded by a formula segment so
+// Begin()'s pPrevSeg requirement is met, and overwrite the samples afterwards
+// with known values -- Begin() seeds m_pSamples[0] from the previous segment,
+// which for a NaN start point is itself NaN, and a NaN return would not tell us
+// whether the index was in range.
+struct SegmentFixture {
+  CIccFormulaCurveSegment *pPrev;
+  CIccSampledCurveSegment *pSeg;
+
+  SegmentFixture() : pPrev(NULL), pSeg(NULL) {}
+  ~SegmentFixture() { delete pSeg; delete pPrev; }
+};
+
+bool buildSegment(SegmentFixture &f, icFloatNumber start, icFloatNumber end)
+{
+  f.pPrev = new CIccFormulaCurveSegment(icMinFloat32Number, start);
+  icFloatNumber params[4] = { 1.0f, 1.0f, 0.0f, 0.0f };
+  f.pPrev->SetFunction(0, 4, params);
+  if (!f.pPrev->Begin(NULL))
+    return false;
+
+  f.pSeg = new CIccSampledCurveSegment(start, end);
+  if (!f.pSeg->SetSize(4))
+    return false;
+  if (!f.pSeg->Begin(f.pPrev))
+    return false;
+
+  icFloatNumber *pSamples = f.pSeg->GetSamples();
+  if (!pSamples)
+    return false;
+  for (int s = 0; s < 4; s++)
+    pSamples[s] = (icFloatNumber)(0.25 + s * 0.25);
+  return true;
+}
+
+// A NaN start point reaches Apply() here by design: Begin() cannot refuse a
+// non-finite span for a segment without also refusing the sentinel-bounded
+// outer segments of every conforming segmented curve. So the per-pixel guard is
+// what has to catch it. Every sample is in [0.25, 1.0], so a returned value in
+// that interval proves the index stayed inside the array; on master the cast is
+// undefined and the read is far outside it.
+void testSegmentApplyKeepsItsGuard()
+{
+  SegmentFixture f;
+  check(buildSegment(f, kNaN, 1.0f), "segment with a NaN start point still begins");
+  if (!f.pSeg)
+    return;
+
+  for (int p = 0; p <= 8; p++) {
+    const icFloatNumber v = (icFloatNumber)(p / 8.0);
+    const icFloatNumber out = f.pSeg->Apply(v);
+    check(std::isfinite((double)out) && out >= 0.25f && out <= 1.0f,
+          "CIccSampledCurveSegment::Apply over a NaN span returns a real sample");
+  }
+}
+
+// The sentinel case the segment guard exists for: a finite span whose numerator
+// overflows. (v - -FLT_MAX) is infinite for a large v, and m_range is infinite
+// too, so pos is inf/inf == NaN with no NaN anywhere in the inputs.
+void testSegmentApplySurvivesAnInfiniteSpan()
+{
+  SegmentFixture f;
+  check(buildSegment(f, icMinFloat32Number, icMaxFloat32Number),
+        "segment spanning the float sentinels still begins");
+  if (!f.pSeg)
+    return;
+
+  const icFloatNumber probes[5] = { 0.0f, 1.0f, 1.0e38f, -1.0e38f, icMaxFloat32Number };
+  for (int p = 0; p < 5; p++) {
+    const icFloatNumber out = f.pSeg->Apply(probes[p]);
+    check(std::isfinite((double)out) && out >= 0.25f && out <= 1.0f,
+          "CIccSampledCurveSegment::Apply over an infinite span returns a real sample");
+  }
+}
+
+// CIccSampledCurveSegment::Validate has to test its endpoints rather than their
+// difference. The last segment of a segmented curve carries the
+// icMaxFloat32Number sentinel, so a sufficiently negative breakpoint overflows
+// the span to infinity while both endpoints stay sound -- warning on the span
+// would report a conforming profile as malformed, and would contradict the
+// reason Apply() keeps its per-pixel guard. Only a non-finite endpoint is a real
+// defect.
+void testSegmentValidateWarnsOnEndpointsNotSpans()
+{
+  struct SegCase {
+    icFloatNumber start;
+    icFloatNumber end;
+    bool          expectWarning;
+    const char   *label;
+  };
+
+  const SegCase cases[] = {
+    { icMinFloat32Number, icMaxFloat32Number, false, "both sentinels: span overflows, endpoints sound" },
+    { -1.0e32f,           icMaxFloat32Number, false, "very negative breakpoint to the end sentinel" },
+    { 1.0f,               icMaxFloat32Number, false, "ordinary last segment" },
+    { 0.0f,               1.0f,               false, "ordinary interior segment" },
+    { kNaN,               1.0f,               true,  "NaN start point" },
+    { 0.0f,               kNaN,               true,  "NaN end point" },
+    { -kInf,              1.0f,               true,  "-inf start point" },
+  };
+
+  for (size_t i = 0; i < sizeof(cases) / sizeof(cases[0]); i++) {
+    const SegCase &c = cases[i];
+
+    CIccSampledCurveSegment seg(c.start, c.end);
+    check(seg.SetSize(4), "segment allocates its samples");
+
+    std::string report;
+    seg.Validate("", report, NULL, NULL);
+    const bool warned = report.find("non-finite") != std::string::npos;
+
+    char msg[192];
+    std::snprintf(msg, sizeof(msg), "CIccSampledCurveSegment::Validate(%s) %s",
+                  c.label, c.expectWarning ? "warns" : "stays quiet");
+    check(warned == c.expectWarning, msg);
+  }
+}
+
+} // namespace
+
+int main()
+{
+  testSingleSampledBeginRefusesNonFiniteRange();
+  testCalculatorCurveBeginRefusesNonFiniteRange();
+  testSegmentApplyKeepsItsGuard();
+  testSegmentApplySurvivesAnInfiniteSpan();
+  testSegmentValidateWarnsOnEndpointsNotSpans();
+
+  if (g_fail) {
+    std::fprintf(stderr, "[sampled-curve-nonfinite] %d assertion(s) failed\n", g_fail);
+    // Deliberately not "return g_fail" as the neighbouring regression tests do.
+    // This one asserts per probe value, so on an unfixed tree the count is 77 --
+    // the exit status this repository uses with SKIP_RETURN_CODE to mean
+    // "skipped". A red run must never be able to read as a skip, and a count
+    // above 255 would wrap to an arbitrary status including 0, so report the
+    // count on stderr and exit with a plain failure.
+    return 1;
+  }
+  std::printf("[sampled-curve-nonfinite] all assertions passed\n");
+  return 0;
+}

--- a/.github/workflows/ci-preflight-safety.yml
+++ b/.github/workflows/ci-preflight-safety.yml
@@ -100,7 +100,7 @@ jobs:
           /tmp/iccdev-preflight/bin/python -m pip install \
             'PyYAML>=6,<7' \
             'yamllint>=1.35,<2' \
-            'zizmor>=1.9,<2' \
+            'zizmor==1.26.1' \
             --quiet
           echo "/tmp/iccdev-preflight/bin" >> "$GITHUB_PATH"
 

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5956,6 +5956,49 @@ function(iccdev_add_spectral_clut_channel_count_test)
   endif()
 endfunction()
 
+# The sampled-curve half of the same guard retirement clut-apply-guard-retirement
+# covers. Those three removals were not redundant: m_range is a difference of two
+# unvalidated wire floats, NaN == 0.0 is false, so Begin()'s zero-span test never
+# excluded a NaN span and Apply() cast a NaN to a sample index (#2324, #2347).
+# The two sampled curves now refuse a non-finite span in Begin(); the sampled
+# segment cannot, because its outer segments are legitimately sentinel-bounded,
+# so it keeps the per-pixel guard. This test links IccProfLib alone and calls
+# functions only, so it needs no corpus fixture and runs on every platform.
+function(iccdev_add_sampled_curve_nonfinite_range_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccSampledCurveNonFiniteRangeTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/sampled-curve-nonfinite-range.cpp"
+  )
+  target_link_libraries(iccSampledCurveNonFiniteRangeTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccSampledCurveNonFiniteRangeTest)
+
+  add_test(
+    NAME iccdev.sampled-curve-nonfinite-range
+    COMMAND "$<TARGET_FILE:iccSampledCurveNonFiniteRangeTest>"
+  )
+  set_tests_properties(iccdev.sampled-curve-nonfinite-range PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;iccprofLib;mpe;curve;apply;security;regression"
+  )
+  if(WIN32)
+    set(_sampled_curve_nonfinite_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccSampledCurveNonFiniteRangeTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _sampled_curve_nonfinite_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.sampled-curve-nonfinite-range PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_sampled_curve_nonfinite_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_clut_apply_guard_retirement_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -6383,6 +6426,7 @@ if(WIN32)
   iccdev_add_spectral_clut_channel_count_test()
   iccdev_add_spectral_clut_xml_channel_mismatch_test()
   iccdev_add_clut_apply_guard_retirement_test()
+  iccdev_add_sampled_curve_nonfinite_range_test()
 
   if(TARGET iccFromXml AND TARGET iccDumpProfile AND TARGET iccApplyNamedCmm)
     add_test(
@@ -6741,6 +6785,7 @@ iccdev_add_zip_utf8_text_zlib_test()
 iccdev_add_spectral_clut_channel_count_test()
 iccdev_add_spectral_clut_xml_channel_mismatch_test()
 iccdev_add_clut_apply_guard_retirement_test()
+iccdev_add_sampled_curve_nonfinite_range_test()
 
 function(iccdev_add_script_test NAME TIMEOUT LABELS WORKING_DIRECTORY SCRIPT)
   if(NOT EXISTS "${SCRIPT}")

--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -1216,11 +1216,18 @@ icFloatNumber CIccSampledCurveSegment::Apply(icFloatNumber v) const
   else if (v>m_endPoint)
     v=m_endPoint;
 
-  // No isfinite guard: v is clamped into [m_startPoint, m_endPoint] above, and
-  // Begin() refuses a zero span (m_endPoint-m_startPoint == 0.0 returns false),
-  // so pos cannot be non-finite. The clamps stay -- they bound the index.
+  // The isfinite guard has to stay here, unlike the two sampled curves below,
+  // because Begin() cannot establish the invariant for a segment. A sampled
+  // segment is never the first one -- Begin() refuses a null pPrevSeg, and
+  // CIccSegmentedCurve::Begin() passes null for the first -- but it can be the
+  // last, and CIccSegmentedCurve::Read() gives the last segment the
+  // icMaxFloat32Number sentinel as its end point. An infinite m_range is
+  // therefore a legitimate configuration that Begin() must not reject, and even
+  // between finite endpoints (v-m_startPoint) can overflow to infinity, leaving
+  // inf/inf == NaN. NaN survives both clamps below and makes the cast to a
+  // sample index undefined (#2347).
   icFloatNumber pos = (v-m_startPoint)/m_range * m_last;
-  if (pos<0.0f)
+  if (!std::isfinite(pos) || pos<0.0f)
     pos=0.0f;
   else if (pos>m_last)
     pos=m_last;
@@ -1262,6 +1269,19 @@ icValidateStatus CIccSampledCurveSegment::Validate(std::string sigPath, std::str
     sReport += sSigPathName;
     sReport += " sampled curve has too few sample points.\n";
     rv = icMaxStatus(rv, icValidateCriticalError);
+  }
+  // Each endpoint is tested on its own rather than their difference, unlike the
+  // two sampled curves below. The difference is legitimately infinite here: the
+  // last segment of a segmented curve gets the icMaxFloat32Number sentinel as
+  // its end point, so any sufficiently negative breakpoint overflows the span
+  // while both endpoints remain sound wire values. What is actually malformed
+  // is a non-finite endpoint, which every comparison in Apply() then answers
+  // false and which the zero-range test below cannot see (#2347).
+  else if (!std::isfinite(m_startPoint) || !std::isfinite(m_endPoint)) {
+    sReport += icMsgValidateWarning;
+    sReport += sSigPathName;
+    sReport += " sampled curve has a non-finite end point.\n";
+    rv = icMaxStatus(rv, icValidateWarning);
   }
   else if (m_endPoint-m_startPoint == 0.0) {
     sReport += icMsgValidateWarning;
@@ -1785,8 +1805,14 @@ bool CIccSingleSampledCurve::Begin(icElemInterp /* nInterp */, CIccTagMultiProce
   if (m_nCount<2)
     return false;
 
+  // m_firstEntry and m_lastEntry come straight off the wire (Read() reads them
+  // with ReadFloat32Float, and the XML parser with atof), so either can be NaN
+  // or an infinity. NaN == 0.0 is false, so a NaN span used to pass the test
+  // below and reach Apply(), where it made the cast to a sample index undefined
+  // (#2324). isfinite() on the span covers both endpoints at once: a difference
+  // is finite only when both operands are finite and it does not overflow.
   m_range = m_lastEntry - m_firstEntry;
-  if (m_range == 0.0)
+  if (!std::isfinite(m_range) || m_range == 0.0)
     return false;
   m_last = (icFloatNumber)(m_nCount - 1);
   if (m_last == 0)
@@ -1846,8 +1872,9 @@ icFloatNumber CIccSingleSampledCurve::Apply(icFloatNumber v) const
     return m_hiSlope * v + m_hiIntercept;
   }
 
-  // No isfinite guard: v is inside [m_firstEntry, m_lastEntry] on this path, and
-  // Begin() refuses m_range == 0 and m_last == 0, so pos cannot be non-finite.
+  // No isfinite guard: v is non-NaN and inside [m_firstEntry, m_lastEntry] on
+  // this path, and Begin() refuses a zero or non-finite m_range and a zero
+  // m_last, so (v-m_firstEntry) lies in [0, m_range] and pos in [0, m_last].
   icFloatNumber pos = (v-m_firstEntry)/m_range * m_last;
   if (pos<0.0f)
     pos=0.0f;
@@ -1907,7 +1934,17 @@ icValidateStatus CIccSingleSampledCurve::Validate(std::string sigPath, std::stri
     rv = icMaxStatus(rv, icValidateCriticalError);
   }
   
-  if (m_lastEntry-m_firstEntry <= 0.0) {
+  // The non-finite case is tested first and separately: NaN <= 0.0 is false, so
+  // the range test below reported a NaN domain as valid even though Begin() now
+  // refuses it (#2324). Leaving it out would have this validator call a profile
+  // clean that the CMM will not apply.
+  if (!std::isfinite(m_lastEntry-m_firstEntry)) {
+    sReport += icMsgValidateWarning;
+    sReport += sSigPathName;
+    sReport += " single sampled curve has a non-finite sample range.\r\n";
+    rv = icMaxStatus(rv, icValidateWarning);
+  }
+  else if (m_lastEntry-m_firstEntry <= 0.0) {
     sReport += icMsgValidateWarning;
     sReport += sSigPathName;
     sReport += " single sampled curve has an invalid sample range.\r\n";
@@ -2424,8 +2461,13 @@ bool CIccSampledCalculatorCurve::Begin(icElemInterp nInterp, CIccTagMultiProcess
 
   SetSize(nSize);
 
+  // Same wire-supplied endpoints as CIccSingleSampledCurve::Begin, and the same
+  // NaN-slips-past-== 0.0 hole (#2324). This bounds the src values the sample
+  // loop below feeds to the calculator; it says nothing about what comes back,
+  // since a calculator can return non-finite for finite input (an explicit
+  // divide by zero, say), so the sample table itself carries no such guarantee.
   m_range = m_lastEntry - m_firstEntry;
-  if (m_range == 0.0)
+  if (!std::isfinite(m_range) || m_range == 0.0)
     return false;
   m_last = (icFloatNumber)(m_nCount - 1);
   if (m_last == 0)
@@ -2493,7 +2535,8 @@ icFloatNumber CIccSampledCalculatorCurve::Apply(icFloatNumber v) const
   }
 
   // No isfinite guard: same argument as CIccSingleSampledCurve::Apply -- v is
-  // inside the sampled range here and Begin() refuses a zero range.
+  // forced finite above, is inside the sampled range here, and Begin() refuses a
+  // zero or non-finite range.
   icFloatNumber pos = (v - m_firstEntry) / m_range * m_last;
   if (pos<0.0f)
     pos=0.0f;
@@ -2546,7 +2589,14 @@ icValidateStatus CIccSampledCalculatorCurve::Validate(std::string sigPath, std::
     rv = icMaxStatus(rv, icValidateWarning);
   }
 
-  if (m_lastEntry - m_firstEntry <= 0.0) {
+  // Same NaN blind spot as CIccSingleSampledCurve::Validate, same reason (#2324).
+  if (!std::isfinite(m_lastEntry - m_firstEntry)) {
+    sReport += icMsgValidateWarning;
+    sReport += sSigPathName;
+    sReport += " sampled calculator curve has a non-finite sample range.\n";
+    rv = icMaxStatus(rv, icValidateWarning);
+  }
+  else if (m_lastEntry - m_firstEntry <= 0.0) {
     sReport += icMsgValidateWarning;
     sReport += sSigPathName;
     sReport += " sampled calculator curve has an invalid sample range.\n";


### PR DESCRIPTION
Closes #2324
Closes #2347

## Root cause

#2307 dropped `!std::isfinite(pos) ||` from three sampled-curve `Apply()` routines, on the argument that `Begin()` already refuses any range that could make `pos` non-finite. It does not: `m_range` is the difference of two endpoints read unvalidated from the wire (`ReadFloat32Float`; the XML front end uses `atof`, which accepts `"nan"`), and `NaN == 0.0` is false. A NaN domain passed every test in `Begin()`, reached `Apply()`, survived both `pos` clamps — NaN compares false against everything — and `static_cast<icUInt32Number>(NaN)` is undefined.

The guards were removed in `a019f7b2` -- the bisect cited on both issues, correct -- which
reached master squashed as `7f25ed0a`. An earlier revision of this description called that
SHA unreachable; that was wrong. It is a commit on #2307's branch, and squash-merging is
why it is absent from master's history and from a normal clone.

## Fix

Split, because the three sites do not share an invariant.

**`CIccSingleSampledCurve` / `CIccSampledCalculatorCurve`** — `Begin()` refuses a non-finite `m_range`; `Apply()` keeps #2307's cleared hot path, so the check runs once per setup instead of once per pixel. `isfinite()` on the span is the whole test: a difference is finite only when both endpoints are finite and it does not overflow, so one check covers NaN, infinity and the ±FLT_MAX pair.

**`CIccSampledCurveSegment`** — keeps its per-pixel guard. `Begin()` cannot promise this one: a sampled segment is never the first segment (`Begin()` refuses a null `pPrevSeg`) but it can be the last, and `CIccSegmentedCurve::Read()` gives the last segment the `icMaxFloat32Number` sentinel, so an infinite `m_range` is a legitimate configuration there. Even between finite endpoints `(v-m_startPoint)` can overflow and leave `inf/inf`.

**`Validate()`, all three** — same blind spot, same cause: the range tests are `<= 0.0` and `== 0.0`, both false for NaN. Before this change `iccDumpProfile -v` called a NaN-domain profile `Profile is valid for version 5.00` while the CMM aborted on it. Fixing only `Begin()` would have widened that disagreement, so the non-finite case is now reported alongside the existing warnings.

The two sampled curves test the **span**, matching exactly what their `Begin()` refuses on, so validation and application agree. The segment tests its **endpoints** instead, because there the span is legitimately infinite — warning on it would flag the sentinel-bounded last segment of a conforming profile. `testSegmentValidateWarnsOnEndpointsNotSpans()` pins the distinction.

## Reproduction

Self-contained, text-authored; no fuzz artifact needed. Take `Testing/ICS/Rec2100HlgFull-Part1.xml`, set one `SingleSampledCurve`'s `FirstEntry="nan"`, then:

```
iccFromXml poc.xml poc.icc
iccApplyNamedCmm Testing/ApplyDataFiles/rgbFloat.txt 0 1 poc.icc 1
```

On master, built with `--preset linux-clang-sanitizers`:

```
IccMpeBasic.cpp:1857:54: runtime error: nan is outside the range of representable values of type 'unsigned int'
    #0 CIccSingleSampledCurve::Apply(float) const IccMpeBasic.cpp:1857:54
    #1 CIccMpeCurveSet::Apply(CIccApplyMpe*, float*, float const*) const
```

— the same file:line:col as #2324. The sibling PoCs hit `1228:54` (#2347's site) and `2503:54`.

## Verification

- New CTest is red on master — 77 failed assertions in a plain build, SIGABRT under sanitizers — and green with the fix, in both.
- `iccDumpProfile -v` red/green: `Profile is valid for version 5.00` → `single sampled curve has a non-finite sample range`.
- Full suite 228/229. The one failure is pre-existing and unrelated: `spectral-tiff-preview` needs the `imagecodecs` Python module.
- `hybrid-pipeline`, which exercises these curves across the MCS corpus, passes (626s).
- No over-rejection risk: every `FirstEntry`/`LastEntry` in the tracked XML corpus is finite.
- Set-diff of #2307: it removed exactly four finiteness guards. Three are these; the fourth (`surround`) was relocated inside `CIccMpeCAM::Begin()`, not dropped. There is no fourth site.

`sampled-curve-nonfinite-range.cpp` links IccProfLib alone and calls functions only, so it needs no fixture and is registered outside the `WIN32` branch, at both call sites. Its controls (`0..1`, and the real `0.03..4.8` HLG domain) are there to catch over-rejection rather than only under-rejection.

## CI

Dispatched before opening this PR per the suggested workflow, `ci_scope=source`: run [33546080895](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33546080895) — **16 success, 2 skipped**, including GCC 15.2 Strict Release LTO, Windows MSVC, Windows ClangCL, MinGW UCRT64, macOS clang Debug + Release, and Tool Smoke Tests (ASAN+UBSAN). The Windows legs matter here: the new test target has to configure and run under MSVC.

Locally, CI's own zero-warning gate (`grep -cE 'warning:'` on the build log) was run against both strict profiles — clang 21.1.3 and GCC 15.2 Release LTO in the CI container — and returns 0 for each.

## Overlap with #2309 — please read before duplicating

Copilot flagged all three of these sites during review of #2307, at lines 1229 / 1849 / 2495, with the same diagnosis. They were merged as suppressed comments and filed into #2309, which is assigned to @maxderhak and still open.

This PR resolves the substance of those three suppressed findings. It does **not** touch #2309's remaining Medium item — `m_nMaxDataOffset2d` computed in `CIccCLUT::Begin()` while `Interp2d()` still recomputes it per pixel — which is a separate perf/ABI question and stays with @maxderhak. Flagging it here only so the same three findings do not get fixed twice; the disposition of #2309 is his call.

## One question for a maintainer

The non-finite range is reported at `icValidateWarning`, matching the adjacent `m_range == 0.0` branch. But `Begin()` now refuses these profiles outright, so `icValidateCriticalError` is arguably the honest status for a condition the library will not apply. I kept the existing severity because re-tiering changes validation output for a whole class of profiles, which seemed a policy call rather than part of a UB fix. Happy to change it either way.

## Not addressed

- `CIccMpeCalculator::Begin()` dereferences `pMPE` with no null test (`IccMpeCalc.cpp:5231`). Not reachable from a profile — the enclosing tag is always passed — so the regression test passes a real `CIccTagMultiProcessElement` rather than widening this PR's scope. Noted in case it is worth its own issue.
- A sampled segment bounded by `icMaxFloat32Number` has an infinite `m_range`, so `pos` is always 0 and the segment collapses to `m_pSamples[0]`. Defined behaviour, pre-existing, and independent of this defect — not changed here.

