### PR TITLE
fix(#2328): call the existing HDR generator instead of duplicating its command list

### DIFF
--- a/Build/Cmake/wasm-package/regression.js
+++ b/Build/Cmake/wasm-package/regression.js
@@ -153,10 +153,11 @@ function collectInitialIccs(dir) {
   return files;
 }
 
-function parseCreateAllProfiles(scriptPath) {
-  const generated = new Set();
-  const cleanupDirs = new Set();
-  let cwd = '';
+function parseCreateAllProfiles(scriptPath, inherited) {
+  const generated = inherited ? inherited.generated : new Set();
+  const cleanupDirs = inherited ? inherited.cleanupDirs : new Set();
+  const scriptDir = path.dirname(scriptPath);
+  let cwd = inherited ? inherited.cwd : '';
   for (const line of fs.readFileSync(scriptPath, 'utf8').split('\n')) {
     const cd = line.match(/^\s*cd\s+([^;&|]+)/);
     if (cd) {
@@ -165,6 +166,20 @@ function parseCreateAllProfiles(scriptPath) {
     }
     if (/find\s+\.\s+-iname\s+["']?\*\\?\.icc["']?\s+-delete/.test(line)) {
       cleanupDirs.add(cwd);
+      continue;
+    }
+    // #2328: CreateAllProfiles.sh delegates its HDR block to HDR/mkprofiles.sh
+    // rather than repeating that generator's ten iccFromXml lines. This parser is
+    // a third consumer of those lines, so it has to follow the call: without this
+    // the ten HDR/BT2100*.icc are absent from expectedIccs while HDR stays in
+    // cleanupDirs, and the real run below reports them as unexpected output.
+    // The callee runs in a subshell, so its cd's do not leak back into cwd here.
+    const nested = line.match(/^\s*(?:sh|bash)\s+(?:-[A-Za-z]+\s+)*(\S+\.sh)\s*$/);
+    if (nested) {
+      const nestedPath = path.join(scriptDir, cwd, nested[1]);
+      if (fs.existsSync(nestedPath)) {
+        parseCreateAllProfiles(nestedPath, { generated, cleanupDirs, cwd });
+      }
       continue;
     }
     const fromXml = line.match(/^\s*iccFromXml\s+(\S+)\s+(\S+)/);

--- a/Testing/CreateAllProfiles.bat
+++ b/Testing/CreateAllProfiles.bat
@@ -255,17 +255,13 @@ if not "%1"=="clean" goto do_HDR
 del /F/Q *.icc 2>NUL:
 goto end_HDR
 :do_HDR
+REM #2328: HDR\mkprofiles.bat already builds exactly these ten profiles, so call it
+REM rather than keeping a second copy of the same command list here -- a duplicate
+REM list drifts silently and leaves iccdev.qa-profile-manifest short a profile or a
+REM manifest row depending on which copy was edited. CALL is required: invoking a
+REM .bat without it transfers control and never returns to this script.
 @echo on
-iccFromXml BT2100HlgFullScene.xml BT2100HlgFullScene.icc
-iccFromXml BT2100HlgNarrowScene.xml BT2100HlgNarrowScene.icc
-iccFromXml BT2100HlgFullDisplay.xml BT2100HlgFullDisplay.icc
-iccFromXml BT2100HlgNarrowDisplay.xml BT2100HlgNarrowDisplay.icc
-iccFromXml BT2100PQFullScene.xml BT2100PQFullScene.icc
-iccFromXml BT2100PQNarrowScene.xml BT2100PQNarrowScene.icc
-iccFromXml BT2100PQFullDisplay.xml BT2100PQFullDisplay.icc
-iccFromXml BT2100PQNarrowDisplay.xml BT2100PQNarrowDisplay.icc
-iccFromXml BT2100HlgSceneToDisplayLink.xml BT2100HlgSceneToDisplayLink.icc
-iccFromXml BT2100PQSceneToDisplayLink.xml BT2100PQSceneToDisplayLink.icc
+call mkprofiles.bat
 @echo off
 :end_HDR
 

--- a/Testing/CreateAllProfiles.sh
+++ b/Testing/CreateAllProfiles.sh
@@ -304,18 +304,14 @@ cd HDR
 find . -iname "*\.icc" -delete
 if [ "$1" != "clean" ]
 then
-	set -x
-	iccFromXml BT2100HlgFullScene.xml BT2100HlgFullScene.icc
-	iccFromXml BT2100HlgNarrowScene.xml BT2100HlgNarrowScene.icc
-	iccFromXml BT2100HlgFullDisplay.xml BT2100HlgFullDisplay.icc
-	iccFromXml BT2100HlgNarrowDisplay.xml BT2100HlgNarrowDisplay.icc
-	iccFromXml BT2100PQFullScene.xml BT2100PQFullScene.icc
-	iccFromXml BT2100PQNarrowScene.xml BT2100PQNarrowScene.icc
-	iccFromXml BT2100PQFullDisplay.xml BT2100PQFullDisplay.icc
-	iccFromXml BT2100PQNarrowDisplay.xml BT2100PQNarrowDisplay.icc
-	iccFromXml BT2100HlgSceneToDisplayLink.xml BT2100HlgSceneToDisplayLink.icc
-	iccFromXml BT2100PQSceneToDisplayLink.xml BT2100PQSceneToDisplayLink.icc
-	set +x
+	# #2328: HDR/mkprofiles.sh already builds exactly these ten profiles and is what
+	# the CI workflows invoke directly, so call it rather than keeping a second copy
+	# of the same command list here. A duplicate list drifts silently: an eleventh
+	# HDR profile added to one copy would leave iccdev.qa-profile-manifest either
+	# short a profile or short a manifest row, depending on which copy was edited.
+	# sh -x, not a bare sh: set -x does not cross the process boundary, and every
+	# other section of this script traces its iccFromXml calls into CreateAllProfiles.log.
+	sh -x mkprofiles.sh
 fi
 cd ..
 


### PR DESCRIPTION
Part of #2328.

## What changed

`Testing/CreateAllProfiles.{sh,bat}` carried a byte-for-byte copy of the ten
`iccFromXml` commands already in `Testing/HDR/mkprofiles.{sh,bat}`. Both copies now
delegate to the generator, which is the fix this issue asked for.

Crossing a process boundary has two consequences, both handled here — see
"Two things the delegation broke" below.

## Why it matters

`iccdev.qa-profile-manifest` (`FIXTURES_REQUIRED iccdev_profiles`) enforces
`Testing/qa-profile-manifest.tsv` exactly, so a drift between the two copies is a
test failure, not a silent difference:

- an 11th HDR profile added to `mkprofiles.sh` only -> the fixture never builds it
- added to the manifest but neither copy -> `[MISSING]`

`mkprofiles.sh` is also what the CI workflows already call directly
(`_build-test-unix.yml:223`, `ci-pr-unix.yml:445`, `ci-code-coverage.yml:313`), so
the duplicated copy in `CreateAllProfiles.sh` was the one caller that could go stale
without anyone noticing.

Semantics are preserved: the `find -delete` and the `"$1" != "clean"` gate stay in
`CreateAllProfiles.sh`; `mkprofiles.sh` runs only on the generate path. The `.bat`
uses `CALL` — without it control transfers to `mkprofiles.bat` and never returns.

## Measured (this branch, Release, iccFromXml + iccDumpProfile)

| check | result |
|---|---|
| `iccdev.create-profiles` (CTest #145) | Passed 1.16s |
| `iccdev.qa-profile-manifest` (CTest #147) | Passed 3.53s |
| manifest check | 225 profiles, 225 matched, 0 mismatched, 0 unlisted, 0 missing |
| `CreateAllProfiles.sh` | rc=0, 10 HDR profiles, control returns to the V2 section |
| `CreateAllProfiles.sh clean` | rc=0, 10 deleted, `mkprofiles.sh` not invoked |
| **mutation:** HDR removed, manifest re-run | **rc=1, 10 `[MISSING]`** — the guard is real |
| `CreateAllProfiles.sh` trace | 10x `+ iccFromXml BT2100...` restored in the log |
| WASM parity parser | 145 generated entries incl. the same 10 `HDR/*.icc`, before and after |
| shellcheck | finding counts identical to `origin/master` (14x SC2164, 2x SC3037, 1x SC2103, 1x SC1091 — all pre-existing) |

## Two things the delegation broke

Both caught by self-review before this was pushed, both fixed in this commit.

**1. `Build/Cmake/wasm-package/regression.js` is a third consumer of that command
list.** `parseCreateAllProfiles()` regex-scrapes `iccFromXml` lines out of the script
*text* to build `expectedIccs`, and it does not follow a delegated call. Left alone the
ten HDR profiles drop out of `expectedIccs`, while `cd HDR` plus the retained
`find -delete` keep `HDR` in `cleanupDirs` — so the run that follows reports all ten as
**unexpected output and exits 1**, taking the WASM parity gate
(`ci-pr-wasm.yml:389`, `ci-latest-release.yml:1394`) red. The parser now follows a
`sh <script>.sh` line, inheriting `cwd` and treating the callee as a subshell.

There is an irony worth stating plainly: this PR removes one duplicate of the list and
was broken by a *second* consumer that had been using the removed copy as its source of
truth. That is the same drift the change exists to prevent, one layer up.

**2. `set -x` does not cross into a child process.** A bare `sh mkprofiles.sh` would
drop the per-command trace every other section writes into `CreateAllProfiles.log`
(teed at `_build-test-unix.yml:198`, screened at `:1042`). It is invoked as `sh -x`,
and the parser's nested-call pattern accepts the flag.

Known and accepted: on Windows the `@echo on` before the `CALL` is undone by
`mkprofiles.bat`'s own `@echo off`, so the HDR block is the one unechoed section of the
Windows log. Diagnostic only — the manifest-existence check and the forbidden-text
regex in `RunWindowsBatchTest.cmake` both still fire — and fixing it would mean changing
the shared generator's behaviour for its standalone callers. Say the word if you'd
rather I did.

## Two premises in the issue do not hold

Recording these because they change what is left to do, not to argue the fix — the
stated remedy was right.

1. **`c7883bd1` did not create an HDR dependency.** Its manifest listed **zero**
   `HDR/` rows, and so did every revision up to `e88bf719^`:
   ```
   git show c7883bd1:Testing/qa-profile-manifest.tsv        | grep -c '^HDR/'   -> 0
   git show e88bf719^:Testing/qa-profile-manifest.tsv       | grep -c '^HDR/'   -> 0
   git show e88bf719:Testing/qa-profile-manifest.tsv        | grep -c '^HDR/'   -> 10
   ```
   `e88bf719` added the ten manifest rows and the generation together, so there was
   never a window where the manifest required HDR profiles the fixture did not build.
   What it left behind is the duplication, which is what this PR removes.

2. **`iccdev.hybrid-pipeline` never generates HDR profiles.**
   `.github/scripts/iccdev-hybrid-pipeline-tests.sh` contains no reference to HDR,
   BT2100, `iccFromXml` or `.icc` at all. The ordering hazard it *was* involved in is
   `Testing/hybrid/ICC` and `Testing/hybrid/Results`, which `c7883bd1` already
   excluded via the `! -path` filters in `list_corpus()`.

## CI coverage — the dispatched green is vacuous, the Windows one is not

`ci-pr-action.yml` sets `native_changed` **only** from `source_changed`, i.e. a changed
`.c/.cpp/.h` file (`:587-590`). This PR touches no such file, so `native_changed=false`
and every compiler and CTest job (`:998, :1007, :1022, :1030, :1044`) is skipped — for
**any** `ci_scope`, since no scope input overrides it.

Dispatched `ci_scope=auto` before opening this PR, run
**[33676870161](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33676870161)**
— `conclusion=success`, and measured against that prediction:

```
skipped  GCC 15.2 Strict Release LTO
skipped  Tool Smoke Tests (ASAN+UBSAN, Debug)
skipped  macOS Clang Debug / Release LTO
skipped  Windows Build & Test Profiles
success  Docker Clang 22 Verification, PR Summary
```

So that green ran none of the tests covering this change. Flagging the gap rather than
patching the shared workflow.

Because the `.bat` half is the part I cannot exercise locally, I also dispatched
`ci-pr-win.yml` against the branch, run
**[33676905279](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33676905279)**
— `conclusion=success`, MSVC + ClangCL + MinGW UCRT64, **100% tests passed out of 147**
on each. The test that actually executes the changed `CreateAllProfiles.bat` ran, by
number and runtime rather than by the leg being green:

```
3/147 Test #23: iccdev.windows-create-profiles ... Passed 7.88 sec   (MSVC)
3/147 Test #23: iccdev.windows-create-profiles ... Passed 9.06 sec   (ClangCL)
      Test #22/#23 ................................ Passed 4.08 / 5.17 sec
```

That test carries `VERIFY_GENERATED_PROFILE_MANIFEST`, which `FATAL_ERROR`s on any
manifest row with source `generated` that is missing from the work directory — so it
passing is positive evidence that `CALL mkprofiles.bat` produced all ten
`HDR/BT2100*.icc` on Windows. Zero matches for the wrapper's forbidden-text set
(`not recognized as an internal or external command`, `cannot find the file specified`),
so the `CALL` resolved cleanly.
