### PR TITLE
fix(#2262): correct the BRDF rendering-intent rows in three Usage() screens

### DIFF
--- a/.github/scripts/iccdev-issue-2262-brdf-usage-regression.sh
+++ b/.github/scripts/iccdev-issue-2262-brdf-usage-regression.sh
@@ -1,0 +1,360 @@
+#!/bin/bash
+###############################################################################
+# #2262 -- the BRDF rendering-intent lines printed by Usage()
+###############################################################################
+#
+# Three tools publish the same decimal rendering-intent table -- iccApplyNamedCmm,
+# iccApplyProfiles and iccApplyToLink -- and all three carried the same two
+# defects on its BRDF rows.
+#
+#   1. The acronym was transposed, B-D-R-F.  ICC.2-2023 9.2.14-17 and 9.2.26-29
+#      spell the tags brdfAToB0Tag..brdfDToB3Tag, and the library's own
+#      identifiers have always agreed (icXformLutBRDFParam, icSigBRDFDToB0Tag,
+#      CIccStructBRDF).  Only the three Usage() screens disagreed.
+#
+#   2. Codes 50/60/70/80 were printed as flat values, while the structurally
+#      identical Preview row above them is printed as "20 + Intent".  All four
+#      do take an intent in their units digit: CIccXform::Create() indexes a
+#      four-entry tag array with nTagIntent in each of the
+#      icXformLutBRDFParam..icXformLutMCS cases, and the decode that feeds it
+#      falls through its type switch for 5..8 so the units digit reaches the
+#      intent unchanged.  The omission is not cosmetic -- it is what produced
+#      the "51/61/71/81 are bogus codes" finding that had to be refuted on
+#      #2261, i.e. it had already cost a review round before it was fixed.
+#
+# The two halves are asserted differently, and deliberately so:
+#
+#   - The Usage() assertions below are what red/green this change.  Every one
+#     of them fails against master, where all three tools print the four rows as
+#     flat values with the acronym transposed, and iccApplyNamedCmm additionally
+#     names the three transforms Model/Light/Output.
+#   - The decode assertions do NOT fail against master: the decoder was always
+#     right, which is precisely why the printed table was wrong rather than the
+#     behaviour.  They are here as the evidence that the corrected text is
+#     true, and as the guard against the other repair someone could reach for
+#     -- making the tool reject 51/61/71/81 to match the old wording.  That is
+#     the regression this half bites on, and it would remove reachable function.
+#
+# Registered as a script test, so it does not run on Windows (script tests are
+# not registered there at all).  The text under test is emitted by a printf
+# block with no platform-conditional code, so a Linux/macOS lane covers it.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools
+#   ICCDEV_TESTING_DIR -- path to Testing
+#   ICCDEV_TEST_OUTDIR -- output directory for generated logs/configs
+###############################################################################
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+TESTING_DIR="${ICCDEV_TESTING_DIR:-$REPO_ROOT/Testing}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-2262-brdf-usage}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/build-dbg/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+# Tested before the cd rather than after it.  Under "set -e" a command
+# substitution whose cd fails aborts the script right here with no output at
+# all, which makes the "-n" guard below dead code and hides require_tool's
+# "missing executable" diagnostic behind a bare exit 1 -- in CI that reads as
+# "failed, no reason".  Guarding first leaves BUILD_ROOT empty and lets the
+# script reach a failure it can name.  (Written as a test rather than
+# "cd ... || true", which is the A && B || C shape shellcheck flags as SC2015 --
+# and the pre-flight gate runs shellcheck at default severity, so info-level
+# findings fail it.)
+BUILD_ROOT=""
+if [ -d "$TOOLS_DIR" ]; then
+  BUILD_ROOT="$(cd "$TOOLS_DIR/.." && pwd -P)"
+fi
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect:$BUILD_ROOT/IccConnect/IccLibConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+export LLVM_PROFILE_FILE="${LLVM_PROFILE_FILE:-/dev/null}"
+
+# The tracked sRGB v4 profile.  It carries none of the BRDF or MCS tags these
+# codes select, which is exactly what makes it the right fixture here: the
+# decode is asserted from the exported configuration, written before any
+# transform is built, so the test needs no BRDF profile and takes no dependency
+# on the generated-profile fixture.
+SRGB="$TESTING_DIR/sRGB_v4_ICC_preference.icc"
+DATA="$TESTING_DIR/ApplyDataFiles/rgb8bit.txt"
+
+# errexit is lifted across the three lookups for the same reason it is lifted
+# around every tool invocation below.  "find | head" is a pipeline, and under
+# "set -o pipefail" find's non-zero exit for an unreadable or absent TOOLS_DIR
+# becomes the substitution's exit, which under "set -e" aborts the script here
+# with no output whatsoever.  That is what made require_tool's "missing
+# executable" diagnostic unreachable: the failure CI actually saw was a bare
+# exit 1 with an empty log.  Letting the variables come back empty routes the
+# same condition through require_tool, which names it.
+set +e
+APPLYNCM="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplyNamedCmm -type f 2>/dev/null | head -1)"
+APPLYPRF="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplyProfiles -type f 2>/dev/null | head -1)"
+APPLYLNK="$(find "$TOOLS_DIR" -maxdepth 2 -name iccApplyToLink -type f 2>/dev/null | head -1)"
+set -e
+
+PASS=0
+
+fail() {
+  echo "  [FAIL] issue-2262-brdf-usage -- $1"
+  exit 1
+}
+
+require_file() {
+  if [ ! -f "$1" ]; then
+    fail "missing fixture: $1"
+  fi
+}
+
+require_tool() {
+  local what="$1" path="$2"
+
+  if [ -z "$path" ]; then
+    fail "$what not found under $TOOLS_DIR"
+  fi
+  if [ ! -x "$path" ]; then
+    fail "$what is not executable: $path"
+  fi
+}
+
+check_sanitizers() {
+  if grep -qE "ERROR: AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:|LeakSanitizer|DEADLYSIGNAL" "$1" 2>/dev/null; then
+    sed -n '1,120p' "$1"
+    return 1
+  fi
+
+  return 0
+}
+
+require_tool iccApplyNamedCmm "$APPLYNCM"
+require_tool iccApplyProfiles "$APPLYPRF"
+require_tool iccApplyToLink   "$APPLYLNK"
+require_file "$SRGB"
+require_file "$DATA"
+
+echo "=== #2262 BRDF rendering-intent Usage() regression ==="
+
+###############################################################################
+# Part 1 -- the three Usage() screens
+#
+# Each tool prints its table with its own leading indent, so every row here is
+# matched against a copy of the screen with leading whitespace stripped, as a
+# whole-line FIXED string (grep -Fqx).  Fixed rather than a regex on purpose:
+# the MCS row carries "(", ")" and "/", which are ERE metacharacters, so an -E
+# pattern would quietly stop meaning what it reads as.  Whole-line rather than a
+# substring for the same reason it matters at all -- an unanchored "50 + Intent"
+# is satisfied by a row that appended anything to the transform name, and the
+# point of this test is that each row says exactly one thing.
+###############################################################################
+
+# The transposed spelling, split across two adjacent literals so that the
+# repository-wide grep this issue was reopened on finds nothing anywhere in the
+# tree, this test included.  Bash concatenates adjacent quoted strings within a
+# word, so the variable holds the four letters while no line contains them.
+TRANSPOSED="BD""RF"
+
+assert_usage_row() {
+  local name="$1" row="$2"
+
+  grep -Fqx "$row" "$OUTDIR/$name.stripped" ||
+    fail "$name does not print \"$row\""
+}
+
+check_usage() {
+  local name="$1" tool="$2"
+  local log="$OUTDIR/$name.log"
+  local rc=0
+
+  rm -f "$log"
+  set +e
+  timeout 60 "$tool" > "$log" 2>&1
+  rc=$?
+  set -e
+
+  check_sanitizers "$log" || fail "$name usage emitted sanitizer diagnostics"
+  if [ "$rc" -eq 124 ]; then
+    fail "$name timed out printing usage"
+  fi
+  if [ "$rc" -ne 0 ]; then
+    fail "$name did not exit 0 when printing usage (exit=$rc)"
+  fi
+
+  sed 's/^[[:space:]]*//' "$log" > "$OUTDIR/$name.stripped"
+
+  # Anti-vacuity: an empty or truncated capture satisfies the negative
+  # assertion below and none of the positive ones, so pin a row this change
+  # does not touch as evidence the screen was captured whole.  The gamut row is
+  # the one all three tools spell identically -- their Preview rows do not
+  # agree, which is the pre-existing divergence noted on the issue and left
+  # alone here.
+  grep -Fqx "30 - Gamut" "$OUTDIR/$name.stripped" ||
+    fail "$name usage output does not carry the untouched gamut row"
+
+  assert_usage_row "$name" "50 + Intent - BRDF Parameters"
+  assert_usage_row "$name" "60 + Intent - BRDF Direct"
+  assert_usage_row "$name" "70 + Intent - BRDF MCS Parameters"
+  # 80 is the one row carrying a qualifier.  icXformLutMCS offsets by
+  # nTagIntent only on its MVIS/Output branch (MToS0..3, MToB0..3); the
+  # MultiplexIdentification/Input branch reads a single AToM0Tag and the
+  # MultiplexLink branch a single MToA0Tag, so 80..83 are indistinguishable in
+  # the to-MCS direction.  Leaving the row unqualified would have over-claimed
+  # by exactly the criterion that keeps gamut in the flat form.
+  assert_usage_row "$name" "80 + Intent - MCS connection (Intent applies to MToS/MToB only)"
+
+  if grep -Fq "$TRANSPOSED" "$log"; then
+    fail "$name usage output still spells the acronym with the letters transposed"
+  fi
+
+  # ...and the superseded flat form is gone.  Asserting only that the new rows
+  # are present would still pass on a screen that printed both, which is the
+  # shape a careless merge produces.  Scoped to these four codes: 30 and 33
+  # print in the flat form legitimately, because the gamut transform reads
+  # icSigGamutTag with no intent offset.
+  if grep -Eq "^[[:space:]]*(50|60|70|80) - " "$log"; then
+    fail "$name usage output still prints a BRDF/MCS row in the flat form"
+  fi
+
+  PASS=$((PASS + 1))
+}
+
+check_usage applynamedcmm-usage "$APPLYNCM"
+check_usage applyprofiles-usage "$APPLYPRF"
+check_usage applytolink-usage   "$APPLYLNK"
+
+# The three tables must agree with each other.  Each tool prints these rows at
+# its own indent, so compare the stripped rows: the whole reason the wording
+# diverged -- the same three transforms named "Model"/"Light"/"Output" in one
+# tool and "Parameters"/"Direct"/"MCS Parameters" in the other two -- is that
+# nothing ever compared them.
+#
+# The four per-row assertions above already pin the exact wording, so what this
+# adds is narrower than it looks: it catches a row order or a duplicate that
+# every per-row match would still be satisfied by.  Verified live rather than
+# assumed -- swapping the 60 and 70 rows in one tool passes all four row
+# assertions and fails here.
+extract_rows() {
+  grep -E '^(50|60|70|80) \+ Intent - ' "$OUTDIR/$1.stripped"
+}
+
+extract_rows applynamedcmm-usage > "$OUTDIR/rows-namedcmm.txt"
+extract_rows applyprofiles-usage > "$OUTDIR/rows-profiles.txt"
+extract_rows applytolink-usage   > "$OUTDIR/rows-tolink.txt"
+
+if [ "$(wc -l < "$OUTDIR/rows-namedcmm.txt")" -ne 4 ]; then
+  fail "expected four BRDF/MCS rows from iccApplyNamedCmm, found $(wc -l < "$OUTDIR/rows-namedcmm.txt")"
+fi
+
+cmp -s "$OUTDIR/rows-namedcmm.txt" "$OUTDIR/rows-profiles.txt" ||
+  fail "iccApplyNamedCmm and iccApplyProfiles disagree on the BRDF/MCS rows"
+cmp -s "$OUTDIR/rows-namedcmm.txt" "$OUTDIR/rows-tolink.txt" ||
+  fail "iccApplyNamedCmm and iccApplyToLink disagree on the BRDF/MCS rows"
+
+###############################################################################
+# Part 2 -- the "+ Intent" claim is true, not merely printed
+#
+# Asserted through -exportcfg rather than exit status.  Every invocation here
+# exits non-zero, because the tracked sRGB profile carries none of these tags
+# and CIccCmm::AddXform() fails once the transform is actually built -- so exit
+# status cannot tell "the parser refused the code" from "the parser accepted it
+# and the profile had no such tag".  The exported configuration can: it is
+# written after the decode and before the transform, so its presence and its
+# contents are the decode, and a code the parser refuses produces no file at
+# all.  (Reading a downstream failure as a rejection is the vacuity that made
+# an earlier run_expect_reject arm on #2190 pass against the defect.)
+###############################################################################
+
+decode_cfg() {
+  local code="$1" cfg="$OUTDIR/decode-$1.cfg.json" log="$OUTDIR/decode-$1.log"
+
+  local rc=0
+
+  rm -f "$cfg" "$log"
+  set +e
+  timeout 60 "$APPLYNCM" -exportcfg "$cfg" "$DATA" 0 1 "$SRGB" "$code" > "$log" 2>&1
+  rc=$?
+  set -e
+
+  check_sanitizers "$log" || fail "decode-$code emitted sanitizer diagnostics"
+  # Exit status is not the assertion here -- see the block comment above -- but
+  # a timeout and a crash are still worth naming, or they would surface below as
+  # the much less informative "produced no exported configuration".
+  if [ "$rc" -eq 124 ]; then
+    fail "intent code $code timed out"
+  fi
+  if [ "$rc" -ge 128 ] && [ "$rc" -le 192 ]; then
+    fail "intent code $code crashed with signal $((rc - 128))"
+  fi
+
+  # A refused code never reaches the export, so this is the discriminator
+  # between "accepted and decoded" and "rejected".  It is proved non-vacuous by
+  # the rejection control below, which asserts this same line does appear.
+  if grep -Fqx "Unable to parse profile sequence arguments" "$log"; then
+    fail "intent code $code was refused by the profile-sequence parser"
+  fi
+  if [ ! -f "$cfg" ]; then
+    fail "intent code $code produced no exported configuration"
+  fi
+}
+
+assert_decoded() {
+  local code="$1" transform="$2" intent="$3"
+  local cfg="$OUTDIR/decode-$code.cfg.json"
+
+  grep -Fq "\"transform\": \"$transform\"" "$cfg" ||
+    fail "intent code $code did not decode to transform \"$transform\""
+  grep -Fq "\"intent\": \"$intent\"" "$cfg" ||
+    fail "intent code $code did not decode to intent \"$intent\""
+}
+
+# Each family is walked across all four intent digits.  Walking all four is
+# what makes this an assertion about the units digit rather than about one
+# code: a decode that ignored the digit would give the same intent four times
+# and fail on three of them, and one that had been changed to refuse the
+# non-zero digits would fail in decode_cfg.
+INTENTS=(perceptual relative saturation absolute)
+
+for base_and_name in "50:brdfParam" "60:brdfDirect" "70:brdfMcsParam" "80:MCS"; do
+  base="${base_and_name%%:*}"
+  transform="${base_and_name##*:}"
+
+  for digit in 0 1 2 3; do
+    code=$((base + digit))
+    decode_cfg "$code"
+    assert_decoded "$code" "$transform" "${INTENTS[$digit]}"
+    PASS=$((PASS + 1))
+  done
+done
+
+# Rejection control.  3000000 is the unrecognised-overprint code from #2190 and
+# is genuinely refused, so it proves the "Unable to parse profile sequence
+# arguments" check above can fire -- without it, a build that had stopped
+# emitting that diagnostic would let every decode arm pass on a tool that
+# accepted nothing.
+REJECT_CFG="$OUTDIR/decode-reject.cfg.json"
+REJECT_LOG="$OUTDIR/decode-reject.log"
+rm -f "$REJECT_CFG" "$REJECT_LOG"
+set +e
+timeout 60 "$APPLYNCM" -exportcfg "$REJECT_CFG" "$DATA" 0 1 "$SRGB" 3000000 > "$REJECT_LOG" 2>&1
+set -e
+check_sanitizers "$REJECT_LOG" || fail "decode-reject emitted sanitizer diagnostics"
+grep -Fqx "Unable to parse profile sequence arguments" "$REJECT_LOG" ||
+  fail "the rejection control was not refused by the profile-sequence parser"
+if [ -f "$REJECT_CFG" ]; then
+  fail "the rejection control exported a configuration for a refused code"
+fi
+PASS=$((PASS + 1))
+
+echo "  [PASS] issue-2262-brdf-usage -- $PASS assertions"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -8248,6 +8248,40 @@ if(TARGET iccApplyProfiles)
    )
 endif()
 
