### PR TITLE
analysis: add bounded MCS apply profiling

### DIFF
--- a/.github/ci/quality-assurance/scripts/iccApplyProfiles-quick-check.sh
+++ b/.github/ci/quality-assurance/scripts/iccApplyProfiles-quick-check.sh
@@ -14,7 +14,9 @@ source "$SCRIPT_DIR/qa-common.sh"
 qa_init "iccApplyProfiles-quick-check"
 
 BIN="$ICCDEV_BUILD_DIR/Tools/IccApplyProfiles/iccApplyProfiles"
-SRC="$ICCDEV_ROOT/Testing/ApplyDataFiles/seed-tiff-none-rgb-8x8.tif"
+# This 1024-pixel-wide RGB TIFF exceeds the threaded CMM's 256-pixel
+# per-worker threshold, so the -threads cases dispatch worker threads.
+SRC="$ICCDEV_ROOT/Testing/mcs/prev.tif"
 PROFILE="$ICCDEV_ROOT/Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc"
 CFG="$QA_OUTDIR/profiles.json"
 
@@ -42,5 +44,43 @@ qa_run legacy-extra reject "Unexpected extra arguments" \
     "$BIN" "$SRC" "$QA_OUTDIR/legacy-extra.tif" 1 0 0 0 0 "$PROFILE" 1 ignored-extra
 qa_run threads-one success "" \
     "$BIN" -threads 1 "$SRC" "$QA_OUTDIR/threads-one.tif" 1 0 0 0 0 "$PROFILE" 1
+qa_require_file "$QA_OUTDIR/threads-one.tif"
+qa_run threads-nonnumeric reject "Invalid thread count 'abc'" \
+    "$BIN" -threads abc "$SRC" "$QA_OUTDIR/threads-abc.tif" 1 0 0 0 0 "$PROFILE" 1
+qa_run threads-over-limit reject "Invalid thread count '257'" \
+    "$BIN" -threads 257 "$SRC" "$QA_OUTDIR/threads-257.tif" 1 0 0 0 0 "$PROFILE" 1
+for nthreads in 0 2 4; do
+    out="$QA_OUTDIR/threads-$nthreads.tif"
+    qa_run "threads-$nthreads" success "" \
+        "$BIN" -threads "$nthreads" "$SRC" "$out" 1 0 0 0 0 "$PROFILE" 1
+    if [ ! -s "$out" ]; then
+        qa_fail "threads-$nthreads did not create a TIFF"
+    elif ! cmp -s "$QA_OUTDIR/threads-one.tif" "$out"; then
+        qa_fail "threads-$nthreads output differs from threads-one"
+    fi
+done
+
+qa_run threads-2-timing success "" env ICC_APPLY_PROFILES_TIMING=1 \
+    "$BIN" -threads 2 "$SRC" "$QA_OUTDIR/threads-2-timing.tif" \
+    1 0 0 0 0 "$PROFILE" 1
+if ! grep -Eq '^\[TIMING\] Async worker strips: [1-9][0-9]*$' "$QA_LAST_LOG"; then
+    qa_fail "threads-2-timing did not report asynchronous worker strips"
+fi
+
+trace_dst="$QA_OUTDIR/trace"$'\n'"[APPLY_TRACE] event=forged.tif"
+qa_run trace-escapes success "" env ICC_APPLY_TRACE=2 \
+    "$BIN" "$SRC" "$trace_dst" 1 0 0 0 0 "$PROFILE" 1
+qa_assert_contains "$QA_LAST_LOG" '\x0A' "trace-escapes encodes newlines"
+if grep -q '^\[APPLY_TRACE\] event=forged' "$QA_LAST_LOG"; then
+    qa_fail "trace-escapes permitted a forged trace record"
+fi
+
+trace_utf8_dst="$QA_OUTDIR/trace-"$'\302\205'"[APPLY_TRACE] event=forged-utf8.tif"
+qa_run trace-escapes-nonascii success "" env ICC_APPLY_TRACE=2 \
+    "$BIN" "$SRC" "$trace_utf8_dst" 1 0 0 0 0 "$PROFILE" 1
+qa_assert_contains "$QA_LAST_LOG" '\xC2\x85' "trace-escapes-nonascii encodes UTF-8 bytes"
+if grep -q '^\[APPLY_TRACE\] event=forged-utf8' "$QA_LAST_LOG"; then
+    qa_fail "trace-escapes-nonascii permitted a forged trace record"
+fi
 
 qa_finish

--- a/.github/ci/quality-assurance/scripts/iccApplySearch-quick-check.sh
+++ b/.github/ci/quality-assurance/scripts/iccApplySearch-quick-check.sh
@@ -38,5 +38,25 @@ qa_run export-config success "" "$BIN" -exportcfganddata "$CFG" \
 qa_require_file "$CFG"
 qa_run replay-config success "" "$BIN" -cfg "$CFG"
 qa_run config-extra reject "Unexpected extra arguments for -cfg" "$BIN" -cfg "$CFG" ignored-extra
+threaded_data="$QA_OUTDIR/rgb8bit-threaded.txt"
+awk '
+    /^icEncode/ { print; have_encoding = 1; next }
+    !have_encoding { print; next }
+    { rows = rows $0 ORS }
+    END {
+        for (i = 0; i < 64; i++)
+            printf "%s", rows
+    }
+' "$DATA" > "$threaded_data"
+qa_run threads-one success "" \
+    "$BIN" -threads 1 "$threaded_data" 0 0 "$PROFILE" 1 "$PROFILE" 1 -INIT 1
+threads_reference="$QA_LAST_LOG"
+for nthreads in 0 2 4; do
+    qa_run "threads-$nthreads" success "" \
+        "$BIN" -threads "$nthreads" "$threaded_data" 0 0 "$PROFILE" 1 "$PROFILE" 1 -INIT 1
+    if ! cmp -s "$threads_reference" "$QA_LAST_LOG"; then
+        qa_fail "threads-$nthreads output differs from threads-one"
+    fi
+done
 
 qa_finish

--- a/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
+++ b/.github/scripts/iccdev-iccapplyprofiles-threading-regression-tests.sh
@@ -4,7 +4,8 @@
 ###############################################################################
 #
 # Verifies that iccApplyProfiles produces bit-identical TIFF output under
-# every non-negative -threads mode supported by CIccConnectCmm::CreateStandard():
+# every requested non-negative -threads mode supported by
+# CIccConnectCmm::CreateStandard():
 #   -threads  1   single-threaded (no CIccThreadedCmm wrapper, per-pixel apply)
 #   -threads  0   wrapper with std::thread::hardware_concurrency() workers
 #   -threads  N   wrapper with N workers (default N=4 here)
@@ -22,6 +23,7 @@
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools/ (contains tool subdirs)
 #   ICCDEV_TESTING_DIR -- path to Testing/ (contains sRGB_v4_ICC_preference.icc)
 #   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#   ICCDEV_THREAD_VALUES -- comma-separated worker counts (default: 1,0,2,4)
 #
 # Exit code: 0 = all pass, 1 = test failure, 2 = ASAN/UBSAN finding
 ###############################################################################
@@ -31,6 +33,7 @@ set -uo pipefail
 TOOLS_DIR="${ICCDEV_TOOLS_DIR:?Set ICCDEV_TOOLS_DIR to iccDEV Build/Tools path}"
 TESTING_DIR="${ICCDEV_TESTING_DIR:?Set ICCDEV_TESTING_DIR to iccDEV Testing path}"
 OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-iccapplyprofiles-threading}"
+THREAD_VALUES="${ICCDEV_THREAD_VALUES:-1,0,2,4}"
 mkdir -p "$OUTDIR"
 
 APPLY_PROFILES="$TOOLS_DIR/IccApplyProfiles/iccApplyProfiles"
@@ -164,10 +167,33 @@ run_threads() {
 }
 
 REF=""
-for entry in "1:t1" "0:auto" "4:t4"; do
+IFS=, read -r -a THREAD_MODES <<< "$THREAD_VALUES"
+if [ "${#THREAD_MODES[@]}" -eq 0 ]; then
+  echo "  [FAIL] no thread modes requested"
+  exit 1
+fi
+
+for nthreads in "${THREAD_MODES[@]}"; do
+  case "$nthreads" in
+    0|[1-9]|[1-9][0-9]|[1-9][0-9][0-9])
+      ;;
+    *)
+      echo "  [FAIL] invalid thread mode: $nthreads"
+      FAIL=$((FAIL + 1))
+      continue
+      ;;
+  esac
+  if [ "$nthreads" -gt 256 ]; then
+    echo "  [FAIL] thread mode exceeds supported maximum: $nthreads"
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
   TOTAL=$((TOTAL + 1))
-  nthreads="${entry%%:*}"
-  label="${entry##*:}"
+  label="t${nthreads}"
+  if [ "$nthreads" = "0" ]; then
+    label="auto"
+  fi
 
   out="$(run_threads "$nthreads" "$label")" || { FAIL=$((FAIL + 1)); continue; }
 

