### PR TITLE
test(#2220): give the ResolutionUnit regression a timeout budget it can use

### DIFF
--- a/.github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh
+++ b/.github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh
@@ -239,6 +239,12 @@ require_tool() {
   return 0
 }
 
+# Per-case timeouts are held well under the CTest TIMEOUT this script is registered
+# with (Build/Cmake/Testing/CMakeLists.txt).  They were 60 and 120 against a 120s
+# budget, so across seven case invocations the worst case was 480s: CTest killed the
+# whole script first and the per-case "got exit=124" line and its log tail -- the only
+# things that say WHICH case hung -- were never printed.
+#
 # iccSpecSepToTiff must hand the unit of its input channels to its output.  Run
 # for each of the three units TIFF defines, including RESUNIT_INCH: before the
 # fix no unit tag was written at all, so the inch case is a real assertion rather
@@ -267,7 +273,7 @@ run_specsep_unit_preserved() {
     fi
   done
 
-  timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$WORKDIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
+  timeout 30 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$WORKDIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
 
   if ! check_sanitizers "$name" "$LOGFILE"; then
     sed -n '1,40p' "$LOGFILE"
@@ -312,7 +318,7 @@ run_specsep_unit_mismatch_rejected() {
     return
   fi
 
-  timeout 60 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$WORKDIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
+  timeout 30 "$SPECSEP" "$OUTPUT_TIFF" 0 0 "$WORKDIR/spec_" 1 2 1 > "$LOGFILE" 2>&1 || exit_code=$?
 
   if ! check_sanitizers "$name" "$LOGFILE"; then
     sed -n '1,40p' "$LOGFILE"
@@ -365,7 +371,7 @@ run_applyprofiles_unit_preserved() {
     return
   fi
 
-  timeout 120 "$APPLYPROFILES" "$WORKDIR/source.tif" "$OUTPUT_TIFF" 0 0 0 0 1 \
+  timeout 30 "$APPLYPROFILES" "$WORKDIR/source.tif" "$OUTPUT_TIFF" 0 0 0 0 1 \
     "$SRGB_PROFILE" 1 > "$LOGFILE" 2>&1 || exit_code=$?
 
   if ! check_sanitizers "$name" "$LOGFILE"; then
@@ -411,7 +417,7 @@ run_tiffdump_reports_unit() {
     return
   fi
 
-  timeout 60 "$TIFFDUMP" "$WORKDIR/source.tif" > "$LOGFILE" 2>&1 || exit_code=$?
+  timeout 30 "$TIFFDUMP" "$WORKDIR/source.tif" > "$LOGFILE" 2>&1 || exit_code=$?
 
   if ! check_sanitizers "$name" "$LOGFILE"; then
     sed -n '1,40p' "$LOGFILE"
@@ -462,7 +468,7 @@ run_tiffdump_relative_resolution() {
     return
   fi
 
-  timeout 60 "$TIFFDUMP" "$WORKDIR/source.tif" > "$LOGFILE" 2>&1 || exit_code=$?
+  timeout 30 "$TIFFDUMP" "$WORKDIR/source.tif" > "$LOGFILE" 2>&1 || exit_code=$?
 
   if ! check_sanitizers "$name" "$LOGFILE"; then
     sed -n '1,40p' "$LOGFILE"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7612,7 +7612,7 @@ endif()
 if(TARGET iccSpecSepToTiff AND TARGET iccApplyProfiles AND TARGET iccTiffDump)
   iccdev_add_script_test(
     iccdev.tiff-resolution-unit-regression
-    120
+    300
     "iccdev;tools;tiff;resolution;regression;asan"
     "${ICCDEV_REPO_ROOT}"
     "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-tiff-resolution-unit-regression-tests.sh"


### PR DESCRIPTION
Follow-up to #2220, found while adding a sibling script in #2392 (#2379 item 3). No behaviour under test changes.

## Defect

`iccdev-tiff-resolution-unit-regression-tests.sh` guards each case with `timeout 60` (and one `timeout 120`), but the CTest it is registered with had `TIMEOUT 120`. Seven case invocations at those values is a **480s worst case against a 120s budget**, so the per-case guard could never do its job — CTest killed the whole script first, and the `expected a successful conversion, got exit=124` line plus the `sed -n '1,40p' "$LOGFILE"` tail, the only output identifying *which* case hung, were never printed. The `timeout 120` call could not fire at all, being equal to the entire budget.

| | before | after |
|---|---|---|
| per-case timeout | 60s / 120s | 30s |
| worst case (7 invocations) | 480s | 210s |
| CTest `TIMEOUT` | 120s | 300s |
| observed suite runtime | ~1.1s | ~1.1s |

## Measured

Stubbing `iccSpecSepToTiff` with a `sleep`, the four cases that reach it each report their own name and `exit=124`, and the run finishes in **125s** — inside the new budget:

```
[FAIL] specsep-resolution-unit-centimeter-preserved -- expected a successful conversion, got exit=124
[FAIL] specsep-resolution-unit-inch-preserved -- expected a successful conversion, got exit=124
[FAIL] specsep-resolution-unit-none-preserved -- expected a successful conversion, got exit=124
[FAIL] specsep-resolution-unit-mismatch-rejected -- expected graceful reject exit=255, got exit=124
TIFF ResolutionUnit propagation regression: 3 passed, 4 failed, 7 total
```

Before this change CTest terminated the script partway through the third case with no per-case output at all.

Unstubbed, `ctest -R tiff-resolution-unit` passes in 1.07s. `shellcheck` clean.

## ⚠️ CI cannot validate this PR — please read the check list accordingly

This diff touches only a `.sh` and `CMakeLists.txt`. `ci-pr-action.yml:557,599` sets `native_changed` **only** for a `.cpp|.cxx|.cc|.c|.h|.hpp|.hh` edit, and every compiler and CTest job gates on `native_changed == 'true'` (`:1011,1020,1035,1043,1057`) — independent of `ci_scope`. So the CTest lanes will be **skipped**, and a green check list here is not evidence that the test still passes.

Confirmed, not predicted. Pre-PR dispatch `ci_scope=auto`, run [33913220884](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33913220884) — **conclusion `success`**, with every build and test lane skipped:

```
success  Welcome to iccDEV / Thank You for the PR / Init PR Validation
success  Risk Analysis Gate / Workflow Security Audit
skipped  GCC 15.2 Strict Release LTO
skipped  macOS Clang Debug / macOS Clang Release LTO
skipped  Windows Build & Test Profiles
skipped  Tool Smoke Tests (ASAN+UBSAN, Debug)
success  PR Summary
```

So this PR's green is governance only. The evidence for the change itself is the local run and the stubbed-hang measurement above.
