### PR TITLE
fix(#2101): name the four ICC.1 v4.3 technology signatures, mark the dcpj/dcjp spec row

### DIFF
--- a/.github/ci/regression/signature-utils-contract.cpp
+++ b/.github/ci/regression/signature-utils-contract.cpp
@@ -26,8 +26,11 @@
 // Returns 0 on success; the number of failed assertions otherwise (each printed).
 
 #include "IccSignatureUtils.h"
+#include "IccTagBasic.h"
 #include "IccUtil.h"
 #include "icProfileHeader.h"
+
+#include <string>
 
 #include <cstdio>
 #include <cstring>
@@ -177,6 +180,257 @@ void testMcsNamingStillHolds()
         "CIccInfo::GetColorSpaceSigName keeps the MCS context");
 }
 
+// --- 7. The technology signature lists, which drifted the way section 4 guards against. ---
+// FOUR places carry technology-signature knowledge and none of them consulted the others:
+//
+//   CIccInfo::GetTechnologySigName()      names one         (IccUtil.cpp)
+//   IsValidTechnologySignature()          accepts one       (this header)
+//   CIccTagSignature::Validate()          accepts one, for a technologyTag
+//                                                           (IccTagBasic.cpp:3021)
+//   CIccTagProfileSeqDesc::Validate()     accepts one, for a profileSequenceDesc entry
+//                                                           (IccTagBasic.cpp:10932)
+//
+// Only CIccTagSignature::Validate() carried all 26 enum members. The other three stopped
+// at the 22 that predate ICC.1 v4.3, so the four motion picture and digital cinema
+// signatures validated as compliant in a technologyTag and simultaneously printed as
+// "Unknown 'mpfs'" -- measured on master dd6164ee via iccDumpProfile before #2101.
+//
+// The two Validate() sites legitimately differ -- the profileSequenceDesc one also
+// accepts icSigUndefined, "technology not defined", which is not valid for a
+// technologyTag -- so they cannot share this header's predicate without an "undefined
+// permitted" flag, and each keeps its own switch. Both are callable in process:
+// CIccTag::Validate ignores its pProfile argument, CIccTagSignature carries SetValue()
+// and CIccTagProfileSeqDesc::m_Descriptions is public, so testValidateTechnologyRows()
+// below pins them directly rather than trusting the switches to stay in step.
+const char *expectedTechnologyName(icTechnologySignature sig)
+{
+  // Deliberately NO default: label. Adding a member to icTechnologySignature makes this
+  // switch incomplete, which -Wswitch reports and which this target promotes to an error
+  // via -Werror=switch (set in iccdev_add_signature_utils_contract_test).  The promotion
+  // is the point: this target is EXCLUDE_FROM_ALL, so the -Werror lane (ci-pr-gcc15.yml)
+  // builds the default `all` target and never compiles this file -- an unpromoted warning
+  // here would be emitted into a log nothing greps.  That is the compile-time half of the
+  // guard; the runtime table below is hand-maintained and would stay green for a 27th
+  // member, which is precisely the failure mode #2101 is about.
+  switch (sig) {
+  case icSigDigitalCamera:              return "DigitalCamera";
+  case icSigFilmScanner:                return "FilmScanner";
+  case icSigReflectiveScanner:          return "ReflectiveScanner";
+  case icSigInkJetPrinter:              return "InkJetPrinter";
+  case icSigThermalWaxPrinter:          return "ThermalWaxPrinter";
+  case icSigElectrophotographicPrinter: return "ElectrophotographicPrinter";
+  case icSigElectrostaticPrinter:       return "ElectrostaticPrinter";
+  case icSigDyeSublimationPrinter:      return "DyeSublimationPrinter";
+  case icSigPhotographicPaperPrinter:   return "PhotographicPaperPrinter";
+  case icSigFilmWriter:                 return "FilmWriter";
+  case icSigVideoMonitor:               return "VideoMonitor";
+  case icSigVideoCamera:                return "VideoCamera";
+  case icSigProjectionTelevision:       return "ProjectionTelevision";
+  case icSigCRTDisplay:                 return "CRTDisplay";
+  case icSigPMDisplay:                  return "PMDisplay";
+  case icSigAMDisplay:                  return "AMDisplay";
+  case icSigPhotoCD:                    return "PhotoCD";
+  case icSigPhotoImageSetter:           return "PhotoImageSetter";
+  case icSigGravure:                    return "Gravure";
+  case icSigOffsetLithography:          return "OffsetLithography";
+  case icSigSilkscreen:                 return "Silkscreen";
+  case icSigFlexography:                return "Flexography";
+  case icSigMotionPictureFilmScanner:   return "MotionPictureFilmScanner";
+  case icSigMotionPictureFilmRecorder:  return "MotionPictureFilmRecorder";
+  case icSigDigitalMotionPictureCamera: return "DigitalMotionPictureCamera";
+  case icSigDigitalCinemaProjector:     return "DigitalCinemaProjector";
+
+  // Not technologies: "not defined" and the enum terminator. Named only so the switch
+  // stays exhaustive; both are deliberately absent from kTechnology[] below, and the NULL
+  // return means that adding either one there would be reported as a failure rather than
+  // silently tolerated.
+  case icSigUndefined:                  return NULL;
+  case icMaxEnumTechnology:             return NULL;
+  }
+
+  return NULL;
+}
+
+void testTechnologySignatures()
+{
+  // The iteration list. Names are NOT repeated here -- expectedTechnologyName() above is
+  // the single source for those, so the two cannot disagree.
+  const icUInt32Number kTechnology[] = {
+    (icUInt32Number)icSigDigitalCamera,              (icUInt32Number)icSigFilmScanner,
+    (icUInt32Number)icSigReflectiveScanner,          (icUInt32Number)icSigInkJetPrinter,
+    (icUInt32Number)icSigThermalWaxPrinter,          (icUInt32Number)icSigElectrophotographicPrinter,
+    (icUInt32Number)icSigElectrostaticPrinter,       (icUInt32Number)icSigDyeSublimationPrinter,
+    (icUInt32Number)icSigPhotographicPaperPrinter,   (icUInt32Number)icSigFilmWriter,
+    (icUInt32Number)icSigVideoMonitor,               (icUInt32Number)icSigVideoCamera,
+    (icUInt32Number)icSigProjectionTelevision,       (icUInt32Number)icSigCRTDisplay,
+    (icUInt32Number)icSigPMDisplay,                  (icUInt32Number)icSigAMDisplay,
+    (icUInt32Number)icSigPhotoCD,                    (icUInt32Number)icSigPhotoImageSetter,
+    (icUInt32Number)icSigGravure,                    (icUInt32Number)icSigOffsetLithography,
+    (icUInt32Number)icSigSilkscreen,                 (icUInt32Number)icSigFlexography,
+    // The four v4.3 rows. Before #2101 each of these failed BOTH checks below.
+    (icUInt32Number)icSigMotionPictureFilmScanner,   (icUInt32Number)icSigMotionPictureFilmRecorder,
+    (icUInt32Number)icSigDigitalMotionPictureCamera, (icUInt32Number)icSigDigitalCinemaProjector,
+  };
+
+  CIccInfo info;
+
+  for (size_t i = 0; i < sizeof(kTechnology) / sizeof(kTechnology[0]); i++) {
+    const icTechnologySignature sig = (icTechnologySignature)kTechnology[i];
+    const char *want = expectedTechnologyName(sig);
+    const char *got  = info.GetTechnologySigName(sig);
+
+    // GetUnknownName() formats "Unknown 'xxxx' = ...", so an unnamed signature is not
+    // merely a different string -- asserting the exact name is what makes this fail
+    // loudly rather than drift into a plausible-looking fallback.
+    if (!want || !got || std::strcmp(got, want) != 0) {
+      ++g_fail;
+      std::fprintf(stderr, "[signature-utils-contract] FAIL: GetTechnologySigName(0x%08X) "
+                           "(got \"%s\", want \"%s\")\n",
+                   (unsigned)kTechnology[i], got ? got : "(null)", want ? want : "(null)");
+    }
+
+    // Named per signature rather than with one shared string: the two lists are
+    // independent, so a signature that is named but not accepted has to say which.
+    if (!IsValidTechnologySignature(kTechnology[i])) {
+      ++g_fail;
+      std::fprintf(stderr, "[signature-utils-contract] FAIL: IsValidTechnologySignature"
+                           "(0x%08X) rejects %s\n",
+                   (unsigned)kTechnology[i], want ? want : "(unnamed)");
+    }
+  }
+
+  // SPEC-ISSUE #2101: ICC.1-2022-05 prints the digital cinema projector mnemonic as
+  // 'dcpj' while giving its hex as 64636A70h = 'dcjp'. iccDEV encodes the hex, so the
+  // transposed spelling is NOT a technology signature. Pinned in both directions so that
+  // a future "correction" toward the mnemonic cannot land silently: it would flip which
+  // of these two assertions fails, and whichever way the ICC rules, that flip must be a
+  // deliberate change to this test rather than an invisible one.
+  check(IsValidTechnologySignature(0x64636A70), "the published hex 'dcjp' is the signature");
+  check(!IsValidTechnologySignature(0x6463706A), "the published mnemonic 'dcpj' is not");
+
+  check(!IsValidTechnologySignature((icUInt32Number)icSigUndefined),
+        "icSigUndefined is not a technology");
+  check(!IsValidTechnologySignature(0x4A554E4B), "'JUNK' is not a technology");
+}
+
+// --- 8. The two Validate() sites, pinned directly. ---
+// Section 7 covers the naming pair; this covers the only change in #2101 that alters a
+// validation VERDICT. Without it that hunk has no coverage at all: no profile in the
+// tracked corpus carries these four signatures, so reverting it leaves CI green while a
+// legal profileSequenceDesc entry is again reported NonCompliant.
+// Build a profileSequenceDesc entry that is safe to validate.
+//
+// CIccProfileDescStruct's default constructor is empty (IccTagBasic.cpp:10605) while its
+// copy constructor reads every member, and push_back copies -- so m_deviceMfg,
+// m_deviceModel and m_attributes have to be set or the copy reads indeterminate values,
+// which a sanitizer lane would flag even though Validate() never inspects them.
+//
+// Both description tags are required for a different reason: Validate() dereferences
+// m_deviceMfgDesc.GetTag() and m_deviceModelDesc.GetTag() unconditionally
+// (IccTagBasic.cpp:10995-10996), so a struct without them segfaults before reaching the
+// technology switch. SetType() returns false and leaves the pointer null if the tag
+// factory fails, so its result is checked -- otherwise a factory regression would crash
+// this test instead of failing an assertion in it.
+void addSeqEntry(CIccTagProfileSeqDesc &seq, icTechnologySignature tech)
+{
+  CIccProfileDescStruct desc;
+  desc.m_deviceMfg   = 0;
+  desc.m_deviceModel = 0;
+  desc.m_attributes  = 0;
+  desc.m_technology  = tech;
+
+  check(desc.m_deviceMfgDesc.SetType(icSigMultiLocalizedUnicodeType),
+        "deviceMfgDesc tag allocated");
+  check(desc.m_deviceModelDesc.SetType(icSigMultiLocalizedUnicodeType),
+        "deviceModelDesc tag allocated");
+
+  seq.m_Descriptions->push_back(desc);
+}
+
+void testValidateTechnologyRows()
+{
+  // Assert on the technology FINDING, not on the aggregate verdict. A hand-built
+  // profileSequenceDesc entry carries empty text tags and so validates as Warning no
+  // matter what the technology switch decides; keying off icValidateOK would couple this
+  // test to unrelated findings and, worse, would still pass if "Unknown Technology" came
+  // back alongside some other warning.
+  const char *kUnknown = "Unknown Technology";
+
+  const icTechnologySignature kV43[] = {
+    icSigMotionPictureFilmScanner, icSigMotionPictureFilmRecorder,
+    icSigDigitalMotionPictureCamera, icSigDigitalCinemaProjector,
+  };
+
+  for (size_t i = 0; i < sizeof(kV43) / sizeof(kV43[0]); i++) {
+    // A technologyTag holding the signature. CIccTagSignature::Validate keys off the
+    // first signature in the path, so the path has to say technologyTag for the
+    // technology switch to be the one that runs.
+    CIccTagSignature tag;
+    tag.SetValue((icUInt32Number)kV43[i]);
+    std::string rpt;
+    tag.Validate(icGetSigPath(icSigTechnologyTag), rpt, NULL);
+    if (rpt.find(kUnknown) != std::string::npos) {
+      ++g_fail;
+      std::fprintf(stderr, "[signature-utils-contract] FAIL: technologyTag 0x%08X "
+                           "reported unknown by CIccTagSignature::Validate\n",
+                   (unsigned)kV43[i]);
+    }
+
+    // The same signature in a profileSequenceDesc entry, which is a separate switch.
+    CIccTagProfileSeqDesc seq;
+    addSeqEntry(seq, kV43[i]);
+    std::string seqRpt;
+    seq.Validate(icGetSigPath(icSigProfileSequenceDescTag), seqRpt, NULL);
+    if (seqRpt.find(kUnknown) != std::string::npos) {
+      ++g_fail;
+      std::fprintf(stderr, "[signature-utils-contract] FAIL: profileSequenceDesc 0x%08X "
+                           "reported unknown by CIccTagProfileSeqDesc::Validate\n",
+                   (unsigned)kV43[i]);
+    }
+  }
+
+  // Anti-vacuity: the same two calls with a signature that really is not a technology
+  // must still produce the finding. Without this pair, deleting the switches' default
+  // branch entirely would leave every assertion above green.
+  {
+    CIccTagSignature tag;
+    tag.SetValue(0x4A554E4B);  // 'JUNK'
+    std::string rpt;
+    tag.Validate(icGetSigPath(icSigTechnologyTag), rpt, NULL);
+    check(rpt.find(kUnknown) != std::string::npos,
+          "CIccTagSignature::Validate still reports a genuine unknown technology");
+  }
+  {
+    CIccTagProfileSeqDesc seq;
+    addSeqEntry(seq, (icTechnologySignature)0x4A554E4B);
+    std::string rpt;
+    seq.Validate(icGetSigPath(icSigProfileSequenceDescTag), rpt, NULL);
+    check(rpt.find(kUnknown) != std::string::npos,
+          "CIccTagProfileSeqDesc::Validate still reports a genuine unknown technology");
+  }
+
+  // The asymmetry the two switches are entitled to: "technology not defined" is a legal
+  // profileSequenceDesc entry and is NOT a legal technologyTag. Pinned so that any future
+  // attempt to share one predicate between them has to confront it rather than silently
+  // pick one side.
+  {
+    CIccTagProfileSeqDesc seq;
+    addSeqEntry(seq, icSigUndefined);
+    std::string rpt;
+    seq.Validate(icGetSigPath(icSigProfileSequenceDescTag), rpt, NULL);
+    check(rpt.find(kUnknown) == std::string::npos,
+          "profileSequenceDesc accepts icSigUndefined");
+  }
+  {
+    CIccTagSignature tag;
+    tag.SetValue((icUInt32Number)icSigUndefined);
+    std::string rpt;
+    tag.Validate(icGetSigPath(icSigTechnologyTag), rpt, NULL);
+    check(rpt.find(kUnknown) != std::string::npos,
+          "technologyTag rejects icSigUndefined");
+  }
+}
+
 } // namespace
 
 int main()
