### PR TITLE
fix(#2323): refuse an unterminated index in a calculator channel reference

### DIFF
--- a/.github/ci/regression/calc-channel-ref-unterminated-index-json.cpp
+++ b/.github/ci/regression/calc-channel-ref-unterminated-index-json.cpp
@@ -1,0 +1,229 @@
+/*
+    File:       calc-channel-ref-unterminated-index-json.cpp
+
+    Contains:   CTest helper for CIccMpeJsonCalculator::Flatten()'s in{}/out{}
+                channel-reference index parsing (#2323).
+
+    The JSON calculator carries a byte-for-byte copy of the defect fixed in
+    CIccMpeXmlCalculator::Flatten(): it scans an index selector for its closing
+    bracket and then steps one past it,
+
+        for (p = select.c_str() + 1; *p && *p != ')' && *p != ']'; p++);
+        select = p + 1;
+
+    so an unterminated index leaves p on the NUL terminator and the assignment
+    runs strlen from one past it.  The three length regimes are the same as on
+    the XML side -- silently accepted at 14 characters or fewer, a
+    1-byte-read-stack-buffer-overflow at exactly 15 where the selector fills the
+    string's inline SSO buffer, a heap overflow at 16 or more.
+
+    This is a SEPARATE reachable entry point, not a duplicate of the XML test:
+    CIccMpeJsonCalculator is registered for icSigCalculatorElemType in
+    IccMpeJsonFactory.cpp, so iccFromJson on a hand-authored document reaches it
+    without any XML involved.  It is also reachable through MORE spellings than
+    the XML copy, because its entry condition is the correct
+    "select[0] == '('" where the XML one has a typo ("select[1]"): both
+    "in{Lab[XXXX" and "in{Lab(XXXX" arrive here, and only the first arrives on
+    the XML side.  Both are asserted below for exactly that reason.
+
+    Registered separately from the XML helper rather than folded into it so that
+    neither can mask the other: this one is skipped where IccJSON is not built,
+    and the XML coverage does not disappear with it.
+
+    Args:
+      argv[1] - scratch directory to generate fixtures in (created if absent)
+
+    Exit codes:
+      0 - expected result observed
+      1 - unexpected result
+*/
+
+#include "IccProfileJson.h"
+#include "IccTagJsonFactory.h"
+#include "IccMpeJsonFactory.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+static int check(bool condition, const char* label)
+{
+  if (condition) {
+    std::fprintf(stdout, "calc-channel-ref-unterminated-index-json: PASS  %s\n", label);
+    return 0;
+  }
+
+  std::fprintf(stderr, "calc-channel-ref-unterminated-index-json: FAIL  %s\n", label);
+  return 1;
+}
+
+// The same seven-in / three-out named calculator the XML helper uses, so "Lab"
+// is a three-wide group at offset 4.  Only mainFunction varies.
+static std::string profileJson(const std::string& mainFunction)
+{
+  return
+    "{\n"
+    "  \"IccProfile\": {\n"
+    "    \"Header\": {\n"
+    "      \"ProfileVersion\": \"5.00\",\n"
+    "      \"ProfileDeviceClass\": \"spac\",\n"
+    "      \"DataColourSpace\": \"7CLR\",\n"
+    "      \"PCS\": \"XYZ \",\n"
+    "      \"CreationDateTime\": \"2026-09-02T00:00:00\",\n"
+    "      \"RenderingIntent\": \"Relative\",\n"
+    "      \"PCSIlluminant\": [0.9642, 1.0, 0.8249]\n"
+    "    },\n"
+    "    \"Tags\": [\n"
+    "      {\n"
+    "        \"AToB1Tag\": {\n"
+    "          \"data\": {\n"
+    "            \"type\": \"multiProcessElementType\",\n"
+    "            \"inputChannels\": 7,\n"
+    "            \"outputChannels\": 3,\n"
+    "            \"elements\": [\n"
+    "              {\n"
+    "                \"type\": \"CalculatorElement\",\n"
+    "                \"inputChannels\": 7,\n"
+    "                \"outputChannels\": 3,\n"
+    "                \"inputNames\": \"C M Y K Lab[3]\",\n"
+    "                \"outputNames\": \"a b L\",\n"
+    "                \"mainFunction\": \"" + mainFunction + "\"\n"
+    "              }\n"
+    "            ]\n"
+    "          }\n"
+    "        }\n"
+    "      }\n"
+    "    ]\n"
+    "  }\n"
+    "}\n";
+}
+
+static bool writeFile(const std::string& path, const std::string& text)
+{
+  std::ofstream f(path, std::ios::binary);
+  if (!f)
+    return false;
+  f << text;
+  return f.good();
+}
+
+// Returns whether the document parsed.  A sanitizer abort inside here IS the
+// defect on an instrumented lane: the caller never gets its result back.
+static bool loadJson(const char* file, std::string& parseStr)
+{
+  CIccProfileJson profile;
+  return profile.LoadJson(file, &parseStr);
+}
+
+// n filler characters, none of which closes a bracket, so the scan runs to the
+// terminator.  The selector is the bracket plus these, so pass n = length - 1.
+static std::string filler(unsigned n)
+{
+  return std::string(n, 'X');
+}
+
+static int expectRefused(const std::string& mainFunction, const char* file, const char* label,
+                         const char* needle = "Unterminated index")
+{
+  if (!writeFile(file, profileJson(mainFunction)))
+    return check(false, label);
+
+  std::string parseStr;
+  bool loaded = loadJson(file, parseStr);
+  bool named = parseStr.find(needle) != std::string::npos;
+
+  return check(!loaded && named, label);
+}
+
+static int expectParsed(const std::string& mainFunction, const char* file, const char* label)
+{
+  if (!writeFile(file, profileJson(mainFunction)))
+    return check(false, label);
+
+  std::string parseStr;
+  return check(loadJson(file, parseStr), label);
+}
+
+int main(int argc, char* argv[])
+{
+  if (argc < 2) {
+    std::fprintf(stderr, "usage: %s <scratch-dir>\n", argv[0]);
+    return 1;
+  }
+
+  std::error_code ec;
+  std::filesystem::create_directories(argv[1], ec);
+  std::filesystem::current_path(argv[1], ec);
+  if (ec) {
+    std::fprintf(stderr,
+                 "calc-channel-ref-unterminated-index-json: cannot use scratch dir '%s'\n",
+                 argv[1]);
+    return 1;
+  }
+
+  // The factories iccFromJson pushes before LoadJson.  Without them no
+  // CIccMpeJsonCalculator is ever constructed and every load fails for want of
+  // an element handler, which would make the "is refused" assertions pass
+  // without the code under test being entered.  The controls catch that.
+  CIccTagCreator::PushFactory(new CIccTagJsonFactory());
+  CIccMpeCreator::PushFactory(new CIccMpeJsonFactory());
+
+  int failures = 0;
+
+  // The three length regimes.  The first is the one that red/greens without a
+  // sanitizer: before the fix that document parsed.
+  failures += expectRefused("{\\nin{Lab[" + filler(1) + "\\nout{L}\\n}\\n",
+                            "json-unterminated-sso.json",
+                            "selector inside the SSO buffer is refused, not silently accepted");
+
+  failures += expectRefused("{\\nin{Lab[" + filler(14) + "\\nout{L}\\n}\\n",
+                            "json-unterminated-stack.json",
+                            "selector of exactly 15 (the stack overflow) is refused");
+
+  failures += expectRefused("{\\nin{Lab[" + filler(39) + "\\nout{L}\\n}\\n",
+                            "json-unterminated-heap.json",
+                            "selector past the SSO buffer (heap overflow) is refused");
+
+  // The '(' spelling.  This one reaches the block here but NOT on the XML side,
+  // where select[1] == '(' keeps it out -- so it is only covered by this file.
+  failures += expectRefused("{\\nin{Lab(" + filler(14) + "\\nout{L}\\n}\\n",
+                            "json-unterminated-paren.json",
+                            "the '(' spelling, which the XML typo blocks, is refused here");
+
+  failures += expectRefused("{\\nin{C}\\nout{a[" + filler(14) + "\\n}\\n",
+                            "json-unterminated-out.json",
+                            "out{} references are guarded by the same check");
+
+  // The same int-overflow in this file's copy of the offset/size bound: the sum
+  // wrapped negative and passed the test meant to refuse it.
+  failures += expectRefused("{\\nin{Lab[2000000000],2000000000}\\nout{L}\\n}\\n",
+                            "json-overflowing-offset-size.json",
+                            "an offset/size pair that overflows the bound is refused by it",
+                            "Invalid 'in' channel offset/size");
+
+  // Controls, so that refusing every indexed reference cannot satisfy the above.
+  failures += expectParsed("{\\nin{Lab[1],2}\\nout{a,2}\\n}\\n",
+                           "json-wellformed-offset-size.json",
+                           "in{Lab[1],2} still parses");
+
+  failures += expectParsed("{\\nin{Lab[0]}\\nout{L}\\n}\\n",
+                           "json-wellformed-offset.json",
+                           "in{Lab[0]} still parses");
+
+  // The '(' spelling in its well-formed form: this branch is live here, so it
+  // must keep working rather than being refused along with the bad ones.
+  //
+  // Written as "(1)" and matched with a single-channel out{}, deliberately.
+  // "in{Lab(1,2)}" would NOT be a control: the size is only read from a ",size"
+  // that FOLLOWS the closing bracket, so the "2" inside the parentheses is
+  // discarded, the operator flattens to in(5,1), and the function then fails on
+  // stack balance rather than on anything this fix touches.  That is the same
+  // deferred defect as the select[1] typo -- an index quietly narrowed instead
+  // of refused -- and pinning it here would assert today's wrong behaviour.
+  failures += expectParsed("{\\nin{Lab(1)}\\nout{L}\\n}\\n",
+                           "json-wellformed-paren.json",
+                           "the well-formed '(' spelling still parses");
+
+  return failures ? 1 : 0;
+}

--- a/.github/ci/regression/calc-channel-ref-unterminated-index.cpp
+++ b/.github/ci/regression/calc-channel-ref-unterminated-index.cpp
@@ -1,0 +1,263 @@
+/*
+    File:       calc-channel-ref-unterminated-index.cpp
+
+    Contains:   CTest helper for CIccMpeXmlCalculator::Flatten()'s in{}/out{}
+                channel-reference index parsing (#2323).
+
+    Flatten() splits a channel reference such as "Lab[1],2" into a root name and
+    an index selector, then walks the selector looking for the closing bracket:
+
+        for (ptr = select.c_str() + 1; *ptr && *ptr != ')' && *ptr != ']'; ptr++);
+        select = ptr + 1;
+
+    When the reference has no closing bracket the loop stops on the NUL
+    terminator instead, so "ptr + 1" addresses one past it and the assignment
+    runs strlen() from there.  How that presents depends only on how long the
+    selector is, because it decides where the string keeps its bytes:
+
+      <= 14 chars  no diagnostic at all.  The read stays inside libstdc++'s
+                   16-byte inline SSO buffer, and the malformed reference is
+                   ACCEPTED -- "in{Lab[XX" resolves quietly to in(4).
+         15 chars  the selector exactly fills the SSO buffer, so the read leaves
+                   the enclosing stack frame: AddressSanitizer reports a
+                   1-byte-read-stack-buffer-overflow, scariness 27.  This is the
+                   case the issue was filed on.
+      >= 16 chars  the string has moved to the heap, so the same read is a
+                   1-byte-read-heap-buffer-overflow, scariness 12.
+
+    The reported case is therefore the narrowest of the three -- it needs the
+    selector to be exactly one length -- and it is the only one a sanitizer lane
+    can see.  The <= 14 case is the one that red/greens everywhere, sanitizer or
+    not, because before the fix it PARSES: that is what keeps this test from
+    being vacuous on the lanes that carry no instrumentation.
+
+    Two spellings reach the same block.  "select[0] == '['" is the ordinary one;
+    "select[1] == '('" is a second entry with a defect of its own (it is a typo
+    for select[0], which is why "in{C(0,3)}" silently ignores its index while
+    tget/tput handle the same spelling correctly through
+    CIccFuncTokenizer::GetIndex).  That typo is NOT changed here -- it alters
+    which references are accepted, which is a maintainer ruling -- but it is
+    covered, because a reference reaching the block that way overflowed too.
+
+    The controls matter as much as the failures: an "unterminated index is
+    refused" assertion is satisfied just as well by refusing every indexed
+    reference, so the well-formed forms the corpus actually uses are pinned
+    alongside.
+
+    Args:
+      argv[1] - scratch directory to generate fixtures in (created if absent)
+
+    Exit codes:
+      0 - expected result observed
+      1 - unexpected result
+*/
+
+#include "IccProfileXml.h"
+#include "IccTagXmlFactory.h"
+#include "IccMpeXmlFactory.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+static int check(bool condition, const char* label)
+{
+  if (condition) {
+    std::fprintf(stdout, "calc-channel-ref-unterminated-index: PASS  %s\n", label);
+    return 0;
+  }
+
+  std::fprintf(stderr, "calc-channel-ref-unterminated-index: FAIL  %s\n", label);
+  return 1;
+}
+
+// A calculator element with seven named input channels and three named outputs,
+// so that "Lab" resolves to a three-wide group at offset 4 and indexed forms
+// have somewhere real to point.  Only the function body and the optional macro
+// block vary.
+static std::string profileXml(const std::string& body, const std::string& macros = "")
+{
+  return
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<IccProfile>\n"
+    "  <Header>\n"
+    "    <ProfileVersion>5.0</ProfileVersion>\n"
+    "    <ProfileDeviceClass>spac</ProfileDeviceClass>\n"
+    "    <DataColourSpace>7CLR</DataColourSpace>\n"
+    "    <PCS>XYZ </PCS>\n"
+    "    <CreationDateTime>2026-09-02T00:00:00</CreationDateTime>\n"
+    "    <RenderingIntent>Relative Colorimetric</RenderingIntent>\n"
+    "    <PCSIlluminant><XYZNumber X=\"0.9642\" Y=\"1.0\" Z=\"0.8249\"/></PCSIlluminant>\n"
+    "  </Header>\n"
+    "  <Tags>\n"
+    "    <multiProcessElementType>\n"
+    "      <TagSignature>A2B1</TagSignature>\n"
+    "      <MultiProcessElements InputChannels=\"7\" OutputChannels=\"3\">\n"
+    "        <CalculatorElement InputChannels=\"7\" OutputChannels=\"3\"\n"
+    "            InputNames=\"C M Y K Lab[3]\" OutputNames=\"a b L\">\n"
+    + macros +
+    "          <MainFunction>\n{\n" + body + "\n}\n          </MainFunction>\n"
+    "        </CalculatorElement>\n"
+    "      </MultiProcessElements>\n"
+    "    </multiProcessElementType>\n"
+    "  </Tags>\n"
+    "</IccProfile>\n";
+}
+
+static bool writeFile(const std::string& path, const std::string& text)
+{
+  std::ofstream f(path, std::ios::binary);
+  if (!f)
+    return false;
+  f << text;
+  return f.good();
+}
+
+// Returns whether the document parsed.  A sanitizer abort inside here IS the
+// defect on an instrumented lane: the caller never gets its result back.
+static bool loadXml(const char* file, std::string& parseStr)
+{
+  CIccProfileXml profile;
+  return profile.LoadXml(file, "", &parseStr);
+}
+
+// n filler characters, none of which is a closing bracket, so the scan runs to
+// the terminator.  The selector is "[" plus these, so pass n = length - 1.
+static std::string filler(unsigned n)
+{
+  return std::string(n, 'X');
+}
+
+// Write one case and report whether it was refused with the guard's own message.
+// Matching the text matters: "refused" on its own is also satisfied by an
+// unrelated parse failure, and every case here is one character away from a
+// document that parses.
+static int expectRefused(const std::string& body, const char* file, const char* label,
+                         const std::string& macros = "",
+                         const char* needle = "Unterminated index")
+{
+  if (!writeFile(file, profileXml(body, macros)))
+    return check(false, label);
+
+  std::string parseStr;
+  bool loaded = loadXml(file, parseStr);
+  bool named = parseStr.find(needle) != std::string::npos;
+
+  return check(!loaded && named, label);
+}
+
+static int expectParsed(const std::string& body, const char* file, const char* label,
+                        const std::string& macros = "")
+{
+  if (!writeFile(file, profileXml(body, macros)))
+    return check(false, label);
+
+  std::string parseStr;
+  return check(loadXml(file, parseStr), label);
+}
+
+int main(int argc, char* argv[])
+{
+  if (argc < 2) {
+    std::fprintf(stderr, "usage: %s <scratch-dir>\n", argv[0]);
+    return 1;
+  }
+
+  std::error_code ec;
+  std::filesystem::create_directories(argv[1], ec);
+  std::filesystem::current_path(argv[1], ec);
+  if (ec) {
+    std::fprintf(stderr,
+                 "calc-channel-ref-unterminated-index: cannot use scratch dir '%s'\n",
+                 argv[1]);
+    return 1;
+  }
+
+  // The factories iccFromXml pushes before LoadXml.  Without them no
+  // CIccMpeXmlCalculator is ever constructed, every load fails for want of an
+  // element handler, and the "is refused" assertions below would all pass
+  // without the code under test being entered.  The controls are what catch
+  // that, which is why they are here and not merely for completeness.
+  CIccTagCreator::PushFactory(new CIccTagXmlFactory());
+  CIccMpeCreator::PushFactory(new CIccMpeXmlFactory());
+
+  int failures = 0;
+
+  // The three length regimes, smallest first.  The first is the one that
+  // red/greens without a sanitizer: before the fix this document PARSED.
+  failures += expectRefused("in{Lab[" + filler(1) + " out{L}",
+                            "unterminated-sso.xml",
+                            "selector inside the SSO buffer is refused, not silently accepted");
+
+  failures += expectRefused("in{Lab[" + filler(14) + " out{L}",
+                            "unterminated-stack.xml",
+                            "selector of exactly 15 (the reported stack overflow) is refused");
+
+  failures += expectRefused("in{Lab[" + filler(39) + " out{L}",
+                            "unterminated-heap.xml",
+                            "selector past the SSO buffer (heap overflow) is refused");
+
+  // The second way into the same block: select[1] == '(' rather than
+  // select[0] == '['.  Reached with a reference whose selector starts ",(".
+  failures += expectRefused("in{C,(" + filler(13) + " out{L}",
+                            "unterminated-paren.xml",
+                            "the select[1] == '(' entry into the block is refused too");
+
+  // Same guard from the out{} operator, which shares the code path and only
+  // differs in which channel map it consults -- the message names the operator.
+  failures += expectRefused("in{C} out{a[" + filler(14),
+                            "unterminated-out.xml",
+                            "out{} references are guarded by the same check");
+
+  // The same bad reference inside a <Macro> body.  Flatten() recurses to expand a
+  // macro and used to DISCARD that call's result, so every refusal raised inside a
+  // macro -- this one included -- was written into parseStr and then dropped: the
+  // offending operator vanished from the flattened function and LoadXml() still
+  // returned true.  The guard above fired and the document was accepted anyway.
+  // The JSON twin has always checked this return, so the XML side was the outlier.
+  failures += expectRefused("#mm 0.5 out{L}",
+                            "unterminated-macro.xml",
+                            "a bad reference inside a macro body fails the load, not just parseStr",
+                            "          <Macros>\n"
+                            "            <Macro Name=\"mm\">in{Lab[" + filler(14) + "</Macro>\n"
+                            "          </Macros>\n");
+
+  // The offset/size bound two lines below the guard summed "first + offset + size"
+  // as int over two atoi() results, so a large pair WRAPPED NEGATIVE and passed the
+  // very test meant to refuse it -- 4 + 2000000000 + 2000000000 becomes -294967292.
+  // UBSan reports it as signed integer overflow.  The value was refused downstream
+  // by SetCalcFunc(), so this pins that it is now refused HERE, by its own guard,
+  // and without the undefined behaviour on the way.
+  failures += expectRefused("in{Lab[2000000000],2000000000} out{L}",
+                            "overflowing-offset-size.xml",
+                            "an offset/size pair that overflows the bound is refused by it",
+                            "",
+                            "Invalid 'in' operation channel offset or size");
+
+  // Controls.  Every well-formed indexed spelling the tracked corpus uses must
+  // still parse, or "refuse everything" would satisfy all five assertions above.
+  failures += expectParsed("in{Lab[1],2} out{a,2}",
+                           "wellformed-offset-size.xml",
+                           "in{Lab[1],2} still parses");
+
+  failures += expectParsed("in{Lab[0]} out{L}",
+                           "wellformed-offset.xml",
+                           "in{Lab[0]} still parses");
+
+  failures += expectParsed("in{Lab} out{a,2}",
+                           "wellformed-sizeonly.xml",
+                           "the size-only form out{a,2} still parses");
+
+  // The control for the propagation change specifically: a macro whose body is
+  // fine must still expand, or "return false on any macro" would satisfy the
+  // assertion above.
+  failures += expectParsed("#mm out{L}",
+                           "wellformed-macro.xml",
+                           "a macro whose body is well formed still expands",
+                           "          <Macros>\n"
+                           "            <Macro Name=\"mm\">in{Lab[0]}</Macro>\n"
+                           "          </Macros>\n");
+
+  return failures ? 1 : 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4034,6 +4034,139 @@ function(iccdev_add_xml_curve_oversize_file_test)
   endif()
 endfunction()
 
+# #2323: CIccMpeXmlCalculator::Flatten() scanned an in{}/out{} channel-reference
+# index for its closing bracket and then did "select = ptr + 1" unconditionally.
+# With no closing bracket the scan stops on the NUL terminator, so that assignment
+# ran strlen() one past it. Which diagnostic appears depends only on the selector
+# length, because that decides where the string keeps its bytes: <= 14 chars stays
+# inside libstdc++'s inline SSO buffer and is not caught at all (the malformed
+# reference is simply accepted), exactly 15 fills it and the read leaves the stack
+# frame (the reported 1-byte-read-stack-buffer-overflow, scariness 27), and >= 16
+# has moved to the heap. The helper covers all three plus the select[1] == '('
+# entry, and pins the well-formed spellings the corpus uses so that the guard
+# cannot be satisfied by refusing every indexed reference.
+function(iccdev_add_calc_channel_ref_unterminated_index_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCalcChannelRefUnterminatedIndexTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/calc-channel-ref-unterminated-index.cpp"
+  )
+  target_compile_features(iccCalcChannelRefUnterminatedIndexTest PRIVATE cxx_std_17)
+  target_include_directories(iccCalcChannelRefUnterminatedIndexTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccXML/IccLibXML"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+    ${LIBXML2_INCLUDE_DIR}
+  )
+  target_link_libraries(iccCalcChannelRefUnterminatedIndexTest PRIVATE
+    ${TARGET_LIB_ICCXML} ${TARGET_LIB_ICCPROFLIB} ${LIBXML2_LIBRARIES})
+  add_dependencies(check iccCalcChannelRefUnterminatedIndexTest)
+
+  # The helper writes its ten generated documents into this directory and
+  # chdir()s there, so nothing lands in the source tree.
+  set(_calc_unterminated_scratch
+    "${CMAKE_CURRENT_BINARY_DIR}/ctest-output/calc-channel-ref-unterminated-index")
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.calc-channel-ref-unterminated-index
+      COMMAND "$<TARGET_FILE:iccCalcChannelRefUnterminatedIndexTest>"
+              "${_calc_unterminated_scratch}"
+    )
+  else()
+    add_test(
+      NAME iccdev.calc-channel-ref-unterminated-index
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccCalcChannelRefUnterminatedIndexTest>"
+        "${_calc_unterminated_scratch}"
+    )
+  endif()
+  set_tests_properties(iccdev.calc-channel-ref-unterminated-index PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;xml;mpe;calculator;issue-2323;regression"
+  )
+  if(WIN32)
+    set(_calc_unterminated_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCalcChannelRefUnterminatedIndexTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCXML}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _calc_unterminated_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.calc-channel-ref-unterminated-index PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_calc_unterminated_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
+# #2323 (JSON twin): CIccMpeJsonCalculator::Flatten() carries a byte-for-byte copy
+# of the XML defect -- "select = p + 1" after a scan that stops on the NUL when the
+# index is unterminated. It is a separate reachable entry point (iccFromJson on a
+# hand-authored document), and reachable through MORE spellings than the XML copy,
+# whose "select[1] == '('" typo keeps the '(' form out. Registered separately from
+# the XML helper so neither masks the other: this one is skipped where IccJSON is
+# not built, and the XML coverage does not disappear with it.
+function(iccdev_add_calc_channel_ref_unterminated_index_json_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCJSON}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccCalcChannelRefUnterminatedIndexJsonTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/calc-channel-ref-unterminated-index-json.cpp"
+  )
+  target_compile_features(iccCalcChannelRefUnterminatedIndexJsonTest PRIVATE cxx_std_17)
+  target_include_directories(iccCalcChannelRefUnterminatedIndexJsonTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccJSON/IccLibJSON"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccCalcChannelRefUnterminatedIndexJsonTest PRIVATE
+    ${TARGET_LIB_ICCJSON} ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccCalcChannelRefUnterminatedIndexJsonTest)
+
+  set(_calc_unterminated_json_scratch
+    "${CMAKE_CURRENT_BINARY_DIR}/ctest-output/calc-channel-ref-unterminated-index-json")
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.calc-channel-ref-unterminated-index-json
+      COMMAND "$<TARGET_FILE:iccCalcChannelRefUnterminatedIndexJsonTest>"
+              "${_calc_unterminated_json_scratch}"
+    )
+  else()
+    add_test(
+      NAME iccdev.calc-channel-ref-unterminated-index-json
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccCalcChannelRefUnterminatedIndexJsonTest>"
+        "${_calc_unterminated_json_scratch}"
+    )
+  endif()
+  set_tests_properties(iccdev.calc-channel-ref-unterminated-index-json PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;json;mpe;calculator;issue-2323;regression"
+  )
+  if(WIN32)
+    set(_calc_unterminated_json_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccCalcChannelRefUnterminatedIndexJsonTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCJSON}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _calc_unterminated_json_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.calc-channel-ref-unterminated-index-json PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_calc_unterminated_json_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #2006 part 4a: CIccTagCurve::SetSize() answered an over-cap request the same
 # way it answered SetSize(0) -- free the table, m_nSize = 0, return true -- so
 # the return value could not distinguish "emptied" (a success, and ICC.1 10.6's
