### PR TITLE
fix(#2323): read a parenthesised channel index in the XML calculator, as the JSON parser does

### DIFF
--- a/.github/ci/regression/calc-channel-ref-unterminated-index-json.cpp
+++ b/.github/ci/regression/calc-channel-ref-unterminated-index-json.cpp
@@ -20,11 +20,10 @@
     This is a SEPARATE reachable entry point, not a duplicate of the XML test:
     CIccMpeJsonCalculator is registered for icSigCalculatorElemType in
     IccMpeJsonFactory.cpp, so iccFromJson on a hand-authored document reaches it
-    without any XML involved.  It is also reachable through MORE spellings than
-    the XML copy, because its entry condition is the correct
-    "select[0] == '('" where the XML one has a typo ("select[1]"): both
-    "in{Lab[XXXX" and "in{Lab(XXXX" arrive here, and only the first arrives on
-    the XML side.  Both are asserted below for exactly that reason.
+    without any XML involved.  Both "in{Lab[XXXX" and "in{Lab(XXXX" arrive
+    here, and both are asserted below.  (The XML copy once admitted only the
+    first, through a select[1] typo in its entry test; that was corrected as the
+    follow-up deferred from #2365, and the XML helper now pins the same two.)
 
     Registered separately from the XML helper rather than folded into it so that
     neither can mask the other: this one is skipped where IccJSON is not built,
@@ -41,6 +40,7 @@
 #include "IccProfileJson.h"
 #include "IccTagJsonFactory.h"
 #include "IccMpeJsonFactory.h"
+#include "IccTagMPE.h"
 
 #include <cstdio>
 #include <filesystem>
@@ -110,9 +110,8 @@ static bool writeFile(const std::string& path, const std::string& text)
 
 // Returns whether the document parsed.  A sanitizer abort inside here IS the
 // defect on an instrumented lane: the caller never gets its result back.
-static bool loadJson(const char* file, std::string& parseStr)
+static bool loadJson(CIccProfileJson& profile, const char* file, std::string& parseStr)
 {
-  CIccProfileJson profile;
   return profile.LoadJson(file, &parseStr);
 }
 
@@ -129,8 +128,9 @@ static int expectRefused(const std::string& mainFunction, const char* file, cons
   if (!writeFile(file, profileJson(mainFunction)))
     return check(false, label);
 
+  CIccProfileJson profile;
   std::string parseStr;
-  bool loaded = loadJson(file, parseStr);
+  bool loaded = loadJson(profile, file, parseStr);
   bool named = parseStr.find(needle) != std::string::npos;
 
   return check(!loaded && named, label);
@@ -141,8 +141,53 @@ static int expectParsed(const std::string& mainFunction, const char* file, const
   if (!writeFile(file, profileJson(mainFunction)))
     return check(false, label);
 
+  CIccProfileJson profile;
   std::string parseStr;
-  return check(loadJson(file, parseStr), label);
+  return check(loadJson(profile, file, parseStr), label);
+}
+
+// The flattened function, as Describe() prints it.  The XML helper's header
+// calls a bare "it loaded" assertion worthless for this defect, and it is worth
+// exactly as little here: the claim these two files jointly make is that the two
+// parsers agree on WHICH CHANNEL a parenthesised index selects, and only the
+// flattened function says that.  Without this the JSON side could regain the
+// same slip -- select[1] for select[0] -- and stay green while reading channel 4.
+static std::string flattenedFunction(const char* file)
+{
+  CIccProfileJson profile;
+  std::string parseStr;
+  if (!loadJson(profile, file, parseStr))
+    return "<did not load: " + parseStr.substr(0, 120) + ">";
+
+  CIccTagMultiProcessElement* mpe =
+      dynamic_cast<CIccTagMultiProcessElement*>(profile.FindTag(icSigAToB1Tag));
+  if (!mpe || mpe->NumElements() < 1)
+    return "<no A2B1 multiProcessElement>";
+
+  std::string text;
+  mpe->GetElement(0)->Describe(text, 100);
+  const std::string begin = "BEGIN_CALC_FUNCTION\n";
+  size_t b = text.find(begin);
+  size_t e = text.find("\nEND_CALC_FUNCTION", b);
+  if (b == std::string::npos || e == std::string::npos)
+    return "<no BEGIN_CALC_FUNCTION marker in Describe() output>";
+  b += begin.size();
+  return text.substr(b, e - b);
+}
+
+static int expectFlatten(const std::string& mainFunction, const char* file,
+                         const char* expected, const char* label)
+{
+  if (!writeFile(file, profileJson(mainFunction)))
+    return check(false, label);
+
+  std::string flat = flattenedFunction(file);
+  const bool ok = flat.find(expected) != std::string::npos;
+  if (!ok)
+    std::fprintf(stderr,
+                 "calc-channel-ref-unterminated-index-json:       got '%s'  expected to contain '%s'\n",
+                 flat.c_str(), expected);
+  return check(ok, label);
 }
 
 int main(int argc, char* argv[])
@@ -185,11 +230,11 @@ int main(int argc, char* argv[])
                             "json-unterminated-heap.json",
                             "selector past the SSO buffer (heap overflow) is refused");
 
-  // The '(' spelling.  This one reaches the block here but NOT on the XML side,
-  // where select[1] == '(' keeps it out -- so it is only covered by this file.
+  // The '(' spelling.  Reaches the block here, and -- since the select[1] typo
+  // was corrected -- on the XML side too; each helper pins its own parser.
   failures += expectRefused("{\\nin{Lab(" + filler(14) + "\\nout{L}\\n}\\n",
                             "json-unterminated-paren.json",
-                            "the '(' spelling, which the XML typo blocks, is refused here");
+                            "the '(' spelling of an unterminated index is refused here too");
 
   failures += expectRefused("{\\nin{C}\\nout{a[" + filler(14) + "\\n}\\n",
                             "json-unterminated-out.json",
@@ -218,12 +263,21 @@ int main(int argc, char* argv[])
   // "in{Lab(1,2)}" would NOT be a control: the size is only read from a ",size"
   // that FOLLOWS the closing bracket, so the "2" inside the parentheses is
   // discarded, the operator flattens to in(5,1), and the function then fails on
-  // stack balance rather than on anything this fix touches.  That is the same
-  // deferred defect as the select[1] typo -- an index quietly narrowed instead
-  // of refused -- and pinning it here would assert today's wrong behaviour.
-  failures += expectParsed("{\\nin{Lab(1)}\\nout{L}\\n}\\n",
-                           "json-wellformed-paren.json",
-                           "the well-formed '(' spelling still parses");
+  // stack balance rather than on anything this fix touches.  That is a deferred
+  // defect of the same shape the select[1] typo had -- an index quietly narrowed
+  // instead of refused -- and pinning it here would assert today's wrong behaviour.
+  // Not expectParsed: this is the assertion the XML helper's parity claim rests
+  // on, so it names the channel.  "Lab" is at offset 4, so index 1 is channel 5 --
+  // the same in[5] the XML helper requires of both of its spellings.
+  failures += expectFlatten("{\\nin{Lab(1)}\\nout{L}\\n}\\n",
+                            "json-wellformed-paren.json",
+                            "in[5]",
+                            "in{Lab(1)} selects channel 5 here, as it now does in XML");
+
+  failures += expectFlatten("{\\nin{Lab[1]}\\nout{L}\\n}\\n",
+                            "json-wellformed-bracket.json",
+                            "in[5]",
+                            "in{Lab[1]} selects channel 5 here too");
 
   return failures ? 1 : 0;
 }

--- a/.github/ci/regression/calc-channel-ref-unterminated-index.cpp
+++ b/.github/ci/regression/calc-channel-ref-unterminated-index.cpp
@@ -31,13 +31,27 @@
     not, because before the fix it PARSES: that is what keeps this test from
     being vacuous on the lanes that carry no instrumentation.
 
-    Two spellings reach the same block.  "select[0] == '['" is the ordinary one;
-    "select[1] == '('" is a second entry with a defect of its own (it is a typo
-    for select[0], which is why "in{C(0,3)}" silently ignores its index while
-    tget/tput handle the same spelling correctly through
-    CIccFuncTokenizer::GetIndex).  That typo is NOT changed here -- it alters
-    which references are accepted, which is a maintainer ruling -- but it is
-    covered, because a reference reaching the block that way overflowed too.
+    Two spellings reach the block, "in{Lab[1]}" and "in{Lab(1)}".  The second
+    only does so since the select[1] typo in its entry test was corrected (the
+    follow-up deferred from #2365).  That one-character change moves FIVE input
+    families, in both directions, and every one of them is pinned below --
+    measured against a build of each side, 7-in/3-out, "Lab" at offset 4:
+
+      document              before          after
+      in{Lab(1)}            in[4]           in[5]     the intended fix
+      in{Lab(XXXX (unterm)  LOADED in[4]    REFUSED   by the #2323 guard
+      in{Lab(1),2}          REFUSED         in[5,2]   parity with "[1],2"
+      in{C,(3)}             LOADED in[0]    REFUSED   acceptance regression
+      in{C,(XXXX (unterm)   REFUSED here    REFUSED downstream
+
+    The last two are the ",(" family: a selector whose first character is a
+    comma, which is what the typo's second-character test used to admit.  Their
+    refusal is no longer this guard's, so they are kept as cases rather than
+    dropped along with the typo -- see the notes on each.
+
+    Describe() text is the oracle wherever two spellings must agree, because a
+    load that merely succeeds is exactly what the typo produced: both documents
+    parsed either way, and only the channel differed.
 
     The controls matter as much as the failures: an "unterminated index is
     refused" assertion is satisfied just as well by refusing every indexed
@@ -55,6 +69,7 @@
 #include "IccProfileXml.h"
 #include "IccTagXmlFactory.h"
 #include "IccMpeXmlFactory.h"
+#include "IccTagMPE.h"
 
 #include <cstdio>
 #include <filesystem>
@@ -116,9 +131,8 @@ static bool writeFile(const std::string& path, const std::string& text)
 
 // Returns whether the document parsed.  A sanitizer abort inside here IS the
 // defect on an instrumented lane: the caller never gets its result back.
-static bool loadXml(const char* file, std::string& parseStr)
+static bool loadXml(CIccProfileXml& profile, const char* file, std::string& parseStr)
 {
-  CIccProfileXml profile;
   return profile.LoadXml(file, "", &parseStr);
 }
 
@@ -140,8 +154,9 @@ static int expectRefused(const std::string& body, const char* file, const char* 
   if (!writeFile(file, profileXml(body, macros)))
     return check(false, label);
 
+  CIccProfileXml profile;
   std::string parseStr;
-  bool loaded = loadXml(file, parseStr);
+  bool loaded = loadXml(profile, file, parseStr);
   bool named = parseStr.find(needle) != std::string::npos;
 
   return check(!loaded && named, label);
@@ -153,8 +168,60 @@ static int expectParsed(const std::string& body, const char* file, const char* l
   if (!writeFile(file, profileXml(body, macros)))
     return check(false, label);
 
+  CIccProfileXml profile;
   std::string parseStr;
-  return check(loadXml(file, parseStr), label);
+  return check(loadXml(profile, file, parseStr), label);
+}
+
+// The flattened function the calculator element was built from, as Describe()
+// prints it ("{ 0 0 in[5] out[0,3] }").  This is the only observable that
+// separates "in{Lab(1)}" from "in{Lab[1]}": both LOAD, and under the typo both
+// applied cleanly -- one of them on the wrong channel.
+//
+// Each way of not getting one is reported distinctly rather than collapsed into
+// "": a fixture that stops loading for an unrelated reason, a tag lookup that
+// breaks, and a Describe() marker that is reworded would otherwise all present
+// as the same empty-string mismatch, and the diagnostic could not say which.
+static std::string flattenedFunction(const char* file)
+{
+  CIccProfileXml profile;
+  std::string parseStr;
+  if (!loadXml(profile, file, parseStr))
+    return "<did not load: " + parseStr.substr(0, 120) + ">";
+
+  CIccTagMultiProcessElement* mpe =
+      dynamic_cast<CIccTagMultiProcessElement*>(profile.FindTag(icSigAToB1Tag));
+  if (!mpe || mpe->NumElements() < 1)
+    return "<no A2B1 multiProcessElement>";
+
+  std::string text;
+  mpe->GetElement(0)->Describe(text, 100);
+  const std::string begin = "BEGIN_CALC_FUNCTION\n";
+  size_t b = text.find(begin);
+  size_t e = text.find("\nEND_CALC_FUNCTION", b);
+  if (b == std::string::npos || e == std::string::npos)
+    return "<no BEGIN_CALC_FUNCTION marker in Describe() output>";
+  b += begin.size();
+  return text.substr(b, e - b);
+}
+
+// Write the same reference in both spellings and require the same function.
+static int expectSameFlatten(const std::string& bracketBody, const std::string& parenBody,
+                             const char* bracketFile, const char* parenFile,
+                             const char* expected, const char* label)
+{
+  if (!writeFile(bracketFile, profileXml(bracketBody)) ||
+      !writeFile(parenFile, profileXml(parenBody)))
+    return check(false, label);
+
+  std::string bracket = flattenedFunction(bracketFile);
+  std::string paren = flattenedFunction(parenFile);
+  const bool same = (bracket == paren) && bracket.find(expected) != std::string::npos;
+  if (!same)
+    std::fprintf(stderr,
+                 "calc-channel-ref-unterminated-index:       bracket '%s'  paren '%s'  expected to contain '%s'\n",
+                 bracket.c_str(), paren.c_str(), expected);
+  return check(same, label);
 }
 
 int main(int argc, char* argv[])
@@ -198,11 +265,39 @@ int main(int argc, char* argv[])
                             "unterminated-heap.xml",
                             "selector past the SSO buffer (heap overflow) is refused");
 
-  // The second way into the same block: select[1] == '(' rather than
-  // select[0] == '['.  Reached with a reference whose selector starts ",(".
-  failures += expectRefused("in{C,(" + filler(13) + " out{L}",
+  // The '(' spelling of the same reference.  Before the select[1] typo was
+  // corrected this document never entered the block at all -- the unterminated
+  // index was ACCEPTED, as offset 0 -- so this case is red on the typo alone.
+  failures += expectRefused("in{Lab(" + filler(14) + " out{L}",
                             "unterminated-paren.xml",
-                            "the select[1] == '(' entry into the block is refused too");
+                            "the '(' spelling of an unterminated index is refused by the same guard");
+
+  // The ",(" selector, which is where the typo used to send a reference whose
+  // FIRST character is a comma.  Correcting the entry test moved this family out
+  // of the block, so its refusal is no longer this guard's: the selector is
+  // discarded, ",(XXXX" reaches the size branch as atoi("(XXXX") == 0, and the
+  // flattened "in(0,0)" is refused by CIccFuncTokenizer::GetIndex, which rejects
+  // a zero size.  Kept, rather than dropped with the typo that created it,
+  // because the refusal now rests on a check nothing else here pins: were
+  // GetIndex ever to accept in(n,0), this document would be silently accepted
+  // with its malformed selector thrown away -- the #2323 class exactly.  The
+  // needle is the downstream message, and the flattened text names WHERE.
+  failures += expectRefused("in{C,(" + filler(13) + " out{L}",
+                            "unterminated-comma-paren.xml",
+                            "an unterminated ',(' index is still refused, now downstream",
+                            "",
+                            "Main Calculator Function from \"{ in(0,0)");
+
+  // The same family, terminated.  This one CHANGED DIRECTION: it loaded before
+  // the fix, as in(0,1) with the "(3)" silently discarded, and is refused now.
+  // That is the narrowing standard #2323 applied, but it is an acceptance
+  // regression for any hand-authored document using the spelling, so it is
+  // stated here rather than left to be discovered.  No tracked XML uses it.
+  failures += expectRefused("in{C,(3)} out{L}",
+                            "terminated-comma-paren.xml",
+                            "a terminated ',(' index, accepted before the fix, is refused now",
+                            "",
+                            "Main Calculator Function from \"{ in(0,0)");
 
   // Same guard from the out{} operator, which shares the code path and only
   // differs in which channel map it consults -- the message names the operator.
@@ -244,6 +339,26 @@ int main(int argc, char* argv[])
   failures += expectParsed("in{Lab[0]} out{L}",
                            "wellformed-offset.xml",
                            "in{Lab[0]} still parses");
+
+  // The control for the typo itself.  Both documents load before and after the
+  // fix; what changed is WHICH channel the '(' form reads.  Lab sits at offset 4,
+  // so index 1 is channel 5, and the bracket form is the reference the paren form
+  // must agree with -- the same agreement the JSON parser has always had.
+  failures += expectSameFlatten("in{Lab[1]} out{L}", "in{Lab(1)} out{L}",
+                                "wellformed-bracket.xml", "wellformed-paren.xml",
+                                "in[5]",
+                                "in{Lab(1)} flattens to the same function as in{Lab[1]}, in[5]");
+
+  // The offset+size pair, which is the second thing the corrected entry test
+  // changed direction on: "in{Lab(1),2}" was REFUSED before the fix (the paren
+  // form never entered the block, so the size stayed 1 and in(4,1) failed stack
+  // balance against a two-channel out{}) and now flattens to in[5,2], the same
+  // as the bracket spelling.  Asserted for the same reason as the bare form:
+  // parity is the contract, and only a comparison of the two can state it.
+  failures += expectSameFlatten("in{Lab[1],2} out{a,2}", "in{Lab(1),2} out{a,2}",
+                                "wellformed-bracket-size.xml", "wellformed-paren-size.xml",
+                                "in[5,2]",
+                                "in{Lab(1),2} flattens to the same function as in{Lab[1],2}, in[5,2]");
 
   failures += expectParsed("in{Lab} out{a,2}",
                            "wellformed-sizeonly.xml",

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4042,9 +4042,12 @@ endfunction()
 # inside libstdc++'s inline SSO buffer and is not caught at all (the malformed
 # reference is simply accepted), exactly 15 fills it and the read leaves the stack
 # frame (the reported 1-byte-read-stack-buffer-overflow, scariness 27), and >= 16
-# has moved to the heap. The helper covers all three plus the select[1] == '('
-# entry, and pins the well-formed spellings the corpus uses so that the guard
-# cannot be satisfied by refusing every indexed reference.
+# has moved to the heap. The helper covers all three. It also carries the
+# follow-up deferred from #2365 -- Flatten()'s entry test read select[1] where it
+# meant select[0], so a parenthesised index selected the wrong channel -- and
+# pins each of the five input families that correction moves, together with the
+# well-formed spellings the corpus uses, so that the guard cannot be satisfied by
+# refusing every indexed reference.
 function(iccdev_add_calc_channel_ref_unterminated_index_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
     return()
@@ -4063,8 +4066,8 @@ function(iccdev_add_calc_channel_ref_unterminated_index_test)
     ${TARGET_LIB_ICCXML} ${TARGET_LIB_ICCPROFLIB} ${LIBXML2_LIBRARIES})
   add_dependencies(check iccCalcChannelRefUnterminatedIndexTest)
 
-  # The helper writes its ten generated documents into this directory and
-  # chdir()s there, so nothing lands in the source tree.
+  # The helper writes its generated documents into this directory and chdir()s
+  # there, so nothing lands in the source tree.
   set(_calc_unterminated_scratch
     "${CMAKE_CURRENT_BINARY_DIR}/ctest-output/calc-channel-ref-unterminated-index")
 
@@ -4107,10 +4110,12 @@ endfunction()
 # #2323 (JSON twin): CIccMpeJsonCalculator::Flatten() carries a byte-for-byte copy
 # of the XML defect -- "select = p + 1" after a scan that stops on the NUL when the
 # index is unterminated. It is a separate reachable entry point (iccFromJson on a
-# hand-authored document), and reachable through MORE spellings than the XML copy,
-# whose "select[1] == '('" typo keeps the '(' form out. Registered separately from
-# the XML helper so neither masks the other: this one is skipped where IccJSON is
-# not built, and the XML coverage does not disappear with it.
+# hand-authored document). It also asserts the flattened function, not merely
+# that the document loads, because the parity the XML helper claims -- both
+# parsers select the same channel for a parenthesised index -- is only measured
+# if both sides name the channel. Registered separately from the XML helper so
+# neither masks the other: this one is skipped where IccJSON is not built, and
+# the XML coverage does not disappear with it.
 function(iccdev_add_calc_channel_ref_unterminated_index_json_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCJSON}")
     return()

--- a/IccJSON/IccLibJSON/IccMpeJson.cpp
+++ b/IccJSON/IccLibJSON/IccMpeJson.cpp
@@ -1592,10 +1592,10 @@ bool CIccMpeJsonCalculator::Flatten(std::string &flatStr, std::string macroName,
           offset = atoi(select.c_str() + 1);
           for (p = select.c_str() + 1; *p && *p != ')' && *p != ']'; p++);
           // Identical to the defect fixed in CIccMpeXmlCalculator::Flatten (#2323),
-          // and reachable through MORE spellings than that one: the entry condition
-          // here is correctly "select[0] == '('", where the XML copy has a typo
-          // ("select[1]"), so "in{Lab(XXXX" reaches this line as well as
-          // "in{Lab[XXXX".  An unterminated index leaves p on the NUL terminator, so
+          // reachable as "in{Lab(XXXX" as well as "in{Lab[XXXX".  (The XML copy
+          // tested select[1] for the '(' case -- a typo that kept that spelling
+          // out of its block and quietly read index 0; corrected as the follow-up
+          // to #2365.)  An unterminated index leaves p on the NUL terminator, so
           // "p + 1" addresses one past it and the assignment runs strlen from there:
           // a stack-buffer-overflow read when the selector is exactly 15 characters
           // and fills the string's inline SSO buffer, a heap-buffer-overflow at 16 or

--- a/IccXML/IccLibXML/IccMpeXml.cpp
+++ b/IccXML/IccLibXML/IccMpeXml.cpp
@@ -3202,7 +3202,29 @@ bool CIccMpeXmlCalculator::Flatten(std::string &flatStr, std::string macroName, 
         int offset = 0;
         int size = 1;
 
-        if (select[0] == '[' || select[1] == '(') {
+        // select[1] was a typo for select[0] -- since RefIccMAX 2.1.10, 4f5b3d38.
+        // refroot stops at '(' exactly as at '[', so "in{Lab(1)}" arrived here
+        // with select = "(1)", failed BOTH halves of the test, and fell through
+        // with offset 0: it flattened to in(4,1) where "in{Lab[1]}" flattens to
+        // in(5,1) -- Describe() renders those in[4] and in[5] -- and the profile
+        // applied channel 4.  The JSON twin (CIccMpeJsonCalculator::Flatten)
+        // tests select[0] and has always produced in(5,1) for the same document,
+        // and tget/tput/tsav accept "(n)" through CIccFuncTokenizer::GetIndex,
+        // so the parenthesised index was a recognised spelling everywhere except
+        // this one line.  Deferred from #2365 (#2323) because it changes what the
+        // parser accepts.
+        //
+        // It changes five input families, not one, and the CTest pins each --
+        // "in{Lab(1)}" 4 -> 5, an unterminated "(XXXX" from silently accepted to
+        // refused by the guard below, "in{Lab(1),2}" from refused to in(5,2), and
+        // the two ",(" spellings (a selector whose FIRST character is a comma,
+        // which is what a second-character test used to admit) out of this block
+        // altogether: "in{C,(3)}" was accepted as in(0,1) with its index
+        // discarded and is now refused downstream, and an unterminated ",(XXXX"
+        // is still refused but no longer by this function.  No tracked XML or
+        // JSON uses any parenthesised in{}/out{} index, so no generated profile
+        // moves; the corpus's "(n)" spellings are all tget/tput.
+        if (select[0] == '[' || select[0] == '(') {
           const char *ptr;
           offset = atoi(select.c_str() + 1);
           for (ptr = select.c_str() + 1; *ptr && *ptr != ')' && *ptr != ']'; ptr++);


### PR DESCRIPTION
## Summary

Follow-up to #2365, item (a) of its PR body. `CIccMpeXmlCalculator::Flatten` tested `select[1] == '('` where it meant `select[0]`, since RefIccMAX 2.1.10 (`4f5b3d38`). A parenthesised channel index was recognised by `refroot` but never entered the index block, so it fell through with offset 0 and the profile applied the wrong channel.

`CIccMpeJsonCalculator::Flatten` tests `select[0]`, and `tget`/`tput`/`tsav` parse `(n)` through `CIccFuncTokenizer::GetIndex`, so the spelling was recognised everywhere but this one line.

## The correction moves five input families, not one

Measured against a build of each side. 7-in/3-out calculator, `Lab` at offset 4, rendered as `Describe()` prints the flattened function:

| document | before | after | |
|---|---|---|---|
| `in{Lab(1)}` | `in[4]` | `in[5]` | the intended fix |
| `in{Lab(XXXX` (unterminated) | **LOADED** `in[4]` | REFUSED | by the #2323 guard |
| `in{Lab(1),2}` | REFUSED | `in[5,2]` | parity with `[1],2` |
| `in{C,(3)}` | **LOADED** `in[0]` | REFUSED | acceptance regression |
| `in{C,(XXXX` (unterminated) | REFUSED here | REFUSED downstream | guard coverage moved |

The last two are the `,(` family: a selector whose **first** character is a comma, which is what a second-character test admits by accident. Correcting the entry test moves them out of the block, so their selector is discarded, the size branch reads `atoi("(...")` as 0, and the flattened `in(0,0)` is refused by `GetIndex`.

`in{C,(3)}` therefore changes from accepted-with-its-index-thrown-away to refused. That is the standard #2323 applied, but it is still an acceptance regression, so it is named here rather than left to be found.

No tracked XML or JSON uses a parenthesised `in{}`/`out{}` index. The corpus's 20 `(n)` spellings are all `tget`/`tput` in `Testing/Calc/srgbCalc++Test.xml`, which `GetIndex` parses. No generated profile moves.

## CTest

`iccdev.calc-channel-ref-unterminated-index` pins all five families. Its old `,(` case is **retargeted, not dropped**: that path's refusal now rests on `GetIndex` rejecting a zero size, which nothing else in either helper covered, so were `in(n,0)` ever accepted the malformed selector would be silently discarded, which is the #2323 class exactly.

Two spellings that must agree are compared by their **flattened function** rather than by loading, because both documents load either way and only the channel differs.

`iccdev.calc-channel-ref-unterminated-index-json` gains the same oracle. It previously asserted only that `in{Lab(1)}` loads, which cannot see the slip it exists to guard against: introducing `select[1]` in the JSON parser left it green.

Red/green, by re-introducing the typo in each parser:

| | red | green |
|---|---|---|
| XML | 5 assertions | 15 pass |
| JSON | 2 assertions | 10 pass |

The JSON failure reports `in[4]` against `in[5]`. Strict `-Wall -Wextra -Wpedantic -Werror` lane builds clean.

## Not changed

An index that is neither empty nor numeric is still narrowed rather than refused: `in{Lab[]}`, `in{Lab[x]}` and `in{Lab()}` all load as offset 0. `(n,m)` still discards `m`. Both are pre-existing on either side of this change and are a maintainer ruling, not folded in here.

## CI

Dispatched before opening this PR, `ci_scope=source`: run [33804010891](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33804010891) — 14 success, 2 skipped.

Both CTests are confirmed to have *run*, not merely to have been registered:

| leg | tests | this pair |
|---|---|---|
| GCC Strict ASAN+UBSAN Debug | 239, 100% passed | #61, #62 passed |
| Windows MSVC | 147, 100% passed | #56, #57 passed |

The Windows leg also settles the `dynamic_cast` the new oracle uses: it resolves across the IccXML/IccJSON to IccProfLib boundary on MSVC, as it already does for `json-srng-uf32-roundtrip`.
