### PR TITLE
fix(#2368): name ICC.1:2022 Table 29's 'LCD ' and 'OLED' technology signatures

### DIFF
--- a/.github/ci/regression/signature-utils-contract.cpp
+++ b/.github/ci/regression/signature-utils-contract.cpp
@@ -229,6 +229,8 @@ const char *expectedTechnologyName(icTechnologySignature sig)
   case icSigCRTDisplay:                 return "CRTDisplay";
   case icSigPMDisplay:                  return "PMDisplay";
   case icSigAMDisplay:                  return "AMDisplay";
+  case icSigLCDDisplay:                 return "LCDDisplay";
+  case icSigOLEDDisplay:                return "OLEDDisplay";
   case icSigPhotoCD:                    return "PhotoCD";
   case icSigPhotoImageSetter:           return "PhotoImageSetter";
   case icSigGravure:                    return "Gravure";
@@ -264,6 +266,9 @@ void testTechnologySignatures()
     (icUInt32Number)icSigVideoMonitor,               (icUInt32Number)icSigVideoCamera,
     (icUInt32Number)icSigProjectionTelevision,       (icUInt32Number)icSigCRTDisplay,
     (icUInt32Number)icSigPMDisplay,                  (icUInt32Number)icSigAMDisplay,
+    // Table 29 prints these between 'AMD ' and 'KPCD'.  Unlike the v4.3 rows below they
+    // had no enumerator at all, so -Werror=switch could not have flagged their absence.
+    (icUInt32Number)icSigLCDDisplay,                 (icUInt32Number)icSigOLEDDisplay,
     (icUInt32Number)icSigPhotoCD,                    (icUInt32Number)icSigPhotoImageSetter,
     (icUInt32Number)icSigGravure,                    (icUInt32Number)icSigOffsetLithography,
     (icUInt32Number)icSigSilkscreen,                 (icUInt32Number)icSigFlexography,
@@ -356,36 +361,41 @@ void testValidateTechnologyRows()
   // back alongside some other warning.
   const char *kUnknown = "Unknown Technology";
 
-  const icTechnologySignature kV43[] = {
+  // Every row whose Validate() verdict #2101 changed: the four ICC.1 v4.3 technologies,
+  // then Table 29's two display rows, which had no enumerator at all until they were
+  // added alongside these.  Both switches below carry a default: label, so a row missing
+  // from either is reported NonCompliant rather than caught by -Werror=switch.
+  const icTechnologySignature kAddedRows[] = {
     icSigMotionPictureFilmScanner, icSigMotionPictureFilmRecorder,
     icSigDigitalMotionPictureCamera, icSigDigitalCinemaProjector,
+    icSigLCDDisplay, icSigOLEDDisplay,
   };
 
-  for (size_t i = 0; i < sizeof(kV43) / sizeof(kV43[0]); i++) {
+  for (size_t i = 0; i < sizeof(kAddedRows) / sizeof(kAddedRows[0]); i++) {
     // A technologyTag holding the signature. CIccTagSignature::Validate keys off the
     // first signature in the path, so the path has to say technologyTag for the
     // technology switch to be the one that runs.
     CIccTagSignature tag;
-    tag.SetValue((icUInt32Number)kV43[i]);
+    tag.SetValue((icUInt32Number)kAddedRows[i]);
     std::string rpt;
     tag.Validate(icGetSigPath(icSigTechnologyTag), rpt, NULL);
     if (rpt.find(kUnknown) != std::string::npos) {
       ++g_fail;
       std::fprintf(stderr, "[signature-utils-contract] FAIL: technologyTag 0x%08X "
                            "reported unknown by CIccTagSignature::Validate\n",
-                   (unsigned)kV43[i]);
+                   (unsigned)kAddedRows[i]);
     }
 
     // The same signature in a profileSequenceDesc entry, which is a separate switch.
     CIccTagProfileSeqDesc seq;
-    addSeqEntry(seq, kV43[i]);
+    addSeqEntry(seq, kAddedRows[i]);
     std::string seqRpt;
     seq.Validate(icGetSigPath(icSigProfileSequenceDescTag), seqRpt, NULL);
     if (seqRpt.find(kUnknown) != std::string::npos) {
       ++g_fail;
       std::fprintf(stderr, "[signature-utils-contract] FAIL: profileSequenceDesc 0x%08X "
                            "reported unknown by CIccTagProfileSeqDesc::Validate\n",
-                   (unsigned)kV43[i]);
+                   (unsigned)kAddedRows[i]);
     }
   }
 

--- a/IccProfLib/IccSignatureUtils.h
+++ b/IccProfLib/IccSignatureUtils.h
@@ -667,6 +667,9 @@ inline bool IsValidTechnologySignature(icUInt32Number sig)
     case (icUInt32Number)icSigCRTDisplay:
     case (icUInt32Number)icSigPMDisplay:
     case (icUInt32Number)icSigAMDisplay:
+    // ICC.1:2022 Table 29's two display rows, absent from the enum until now (#2101).
+    case (icUInt32Number)icSigLCDDisplay:
+    case (icUInt32Number)icSigOLEDDisplay:
     case (icUInt32Number)icSigPhotoCD:
     case (icUInt32Number)icSigPhotoImageSetter:
     case (icUInt32Number)icSigGravure:

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -3035,6 +3035,10 @@ icValidateStatus CIccTagSignature::Validate(std::string sigPath, std::string &sR
     case icSigCRTDisplay:
     case icSigPMDisplay:
     case icSigAMDisplay:
+    // ICC.1:2022 Table 29 lists these between 'AMD ' and 'KPCD'; both Validate()
+    // lists rejected them as NonCompliant because the enum had no row (#2101).
+    case icSigLCDDisplay:
+    case icSigOLEDDisplay:
     case icSigPhotoCD:
     case icSigPhotoImageSetter:
     case icSigGravure:
@@ -10947,6 +10951,10 @@ icValidateStatus CIccTagProfileSeqDesc::Validate(std::string sigPath, std::strin
     case icSigCRTDisplay:
     case icSigPMDisplay:
     case icSigAMDisplay:
+    // ICC.1:2022 Table 29 lists these between 'AMD ' and 'KPCD'; both Validate()
+    // lists rejected them as NonCompliant because the enum had no row (#2101).
+    case icSigLCDDisplay:
+    case icSigOLEDDisplay:
     case icSigPhotoCD:
     case icSigPhotoImageSetter:
     case icSigGravure:

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -1705,6 +1705,14 @@ const icChar *CIccInfo::GetTechnologySigName(icTechnologySignature sig)
   case icSigAMDisplay:
     return "AMDisplay";
 
+  // ICC.1:2022 Table 29 rows that never reached the enum, so every list below keyed
+  // off it silently omitted them and GetSigName() reported "Unknown 'LCD '" (#2101).
+  case icSigLCDDisplay:
+    return "LCDDisplay";
+
+  case icSigOLEDDisplay:
+    return "OLEDDisplay";
+
   case icSigPhotoCD:
     return "PhotoCD";
 

--- a/IccProfLib/icProfileHeader.h
+++ b/IccProfLib/icProfileHeader.h
@@ -522,6 +522,13 @@ typedef enum {
     icSigCRTDisplay                     = 0x43525420,  /* 'CRT ' */
     icSigPMDisplay                      = 0x504D4420,  /* 'PMD ' */
     icSigAMDisplay                      = 0x414D4420,  /* 'AMD ' */
+    /* ICC.1:2022 Table 29 prints these two display rows between 'AMD ' and 'KPCD'.
+     * They were never transcribed, so unlike the v4.3 rows named in #2101 they are
+     * absent from the enum entirely -- which is why -Werror=switch cannot flag them:
+     * a signature that has no enumerator leaves every switch over the enum
+     * exhaustive.  A profile carrying either one validated as NonCompliant. */
+    icSigLCDDisplay                     = 0x4C434420,  /* 'LCD ' */
+    icSigOLEDDisplay                    = 0x4F4C4544,  /* 'OLED' */
     icSigPhotoCD                        = 0x4B504344,  /* 'KPCD' */
     icSigPhotoImageSetter               = 0x696D6773,  /* 'imgs' */
     icSigGravure                        = 0x67726176,  /* 'grav' */


### PR DESCRIPTION
Closes #2368
Part of #2101 — the `dcpj`/`dcjp` spec question there is untouched and stays open.

## What

ICC.1:2022 Table 29 lists `'LCD '` (4C434420h) and `'OLED'` (4F4C4544h) between `'AMD '` and
`'KPCD'`. Neither was ever transcribed: `icTechnologySignature` went straight from
`icSigAMDisplay` to `icSigPhotoCD`, so both signatures were absent from the tree entirely and
a profile naming either was reported `icValidateNonCompliant`.

## Why #2367's guard could not catch it

#2367 added `-Werror=switch` over `icTechnologySignature` so an incomplete switch is a build
failure. That guard is blind to this class by construction: **a signature with no enumerator
leaves every switch over the enum exhaustive.** Both `Validate()` switches also end in
`default:`, so an unlisted row is reported NonCompliant rather than diagnosed. Worth
recording as a limit of that guard.

## Measured

master `49d0df51`, clang 18 Release, `'AMD '` as the control — the adjacent Table 29 row that
*was* transcribed:

| tree | signature | `GetTechnologySigName` | `IsValidTechnologySignature` | `Validate` |
|---|---|---|---|---|
| master | 0x4C434420 | `Unknown 'LCD ' = 4C434420` | false | NonCompliant |
| master | 0x4F4C4544 | `Unknown 'OLED' = 4F4C4544` | false | NonCompliant |
| master | 0x414D4420 | `AMDisplay` | true | accepted |
| this PR | 0x4C434420 | `LCDDisplay` | true | accepted |
| this PR | 0x4F4C4544 | `OLEDDisplay` | true | accepted |
| this PR | 0x414D4420 | `AMDisplay` | true | accepted |

## Scope

Four lists key off the enum and all four omitted both rows — `GetTechnologySigName`,
`IsValidTechnologySignature`, `CIccTagSignature::Validate`, `CIccTagProfileSeqDesc::Validate`.
A repo-wide set-diff on `icSigAMDisplay` returns exactly those four plus the contract test;
there is no fifth list.

**Purely additive.** It only widens the accepted set, so no profile that validated before can
validate differently now. No tracked fixture carries either signature, so the corpus is
unchanged and no expectation file moves.

## Coverage

The two rows go where the harness already reaches both switches: `kV43[]` in section 8 of
`signature-utils-contract.cpp` — renamed `kAddedRows[]`, since it is no longer v4.3-only —
which drives `CIccTagSignature::Validate` and `CIccTagProfileSeqDesc::Validate` against the
same signature, plus the naming list in section 7.

Each of the four library sites was verified individually load-bearing by deleting it and
re-running:

| site removed | result |
|---|---|
| `GetTechnologySigName` | FAILS (1) — got `Unknown 'LCD '`, want `LCDDisplay` |
| `IsValidTechnologySignature` | FAILS (1) — rejects LCDDisplay |
| `CIccTagSignature::Validate` | FAILS (2) |
| `CIccTagProfileSeqDesc::Validate` | FAILS (2) |

## Evidence

Pre-PR dispatch `ci_scope=source`, run **33696351232** — 16 success, 2 skipped, 0 failures:
GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL + MinGW UCRT64, macOS Release and Debug,
Tool Smoke Tests ASAN+UBSAN, Docker Clang 22. `iccdev.signature-utils-contract` ran as test
#69 (70/239) and passed in the ASAN+UBSAN lane, so the new assertions were executed rather
than skipped.