@@ -187,6 +441,8 @@ int main()
   testAgreement();
   testSpectralPcs();
   testMcsNamingStillHolds();
+  testTechnologySignatures();
+  testValidateTechnologyRows();
 
   if (g_fail)
     std::fprintf(stderr, "[signature-utils-contract] %d assertion(s) failed\n", g_fail);

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4636,6 +4636,19 @@ function(iccdev_add_signature_utils_contract_test)
     "${ICCDEV_REPO_ROOT}/.github/ci/regression/signature-utils-contract.cpp"
   )
   target_compile_features(iccSignatureUtilsContractTest PRIVATE cxx_std_17)
+
+  # expectedTechnologyName() is an exhaustive switch with no default label, so a new
+  # icTechnologySignature member makes it incomplete.  -Wswitch alone only warns, and
+  # this target is EXCLUDE_FROM_ALL (iccdev_add_regression_executable above), so the one
+  # -Werror lane -- ci-pr-gcc15.yml, which builds the default `all` target and greps its
+  # log for "warning:" -- never compiles this file and never sees it.  Promote it here so
+  # the guard is a build failure on the lanes that DO build this target (`check` /
+  # `build-test-binaries`) rather than a warning nobody reads.  MSVC's nearest equivalent
+  # (C4062) is off by default and is not promoted; the GCC/clang lanes carry this one.
+  if(NOT MSVC)
+    target_compile_options(iccSignatureUtilsContractTest PRIVATE -Werror=switch)
+  endif()
+
   target_include_directories(iccSignatureUtilsContractTest PRIVATE
     "${ICCDEV_REPO_ROOT}/IccProfLib"
   )