+# #2262 - the same three tools publish the same decimal rendering-intent table,
+# and all three carried the same two defects on its BRDF rows: the acronym was
+# transposed, and 50/60/70/80 were printed as flat values although each of them
+# takes an intent in its units digit exactly as the "20 + Intent" row above them
+# does. Registered as one test rather than folded into the *-cli-args siblings
+# because the defect is a disagreement *between* the three screens -- nothing
+# ever compared them, which is how iccApplyNamedCmm came to name the same three
+# transforms "Model"/"Light"/"Output" while the other two named them
+# "Parameters"/"Direct"/"MCS Parameters" -- so the cross-tool comparison is the
+# assertion, and it needs all three tools in one process list.
+#
+# Needs no profile fixture: the only .icc it opens is the tracked
+# Testing/sRGB_v4_ICC_preference.icc, and it is opened for its *decode*, read
+# back from -exportcfg, which is written before any transform is built. A
+# profile actually carrying BRDF tags would be needed to apply these transforms
+# and is not needed to assert what the codes decode to.
+#
+# Timeout matches the siblings. Three no-argument usage runs plus seventeen
+# argument decodes: 0.27s in total on a strict Release clang build and 2.24s
+# under GCC Strict ASAN+UBSAN Debug in CI, a 54x margin on the 120 budget at
+# the slower of the two. None of the runs transforms any data -- the usage runs
+# print and exit, and the decode runs stop at transform creation -- so what the
+# sanitized build adds is twenty process startups rather than work, which is
+# why the two figures differ by 8x on a test that does almost nothing.
+if(TARGET iccApplyNamedCmm AND TARGET iccApplyProfiles AND TARGET iccApplyToLink)
+  iccdev_add_script_test(
+    iccdev.issue-2262-brdf-usage
+    120
+    "iccdev;cmm;tools;cli;issue-2190;issue-2262;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2262-brdf-usage-regression.sh"
+   )
+endif()
+
 # #2150 - both iccApply* tools remap a PCS source signature to icSigDevXYZData /
 # icSigDevLabData so PCS numbers are not reinterpreted as device data, then
 # cleared the resulting 0.0-1.0 clip for icEncodeFloat only. Three encodings

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -252,10 +252,43 @@ void Usage()
   printf("     30 - Gamut\n");
   printf("     33 - Gamut Absolute\n");
   printf("     40 + Intent - with BPC\n");
