### PR TITLE
fix(#2341): fill every curve-set channel in the V5 device-link writer

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2965,6 +2965,159 @@ function(iccdev_add_applytolink_v4_missing_desc_test)
   endif()
 endfunction()
 
+# #2341: CDevLinkWriter::begin() wrote curve-set slot 1 nSrcSamples-1 times.
+#
+# The V5 branch attaches a CIccMpeCurveSet when the input range is not the default
+# [0,1], sharing one CIccSingleSampledCurve across every input channel -- which the
+# class supports: SetCurve() only deletes an outgoing pointer no other slot still
+# aliases, and Write() emits a shared curve once with every position-table entry
+# pointing at it. The loop that filled slots 1..n-1 ignored its own counter and
+# wrote index 1 each pass, so slots 2..n-1 stayed NULL. Write() skips a NULL slot
+# instead of failing, leaving those channels the calloc'd {offset 0, size 0}
+# position entry, and the writer reported success.
+#
+# Which is why these assert the READ-BACK file, not the writer. On the unfixed
+# tool every case below exits 0 and prints "LUT successfully written": an
+# exit-status or message assertion, the shape every other iccApplyToLink test in
+# this file uses, passes against the defect.
+#
+# The verdict alone is not enough either, and that is measured rather than
+# assumed. An earlier version of this block asserted only "Profile is valid", and
+# replacing the curve-set condition in CDevLinkWriter::begin() with if(false) --
+# dropping the input-domain curves from every V5 link -- left every test green,
+# because a link with no curve set is perfectly valid. So the cases also assert
+# the structure: EXPECT_DUMP_COUNT pins one per-channel curve carrying the
+# requested domain for every input channel, and the default-range case asserts
+# the curve set is ABSENT.
+#
+# The defect needs a source space with at least THREE channels: a 1-channel
+# source never enters the loop, and for a 2-channel source the loop's single
+# iteration (i=1) writes slot 1, which is the slot it should write. Both are
+# therefore correct on the unfixed tool, which is how this survived from
+# 889db62b (2023-11-03) until now.
+#
+# The pair below is what pins it, and the two are jointly sufficient -- each of
+# the four mutations that matter turns at least one of them red, measured:
+#   RGB at 0.001..0.999  -- red for the original bug, for dropping the curve set,
+#                           and for filling the extra channels with the wrong
+#                           domain. EXPECT_DUMP_COUNT=3 is what carries the
+#                           general claim "one curve per input channel", which is
+#                           why a wider source is not needed to state it.
+#   RGB at 0 1           -- valid on BOTH trees; takes the branch that attaches
+#                           no curve set, so REJECT_DUMP asserts the absence the
+#                           other asserts the presence of. Red if the range
+#                           condition is widened to attach one unconditionally.
+# The second is a control and is not optional: without it a "fix" that attached a
+# curve set to every link would satisfy the first.
+#
+# Deliberately NOT registered: CMYK (4 channels) and Gray (1 channel) cases,
+# which ran green locally and turned all three Windows legs red -- MSVC, ClangCL
+# and MinGW alike -- with
+#   Error - Unable to add '...' to transform chain (status 3: Invalid profile)
+# for Testing/CMYK-3DLUTs/CMYK-3DLUTs.icc and Testing/Display/GrayGSDF.icc. Both
+# validate clean here and both are written by CreateAllProfiles.bat reporting
+# "Profile parsed and saved correctly", so the divergence is in reading them back,
+# not in generating them, and it is not understood. It is also invisible today:
+# no other CTest in this file uses either profile, and the manifest check that
+# would validate them is a script test, which is not registered on Windows at all.
+# That is a separate defect from #2341 and is reported separately; gating those
+# two cases to non-Windows here would have buried it. Every fixture used above is
+# tracked in git rather than generated, which is what makes the pair portable.
+function(iccdev_add_applytolink_curveset_channels_tests)
+  if(NOT TARGET iccApplyToLink OR NOT TARGET iccDumpProfile)
+    return()
+  endif()
+
+  add_dependencies(check iccApplyToLink iccDumpProfile)
+  add_dependencies(check-fast iccApplyToLink iccDumpProfile)
+
+  set(_applytolink_curveset_tests "")
+
+  # Spelled out rather than looped: foreach() flattens a "name;profile;range"
+  # element into separate iterations, so the grouping would not survive it -- the
+  # same reason the negative-intent pairs above are written out.
+  #
+  # The EXPECT_DUMP regex has two deliberate properties, both established by
+  # measurement rather than by reading.
+  #
+  # It must run through the closing bracket. string(REGEX MATCHALL) returns only
+  # ONE match for a pattern that stops mid-line -- "Single Sampled Curve
+  # \\[0\\.00100000" counts 1 against a dump holding three identical lines, while
+  # the same pattern extended to "\\]" counts 3. A truncated pattern would
+  # therefore fail every count here for a reason that has nothing to do with the
+  # profile, so the pattern is anchored to the end of the printed value.
+  #
+  # The trailing digits are matched as [0-9]* rather than spelled out.
+  # CIccSingleSampledCurve::Describe() renders the domain with %.8f
+  # (IccMpeBasic.cpp:1576) and icFloatNumber is unconditionally float
+  # (IccDefs.h:88), so "0.99900001" is deterministic -- but the Windows legs
+  # cannot be exercised locally, and this drops a printf last-digit-rounding
+  # assumption at no cost: the domain is still pinned to 0.999x, and the wrong
+  # domain a mis-fix produces renders "0.00000000, 1.00000000", which fails.
+  add_test(
+    NAME iccdev.applytolink-curveset-rgb-channels
+    COMMAND "${CMAKE_COMMAND}"
+      "-DWRITER=$<TARGET_FILE:iccApplyToLink>"
+      "-DREADER=$<TARGET_FILE:iccDumpProfile>"
+      "-DLABEL=applytolink-curveset"
+      "-DWRITER_ARGS=${ICCDEV_TEST_OUTDIR}/applytolink-curveset-rgb.icc;0;3;1;CurveSetRGB;0.001;0.999;1;0;${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc;0"
+      "-DEXPECT_VERDICT=Profile is valid"
+      "-DREJECT_VERDICT=Critical Error|Unable to parse"
+      "-DEXPECT_DUMP=Single Sampled Curve \\[0\\.00100000, 0\\.999[0-9]*\\]"
+      "-DEXPECT_DUMP_COUNT=3"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunDeviceLinkRoundTripTest.cmake"
+  )
+  list(APPEND _applytolink_curveset_tests iccdev.applytolink-curveset-rgb-channels)
+
+
+
+  # Control: the same RGB chain at the default range, which takes the branch that
+  # attaches no curve set. This is the case that fixes the range condition in
+  # place: REJECT_DUMP asserts the absence the other three assert the presence of,
+  # so widening the condition to attach a curve set unconditionally is red here
+  # while narrowing it to attach one never is red in the three above.
+  add_test(
+    NAME iccdev.applytolink-curveset-default-range
+    COMMAND "${CMAKE_COMMAND}"
+      "-DWRITER=$<TARGET_FILE:iccApplyToLink>"
+      "-DREADER=$<TARGET_FILE:iccDumpProfile>"
+      "-DLABEL=applytolink-curveset"
+      "-DWRITER_ARGS=${ICCDEV_TEST_OUTDIR}/applytolink-curveset-default-range.icc;0;3;1;CurveSetDefault;0;1;1;0;${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc;0"
+      "-DEXPECT_VERDICT=Profile is valid"
+      "-DREJECT_VERDICT=Critical Error|Unable to parse"
+      "-DREJECT_DUMP=BEGIN_CURVE_SET"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunDeviceLinkRoundTripTest.cmake"
+  )
+  list(APPEND _applytolink_curveset_tests iccdev.applytolink-curveset-default-range)
+
+  set_tests_properties(${_applytolink_curveset_tests} PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;tools;applytolink;mpe;curveset;issue-2341;regression"
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+
+  if(WIN32)
+    # Both tools are reached through cmake -P and inherit this test process's
+    # PATH, so both need the runtime paths -- the reader as much as the writer.
+    # A missing IccProfLib2.dll makes iccDumpProfile print nothing, and an empty
+    # report matches no EXPECT_VERDICT, so this presents as a verdict mismatch
+    # rather than as a load failure.
+    set(_applytolink_curveset_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccApplyToLink>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccDumpProfile>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _applytolink_curveset_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(${_applytolink_curveset_tests} PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_applytolink_curveset_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_fileio_getlength_position_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -6419,6 +6572,7 @@ if(WIN32)
   iccdev_add_applytolink_invalid_arg_test()
   iccdev_add_applytolink_negative_intent_tests()
   iccdev_add_applytolink_v4_missing_desc_test()
+  iccdev_add_applytolink_curveset_channels_tests()
   iccdev_add_prmg_hue_normalization_test()
   iccdev_add_qa_evidence_helpers_test()
   iccdev_add_windows_iccdevcmm_smoke_test()
@@ -6489,6 +6643,7 @@ endif()
 iccdev_add_applytolink_invalid_arg_test()
 iccdev_add_applytolink_negative_intent_tests()
 iccdev_add_applytolink_v4_missing_desc_test()
+iccdev_add_applytolink_curveset_channels_tests()
 
 set(ICCDEV_TIMEOUT_COMPAT_DIR "")
 if(NOT WIN32)

--- a/Build/Cmake/Testing/RunDeviceLinkRoundTripTest.cmake
+++ b/Build/Cmake/Testing/RunDeviceLinkRoundTripTest.cmake
@@ -1,0 +1,192 @@
+#################################################################################
+# Device-link write-then-read contract driver, introduced for #2341
+# Copyright (c) 2026 The International Color Consortium.
+#                                        All rights reserved.
+#################################################################################
+
+# RunDeviceLinkRoundTripTest.cmake - writes a device link with one tool, then
+# reads it back with another and asserts the verdict the reader reports.
+#
+# The existing single-tool drivers cannot express this. RunBenchApplyCliTest
+# asserts an exit status and a message from ONE process, and #2341 is precisely a
+# defect that both of those agree with: CDevLinkWriter::begin() left the curve-set
+# slots for input channels 2..n-1 NULL, CIccMpeCurveSet::Write() skips a NULL slot
+# rather than failing, so the writer printed "LUT successfully written" and exited
+# 0 while emitting a link every reader rejects. Measured on the unfixed tool, all
+# four cases registered below report success at the CLI; only reading the file
+# back separates them. An assertion on the writer alone is therefore vacuous here
+# by construction, not by oversight.
+#
+# The verdict oracle is iccDumpProfile's validation report, which is the same
+# string the corpus manifest is expressed in (Testing/qa-profile-manifest.tsv), so
+# a link this driver calls valid is valid in the sense the rest of the suite
+# already uses.
+#
+# The verdict ALONE is too coarse to be the whole assertion, which is worth
+# spelling out because the first version of this file made exactly that mistake.
+# "Parses and validates" is satisfied by a link that simply omits the structure
+# under test: dropping the curve set entirely produces a perfectly valid device
+# link, so a verdict-only suite stayed green through a mutation that deleted the
+# feature. The reader is therefore invoked with ALL, which dumps tag contents, and
+# EXPECT_DUMP/EXPECT_DUMP_COUNT/REJECT_DUMP assert the structure itself. The
+# validation report is present in the same output, so this still costs one process.
+#
+# EXPECT_DUMP_COUNT is what makes the assertion exact rather than merely present:
+# a per-channel structure is only correct if it appears once PER CHANNEL, and
+# "at least one" would pass a link whose remaining channels were wrong or absent.
+#
+# Required -D args:
+#   WRITER          - path to the device-link writer (iccApplyToLink)
+#   WRITER_ARGS     - ';'-separated argument list; the FIRST element must be the
+#                     output path, which is what gets read back
+#   READER          - path to the validating reader (iccDumpProfile)
+#   EXPECT_VERDICT  - regex the reader's report must match
+# Optional -D args:
+#   REJECT_VERDICT    - regex the reader's report must NOT match
+#   EXPECT_DUMP       - regex that must appear in the tag dump
+#   EXPECT_DUMP_COUNT - exact number of times EXPECT_DUMP must appear; when unset,
+#                       EXPECT_DUMP need only appear at least once
+#   REJECT_DUMP       - regex that must NOT appear in the tag dump
+#   LABEL             - prefix for this driver's own log lines
+
+cmake_minimum_required(VERSION 3.18...3.29)
+
+if(NOT DEFINED LABEL OR "${LABEL}" STREQUAL "")
+  set(LABEL "devicelink-roundtrip")
+endif()
+
+foreach(_required WRITER WRITER_ARGS READER EXPECT_VERDICT)
+  if(NOT DEFINED ${_required} OR "${${_required}}" STREQUAL "")
+    message(FATAL_ERROR "[${LABEL}] ${_required} not set")
+  endif()
+endforeach()
+
+foreach(_tool WRITER READER)
+  if(NOT EXISTS "${${_tool}}")
+    message(FATAL_ERROR "[${LABEL}] ${_tool} not found: ${${_tool}}")
+  endif()
+endforeach()
+
+if(DEFINED EXPECT_DUMP_COUNT AND NOT "${EXPECT_DUMP_COUNT}" STREQUAL "")
+  if(NOT EXPECT_DUMP_COUNT MATCHES "^[0-9]+$")
+    message(FATAL_ERROR
+      "[${LABEL}] EXPECT_DUMP_COUNT must be a non-negative integer,"
+      " got '${EXPECT_DUMP_COUNT}'")
+  endif()
+  if(NOT DEFINED EXPECT_DUMP OR "${EXPECT_DUMP}" STREQUAL "")
+    message(FATAL_ERROR
+      "[${LABEL}] EXPECT_DUMP_COUNT requires EXPECT_DUMP: a count with nothing"
+      " to count is not an assertion")
+  endif()
+endif()
+
+list(GET WRITER_ARGS 0 _output)
+
+# Re-created at run time rather than relying on the configure-time mkdir, matching
+# every sibling driver: the directory can be wiped between configure and test, and
+# without it the writer fails to open its output and the run dies pointing at the
+# tool instead of at the missing directory.
+get_filename_component(_output_dir "${_output}" DIRECTORY)
+if(_output_dir)
+  file(MAKE_DIRECTORY "${_output_dir}")
+endif()
+
+# Remove any output left by an earlier run before writing. Without this a writer
+# that silently produced nothing would be validated against the previous run's
+# file, which is a stale-artifact pass of exactly the kind #2254 collects.
+file(REMOVE "${_output}")
+if(EXISTS "${_output}")
+  message(FATAL_ERROR "[${LABEL}] could not clear stale output: ${_output}")
+endif()
+
+execute_process(
+  COMMAND "${WRITER}" ${WRITER_ARGS}
+  RESULT_VARIABLE _write_result
+  OUTPUT_VARIABLE _write_stdout
+  ERROR_VARIABLE  _write_stderr
+)
+set(_write_output "${_write_stdout}${_write_stderr}")
+
+message(STATUS "[${LABEL}] ${WRITER} ${WRITER_ARGS}")
+message(STATUS "[${LABEL}] writer exit=${_write_result}")
+message(STATUS "[${LABEL}] writer output:\n${_write_output}")
+
+if(NOT _write_result MATCHES "^-?[0-9]+$")
+  message(FATAL_ERROR "[${LABEL}] writer did not run: ${_write_result}")
+endif()
+
+if(NOT _write_result EQUAL 0)
+  message(FATAL_ERROR "[${LABEL}] writer failed with exit ${_write_result}")
+endif()
+
+# Asserted so the test still means something if the writer is ever changed to
+# refuse this input: a refusal that wrote no file would otherwise be caught only
+# by the EXISTS check below, with a message pointing at the wrong tool.
+if(NOT _write_output MATCHES "LUT successfully written")
+  message(FATAL_ERROR
+    "[${LABEL}] writer exited 0 without reporting a successful write")
+endif()
+
+if(NOT EXISTS "${_output}")
+  message(FATAL_ERROR
+    "[${LABEL}] writer reported success but produced no file: ${_output}")
+endif()
+
+# ALL dumps tag contents as well as the header and validation report, so the one
+# invocation feeds both the verdict assertions and the structural ones below.
+execute_process(
+  COMMAND "${READER}" -v "${_output}" ALL
+  RESULT_VARIABLE _read_result
+  OUTPUT_VARIABLE _read_stdout
+  ERROR_VARIABLE  _read_stderr
+)
+set(_read_output "${_read_stdout}${_read_stderr}")
+
+message(STATUS "[${LABEL}] reader exit=${_read_result}")
+message(STATUS "[${LABEL}] reader output:\n${_read_output}")
+
+if(NOT _read_result MATCHES "^-?[0-9]+$")
+  message(FATAL_ERROR "[${LABEL}] reader did not run: ${_read_result}")
+endif()
+
+# REJECT_VERDICT is checked before EXPECT_VERDICT so the failure message names the
+# problem the file actually has rather than the string that was missing.
+if(DEFINED REJECT_VERDICT AND NOT "${REJECT_VERDICT}" STREQUAL "")
+  if(_read_output MATCHES "${REJECT_VERDICT}")
+    message(FATAL_ERROR
+      "[${LABEL}] reader reported '${REJECT_VERDICT}' for a link the writer"
+      " called successful: ${_output}")
+  endif()
+endif()
+
+if(NOT _read_output MATCHES "${EXPECT_VERDICT}")
+  message(FATAL_ERROR
+    "[${LABEL}] reader verdict did not match '${EXPECT_VERDICT}': ${_output}")
+endif()
+
+# Structural assertions. A valid verdict says the file parses; these say the
+# structure under test is actually in it, and in the right quantity.
+if(DEFINED REJECT_DUMP AND NOT "${REJECT_DUMP}" STREQUAL "")
+  if(_read_output MATCHES "${REJECT_DUMP}")
+    message(FATAL_ERROR
+      "[${LABEL}] tag dump contains '${REJECT_DUMP}', which this case requires"
+      " to be absent: ${_output}")
+  endif()
+endif()
+
+if(DEFINED EXPECT_DUMP AND NOT "${EXPECT_DUMP}" STREQUAL "")
+  if(DEFINED EXPECT_DUMP_COUNT AND NOT "${EXPECT_DUMP_COUNT}" STREQUAL "")
+    string(REGEX MATCHALL "${EXPECT_DUMP}" _dump_matches "${_read_output}")
+    list(LENGTH _dump_matches _dump_match_count)
+    if(NOT _dump_match_count EQUAL EXPECT_DUMP_COUNT)
+      message(FATAL_ERROR
+        "[${LABEL}] tag dump matched '${EXPECT_DUMP}' ${_dump_match_count}"
+        " time(s), expected exactly ${EXPECT_DUMP_COUNT}: ${_output}")
+    endif()
+  elseif(NOT _read_output MATCHES "${EXPECT_DUMP}")
+    message(FATAL_ERROR
+      "[${LABEL}] tag dump did not match '${EXPECT_DUMP}': ${_output}")
+  endif()
+endif()
+
+message(STATUS "[${LABEL}] OK")

--- a/Build/Cmake/Testing/RunDeviceLinkRoundTripTest.cmake
+++ b/Build/Cmake/Testing/RunDeviceLinkRoundTripTest.cmake
@@ -149,6 +149,10 @@ if(NOT _read_result MATCHES "^-?[0-9]+$")
   message(FATAL_ERROR "[${LABEL}] reader did not run: ${_read_result}")
 endif()
 
+if(NOT _read_result EQUAL 0)
+  message(FATAL_ERROR "[${LABEL}] reader failed with exit ${_read_result}")
+endif()
+
 # REJECT_VERDICT is checked before EXPECT_VERDICT so the failure message names the
 # problem the file actually has rather than the string that was missing.
 if(DEFINED REJECT_VERDICT AND NOT "${REJECT_VERDICT}" STREQUAL "")

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -467,10 +467,25 @@ public:
         pCurve0->GetSamples()[0] = 0;
         pCurve0->GetSamples()[1] = 1;
 
+        // Every input channel samples the same [range_min, range_max] domain, so
+        // one curve is shared across all of them -- CIccMpeCurveSet is built for
+        // that: SetCurve() only deletes the outgoing pointer when no other slot
+        // still aliases it, ~CIccMpeCurveSet()/SetSize(0) dedupe before deleting,
+        // and Write() emits the curve once with every position-table entry
+        // pointing at it.
+        //
+        // The loop counter was unused: it wrote slot 1 nSrcSamples-1 times and
+        // left slots 2..n-1 NULL (#2341). Write() skips a NULL slot instead of
+        // failing, so those channels kept the calloc'd {offset 0, size 0}
+        // position entry and the writer still reported success -- an RGB link
+        // was emitted, and rejected on read with "AToB0Tag - Tag has invalid
+        // structure!". A 1-channel source never enters the loop and a 2-channel
+        // source has slot 1 as its only iteration, so both were already correct
+        // -- which is why this survived since 889db62b.
         pCurves->SetCurve(0, pCurve0);
 
         for (icUInt16Number i = 1; i < nSrcSamples; i++) {
-          pCurves->SetCurve(1, pCurve0);
+          pCurves->SetCurve(i, pCurve0);
         }
 
         pTag->Attach(pCurves);


### PR DESCRIPTION
Closes #2341

## Root cause

`CDevLinkWriter::begin()` attaches a `CIccMpeCurveSet` when the input range is not the default `[0,1]`, sharing one `CIccSingleSampledCurve` across every input channel. The loop that filled slots `1..n-1` ignored its own counter:

```cpp
pCurves->SetCurve(0, pCurve0);

for (icUInt16Number i = 1; i < nSrcSamples; i++) {
  pCurves->SetCurve(1, pCurve0);   // always index 1, never i
}
```

so slot 1 was rewritten `nSrcSamples-1` times and slots `2..n-1` stayed `NULL`.

`CIccMpeCurveSet::Write()` **skips** a NULL slot rather than failing, so those channels kept the `calloc`'d `{offset 0, size 0}` position-table entry and `Write()` still returned `true`. The tool printed `LUT successfully written` and exited 0 while emitting a link every reader rejects; `CIccMpeCurveSet::Begin()` refuses the same file, so it could not be applied either.

Visible in the 716-byte RGB link, at the `cvst` element's position table:

```
00000128: 6376 7374 0000 0000 0003 0003 0000 0024  cvst...........$
00000138: 0000 0020 0000 0024 0000 0020 0000 0000  ... ...$... ....
00000148: 0000 0000 736e 6766                      ....sngf
```

ch0 `{0x24,0x20}`, ch1 `{0x24,0x20}`, **ch2 `{0,0}`** — the third entry is the defect.

A 1-channel source never enters the loop, and a 2-channel source has slot 1 as its only iteration, so both were already correct. That is why this survived from `889db62b` (2023-11-03) until now: it needs a source space with at least three channels.

## Fix

The one-line correction the issue proposes, `SetCurve(1, …)` → `SetCurve(i, …)`.

Sharing one curve across all channels is deliberate and is kept — the class is built for it. `SetCurve()` only deletes an outgoing pointer that no other slot still aliases; `~CIccMpeCurveSet()` → `SetSize(0)` dedupes through `icCurveMap` before deleting; and `Write()` emits the curve once with every position entry pointing at it. Ownership is unchanged: one allocation, one delete, before and after. The fixed RGB link is byte-for-byte the same size as the broken one (716 bytes) — only the two zero-filled position entries become real.

## Reproduction

From the issue, no fuzz artifact needed:

```
iccApplyToLink foo.bar 0 3 1 repro 0.001 0.999 1 0 \
  Testing/sRGB_v4_ICC_preference.icc 0 Testing/sRGB_v4_ICC_preference.icc 0
iccDumpProfile -v foo.bar
```

On master the writer reports success and exits 0, then:

```
Unable to parse 'foo.bar' as ICC profile!
Profile has Critical Error(s) that violate ICC specification
Error! -  - AToB0Tag - Tag has invalid structure!
```

With the fix: `Profile is valid for version 5.00`.

## Verification

The regression coverage asserts the **read-back file**, not the writer. On the unfixed tool both registered cases exit 0 and print `LUT successfully written`, so an exit-status or message assertion — the shape every other `iccApplyToLink` test in the suite uses — is vacuous here by construction.

It also does not stop at the validation verdict. `Profile is valid` is satisfied by a link that simply *omits* the structure under test, so each case is pinned by mutation instead. All four measured:

| Mutation | Test that goes red |
|---|---|
| original bug — slot 1 rewritten | `rgb-channels` |
| curve set dropped entirely (`if (false)`) | `rgb-channels` |
| right curve count, wrong per-channel domain | `rgb-channels` |
| curve set attached unconditionally (`if (true)`) | `default-range` |

An earlier verdict-only version of these tests stayed green through the second and fourth of those. `EXPECT_DUMP_COUNT=3` now pins one curve carrying the requested domain **per input channel** — that count is what carries the general claim, so a wider source is not needed to state it — and the default-range case asserts the curve set is *absent*, which is what gives that control a job.

CMYK (4-channel) and Gray (1-channel) cases were written and withdrawn. They passed locally and turned all three Windows legs red with `Unable to add ... to transform chain (status 3: Invalid profile)` for `Testing/CMYK-3DLUTs/CMYK-3DLUTs.icc` and `Testing/Display/GrayGSDF.icc`. Both validate clean on Linux, and `CreateAllProfiles.bat` reports *"Profile parsed and saved correctly"* for both, so the divergence is in reading the profiles back rather than in this change — reported separately rather than gated to non-Windows, which would have buried it. Every fixture that ships here is tracked in git rather than generated, which is what makes the pair portable.

`RunDeviceLinkRoundTripTest.cmake` is new because the existing single-tool drivers cannot express write-then-read: `RunBenchApplyCliTest` asserts an exit status and a message from one process, which is exactly what this defect agrees with. Registered from both call lists, since the `if(WIN32)` branch ends in `return()` and the two lists are mutually exclusive (#2237).

**Pre-flight**

- Strict clang 21.1.3 — `strict warnings ENABLED`, **0 warnings**.
- GCC 15.2.0 + LTO in `ghcr.io/internationalcolorconsortium/iccdev:latest` — `strict warnings ENABLED`, **0 warnings**.
- ASAN+UBSAN with `detect_leaks=1` (CI runs `detect_leaks=0`) clean on every case measured, including a 4-channel CMYK source — relevant here because the fix aliases one pointer into N slots, so the dedupe in `SetCurve()`/`SetSize(0)` is what keeps it to one delete. LeakSanitizer was confirmed to fire in that same configuration, so the clean result is not a dead detector.
- Full suite 231/232. The single failure is `iccdev.spectral-tiff-preview`, which dies on a missing local `imagecodecs` Python module — pre-existing and unrelated.

## Out of scope

`CIccMpeCurveSet::SetCurve` bounds-checks `nIndex > m_nInputChannels` where `>=` is required, so index `== m_nInputChannels` would write one past the `calloc`'d array (`IccMpeBasic.cpp:3305`). Not touched here: it is unreachable from every caller in the tree, and this change does not widen its reachability — the old code passed indices `{0,1}` and the new code passes `0..n-1`, both strictly inside. Noted for a maintainer ruling rather than fixed in a bug-fix PR.

## CI evidence

Pre-PR dispatch, `ci_scope=source`: run [33558430421](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33558430421). Green on GCC 15.2 Strict Release LTO, Windows MSVC, Windows ClangCL, MinGW UCRT64, macOS Clang Debug and Release, Tool Smoke Tests (ASAN+UBSAN), and the Workflow Security Audit. Both new tests are confirmed to have *run* on Windows MSVC — `Test #127` and `#128` of 137, 0.04s each — rather than being absent from that lane.

`Docker Clang 22 Verification` is red for a reason outside this branch, and `PR Summary` is only the rollup reporting it — its own inputs are `DOCKER_RESULT: failure` with every other result `success` or `skipped`, so this is one condition, not two.

The job fails in step 7 `Pull trusted base image` with `manifest unknown` on `ghcr.io/…/iccdev:sha-$BASE_SHA`. Two things combine:

1. `ci-docker`, which publishes those `sha-` base images, has been **cancelled on every master run since 2026-08-30** — `f8c48f1b`, `045003f9`, `0e6b0ede`, `7c872606`; last success `faa6b311`. So no recent master commit has a published image.
2. `detect-src` nevertheless reports one as available. `trusted_base_image_available` is set from a **branch-name test**, not an image probe — `if [ "$base_ref" = "master" ]` (`ci-pr-action.yml:496-498`) — so for any PR targeting master `build_pr_image` (`:1160`) collapses to `image_definition_changed`. A PR that does not touch the image definition therefore takes the pull path (`ci-docker-pr.yml:236`) and asks for a tag that was never pushed, instead of falling back to building it as the `trusted_base_image_available != 'true'` clause intends.

That is why this is not visible on every PR: #2344 passed the same leg at the same time because it changed `.github/ci/requirements/docker-spectral-preview.txt`, which matches the `image_definition_changed` pattern at `:566` and sent it down the build path. This PR touches only `Build/` and `Tools/`, so it pulls.

Flagging rather than patching, since `ci-pr-action.yml` is shared CI and the standing guidance is not to modify it in a bug-fix PR.