--- a/IccProfLib/IccSignatureUtils.h
+++ b/IccProfLib/IccSignatureUtils.h
@@ -633,6 +633,13 @@ inline bool IsValidColorSpaceSignature(icUInt32Number sig)
 //   This should be used to verify the `technology` field in `profileDescription`
 //   tags or `outputDevice` blocks.
 //
+//   CAVEAT: it rejects icSigUndefined (0), which CIccTagProfileSeqDesc::Validate
+//   accepts as "technology not defined" and which is a common real-world value --
+//   iccFromCube writes it (Tools/CmdLine/IccFromCube/iccFromCube.cpp:624). Gating a
+//   profileSequenceDesc entry on this predicate alone therefore rejects legitimate
+//   profiles; test for zero separately. It matches CIccTagSignature::Validate, where a
+//   technologyTag holding zero is genuinely non-compliant (#2101).
+//
 // HISTORY:
 //   Instrumented and standardized by David Hoyt on 01-MAR-2025.
 //   V2: Gate logging behind ICC_SIGNATURE_VERBOSE. 19-MAR-2026 DHOYT.
@@ -666,6 +673,15 @@ inline bool IsValidTechnologySignature(icUInt32Number sig)
     case (icUInt32Number)icSigOffsetLithography:
     case (icUInt32Number)icSigSilkscreen:
     case (icUInt32Number)icSigFlexography:
