### PR TITLE
fix(#2181): describe an ACS element by its type, and keep AllocData's size/pointer pair consistent

### DIFF
--- a/.github/ci/regression/mpe-acs-zero-signature.cpp
+++ b/.github/ci/regression/mpe-acs-zero-signature.cpp
@@ -1,0 +1,221 @@
+// Copyright (c) 2026 The International Color Consortium. All rights reserved.
+// Licensed under the BSD 3-Clause "New" or "Revised" License; see the ICC
+// Software License in the repository root and CONTRIBUTING.md.
+//
+// Regression: two defects in the ACS multi-process elements (#2181).
+//
+// (1) CIccMpeAcs::Describe() chose its label from the ACS DATA SIGNATURE rather
+//     than from the element type:
+//
+//       if (GetBAcsSig())
+//         sDescription += "ELEM_bACS\n";
+//       else
+//         sDescription += "ELEM_eACS\n";
+//
+//     GetBAcsSig() returns m_signature on a bACS element and the base class's
+//     icSigAcsZero on everything else, so the test conflates "is a bACS element"
+//     with "has a non-zero signature". Those coincide for every bACS element
+//     EXCEPT one carrying icSigAcsZero -- a legitimate, explicitly named value
+//     that CIccMpeXmlBAcs::ToXml deliberately preserves (#1843) -- which then
+//     described itself as ELEM_eACS.
+//
+//     The reported reproducer went through XML: a <BAcsElement Signature="">
+//     dumped as ELEM_eACS. The written profile is not at fault, which is worth
+//     recording because it narrows the fix. Reading the bytes of the file
+//     iccFromXml produces, the element type signatures are 'bACS' and 'eACS' in
+//     the right order and the right places; only Describe() disagrees. So this
+//     test drives Describe() directly rather than shelling out to two tools --
+//     it is the actual defect site, it is deterministic, and unlike a script
+//     test it is registered on Windows.
+//
+// (2) CIccMpeAcs::AllocData() did not reset m_nDataSize when malloc failed:
+//
+//       free(m_pData);
+//       if (size) {
+//         m_pData = (icUInt8Number*)malloc(size);
+//         if (m_pData)
+//           m_nDataSize = size;      // <-- only on success
+//       }
+//
+//     leaving m_pData NULL beside a stale non-zero m_nDataSize. That pair is
+//     reachable as a NULL read, because all four copy paths guard the memcpy on
+//     the DESTINATION pointer and the SOURCE size:
+//
+//       AllocData(elemAcs.m_nDataSize);
+//       if (m_pData && elemAcs.m_nDataSize)
+//         memcpy(m_pData, elemAcs.m_pData, m_nDataSize);
+//
+//     Copying an element in that state allocates fine from the stale size, sees
+//     a non-zero source size, and memcpy()s from a NULL source. NewCopy() is one
+//     of those four paths.
+//
+//     Forcing the failure needs no allocator interposition: a request of
+//     SIZE_MAX/2 is refused outright by every malloc this builds against, which
+//     makes the red/green deterministic rather than OOM-dependent. Case 4 then
+//     performs the copy that would have dereferenced NULL, so this test is a
+//     crash probe under ASan as well as a value assertion.
+//
+// Exit code 0 = pass, 1 = a case regressed.
+#include "IccMpeACS.h"
+#include "IccMpeXml.h"
+#include "IccTagMPE.h"
+
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <string>
+
+static int g_failures = 0;
+
+static void check(bool bOk, const char *szCase, const char *szDetail)
+{
+  printf("  %-46s %s%s%s\n", szCase, bOk ? "PASS" : "FAIL",
+         bOk ? "" : "  -- ", bOk ? "" : szDetail);
+  if (!bOk)
+    g_failures++;
+}
+
+// Reported, never counted. Used for the one case whose premise is an allocator
+// property rather than a property of this library: see case 4.
+static void skip(const char *szCase, const char *szWhy)
+{
+  printf("  %-46s SKIP  -- %s\n", szCase, szWhy);
+}
+
+// Run ParseXml over a literal document, following the shape
+// mpexml-unknown-reserved.cpp already uses for this.
+static bool parseFragment(CIccMpeXmlBAcs &elem, const char *szDoc,
+                          std::string &parseStr)
+{
+  xmlDoc *pDoc = xmlReadMemory(szDoc, (int)strlen(szDoc), "frag.xml", NULL,
+                               XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+  if (!pDoc) {
+    fprintf(stderr, "[mpe-acs-zero-signature] fixture is not valid XML\n");
+    return false;
+  }
+  xmlNode *pRoot = xmlDocGetRootElement(pDoc);
+  bool rv = pRoot && elem.ParseXml(pRoot, parseStr);
+  xmlFreeDoc(pDoc);
+  return rv;
+}
+
+// Describe() emits the label first, so a prefix test is exact and does not
+// depend on the "  Signature = ..." line that follows it.
+static bool describesAs(CIccMultiProcessElement &elem, const char *szExpect)
+{
+  std::string sDesc;
+  elem.Describe(sDesc, 100);
+  return sDesc.compare(0, strlen(szExpect), szExpect) == 0;
+}
+
+int main(void)
+{
+  printf("#2181 ACS element regression\n");
+
+  // --- 1. the reported defect: a bACS element whose signature is icSigAcsZero.
+  // Pre-fix this printed ELEM_eACS.
+  {
+    CIccMpeBAcs elem(3, icSigAcsZero);
+    check(describesAs(elem, "ELEM_bACS"),
+          "bACS with icSigAcsZero describes as bACS",
+          "described itself as an eACS element");
+  }
+
+  // --- 2. the case that already worked, kept as the positive control. Without
+  // it a Describe() hard-wired to "ELEM_bACS" would satisfy case 1 and prove
+  // nothing.
+  {
+    CIccMpeEAcs elem(3, icSigAcsZero);
+    check(describesAs(elem, "ELEM_eACS"),
+          "eACS with icSigAcsZero describes as eACS",
+          "described itself as a bACS element");
+  }
+
+  // --- 3. and the non-zero signatures, so the fix cannot have inverted the
+  // discrimination it replaced. These are the two the reporter's XML used.
+  {
+    CIccMpeBAcs bElem(3, (icAcsSignature)0x62414353 /* 'bACS' */);
+    CIccMpeEAcs eElem(3, (icAcsSignature)0x65414353 /* 'eACS' */);
+    check(describesAs(bElem, "ELEM_bACS"),
+          "bACS with a non-zero signature", "regressed");
+    check(describesAs(eElem, "ELEM_eACS"),
+          "eACS with a non-zero signature", "regressed");
+  }
+
+  // --- 4. the AllocData invariant, and the copy that the broken pair made
+  // dereference NULL.
+  {
+    CIccMpeBAcs elem(3, icSigAcsZero);
+
+    check(elem.AllocData(16) && elem.GetData() != NULL && elem.GetDataSize() == 16,
+          "AllocData(16) succeeds and records the size",
+          "a plain allocation did not take");
+
+    // SIZE_MAX/2 is refused outright by every 64-bit allocator this builds
+    // against, which is what makes the failure deterministic instead of
+    // OOM-dependent. It is NOT a property of this library, though, so a host
+    // that honours the request skips the two cases below rather than failing
+    // them -- on a 32-bit build SIZE_MAX/2 is 2 GB and could succeed, and an
+    // environment property must not read as a regression in iccDEV.
+    const size_t nRefused = ((size_t)-1) / 2;
+
+    if (elem.AllocData(nRefused)) {
+      skip("a failed AllocData leaves the element empty",
+           "this host honoured a SIZE_MAX/2 request");
+      skip("copying after a failed AllocData stays empty",
+           "this host honoured a SIZE_MAX/2 request");
+    }
+    else {
+      // The invariant. Pre-fix: GetData() is NULL but GetDataSize() is still 16.
+      check(elem.GetData() == NULL && elem.GetDataSize() == 0,
+            "a failed AllocData leaves the element empty",
+            "pointer and size disagree after a failed allocation");
+
+      // The consequence. Pre-fix this memcpy()s from a NULL source and the
+      // process dies here, so this case is a crash probe as well as an
+      // assertion -- measured: reverting only the AllocData hunk segfaults.
+      CIccMpeBAcs copy(elem);
+      check(copy.GetData() == NULL && copy.GetDataSize() == 0,
+            "copying after a failed AllocData stays empty",
+            "the copy claims data it does not have");
+    }
+  }
+
+  // --- 5. ParseXml() must fully define the element it parses. The overloads
+  // used to call AllocData() only inside "if (nSize)", so re-parsing an element
+  // that already held data, from a node carrying none, kept the old buffer.
+  // Every in-tree caller builds a fresh element per node, so this is the change
+  // in this commit with no mainline path -- which is exactly why it needs a test
+  // of its own rather than riding on the two above.
+  {
+    CIccMpeXmlBAcs elem;
+    std::string parseStr;
+
+    const bool bLoaded = parseFragment(elem,
+      "<BAcsElement InputChannels=\"3\" OutputChannels=\"3\" Signature=\"\">"
+      "00 01 7f ff</BAcsElement>", parseStr);
+    check(bLoaded && elem.GetDataSize() == 4 && elem.GetData() != NULL,
+          "ParseXml loads hex payload", "the fixture did not parse");
+
+    // Same object, second parse, no hex this time.
+    const bool bCleared = parseFragment(elem,
+      "<BAcsElement InputChannels=\"3\" OutputChannels=\"3\" Signature=\"\"/>",
+      parseStr);
+    check(bCleared && elem.GetData() == NULL && elem.GetDataSize() == 0,
+          "re-parsing from a node with no hex clears it",
+          "the previous payload survived the re-parse");
+
+    // And the element still knows what it is.
+    check(describesAs(elem, "ELEM_bACS"),
+          "an XML-parsed bACS still describes as bACS",
+          "the XML subclass lost its type");
+  }
+
+  xmlCleanupParser();
+
+  printf("%s (%d failure(s))\n", g_failures ? "FAILED" : "OK", g_failures);
+  return g_failures ? 1 : 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1655,6 +1655,89 @@ function(iccdev_add_cicp_copy_ctor_test)
   endif()
 endfunction()
 
+# #2181: two defects in the ACS multi-process elements.
+#
+# CIccMpeAcs::Describe() picked its label with "if (GetBAcsSig())", which returns
+# m_signature on a bACS element and the base class's icSigAcsZero on everything
+# else -- so it conflated the element TYPE with whether the ACS data signature
+# happened to be non-zero. Those agree for every bACS element except one carrying
+# icSigAcsZero, a legitimate value CIccMpeXmlBAcs::ToXml deliberately preserves
+# (#1843), which therefore reported itself as ELEM_eACS. GetType() is fixed per
+# class and cannot be confused. Describe() was the ONLY reader of GetBAcsSig() in
+# the tree -- everything else discriminates on IsAcs(), which was always
+# type-based -- so the blast radius is the dump, not the CMM.
+#
+# And CIccMpeAcs::AllocData() left m_nDataSize at the previous allocation's value
+# when malloc failed, so the element carried a NULL pointer beside a non-zero
+# size. All four copy paths guard their memcpy on the destination pointer and the
+# SOURCE size, so copying such an element reads from NULL -- and NewCopy() is one
+# of them. Case 4 of the test forces the failure with SIZE_MAX/2, which every
+# malloc refuses outright, so the red/green is deterministic rather than
+# OOM-dependent, and then performs that copy.
+#
+# Drives Describe() directly rather than chaining iccFromXml into iccDumpProfile:
+# the bytes iccFromXml writes were verified correct, so the tool chain would test
+# two innocent tools to reach one defective function -- and unlike a script test,
+# this is registered on Windows. Header + IccProfLib only.
+function(iccdev_add_mpe_acs_zero_signature_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccMpeAcsZeroSigTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/mpe-acs-zero-signature.cpp"
+  )
+  target_compile_features(iccMpeAcsZeroSigTest PRIVATE cxx_std_17)
+  target_include_directories(iccMpeAcsZeroSigTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccXML/IccLibXML"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+    ${LIBXML2_INCLUDE_DIR}
+  )
+  target_link_libraries(iccMpeAcsZeroSigTest PRIVATE
+    ${TARGET_LIB_ICCXML} ${TARGET_LIB_ICCPROFLIB} ${LIBXML2_LIBRARIES})
+  add_dependencies(check iccMpeAcsZeroSigTest)
+
+  # Launched through `cmake -E env` because case 4 deliberately asks for
+  # SIZE_MAX/2 to force a malloc failure, and ASan does NOT return NULL for an
+  # oversize request: with the default allocator_may_return_null=0 it reports
+  # allocation-size-too-big and ABORTS the process.  Measured under the sanitizer
+  # lane's own options (ci-docker-pr.yml exports
+  # ASAN_OPTIONS="halt_on_error=0,detect_leaks=0"): exit 1, so this test would
+  # have gone red there while passing everywhere else.  halt_on_error does not
+  # cover allocator errors.  allocator_may_return_null=1 restores the NULL return
+  # the test is written against, and downgrades the message to a WARNING line
+  # that matches none of the in-tree "ERROR: AddressSanitizer" screens.  The same
+  # option is used for the same reason by the issue-1846, issue-1909 and AFL
+  # scripts.  detect_leaks=0 mirrors what the lanes already set, since setting
+  # ASAN_OPTIONS here replaces the inherited value rather than adding to it; a
+  # CTest ENVIRONMENT property is not reliable for ASAN_OPTIONS (see
+  # iccdev.xform-create-tag-ownership above).
+  add_test(
+    NAME iccdev.mpe-acs-zero-signature
+    COMMAND "${CMAKE_COMMAND}" -E env
+      "ASAN_OPTIONS=detect_leaks=0:allocator_may_return_null=1"
+      "$<TARGET_FILE:iccMpeAcsZeroSigTest>"
+  )
+  set_tests_properties(iccdev.mpe-acs-zero-signature PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 60
+    LABELS "iccdev;mpe;acs;issue-2181;regression"
+  )
+  if(WIN32)
+    set(_mpe_acs_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccMpeAcsZeroSigTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _mpe_acs_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.mpe-acs-zero-signature PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_mpe_acs_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #2001: iccPawgReport check C5 warned on every profile carrying a cicpTag,
 # because icSigCicpTag was missing from kCommonOptional. The tag is recognised by
 # IsSpecTag() (CIccTagCreator resolves 'cicp' to "cicpTag"), so it is never
@@ -6745,6 +6828,7 @@ if(WIN32)
   iccdev_add_getvalues_nstart_test()
   iccdev_add_chromaticity_validate_test()
   iccdev_add_cicp_copy_ctor_test()
+  iccdev_add_mpe_acs_zero_signature_test()
   iccdev_add_pawg_c5_cicp_test()
   iccdev_add_gamut_xform_semantics_test()
   iccdev_add_rangemap_uninitialized_test()
@@ -7112,6 +7196,7 @@ iccdev_add_colorimetry_methods_test()
 iccdev_add_getvalues_nstart_test()
 iccdev_add_chromaticity_validate_test()
 iccdev_add_cicp_copy_ctor_test()
+iccdev_add_mpe_acs_zero_signature_test()
 iccdev_add_pawg_c5_cicp_test()
 iccdev_add_gamut_xform_semantics_test()
 iccdev_add_rangemap_uninitialized_test()

--- a/IccProfLib/IccMpeACS.cpp
+++ b/IccProfLib/IccMpeACS.cpp
@@ -127,7 +127,18 @@ void CIccMpeAcs::Describe(std::string &sDescription, int nVerboseness)
 {
   icChar sigBuf[30];
 
-  if (GetBAcsSig())
+  // Label from the ELEMENT TYPE, not from the value of the ACS data signature.
+  // GetBAcsSig() returns m_signature on a bACS element and the base class's
+  // icSigAcsZero on everything else (IccTagMPE.h:177), so testing its truth
+  // conflates "this is a bACS element" with "this element's signature is
+  // non-zero".  Those two agree only by luck.  icSigAcsZero is a legitimate,
+  // explicitly named signature -- CIccMpeXmlBAcs::ToXml goes out of its way to
+  // round-trip it rather than writing the text "NULL" (#1843) -- and a bACS
+  // element carrying it therefore described itself as ELEM_eACS (#2181).
+  // GetType() is fixed per class (IccMpeACS.h:135 and :159) and cannot be
+  // confused by the payload.  This is the only reader of GetBAcsSig() in the
+  // tree; everything else discriminates on IsAcs(), which was always type-based.
+  if (GetType() == icSigBAcsElemType)
     sDescription += "ELEM_bACS\n";
   else
     sDescription += "ELEM_eACS\n";
@@ -303,19 +314,34 @@ icValidateStatus CIccMpeAcs::Validate(std::string sigPath, std::string &sReport,
 ******************************************************************************/
 bool CIccMpeAcs::AllocData(size_t size)
 {
+  // Clear both members before allocating, so the class invariant
+  // "m_pData == NULL if and only if m_nDataSize == 0" holds on EVERY exit,
+  // failure included.  It previously did not: on a failed malloc m_pData became
+  // NULL while m_nDataSize kept the PREVIOUS allocation's size (#2181).
+  //
+  // That stale pair is not merely untidy, because the four copy paths below
+  // guard the memcpy on the DESTINATION pointer and the SOURCE size:
+  //
+  //     AllocData(elemAcs.m_nDataSize);
+  //     if (m_pData && elemAcs.m_nDataSize)
+  //       memcpy(m_pData, elemAcs.m_pData, m_nDataSize);
+  //
+  // Copying an element left in the broken state allocates successfully from the
+  // stale non-zero size, finds the source size non-zero, and reads from a source
+  // pointer that is NULL.  Restoring the invariant at its origin fixes all four
+  // sites -- and NewCopy() is one of them -- without four separate guards.
   free(m_pData);
+  m_pData = NULL;
+  m_nDataSize = 0;
 
   if (size) {
     m_pData = (icUInt8Number*)malloc(size);
-    if (m_pData)
-      m_nDataSize = size;
-  }
-  else {
-    m_pData = NULL;
-    m_nDataSize = 0;
+    if (!m_pData)
+      return false;
+    m_nDataSize = size;
   }
 
-  return (size==0 || m_pData!=NULL);
+  return true;
 }
 
 

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -2332,15 +2332,24 @@ bool CIccMpeXmlBAcs::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   m_signature = icXmlStrToSig(icXmlAttrValue(pNode, "Signature"));
 
-  if (pNode->children && pNode->children->type == XML_TEXT_NODE && pNode->children->content) {
-    icUInt32Number nSize = icXmlGetHexDataSize((const char*)pNode->children->content);
+  // AllocData() is called unconditionally, the no-data case included.  The old
+  // shape only called it inside "if (nSize)", so parsing into an element that
+  // already held data, from a node carrying none, left the OLD buffer and the
+  // OLD size in place -- the element would then write out a payload its XML
+  // never asked for.  Every in-tree caller builds a fresh object per element
+  // (IccTagXml.cpp), so this is reachability-by-reuse rather than a live defect
+  // today; it is fixed because ParseXml() reads as though it fully defines the
+  // element, and the next caller to reuse one is entitled to that (#2181).
+  icUInt32Number nSize = 0;
+  if (pNode->children && pNode->children->type == XML_TEXT_NODE && pNode->children->content)
+    nSize = icXmlGetHexDataSize((const char*)pNode->children->content);
 
-    if (nSize) {
-      if (!AllocData(nSize))
-        return false;
-      icXmlGetHexData(m_pData, (const char *)pNode->children->content, nSize);
-    }
-  }
+  if (!AllocData(nSize))
+    return false;
+
+  if (nSize)
+    icXmlGetHexData(m_pData, (const char *)pNode->children->content, nSize);
+
   return true;
 }
 
@@ -2385,15 +2394,24 @@ bool CIccMpeXmlEAcs::ParseXml(xmlNode *pNode, std::string &parseStr)
 
   m_signature = icXmlStrToSig(icXmlAttrValue(pNode, "Signature"));
 
-  if (pNode->children && pNode->children->type == XML_TEXT_NODE && pNode->children->content) {
-    icUInt32Number nSize = icXmlGetHexDataSize((const char*)pNode->children->content);
+  // AllocData() is called unconditionally, the no-data case included.  The old
+  // shape only called it inside "if (nSize)", so parsing into an element that
+  // already held data, from a node carrying none, left the OLD buffer and the
+  // OLD size in place -- the element would then write out a payload its XML
+  // never asked for.  Every in-tree caller builds a fresh object per element
+  // (IccTagXml.cpp), so this is reachability-by-reuse rather than a live defect
+  // today; it is fixed because ParseXml() reads as though it fully defines the
+  // element, and the next caller to reuse one is entitled to that (#2181).
+  icUInt32Number nSize = 0;
+  if (pNode->children && pNode->children->type == XML_TEXT_NODE && pNode->children->content)
+    nSize = icXmlGetHexDataSize((const char*)pNode->children->content);
 
-    if (nSize) {
-      if (!AllocData(nSize))
-        return false;
-      icXmlGetHexData(m_pData, (const char *)pNode->children->content, nSize);
-    }
-  }
+  if (!AllocData(nSize))
+    return false;
+
+  if (nSize)
+    icXmlGetHexData(m_pData, (const char *)pNode->children->content, nSize);
+
   return true;
 }
 


### PR DESCRIPTION
Part of #2181.

Not a closing keyword: @xsscx said he would "continue QA for 0-sig BAcs & EAcs
after PR", so the issue should stay open for that pass rather than close under
him. Both items in the thread are addressed — the reported mislabel and the QA
note left mid-thread on 2026-08-16.

## The reported defect

`CIccMpeAcs::Describe()` chose its label from the ACS **data signature** rather
than the element type:

```cpp
if (GetBAcsSig())
  sDescription += "ELEM_bACS\n";
else
  sDescription += "ELEM_eACS\n";
```

`GetBAcsSig()` returns `m_signature` on a bACS element and the base class's
`icSigAcsZero` on everything else (`IccTagMPE.h:177`), so the test conflates *"is
a bACS element"* with *"has a non-zero signature"*. Those coincide for every bACS
element except one carrying `icSigAcsZero` — which is a legitimate, explicitly
named value that `CIccMpeXmlBAcs::ToXml` goes out of its way to round-trip rather
than writing the text `"NULL"` (#1843). Hence the reporter's
`<BAcsElement Signature="">` describing itself as `ELEM_eACS`.

Two findings that narrow the fix:

**The written profile is not at fault.** Reading the bytes `iccFromXml` produces
from the reporter's XML, the `B2A0` element type signatures are `'bACS'` at
offset 524 and `'eACS'` at 544 — correct, and in the right order. Only
`Describe()` disagreed. That is why this does not need a change anywhere in the
read or write path.

**The blast radius is the dump, not the CMM.** `Describe()` is the *only* reader
of `GetBAcsSig()` in the tree; every other ACS discrimination goes through
`IsAcs()`, which was always type-based. `GetType()` is pure virtual on
`CIccMultiProcessElement` and fixed per class, so it cannot be confused by the
payload.

## The QA note

`AllocData()` did not reset `m_nDataSize` when `malloc` failed, leaving the
element with a NULL pointer beside the **previous** allocation's size. That pair
is reachable as a NULL read rather than merely untidy, because all four copy
paths guard their `memcpy` on the **destination** pointer and the **source**
size:

```cpp
AllocData(elemAcs.m_nDataSize);
if (m_pData && elemAcs.m_nDataSize)
  memcpy(m_pData, elemAcs.m_pData, m_nDataSize);
```

Copying such an element allocates fine from the stale size, sees a non-zero
source size, and copies from NULL. `NewCopy()` is one of those four. Clearing
both members before allocating restores the invariant at its origin and fixes all
four sites without four separate guards — reverting only this hunk **segfaults**
the new test.

Per the standing "if a tag has an `IccXML/` handler, check `IccJSON/` for the
sibling" rule, I checked the JSON path: `IccMpeJson.cpp:1229-1234` and
`:1271-1276` open-code the same free/malloc and *already* do
`if (!m_pData) { m_nDataSize = 0; return false; }`. So the JSON author got this
invariant right, which is decent corroboration that the ACS behaviour was a
defect rather than a deliberate design. No change needed there, and the shared
`Describe()` fix covers the JSON classes too.

Both ACS `ParseXml()` overloads now call `AllocData()` unconditionally rather
than only inside `if (nSize)`, so a node carrying no hex clears data the element
already held. Every in-tree caller builds a fresh element per node
(`IccTagXml.cpp:4911`/`:4914`), so this one is reachability-by-reuse rather than a
live defect; it is fixed because `ParseXml()` reads as though it fully defines
the element, and it gets its own test case rather than riding on the other two.

## Tests

One C++ regression, 10 cases. It drives `Describe()` directly instead of chaining
`iccFromXml` into `iccDumpProfile`: the written bytes were verified correct, so
the tool chain would exercise two innocent tools to reach one defective function
— and unlike a script test, a C++ one is registered on Windows.

| mutation | red | green |
|---|---|---|
| revert the `Describe()` label fix | the `icSigAcsZero` case **and** the XML-subclass case | other 8 |
| revert the `AllocData` invariant | the invariant case, then **segfault** on the copy | others |
| revert both `ParseXml` hunks | the re-parse case | other 9 |

The first mutation tripping the XML-subclass case as well is the useful part: it
confirms `CIccMpeXmlBAcs`'s multiple inheritance resolves `GetType()` to the
right override.

### One thing the review caught that would have shipped red

Case 4 forces the allocation failure with `SIZE_MAX/2`, and **ASan does not
return NULL for an oversize request** — with the default
`allocator_may_return_null=0` it reports `allocation-size-too-big` and *aborts*.
Measured under the sanitizer lane's own options
(`ci-docker-pr.yml` exports `ASAN_OPTIONS="halt_on_error=0,detect_leaks=0"`):

```
==ERROR: AddressSanitizer: requested allocation size 0x7fffffffffffffff ... ABORTING
exit=1
```

`halt_on_error` does not cover allocator errors, so this test would have been
green on every lane except that one. It is now launched through `cmake -E env`
with `allocator_may_return_null=1` — the same override
`iccdev.xform-create-tag-ownership` uses because a CTest `ENVIRONMENT` property is
not reliable for `ASAN_OPTIONS`, and the same option the issue-1846, issue-1909
and AFL scripts set for the same reason. Verified end to end: the bare binary
exits 1 under those options, and through the wrapper it passes with them still
exported in the parent environment.

A host that *honours* a `SIZE_MAX/2` request reports those two cases as SKIP
rather than FAIL, so an allocator property (a 32-bit build, where that is 2 GB)
cannot read as an iccDEV regression.

## Pre-flight

- clang 21.1.3 Release, default flags — **0 warnings**; full `ctest` **232/233**.
  The one failure is `iccdev.spectral-tiff-preview`, `ModuleNotFoundError: No
  module named 'imagecodecs'` — a local environment gap.
- clang 21.1.3 `-Wall -Wextra -Wpedantic -Werror`, "strict warnings ENABLED" —
  **0 warnings**.
- GCC 15.2.0 + LTO inside CI's own container, "strict warnings ENABLED" —
  **0 warnings**, and the test passes there too, which also confirms the
  `SIZE_MAX/2` refusal is not specific to one allocator.
- The reporter's PoC end to end: `B2A0` now dumps `ELEM_bACS` / `ELEM_eACS`, and
  an `iccToXml` round trip brings back `<BAcsElement … Signature="">` unchanged.

Note on the issue text: the "Expected Output" block there does not match its own
PoC input — it shows a single tag with two `bACS`, but the input has two tags and
gives element #2 an `eACS` signature. The output above is what the input actually
calls for.

## CI

Dispatched before this PR existed, per the workflow: run **33607055322**,
`ci_scope=source` — **16 success, 2 skipped, 0 failed**.

`iccdev.mpe-acs-zero-signature` is confirmed to have actually run, not merely to
have been registered:

| lane | test | runtime |
|---|---|---|
| Windows MSVC | #97 | 0.04s |
| **GCC Strict ASAN+UBSAN (Debug)** | #101 | 0.05s |
| Docker Clang 22 regression | #101 | 0.02s |

The middle row is the one that matters: that is the lane the `SIZE_MAX/2` request
would have aborted, so it is the `cmake -E env` fix verified in CI rather than
only on my machine.
