### PR TITLE
CI: bump zizmore, ssl & other sha pins

### DIFF
--- a/.github/ci/cfl/build.sh
+++ b/.github/ci/cfl/build.sh
@@ -248,6 +248,7 @@ for target in "${selected_targets[@]}"; do
     "-Wall" "-Wextra" "-Werror"
     "-fsanitize=fuzzer-no-link,address,undefined"
     "-I$repo_root/IccProfLib"
+    "-I$repo_root/Tools/CmdLine"
     "-I$local_viz_dir"
   )
 

--- a/.github/ci/requirements/docker-workflow-qa.txt
+++ b/.github/ci/requirements/docker-workflow-qa.txt
@@ -1,2 +1,2 @@
 # Docker-only workflow security analyzer.
-zizmor==1.29.0
+zizmor==1.30.0

--- a/.github/instructions/workflow-governance.instructions.md
+++ b/.github/instructions/workflow-governance.instructions.md
@@ -270,6 +270,14 @@ workflow permission audit for workflow files. Use `hadolint`, Trivy config, or
 equivalent Dockerfile checks when container files are in scope. Run CodeQL for
 related C/C++ or CMake changes, not as the workflow YAML checker.
 
+The repository-level `.github/zizmor.yml` temporarily disables zizmor 1.30's
+`self-repository` audit. Keep same-repository `uses:` references in the `./`
+form until released actionlint supports GitHub's `$/` form
+([actionlint #711](https://github.com/rhysd/actionlint/issues/711)) and the
+repository no longer needs GitHub Enterprise Server compatibility.
+Remove the exception and migrate all local references together; do not suppress
+actionlint's syntax validation per workflow.
+
 The pre-flight gate must include Dockerfile paths when container files change.
 Dockerfile checks are blocking for changed container files: avoid advisory-only
 suppression for package pinning, `RUN cd` patterns, missing healthchecks, or

--- a/.github/workflows/ci-pr-risk-security-analysis.yml
+++ b/.github/workflows/ci-pr-risk-security-analysis.yml
@@ -1389,7 +1389,7 @@ jobs:
           echo "Runs pinned zizmor offline against workflow and composite-action definitions." >> "$RISK_REPORT_PATH"
           echo "" >> "$RISK_REPORT_PATH"
 
-          ZIZMOR_VERSION="1.26.1"
+          ZIZMOR_VERSION="1.30.0"
           ZIZMOR_VENV="${RUNNER_TEMP}/zizmor-venv"
           ZIZMOR_JSON="${RUNNER_TEMP}/zizmor-findings.json"
           ZIZMOR_LOG="${RUNNER_TEMP}/zizmor.log"

--- a/.github/workflows/ci-preflight-safety.yml
+++ b/.github/workflows/ci-preflight-safety.yml
@@ -100,7 +100,7 @@ jobs:
           /tmp/iccdev-preflight/bin/python -m pip install \
             'PyYAML>=6,<7' \
             'yamllint>=1.35,<2' \
-            'zizmor==1.26.1' \
+            'zizmor==1.30.0' \
             --quiet
           echo "/tmp/iccdev-preflight/bin" >> "$GITHUB_PATH"
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,8 @@
+# zizmor 1.30 recommends GitHub's new self-repository $/ syntax. Keep this
+# audit deferred while released actionlint rejects that syntax and GitHub
+# Enterprise Server does not support it. Re-enable the audit after both
+# compatibility boundaries are removed.
+# https://github.com/rhysd/actionlint/issues/711
+rules:
+  self-repository:
+    disable: true


### PR DESCRIPTION
## PR Summary

#2350 

## Checklist

- [ ] Signed all Commits in PR
- [ ] Built locally according to `docs/build.md`
- [ ] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [ ] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes
- [ ] Added or updated regression coverage for behavior changes
- [ ] Attached a `base...HEAD` contract matrix for cross-cutting changes:
      producer, consumer, build/runtime behavior, platform/toolchain boundary,
      CI trigger, dependency owner, and local evidence
- [ ] Reviewed active and suppressed automated findings from review threads and summaries
- [ ] For Python package changes, followed `docs/python-packaging-release.md` for PR and merge requirements
- [ ] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [ ] New source files include the ICC copyright and BSD 3-Clause license header
- [ ] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consortium (ICC)
follows the open source software best practice policies. The [International Color Consortium IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