+
+    // Same four ICC.1 v4.3 rows missing from CIccInfo::GetTechnologySigName().  This
+    // header ships as a public API, so its answer disagreeing with
+    // CIccTagSignature::Validate is visible to consumers even though nothing in the
+    // tree calls it today (#2101).
+    case (icUInt32Number)icSigMotionPictureFilmScanner:
+    case (icUInt32Number)icSigMotionPictureFilmRecorder:
+    case (icUInt32Number)icSigDigitalMotionPictureCamera:
+    case (icUInt32Number)icSigDigitalCinemaProjector:
       return true;
 
     default:

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -10953,6 +10953,16 @@ icValidateStatus CIccTagProfileSeqDesc::Validate(std::string sigPath, std::strin
     case icSigOffsetLithography:
     case icSigSilkscreen:
     case icSigFlexography:
+
+    // The same four ICC.1 v4.3 rows CIccTagSignature::Validate already accepts.  Without
+    // them a profileSequenceDesc entry recording a legal technology was reported
+    // NonCompliant here while the identical signature in a technologyTag validated, and
+    // once GetSigName() names them the message read "MotionPictureFilmScanner: Unknown
+    // Technology" -- naming the signature and calling it unknown in one line (#2101).
+    case icSigMotionPictureFilmScanner:
+    case icSigMotionPictureFilmRecorder:
+    case icSigDigitalMotionPictureCamera:
+    case icSigDigitalCinemaProjector:
       break;
 
     default:

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -1723,6 +1723,24 @@ const icChar *CIccInfo::GetTechnologySigName(icTechnologySignature sig)
   case icSigFlexography:
     return "Flexography";
 
+  // The motion picture and digital cinema rows arrived with ICC.1 v4.3 and were never
+  // added here, so CIccTagSignature::Validate accepted them as compliant while every
+  // caller of GetSigName() -- iccDumpProfile among them -- reported them as
+  // "Unknown 'mpfs'" and so on.  Naming them is what makes the two agree (#2101).
+  case icSigMotionPictureFilmScanner:
+    return "MotionPictureFilmScanner";
+
+  case icSigMotionPictureFilmRecorder:
+    return "MotionPictureFilmRecorder";
+
+  case icSigDigitalMotionPictureCamera:
+    return "DigitalMotionPictureCamera";
+
+  // Named by the enum's value, not by the mnemonic ICC.1 prints beside it; see the
+  // SPEC-ISSUE #2101 note at icProfileHeader.h's icSigDigitalCinemaProjector.
+  case icSigDigitalCinemaProjector:
+    return "DigitalCinemaProjector";
+
   default:
     return GetUnknownName(sig);
   }

