### PR TITLE
fix(cmm): Begin() the CIccPcsXforms that CheckPCSConnections() builds

### DIFF
--- a/.github/ci/regression/pcs-adjust-placement.cpp
+++ b/.github/ci/regression/pcs-adjust-placement.cpp
@@ -749,7 +749,125 @@ public:
     }
     return n;
   }
+
 };
+
+
+// --- The Begin() ordering contract ---------------------------------------
+//
+// Regression for the flat-colour defect introduced by #2217 and found through
+// the ICS example packages: every render whose chain contained a PCS connection
+// that reduces to a sparse matrix came out one uniform colour, and a different
+// colour on each run.
+//
+// #2217 hoisted CIccSparseMatrix construction out of
+// CIccPcsStepSparseMatrix::Apply() into a new BeginStep(), reached from a new
+// CIccPcsXform::Begin(). Nothing ever called it. CIccCmm::Begin() and
+// CIccNamedColorCmm::Begin() both run their per-xform Begin() loop over
+// m_Xforms *before* calling CheckPCSConnections(), which is where every
+// CIccPcsXform is created, and neither revisits the list. So m_pMtx stayed
+// null, Apply()'s null guard returned without writing pDst, and the caller read
+// back an untouched buffer -- identical for every pixel, hence flat, and
+// uninitialised, hence run-dependent.
+//
+// The fix is in two parts. CheckPCSConnections() now Begin()s every
+// CIccPcsXform it builds, which is the defect proper; and Apply() no longer
+// returns without writing pDst when the matrix is missing, which is what turned
+// a missed initialisation into undefined pixels rather than a clean failure.
+//
+// Only the second part is asserted below, because the first is not observable
+// once the second is in place -- an un-begun step now produces the right answer
+// anyway. Asserting the ordering itself needs either an accessor on
+// CIccPcsXform (an ABI break on an exported class) or a two-range spectral CMM
+// fixture that puts a real sparse step in a real chain; neither is here yet.
+static icSpectralRange makeSpectralRange(icFloat16Number start,
+                                         icFloat16Number end,
+                                         icUInt16Number steps)
+{
+  icSpectralRange r;
+  r.start = start;
+  r.end = end;
+  r.steps = steps;
+  return r;
+}
+
+// The consequence, at the step that actually carried it.
+//
+// A spectral range map is the sparse matrix these chains contain: rangeMap()
+// interpolates each destination sample from two adjacent source samples, so an
+// n x m map holds ~2n non-zeros and reduce() converts it. Apply()ing that step
+// without BeginStep() must still produce the dense matrix's answer -- it may
+// pay the pre-hoist per-pixel construction to do so, but it must never return
+// leaving the destination as the caller left it. Apply() cannot report an
+// error, so silence there is indistinguishable from a correct result.
+static void sparseMatrixStepWritesEveryOutputWithoutBeginStep()
+{
+  const icSpectralRange src = makeSpectralRange(icRange380nm, icRange700nm, 36);
+  const icSpectralRange dst = makeSpectralRange(icRange380nm, icRange780nm, 41);
+
+  CIccPcsStepMatrix *pDense = CIccPcsXform::rangeMap(src, dst);
+  check(pDense != NULL, "sparse step: rangeMap() built a matrix");
+  if (!pDense)
+    return;
+
+  CIccPcsStep *pSparse = pDense->reduce();
+  check(pSparse != (CIccPcsStep *)pDense,
+        "sparse step: a range map is sparse enough for reduce() to convert it");
+  check(pSparse->GetType() == icPcsStepSparseMatrix,
+        "sparse step: reduce() produced a CIccPcsStepSparseMatrix");
+
+  icFloatNumber in[36];
+  for (int i = 0; i < 36; i++)
+    in[i] = icFloatNumber(0.1 + 0.02 * i);
+
+  icFloatNumber want[41];
+  pDense->Apply(NULL, want, in);
+
+  // A value no correct result can hold, so "never written" is distinguishable
+  // from "written with the right answer" without relying on heap contents.
+  static const icFloatNumber kPoison = icFloatNumber(-12345.0);
+
+  icFloatNumber got[41];
+  int i;
+
+  for (i = 0; i < 41; i++)
+    got[i] = kPoison;
+
+  // Deliberately no BeginStep() here: this is the state CheckPCSConnections()
+  // used to leave every step in.
+  pSparse->Apply(NULL, got, in);
+
+  int nUnwritten = 0, nWrong = 0;
+  for (i = 0; i < 41; i++) {
+    if (got[i] == kPoison)
+      nUnwritten++;
+    else if (!closeRel(got[i], want[i], kTol))
+      nWrong++;
+  }
+  check(nUnwritten == 0,
+        "sparse step: Apply() without BeginStep() writes every destination sample");
+  check(nWrong == 0,
+        "sparse step: Apply() without BeginStep() agrees with the dense matrix");
+
+  // And the begun path, which is what the chain actually takes, agrees too.
+  check(pSparse->BeginStep(), "sparse step: BeginStep() succeeds");
+
+  for (i = 0; i < 41; i++)
+    got[i] = kPoison;
+
+  pSparse->Apply(NULL, got, in);
+
+  nWrong = 0;
+  for (i = 0; i < 41; i++) {
+    if (got[i] == kPoison || !closeRel(got[i], want[i], kTol))
+      nWrong++;
+  }
+  check(nWrong == 0,
+        "sparse step: Apply() after BeginStep() agrees with the dense matrix");
+
+  delete pSparse;
+  delete pDense;
+}
 
 // The core claim of this refactor, asserted structurally rather than
 // numerically: after Begin(), no device xform is left holding an adjustment.