-  printf("     50 - BDRF Model\n");
-  printf("     60 - BDRF Light\n");
-  printf("     70 - BDRF Output\n");
-  printf("     80 - MCS connection\n");
+  // Two corrections, both #2262.
+  //
+  // (1) The acronym was transposed, B-D-R-F.  ICC.2-2023 9.2.14-17 and 9.2.26-29
+  // spell the tags brdfAToB0Tag..brdfDToB3Tag, and every identifier in the
+  // library already agrees: icXformLutBRDFParam (IccCmm.h), icSigBRDFDToB0Tag,
+  // CIccStructBRDF.  The same three lines carry the typo in iccApplyProfiles
+  // and iccApplyToLink and are corrected there too.
+  //
+  // (2) These four codes take a rendering intent in their units digit exactly
+  // as "20 + Intent" does, and printing them as flat values said they did not.
+  // Each of the four transform types selects from a four-entry tag array
+  // indexed by nTagIntent in CIccXform::Create() -- brdfSpectralParameter0 /
+  // brdfColorimetricParameter0 for 50, BRDFDToB0 / BRDFAToB0 for 60,
+  // BRDFMToS0 / BRDFMToB0 for 70, MToS0 / MToB0 for 80 (IccProfLib/IccCmm.cpp,
+  // the icXformLutBRDFParam..icXformLutMCS cases).  80 is qualified because it
+  // is the one code where that is only half true: icXformLutMCS offsets by
+  // nTagIntent on its MVIS/Output branch (MToS0..3, MToB0..3) but reads a
+  // single AToM0Tag for MultiplexIdentification/Input and a single MToA0Tag for
+  // MultiplexLink, so 80..83 are indistinguishable in the to-MCS direction --
+  // the same reason 30/31/32 are identical and gamut stays in the flat form.
+  //
+  // The decode that feeds them preserves the digit: fromArgs() falls through
+  // its type switch for 5..8, so "nIntent % 10" reaches m_intent unchanged
+  // (IccCmmConfig.cpp).  Reading these lines as "51 is not a valid code" is
+  // what produced the refuted Finding 2 on #2261, so the omission had already
+  // cost a review round.
+  //
+  // The transform names are the ones the exported configuration and
+  // docs/icc-connect-config.schema.json publish for these same types --
+  // brdfParam, brdfDirect, brdfMcsParam -- rather than the previous
+  // "Model"/"Light"/"Output" wording, which matched neither the schema nor the
+  // two sibling tools: nothing connected the old row for 60 to the
+  // "transform": "brdfDirect" that -exportcfg writes when it is given.
+  printf("     50 + Intent - BRDF Parameters\n");
+  printf("     60 + Intent - BRDF Direct\n");
+  printf("     70 + Intent - BRDF MCS Parameters\n");
+  printf("     80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
   printf("     90 + Intent - Colorimetric Only\n");
   printf("    100 + Intent - Spectral Only\n");
   printf("    +1000 - Use Luminance based PCS adjustment\n");

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -221,10 +221,33 @@ void Usage()
   printf("    40 - Perceptual with BPC\n");
   printf("    41 - Relative Colorimetric with BPC\n");
   printf("    42 - Saturation with BPC\n");
-  printf("    50 - BDRF Parameters\n");
-  printf("    60 - BDRF Direct\n");
-  printf("    70 - BDRF MCS Parameters\n");
-  printf("    80 - MCS connection\n");
+  // #2262: the acronym was transposed, B-D-R-F -- ICC.2-2023 9.2.14-17 and
+  // 9.2.26-29 spell the tags brdfAToB0Tag..brdfDToB3Tag, and the library's own
+  // identifiers already agree (icXformLutBRDFParam, icSigBRDFDToB0Tag,
+  // CIccStructBRDF).  The same three lines carry the typo in iccApplyNamedCmm
+  // and iccApplyToLink and are corrected there too.
+  //
+  // The four codes also take a rendering intent in their units digit, which
+  // printing them as flat values said they did not: CIccXform::Create() indexes
+  // a four-entry tag array with nTagIntent in each of the
+  // icXformLutBRDFParam..icXformLutMCS cases, and the decode that feeds it
+  // falls through its type switch for 5..8, so "nIntent % 10" reaches the
+  // intent unchanged.  80 is qualified because it is the one code where that is
+  // only half true: icXformLutMCS offsets by nTagIntent on its MVIS/Output
+  // branch (MToS0..3, MToB0..3) but reads a single AToM0Tag for
+  // MultiplexIdentification/Input and a single MToA0Tag for MultiplexLink, so
+  // 80..83 are indistinguishable in the to-MCS direction.
+  //
+  // Written in the "NN + Intent" form iccApplyNamedCmm uses for its 10/20/40
+  // rows rather than enumerated in this screen's own style:
+  // spelling out 50..53, 60..63, 70..73 and 80..83 would add twelve lines to
+  // say the same thing, and this way the three tools' BRDF and MCS rows agree
+  // line for line -- nothing had ever compared them, which is how the same
+  // three transforms came to be named two different ways.
+  printf("    50 + Intent - BRDF Parameters\n");
+  printf("    60 + Intent - BRDF Direct\n");
+  printf("    70 + Intent - BRDF MCS Parameters\n");
+  printf("    80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
   printf("  +1000 - Use Luminance based PCS adjustment\n");
   printf(" +10000 - Use V5 sub-profile if present\n");
 }

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -823,10 +823,33 @@ void Usage()
   printf("    40 - Perceptual with BPC\n");
   printf("    41 - Relative Colorimetric with BPC\n");
   printf("    42 - Saturation with BPC\n");
-  printf("    50 - BDRF Parameters\n");
-  printf("    60 - BDRF Direct\n");
-  printf("    70 - BDRF MCS Parameters\n");
-  printf("    80 - MCS connection\n");
+  // #2262: the acronym was transposed, B-D-R-F -- ICC.2-2023 9.2.14-17 and
+  // 9.2.26-29 spell the tags brdfAToB0Tag..brdfDToB3Tag, and the library's own
+  // identifiers already agree (icXformLutBRDFParam, icSigBRDFDToB0Tag,
+  // CIccStructBRDF).  The same three lines carry the typo in iccApplyNamedCmm
+  // and iccApplyProfiles and are corrected there too.
+  //
+  // The four codes also take a rendering intent in their units digit, which
+  // printing them as flat values said they did not: CIccXform::Create() indexes
+  // a four-entry tag array with nTagIntent in each of the
+  // icXformLutBRDFParam..icXformLutMCS cases, and the decode that feeds it
+  // falls through its type switch for 5..8, so "nIntent % 10" reaches the
+  // intent unchanged.  80 is qualified because it is the one code where that is
+  // only half true: icXformLutMCS offsets by nTagIntent on its MVIS/Output
+  // branch (MToS0..3, MToB0..3) but reads a single AToM0Tag for
+  // MultiplexIdentification/Input and a single MToA0Tag for MultiplexLink, so
+  // 80..83 are indistinguishable in the to-MCS direction.
+  //
+  // Written in the "NN + Intent" form iccApplyNamedCmm uses for its 10/20/40
+  // rows rather than enumerated in this screen's own style:
+  // spelling out 50..53, 60..63, 70..73 and 80..83 would add twelve lines to
+  // say the same thing, and this way the three tools' BRDF and MCS rows agree
+  // line for line -- nothing had ever compared them, which is how the same
+  // three transforms came to be named two different ways.
+  printf("    50 + Intent - BRDF Parameters\n");
+  printf("    60 + Intent - BRDF Direct\n");
+  printf("    70 + Intent - BRDF MCS Parameters\n");
+  printf("    80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
   printf("  +100 - Use Luminance based PCS adjustment\n");
   printf(" +1000 - Use V5 sub-profile if present\n");
 }

--- a/docs/iccapply/iccApplyProfiles.dox
+++ b/docs/iccapply/iccApplyProfiles.dox
@@ -39,7 +39,7 @@ trailing direct-mode token is rejected rather than ignored.
 | profile sequence | pairs with optional `-ENV:sig value` and `-PCC file` | Standard CMM transforms and connection conditions. |
 
 The rendering-intent selector supports the documented base, transform,
-preview, gamut, BPC, BDRF, and MCS values printed by `Usage()`. Add 1000 for
+preview, gamut, BPC, BRDF, and MCS values printed by `Usage()`. Add 1000 for
 luminance-based PCS adjustment and 10000 to use a V5 sub-profile where present.
 
 \section profiles_runtime Transform and output behavior


### PR DESCRIPTION
Part of #2262.

`iccApplyNamedCmm`, `iccApplyProfiles` and `iccApplyToLink` publish the same decimal rendering-intent table, and all three carried the same two defects on its BRDF rows. Nothing had ever compared the three screens, which is how they came to disagree with each other as well as with the spec. (`iccApplySearch` publishes a fourth, much shorter table through the same decoder — see the follow-up note at the end.)

## 1. The acronym was transposed

ICC.2-2023 §9.2.14-17 and §9.2.26-29 spell the tags `brdfAToB0Tag`..`brdfDToB3Tag`. Every identifier in the library already agreed — `icXformLutBRDFParam`, `icSigBRDFDToB0Tag`, `CIccStructBRDF`, and the `brdf*` names `.github/ci/regression/tag-name-spelling.cpp` pins. Only the three `Usage()` screens and one line of `docs/iccapply/iccApplyProfiles.dox` disagreed.

The repro on the issue is now empty tree-wide:

```
$ git grep -n BDRF
$
```

The new test does not reintroduce it either — it assembles the string from two adjacent literals so the grep stays clean including the test itself.

## 2. `50/60/70/80` were printed as flat values, and they are not

Each of these four codes takes a rendering intent in its units digit, exactly as the structurally identical `20 + Intent - Preview` row above them does. `CIccXform::Create()` indexes a four-entry tag array with `nTagIntent` in every one of the `icXformLutBRDFParam`..`icXformLutMCS` cases:

| code | transform | tag family (`IccProfLib/IccCmm.cpp`) |
|---|---|---|
| 50 | `icXformLutBRDFParam` | `icSigBrdfSpectralParameter0Tag + nTagIntent` :977, `icSigBrdfColorimetricParameter0Tag + nTagIntent` :985 |
| 60 | `icXformLutBRDFDirect` | `icSigBRDFDToB0Tag + nTagIntent` :1021, `icSigBRDFAToB0Tag + nTagIntent` :1056 |
| 70 | `icXformLutBRDFMcsParam` | `icSigBRDFMToS0Tag + nTagIntent` :1078, `icSigBRDFMToB0Tag + nTagIntent` :1111 |
| 80 | `icXformLutMCS` | `icSigMToS0Tag + nTagIntent` :1171, `icSigMToB0Tag + nTagIntent` :1204 — **but** a bare `icSigAToM0Tag` :1163 and a bare `icSigMToA0Tag` :1241 on the other two branches; see below |

`CIccCfgProfileSequence::fromArgs()` falls through its type switch for 5..8, so `nIntent % 10` reaches `m_intent` unchanged. The table below is the *decode*, measured not derived — all sixteen codes read back through `-exportcfg` against the tracked `Testing/sRGB_v4_ICC_preference.icc`:

```
CODE  TRANSFORM       INTENT        CODE  TRANSFORM       INTENT
50    brdfParam       perceptual    70    brdfMcsParam    perceptual
51    brdfParam       relative      71    brdfMcsParam    relative
52    brdfParam       saturation    72    brdfMcsParam    saturation
53    brdfParam       absolute      73    brdfMcsParam    absolute
60    brdfDirect      perceptual    80    MCS             perceptual
61    brdfDirect      relative      81    MCS             relative
62    brdfDirect      saturation    82    MCS             saturation
63    brdfDirect      absolute      83    MCS             absolute
```

This omission was not cosmetic. It is what produced the "51/61/71/81 are bogus codes" finding that had to be refuted on #2261 — the screen had already cost a review round. There is also a live CTest that has been depending on the undocumented digit all along: `iccdev.v5-namedcmm-regressions` runs `iccApplyNamedCmm ... 60` **and** `... 61` against a v5 BRDF DToB profile and expects both to succeed (`.github/scripts/iccdev-v5-namedcmm-regression-tests.sh:100-104`).

## 3. `iccApplyNamedCmm` named the three transforms differently from everything else

It printed `Model` / `Light` / `Output` where the other two tools printed `Parameters` / `Direct` / `MCS Parameters` for the same three `icXformLut*` values, and where `-exportcfg` and `docs/icc-connect-config.schema.json` publish `brdfParam` / `brdfDirect` / `brdfMcsParam`. Nothing connected `60 - BDRF Light` to the `"transform": "brdfDirect"` the tool itself writes for that code. All three now print the same four rows.

## `80` is qualified, and that is deliberate

`80 + Intent` is the one row where the claim is only half true, so it does not print bare:

```
80 + Intent - MCS connection (Intent applies to MToS/MToB only)
```

`icXformLutMCS` offsets by `nTagIntent` on its MVIS/Output branch (`MToS0..3`, `MToB0..3`), but reads a **single** `AToM0Tag` for MultiplexIdentification/Input and a **single** `MToA0Tag` for MultiplexLink — so 80..83 are indistinguishable in the to-MCS direction. Printing it unqualified would have over-claimed by exactly the criterion I used to justify leaving gamut flat, which would have made this PR commit a smaller version of the defect it fixes. Caught in review, not in the first draft.

## Form

Written as `NN + Intent - <name>` in all three tools rather than enumerated. `iccApplyProfiles` and `iccApplyToLink` spell their 10/20/40 groups out, so the in-style alternative there would be 50..53, 60..63, 70..73 and 80..83 — twelve extra lines per screen to say what four say. This way the three tools' BRDF and MCS rows agree line for line, which the new test asserts.

## Test — `iccdev.issue-2262-brdf-usage`

One script covering all three tools, because the defect *is* a disagreement between the three screens, so the cross-tool comparison is the assertion. Needs no profile fixture: the only `.icc` it opens is the tracked sRGB v4 profile, and it is opened for its decode, read back from `-exportcfg`, which is written before any transform is built.

The two halves are deliberately different, and the script says so:

- The **`Usage()` assertions red/green the change** — they fail against master.
- The **decode assertions pass against master**, because the decoder was always correct. They are the evidence that the corrected text is true, and the guard against the opposite repair — making the tool refuse 51/61/71/81 to match the old wording, which would remove reachable function.

Exit status is not the assertion for the decode half: every one of those invocations exits non-zero, because sRGB carries none of these tags and `AddXform` fails once the transform is built. A non-zero exit therefore cannot distinguish "the parser refused the code" from "the parser accepted it and the profile had no such tag" — the same vacuity that let a `run_expect_reject` arm on #2190 pass against the defect. The exported configuration can, and a rejection control (`3000000`, from #2190) proves the discriminator fires.

**Mutation-tested**, each mutation failing on its own assertion and no other:

| mutation | assertion that caught it |
|---|---|
| decoder discards the units digit for types 5..8 | `intent code 51 did not decode to intent "relative"` |
| decoder refuses 51/61/71/81 | `intent code 51 was refused by the profile-sequence parser` |
| one tool's row reworded | `applyprofiles-usage does not print "70 + Intent - BRDF MCS Parameters"` |
| one tool's rows reordered (all per-row matches still pass) | `iccApplyNamedCmm and iccApplyProfiles disagree on the BRDF/MCS rows` |
| a screen printing both the old flat row and the new one | `applynamedcmm-usage usage output still prints a BRDF/MCS row in the flat form` |
| the qualified MCS row reworded (its text carries `(`, `)`, `/`) | `does not print "80 + Intent - MCS connection (Intent applies to MToS/MToB only)"` |

Rows are matched as whole-line **fixed** strings against a whitespace-stripped copy of each screen, not as regexes — the MCS row's `(`, `)` and `/` are ERE metacharacters, and a `-E` pattern there would quietly stop meaning what it reads as.

Two failure paths in the script are named rather than silent. `find | head` is a pipeline, so under `set -o pipefail` `find`'s non-zero exit for an absent tools directory became the substitution's exit and `set -e` aborted with a completely empty log — `require_tool`'s diagnostic was unreachable, and in CI that reads as "failed, no reason". Same shape one line earlier for `BUILD_ROOT`. Both now reach a message naming which tool was missing and where it was looked for; verified by running with a bogus `ICCDEV_TOOLS_DIR` and a bogus `ICCDEV_TESTING_DIR`. (The pattern is inherited from the `*-cli-args` siblings — I fixed it only in the new file rather than churning theirs.)

## Pre-flight

| lane | result |
|---|---|
| Clang 21.1.3, `-Wall -Wextra -Wpedantic -Werror`, clean build dir | 148 TUs, 30 targets, **0 warnings**, 0 errors — CMake reported `strict warnings ENABLED (Clang 21.1.3)` |
| GCC 15.2.0 in CI's own container (`ghcr.io/internationalcolorconsortium/iccdev:latest`), same flags + `-DENABLE_LTO=ON` | 148 TUs, 30 targets, **0 warnings**, 0 errors — `strict warnings ENABLED (GNU 15.2.0)` |
| `grep -cE 'warning:'` on each full build log | `0` / `0` |
| `shellcheck` 0.9.0 (the version CI installs) on the new script | rc=0 |
| targeted CTests | 10/10 pass, incl. the three `*-cli-args` siblings, `iccdev.v5-namedcmm-regressions`, `iccdev.issue-1421-cfg-transform-enum-load` and `iccdev.issue-2150-pcs-unitfloat-clip` |
| new test runtime | 0.27s unsanitized locally; **2.24s** under GCC Strict ASAN+UBSAN in CI — a 54x margin on the 120s budget at the slower of the two |

No existing expectation site depends on the old text — `git grep` over `.github/`, `Build/`, `Testing/` and `docs/` finds nothing asserting the superseded rows.

## Deliberately not changed

- **`+100000 - Use HToS tag if present` still overclaims.** This is item 1 of the punch list and is the one that needs your call, not mine. Re-verified on `12038392`: `m_useHToS` is written by `fromArgs()` and `jsonToValue()` and read only by `toJson()` (`IccCmmConfig.cpp:1003`); the CMM's HToS injection at `IccCmm.cpp:10016` keys off tag presence and the previous xform's intent and consults no flag. So the column round-trips through the exported config and selects nothing. Two ways to close it — wire the flag through (a library API change, `AddXform` takes no HToS argument) or reword the line to say it is recorded only — and picking between them is a design decision. Happy to PR either once you rule.
- **Gamut stays in the flat form.** `icXformLutGamut` reads `icSigGamutTag` with no intent offset and only absolute is special-cased, so 30/31/32 really are identical and `30 - Gamut` / `33 - Gamut Absolute` are already correct. This is the half of #2261's Finding 2 that was right.
- **`iccApplyProfiles` and `iccApplyToLink` list 40/41/42 but not 43**, and their Preview rows are worded differently from `iccApplyNamedCmm`'s. Both are pre-existing and untouched here; the new test pins only the four rows this change owns.

- **`iccApplySearch` needs a follow-up, not a wider PR.** It decodes intent codes through the same `CIccCfgProfileSequence::fromArgs`, but its table (`iccApplySearch.cpp:229-238`) lists only 0-3, 10, 40, 90 and 100 — it omits 20, 30/33, 50/60/70/80 and the `+1000` luminance digit entirely. It never carried the transposed acronym, so it is outside this fix, but the new test enforces agreement across three screens only, so the "nothing ever compared them" divergence can still reappear on the fourth. Happy to file it.

Script tests are not registered on Windows, so this test runs on the Linux/macOS lanes only. The text under test is a `printf` block with no platform-conditional code.

Dispatched `ci-pr-action` with `ci_scope=source` before opening, per the pre-PR ordering: [run 33587382187](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33587382187) — **15 success, 3 skipped, 0 failures**, covering GCC 15.2 Strict Release LTO, macOS Clang Debug + Release LTO, Tool Smoke Tests ASAN+UBSAN, Windows MSVC / ClangCL / MinGW UCRT64, and Docker Clang 22. `source` because the new `if(TARGET ...)` registration has to configure under MSVC.

The new test is confirmed to have *run* there, not skipped: `Test #227 iccdev.issue-2262-brdf-usage ... Passed 2.24 sec` on the GCC Strict ASAN+UBSAN lane and `Test #226 ... Passed 2.23 sec` on the Docker Clang 22 lane.

One amend landed after that run: the CMake comment had claimed "more than two orders of magnitude inside the 120 budget" from the 0.27s unsanitized figure, which the CI-measured 2.24s makes wrong (54x, not 100x+). `git diff` between the validated commit and this one is that comment and nothing else.