--- a/.github/scripts/iccdev-mcs-applyprofiles-profile.sh
+++ b/.github/scripts/iccdev-mcs-applyprofiles-profile.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 The International Color Consortium. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+###############################################################################
+# Profile the MCS overprint iccApplyProfiles path with bounded diagnostics.
+###############################################################################
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 DEBUG_BUILD RELEASE_BUILD OUTPUT_DIR" >&2
+    exit 2
+fi
+
+debug_build="$(cd "$1" && pwd)"
+release_build="$(cd "$2" && pwd)"
+output_dir="$3"
+target_seconds="${ICCDEV_MCS_PROFILE_SECONDS:-300}"
+maximum_seconds="${ICCDEV_MCS_PROFILE_MAX_SECONDS:-600}"
+run_timeout="${ICCDEV_MCS_PROFILE_RUN_TIMEOUT:-120}"
+
+for time_limit in "$target_seconds" "$maximum_seconds" "$run_timeout"; do
+    case "$time_limit" in
+        ''|*[!0-9]*|0|0[0-9]*|????*)
+            echo "profiling time limits must be positive integers" >&2
+            exit 2
+            ;;
+    esac
+done
+if [ "$target_seconds" -gt "$maximum_seconds" ]; then
+    echo "ICCDEV_MCS_PROFILE_SECONDS must not exceed the maximum" >&2
+    exit 2
+fi
+if [ "$maximum_seconds" -gt 600 ]; then
+    echo "ICCDEV_MCS_PROFILE_MAX_SECONDS must not exceed 600" >&2
+    exit 2
+fi
+if [ "$run_timeout" -gt 600 ]; then
+    echo "ICCDEV_MCS_PROFILE_RUN_TIMEOUT must not exceed 600" >&2
+    exit 2
+fi
+if [ -e "$output_dir" ]; then
+    echo "OUTPUT_DIR already exists: $output_dir" >&2
+    exit 2
+fi
+if ! command -v tiffcrop >/dev/null 2>&1; then
+    echo "tiffcrop is required to construct the diagnostic images" >&2
+    exit 2
+fi
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+debug_apply="$debug_build/Tools/IccApplyProfiles/iccApplyProfiles"
+debug_from_xml="$debug_build/Tools/IccFromXml/iccFromXml"
+release_apply="$release_build/Tools/IccApplyProfiles/iccApplyProfiles"
+release_bench="$release_build/Tools/IccBenchApply/iccBenchApply"
+source_tiff="$repo_root/Testing/mcs/CMYKSS-Numbered-Overprint.tif"
+source_srgb="$repo_root/Testing/sRGB_v4_ICC_preference.icc"
+
+for path in "$debug_apply" "$debug_from_xml" "$release_apply" "$release_bench" \
+            "$source_tiff" "$source_srgb"; do
+    if [ ! -e "$path" ]; then
+        echo "required path is missing: $path" >&2
+        exit 2
+    fi
+done
+
+cache_value()
+{
+    local build_dir="$1"
+    local key="$2"
+    awk -F= -v key="$key" '$1 == key { print $2; exit }' \
+        "$build_dir/CMakeCache.txt"
+}
+
+debug_sanitizers="$(cache_value "$debug_build" ENABLE_SANITIZERS:BOOL)"
+debug_asan="$(cache_value "$debug_build" ENABLE_ASAN:BOOL)"
+debug_ubsan="$(cache_value "$debug_build" ENABLE_UBSAN:BOOL)"
+if [ "$(cache_value "$debug_build" CMAKE_BUILD_TYPE:STRING)" != "Debug" ] ||
+   { [ "$debug_sanitizers" != "ON" ] &&
+     { [ "$debug_asan" != "ON" ] || [ "$debug_ubsan" != "ON" ]; }; } ||
+   [ "$(cache_value "$debug_build" ICCDEV_ENABLE_PERF_MONITORING:BOOL)" != "ON" ] ||
+   [ "$(cache_value "$debug_build" ICC_VERBOSE_CALC_APPLY:BOOL)" != "OFF" ]; then
+    echo "DEBUG_BUILD must be instrumented Debug ASAN+UBSAN with calculator logging OFF" >&2
+    exit 2
+fi
+if [ "$(cache_value "$release_build" CMAKE_BUILD_TYPE:STRING)" != "Release" ] ||
+   [ "$(cache_value "$release_build" ICCDEV_ENABLE_PERF_MONITORING:BOOL)" != "ON" ] ||
+   [ "$(cache_value "$release_build" ICC_VERBOSE_CALC_APPLY:BOOL)" != "OFF" ]; then
+    echo "RELEASE_BUILD must be instrumented Release with calculator logging OFF" >&2
+    exit 2
+fi
+
+start_epoch="$(date +%s)"
+mkdir -p "$output_dir/images" "$output_dir/profiles" "$output_dir/runs"
+summary="$output_dir/summary.tsv"
+printf 'case\tbuild\tpixels\tstatus\telapsed_s\tuser_s\tsystem_s\tmax_rss_kb\tapply_ms\tapply_pct\tsha256\tlog\n' \
+    > "$summary"
+
+output_dir="$(cd "$output_dir" && pwd)"
+
+remaining_timeout()
+{
+    local label="$1"
+    local now
+    local remaining
+    local timeout_seconds
+
+    now="$(date +%s)"
+    remaining=$((maximum_seconds - (now - start_epoch)))
+    if [ "$remaining" -le 0 ]; then
+        echo "[TIMEOUT] profiling window reached before $label" >&2
+        return 124
+    fi
+    timeout_seconds="$run_timeout"
+    if [ "$remaining" -lt "$timeout_seconds" ]; then
+        timeout_seconds="$remaining"
+    fi
+    printf '%s\n' "$timeout_seconds"
+}
+
+run_with_remaining_budget()
+{
+    local label="$1"
+    local timeout_seconds
+    shift
+
+    timeout_seconds="$(remaining_timeout "$label")" || return $?
+    timeout --signal=KILL "$timeout_seconds" "$@"
+}
+
+(
+    cd "$repo_root/Testing/mcs"
+    run_with_remaining_budget profile-6ChanSelect-MID \
+        "$debug_from_xml" 6ChanSelect-MID.xml \
+        "$output_dir/profiles/6ChanSelect-MID.icc" >/dev/null
+    run_with_remaining_budget profile-18ChanWithSpots-MVIS \
+        "$debug_from_xml" 18ChanWithSpots-MVIS.xml \
+        "$output_dir/profiles/18ChanWithSpots-MVIS.icc" >/dev/null
+)
+
+run_benchmark()
+{
+    local label="$1"
+    shift
+    local log="$output_dir/runs/$label.log"
+    local time_file="$output_dir/runs/$label.time"
+    local status=0
+    local timeout_seconds
+
+    timeout_seconds="$(remaining_timeout "$label")" || return $?
+
+    /usr/bin/time -f 'elapsed_s=%e' -o "$time_file" \
+        timeout --signal=KILL "$timeout_seconds" \
+        "$release_bench" -csv -pixels 1048576 -repeats 5 1 \
+        "$output_dir/profiles/6ChanSelect-MID.icc" 0 \
+        "$@" \
+        "$output_dir/profiles/18ChanWithSpots-MVIS.icc" 0 \
+        "$source_srgb" 1 > "$log" 2>&1 || status=$?
+
+    if [ "$status" -ne 0 ] ||
+       ! awk -F, '$1 == "chain" && $7 == "ok" { found = 1 }
+                    END { exit !found }' "$log"; then
+        echo "[FAIL] $label benchmark failed; see $log" >&2
+        return 1
+    fi
+}
+
+run_benchmark release-bench-no-env
+run_benchmark release-bench-env \
+    -ENV:bkgX 0.4014 -ENV:bkgY 0.2391 -ENV:bkgZ 0.0272
+
+bench_no_env_line="$(awk -F, '$1 == "chain" { print; exit }' \
+    "$output_dir/runs/release-bench-no-env.log")"
+bench_env_line="$(awk -F, '$1 == "chain" { print; exit }' \
+    "$output_dir/runs/release-bench-env.log")"
+bench_no_env_rate="$(printf '%s\n' "$bench_no_env_line" | cut -d, -f3)"
+bench_env_rate="$(printf '%s\n' "$bench_env_line" | cut -d, -f3)"
+bench_no_env_checksum="$(printf '%s\n' "$bench_no_env_line" | cut -d, -f6)"
+bench_env_checksum="$(printf '%s\n' "$bench_env_line" | cut -d, -f6)"
+if [ "$bench_no_env_checksum" = "$bench_env_checksum" ]; then
+    echo "[FAIL] MCS benchmark environment values did not affect output" >&2
+    exit 1
+fi
+
+run_with_remaining_budget setup-1x1 \
+    tiffcrop -U px -z 0,0,0,0 -c lzw -p contig "$source_tiff" \
+    "$output_dir/images/setup-1x1.tif"
+run_with_remaining_budget setup-smoke-64x64 \
+    tiffcrop -U px -z 480,480,543,543 -c lzw -p contig "$source_tiff" \
+    "$output_dir/images/smoke-center-64x64.tif"
+run_with_remaining_budget setup-representative-512x512 \
+    tiffcrop -U px -z 256,256,767,767 -c lzw -p contig "$source_tiff" \
+    "$output_dir/images/representative-center-512x512.tif"
+
+run_case()
+{
+    local label="$1"
+    local build_name="$2"
+    local tool="$3"
+    local input="$4"
+    local pixels="$5"
+    local collect_telemetry="${6:-0}"
+    local log="$output_dir/runs/$label.log"
+    local time_file="$output_dir/runs/$label.time"
+    local telemetry="$output_dir/runs/$label.telemetry"
+    local telemetry_path=0
+    local destination="$output_dir/runs/$label.tif"
+    local status=0
+    local timeout_seconds
+
+    if [ "$collect_telemetry" = "1" ]; then
+        telemetry_path="$telemetry"
+    fi
+
+    timeout_seconds="$(remaining_timeout "$label")" || return $?
+
+    /usr/bin/time \
+        -f 'elapsed_s=%e\nuser_s=%U\nsystem_s=%S\nmax_rss_kb=%M' \
+        -o "$time_file" \
+        timeout --signal=KILL "$timeout_seconds" \
+        env ICC_APPLY_TRACE=1 ICC_APPLY_PROFILES_TIMING=1 \
+            "ICC_PERF_STATS_FILE=$telemetry_path" \
+            ASAN_OPTIONS=detect_leaks=0:halt_on_error=1:abort_on_error=1 \
+            UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
+        "$tool" "$input" "$destination" 1 0 1 0 1 \
+        "$output_dir/profiles/6ChanSelect-MID.icc" 0 \
+        -ENV:bkgX 0.4014 -ENV:bkgY 0.2391 -ENV:bkgZ 0.0272 \
+        "$output_dir/profiles/18ChanWithSpots-MVIS.icc" 0 \
+        "$source_srgb" 1 > "$log" 2>&1 || status=$?
+
+    elapsed="$(awk -F= '$1 == "elapsed_s" { print $2; exit }' "$time_file")"
+    user_time="$(awk -F= '$1 == "user_s" { print $2; exit }' "$time_file")"
+    system_time="$(awk -F= '$1 == "system_s" { print $2; exit }' "$time_file")"
+    max_rss="$(awk -F= '$1 == "max_rss_kb" { print $2; exit }' "$time_file")"
+    apply_ms="$(awk -F': ' '/^\[TIMING\] Apply ms:/ { print $2; exit }' "$log")"
+    apply_pct="$(awk -F': ' '/^\[TIMING\] Apply pct:/ { print $2; exit }' "$log")"
+    checksum="n/a"
+    if [ "$status" -eq 0 ]; then
+        checksum="$(sha256sum "$destination" | awk '{ print $1 }')"
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$label" "$build_name" "$pixels" "$status" "${elapsed:-n/a}" \
+        "${user_time:-n/a}" "${system_time:-n/a}" "${max_rss:-n/a}" \
+        "${apply_ms:-n/a}" "${apply_pct:-n/a}" "$checksum" "$log" >> "$summary"
+
+    if [ "$status" -ne 0 ]; then
+        echo "[FAIL] $label exited with status $status; see $log" >&2
+        return "$status"
+    fi
+}
+
+run_case debug-setup-1x1 debug "$debug_apply" \
+    "$output_dir/images/setup-1x1.tif" 1
+run_case debug-smoke-64x64 debug "$debug_apply" \
+    "$output_dir/images/smoke-center-64x64.tif" 4096
+run_case debug-representative-512x512 debug "$debug_apply" \
+    "$output_dir/images/representative-center-512x512.tif" 262144
+run_case debug-full-calibration debug "$debug_apply" "$source_tiff" 1048576
+run_case release-full release "$release_apply" "$source_tiff" 1048576
+run_case debug-full-telemetry debug "$debug_apply" "$source_tiff" 1048576 1
+run_case release-full-telemetry release "$release_apply" "$source_tiff" 1048576 1
+
+for telemetry in \
+    "$output_dir/runs/debug-full-telemetry.telemetry" \
+    "$output_dir/runs/release-full-telemetry.telemetry"; do
+    if [ ! -s "$telemetry" ] ||
+       ! grep -q '^clut_calls_dimensions_4=' "$telemetry"; then
+        echo "[FAIL] missing 4D CLUT telemetry: $telemetry" >&2
+        exit 1
+    fi
+done
+
+calibration_seconds="$(awk -F '\t' '
+    $1 == "debug-full-calibration" { print $5; exit }
+' "$summary")"
+measured_seconds="$(awk -F '\t' '
+    $1 == "debug-full-calibration" || $1 ~ /^debug-full-repeat-/ {
+        elapsed += $5
+    }
+    END { printf "%.6f\n", elapsed }
+' "$summary")"
+bench_elapsed_seconds="$(awk -F= '$1 == "elapsed_s" { elapsed += $2 }
+    END { printf "%.6f\n", elapsed }' \
+    "$output_dir/runs/release-bench-no-env.time" \
+    "$output_dir/runs/release-bench-env.time")"
+additional_runs="$(awk -v target="$target_seconds" \
+    -v measured="$measured_seconds" -v calibration="$calibration_seconds" '
+    BEGIN {
+        if (calibration <= 0)
+            exit 1
+        remaining = target - measured
+        if (remaining > 0)
+            print int((remaining / calibration) + 0.5)
+        else
+            print 0
+    }
+')"
+repeat_budget="$(awk -v calibration="$calibration_seconds" '
+    BEGIN { print int((calibration * 1.25) + 5.999999) }
+')"
+
+for run in $(seq 1 "$additional_runs"); do
+    now="$(date +%s)"
+    remaining=$((maximum_seconds - (now - start_epoch)))
+    if [ "$remaining" -lt "$repeat_budget" ]; then
+        echo "[LIMIT] stopping before repeat $run with ${remaining}s remaining"
+        break
+    fi
+    run_case "debug-full-repeat-$run" debug "$debug_apply" "$source_tiff" 1048576
+done
+
+debug_checksum="$(awk -F '\t' '
+    $1 == "debug-full-calibration" { print $11; exit }
+' "$summary")"
+release_checksum="$(awk -F '\t' '
+    $1 == "release-full" { print $11; exit }
+' "$summary")"
+if [ "$debug_checksum" != "$release_checksum" ]; then
+    echo "[FAIL] Debug and Release output checksums differ" >&2
+    exit 1
+fi
+if ! awk -F '\t' -v expected="$debug_checksum" '
+    NR > 1 && ($1 ~ /^debug-full/ || $1 ~ /^release-full/) &&
+        $11 != expected {
+        print "[FAIL] checksum mismatch: " $1 " " $11 > "/dev/stderr"
+        failed = 1
+    }
+    END { exit failed }
+' "$summary"; then
+    exit 1
+fi
+
+wall_elapsed_seconds=$(( $(date +%s) - start_epoch ))
+awk -F '\t' -v target="$target_seconds" -v maximum="$maximum_seconds" \
+    -v wall="$wall_elapsed_seconds" -v bench_elapsed="$bench_elapsed_seconds" '
+    NR > 1 {
+        elapsed += $5
+        apply += $9
+        pixels += $3
+        runs++
+        if ($1 ~ /^debug-full/) {
+            if ($1 == "debug-full-telemetry") {
+                debug_telemetry_elapsed = $5
+                debug_telemetry_apply = $9
+                next
+            }
+            debug_elapsed += $5
+            debug_apply += $9
+            debug_pixels += $3
+            debug_runs++
+        }
+        if ($1 == "release-full-telemetry") {
+            release_telemetry_elapsed = $5
+            release_telemetry_apply = $9
+            next
+        }
+        if ($1 == "release-full") {
+            release_elapsed = $5
+            release_apply = $9
+            release_pixels = $3
+        }
+    }
+    END {
+        printf "target_seconds=%s\nmaximum_seconds=%s\n", target, maximum
+        printf "wall_elapsed_s=%s\nruns=%d\npixels=%d\n", wall, runs, pixels
+        printf "bench_runs=2\ntotal_measured_runs=%d\n", runs + 2
+        printf "measured_elapsed_s=%.3f\napply_ms=%.3f\n",
+            elapsed + bench_elapsed, apply
+        printf "bench_elapsed_s=%.3f\n", bench_elapsed
+        if (debug_runs > 0) {
+            printf "debug_full_runs=%d\n", debug_runs
+            printf "debug_full_mean_elapsed_s=%.6f\n", debug_elapsed / debug_runs
+            printf "debug_full_mean_apply_ms=%.3f\n", debug_apply / debug_runs
+            printf "debug_full_mpix_per_s=%.6f\n",
+                debug_pixels / debug_elapsed / 1000000
+        }
+        if (release_elapsed > 0) {
+            printf "release_full_elapsed_s=%.6f\n", release_elapsed
+            printf "release_full_apply_ms=%.3f\n", release_apply
+            printf "release_full_mpix_per_s=%.6f\n",
+                release_pixels / release_elapsed / 1000000
+            printf "release_full_apply_mpix_per_s=%.6f\n",
+                release_pixels / (release_apply / 1000) / 1000000
+        }
+        if (debug_runs > 0 && release_elapsed > 0)
+            printf "debug_release_elapsed_ratio=%.6f\n",
+                (debug_elapsed / debug_runs) / release_elapsed
+        if (debug_telemetry_elapsed > 0 && debug_runs > 0)
+            printf "debug_telemetry_elapsed_overhead_pct=%.6f\n",
+                ((debug_telemetry_elapsed / (debug_elapsed / debug_runs)) - 1) * 100
+        if (release_telemetry_elapsed > 0 && release_elapsed > 0)
+            printf "release_telemetry_elapsed_overhead_pct=%.6f\n",
+                ((release_telemetry_elapsed / release_elapsed) - 1) * 100
+    }
+' "$summary" > "$output_dir/report.txt"
+{
+    sed 's/^/debug_telemetry_/' \
+        "$output_dir/runs/debug-full-telemetry.telemetry"
+    sed 's/^/release_telemetry_/' \
+        "$output_dir/runs/release-full-telemetry.telemetry"
+    printf 'output_sha256=%s\n' "$debug_checksum"
+} >> "$output_dir/report.txt"
+release_rate="$(awk -F= '$1 == "release_full_mpix_per_s" {
+    print $2; exit }' "$output_dir/report.txt")"
+release_apply_rate="$(awk -F= '$1 == "release_full_apply_mpix_per_s" {
+    print $2; exit }' "$output_dir/report.txt")"
+{
+    printf 'bench_input=deterministic_lcg_not_tiff\n'
+    printf 'bench_apply_granularity=multi_pixel_not_tiff_scalar\n'
+    printf 'bench_comparison=diagnostic_not_directly_comparable\n'
+    printf 'bench_pixels=1048576\n'
+    printf 'bench_repeats=5\n'
+    printf 'bench_no_env_mpix_per_s=%s\n' "$bench_no_env_rate"
+    printf 'bench_no_env_checksum=%s\n' "$bench_no_env_checksum"
+    printf 'bench_env_mpix_per_s=%s\n' "$bench_env_rate"
+    printf 'bench_env_checksum=%s\n' "$bench_env_checksum"
+    awk -v env="$bench_env_rate" -v noenv="$bench_no_env_rate" \
+        -v release="$release_rate" -v apply="$release_apply_rate" 'BEGIN {
+        printf "bench_env_rate_delta_pct=%.6f\n", ((env / noenv) - 1) * 100
+        printf "bench_vs_tiff_processing_diagnostic_pct=%.6f\n",
+            ((env / release) - 1) * 100
+        printf "bench_vs_tiff_scalar_apply_diagnostic_pct=%.6f\n",
+            ((env / apply) - 1) * 100
+    }'
+} >> "$output_dir/report.txt"
+
+echo "[PASS] MCS profiling report: $output_dir"
+cat "$output_dir/report.txt"

