### PR TITLE
fix(#2270,#2271): read every intent column in iccBenchApply, drop the dead transform-type bound

### DIFF
--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -2927,6 +2927,87 @@ function(iccdev_add_applytolink_negative_intent_tests)
   endif()
 endfunction()
 
+# #2270: iccApplyToLink's transform-type range check could never fire.
+#
+# nType is "abs(code % 100) / 10", so it spans 0..9; the check tested it against
+# icXformLutMinimum (0) and icXformLutMaximum (0xD). Sweeping all 1000 codes on
+# master, "decoded transform type is out of range" printed zero times. The check
+# was removed rather than widened, per the ruling on the issue.
+#
+# BOTH TESTS BELOW ARE GREEN ON THE UNFIXED TREE, and that is not a defect in
+# them: removing unreachable code cannot change behaviour, so there is no red
+# probe to write. What they pin is the ruling itself -- the two column widths a
+# future change could plausibly get wrong -- and each goes red under the
+# alternative that was rejected.
+#
+# "90" is the largest tens digit the column can hold (icXformLutColorimetric).
+# "140" is the case that separates this decode from CIccCfgProfileSequence::
+# fromArgs(): that one strips "% 1000", so its hundreds column feeds nType and
+# "140" is refused there as type 14 -- measured, alongside "130" resolving to
+# icXformLutNamedDevice. This tool spends the same column on nLuminance, so 140
+# is a luminance-matched BPC request and succeeds. Widening the tens column here
+# to 0..13 -- option (b) on the issue, the one not taken -- would silently
+# redefine every code from 100 up and turn this test red.
+function(iccdev_add_applytolink_transform_type_tests)
+  if(NOT TARGET iccApplyToLink)
+    return()
+  endif()
+
+  add_dependencies(check iccApplyToLink)
+  add_dependencies(check-fast iccApplyToLink)
+
+  set(_applytolink_type_tests "")
+
+  add_test(
+    NAME iccdev.applytolink-max-transform-type-digit
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccApplyToLink>"
+      "-DLABEL=applytolink-cli"
+      "-DTOOL_ARGS=${ICCDEV_TEST_OUTDIR}/applytolink-max-transform-type-digit.icc;0;2;1;MaxTypeDigit;0;1;0;0;${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc;90"
+      "-DEXPECT_EXIT=zero"
+      "-DEXPECT_MATCH=LUT successfully written"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  list(APPEND _applytolink_type_tests iccdev.applytolink-max-transform-type-digit)
+
+  add_test(
+    NAME iccdev.applytolink-hundreds-column-is-not-a-type
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccApplyToLink>"
+      "-DLABEL=applytolink-cli"
+      "-DTOOL_ARGS=${ICCDEV_TEST_OUTDIR}/applytolink-hundreds-column-is-not-a-type.icc;0;2;1;HundredsIsLuminance;0;1;0;0;${ICCDEV_TESTING_DIR}/sRGB_v4_ICC_preference.icc;140"
+      "-DEXPECT_EXIT=zero"
+      "-DEXPECT_MATCH=LUT successfully written"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  list(APPEND _applytolink_type_tests iccdev.applytolink-hundreds-column-is-not-a-type)
+
+  set_tests_properties(${_applytolink_type_tests} PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;tools;applytolink;cli;exitcode;issue-2270;regression"
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+
+  if(WIN32)
+    # Same reason as the sibling above: the tool is reached through cmake -P and
+    # the child inherits this process's PATH, so without these a missing
+    # IccProfLib2.dll would exit nonzero and fail these positive tests for a
+    # reason that has nothing to do with the decode.
+    set(_applytolink_type_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccApplyToLink>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _applytolink_type_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(${_applytolink_type_tests} PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_applytolink_type_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_applytolink_v4_missing_desc_test)
   if(NOT TARGET iccApplyToLink)
     return()
@@ -5878,6 +5959,120 @@ if(TARGET iccBenchApply)
     FIXTURES_REQUIRED iccdev_profiles
   )
 
+  # #2271: two columns of DecodeIntent() disagreed with the iccApplyToLink decode
+  # its own comment claimed to reproduce.
+  #
+  # A tens digit of 4 asks for black-point compensation. iccApplyToLink maps it to
+  # lookup type 0 plus a CIccApplyBPCHint; DecodeIntent() special-cased only
+  # nType == 1, so 4 reached AddXform() as the lookup type icXformLutBPC
+  # (IccCmm.h:136 is 0x4) and the whole chain failed. Measured on master: the same
+  # "40" wrote a device link through one tool and printed "Invalid Look-Up Table
+  # type" through the other. This is the red probe -- it fails to even exit 0
+  # before the fix.
+  add_test(
+    NAME iccdev.bench-apply-bpc-intent-code
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;40"
+      "-DEXPECT_EXIT=zero"
+      "-DEXPECT_MATCH=chain: 1 profile"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+
+  # Accepting "40" is not the same as honouring it, and the difference is exactly
+  # the defect: a fix that mapped the digit to type 0 and forgot the hint would
+  # pass the test above and change nothing. So this one pins the RESULT. The two
+  # runs differ only in the tens digit, and the checksum is over the applied
+  # pixels, so a hint that never reached the xform leaves them equal.
+  #
+  # Compared rather than pinned to a literal because the checksum is FNV-1a over
+  # raw float bytes -- portable across runs of one binary, not across compilers.
+  add_test(
+    NAME iccdev.bench-apply-bpc-changes-result
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;40"
+      "-DEXPECT_EXIT=zero"
+      "-DCOMPARE_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;0"
+      "-DCOMPARE_EXTRACT=0x([0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])"
+      "-DCOMPARE_MODE=differ"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+
+  # The hundreds column is a luminance-matching request. DecodeIntent() stripped
+  # it with "nIntent % 100" and never assigned it, so codes 0, 100 and 200 built
+  # the identical chain -- measured on master, all three gave 0x927c370d.
+  #
+  # TWO profiles, and first_transform=1, are both load-bearing. The hint sets
+  # m_bLuminanceMatching, which is read only by CIccPcsXform::pushXYZConvert()
+  # when connecting one profile's xform to the next -- a single-profile chain has
+  # no such connection and shows nothing. That is why the issue as filed reported
+  # the divergence from code inspection alone: the probe behind it used one
+  # profile and first_transform=0.
+  add_test(
+    NAME iccdev.bench-apply-luminance-column
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;100;Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc;0"
+      "-DEXPECT_EXIT=zero"
+      "-DCOMPARE_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;0;Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc;0"
+      "-DCOMPARE_EXTRACT=0x([0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])"
+      "-DCOMPARE_MODE=differ"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+
+  # The column is a flag, not a magnitude: iccApplyToLink tests "if (nLuminance)",
+  # so 100 and 200 request the same thing. Green before the fix as well as after
+  # -- both codes used to be dropped, and dropping two codes also makes them
+  # agree -- so it is a semantic pin rather than a red probe, and it is the
+  # partner the test above needs: on its own, "differ" is satisfied by any change
+  # that makes the hundreds column matter in any way at all, including reading it
+  # as a transform type. It is also the only caller exercising COMPARE_MODE=same,
+  # which would otherwise be an untested branch of the driver.
+  add_test(
+    NAME iccdev.bench-apply-luminance-column-is-a-flag
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;100;Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc;0"
+      "-DEXPECT_EXIT=zero"
+      "-DCOMPARE_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;200;Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc;0"
+      "-DCOMPARE_EXTRACT=0x([0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])"
+      "-DCOMPARE_MODE=same"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+
+  # The rejection path that now runs AFTER a hint has been constructed. "45" has
+  # tens digit 4, so DecodeIntent() adds the BPC hint, and then refuses the code
+  # on the units digit. Moving hint construction ahead of the range test is new in
+  # this change, and this is the case that proves the refusal survived it: an
+  # early "return true" bolted on next to the AddHint() calls would pass every
+  # other test in this block.
+  add_test(
+    NAME iccdev.bench-apply-hinted-then-rejected
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;45"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=decoded intent out of range"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+
+  # Both profiles these five name are tracked in the repository, not generated, so
+  # the fixture is a scheduling dependency rather than a source of them -- which
+  # is why a Windows leg cannot satisfy it while the file sits somewhere else.
+  set_tests_properties(
+    iccdev.bench-apply-bpc-intent-code
+    iccdev.bench-apply-bpc-changes-result
+    iccdev.bench-apply-luminance-column
+    iccdev.bench-apply-luminance-column-is-a-flag
+    iccdev.bench-apply-hinted-then-rejected
+    PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;issue-2271;regression"
+    FIXTURES_REQUIRED iccdev_profiles
+  )
+
   if(WIN32)
     set(_bench_windows_env_mods
       "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccBenchApply>"
@@ -5898,7 +6093,12 @@ if(TARGET iccBenchApply)
       iccdev.bench-apply-empty-suite
       iccdev.bench-apply-negative-intent-code
       iccdev.bench-apply-valid-intent-code
-      iccdev.bench-apply-valid-intent-code-typed)
+      iccdev.bench-apply-valid-intent-code-typed
+      iccdev.bench-apply-bpc-intent-code
+      iccdev.bench-apply-bpc-changes-result
+      iccdev.bench-apply-luminance-column
+      iccdev.bench-apply-luminance-column-is-a-flag
+      iccdev.bench-apply-hinted-then-rejected)
     if(TARGET iccFromXml)
       list(APPEND _bench_env_mod_tests
         iccdev.apply-throughput
@@ -6571,6 +6771,7 @@ if(WIN32)
   iccdev_add_iccprofileplot_exitcode_test()
   iccdev_add_applytolink_invalid_arg_test()
   iccdev_add_applytolink_negative_intent_tests()
+  iccdev_add_applytolink_transform_type_tests()
   iccdev_add_applytolink_v4_missing_desc_test()
   iccdev_add_applytolink_curveset_channels_tests()
   iccdev_add_prmg_hue_normalization_test()
@@ -6642,6 +6843,7 @@ endif()
 # been called from both places.
 iccdev_add_applytolink_invalid_arg_test()
 iccdev_add_applytolink_negative_intent_tests()
+iccdev_add_applytolink_transform_type_tests()
 iccdev_add_applytolink_v4_missing_desc_test()
 iccdev_add_applytolink_curveset_channels_tests()
 

--- a/Build/Cmake/Testing/RunBenchApplyCliTest.cmake
+++ b/Build/Cmake/Testing/RunBenchApplyCliTest.cmake
@@ -31,9 +31,27 @@
 #   EXPECT_EXIT  - "zero" or "nonzero"
 # Optional -D args:
 #   TOOL_ARGS    - ';'-separated argument list passed to the tool
-#   EXPECT_MATCH - regex that must appear in stdout or stderr
+#   EXPECT_MATCH - regex that must appear in stdout or stderr (run A only)
 #   LABEL        - prefix for this driver's own log lines
 #                  (default: bench-apply-cli, so existing callers are unchanged)
+# Optional -D args for a two-run differential assertion (#2271):
+#   COMPARE_ARGS    - a second ';'-separated argument list. When set, the tool is
+#                     run a second time with it and the two runs are compared.
+#   COMPARE_EXTRACT - regex with exactly ONE capture group, applied to both
+#                     outputs. BOTH runs must match it or the test fails, so a
+#                     regex that silently stops matching cannot degrade into a
+#                     comparison of two empty strings.
+#   COMPARE_MODE    - "differ" (default) or "same".
+#
+# The differential mode exists because the interesting assertions for #2271 are
+# about a value that is not portable enough to write down. iccBenchApply prints
+# an FNV-1a checksum over the raw bytes of the applied floats; the last bits of a
+# colour transform legitimately differ between compilers and CPUs, so pinning a
+# literal 0x7be0e6ba here would be a Windows and macOS flake waiting to happen.
+# Comparing two runs of the SAME binary on the SAME machine asserts the thing
+# that actually matters -- that the hint changed the result -- and is stable
+# everywhere. EXPECT_MATCH cannot express it: the two codes differ by a hint, not
+# by any word the tool prints.
 
 cmake_minimum_required(VERSION 3.18...3.29)
 
@@ -71,42 +89,103 @@ if(EXPECT_EXIT STREQUAL "nonzero"
     " or a missing runtime library")
 endif()
 
-execute_process(
-  COMMAND "${TOOL}" ${TOOL_ARGS}
-  RESULT_VARIABLE _result
-  OUTPUT_VARIABLE _stdout
-  ERROR_VARIABLE  _stderr
-)
+# One invocation plus the status assertions that apply to every run. Factored out
+# so the second, comparison run of a differential test is held to exactly the
+# same rules as the first -- a comparison against a run that crashed would
+# otherwise "pass" by differing (#2271).
+function(icc_run_tool_once _args _tag _out_var)
+  execute_process(
+    COMMAND "${TOOL}" ${_args}
+    RESULT_VARIABLE _result
+    OUTPUT_VARIABLE _stdout
+    ERROR_VARIABLE  _stderr
+  )
 
-set(_output "${_stdout}${_stderr}")
+  set(_out "${_stdout}${_stderr}")
 
-message(STATUS "[${LABEL}] ${TOOL} ${TOOL_ARGS}")
-message(STATUS "[${LABEL}] exit=${_result}")
-message(STATUS "[${LABEL}] output:\n${_output}")
+  message(STATUS "[${LABEL}] ${_tag}: ${TOOL} ${_args}")
+  message(STATUS "[${LABEL}] ${_tag}: exit=${_result}")
+  message(STATUS "[${LABEL}] ${_tag}: output:\n${_out}")
 
-# A non-numeric RESULT_VARIABLE means the process could not be started at all --
-# execute_process reports the reason as a string rather than a status. That is a
-# narrower case than it looks: a process that starts and then dies for a missing
-# DLL still yields a number. The EXPECT_MATCH requirement above is what covers
-# that; this check only keeps a failure-to-launch from being read as a status.
-if(NOT _result MATCHES "^-?[0-9]+$")
-  message(FATAL_ERROR "[${LABEL}] tool did not run: ${_result}")
-endif()
+  # A non-numeric RESULT_VARIABLE means the process could not be started at all
+  # -- execute_process reports the reason as a string rather than a status. That
+  # is a narrower case than it looks: a process that starts and then dies for a
+  # missing DLL still yields a number. The EXPECT_MATCH requirement above is what
+  # covers that; this check only keeps a failure-to-launch from being read as a
+  # status.
+  if(NOT _result MATCHES "^-?[0-9]+$")
+    message(FATAL_ERROR "[${LABEL}] ${_tag}: tool did not run: ${_result}")
+  endif()
 
-if(EXPECT_EXIT STREQUAL "zero" AND NOT _result EQUAL 0)
-  message(FATAL_ERROR
-    "[${LABEL}] expected success, got exit ${_result}")
-endif()
+  if(EXPECT_EXIT STREQUAL "zero" AND NOT _result EQUAL 0)
+    message(FATAL_ERROR
+      "[${LABEL}] ${_tag}: expected success, got exit ${_result}")
+  endif()
 
-if(EXPECT_EXIT STREQUAL "nonzero" AND _result EQUAL 0)
-  message(FATAL_ERROR
-    "[${LABEL}] expected a nonzero exit, got 0")
-endif()
+  if(EXPECT_EXIT STREQUAL "nonzero" AND _result EQUAL 0)
+    message(FATAL_ERROR
+      "[${LABEL}] ${_tag}: expected a nonzero exit, got 0")
+  endif()
+
+  set(${_out_var} "${_out}" PARENT_SCOPE)
+endfunction()
+
+icc_run_tool_once("${TOOL_ARGS}" "run" _output)
 
 if(DEFINED EXPECT_MATCH AND NOT "${EXPECT_MATCH}" STREQUAL "")
   if(NOT _output MATCHES "${EXPECT_MATCH}")
     message(FATAL_ERROR
       "[${LABEL}] output did not match '${EXPECT_MATCH}'")
+  endif()
+endif()
+
+if(DEFINED COMPARE_ARGS AND NOT "${COMPARE_ARGS}" STREQUAL "")
+  if(NOT DEFINED COMPARE_EXTRACT OR "${COMPARE_EXTRACT}" STREQUAL "")
+    message(FATAL_ERROR
+      "[${LABEL}] COMPARE_ARGS requires COMPARE_EXTRACT: comparing whole"
+      " outputs would compare the timing figures too, which differ on every"
+      " run and would make every 'differ' assertion vacuously true")
+  endif()
+
+  if(NOT DEFINED COMPARE_MODE OR "${COMPARE_MODE}" STREQUAL "")
+    set(COMPARE_MODE "differ")
+  endif()
+  if(NOT COMPARE_MODE STREQUAL "differ" AND NOT COMPARE_MODE STREQUAL "same")
+    message(FATAL_ERROR
+      "[${LABEL}] COMPARE_MODE must be 'differ' or 'same', got '${COMPARE_MODE}'")
+  endif()
+
+  icc_run_tool_once("${COMPARE_ARGS}" "compare" _compare_output)
+
+  # Both extractions are mandatory. If the tool's output format changes so the
+  # regex no longer matches, CMAKE_MATCH_1 would be left empty in both runs and a
+  # "differ" test would fail loudly while a "same" test would pass having
+  # measured nothing. Failing here means the second outcome cannot happen.
+  string(REGEX MATCH "${COMPARE_EXTRACT}" _matched_a "${_output}")
+  if("${_matched_a}" STREQUAL "")
+    message(FATAL_ERROR
+      "[${LABEL}] run: COMPARE_EXTRACT '${COMPARE_EXTRACT}' matched nothing")
+  endif()
+  set(_value_a "${CMAKE_MATCH_1}")
+
+  string(REGEX MATCH "${COMPARE_EXTRACT}" _matched_b "${_compare_output}")
+  if("${_matched_b}" STREQUAL "")
+    message(FATAL_ERROR
+      "[${LABEL}] compare: COMPARE_EXTRACT '${COMPARE_EXTRACT}' matched nothing")
+  endif()
+  set(_value_b "${CMAKE_MATCH_1}")
+
+  message(STATUS "[${LABEL}] extracted run='${_value_a}' compare='${_value_b}'")
+
+  if(COMPARE_MODE STREQUAL "differ" AND "${_value_a}" STREQUAL "${_value_b}")
+    message(FATAL_ERROR
+      "[${LABEL}] expected the two runs to differ, both gave '${_value_a}'")
+  endif()
+
+  if(COMPARE_MODE STREQUAL "same" AND NOT "${_value_a}" STREQUAL "${_value_b}")
+    message(FATAL_ERROR
+      "[${LABEL}] expected the two runs to agree, got"
+      " '${_value_a}' and '${_value_b}'")
   endif()
 endif()
 

--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -1158,7 +1158,17 @@ int CIccCfgProfileSequence::fromArgs(const char** args, int nArg, bool bReset)
       if (nIntent > (int)icAbsoluteColorimetric)
         return 0;
       
-      if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
+      // Only the upper bound is testable, and unlike the identically spelled check
+      // in iccApplyToLink it is genuinely live here: this decode strips "% 1000"
+      // rather than "% 100", so nType carries the hundreds column and spans 0..99.
+      // Measured on master: "130" resolves to icXformLutNamedDevice and "140" is
+      // refused by this very comparison.  The lower half cannot fire -- nType is
+      // "abs(...) / 10", never negative -- so it is dropped for the same reason
+      // #2267 dropped the intent lower bounds two lines up.  CodeQL did not raise
+      // this one the way it raised those: cpp/constant-comparison cannot see through
+      // abs(), so it had to be found by set-diffing the four copies of the check by
+      // hand (#2270).
+      if (nType > (int)icXformLutMaximum)
         return 0;
 
       pProf->m_intent = (icRenderingIntent)nIntent;
@@ -1428,7 +1438,17 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
       if (nIntent > (int)icAbsoluteColorimetric)
         return 0;
       
-      if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
+      // Only the upper bound is testable, and unlike the identically spelled check
+      // in iccApplyToLink it is genuinely live here: this decode strips "% 1000"
+      // rather than "% 100", so nType carries the hundreds column and spans 0..99.
+      // Measured on master: "130" resolves to icXformLutNamedDevice and "140" is
+      // refused by this very comparison.  The lower half cannot fire -- nType is
+      // "abs(...) / 10", never negative -- so it is dropped for the same reason
+      // #2267 dropped the intent lower bounds two lines up.  CodeQL did not raise
+      // this one the way it raised those: cpp/constant-comparison cannot see through
+      // abs(), so it had to be found by set-diffing the four copies of the check by
+      // hand (#2270).
+      if (nType > (int)icXformLutMaximum)
         return 0;
 
       pProf->m_intent = (icRenderingIntent)nIntent;
@@ -1503,7 +1523,17 @@ int CIccCfgSearchApply::fromArgs(const char** args, int nArg, bool bReset)
     if (nIntent > (int)icAbsoluteColorimetric)
       return 0;
       
-    if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum)
+    // Only the upper bound is testable, and unlike the identically spelled check
+    // in iccApplyToLink it is genuinely live here: this decode strips "% 1000"
+    // rather than "% 100", so nType carries the hundreds column and spans 0..99.
+    // Measured on master: "130" resolves to icXformLutNamedDevice and "140" is
+    // refused by this very comparison.  The lower half cannot fire -- nType is
+    // "abs(...) / 10", never negative -- so it is dropped for the same reason
+    // #2267 dropped the intent lower bounds two lines up.  CodeQL did not raise
+    // this one the way it raised those: cpp/constant-comparison cannot see through
+    // abs(), so it had to be found by set-diffing the four copies of the check by
+    // hand (#2270).
+    if (nType > (int)icXformLutMaximum)
       return 0;
 
     m_intentInitial = (icRenderingIntent)nIntent;

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -1139,11 +1139,22 @@ int main(int argc, icChar* argv[])
         return 1;
       }
       
-      if (nType < (int)icXformLutMinimum || nType > (int)icXformLutMaximum) {
-        printf("Invalid rendering intent '%s': decoded transform type is out of range\n", argv[nCount+1]);
-        releasePccList(pccList);
-        return 1;
-      }
+      // No transform-type range test here: neither bound can be crossed, and the
+      // message this used to print was unreachable for every one of the 2^31
+      // codes ParseIntArg accepts.  nType is "abs(value % 100) / 10" of a value
+      // the sign guard above has already refused if negative, so it is 0..9 --
+      // icXformLutMinimum is 0, and icXformLutMaximum is 0xD, four above the
+      // largest tens digit the column can hold (#2270).
+      //
+      // The check read as live because the sibling decode in
+      // CIccCfgProfileSequence::fromArgs() genuinely needs it: that one strips
+      // "% 1000" rather than "% 100", so its hundreds column feeds nType and
+      // "100".."130" really do select icXformLutSpectral..icXformLutNamedDevice
+      // there, with "140" and up refused by the same comparison.  This tool
+      // spends its hundreds column on nLuminance below instead, which is why the
+      // four types above 9 have no spelling on THIS command line and why
+      // widening the column here would silently redefine every code from 100 up.
+      // Removed rather than widened for that reason (#2270 ruling).
 
       if (nLuminance) {
         Hint.AddHint(new CIccLuminanceMatchingHint());

--- a/Tools/CmdLine/IccBenchApply/Readme.md
+++ b/Tools/CmdLine/IccBenchApply/Readme.md
@@ -15,23 +15,34 @@ their code in the thing being measured.
 iccBenchApply {options} interpolation {profile_path rendering_intent {-PCC pcc_path}}...
 ```
 
-`interpolation` is `0` for linear or `1` for tetrahedral. `rendering_intent`
-takes `0..3` plus the `+1000` / `+10000` modifiers, and a negative code is
-rejected here exactly as `iccApplyToLink` rejects it — the column arithmetic
-drops the sign, so `-10` used to resolve as `10` in both tools (#2268).
+`interpolation` is `0` for linear or `1` for tetrahedral. `rendering_intent` is
+decoded column by column, exactly as `iccApplyToLink` decodes it: the units digit
+is the base intent `0`-`3`, the tens digit is the transform-lookup type
+(`icXformLutType`, reachable values `0`-`9`; `+10` drops the D2Bx/B2Dx tags and
+`+40` adds black-point compensation), `+100` requests luminance matching, and
+`+1000` uses a V5 sub-profile if present. A negative code is rejected here exactly
+as `iccApplyToLink` rejects it — the column arithmetic drops the sign, so `-10`
+used to resolve as `10` in both tools (#2268).
 
-The decode is **not** otherwise identical to `iccApplyToLink`'s, despite what
-this file said before #2268. Two columns diverge, so a chain given to the two
-tools does not always resolve the same way:
+Two columns used to diverge and no longer do (#2271). The hundreds column was
+stripped without being read, so `0`, `100` and `200` built the identical chain;
+and a tens digit of `4` reached `AddXform()` as the lookup type `icXformLutBPC`
+rather than as a hint, so `iccBenchApply … profile.icc 40` failed with `Invalid
+Look-Up Table type` where `iccApplyToLink … profile.icc 40` succeeded. Both are
+closed, so this tool can now time a BPC or luminance-matched chain;
+`iccdev.bench-apply-bpc-changes-result` and `iccdev.bench-apply-luminance-column`
+hold it to that by comparing the applied checksum against the same chain without
+the hint.
 
-| column | `iccApplyToLink` | `iccBenchApply` |
-|---|---|---|
-| `+100` | read as a luminance-matching request (`CIccLuminanceMatchingHint`) | discarded — the hundreds column is never read |
-| tens digit `4` | mapped to lookup type `0` plus a black-point-compensation hint | passed through as `icXformLutBPC`, which `AddXform` refuses with `Invalid Look-Up Table type` |
-
-So `iccBenchApply … profile.icc 40` fails where `iccApplyToLink … profile.icc 40`
-succeeds. Use this tool to time the plain intent and sub-profile columns; it
-cannot currently time a BPC or luminance-matched chain.
+`+10000` is **not** a separate modifier here, despite what this file said before:
+the sub-profile test is `(code / 1000) > 0`, so `10000` requests exactly what
+`1000` requests. A `+10000` column does exist in
+`CIccCfgProfileSequence::fromArgs()` — the decode behind `iccApplyNamedCmm`,
+`iccApplyProfiles` and `iccApplySearch` — which is a genuinely different decode:
+it strips `% 1000` rather than `% 100`, so there the hundreds column is part of
+the transform type and `100`-`130` select
+`icXformLutSpectral`-`icXformLutNamedDevice` instead of requesting luminance
+matching. The same code means different things in the two families (#2270).
 
 | option | effect |
 |---|---|

--- a/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
+++ b/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
@@ -79,6 +79,7 @@
 #include <utility>
 #include <vector>
 
+#include "IccApplyBPC.h"
 #include "IccCmm.h"
 #include "IccCmmThread.h"
 #include "IccDefs.h"
@@ -104,8 +105,25 @@ static void Usage()
   printf("Usage: iccBenchApply {options} interpolation"
          " {profile_path rendering_intent {-PCC pcc_path}}...\n\n");
   printf("  interpolation      0 = Linear, 1 = Tetrahedral\n");
-  printf("  rendering_intent   0..3, plus +1000 / +10000 modifiers"
-         " (as iccApplyToLink)\n\n");
+  // Deliberately describes the columns and points at iccApplyToLink for the
+  // tens-column list rather than reprinting it.  Four tools already publish
+  // their own copy of that table and they do not agree; a fifth copy here would
+  // be a fifth thing to keep in step (#2262).  The old line was wrong in both
+  // directions anyway: it claimed "0..3" when the tens and hundreds columns are
+  // read too, and it advertised a "+10000" modifier this decode does not have --
+  // bUseSubProfile is (code / 1000) > 0, so 10000 is just another way of saying
+  // 1000.  The +10000 column belongs to CIccCfgProfileSequence::fromArgs, a
+  // different decode used by different tools (#2271).
+  printf("  rendering_intent   decimal columns, decoded exactly as"
+         " iccApplyToLink:\n");
+  printf("                       units 0..3   rendering intent\n");
+  printf("                       tens  0..9   transform type"
+         " (1 = no D2Bx/B2Dx, 4 = BPC)\n");
+  printf("                       +100         luminance-based PCS adjustment\n");
+  printf("                       +1000        use V5 sub-profile if present\n");
+  printf("                     Run iccApplyToLink with no arguments for the"
+         " full\n");
+  printf("                     list of tens-column codes.\n\n");
   printf("  -pixels N          pixels per buffer      (default 1048576)\n");
   printf("  -repeats N         timed repeats per case (default 7)\n");
   printf("  -perxform          per-xform breakdown, including PCS steps\n");
@@ -138,11 +156,25 @@ static bool ParseIntArg(const char *arg, int minValue, int maxValue, int &value)
   return true;
 }
 
-// Decodes one encoded rendering intent the way iccApplyToLink.cpp:1054-1059 does,
-// so a chain given to this tool and the same chain given to that one resolve
+// Decodes one encoded rendering intent the way iccApplyToLink.cpp does, so a
+// chain given to this tool and the same chain given to that one resolve
 // identically. Returns false when the decoded intent is out of range.
+//
+// Every column is now read here.  The two that were not are #2271: the hundreds
+// column is a luminance-matching request, which this function used to strip
+// without assigning, and a tens digit of 4 asks for black-point compensation,
+// which used to reach AddXform() as the lookup type icXformLutBPC (IccCmm.h:136
+// happens to be 0x4) and made the whole chain fail with "Invalid Look-Up Table
+// type".  Both are hints rather than return values, which is why the caller now
+// supplies a hint manager -- there was previously nowhere to put them.
+//
+// Hint is filled, never cleared: the caller owns it and may already have put
+// something in it.  Ownership of each hint passes to Hint, and Hint must outlive
+// the AddXform() call that reads it, so both callers declare one per profile
+// inside the loop, exactly as iccApplyToLink does.
 static bool DecodeIntent(int nEncoded, int &nIntent, int &nType,
-                         bool &bUseSubProfile, bool &bUseD2BxB2DxTags)
+                         bool &bUseSubProfile, bool &bUseD2BxB2DxTags,
+                         CIccCreateXformHintManager &Hint)
 {
   // Assigned before the guard below so every return path leaves the caller with
   // defined values.  The early return is new, and both current callers treat
@@ -162,24 +194,48 @@ static bool DecodeIntent(int nEncoded, int &nIntent, int &nType,
   // the built-in -suite table held to the same rule as the command line, and
   // matches the guard iccApplyToLink grew in the same change (#2268, #2190).
   //
-  // The sign rule is the only part of this decode that is now known to match
-  // that tool column for column.  Two others do NOT: the hundreds column is
-  // read there as a luminance-matching request and is discarded here, and a
-  // tens digit of 4 selects black-point compensation there while reaching
-  // AddXform() as icXformLutBPC here.  Do not widen the equivalence claim
-  // above without closing those.
+  // This guard alone refuses before any hint is constructed.  The OTHER rejection
+  // -- the intent range test at the bottom -- deliberately does not: it runs after
+  // both AddHint() calls, so "45" adds the BPC hint and then returns false,
+  // leaving a partially filled manager.  That order is iccApplyToLink's, and
+  // keeping the two diffable is worth more than the narrower guarantee, because
+  // the manager is per profile and both callers treat false as fatal and destroy
+  // it unread.  A third caller that ignored the return value would be the one
+  // case this matters for, so: the return value is the contract, not the manager.
   if (nEncoded < 0)
     return false;
 
   bUseSubProfile = (nEncoded / 1000) > 0;
   nIntent = nEncoded % 1000;
+  // Split out rather than folded into the "% 100" below: this is the column
+  // iccApplyToLink reads as nLuminance, and reading it is the point (#2271).
+  const int nLuminance = nIntent / 100;
   nIntent = nIntent % 100;
   nType   = abs(nIntent) / 10;
   nIntent = nIntent % 10;
 
-  if (nType == 1) {
+  // Spelled as the same switch iccApplyToLink uses, in the same order, because
+  // the two are required to agree and a divergence is easiest to see when the
+  // two blocks read alike.  Types 2, 3 and 5..9 fall through to AddXform() as
+  // themselves; only 1 and 4 are re-encoded as flags on type 0.
+  switch (nType) {
+  case 1:
     nType = 0;
     bUseD2BxB2DxTags = false;
+    break;
+  case 4:
+    nType = 0;
+    Hint.AddHint(new CIccApplyBPCHint());
+    break;
+  default:
+    break;
+  }
+
+  // Added after the type switch and before the range test, matching the order in
+  // iccApplyToLink -- the hint is independent of both, but keeping the sequence
+  // identical is what makes the two decodes diffable.
+  if (nLuminance) {
+    Hint.AddHint(new CIccLuminanceMatchingHint());
   }
 
   // Only the upper bound is testable.  nIntent is "% 100" then "% 10" of a
@@ -499,7 +555,13 @@ static int RunSuite()
     for (size_t i = 0; i < bc.chain.size(); i++) {
       int nIntent, nType;
       bool bSub, bD2B;
-      if (!DecodeIntent(bc.chain[i].encodedIntent, nIntent, nType, bSub, bD2B)) {
+      // Declared inside the loop: a hint manager owns the hints it is given and
+      // is read during AddXform(), so each profile in the chain needs its own
+      // (#2271).  One hoisted out would carry profile 0's BPC request onto every
+      // later profile in the same case.
+      CIccCreateXformHintManager Hint;
+      if (!DecodeIntent(bc.chain[i].encodedIntent, nIntent, nType, bSub, bD2B,
+                        Hint)) {
         printf("  %-16s SKIP   bad encoded intent %d\n",
                bc.name.c_str(), bc.chain[i].encodedIntent);
         bBuilt = false;
@@ -511,7 +573,7 @@ static int RunSuite()
                                          bc.interpolation ? icInterpTetrahedral
                                                           : icInterpLinear,
                                          NULL, (icXformLutType)nType,
-                                         bD2B, NULL, bSub);
+                                         bD2B, &Hint, bSub);
       if (stat != icCmmStatOk) {
         if (g_bCsv)
           printf("%s,,,,,,skip-addxform\n", bc.name.c_str());
@@ -777,8 +839,10 @@ int main(int argc, const char *argv[])
 
     int nIntent, nType;
     bool bUseSubProfile, bUseD2BxB2DxTags;
+    // Per profile, for the reason given at the -suite call site above.
+    CIccCreateXformHintManager Hint;
     if (!DecodeIntent(nEncoded, nIntent, nType,
-                      bUseSubProfile, bUseD2BxB2DxTags)) {
+                      bUseSubProfile, bUseD2BxB2DxTags, Hint)) {
       // Two distinct rejections share one gate, so name which one fired.  The
       // sign case is the whole point of the guard: "-10" used to be accepted
       // and resolve as "10", so reporting it as an out-of-range decoded intent
@@ -811,7 +875,7 @@ int main(int argc, const char *argv[])
                                        pPccProfile.get(),
                                        (icXformLutType)nType,
                                        bUseD2BxB2DxTags,
-                                       NULL,
+                                       &Hint,
                                        bUseSubProfile);
     if (stat != icCmmStatOk) {
       printf("Unable to add '%s' to the chain: %s\n",

--- a/docs/tools-cli-reference.md
+++ b/docs/tools-cli-reference.md
@@ -138,12 +138,25 @@ tools separately (#2268) -- before that a negative code whose units digit was
 zero, such as `-10`, was accepted by them and produced the same output as its
 positive twin.
 
-The sign rule is the only column the two tools are known to share. `iccBenchApply`
-discards the hundreds column rather than reading it as a luminance request, and
-passes a tens digit of `4` straight through as `icXformLutBPC` instead of mapping
-it to a black-point-compensation hint -- so `iccBenchApply <profile> 40` fails with
-`Invalid Look-Up Table type` where `iccApplyToLink <profile> 40` succeeds. See
+Until #2271 the sign rule was the only column the two tools shared:
+`iccBenchApply` discarded the hundreds column rather than reading it as a
+luminance request, and passed a tens digit of `4` straight through as
+`icXformLutBPC` instead of mapping it to a black-point-compensation hint -- so
+`iccBenchApply <profile> 40` failed with `Invalid Look-Up Table type` where
+`iccApplyToLink <profile> 40` succeeded. Both columns now match, asserted by the
+`iccdev.bench-apply-bpc-*` and `iccdev.bench-apply-luminance-column` tests. See
 <a href="https://github.com/InternationalColorConsortium/iccDEV/blob/master/Tools/CmdLine/IccBenchApply/Readme.md">Tools/CmdLine/IccBenchApply/Readme.md</a>.
+
+One divergence is real and by design, and it is the trap worth knowing about:
+`iccApplyToLink` and `iccBenchApply` strip `% 100` and spend the hundreds column
+on a luminance request, while `CIccCfgProfileSequence::fromArgs()` -- the decode
+behind `iccApplyNamedCmm`, `iccApplyProfiles` and `iccApplySearch` -- strips
+`% 1000`, so there the hundreds column is part of the transform type. Measured
+with `iccApplyNamedCmm -exportcfg`, `100`/`110`/`120`/`130` resolve to
+`spectral`/`namedColorimetric`/`namedSpectral`/`namedDevice` and `140` is
+refused. So `100` means a spectral transform to one family of tools and luminance
+matching to the other; the four `icXformLutType` values above `9` are reachable
+only from the first (#2270).
 
 The over-black / over-gray flags only affect chains that include a v5
 NamedColor profile. JSON callers prefer the `transform` field values,


### PR DESCRIPTION
Part of #2270. Part of #2271.

Deliberately not a closing keyword. Everything ruled on is delivered — #2270's
option (a) plus a CTest, and all four numbered items on #2271 (tool parity, the
hint manager / BPC / LUT type, the parser and documentation claims, CTests). What
is left is the one item @xsscx set aside himself: *"Larger Scope - Extract shared
intent for use by both tools, provide identical semantics."* That is a real
follow-up — there are now **four** copies of this decode and they disagree by
design in one column — and it is his call whether it belongs on #2271 or a new
issue. #2270 I believe is complete as it stands.

Both issues are the same stream as #2190 → #2261 → #2268/#2269: one integer split
into decimal columns, decoded three different ways by three tools. Landed together
because the fix for one is only checkable against the other, and because
`Build/Cmake/Testing/CMakeLists.txt` is shared.

## #2270 — the transform-type range check could never fire

`iccApplyToLink.cpp` computes `nType = abs(nIntent) / 10` after `nIntent %= 100`,
so `nType` spans `0..9`. The check tested it against `icXformLutMinimum` (0) and
`icXformLutMaximum` (0xD). Sweeping every code `0..999` on master:

```
    400 ACCEPTED
    600 decoded intent is out of range
      0 decoded transform type is out of range
```

Removed per the ruling, not widened.

**One claim in the issue body is wrong and I am correcting it here.** I wrote that
the four types above 9 "have no CLI spelling." They do — just not in this tool.
`CIccCfgProfileSequence::fromArgs()` strips `% 1000`, so *its* hundreds column
feeds `nType`. Measured with `iccApplyNamedCmm -exportcfg`:

| code | `"transform"` |
|---|---|
| `100` | `spectral` |
| `110` | `namedColorimetric` |
| `120` | `namedSpectral` |
| `130` | `namedDevice` |
| `140` | rejected |

So the same code means three different things across the tool set: `100` is a
spectral transform in `iccApplyNamedCmm`, a luminance-matching request in
`iccApplyToLink`, and — until this PR — nothing at all in `iccBenchApply`. That
is what makes widening the column here the wrong fix: it would silently redefine
every code from 100 up.

### Set-diff: three more copies, where only the lower half is dead

The same comparison appears at `IccCmmConfig.cpp:1161`, `:1431` and `:1506`.
There `nType` spans `0..99`, so the **upper** bound is live — `130` resolves and
`140` is refused by that comparison, measured — and only the lower half goes.
CodeQL cannot see through `abs()`, so these never surfaced as
`cpp/constant-comparison` the way #2357/#2358/#2359 did; they had to be found by
hand. `icXformLutMinimum` now has no callers, and is left in place as public API.

## #2271 — two columns diverged from the decode they document

**Hundreds column.** A luminance-matching request, stripped by `% 100` without
ever being assigned. Codes `0`, `100` and `200` built the identical chain
(`0x927c370d` all three).

**Tens digit 4.** Black-point compensation. `iccApplyToLink` maps it to lookup
type 0 plus a `CIccApplyBPCHint`; `DecodeIntent()` special-cased only `nType == 1`,
so `4` reached `AddXform()` as the lookup type `icXformLutBPC` (`IccCmm.h:136` is
`0x4`) and the whole chain failed:

```
$ iccBenchApply -pixels 4096 -repeats 1 1 Testing/sRGB_v4_ICC_preference.icc 40
Unable to add '...' to the chain: Invalid Look-Up Table type
$ iccApplyToLink out.icc 0 2 1 t 0 1 0 0 Testing/sRGB_v4_ICC_preference.icc 40
LUT successfully written to 'out.icc'
```

Both are hints rather than return values, which is why `DecodeIntent()` now takes
a `CIccCreateXformHintManager` — there was previously nowhere to put them. Both
callers declare one per profile inside their loop, as `iccApplyToLink` does; a
hoisted one would carry profile 0's BPC request onto every later profile.

`Usage()` also advertised a `+10000` modifier this decode does not have
(`bUseSubProfile` is `(code / 1000) > 0`, so 10000 is just another spelling of
1000) and described the codes as `0..3` when four columns are read. It now
describes the columns and points at `iccApplyToLink` for the tens-column list
rather than becoming a fifth divergent copy of that table.

**A correction to my own #2271 evidence.** I reported that I could not produce an
observable difference for the hundreds column. That was a defect in my probe, not
in the tool: the hint sets `m_bLuminanceMatching`, read only when connecting one
profile's xform to the next, and I had used a single profile with
`first_transform=0`. With two profiles and `first_transform=1` it is unambiguous —
`19f310f6128b` → `247370ad52c0` on the device link. The regression test for that
half is therefore a real behavioural assertion rather than the parity-only
assertion the issue implies.

## Tests

Seven, all through `RunBenchApplyCliTest.cmake`, which grows an optional two-run
differential mode (`COMPARE_ARGS` / `COMPARE_EXTRACT` / `COMPARE_MODE`).

The assertion that matters for #2271 is that a hint *changed the applied result*,
and the value carrying that is an FNV-1a checksum over raw float bytes. Pinning a
literal `0x7be0e6ba` would be a Windows/macOS flake waiting to happen — the last
bits of a colour transform legitimately differ between compilers. Comparing two
runs of one binary on one machine asserts the same thing and is stable
everywhere. `EXPECT_MATCH` cannot express it: the two codes differ by a hint, not
by any word the tool prints.

| test | asserts | red before? |
|---|---|---|
| `bench-apply-bpc-intent-code` | `40` exits 0 | **yes** |
| `bench-apply-bpc-changes-result` | `40` ≠ `0` checksum | **yes** |
| `bench-apply-luminance-column` | `100` ≠ `0` checksum, 2-profile | **yes** |
| `bench-apply-hinted-then-rejected` | `45` still refused after a hint was built | no — guards the new order |
| `bench-apply-luminance-column-is-a-flag` | `100` == `200` | no — semantic pin |
| `applytolink-max-transform-type-digit` | `90` accepted | no — characterization |
| `applytolink-hundreds-column-is-not-a-type` | `140` accepted | no — characterization |

The last three are green before and after, and deliberately so: **removing
unreachable code cannot change behaviour, so #2270 has no red probe to write.**
What they pin is the ruling — each goes red under the alternative that was
rejected. Widening the tens column to `0..13` turns
`applytolink-hundreds-column-is-not-a-type` red, verified by mutation.

Runtime is ~15 ms per test, so the clock is *not* the non-vacuity evidence here.
The mutations are:

| mutation | red | green |
|---|---|---|
| drop the BPC case | the 2 `bpc-*` tests | other 5 |
| drop the luminance hint | `luminance-column` | other 6 |
| widen the tens column to `0..99` | `hundreds-column-is-not-a-type` | other 6 |
| drop the intent range test | `hinted-then-rejected` | other 6 |
| **restore the removed range check** | *none* | all 7 |

That last row is the direct experimental evidence that the removed code was dead.

Five driver-guard probes all refuse correctly (`COMPARE_EXTRACT` matching nothing,
`COMPARE_ARGS` without it, `COMPARE_MODE=same` on differing runs, an invalid mode,
and a comparison run that exits nonzero), with the real differential as the
positive control. Both profiles the tests name are tracked, not generated, so no
Windows leg can satisfy the fixture while the file sits elsewhere.

## Pre-flight

- clang 21.1.3 Release, default flags — **0 warnings**; full `ctest` **237/238**.
  The one failure is `iccdev.spectral-tiff-preview`, `ModuleNotFoundError: No
  module named 'imagecodecs'` — a local environment gap, pinned in
  `.github/ci/requirements/docker-spectral-preview.txt`.
- clang 21.1.3 `-Wall -Wextra -Wpedantic -Werror`, "strict warnings ENABLED" —
  **0 warnings**.
- GCC 15.2.0 + LTO inside CI's own container
  (`ghcr.io/internationalcolorconsortium/iccdev:latest`), "strict warnings
  ENABLED" — **0 warnings**.
- Cross-tool parity swept over codes `0..199`: `iccApplyToLink` and
  `iccBenchApply` now agree on every one.
- `iccBenchApply -suite`: 9 cases measured, 0 skipped.
- `iccApplyNamedCmm -exportcfg` decode table unchanged by the `IccCmmConfig` edit
  (`0/30/100/110/120/130` resolve as before; `140/200/999` still refused).

## Review round

`/code-review high` and `/security-review` were run before this PR was opened, on
the committed tree. Three findings, all folded in:

- **Two documents asserted the divergence as current behaviour.**
  `Tools/CmdLine/IccBenchApply/Readme.md` still told the reader the tool "cannot
  currently time a BPC or luminance-matched chain", and `docs/tools-cli-reference.md`
  — which that Readme is linked from — repeated the `40` failure as fact. Both are
  text I wrote in the #2268 round to record the divergence I was deferring, so
  closing it without them would have left the docs contradicting the new CTests.
  Both now also record the divergence that *is* real and deliberate: the two
  hundreds-column meanings. `Tools/CmdLine/IccApplyToLink/Readme.md` already said
  "reachable values `0`-`9`" and needed no change. The archived design records
  under `docs/superpowers/` quote the old `Usage()` string and are left alone.
- **My own new comment over-claimed.** It said a rejected code "cannot leave a
  half-populated manager behind", but only the *sign* guard runs before the hints;
  the intent range test runs after them, so `45` adds the BPC hint and then returns
  false. Scoped the comment to what is true and added
  `iccdev.bench-apply-hinted-then-rejected` for that path — which is a real
  regression risk I introduced, since moving hint construction ahead of the range
  test is new here.

The security review returned no findings and proved the three things worth
proving: `nType` is still constrained to `0..9` (and `0..99` in `IccCmmConfig`)
on every path after the bound removals, with the `INT_MIN` exclusion retained so
`abs()` is never handed it; and the per-profile stack hint manager cannot dangle,
because `SetParams` copies each hint's *effect* rather than storing a pointer
(`CIccApplyBPCHint` yields a fresh `CIccApplyBPC` owned by the xform;
`CIccLuminanceMatchingHint` sets only a bool). I re-verified the one genuinely new
library path this opens — passing `&Hint` instead of `NULL` lets
`CIccXform::Create` add a named-colour hint into my stack manager — and
`CIccArrayNamedColor::SetColorSpaces` copies the spectral ranges by value
(`IccArrayBasic.cpp:284`), so nothing survives the call.

## CI

Dispatched before this PR existed, per the workflow: run
**33595277038**, `ci_scope=source` — **16 success, 2 skipped, 0 failed**.

`source` rather than `full`: this touches a library TU (`IccCmmConfig.cpp`) and
registers new CTests that have to configure under MSVC, which is exactly what
`source` covers (Windows + the full CTest set) without `full`'s cycle.

All seven new tests ran on three independent lanes, with non-zero runtimes:

| lane | tests | note |
|---|---|---|
| Windows MSVC | #13-#17, #131-#132 | the one that matters most — these are `cmake -P` driven, so unlike a `.sh` CTest they *are* registered on Windows |
| GCC Strict ASAN+UBSAN (Debug) | #13-#17, #29-#30 | |
| Docker Clang 22 regression | #13-#17, #29-#30 | |

The three differential tests consistently cost about twice their single-run
siblings on every lane (e.g. 0.09s vs 0.04s on MSVC), which is the second
invocation showing up where it should.