@@ -1796,6 +1914,8 @@ int main(int /*argc*/, char ** /*argv*/)
 
   xyzPcsChainStillAdjusts();
   setParamsRefreshesCacheAfterBegin();
+
+  sparseMatrixStepWritesEveryOutputWithoutBeginStep();
 
   if (g_failures) {
     std::printf("\n%d check(s) failed\n", g_failures);

--- a/IccProfLib/IccCmm.cpp
+++ b/IccProfLib/IccCmm.cpp
@@ -5798,8 +5798,21 @@ void CIccPcsStepSparseMatrix::Apply(CIccApplyPcsStep * /* pApply */, icFloatNumb
 {
   // Matrix built once in BeginStep(). This used to construct a CIccSparseMatrix
   // here, which allocated and freed on every pixel -- see BeginStep().
-  if (m_pMtx)
+  if (m_pMtx) {
     m_pMtx->MultiplyVector(pDst, pSrc);
+    return;
+  }
+
+  // BeginStep() did not run, so fall back to the pre-hoist behaviour rather
+  // than return with pDst never written. Apply() cannot report an error, and a
+  // silent early return leaves the caller's destination vector holding whatever
+  // the buffer happened to contain -- which is the same garbage for every
+  // pixel, so a whole image renders one flat colour that changes from run to
+  // run (#2332 follow-up). The local matrix is constructed per call, which is
+  // exactly the cost the hoist removed, but it is correct and thread safe.
+  CIccSparseMatrix mtx((icUInt8Number*)m_vals, m_nBytesPerMatrix, icSparseMatrixFloatNum, true);
+
+  mtx.MultiplyVector(pDst, pSrc);
 }
 
 
@@ -9825,6 +9838,7 @@ icStatusCMM CIccCmm::CheckPCSConnections(bool bUsePCSConversions/*=false*/)
   (void)bUsePCSConversions;  // see header: retained for source compatibility
 
   icStatusCMM rv = icCmmStatOk;
+  icStatusCMM rvBegin;
 
   CIccXformList::iterator last, next;
   CIccXformList xforms;
@@ -9857,6 +9871,21 @@ icStatusCMM CIccCmm::CheckPCSConnections(bool bUsePCSConversions/*=false*/)
       }
 
       if (rv != icCmmStatIdentityXform) {
+        // Nothing upstream will Begin() this object. CIccCmm::Begin() and
+        // CIccNamedColorCmm::Begin() both run their per-xform Begin() loop over
+        // m_Xforms *before* calling this function and neither revisits the list
+        // afterwards, so every CIccPcsXform in the chain -- all of which are
+        // built right here -- would otherwise reach Apply() unbegun, and any
+        // step that defers work to BeginStep() would never receive it. Begin()
+        // is safe to call now and not before: ConnectFirst() ends with
+        // Optimize(), so the step list is final. The same three lines follow the
+        // interior Connect() and the trailing ConnectLast() below.
+        rvBegin = pPcs->Begin();
+        if (rvBegin != icCmmStatOk) {
+          delete pPcs;
+          return rvBegin;
+        }
+
         ptr.ptr = pPcs;
         xforms.push_back(ptr);
 
@@ -9894,6 +9923,14 @@ icStatusCMM CIccCmm::CheckPCSConnections(bool bUsePCSConversions/*=false*/)
         }
 
         if (rv!=icCmmStatIdentityXform) {
+          // Begin() the object here for the reason given at the leading edge
+          // above: nothing else in the CMM ever will.
+          rvBegin = pPcs->Begin();
+          if (rvBegin != icCmmStatOk) {
+            delete pPcs;
+            return rvBegin;
+          }
+
           // A real conversion is needed: ownership of pPcs passes to the xform
           // list, which frees it when the CMM is destroyed.
           ptr.ptr = pPcs;
@@ -9927,6 +9964,14 @@ icStatusCMM CIccCmm::CheckPCSConnections(bool bUsePCSConversions/*=false*/)
       }
 
       if (rv != icCmmStatIdentityXform) {
+        // Begin() the object here for the reason given at the leading edge
+        // above: nothing else in the CMM ever will.
+        rvBegin = pPcs->Begin();
+        if (rvBegin != icCmmStatOk) {
+          delete pPcs;
+          return rvBegin;
+        }
+
         ptr.ptr = pPcs;
         xforms.push_back(ptr);
 


### PR DESCRIPTION
## Summary

Renders whose chain contains a PCS connection that reduces to a sparse matrix come out **one uniform colour, and a different colour on each run**. Found through the ICS example packages.

`#2217` hoisted `CIccSparseMatrix` construction out of `CIccPcsStepSparseMatrix::Apply()` into a new `BeginStep()`, reached from a new `CIccPcsXform::Begin()`. **Nothing ever calls it.** `CIccCmm::Begin()` and `CIccNamedColorCmm::Begin()` both run their per-xform `Begin()` loop over `m_Xforms` *before* calling `CheckPCSConnections()` — which is where every `CIccPcsXform` is created — and neither revisits the list.

So `m_pMtx` stays null, `Apply()`'s null guard returns without writing `pDst`, and the caller reads back an untouched buffer: identical for every pixel (hence flat) and uninitialised (hence run-dependent).

**First bad commit:** `a18b2678` — *perf(tier-C): hoist the pre-existing per-pixel invariants that actually pay (#2217)*, found by `git bisect` over 461 commits. The PCS-adjust refactor (`12aefbe1`, #2332) is **not** involved: rebuilding with `IccCmm.cpp`/`.h` reverted to `12aefbe1^` reproduces the failure identically.

## Fix

**1. `CheckPCSConnections()` now `Begin()`s each `CIccPcsXform` it builds** — once `Connect()`/`ConnectFirst()`/`ConnectLast()` has succeeded, which is the point at which the step list is final (each ends with `Optimize()`). This is the defect proper. It also revives `BeginStep()` as an extension point: it has been dead since #2217, so any future step deferring work to it would have broken the same way.

**2. `CIccPcsStepSparseMatrix::Apply()` no longer returns without writing `pDst`** when the matrix is missing. `Apply()` cannot report an error, so a silent early return is indistinguishable from a correct result. It now falls back to the pre-hoist per-pixel construction — slower, but correct and thread safe.

No ABI change; no header change.

## Regression coverage

`sparseMatrixStepWritesEveryOutputWithoutBeginStep()` in `.github/ci/regression/pcs-adjust-placement.cpp` (the nearest existing file, so no new CMake wiring).

It builds a spectral range map via the public `CIccPcsXform::rangeMap()` — each destination sample interpolates from two adjacent source samples, so `reduce()` reliably converts it to a `CIccPcsStepSparseMatrix` — poisons the destination buffer, and applies the step **without** `BeginStep()`. It asserts every destination sample was written and agrees with the dense matrix, then repeats after `BeginStep()`.

Red before this change (`FAIL: sparse step: Apply() without BeginStep() writes every destination sample`, exit 1), green after.

**What it does not cover.** The ordering fix itself is not directly asserted, because it is not observable once the `Apply()` fallback is in place — an un-begun step now produces the right answer anyway. Pinning it needs either:
- an accessor on `CIccPcsXform` (an ABI break on an exported class — I prototyped this and backed it out: four unrelated regression tests that construct `CIccPcsXform` on the stack started failing with `0xc0000409`/`0xc0000374` against the freshly built DLL until a `--clean-first` rebuild), or
- a two-range spectral CMM fixture that puts a real sparse step in a real chain.

Neither is in this PR. Happy to add the fixture as a follow-up if reviewers want the ordering pinned directly.

## Verification

- `ctest -C Release`: **136/137**. The single failure, `iccdev.applytolink-curveset-rgb-channels` (`issue-2341`), is **pre-existing on this base** — verified by stashing this change and running it on a clean checkout of the base commit.
- All five ICS packages regenerated end to end: **61 outputs, 0 flat** (was 8 flat, plus the flat intermediates that caused them). The `HybridMultiSpectralEncoding` `*_fromMS` previews now match their `*_fromRef` counterparts, which is the independent check on the multispectral round trip.

Primary breakages were `ColorimetricEncoding` S2 and S5a, `SpectralEncoding` S3a, `HybridMultiSpectralEncoding` S1. The remaining flat renders (CE S3c/S4/S5b, all six HMSE `*_fromMS`, SE `Preview-cowsMs6`) were cascade — they read those outputs as their input.

## Unrelated note for maintainers

`ics/HybridMultiSpectralEncoding/BuildAndTest.bat:18` hard-codes `E:\_GITWS\iccDev\iccDev\Testing` onto `PATH`. That package silently ignores whatever you just built and runs whatever binaries are in that directory. No other ICS package does this. Not fixed here (different repo), but it masked the fix during verification and is worth removing.

Nothing in CI exercises the ICS packages, which is why this shipped on 2026-08-20 and survived twelve days: the full 134-test suite passes with the bug present. A job that runs the five `BuildAndTest` scripts and asserts no output image is single-valued would have caught it on day one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