--- a/.github/workflows/_build-matrix.yml
+++ b/.github/workflows/_build-matrix.yml
@@ -48,6 +48,21 @@ on:
         required: false
         type: boolean
         default: false
+      run-mcs-profile:
+        description: "Run the bounded MCS iccApplyProfiles performance profile"
+        required: false
+        type: boolean
+        default: false
+      mcs-profile-seconds:
+        description: "Target measured seconds for the MCS performance profile"
+        required: false
+        type: string
+        default: "300"
+      mcs-profile-max-seconds:
+        description: "Hard wall-clock ceiling for the MCS performance profile"
+        required: false
+        type: string
+        default: "600"
 
 concurrency:
   group: "build-matrix-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}"
@@ -187,6 +202,9 @@ jobs:
       ctest_recent_limit: ${{ inputs['ctest-recent-limit'] }}
       tool_build_type: ${{ inputs['tool-build-type'] }}
       run_hybrid_timing: ${{ inputs['run-hybrid-timing'] }}
+      run_mcs_profile: ${{ inputs['run-mcs-profile'] }}
+      mcs_profile_seconds: ${{ inputs['mcs-profile-seconds'] }}
+      mcs_profile_max_seconds: ${{ inputs['mcs-profile-max-seconds'] }}
 
   version-header-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-build-test-no-fuzzers.yml
+++ b/.github/workflows/ci-build-test-no-fuzzers.yml
@@ -41,6 +41,21 @@ on:
         required: false
         default: false
         type: boolean
+      run-mcs-profile:
+        description: "Run bounded MCS iccApplyProfiles performance profiling"
+        required: false
+        default: false
+        type: boolean
+      mcs-profile-seconds:
+        description: "Target measured seconds for the MCS performance profile"
+        required: false
+        default: "300"
+        type: string
+      mcs-profile-max-seconds:
+        description: "Hard wall-clock ceiling for the MCS performance profile"
+        required: false
+        default: "600"
+        type: string
 
 jobs:
   build-matrix:
@@ -52,3 +67,6 @@ jobs:
       ctest-recent-limit: ${{ inputs['ctest-recent-limit'] }}
       tool-build-type: ${{ inputs['tool-build-type'] }}
       run-hybrid-timing: ${{ inputs['run-hybrid-timing'] }}
+      run-mcs-profile: ${{ inputs['run-mcs-profile'] }}
+      mcs-profile-seconds: ${{ inputs['mcs-profile-seconds'] }}
+      mcs-profile-max-seconds: ${{ inputs['mcs-profile-max-seconds'] }}

--- a/.github/workflows/ci-comprehensive-build-test.yml
+++ b/.github/workflows/ci-comprehensive-build-test.yml
@@ -41,6 +41,21 @@ on:
         required: false
         default: false
         type: boolean
+      run-mcs-profile:
+        description: "Run bounded MCS iccApplyProfiles performance profiling"
+        required: false
+        default: false
+        type: boolean
+      mcs-profile-seconds:
+        description: "Target measured seconds for the MCS performance profile"
+        required: false
+        default: "300"
+        type: string
+      mcs-profile-max-seconds:
+        description: "Hard wall-clock ceiling for the MCS performance profile"
+        required: false
+        default: "600"
+        type: string
 
 jobs:
   build-matrix:
@@ -52,3 +67,6 @@ jobs:
       ctest-recent-limit: ${{ inputs['ctest-recent-limit'] }}
       tool-build-type: ${{ inputs['tool-build-type'] }}
       run-hybrid-timing: ${{ inputs['run-hybrid-timing'] }}
+      run-mcs-profile: ${{ inputs['run-mcs-profile'] }}
+      mcs-profile-seconds: ${{ inputs['mcs-profile-seconds'] }}
+      mcs-profile-max-seconds: ${{ inputs['mcs-profile-max-seconds'] }}

--- a/.github/workflows/ci-iccdev-tool-tests.yml
+++ b/.github/workflows/ci-iccdev-tool-tests.yml
@@ -54,6 +54,21 @@ on:
         required: false
         default: false
         type: boolean
+      run_mcs_profile:
+        description: 'Run the bounded MCS iccApplyProfiles performance profile'
+        required: false
+        default: false
+        type: boolean
+      mcs_profile_seconds:
+        description: 'Target measured seconds for the MCS performance profile'
+        required: false
+        default: '300'
+        type: string
+      mcs_profile_max_seconds:
+        description: 'Hard wall-clock ceiling for the MCS performance profile'
+        required: false
+        default: '600'
+        type: string
       run_tool_flamegraphs:
         description: 'Capture opt-in all-tool FlameGraph dashboards'
         required: false
@@ -166,6 +181,21 @@ on:
         required: false
         default: false
         type: boolean
+      run_mcs_profile:
+        description: 'Run the bounded MCS iccApplyProfiles performance profile'
+        required: false
+        default: false
+        type: boolean
+      mcs_profile_seconds:
+        description: 'Target measured seconds for the MCS performance profile'
+        required: false
+        default: '300'
+        type: string
+      mcs_profile_max_seconds:
+        description: 'Hard wall-clock ceiling for the MCS performance profile'
+        required: false
+        default: '600'
+        type: string
       run_tool_flamegraphs:
         description: 'Capture opt-in all-tool FlameGraph dashboards'
         required: false