--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -531,7 +531,15 @@ typedef enum {
     icSigMotionPictureFilmScanner       = 0x6D706673,  /* 'mpfs' */
     icSigMotionPictureFilmRecorder      = 0x6D706672,  /* 'mpfr' */
     icSigDigitalMotionPictureCamera     = 0x646D7063,  /* 'dmpc' */
-    icSigDigitalCinemaProjector         = 0x64636A70,  /* 'dcpj' */
+    /* SPEC-ISSUE #2101: ICC.1-2022-05 prints this row's mnemonic as 'dcpj' but its hex
+     * as 64636A70h, and those disagree -- 'dcpj' encodes as 6463706Ah, 64636A70h decodes
+     * as 'dcjp'.  It is the only self-inconsistent row in either specification's
+     * signature tables, and technology signatures have no published registry to break
+     * the tie.  The normative hex is kept, unchanged since 1f0a9dd2.  Do not "correct"
+     * this toward the mnemonic without an ICC ruling: a profile holding 64636A70h
+     * validates today and one holding 6463706Ah is reported NonCompliant, so flipping
+     * the literal silently moves which existing profiles are conformant. */
+    icSigDigitalCinemaProjector         = 0x64636A70,  /* 'dcpj' as printed; 64636A70h = 'dcjp' */
     icMaxEnumTechnology                 = 0xFFFFFFFF,
 } icTechnologySignature;
 