@@ -6781,6 +6914,8 @@ if(WIN32)
   iccdev_add_xml_writer_graceful_degrade_test()
   iccdev_add_xml_relaxng_validation_leak_test()
   iccdev_add_xml_curve_oversize_file_test()
+  iccdev_add_calc_channel_ref_unterminated_index_test()
+  iccdev_add_calc_channel_ref_unterminated_index_json_test()
   iccdev_add_curve_setsize_contract_test()
   iccdev_add_curve_gamma_u8fixed8_test()
   iccdev_add_luminance_normalization_test()
@@ -7146,6 +7281,8 @@ iccdev_add_json_sparsematrix_huaf_test()
 iccdev_add_xml_writer_graceful_degrade_test()
 iccdev_add_xml_relaxng_validation_leak_test()
 iccdev_add_xml_curve_oversize_file_test()
+iccdev_add_calc_channel_ref_unterminated_index_test()
+iccdev_add_calc_channel_ref_unterminated_index_json_test()
 iccdev_add_curve_setsize_contract_test()
 iccdev_add_curve_gamma_u8fixed8_test()
 iccdev_add_luminance_normalization_test()

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1591,11 +1591,37 @@ bool CIccMpeJsonCalculator::Flatten(std::string &flatStr, std::string macroName,
           const char *p;
           offset = atoi(select.c_str() + 1);
           for (p = select.c_str() + 1; *p && *p != ')' && *p != ']'; p++);
+          // Identical to the defect fixed in CIccMpeXmlCalculator::Flatten (#2323),
+          // and reachable through MORE spellings than that one: the entry condition
+          // here is correctly "select[0] == '('", where the XML copy has a typo
+          // ("select[1]"), so "in{Lab(XXXX" reaches this line as well as
+          // "in{Lab[XXXX".  An unterminated index leaves p on the NUL terminator, so
+          // "p + 1" addresses one past it and the assignment runs strlen from there:
+          // a stack-buffer-overflow read when the selector is exactly 15 characters
+          // and fills the string's inline SSO buffer, a heap-buffer-overflow at 16 or
+          // more, and no diagnostic at all below that -- where the malformed
+          // reference is simply accepted.  Refused for the same reason as the XML
+          // side: the checks either side already refuse an unknown channel name and
+          // an out-of-range offset/size.
+          if (!*p) {
+            parseStr += "Unterminated index in '" + op + "' channel reference '" + ref + "'\n";
+            return false;
+          }
           select = p + 1;
         }
         if (select[0] == ',') sz = atoi(select.c_str() + 1);
