### PR TITLE
docs(#2368): name the two tags that actually carry a technology signature

### DIFF
--- a/IccProfLib/IccSignatureUtils.h
+++ b/IccProfLib/IccSignatureUtils.h
@@ -630,8 +630,12 @@ inline bool IsValidColorSpaceSignature(icUInt32Number sig)
 //   Debug and warning output is gated behind ICC_SIGNATURE_VERBOSE.
 //
 // NOTE:
-//   This should be used to verify the `technology` field in `profileDescription`
-//   tags or `outputDevice` blocks.
+//   A technology signature appears in exactly two places: the top-level
+//   technologyTag ('tech', a signatureType), and the `technology` field of each
+//   icProfileDescStruct entry in profileSequenceDescTag ('pseq'). Use this
+//   predicate for those. It is not carried by profileDescriptionTag ('desc'),
+//   which is a multiLocalizedUnicode, and there is no "outputDevice" block --
+//   this NOTE named both until #2368, contradicting the CAVEAT below.
 //
 //   CAVEAT: it rejects icSigUndefined (0), which CIccTagProfileSeqDesc::Validate
 //   accepts as "technology not defined" and which is a common real-world value --


### PR DESCRIPTION
Follow-up to #2369 (merged `3177716c`). Comment-only, no behaviour change.

## What

Copilot flagged this on #2367 at 23:00 — the same minute that PR merged — so it was never
addressed. The `NOTE:` on `IsValidTechnologySignature` sent consumers to two places that do
not carry a technology signature:

```
//   This should be used to verify the `technology` field in `profileDescription`
//   tags or `outputDevice` blocks.
```

`profileDescriptionTag` (`'desc'`, `icProfileHeader.h:462`) is a multiLocalizedUnicode and has
no `technology` field. ICC.1 has no `outputDevice` block at all.

The two places the signature actually appears:

| where | declared |
|---|---|
| top-level `technologyTag` (`'tech'`), a signatureType | `icProfileHeader.h:483` |
| `technology` in each `icProfileDescStruct` of `profileSequenceDescTag` (`'pseq'`) | `icProfileHeader.h:1773`, `IccTagBasic.h:1626` |

Both are already named by the `CAVEAT` two lines below — `CIccTagProfileSeqDesc::Validate` and
`technologyTag` — so the block contradicted itself inside one comment.

## Why the wording matters here

`IsValidTechnologySignature` has no in-library callers. The only caller in the tree is
`.github/ci/regression/signature-utils-contract.cpp`. The NOTE is therefore pure guidance for
consumers of an installed public header, which is the case where naming the wrong tag costs
something.

## Provenance

The wording predates #2367 — it is from the original 01-MAR-2025 block. #2367 added the CAVEAT
directly beneath it, putting the correct names next to the wrong ones and making the
contradiction visible. Not a regression from #2367 or #2369.

## Scope

One file, six comment lines. `g++ -fsyntax-only -std=c++17` clean on the header standalone and
on the regression TU. No code paths, fixtures, or expectation files touched.