### PR DESCRIPTION
## PR Summary

Part of #2101.

#2101 reports that ICC.1-2022-05's technology-signature table is self-inconsistent for one
row and explicitly proposes no code change. Working it surfaced a separate, live iccDEV
defect underneath: **four places carry technology-signature knowledge and only one was
complete.**

| site | members |
|---|---|
| `CIccTagSignature::Validate()` — `IccTagBasic.cpp:3021` | all 26 |
| `CIccInfo::GetTechnologySigName()` — `IccUtil.cpp:1657` | 22 |
| `IsValidTechnologySignature()` — `IccSignatureUtils.h:640` | 22 |
| `CIccTagProfileSeqDesc::Validate()` — `IccTagBasic.cpp:10932` | 22 |

The three short lists stop at the 22 rows that predate ICC.1 v4.3, so
`icSigMotionPictureFilmScanner`, `icSigMotionPictureFilmRecorder`,
`icSigDigitalMotionPictureCamera` and `icSigDigitalCinemaProjector` were legal in a
`technologyTag` and unknown everywhere else.

### Measured, master `dd6164ee`

`technologyTag` holding `6D706673h`, `iccDumpProfile`:

```
before: Unknown 'mpfs' = 6D706673
after:  MotionPictureFilmScanner
```

Same signature in a `profileSequenceDesc` entry, `iccDumpProfile -v`:

```
before: NonCompliant! - profileSequenceDescTag: - Unknown 'mpfs' = 6D706673: Unknown Technology.
after:  (no finding)
```

`GetSigName()` is the general dispatcher, so the naming gap reached every consumer that
names a signature, not just the dump. The two halves belong in one change: naming the
signatures *without* the `profileSequenceDesc` row would have made that message read
`MotionPictureFilmScanner: Unknown Technology` — naming it and calling it unknown in one
line.

### The two `Validate()` sites legitimately differ