-        if (sz < 0 || offset < 0 ||
-            ci->second.first + offset + sz > (int)m_nInputChannels) {
+        // Summed in a width that cannot wrap, as in the XML twin (#2323): offset
+        // and sz are both atoi() results on attacker-supplied text, so this was int
+        // arithmetic over two unbounded values and overflowed before it could be
+        // tested.  Signed overflow has no defined behaviour, so there is no working
+        // input to preserve; the value is still refused, just at this guard.
+        //
+        // NOTE the bound is m_nInputChannels for BOTH operators here too, so an
+        // out{} reference is range-checked against the INPUT count.  Reported on
+        // #2323 for a ruling rather than changed here, because it changes which
+        // documents are accepted rather than removing undefined behaviour.
+        const long long nEnd = (long long)ci->second.first + offset + sz;
+        if (sz < 0 || offset < 0 || nEnd > (long long)m_nInputChannels) {
           parseStr += "Invalid '" + op + "' channel offset/size '" + refroot + "'\n";
           return false;
         }

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -3155,7 +3155,18 @@ bool CIccMpeXmlCalculator::Flatten(std::string &flatStr, std::string macroName, 
         
         int i;
         for (i = 0; i < iter; i++) {
-          Flatten(flatStr, name, m->second.c_str(), parseStr, nLocalsOffset+nLocalsSize, nDepth + 1);
+          // Propagate the expansion's failure instead of discarding it (#2323).
+          // Every refusal inside a macro body -- an undefined nested macro, an
+          // unknown channel name, an out-of-range offset, and now an unterminated
+          // index -- was reported into parseStr and then dropped here, so the
+          // offending operator was silently left out of the flattened function and
+          // LoadXml() still returned true.  A document the parser had already
+          // decided was bad produced a profile, and the message explaining why sat
+          // unread in parseStr.  The JSON twin has always checked this return
+          // (CIccMpeJsonCalculator::Flatten, IccMpeJson.cpp), so this brings the two
+          // back into agreement rather than inventing a rule.
+          if (!Flatten(flatStr, name, m->second.c_str(), parseStr, nLocalsOffset+nLocalsSize, nDepth + 1))
+            return false;
         }
       }
       else {
@@ -3195,13 +3206,56 @@ bool CIccMpeXmlCalculator::Flatten(std::string &flatStr, std::string macroName, 
           const char *ptr;
           offset = atoi(select.c_str() + 1);
           for (ptr = select.c_str() + 1; *ptr && *ptr != ')' && *ptr != ']'; ptr++);
+          // An unterminated index -- "Lab[1" with no closing bracket -- left ptr on
+          // the NUL terminator, so "ptr + 1" addressed one past it and the
+          // assignment below ran strlen from there (#2323).  What that produces
+          // depends only on how long the selector is, because that decides where
+          // the string keeps its bytes: 14 characters or fewer stay inside
+          // libstdc++'s inline SSO buffer and nothing reports it at all -- the
+          // malformed reference is simply accepted -- exactly 15 fills that buffer
+          // so the read leaves this stack frame, which is the reported
+          // 1-byte-read-stack-buffer-overflow at scariness 27, and 16 or more has
+          // moved to the heap and reads past that allocation instead.  The
+          // reported case is the narrowest of the three.
+          //
+          // Refused rather than silently skipped.  Everything newly rejected here
+          // previously had NO defined behaviour, so there is no working input to
+          // preserve -- and the check above already refuses an unknown channel name
+          // on the same standard.  (The offset/size check below refuses an
+          // out-of-range in{} reference, but bounds out{} against the input count
+          // too; that is a separate defect, noted there.)  Accepting it would let
+          // "in{Lab[1" resolve quietly to in(5).  No tracked XML carries an
+          // unterminated index: every indexed reference in the corpus closes its
+          // bracket.
+          if (!*ptr) {
+            parseStr += "Unterminated index in '" + op + "' operation channel reference '" + ref + "'\n";
+            return false;
+          }
           select = ptr + 1;
         }
 
         if (select[0]==',')
           size = atoi(select.c_str() + 1);
 
-        if (size < 0 || offset<0 || ci->second.first + offset + size > m_nInputChannels) {
+        // Summed in a width that cannot wrap.  offset and size are both atoi()
+        // results on attacker-supplied text, so this was int arithmetic over two
+        // unbounded values and OVERFLOWED BEFORE IT COULD BE TESTED: measured with
+        // "in{Lab[2000000000],2000000000}", 4 + 2000000000 + 2000000000 wraps to
+        // -294967292, the comparison passes, and the operator flattens to
+        // in(2000000004,2000000000) instead of being refused (#2323).  UBSan calls
+        // it out at this line.  Fixed here for the same reason as the unterminated
+        // index above -- signed overflow has no defined behaviour, so there is no
+        // working input to preserve -- and the value is still refused, just at this
+        // guard rather than downstream in SetCalcFunc().
+        //
+        // NOTE the bound itself is m_nInputChannels for BOTH operators, so an out{}
+        // reference is range-checked against the INPUT count: a 7-in/3-out element
+        // accepts out{a[0],6} and writes the profile, and only Validate() reports
+        // "accesses illegal output channels".  That is a live defect, but it changes
+        // which documents are accepted rather than removing undefined behaviour, so
+        // it is reported on #2323 for a ruling rather than changed here.
+        const long long nEnd = (long long)ci->second.first + offset + size;
+        if (size < 0 || offset<0 || nEnd > (long long)m_nInputChannels) {
           parseStr += "Invalid '" + op + "' operation channel offset or size '" + refroot + "'\n";
           return false;
         }


### PR DESCRIPTION
Part of #2323.

Fixes the reported overflow, its identical twin in the JSON calculator, a refusal
that did not actually refuse, and a signed overflow in the guard two lines below it.
The issue stays open for the two rulings listed at the bottom.

## Root cause

`CIccMpeXmlCalculator::Flatten()` scans an `in{}`/`out{}` index selector for its
closing bracket, then steps one past it:

```cpp
for (ptr = select.c_str() + 1; *ptr && *ptr != ')' && *ptr != ']'; ptr++);
select = ptr + 1;
```

With no closing bracket the scan stops on the **NUL terminator**, so `ptr + 1`
addresses one past it and `std::string::operator=` runs `strlen` from there. The
PoC's line 130 is exactly that shape: `in{Lab[1FunctionType2` — `[` with no `]`.

## The reported case is the narrowest of three

The symptom depends only on the selector's length, because that decides where the
string keeps its bytes. Measured one length at a time:

| selector length | before |
|---|---|
| ≤ 14 | **no diagnostic at all** — the read stays inside libstdc++'s 16-byte inline SSO buffer, and the malformed reference is **accepted**: `in{Lab[XX` resolves quietly to `in(4)` |
| exactly 15 | fills the SSO buffer, so the read leaves the stack frame → `stack-buffer-overflow`, **SCARINESS 27** — the reported `sbo-27r` |
| ≥ 16 | the string has moved to the heap → `heap-buffer-overflow`, SCARINESS 12 |

So the filed case needs the selector to be *exactly one length*, and is the only one
a sanitizer lane can see. The `≤ 14` regime is a silent accept on every lane, and is
what lets the regression tests red/green without instrumentation.

## Four defects

**1. The reported overflow** (`IccMpeXml.cpp`). Refuse an unterminated index rather
than stepping past the terminator.

**2. The same overflow in the JSON calculator** (`IccMpeJson.cpp`) — byte-for-byte the
same code. `CIccMpeJsonCalculator` is registered for `icSigCalculatorElemType` and its
`ParseJson` reads `inputNames`/`outputNames`, so `iccFromJson` reaches it on a
hand-authored document with no XML involved. Reproduced independently: same
`stack-buffer-overflow`, same scariness 27. Fixing only the XML side would have left
`iccFromJson` fully exposed.

**3. The refusal did not refuse inside a macro** (`IccMpeXml.cpp`). The recursive
`Flatten()` call discarded its result, so *every* refusal raised while expanding a macro
— undefined nested macro, unknown channel name, out-of-range offset, and now an
unterminated index — was written into `parseStr` and then dropped: the operator vanished
from the flattened function and `LoadXml()` still returned **true**. Measured before the
change: a macro body carrying the bad reference produced `Profile parsed` and a written
profile while `parseStr` held the rejection. The JSON twin has always checked this
return, so this restores agreement rather than inventing a rule.

**4. Signed overflow in the offset/size bound**, two lines below the guard. It summed
`first + offset + size` as `int` over two `atoi()` results, so a large pair wrapped
negative and passed the very test meant to refuse it —
`in{Lab[2000000000],2000000000}` gives `4 + 2000000000 + 2000000000 == -294967292` and
flattens to `in(2000000004,2000000000)`. UBSan reports it at that line in both files.
Summed in a wider type; the value is still refused, now by its own guard rather than
downstream in `SetCalcFunc()`, and without the UB on the way.

## Why these four and not more

One criterion, applied consistently: **everything changed here previously had no defined
behaviour** — an out-of-bounds read, a dropped return, or signed overflow — so there is
no working input to preserve.

## Deliberately NOT changed — two rulings for a maintainer

Both alter *which documents are accepted* rather than removing undefined behaviour.

**(a) `select[1] == '('` is a typo for `select[0]`** (`IccMpeXml.cpp`). `refroot` stops at
`(` just as at `[`, the scan accepts `)` as a terminator, and `CIccFuncTokenizer::GetIndex()`
handles `(n)` / `(n,m)` / `[n]` / `[n,m]` correctly — which is why `tget`/`tput`/`tsav` get
this right and only `in`/`out` hand-roll it. Today `in{C(3)}` silently ignores its offset.

⚠️ **Consequence worth stating plainly:** a `(`-spelled unterminated index still bypasses
the XML guard, so `in{Lab(XXXX` is now refused by `iccFromJson` and still silently accepted
by `iccFromXml`. **Before this commit both sides accepted it.** I have left the typo alone
because correcting it changes accepted semantics, but that means this PR narrows the gap on
one side only. Happy to take the typo as an immediate follow-up if you'd rather have parity
than the deferral.

**(b) The offset/size bound is `m_nInputChannels` for BOTH operators**, so an `out{}`
reference is range-checked against the **input** count. Verified: a 7-in/3-out element
accepts `out{a[0],6}`, flattens it to `out(0,6)` and **writes the profile**; only
`Validate()` reports `accesses illegal output channels`. Same in both files.

## Corpus evidence

All **221** tracked `*.xml` and all **23** tracked `*.json` converted with every fix in
place: **0** newly rejected, **0** sanitizer findings. That is the check that matters for
defect 3, which changes when a macro expansion aborts.

## Tests

Two helpers, registered separately so neither can mask the other — the JSON one is skipped
where IccJSON is not built and the XML coverage does not go with it. Both are C++, so both
are registered on Windows (script tests are not).

- `iccdev.calc-channel-ref-unterminated-index` — 11 assertions
- `iccdev.calc-channel-ref-unterminated-index-json` — 9 assertions

**7 of the 20 are controls**, because "an unterminated index is refused" is satisfied just
as well by refusing *every* indexed reference, and "propagate the macro failure" by refusing
*every* macro.

Mutation-tested one fix at a time on the same binaries:

| mutation | result |
|---|---|
| XML guard removed | 5 refusal assertions FAIL, controls PASS |
| JSON guard removed | 5 FAIL, all 3 controls PASS |
| macro return discarded again | **exactly 1** FAILS (the macro case) |
| widened sum reverted | **exactly 1** FAILS in each helper, UBSan naming the overflow |

## Pre-flight

| gate | result |
|---|---|
| clang 21.1.3, `-Wall -Wextra -Wpedantic -Werror` | `strict warnings ENABLED`, **0 warnings** |
| GCC 15.2.0 in `ghcr.io/internationalcolorconsortium/iccdev:latest`, LTO Release | `strict warnings ENABLED`, **0 warnings** |
| full ASan+UBSan `make check` | 240/242 — the two failures are local environment only (`imagecodecs` absent; `tool-coverage` passes when run with its `create-profiles` fixture) |


## CI

Pre-PR dispatch `ci_scope=source`, run **33664284227** — **16 success / 2 skipped / 0 failures**:
GCC 15.2 Strict Release LTO, Windows MSVC, Windows ClangCL, MinGW UCRT64, Windows Release
performance, macOS Clang Debug + Release LTO, Tool Smoke ASAN+UBSAN, Docker Clang 22.

Both new tests confirmed to have **run**, with non-zero runtimes, on four independent lanes:

| lane | tests | runtime |
|---|---|---|
| Windows MSVC | #56 / #57 | 0.02 s |
| Windows ClangCL | #56 / #57 | 0.02 s |
| MinGW UCRT64 | #53 / #54 | 0.01 s |
| GCC Strict ASAN+UBSAN (Debug) | #61 / #62 | 0.04 / 0.05 s |