@@ -297,6 +327,14 @@ jobs:
         uses: actions/checkout@c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5  # v5.0.0
         with:
           ref: ${{ inputs.target_sha || github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          fetch-depth: 1
+
+      - name: Checkout trusted sanitizer helper
+        uses: actions/checkout@c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5  # v5.0.0
+        with:
+          ref: ${{ github.event.pull_request.base.sha || 'master' }}
+          path: trusted-base
           persist-credentials: false
           fetch-depth: 1
 
@@ -642,6 +680,86 @@ jobs:
           HYBRID_TIMING_INSTRUMENT="$HYBRID_TIMING_INSTRUMENT_INPUT" \
             .github/scripts/iccdev-hybrid-applyprofiles-timing.sh
 
+      # preflight: allow-pr-script-execution reason=mcs-profiling-helper-under-test
+      - name: Run bounded MCS iccApplyProfiles profile
+        id: mcs_profile
+        if: ${{ inputs.run_mcs_profile }}
+        timeout-minutes: 25
+        env:
+          BASH_ENV: /dev/null
+          MCS_PROFILE_SECONDS_INPUT: ${{ inputs.mcs_profile_seconds || '300' }}
+          MCS_PROFILE_MAX_SECONDS_INPUT: ${{ inputs.mcs_profile_max_seconds || '600' }}
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          TRUSTED_SANITIZER="$GITHUB_WORKSPACE/trusted-base/.github/scripts/sanitize-sed.sh"
+          if [ ! -f "$TRUSTED_SANITIZER" ]; then
+            echo "[FAIL] trusted sanitizer helper is unavailable" >&2
+            exit 1
+          fi
+          # shellcheck disable=SC1090
+          source "$TRUSTED_SANITIZER"
+
+          for time_limit in \
+            "$MCS_PROFILE_SECONDS_INPUT" "$MCS_PROFILE_MAX_SECONDS_INPUT"; do
+            case "$time_limit" in
+              ''|*[!0-9]*|0|0[0-9]*|????*)
+                echo "::error title=Invalid MCS profile window::Values must be positive integers"
+                exit 1
+                ;;
+            esac
+          done
+          if [ "$MCS_PROFILE_SECONDS_INPUT" -gt "$MCS_PROFILE_MAX_SECONDS_INPUT" ] ||
+             [ "$MCS_PROFILE_MAX_SECONDS_INPUT" -gt 600 ]; then
+            echo "::error title=Invalid MCS profile window::Target must not exceed maximum; maximum is 600"
+            exit 1
+          fi
+
+          debug_dir="${BUILD_DIR}-mcs-debug"
+          release_dir="${BUILD_DIR}-mcs-release"
+          common_options=(
+            -DENABLE_TOOLS=ON
+            -DENABLE_TESTS=OFF
+            -DENABLE_WXWIDGETS=OFF
+            -DENABLE_SHARED_LIBS=ON
+            -DENABLE_STATIC_LIBS=OFF
+            -DICC_USE_ZLIB=ON
+            -DICCDEV_ENABLE_QA_FLAGS=ON
+            -DICCDEV_ENABLE_STRICT_WARNINGS=ON
+            -DICCDEV_ENABLE_PERF_MONITORING=ON
+            -DICC_VERBOSE_CALC_APPLY=OFF
+            -DICC_CLUT_DEBUG=OFF
+            -DICC_AVX2_CLUT_DEBUG=OFF
+          )
+          cmake -S Build/Cmake -B "$debug_dir" \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DENABLE_SANITIZERS=ON \
+            -DSANITIZER_RECOVER=ON \
+            -DENABLE_LTO=OFF \
+            "${common_options[@]}" \
+            -Wno-dev
+          cmake -S Build/Cmake -B "$release_dir" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_C_COMPILER=gcc \
+            -DCMAKE_CXX_COMPILER=g++ \
+            -DENABLE_LTO=ON \
+            "${common_options[@]}" \
+            -Wno-dev
+          cmake --build "$debug_dir" --parallel "$(nproc)" \
+            --target iccApplyProfiles iccFromXml
+          cmake --build "$release_dir" --parallel "$(nproc)" \
+            --target iccApplyProfiles iccBenchApply
+
+          ICCDEV_MCS_PROFILE_SECONDS="$MCS_PROFILE_SECONDS_INPUT" \
+          ICCDEV_MCS_PROFILE_MAX_SECONDS="$MCS_PROFILE_MAX_SECONDS_INPUT" \
+            .github/scripts/iccdev-mcs-applyprofiles-profile.sh \
+              "$debug_dir" \
+              "$release_dir" \
+              "${BUILD_DIR}/Testing/ctest-output/mcs-applyprofiles-profile"
+
       - name: Run ICC registry profile QA scan
         if: ${{ inputs.run_registry_qa }}
         env:
@@ -712,27 +830,13 @@ jobs:
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
 
-          SANITIZER="$GITHUB_WORKSPACE/.github/scripts/sanitize-sed.sh"
-          if [ -f "$SANITIZER" ]; then
-            # shellcheck disable=SC1090
-            source "$SANITIZER"
-          else
-            escape_html() {
-              local s="$1"
-              s="${s//&/&amp;}" ; s="${s//</&lt;}" ; s="${s//>/&gt;}"
-              s="${s//\"/&quot;}" ; s="${s//\'/&#39;}"
-              printf '%s' "$s"
-            }
-            sanitize_line() { escape_html "$1"; }
-            sanitize_code_line() {
-              local s="$1"
-              s="${s//$'\r'/}"
-              s="${s//$'\n'/ }"
-              s="$(printf '%s' "$s" | tr -d '\000-\011\013\014\016-\037\177')"
-              s="${s//\`\`\`/\` \` \`}"
-              printf '%s' "$s"
-            }
+          TRUSTED_SANITIZER="$GITHUB_WORKSPACE/trusted-base/.github/scripts/sanitize-sed.sh"
+          if [ ! -f "$TRUSTED_SANITIZER" ]; then
+            echo "[FAIL] trusted sanitizer helper is unavailable" >&2
+            exit 1
           fi
+          # shellcheck disable=SC1090
+          source "$TRUSTED_SANITIZER"
           sanitize_table_cell() {
             local s
             s="$(sanitize_line "$1")"
@@ -761,6 +865,9 @@ jobs:
             test_cmd="${test_cmd} --limit ${CTEST_RECENT_LIMIT}"
           fi
           timing_report="${BUILD_DIR}/Testing/ctest-output/hybrid-applyprofiles-timing/hybrid-applyprofiles-timing.tsv"
+          mcs_profile_dir="${BUILD_DIR}/Testing/ctest-output/mcs-applyprofiles-profile"
+          mcs_profile_report="${mcs_profile_dir}/report.txt"
+          mcs_profile_summary="${mcs_profile_dir}/summary.tsv"
           qa_dir="${BUILD_DIR}/Testing/ctest-output/iccdev-qa-target-flags"
           qa_evidence="${qa_dir}/evidence.ndjson"
           qa_summary="${qa_dir}/summary.tsv"
@@ -906,10 +1013,57 @@ jobs:
                 echo "$timing_row"
               done
             fi
+            if [ -f "$mcs_profile_summary" ]; then
+              echo ""
+              echo "## MCS \`iccApplyProfiles\` Performance Profile"
+              echo ""
+              if [ -f "$mcs_profile_report" ]; then
+                echo '```text'
+                while IFS= read -r line; do
+                  sanitize_code_line "$line"
+                  echo ""
+                done < "$mcs_profile_report"
+                echo '```'
+              else
+                echo "[FAIL] Final MCS report was not produced; partial run evidence follows."
+              fi
+              echo ""
+              echo "| Case | Build | Pixels | Status | Elapsed s | Apply ms | Apply % | SHA-256 |"
+              echo "|------|-------|--------|--------|-----------|----------|---------|---------|"
+              tail -n +2 "$mcs_profile_summary" | while IFS=$'\t' read -r \
+                case_name build_name pixels status elapsed_s _user_s _system_s \
+                _rss apply_ms apply_pct checksum _log_path; do
+                printf "| %s | %s | %s | %s | %s | %s | %s | \`%s\` |\n" \
+                  "$(sanitize_table_cell "$case_name")" \
+                  "$(sanitize_table_cell "$build_name")" \
+                  "$(sanitize_table_cell "$pixels")" \
+                  "$(sanitize_table_cell "$status")" \
+                  "$(sanitize_table_cell "$elapsed_s")" \
+                  "$(sanitize_table_cell "$apply_ms")" \
+                  "$(sanitize_table_cell "$apply_pct")" \
+                  "$(sanitize_table_cell "$checksum")"
+              done
+              if [ ! -f "$mcs_profile_report" ] &&
+                 [ -d "${mcs_profile_dir}/runs" ]; then
+                echo ""
+                echo "### MCS Failure Logs"
+                echo ""
+                echo '```text'
+                find "${mcs_profile_dir}/runs" -maxdepth 1 -type f -name '*.log' \
+                  -print | sort | while IFS= read -r log; do
+                    printf '[%s]\n' "$(sanitize_line "${log##*/}")"
+                    sed -n '1,160p' "$log" | while IFS= read -r line; do
+                      sanitize_code_line "$line"
+                      echo ""
+                    done
+                  done
+                echo '```'
+              fi
+            fi
           } >> "$GITHUB_STEP_SUMMARY"  # elements-sanitized
 
       - name: Package developer report
-        if: ${{ success() }}
+        if: always()
         env:
           BASH_ENV: /dev/null
         run: |
@@ -917,19 +1071,13 @@ jobs:
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
 
-          SANITIZER="$GITHUB_WORKSPACE/.github/scripts/sanitize-sed.sh"
-          if [ -f "$SANITIZER" ]; then
-            # shellcheck disable=SC1090
-            source "$SANITIZER"
-          else
-            escape_html() {
-              local s="$1"
-              s="${s//&/&amp;}" ; s="${s//</&lt;}" ; s="${s//>/&gt;}"
-              s="${s//\"/&quot;}" ; s="${s//\'/&#39;}"
-              printf '%s' "$s"
-            }
-            sanitize_line() { escape_html "$1"; }
+          TRUSTED_SANITIZER="$GITHUB_WORKSPACE/trusted-base/.github/scripts/sanitize-sed.sh"
+          if [ ! -f "$TRUSTED_SANITIZER" ]; then
+            echo "[FAIL] trusted sanitizer helper is unavailable" >&2
+            exit 1
           fi
+          # shellcheck disable=SC1090
+          source "$TRUSTED_SANITIZER"
 
           report_dir="${BUILD_DIR}/Testing/ctest-output/developer-report"
           data_dir="${report_dir}/data"
@@ -955,6 +1103,38 @@ jobs:
             fi
           }
 
+          copy_sanitized_text_if_present() {
+            local src="$1"
+            local dst="$2"
+            if [ -f "$src" ]; then
+              mkdir -p "$(dirname "$dst")"
+              while IFS= read -r line || [ -n "$line" ]; do
+                sanitize_line "$line"
+                echo ""
+              done < "$src" > "$dst"
+            fi
+          }
+
+          copy_sanitized_tsv_if_present() {
+            local src="$1"
+            local dst="$2"
+            local line
+            local field
+            if [ -f "$src" ]; then
+              mkdir -p "$(dirname "$dst")"
+              while IFS= read -r line || [ -n "$line" ]; do
+                while [[ "$line" == *$'\t'* ]]; do
+                  field="${line%%$'\t'*}"
+                  sanitize_line "$field"
+                  printf '\t'
+                  line="${line#*$'\t'}"
+                done
+                sanitize_line "$line"
+                printf '\n'
+              done < "$src" > "$dst"
+            fi
+          }
+
           copy_file_if_present "${BUILD_DIR}/build.log" "${data_dir}/build.log"
           copy_file_if_present "${BUILD_DIR}/ctest-list.txt" "${data_dir}/ctest-list.txt"
           copy_file_if_present "${BUILD_DIR}/recent-ctests.txt" "${data_dir}/recent-ctests.txt"
@@ -977,6 +1157,22 @@ jobs:
           copy_dir_if_present \
             "${BUILD_DIR}/Testing/ctest-output/registry-profile-qa" \
             "${data_dir}/registry-profile-qa"
+          mcs_profile_dir="${BUILD_DIR}/Testing/ctest-output/mcs-applyprofiles-profile"
+          copy_sanitized_text_if_present \
+            "${mcs_profile_dir}/report.txt" \
+            "${data_dir}/mcs-applyprofiles-profile/report.txt"
+          copy_sanitized_tsv_if_present \
+            "${mcs_profile_dir}/summary.tsv" \
+            "${data_dir}/mcs-applyprofiles-profile/summary.tsv"
+          if [ ! -f "${mcs_profile_dir}/report.txt" ] &&
+             [ -d "${mcs_profile_dir}/runs" ]; then
+            for log in "${mcs_profile_dir}"/runs/*.log; do
+              [ -f "$log" ] || continue
+              copy_sanitized_text_if_present \
+                "$log" \
+                "${data_dir}/mcs-applyprofiles-profile/$(basename "$log")"
+            done
+          fi
           {
             printf 'iccDEV developer report\n'
             printf '=======================\n\n'
@@ -1060,6 +1256,89 @@ jobs:
         with:
           name: iccdev-developer-report-${{ inputs.tool_build_type || 'Debug' }}
           path: ${{ env.BUILD_DIR }}/Testing/ctest-output/developer-report
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Package MCS failure evidence
+        id: package_mcs_failure_evidence
+        if: ${{ failure() && inputs.run_mcs_profile && steps.mcs_profile.outcome == 'failure' }}
+        env:
+          BASH_ENV: /dev/null
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+
+          TRUSTED_SANITIZER="$GITHUB_WORKSPACE/trusted-base/.github/scripts/sanitize-sed.sh"
+          if [ ! -f "$TRUSTED_SANITIZER" ]; then
+            echo "[FAIL] trusted sanitizer helper is unavailable" >&2
+            exit 1
+          fi
+          # shellcheck disable=SC1090
+          source "$TRUSTED_SANITIZER"
+
+          report_dir="${BUILD_DIR}/Testing/ctest-output/mcs-applyprofiles-failure-report"
+          mcs_profile_dir="${BUILD_DIR}/Testing/ctest-output/mcs-applyprofiles-profile"
+          rm -rf "$report_dir"
+          mkdir -p "$report_dir"
+          {
+            printf 'MCS apply profiling failure evidence\n'
+            printf '===================================\n\n'
+            printf 'Only bounded, sanitized MCS text is included in this artifact.\n'
+          } > "${report_dir}/README.txt"
+
+          copy_sanitized_text_if_present() {
+            local src="$1"
+            local dst="$2"
+            if [ -f "$src" ]; then
+              while IFS= read -r line || [ -n "$line" ]; do
+                sanitize_line "$line"
+                echo ""
+              done < "$src" > "$dst"
+            fi
+          }
+
+          copy_sanitized_tsv_if_present() {
+            local src="$1"
+            local dst="$2"
+            local line
+            local field
+            if [ -f "$src" ]; then
+              while IFS= read -r line || [ -n "$line" ]; do
+                while [[ "$line" == *$'\t'* ]]; do
+                  field="${line%%$'\t'*}"
+                  sanitize_line "$field"
+                  printf '\t'
+                  line="${line#*$'\t'}"
+                done
+                sanitize_line "$line"
+                printf '\n'
+              done < "$src" > "$dst"
+            fi
+          }
+
+          copy_sanitized_text_if_present \
+            "${mcs_profile_dir}/report.txt" \
+            "${report_dir}/report.txt"
+          copy_sanitized_tsv_if_present \
+            "${mcs_profile_dir}/summary.tsv" \
+            "${report_dir}/summary.tsv"
+          if [ -d "${mcs_profile_dir}/runs" ]; then
+            for log in "${mcs_profile_dir}"/runs/*.log; do
+              [ -f "$log" ] || continue
+              copy_sanitized_text_if_present \
+                "$log" \
+                "${report_dir}/$(basename "$log")"
+            done
+          fi
+
+      - name: Upload MCS failure evidence
+        if: ${{ failure() && steps.package_mcs_failure_evidence.outcome == 'success' }}
+        # preflight: allow-untrusted-artifact reason=sanitized-mcs-failure-evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: iccdev-mcs-applyprofiles-failure-${{ inputs.tool_build_type || 'Debug' }}
+          path: ${{ env.BUILD_DIR }}/Testing/ctest-output/mcs-applyprofiles-failure-report
           if-no-files-found: error
           retention-days: 14
 

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5978,6 +5978,107 @@ if(TARGET iccBenchApply)
     LABELS "iccdev;iccprofLib;benchmark;throughput;pcc;leak;issue-2250;regression"
   )
 
+  if(WIN32)
+    set(_bench_environment_testing_root "${ICCDEV_TEST_OUTDIR}/windows-testing")
+  else()
+    set(_bench_environment_testing_root "${ICCDEV_REPO_ROOT}/Testing")
+  endif()
+
+  if(TARGET iccFromXml)
+    add_test(
+      NAME iccdev.bench-apply-env
+      COMMAND "${CMAKE_COMMAND}"
+        "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+        "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;${_bench_environment_testing_root}/mcs/6ChanSelect-MID.icc;0;-ENV:bkgX;0.4014;-ENV:bkgY;0.2391;-ENV:bkgZ;0.0272;${_bench_environment_testing_root}/mcs/18ChanWithSpots-MVIS.icc;0;${_bench_environment_testing_root}/sRGB_v4_ICC_preference.icc;1"
+        "-DEXPECT_EXIT=zero"
+        "-DCOMPARE_ARGS=-pixels;4096;-repeats;1;1;${_bench_environment_testing_root}/mcs/6ChanSelect-MID.icc;0;${_bench_environment_testing_root}/mcs/18ChanWithSpots-MVIS.icc;0;${_bench_environment_testing_root}/sRGB_v4_ICC_preference.icc;1"
+        "-DCOMPARE_EXTRACT=0x([0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f])"
+        "-DCOMPARE_MODE=differ"
+        -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+    )
+    set_tests_properties(iccdev.bench-apply-env PROPERTIES
+      WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+      TIMEOUT 120
+      LABELS "iccdev;iccprofLib;benchmark;cli;environment;regression"
+      FIXTURES_REQUIRED iccdev_profiles
+    )
+  endif()
+
+  add_test(
+    NAME iccdev.bench-apply-env-invalid
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;-ENV:bkgX;nan;Testing/sRGB_v4_ICC_preference.icc;0"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=expected a finite number"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-env-invalid PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;environment;regression"
+  )
+
+  add_test(
+    NAME iccdev.bench-apply-env-nonfinite
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;-ENV:bkgX;inf;Testing/sRGB_v4_ICC_preference.icc;0"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=expected a finite number"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-env-nonfinite PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;environment;regression"
+  )
+
+  add_test(
+    NAME iccdev.bench-apply-env-invalid-signature
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;-ENV:bkgXextra;0.4014;Testing/sRGB_v4_ICC_preference.icc;0"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=expected exactly four characters"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-env-invalid-signature PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;environment;regression"
+  )
+
+  add_test(
+    NAME iccdev.bench-apply-env-missing-value
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;-ENV:bkgX"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=has no environment value"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-env-missing-value PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;environment;regression"
+  )
+
+  add_test(
+    NAME iccdev.bench-apply-env-missing-profile
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-pixels;4096;-repeats;1;1;-ENV:bkgX;0.4014"
+      "-DEXPECT_EXIT=nonzero"
+      "-DEXPECT_MATCH=must be followed by a profile"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-env-missing-profile PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;cli;environment;regression"
+  )
+
   # -------------------------------------------------------------------------
   # #2254: the iccBenchApply command-line contract.
   #
@@ -6316,6 +6417,11 @@ if(TARGET iccBenchApply)
     # are gated on iccFromXml above.
     set(_bench_env_mod_tests
       iccdev.apply-throughput-pcc
+      iccdev.bench-apply-env-invalid
+      iccdev.bench-apply-env-nonfinite
+      iccdev.bench-apply-env-invalid-signature
+      iccdev.bench-apply-env-missing-value
+      iccdev.bench-apply-env-missing-profile
       iccdev.bench-apply-arity-floor
       iccdev.bench-apply-suite-rejects-chain
       iccdev.bench-apply-suite-rejects-perxform
@@ -6331,6 +6437,7 @@ if(TARGET iccBenchApply)
     if(TARGET iccFromXml)
       list(APPEND _bench_env_mod_tests
         iccdev.apply-throughput
+        iccdev.bench-apply-env
         iccdev.bench-apply-testing-cwd)
     endif()
     # #2254: the CLI-contract tests reach the tool through cmake -P, and a child

--- a/IccProfLib/IccCmmThread.cpp
+++ b/IccProfLib/IccCmmThread.cpp
@@ -135,8 +135,10 @@ public:
   icStatusCMM Apply(std::vector<CIccApplyCmm*> &workers,
                     icFloatNumber *dstPixel, const icFloatNumber *srcPixel,
                     icUInt32Number nPixels, int nActive,
-                    int nSrcSamples, int nDstSamples)
+                    int nSrcSamples, int nDstSamples,
+                    int &workerStripsDispatched)
   {
+    workerStripsDispatched = 0;
     if (!EnsureWorkerThreads(nActive - 1))
       return icCmmStatAllocErr;
 
@@ -163,6 +165,7 @@ public:
       for (size_t i = 0; i < m_jobCount; i++)
         m_jobs[i] = i;
     }
+    workerStripsDispatched = nActive - 1;
 
     for (int i = 0; i < nActive - 1; i++)
       m_jobReady.notify_one();
@@ -260,6 +263,7 @@ CIccApplyThreadedCmm::CIccApplyThreadedCmm(CIccCmm *pCmm) : CIccApplyCmm(pCmm)
   m_pool = NULL;
   m_baseCmm = NULL;
   m_nThreads = 1;
+  m_nAsyncWorkerStrips = 0;
 }
 
 
@@ -394,9 +398,13 @@ icStatusCMM CIccApplyThreadedCmm::Apply(icFloatNumber *DstPixel, const icFloatNu
   if (!EnsureWorkers(nActive))
     return icCmmStatAllocErr;
 
+  int workerStripsDispatched = 0;
   ICC_PERF_THREADED_CMM(nPixels, nActive);
-  return m_pool->Apply(m_workers, DstPixel, SrcPixel, nPixels, nActive,
-                       nSrcSamples, nDstSamples);
+  icStatusCMM status = m_pool->Apply(m_workers, DstPixel, SrcPixel, nPixels,
+                                     nActive, nSrcSamples, nDstSamples,
+                                     workerStripsDispatched);
+  m_nAsyncWorkerStrips += static_cast<unsigned long long>(workerStripsDispatched);
+  return status;
 }
 
 

--- a/IccProfLib/IccCmmThread.h
+++ b/IccProfLib/IccCmmThread.h
@@ -102,6 +102,11 @@ public:
   virtual icStatusCMM Apply(icFloatNumber *DstPixel, const icFloatNumber *SrcPixel);
   virtual icStatusCMM Apply(icFloatNumber *DstPixel, const icFloatNumber *SrcPixel, icUInt32Number nPixels);
 
+  unsigned long long GetAsyncWorkerStripCount() const
+  {
+    return m_nAsyncWorkerStrips;
+  }
+
 protected:
   CIccApplyThreadedCmm(CIccCmm *pCmm);
   bool Init(CIccCmm *pCmm, int nThreads);
@@ -111,6 +116,7 @@ protected:
   CIccApplyThreadedCmmPool *m_pool;
   CIccCmm *m_baseCmm;
   int m_nThreads;
+  unsigned long long m_nAsyncWorkerStrips;
 };
 
 

--- a/IccProfLib/IccMpeBasic.cpp
+++ b/IccProfLib/IccMpeBasic.cpp
@@ -2459,7 +2459,8 @@ bool CIccSampledCalculatorCurve::Begin(icElemInterp nInterp, CIccTagMultiProcess
   if (nSize > ICC_MAXCALCCURVESIZE)
     nSize = ICC_MAXCALCCURVESIZE;
 
-  SetSize(nSize);
+  if (!SetSize(nSize))
+    return false;
 
   // Same wire-supplied endpoints as CIccSingleSampledCurve::Begin, and the same
   // NaN-slips-past-== 0.0 hole (#2324). This bounds the src values the sample
@@ -2478,6 +2479,8 @@ bool CIccSampledCalculatorCurve::Begin(icElemInterp nInterp, CIccTagMultiProcess
 
   //Use calculator element to populate lookup table
   CIccApplyMpe *pApply = m_pCalc->GetNewApply(NULL);
+  if (!pApply)
+    return false;
   for (icUInt32Number i = 0; i < m_nCount; i++) {
     icFloatNumber src, dst;
     src = (icFloatNumber)i / m_last * m_range + m_firstEntry;

--- a/IccProfLib/IccSignatureUtils.h
+++ b/IccProfLib/IccSignatureUtils.h
@@ -257,6 +257,7 @@ enum IccPerfClutPath {
 
 struct IccPerfStats {
   std::atomic<unsigned long long> clutCalls[icPerfClutPathCount] = {};
+  std::atomic<unsigned long long> clutInputDimensions[17] = {};
   std::atomic<unsigned long long> clutOutputChannels[17] = {};
   std::atomic<unsigned long long> clutElapsedNanoseconds = {};
   std::atomic<unsigned long long> threadedCalls = {};
@@ -302,6 +303,14 @@ inline void IccPerfWriteReport()
     if (calls)
       std::fprintf(stream, "clut_calls_outputs_%d=%llu\n", outputChannels, calls);
   }
+  for (int inputDimensions = 0; inputDimensions <= 16; inputDimensions++) {
+    const unsigned long long calls =
+      g_iccPerfStats.clutInputDimensions[inputDimensions].load(
+        std::memory_order_relaxed);
+    if (calls)
+      std::fprintf(stream, "clut_calls_dimensions_%d=%llu\n",
+                   inputDimensions, calls);
+  }
   std::fprintf(stream, "threaded_calls=%llu\n",
                g_iccPerfStats.threadedCalls.load(std::memory_order_relaxed));
   std::fprintf(stream, "threaded_pixels=%llu\n",
@@ -329,9 +338,9 @@ inline void IccPerfEnsureReportWriter()
 
 class IccPerfClutScope {
 public:
-  explicit IccPerfClutScope(int outputChannels)
-    : m_outputChannels(outputChannels), m_path(icPerfClutScalar),
-      m_enabled(IccPerfMonitoringEnabled())
+  IccPerfClutScope(int inputDimensions, int outputChannels)
+    : m_inputDimensions(inputDimensions), m_outputChannels(outputChannels),
+      m_path(icPerfClutScalar), m_enabled(IccPerfMonitoringEnabled())
   {
     if (m_enabled) {
       IccPerfEnsureReportWriter();
@@ -348,6 +357,9 @@ public:
       static_cast<unsigned long long>(std::chrono::duration_cast<std::chrono::nanoseconds>(
         std::chrono::steady_clock::now() - m_start).count());
     g_iccPerfStats.clutCalls[m_path].fetch_add(1, std::memory_order_relaxed);
+    if (m_inputDimensions >= 0 && m_inputDimensions <= 16)
+      g_iccPerfStats.clutInputDimensions[m_inputDimensions].fetch_add(
+        1, std::memory_order_relaxed);
     if (m_outputChannels >= 0 && m_outputChannels <= 16)
       g_iccPerfStats.clutOutputChannels[m_outputChannels].fetch_add(
         1, std::memory_order_relaxed);
@@ -361,6 +373,7 @@ public:
   }
 
 private:
+  int m_inputDimensions;
   int m_outputChannels;
   IccPerfClutPath m_path;
   bool m_enabled;
@@ -382,12 +395,15 @@ inline void IccPerfRecordThreadedCmm(icUInt32Number pixels, int activeWorkers)
 }
 
 #define ICC_PERF_CLUT_SCOPE(outputChannels) \
-  IccPerfClutScope iccPerfClutScope(outputChannels)
+  IccPerfClutScope iccPerfClutScope(-1, outputChannels)
+#define ICC_PERF_CLUT_SCOPE_DIMENSIONS(inputDimensions, outputChannels) \
+  IccPerfClutScope iccPerfClutScope(inputDimensions, outputChannels)
 #define ICC_PERF_CLUT_PATH(path) iccPerfClutScope.SetPath(path)
 #define ICC_PERF_THREADED_CMM(pixels, activeWorkers) \
   IccPerfRecordThreadedCmm(pixels, activeWorkers)
 #else
 #define ICC_PERF_CLUT_SCOPE(outputChannels) ((void)0)
+#define ICC_PERF_CLUT_SCOPE_DIMENSIONS(inputDimensions, outputChannels) ((void)0)
 #define ICC_PERF_CLUT_PATH(path) ((void)0)
 #define ICC_PERF_THREADED_CMM(pixels, activeWorkers) ((void)0)
 #endif

--- a/IccProfLib/IccTagLut.cpp
+++ b/IccProfLib/IccTagLut.cpp
@@ -3015,7 +3015,7 @@ void CIccCLUT::Interp3dTetra(icFloatNumber *destPixel, const icFloatNumber *srcP
  */
 void CIccCLUT::Interp3d(icFloatNumber *destPixel, const icFloatNumber *srcPixel) const
 {
-  ICC_PERF_CLUT_SCOPE((int)m_nOutput);
+  ICC_PERF_CLUT_SCOPE_DIMENSIONS(3, (int)m_nOutput);
   icUInt8Number mx = m_MaxGridPoint[0];
   icUInt8Number my = m_MaxGridPoint[1];
   icUInt8Number mz = m_MaxGridPoint[2];
@@ -3170,6 +3170,7 @@ void CIccCLUT::Interp3d(icFloatNumber *destPixel, const icFloatNumber *srcPixel)
  */
 void CIccCLUT::Interp4d(icFloatNumber *destPixel, const icFloatNumber *srcPixel) const
 {
+  ICC_PERF_CLUT_SCOPE_DIMENSIONS(4, (int)m_nOutput);
   icUInt8Number mw = m_MaxGridPoint[0];
   icUInt8Number mx = m_MaxGridPoint[1];
   icUInt8Number my = m_MaxGridPoint[2];

--- a/Tools/CmdLine/IccApplyProfiles/Readme.md
+++ b/Tools/CmdLine/IccApplyProfiles/Readme.md
@@ -76,6 +76,41 @@ Two limits are deliberate rather than oversights:
   two steps is not covered. The check guards against writing through a symlink
   that is already there, not against a race for the path.
 
+## Performance Diagnostics
+
+Set `ICC_APPLY_PROFILES_TIMING=1` to print bounded apply-loop timing:
+
+```text
+[TIMING] Loop ms: 28997.128
+[TIMING] Apply ms: 27611.920
+[TIMING] Apply pct: 95.223
+[TIMING] Apply calls: 1048576
+[TIMING] Async worker strips: 0
+```
+
+`Async worker strips` is the cumulative number of strips queued to background
+workers by the active apply object. It is zero for scalar and short-row calls
+that run entirely on the caller thread.
+
+Timing and trace modes suppress the carriage-return progress display so logs
+remain line-oriented and safe to copy or parse.
+
+Set `ICC_APPLY_TRACE=1` for phase, image geometry, profile-chain, buffer, and
+throughput records through `IccSignatureUtils.h`. Level 2 also logs each row;
+level 3 logs each pixel and is intended only for tiny diagnostic crops. Keep
+`ICC_VERBOSE_CALC_APPLY=OFF` for timing because it dumps the calculator program
+for every pixel and changes the workload into an output-throughput test.
+
+For the MCS overprint command, the bounded profiling helper constructs 1x1,
+64x64, and 512x512 crops, calibrates with the original 1024x1024 TIFF, compares
+Debug sanitizer and Release output checksums, and repeats the full sanitizer
+case to target 300 seconds without exceeding 600 seconds:
+
+```sh
+.github/scripts/iccdev-mcs-applyprofiles-profile.sh \
+  out/debug-asan-ubsan-trace out/release-compare /tmp/iccdev-mcs-profile
+```
+
 ## See Also
 
 - [CLI tool reference](../../../docs/tools-cli-reference.md)

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -71,12 +71,18 @@
 
 
 #include <cstdio>
+#include <cerrno>
 #include <cstdlib>  // EXIT_FAILURE, used by the argument-contract guards in main()
+#include <cstdarg>
+#include <chrono>
+#include <cstring>
 #include <memory>
 #include <string>
 #include "IccCmm.h"
+#include "IccCmmThread.h"
 #include "IccUtil.h"
 #include "IccDefs.h"
+#include "IccSignatureUtils.h"
 #include "IccConnect.h"
 #include "TiffImg.h"
 #include "IccProfLibVer.h"
@@ -87,6 +93,88 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #endif
+
+using IccApplyTraceClock = std::chrono::steady_clock;
+
+static const IccApplyTraceClock::time_point g_iccApplyTraceStart =
+  IccApplyTraceClock::now();
+
+static int IccApplyTraceLevel()
+{
+  static const int level = []() {
+    const char *value = std::getenv("ICC_APPLY_TRACE");
+    if (!value || !value[0])
+      return 0;
+
+    char *end = nullptr;
+    long parsed = std::strtol(value, &end, 10);
+    if (end == value || *end || parsed < 0)
+      return 1;
+    if (parsed > 3)
+      return 3;
+    return static_cast<int>(parsed);
+  }();
+  return level;
+}
+
+static unsigned long long IccApplyElapsedMicroseconds()
+{
+  return static_cast<unsigned long long>(
+    std::chrono::duration_cast<std::chrono::microseconds>(
+      IccApplyTraceClock::now() - g_iccApplyTraceStart).count());
+}
+
+static unsigned long long IccApplyElapsedNanoseconds()
+{
+  return static_cast<unsigned long long>(
+    std::chrono::duration_cast<std::chrono::nanoseconds>(
+      IccApplyTraceClock::now() - g_iccApplyTraceStart).count());
+}
+
+static bool IccApplyTimingEnabled()
+{
+  const char *value = std::getenv("ICC_APPLY_PROFILES_TIMING");
+  return IccApplyTraceLevel() > 0 ||
+         (value && value[0] && std::strcmp(value, "0"));
+}
+
+static void IccApplyTrace(int level, const char *format, ...)
+{
+  if (IccApplyTraceLevel() < level)
+    return;
+
+  char message[4096];
+  va_list args;
+  va_start(args, format);
+  int messageLength = std::vsnprintf(message, sizeof(message), format, args);
+  va_end(args);
+
+  std::fprintf(stderr, "[APPLY_TRACE] elapsed_us=%llu ",
+               IccApplyElapsedMicroseconds());
+  if (messageLength < 0) {
+    std::fputs("trace_format_error", stderr);
+  }
+  else {
+    size_t length = static_cast<size_t>(messageLength);
+    if (length >= sizeof(message))
+      length = sizeof(message) - 1;
+    for (size_t i = 0; i < length; i++) {
+      unsigned char ch = static_cast<unsigned char>(message[i]);
+      if (ch >= 0x20 && ch < 0x7f)
+        std::fputc(ch, stderr);
+      else
+        std::fprintf(stderr, "\\x%02X", static_cast<unsigned int>(ch));
+    }
+  }
+  std::fputc('\n', stderr);
+  std::fflush(stderr);
+}
+
+#define ICC_APPLY_TRACE(level, ...) \
+  do { \
+    if (IccApplyTraceLevel() >= (level)) \
+      IccApplyTrace((level), __VA_ARGS__); \
+  } while (0)
 
 static FILE* OpenWriteTextFile(const std::string& path)
 {
@@ -256,8 +344,14 @@ void Usage()
 
 int main(int argc, const char** argv)
 {
+  ICC_APPLY_TRACE(1, "event=process_start argc=%d trace_level=%d",
+                  argc, IccApplyTraceLevel());
+  for (int argIndex = 0; argIndex < argc; argIndex++)
+    ICC_APPLY_TRACE(2, "event=argument index=%d value=%s", argIndex, argv[argIndex]);
+
   int minargs = 2;
   if (argc < minargs) {
+    ICC_APPLY_TRACE(1, "%s", "event=usage reason=insufficient_arguments");
     Usage();
     return 0;
   }
@@ -269,12 +363,16 @@ int main(int argc, const char** argv)
   int nThreadArg = cfgConnect.m_nThreads;
 
   if (argc > 3 && !stricmp(argv[1], "-threads")) {
-    nThreadArg = atoi(argv[2]);
-    if (nThreadArg < 0 || nThreadArg > 1024) {      // arbitrary upper limit
+    char* end = nullptr;
+    errno = 0;
+    long parsed = strtol(argv[2], &end, 10);
+    if (errno || !end || end == argv[2] || *end || parsed < 0 ||
+        parsed > CIccThreadedCmm::GetMaxThreads()) {
       printf("Invalid thread count '%s'\n", argv[2]);
       Usage();
-      return -1;
+      return EXIT_FAILURE;
     }
+    nThreadArg = static_cast<int>(parsed);
     bThreadArg = true;
     argv += 2;
     argc -= 2;
@@ -406,6 +504,25 @@ int main(int argc, const char** argv)
   if (bThreadArg)
     cfgConnect.m_nThreads = nThreadArg;
 
+  ICC_APPLY_TRACE(
+    1,
+    "event=config_ready src=%s dst=%s profiles=%zu threads=%d",
+    cfgApply.m_srcImgFile.c_str(), cfgApply.m_dstImgFile.c_str(),
+    cfgProfiles.m_profiles.size(), cfgConnect.m_nThreads);
+  for (size_t profileIndex = 0; profileIndex < cfgProfiles.m_profiles.size();
+       profileIndex++) {
+    const CIccCfgProfilePtr &profile = cfgProfiles.m_profiles[profileIndex];
+    ICC_APPLY_TRACE(
+      2,
+      "event=profile index=%zu path=%s embedded=%d intent=%d transform=%d "
+      "icc_env=%zu pcc=%s pcc_env=%zu use_bpc=%d use_v5=%d",
+      profileIndex, profile->m_iccFile.c_str(), profile->m_useEmbedded ? 1 : 0,
+      profile->m_intent, static_cast<int>(profile->m_transform),
+      profile->m_iccEnvVars.size(), profile->m_pccFile.c_str(),
+      profile->m_pccEnvVars.size(), profile->m_useBPC ? 1 : 0,
+      profile->m_useV5SubProfile ? 1 : 0);
+  }
+
   int i, j, k;
   unsigned int sn, sen, photo, bps, dbps;
   CTiffImg SrcImg, DstImg;
@@ -413,13 +530,26 @@ int main(int argc, const char** argv)
   const char *last_path = NULL;
 
   //Open source image file and get information from it
+  unsigned long long phaseStartUs = IccApplyElapsedMicroseconds();
   if (!SrcImg.Open(cfgApply.m_srcImgFile.c_str())) {
+    ICC_APPLY_TRACE(1, "event=source_open_failed path=%s duration_us=%llu",
+                    cfgApply.m_srcImgFile.c_str(),
+                    IccApplyElapsedMicroseconds() - phaseStartUs);
     printf("\nFile [%s] cannot be opened.\n", cfgApply.m_srcImgFile.c_str());
     return -1;
   }
   sn = SrcImg.GetSamples();
   sen = SrcImg.GetExtraSamples();
   bps = SrcImg.GetBitsPerSample();
+  ICC_APPLY_TRACE(
+    1,
+    "event=source_opened path=%s duration_us=%llu width=%u height=%u samples=%u "
+    "extra_samples=%u bits_per_sample=%u bytes_per_line=%u x_res=%.6f "
+    "y_res=%.6f resolution_unit=%u",
+    cfgApply.m_srcImgFile.c_str(),
+    IccApplyElapsedMicroseconds() - phaseStartUs, SrcImg.GetWidth(),
+    SrcImg.GetHeight(), sn, sen, bps, SrcImg.GetBytesPerLine(),
+    SrcImg.GetXRes(), SrcImg.GetYRes(), SrcImg.GetResolutionUnit());
 
   //Setup source encoding based on bits per sample (bps) in source image
   // really just error checking
@@ -464,6 +594,12 @@ int main(int argc, const char** argv)
   bool bSeparation = cfgApply.m_dstPlanar == icDstBoolFromSrc ? SrcImg.GetPlanar() : (cfgApply.m_dstPlanar != icDstBoolFalse);
   bool bEmbed = cfgApply.m_dstEmbedIcc == icDstBoolFromSrc ? bHasSrcProfile : (cfgApply.m_dstEmbedIcc != icDstBoolFalse);
 
+  ICC_APPLY_TRACE(
+    1,
+    "event=output_options dest_bits_per_sample=%u compress=%d planar=%d embed=%d "
+    "source_has_profile=%d source_profile_bytes=%u",
+    dbps, bCompress ? 1 : 0, bSeparation ? 1 : 0, bEmbed ? 1 : 0,
+    bHasSrcProfile ? 1 : 0, nSrcProfileLen);
 
   // Use embedded ICC from source image when first profile entry has no file path.
   unsigned char* pEmbedded = nullptr;
@@ -478,11 +614,19 @@ int main(int argc, const char** argv)
   }
 
   std::string sConnectError;
+  phaseStartUs = IccApplyElapsedMicroseconds();
+  ICC_APPLY_TRACE(
+    1,
+    "event=cmm_create_begin profiles=%zu embedded_bytes=%u requested_threads=%d",
+    cfgProfiles.m_profiles.size(), nEmbeddedLen, cfgConnect.m_nThreads);
   std::unique_ptr<CIccConnectCmm> pConnect(
     CIccConnectCmm::CreateStandard(cfgProfiles, pEmbedded, nEmbeddedLen,
                                    cfgConnect.m_nThreads, &sConnectError));
 
   if (!pConnect) {
+    ICC_APPLY_TRACE(1, "event=cmm_create_failed duration_us=%llu error=%s",
+                    IccApplyElapsedMicroseconds() - phaseStartUs,
+                    sConnectError.c_str());
     if (!sConnectError.empty())
       printf("Error - %s\n", sConnectError.c_str());
     else
@@ -492,6 +636,9 @@ int main(int argc, const char** argv)
 
   CIccCmm* pTheCmm = pConnect->GetCmm();
   const bool bUseRowApply = cfgConnect.m_nThreads != 1;
+  ICC_APPLY_TRACE(1, "event=cmm_create_end duration_us=%llu mode=%s",
+                  IccApplyElapsedMicroseconds() - phaseStartUs,
+                  bUseRowApply ? "row" : "pixel");
 
   // Set last_path to the last profile's file for downstream embed logic.
   if (!cfgProfiles.m_profiles.empty())
@@ -501,6 +648,9 @@ int main(int argc, const char** argv)
   icColorSpaceSignature SrcspaceSig = pTheCmm->GetSourceSpace();
   int nSrcColorSamples = icGetSpaceSamples(SrcspaceSig);
   int nSrcSamples = nSrcColorSamples;
+  ICC_APPLY_TRACE(1, "event=source_space signature=0x%08x name=%s samples=%d",
+                  static_cast<unsigned int>(SrcspaceSig),
+                  ColorSpaceSignatureToStr(SrcspaceSig), nSrcColorSamples);
 
   if (nSrcSamples != (int)sn ) {
     //Allow color management to ignore extra samples when non extra samples match samples in profile
@@ -525,6 +675,14 @@ int main(int argc, const char** argv)
 
   icColorSpaceSignature DestParentSpaceSig = pTheCmm->GetLastParentSpace();
   int nDestParentSamples = icGetSpaceSamples(DestParentSpaceSig);
+  ICC_APPLY_TRACE(
+    1,
+    "event=destination_space signature=0x%08x name=%s samples=%d "
+    "parent_signature=0x%08x parent_name=%s parent_samples=%d",
+    static_cast<unsigned int>(DestSpaceSig),
+    ColorSpaceSignatureToStr(DestSpaceSig), nDestSamples,
+    static_cast<unsigned int>(DestParentSpaceSig),
+    ColorSpaceSignatureToStr(DestParentSpaceSig), nDestParentSamples);
   
   int nExtraSamples = 0;
 
@@ -568,13 +726,25 @@ int main(int argc, const char** argv)
   // with them; without it a centimetre-based source produced an inch-defaulted output
   // and the physical size shifted by 2.54x.  Same defect as iccSpecSepToTiff, because
   // both tools reach it through the same shared CTiffImg::Create() (#2220).
+  phaseStartUs = IccApplyElapsedMicroseconds();
   if (!DstImg.Create(cfgApply.m_dstImgFile.c_str(), SrcImg.GetWidth(), SrcImg.GetHeight(), dbps, photo, nDestSamples, nExtraSamples, SrcImg.GetXRes(), SrcImg.GetYRes(), bCompress, bSeparation, SrcImg.GetResolutionUnit())) {
+    ICC_APPLY_TRACE(1, "event=destination_create_failed path=%s duration_us=%llu",
+                    cfgApply.m_dstImgFile.c_str(),
+                    IccApplyElapsedMicroseconds() - phaseStartUs);
     printf("Unable to create Tiff file - '%s'\n", cfgApply.m_dstImgFile.c_str());
     return -1;
   }
+  ICC_APPLY_TRACE(
+    1,
+    "event=destination_created path=%s duration_us=%llu bytes_per_line=%u "
+    "photo=%u samples=%d extra_samples=%d",
+    cfgApply.m_dstImgFile.c_str(),
+    IccApplyElapsedMicroseconds() - phaseStartUs, DstImg.GetBytesPerLine(),
+    photo, nDestSamples, nExtraSamples);
 
   //Embed the last profile into output image as needed
   if (bEmbed && last_path) {
+    phaseStartUs = IccApplyElapsedMicroseconds();
     size_t length = 0;
     icUInt8Number *pDestProfile = NULL;
 
@@ -589,6 +759,9 @@ int main(int argc, const char** argv)
       }
       io.Close();
     }
+    ICC_APPLY_TRACE(1, "event=profile_embed path=%s bytes=%zu duration_us=%llu",
+                    last_path, length,
+                    IccApplyElapsedMicroseconds() - phaseStartUs);
   }
 
   // Allocate single line buffer for reading source image pixels
@@ -608,10 +781,9 @@ int main(int argc, const char** argv)
 
   icFloatNumber *pSrcRowBuf = nullptr;
   icFloatNumber *pDstRowBuf = nullptr;
+  size_t nSrcRowBytes = 0;
+  size_t nDstRowBytes = 0;
   if (bUseRowApply) {
-    size_t nSrcRowBytes = 0;
-    size_t nDstRowBytes = 0;
-
     if (!GetFloatRowByteCount(SrcImg.GetWidth(), nSrcColorSamples, nSrcRowBytes) ||
         !GetFloatRowByteCount(SrcImg.GetWidth(), nDestSamples, nDstRowBytes) ||
         !AddPixelBufSlack(nSrcRowBytes) ||
@@ -633,6 +805,12 @@ int main(int argc, const char** argv)
       return -1;
     }
   }
+  ICC_APPLY_TRACE(
+    1,
+    "event=buffers_ready source_line_bytes=%u destination_line_bytes=%u "
+    "source_float_row_bytes=%zu destination_float_row_bytes=%zu",
+    SrcImg.GetBytesPerLine(), DstImg.GetBytesPerLine(), nSrcRowBytes,
+    nDstRowBytes);
 
   //Allocate pixel buffers for performing encoding transformations
   CIccPixelBuf SrcPixel(nSrcSamples+16), DestPixel(nDestSamples+16), Pixel(icIntMax(nSrcSamples, nDestSamples)+16);
@@ -713,13 +891,40 @@ int main(int argc, const char** argv)
 
   //Read each line
   bool bApplySuccess = true;
+  unsigned long long readTotalUs = 0;
+  unsigned long long decodeTotalUs = 0;
+  unsigned long long applyTotalNs = 0;
+  unsigned long long encodeTotalUs = 0;
+  unsigned long long writeTotalUs = 0;
+  unsigned long long applyCalls = 0;
+  unsigned int completedRows = 0;
+  const int traceLevel = IccApplyTraceLevel();
+  const bool timingEnabled = IccApplyTimingEnabled();
+  const bool showProgress = !timingEnabled;
+  const unsigned long long processingStartUs = IccApplyElapsedMicroseconds();
+  ICC_APPLY_TRACE(
+    1,
+    "event=processing_begin rows=%u columns=%u pixels=%llu mode=%s "
+    "source_samples=%d destination_samples=%d source_bpp=%lu destination_bpp=%lu",
+    SrcImg.GetHeight(), SrcImg.GetWidth(),
+    static_cast<unsigned long long>(SrcImg.GetWidth()) * SrcImg.GetHeight(),
+    bUseRowApply ? "row" : "pixel", nSrcColorSamples, nDestSamples, sbpp, dbpp);
   for (i=0; i<(int)SrcImg.GetHeight(); i++) {
+    const unsigned long long rowStartUs =
+      timingEnabled ? IccApplyElapsedMicroseconds() : 0;
+    unsigned long long stepStartUs = rowStartUs;
+    ICC_APPLY_TRACE(2, "event=row_begin row=%d", i);
     if (!SrcImg.ReadLine(pSBuf)) {
       printf("Error reading line %d from Tiff file - '%s'\n", i, cfgApply.m_srcImgFile.c_str());
       bApplySuccess = false;
       break;
     }
+    const unsigned long long rowReadUs = timingEnabled ?
+      IccApplyElapsedMicroseconds() - stepStartUs : 0;
+    readTotalUs += rowReadUs;
     if (bUseRowApply) {
+      if (timingEnabled)
+        stepStartUs = IccApplyElapsedMicroseconds();
       for (sptr=pSBuf, j=0; j<(int)SrcImg.GetWidth(); j++, sptr+=sbpp) {
         if (!decodePixel(pSrcRowBuf + j * nSrcColorSamples, sptr)) {
           free(pSBuf);
@@ -729,10 +934,41 @@ int main(int argc, const char** argv)
           return -1;
         }
       }
+      const unsigned long long rowDecodeUs = timingEnabled ?
+        IccApplyElapsedMicroseconds() - stepStartUs : 0;
+      decodeTotalUs += rowDecodeUs;
 
-      pTheCmm->Apply(pDstRowBuf, pSrcRowBuf, SrcImg.GetWidth());
+      const unsigned long long applyStartNs = timingEnabled ?
+        IccApplyElapsedNanoseconds() : 0;
+      const icStatusCMM applyStatus =
+        pTheCmm->Apply(pDstRowBuf, pSrcRowBuf, SrcImg.GetWidth());
+      const unsigned long long rowApplyNs = timingEnabled ?
+        IccApplyElapsedNanoseconds() - applyStartNs : 0;
+      applyTotalNs += rowApplyNs;
+      applyCalls++;
+      if (applyStatus != icCmmStatOk) {
+        printf("Error applying profiles to line %d (status %d: %s)\n",
+               i, (int)applyStatus, CIccCmm::GetStatusText(applyStatus));
+        bApplySuccess = false;
+        break;
+      }
 
+      if (timingEnabled)
+        stepStartUs = IccApplyElapsedMicroseconds();
       for (dptr=pDBuf, j=0; j<(int)SrcImg.GetWidth(); j++, dptr+=dbpp) {
+        if (traceLevel >= 3) {
+          ICC_APPLY_TRACE(
+            3,
+            "event=pixel row=%d column=%d src_first=%.9g src_last=%.9g "
+            "dst_first=%.9g dst_last=%.9g",
+            i, j,
+            nSrcColorSamples > 0 ? pSrcRowBuf[j * nSrcColorSamples] : 0.0f,
+            nSrcColorSamples > 0 ?
+              pSrcRowBuf[j * nSrcColorSamples + nSrcColorSamples - 1] : 0.0f,
+            nDestSamples > 0 ? pDstRowBuf[j * nDestSamples] : 0.0f,
+            nDestSamples > 0 ?
+              pDstRowBuf[j * nDestSamples + nDestSamples - 1] : 0.0f);
+        }
         if (!encodePixel(dptr, pDstRowBuf + j * nDestSamples)) {
           free(pSBuf);
           free(pDBuf);
@@ -741,9 +977,22 @@ int main(int argc, const char** argv)
           return -1;
         }
       }
+      const unsigned long long rowEncodeUs = timingEnabled ?
+        IccApplyElapsedMicroseconds() - stepStartUs : 0;
+      encodeTotalUs += rowEncodeUs;
+      ICC_APPLY_TRACE(
+        2,
+        "event=row_transform row=%d read_us=%llu decode_us=%llu apply_us=%llu "
+        "encode_us=%llu pixels=%u",
+        i, rowReadUs, rowDecodeUs, rowApplyNs / 1000ULL, rowEncodeUs, SrcImg.GetWidth());
     }
     else {
+      unsigned long long rowDecodeUs = 0;
+      unsigned long long rowApplyNs = 0;
+      unsigned long long rowEncodeUs = 0;
       for (sptr=pSBuf, dptr=pDBuf, j=0; j<(int)SrcImg.GetWidth(); j++, sptr+=sbpp, dptr+=dbpp) {
+        if (timingEnabled)
+          stepStartUs = IccApplyElapsedMicroseconds();
         if (!decodePixel(SrcPixel, sptr)) {
           free(pSBuf);
           free(pDBuf);
@@ -751,10 +1000,31 @@ int main(int argc, const char** argv)
           free(pDstRowBuf);
           return -1;
         }
+        if (timingEnabled)
+          rowDecodeUs += IccApplyElapsedMicroseconds() - stepStartUs;
 
         //Use CMM to convert SrcPixel to DestPixel
+        const unsigned long long applyStartNs = timingEnabled ?
+          IccApplyElapsedNanoseconds() : 0;
         pTheCmm->Apply(DestPixel, SrcPixel);
+        const unsigned long long pixelApplyNs = timingEnabled ?
+          IccApplyElapsedNanoseconds() - applyStartNs : 0;
+        rowApplyNs += pixelApplyNs;
+        applyCalls++;
+        if (traceLevel >= 3) {
+          ICC_APPLY_TRACE(
+            3,
+            "event=pixel row=%d column=%d apply_us=%llu src_first=%.9g "
+            "src_last=%.9g dst_first=%.9g dst_last=%.9g",
+            i, j, pixelApplyNs / 1000ULL,
+            nSrcColorSamples > 0 ? SrcPixel[0] : 0.0f,
+            nSrcColorSamples > 0 ? SrcPixel[nSrcColorSamples - 1] : 0.0f,
+            nDestSamples > 0 ? DestPixel[0] : 0.0f,
+            nDestSamples > 0 ? DestPixel[nDestSamples - 1] : 0.0f);
+        }
 
+        if (timingEnabled)
+          stepStartUs = IccApplyElapsedMicroseconds();
         if (!encodePixel(dptr, DestPixel)) {
           free(pSBuf);
           free(pDBuf);
@@ -762,25 +1032,76 @@ int main(int argc, const char** argv)
           free(pDstRowBuf);
           return -1;
         }
+        if (timingEnabled)
+          rowEncodeUs += IccApplyElapsedMicroseconds() - stepStartUs;
       }
+      decodeTotalUs += rowDecodeUs;
+      applyTotalNs += rowApplyNs;
+      encodeTotalUs += rowEncodeUs;
+      ICC_APPLY_TRACE(
+        2,
+        "event=row_transform row=%d read_us=%llu decode_us=%llu apply_us=%llu "
+        "encode_us=%llu pixels=%u",
+        i, rowReadUs, rowDecodeUs, rowApplyNs / 1000ULL, rowEncodeUs, SrcImg.GetWidth());
     }
 
     //Output the converted pixels to the destination image
+    if (timingEnabled)
+      stepStartUs = IccApplyElapsedMicroseconds();
     if (!DstImg.WriteLine(pDBuf)) {
       printf("Error writing line %d to Tiff file - '%s'\n", i, cfgApply.m_dstImgFile.c_str());
       bApplySuccess = false;
       break;
     }
+    const unsigned long long rowWriteUs = timingEnabled ?
+      IccApplyElapsedMicroseconds() - stepStartUs : 0;
+    writeTotalUs += rowWriteUs;
+    completedRows++;
+    ICC_APPLY_TRACE(2, "event=row_end row=%d write_us=%llu total_us=%llu",
+                    i, rowWriteUs,
+                    IccApplyElapsedMicroseconds() - rowStartUs);
 
     //Display status of how much we have accomplished
-    curper = static_cast<int>((static_cast<float>(i + 1) * 100.0f) /
-                              static_cast<float>(SrcImg.GetHeight()));
-    if (curper !=lastPer) {
-      printf("\r%d%%", curper);
-      lastPer = curper;
+    if (showProgress) {
+      curper = static_cast<int>((static_cast<float>(i + 1) * 100.0f) /
+                                static_cast<float>(SrcImg.GetHeight()));
+      if (curper !=lastPer) {
+        printf("\r%d%%", curper);
+        lastPer = curper;
+      }
     }
   }
-  printf("\n");
+  if (showProgress)
+    printf("\n");
+  const unsigned long long processingElapsedUs =
+    IccApplyElapsedMicroseconds() - processingStartUs;
+  const unsigned long long totalPixels =
+    static_cast<unsigned long long>(SrcImg.GetWidth()) * completedRows;
+  const double megaPixelsPerSecond = processingElapsedUs ?
+    static_cast<double>(totalPixels) / static_cast<double>(processingElapsedUs) :
+    0.0;
+  if (timingEnabled) {
+    const double applyPercent = processingElapsedUs ?
+      static_cast<double>(applyTotalNs) * 100.0 /
+        (static_cast<double>(processingElapsedUs) * 1000.0) : 0.0;
+    const CIccApplyThreadedCmm *pThreadedApply =
+      dynamic_cast<const CIccApplyThreadedCmm*>(pTheCmm->GetApply());
+    const unsigned long long asyncWorkerStrips = pThreadedApply ?
+      pThreadedApply->GetAsyncWorkerStripCount() : 0;
+    printf("[TIMING] Loop ms: %.3f\n", processingElapsedUs / 1000.0);
+    printf("[TIMING] Apply ms: %.3f\n", applyTotalNs / 1000000.0);
+    printf("[TIMING] Apply pct: %.3f\n", applyPercent);
+    printf("[TIMING] Apply calls: %llu\n", applyCalls);
+    printf("[TIMING] Async worker strips: %llu\n", asyncWorkerStrips);
+  }
+  ICC_APPLY_TRACE(
+    1,
+    "event=processing_end success=%d elapsed_us=%llu completed_rows=%u pixels=%llu "
+    "megapixels_per_second=%.6f read_us=%llu decode_us=%llu apply_us=%llu "
+    "encode_us=%llu write_us=%llu",
+    bApplySuccess ? 1 : 0, processingElapsedUs, completedRows, totalPixels,
+    megaPixelsPerSecond, readTotalUs, decodeTotalUs, applyTotalNs / 1000ULL,
+    encodeTotalUs, writeTotalUs);
 
   //Clean everything up by closeing files and freeing buffers
   SrcImg.Close();
@@ -792,5 +1113,7 @@ int main(int argc, const char** argv)
 
   DstImg.Close();
 
+  ICC_APPLY_TRACE(1, "event=process_end exit_code=%d total_elapsed_us=%llu",
+                  bApplySuccess ? 0 : -1, IccApplyElapsedMicroseconds());
   return bApplySuccess ? 0 : -1;
 }

--- a/Tools/CmdLine/IccBenchApply/Readme.md
+++ b/Tools/CmdLine/IccBenchApply/Readme.md
@@ -12,7 +12,7 @@ their code in the thing being measured.
 ## Usage
 
 ```
-iccBenchApply {options} interpolation {profile_path rendering_intent {-PCC pcc_path}}...
+iccBenchApply {options} interpolation {{-ENV:sig value} profile_path rendering_intent {-PCC pcc_path}}...
 ```
 
 `interpolation` is `0` for linear or `1` for tetrahedral. `rendering_intent` is
@@ -54,6 +54,21 @@ matching. The same code means different things in the two families (#2270).
 | `-suite` | run the built-in case table; takes no chain arguments |
 | `-csv` | machine-readable output |
 
+`-ENV:sig value` sets a CMM environment variable for the profile immediately
+following it, matching the profile-chain placement used by `iccApplyProfiles`
+and `iccApplyToLink`.
+
+For the MCS sample chain, first generate the MCS profile fixtures in
+`Testing/mcs/`, then run this command from the repository root:
+
+```text
+iccBenchApply -pixels 1048576 -repeats 5 1 \
+  Testing/mcs/6ChanSelect-MID.icc 0 \
+  -ENV:bkgX 0.4014 -ENV:bkgY 0.2391 -ENV:bkgZ 0.0272 \
+  Testing/mcs/18ChanWithSpots-MVIS.icc 0 \
+  Testing/sRGB_v4_ICC_preference.icc 1
+```
+
 Examples:
 
 ```sh
@@ -86,7 +101,7 @@ is the headline number and the only one that reflects the chunked multi-pixel
 path in `CIccCmm.cpp`.
 
 **Per xform** (`-perxform`). After `Begin()`, the chain is enumerated through
-`CIccCmm::IterateXforms` and each xform timed individually — including the
+`CIccCmm::IterateXforms` and each xform timed individually -- including the
 `CIccPcsXform` entries `Begin()` inserts between profiles, which are invisible in
 the whole-chain figure.
 
@@ -104,7 +119,7 @@ accessors. Reported in Mval/s.
 
 2. **Checksums only compare across builds with matching compiler flags.** The
    hash is over raw float bit patterns, which is what makes it an exact
-   equivalence oracle — and also what makes it sensitive to legitimate
+   equivalence oracle -- and also what makes it sensitive to legitimate
    floating-point reassociation. A checksum difference between two different
    builds means *investigate*, not *regression*.
 
@@ -126,16 +141,16 @@ which is not always what the profile names suggest.
 
 | case | resolved chain | notes |
 |---|---|---|
-| `matrix-trc` | MatrixTRC → PCS → Mpe | |
-| `lut-3d-tetra` | 3DLut → PCS → 3DLut | also carries the `Begin()` re-entry check |
-| `spectral-6ch` | Mpe → PCS → 3DLut | see misreading 3 above |
-| `monochrome` | Monochrome → MatrixTRC | no PCS step: XYZ PCS on both sides |
-| `mpe-calc` | Mpe → PCS → Mpe | the Calculator element |
-| `mpe-tonemap` | Mpe → Mpe | no PCS step |
-| `pcs-rel` | 3DLut → PCS → Mpe | relative colorimetric |
-| `pcs-abs` | 3DLut → PCS → Mpe | absolute; the delta against `pcs-rel` isolates PCS adjustment |
+| `matrix-trc` | MatrixTRC -> PCS -> Mpe | |
+| `lut-3d-tetra` | 3DLut -> PCS -> 3DLut | also carries the `Begin()` re-entry check |
+| `spectral-6ch` | Mpe -> PCS -> 3DLut | see misreading 3 above |
+| `monochrome` | Monochrome -> MatrixTRC | no PCS step: XYZ PCS on both sides |
+| `mpe-calc` | Mpe -> PCS -> Mpe | the Calculator element |
+| `mpe-tonemap` | Mpe -> Mpe | no PCS step |
+| `pcs-rel` | 3DLut -> PCS -> Mpe | relative colorimetric |
+| `pcs-abs` | 3DLut -> PCS -> Mpe | absolute; the delta against `pcs-rel` isolates PCS adjustment |
 
-The `pcs` pair is `V2/v2RgbLut8.icc` (D50) → `sRGB_D65_MAT.icc` (D65)
+The `pcs` pair is `V2/v2RgbLut8.icc` (D50) -> `sRGB_D65_MAT.icc` (D65)
 deliberately. The obvious choice of reusing the `lut-3d-tetra` pair does not
 work: both `Testing/V2` LUT profiles carry a `mediaWhitePointTag` of exactly D50,
 which makes the absolute adjustment an identity and produces a checksum
@@ -160,8 +175,8 @@ Never a slow number. Only:
 ## Input data
 
 Deterministic LCG fill with a fixed seed, so runs are comparable. The final row
-of the buffer is deliberately pathological — negative, greater than one, ±inf,
-and NaN — because several of the clamp and non-finite paths worth measuring would
+of the buffer is deliberately pathological -- negative, greater than one, +/-inf,
+and NaN -- because several of the clamp and non-finite paths worth measuring would
 otherwise never execute, and a happy-path-only buffer would let an incorrect
 change pass the checksum oracle unnoticed.
 

--- a/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
+++ b/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
@@ -71,9 +71,11 @@
 
 #include <cerrno>
 #include <climits>
+#include <cmath>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <string>
 #include <utility>
@@ -83,6 +85,7 @@
 #include "IccCmm.h"
 #include "IccCmmThread.h"
 #include "IccDefs.h"
+#include "IccEnvVar.h"
 #include "IccProfLibVer.h"
 #include "IccProfile.h"
 #include "IccTagLut.h"
@@ -103,7 +106,8 @@ static void Usage()
 {
   printf("iccBenchApply built with IccProfLib version " ICCPROFLIBVER "\n\n");
   printf("Usage: iccBenchApply {options} interpolation"
-         " {profile_path rendering_intent {-PCC pcc_path}}...\n\n");
+         " {{-ENV:sig value} profile_path rendering_intent"
+         " {-PCC pcc_path}}...\n\n");
   printf("  interpolation      0 = Linear, 1 = Tetrahedral\n");
   // Deliberately describes the columns and points at iccApplyToLink for the
   // tens-column list rather than reprinting it.  Four tools already publish
@@ -124,6 +128,7 @@ static void Usage()
   printf("                     Run iccApplyToLink with no arguments for the"
          " full\n");
   printf("                     list of tens-column codes.\n\n");
+  printf("  -ENV:sig value     environment value for the next profile\n");
   printf("  -pixels N          pixels per buffer      (default 1048576)\n");
   printf("  -repeats N         timed repeats per case (default 7)\n");
   printf("  -perxform          per-xform breakdown, including PCS steps\n");
@@ -153,6 +158,25 @@ static bool ParseIntArg(const char *arg, int minValue, int maxValue, int &value)
   }
 
   value = (int)parsed;
+  return true;
+}
+
+static bool ParseFloatArg(const char *arg, icFloatNumber &value)
+{
+  char *end = NULL;
+  double parsed;
+
+  if (!arg || !*arg)
+    return false;
+
+  errno = 0;
+  parsed = strtod(arg, &end);
+  if (errno == ERANGE || end == arg || *end != '\0' || !std::isfinite(parsed) ||
+      parsed < -std::numeric_limits<icFloatNumber>::max() ||
+      parsed > std::numeric_limits<icFloatNumber>::max())
+    return false;
+
+  value = (icFloatNumber)parsed;
   return true;
 }
 
@@ -822,6 +846,34 @@ int main(int argc, const char *argv[])
   std::string sFirstProfile;
 
   while (nArg < argc) {
+    icCmmEnvSigMap envVars;
+    while (nArg < argc && !strnicmp(argv[nArg], "-ENV:", 5)) {
+      if (nArg + 1 >= argc) {
+        printf("%s has no environment value\n", argv[nArg]);
+        return 1;
+      }
+
+      const char *envSignature = argv[nArg] + 5;
+      if (strlen(envSignature) != 4) {
+        printf("Invalid environment signature '%s':"
+               " expected exactly four characters\n", envSignature);
+        return 1;
+      }
+
+      icFloatNumber value;
+      if (!ParseFloatArg(argv[nArg + 1], value)) {
+        printf("Invalid environment value '%s' for %s:"
+               " expected a finite number\n", argv[nArg + 1], argv[nArg]);
+        return 1;
+      }
+      envVars[icGetSigVal(envSignature)] = value;
+      nArg += 2;
+    }
+    if (nArg >= argc) {
+      printf("Environment variables must be followed by a profile\n");
+      return 1;
+    }
+
     const char *szProfile = argv[nArg];
 
     if (nArg + 1 >= argc) {
@@ -866,6 +918,15 @@ int main(int argc, const char *argv[])
         return 1;
       }
       nArg += 2;
+    }
+
+    if (!envVars.empty()) {
+      std::unique_ptr<CIccCmmEnvVarHint> envHint(
+        new CIccCmmEnvVarHint(envVars));
+      if (!Hint.AddHint(envHint.release())) {
+        printf("Unable to attach environment variables to '%s'\n", szProfile);
+        return 1;
+      }
     }
 
     icStatusCMM stat = theCmm.AddXform(szProfile,

--- a/docs/avx2-clut-diagnostics.md
+++ b/docs/avx2-clut-diagnostics.md
@@ -62,9 +62,11 @@ Configure a separate release build with
 `-DICCDEV_ENABLE_PERF_MONITORING=ON` to collect aggregate, opt-in library
 telemetry. The library remains silent unless `ICC_PERF_STATS_FILE` names a
 report file. The report records CLUT calls by scalar/SSE2/AVX2/AVX-512 path,
-output-channel counts, aggregate CLUT elapsed nanoseconds, and threaded-CMM
-call, pixel, strip, and active-worker totals. Each process appends one report
-block, so a CTest run preserves its child-process telemetry in one file.
+input-dimensionality and output-channel counts, aggregate CLUT elapsed
+nanoseconds, and threaded-CMM call, pixel, strip, and active-worker totals.
+Three-dimensional and four-dimensional scalar interpolation are currently
+dimension-labeled. Each process appends one report block, so a CTest run
+preserves its child-process telemetry in one file.
 
 On Linux, capture the focused regression in a fresh output directory:
 

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -123,6 +123,12 @@ before running the suite.
 | `iccdev.fileio-seek-tell` | `.github/ci/regression/fileio-seek-tell.cpp` |
 | `iccdev.iccconnect-config-parser` | `.github/ci/regression/iccconnect-config-parser.cpp` |
 | `iccdev.iccconnect-threaded-cmm` | `.github/ci/regression/iccconnect-threaded-cmm.cpp` |
+| `iccdev.bench-apply-env` | `Build/Cmake/Testing/CMakeLists.txt` |
+| `iccdev.bench-apply-env-invalid` | `Build/Cmake/Testing/CMakeLists.txt` |
+| `iccdev.bench-apply-env-nonfinite` | `Build/Cmake/Testing/CMakeLists.txt` |
+| `iccdev.bench-apply-env-invalid-signature` | `Build/Cmake/Testing/CMakeLists.txt` |
+| `iccdev.bench-apply-env-missing-value` | `Build/Cmake/Testing/CMakeLists.txt` |
+| `iccdev.bench-apply-env-missing-profile` | `Build/Cmake/Testing/CMakeLists.txt` |
 | `iccdev.applytolink-invalid-decoded-intent` | `Build/Cmake/Testing/CMakeLists.txt` |
 | `iccdev.applytolink-v4-missing-device-descriptions` | `Build/Cmake/Testing/CMakeLists.txt` |
 | `iccdev.xform-abstorel-adjust` | `.github/ci/regression/xform-abstorel-adjust.cpp` |


### PR DESCRIPTION
## PR Summary

Implements bounded MCS profiling, threaded ApplySearch/ApplyProfiles diagnostics, focused CodeQL loop-bound coverage, and associated CI/reporting hardening.

Tracks InternationalColorConsortium/iccDEV#2346 and InternationalColorConsortium/iccDEV#2348.

## Scope and acceptance contract

| Surface | Required behavior | Evidence |
| --- | --- | --- |
| Bounded MCS profiling | The profile operation is time-bounded. A failure artifact is packaged only when the MCS profile step itself fails, and is uploaded only after that package succeeds. | Step-specific workflow outcomes gate MCS packaging and upload. |
| Threaded ApplySearch and ApplyProfiles | Thread-count inputs are constrained; `-threads 2` exercises row dispatch; timing reports actual queued background worker strips instead of a fixed value. | The wide `Testing/mcs/prev.tif` quick check requires positive worker-strip output. |
| Timing diagnostics | Apply work is accumulated in nanoseconds before conversion. Every trace byte outside printable ASCII is encoded, so each trace event remains one line. | ApplyProfiles quick check covers threaded timing plus newline and UTF-8 trace input. |
| CodeQL and SAST policy | The unbounded-profile-loop query recognizes only direct structural hard caps: top-level `&&` operands or `induction < min(profile field, numeric literal)`. `||` bypasses and field-only bounds are reported. | Query-pack regressions cover nested-OR bypasses and compound/direct field-vs-field `min()` cases. |
| CI report trust boundary | PR-controlled paths and report text are sanitized only with the trusted-base helper; its absence fails the workflow. | The tool-test workflow explicitly sources `trusted-base/.github/scripts/sanitize-sed.sh`. |
| Docker PR lane | The brittle Docker/Clang pre-merge lane is retired; it cannot reliably consume moving stacked-parent image tags. Canonical image publication remains owned by `ci-docker.yml`, while container changes select the normal native platform matrix. | `ci-docker-pr.yml` and its required-gate consumer are removed; GCC, Windows, and macOS validation remain in the PR summary. |

## Validation evidence

- `codeql test run --additional-packs=.github/codeql-queries .github/codeql-queries/test` passes, including nested-OR and field-only `min()` cap regressions.
- `iccApplyProfiles-quick-check.sh` passes threaded output parity, positive worker-strip reporting, and newline/UTF-8 trace encoding.
- `actionlint` passes for the affected workflow changes, and `git diff --check` passes.