`CIccTagProfileSeqDesc::Validate` also accepts `icSigUndefined` ("technology not
defined") — a common real-world value, written by `iccFromCube.cpp:624` — which is *not*
valid for a `technologyTag`. They keep separate switches rather than sharing a predicate,
and `IsValidTechnologySignature()`'s public doc block now states that asymmetry: it
rejects zero, so a consumer following the old wording and gating a `profileSequenceDesc`
entry on it would reject legitimate profiles.

### The specification question is untouched

ICC.1-2022-05 prints the digital cinema projector mnemonic as `'dcpj'` while giving its
hex as `64636A70h` = `'dcjp'`. It is the only self-inconsistent row in either
specification's signature tables, and there is no registry to break the tie. The
published hex is kept, unchanged since `1f0a9dd2`, and `icProfileHeader.h` gains a
greppable `SPEC-ISSUE #2101` note so it is not "corrected" toward the mnemonic without an
ICC ruling. Both arms measured:

```
64636A70h ('dcjp', the published hex)      validates clean
6463706Ah ('dcpj', the published mnemonic) NonCompliant! - Unknown Technology
```

Flipping the literal moves which existing profiles are conformant, so the decision
belongs to the ICC rather than to an implementation. **This PR therefore does not close
#2101.**

### Scope boundary

This fixes tables that disagree with `icTechnologySignature`. It does not change the
enum's own membership, and the enum is separately incomplete against ICC.1:2022 Table 29,
which lists `'LCD '` (`4C434420h`) and `'OLED'` (`4F4C4544h`) between `'AMD '` and
`'KPCD'`. Neither appears anywhere in the tree. That is a different defect with a
different fix — adding public enumerators changes which profiles validate — and the
`-Werror=switch` guard below cannot catch it, because a signature missing from the enum
leaves the switch exhaustive. Raised separately rather than folded in here.

### Coverage

Extends `signature-utils-contract`, which already guards this drift class for the
colour-space triple.

- `expectedTechnologyName()` is an exhaustive `switch` with no `default` label, so a 27th
  enum member breaks the build. The target gets `-Werror=switch` **explicitly**, because
  it is `EXCLUDE_FROM_ALL`: the only `-Werror` lane (`ci-pr-gcc15.yml`) builds the default
  `all` target and never compiles this file, so an unpromoted warning would land in a log
  nothing greps. Verified by deleting a case — `error`, exit 2.
- A new section validates **both** `Validate()` sites in process rather than trusting
  their switches, since no tracked profile carries these four signatures. It asserts on
  the `Unknown Technology` finding rather than the aggregate verdict (a hand-built
  `profileSequenceDesc` entry warns on empty text tags regardless), and carries `'JUNK'`
  anti-vacuity pairs so deleting a `default` branch cannot make it pass. Verified by
  reverting the `IccTagBasic.cpp` hunk — 4 targeted failures.

Against unfixed master the added sections fail 9 assertions.

### Local evidence

| gate | result |
|---|---|
| clang 18.1.3 Release, `-Wall -Wextra -Wpedantic -Werror`, `all` + `build-test-binaries` | 0 warnings, 527 log lines |
| GCC 15.2.0 in `ghcr.io/internationalcolorconsortium/iccdev:latest`, CI's own flags + `-DENABLE_LTO=ON` | 0 warnings, 524 log lines |
| full `ctest -j4` | 242/243 — the one failure is `iccdev.spectral-tiff-preview`, missing local python `imagecodecs` |
| mutation tests | naming guard red on a deleted case; `profileSeqDesc` hunk red on revert |

No corpus profile or expected-output baseline carries any of these four signatures, so
there is no golden-output churn. `IccXML` and `IccJSON` write the raw four-character
signature via `icGetSigStr` and carry no name table, so neither is affected.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md`
- [x] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes — n/a, no allocation or parsing change
- [x] Added or updated regression coverage for behavior changes
- [x] Attached a `base...HEAD` contract matrix for cross-cutting changes
- [x] Reviewed active and suppressed automated findings from review threads and summaries
- [ ] For Python package changes — n/a
- [x] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [x] New source files include the ICC copyright and BSD 3-Clause license header — n/a, no new files
- [x] Code style matches nearby code: 2-space indent, K&R braces, `m_` members
