### PR TITLE
fix(#2387): keep every digit of an XML profile version, and encode the sub-class version as BCD

### DIFF
--- a/.github/ci/regression/xml-version-parse.cpp
+++ b/.github/ci/regression/xml-version-parse.cpp
@@ -1,0 +1,278 @@
+// Regression for #2387 findings 1 and 2: CIccProfileXml::ParseBasic must keep every
+// digit of a multi-component version, and must encode the sub-class version as BCD.
+//
+// This is the XML twin of .github/ci/regression/json-bcd-version-parse.cpp (#1830).
+//
+// ParseBasic walks "<major>.<minor>.<classMajor>.<classMinor>" one component at a
+// time. 889db62b repaired the first two loops from
+//
+//     ver = *szVer;      // assigns -- each pass discards the previous digit
+// to
+//     ver += *szVer;     // accumulates
+//
+// but left the third and fourth loops, and both loops of the separate
+// <ProfileSubClassVersion> element, in the assigning form. Only the last digit of
+// each of those components therefore reached the parser, so a document asking for
+// 5.10.12.34 was written to header bytes 8..11 as 05 10 02 04 -- and iccFromXml
+// still reported "Profile parsed and saved correctly".
+//
+// The <ProfileSubClassVersion> block carried two further defects that only cancel
+// out together with the first:
+//
+//   * its major loop never stepped over the separator, so the minor loop ran zero
+//     times and atoi("") supplied 0 -- "12.34" became 2.00, not 2.04; and
+//   * it used atoi() directly, storing a raw decimal where bytes 10..11 hold BCD.
+//
+// That last one makes a partial repair worse than no repair. Accumulating the digits
+// but keeping atoi() puts "12.34" in the header as 0x0C22, which
+// CIccInfo::GetSubClassVersionName rejects outright:
+//
+//     SubClass Version:   Invalid BCD subclass version 0x0C22
+//
+// where the unrepaired code at least produced the valid-but-wrong 0x0200. Hence the
+// explicit BCD assertions below: they fail for the atoi() form even once the digits
+// accumulate correctly. Both components now go through parseVersion, the strict
+// helper the <ProfileVersion> path already used, which is what
+// icJsonParseBCDVersionStr does on the JSON side.
+//
+// The test drives the public CIccProfileXml::ParseXml so it exercises the real
+// header path rather than the file-static helper.
+//
+// Red-green: restoring "ver = *szVer" in either pair of loops fails the
+// four-component and sub-class cases; keeping atoi() in place of parseVersion fails
+// the BCD assertions.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccProfileXml.h"
+#include "IccUtil.h"
+
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#ifdef USEICCDEVNAMESPACE
+using namespace iccDEV;
+#endif
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    std::fprintf(stderr, "[xml-version] FAIL: %s\n", what);
+  }
+}
+
+// Build the smallest document ParseXml accepts -- it requires an <IccProfile> root
+// carrying both a <Header> and a <Tags> element -- with the supplied version
+// elements, parse it, and hand back the resulting packed header version.
+// bParsed/parseStr report what ParseBasic told the caller, which is how iccFromXml
+// decides whether to print a reason.
+icUInt32Number parseVersion(const char *szVersion, const char *szSubClassVersion,
+                            bool *pParsed = NULL, std::string *pParseStr = NULL)
+{
+  std::string doc = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<IccProfile>\n  <Header>\n";
+
+  if (szVersion) {
+    doc += "    <ProfileVersion>";
+    doc += szVersion;
+    doc += "</ProfileVersion>\n";
+  }
+  if (szSubClassVersion) {
+    doc += "    <ProfileSubClassVersion>";
+    doc += szSubClassVersion;
+    doc += "</ProfileSubClassVersion>\n";
+  }
+  doc += "  </Header>\n  <Tags/>\n</IccProfile>\n";
+
+  xmlDoc *pDoc = xmlReadMemory(doc.c_str(), (int)doc.size(), "version.xml", NULL, 0);
+  if (!pDoc) {
+    ++g_fail;
+    std::fprintf(stderr, "[xml-version] FAIL: libxml2 could not parse the test document\n");
+    return 0;
+  }
+
+  CIccProfileXml profile;
+  std::string parseStr;
+  bool bParsed = profile.ParseXml(xmlDocGetRootElement(pDoc), parseStr);
+
+  if (pParsed)
+    *pParsed = bParsed;
+  if (pParseStr)
+    *pParseStr = parseStr;
+
+  icUInt32Number version = profile.m_Header.version;
+  xmlFreeDoc(pDoc);
+  return version;
+}
+
+void checkVersion(const char *szVersion, icUInt32Number expected, const char *what)
+{
+  icUInt32Number got = parseVersion(szVersion, NULL);
+  if (got != expected) {
+    ++g_fail;
+    std::fprintf(stderr,
+                 "[xml-version] FAIL: %s -- \"%s\" gave 0x%08X, expected 0x%08X\n",
+                 what, szVersion ? szVersion : "(none)",
+                 (unsigned int)got, (unsigned int)expected);
+  }
+}
+
+void checkSubClass(const char *szSubClassVersion, icUInt32Number expectedLow,
+                   const char *what)
+{
+  icUInt32Number got = parseVersion("5.10", szSubClassVersion);
+  if ((got & 0x0000ffffu) != expectedLow) {
+    ++g_fail;
+    std::fprintf(stderr,
+                 "[xml-version] FAIL: %s -- \"%s\" gave low half 0x%04X, expected 0x%04X\n",
+                 what, szSubClassVersion ? szSubClassVersion : "(none)",
+                 (unsigned int)(got & 0x0000ffffu), (unsigned int)expectedLow);
+  }
+  // The <ProfileVersion> half must be untouched by the sub-class element, which
+  // shares the same header word.
+  if ((got & 0xffff0000u) != 0x05100000u) {
+    ++g_fail;
+    std::fprintf(stderr,
+                 "[xml-version] FAIL: %s -- sub-class element disturbed the version half (0x%08X)\n",
+                 what, (unsigned int)got);
+  }
+}
+
+} // namespace
+
+int main()
+{
+  // --- two-component versions are unchanged ------------------------------------
+  // CIccInfo::GetVersionName writes "%.2lf", so "4.30" is the canonical round-trip
+  // form. These pin the repair as behaviour-neutral for input that already parsed.
+
+  checkVersion("4.30", 0x04300000u, "\"4.30\" encodes as 0x0430");
+  checkVersion("5.10", 0x05100000u, "\"5.10\" encodes as 0x0510");
+  checkVersion("2.20", 0x02200000u, "\"2.20\" encodes as 0x0220");
+
+  // A missing minor component keeps its previous meaning ("4" == "4.0"), and a
+  // single-digit minor keeps its previous encoding: parseVersion maps 3 to 0x03
+  // rather than 0x30, matching icJsonParseBCDByte on the JSON side.
+  checkVersion("4", 0x04000000u, "\"4\" encodes as 0x0400");
+  checkVersion("4.3", 0x04030000u, "\"4.3\" encodes as 0x0403 (unchanged quirk)");
+
+  // --- finding 1: the third and fourth components lost their leading digit ------
+  // The issue's own fixture. Before the repair this gave 0x05100204.
+
+  checkVersion("5.10.12.34", 0x05101234u,
+               "four-component version keeps every digit (#2387 finding 1)");
+  checkVersion("5.10.12", 0x05101200u,
+               "three-component version keeps the class major's leading digit");
+  checkVersion("5.10.1.2", 0x05100102u,
+               "single-digit class components are unaffected");
+
+  // The strictness of the shared helper reaches the later components too: a
+  // malformed one rejects the whole version rather than landing partly parsed.
+  checkVersion("5.10.99.99", 0x05109999u, "the BCD ceiling of 99 is accepted");
+  checkVersion("5.10.100.0", 0u, "a three-digit class major rejects the version");
+  checkVersion("5.10.12.-1", 0u, "a negative class minor rejects the version");
+  checkVersion("5.10.ab.34", 0u, "a non-numeric class major rejects the version");
+
+  // --- finding 2: the explicit <ProfileSubClassVersion> element -----------------
+  // Before the repair "12.34" gave 0x0200: the major loop kept only '2', and
+  // because it never stepped over the '.', the minor loop ran zero times.
+
+  checkSubClass("12.34", 0x1234u,
+                "explicit sub-class version keeps both components (#2387 finding 2)");
+  checkSubClass("1.20", 0x0120u, "single-digit sub-class major is unaffected");
+  checkSubClass("12", 0x1200u, "a missing sub-class minor stays 0 (\"12\" == \"12.00\")");
+
+  // These are the assertions a digits-only repair fails. atoi() would store "12" as
+  // decimal 12 == 0x0C and "34" as 0x22, giving 0x0C22 -- a value
+  // GetSubClassVersionName reports as "Invalid BCD subclass version".
+  {
+    icUInt32Number v = parseVersion("5.10", "12.34");
+    check(((v >> 8) & 0xf0u) == 0x10u && ((v >> 8) & 0x0fu) == 0x02u,
+          "sub-class major is BCD 0x12, not decimal 0x0C");
+    check((v & 0xf0u) == 0x30u && (v & 0x0fu) == 0x04u,
+          "sub-class minor is BCD 0x34, not decimal 0x22");
+
+    // The user-visible consequence, asserted through the reader the writer uses.
+    CIccInfo info;
+    const char *szName = info.GetSubClassVersionName(v);
+    check(szName && !std::strstr(szName, "Invalid"),
+          "GetSubClassVersionName accepts the encoded sub-class version");
+    check(szName && !std::strcmp(szName, "12.34"),
+          "GetSubClassVersionName renders the sub-class version back as \"12.34\"");
+  }
+
+  // The sub-class element now shares <ProfileVersion>'s strictness. Each of these
+  // previously reached the header as a silent 0 via atoi() with no diagnostic.
+  checkSubClass("-1", 0u, "a negative sub-class version is rejected");
+  checkSubClass("999", 0u, "a three-digit sub-class major is rejected");
+  checkSubClass("abc", 0u, "a non-numeric sub-class version is rejected");
+  checkSubClass("", 0u, "an empty sub-class version is rejected");
+
+  // --- whitespace around a component ------------------------------------------
+  // A component carries the element's literal text, so a pretty-printed or
+  // hand-edited document indents it or leaves a trailing space. icXmlParseU32
+  // requires the whole string to be consumed and strtoull skips leading blanks but
+  // not trailing ones, so "5.10 " reached the header as 0 -- true of
+  // <ProfileVersion> since #1845, and routing <ProfileSubClassVersion> through the
+  // same helper would have spread it to a field whose atoi() had tolerated it.
+  // parseVersion now trims, so both elements accept surrounding whitespace.
+
+  checkVersion("5.10 ", 0x05100000u, "a trailing space does not zero the version");
+  checkVersion(" 5.10", 0x05100000u, "a leading space does not zero the version");
+  checkVersion("\n    5.10\n  ", 0x05100000u,
+               "an indented, pretty-printed version parses");
+  checkVersion("5 . 10", 0x05100000u, "whitespace around the separator is trimmed");
+  checkVersion("5.10.12.34 ", 0x05101234u,
+               "a trailing space on the four-component form is trimmed");
+  checkSubClass("2.00 ", 0x0200u,
+                "a trailing space does not zero the sub-class version");
+  checkSubClass(" 12.34 ", 0x1234u,
+                "surrounding whitespace on the sub-class version is trimmed");
+
+  // Trimming must not turn an all-blank component into a zero.
+  checkVersion("5. ", 0u, "an all-blank minor component is still rejected");
+  checkSubClass("   ", 0u, "an all-blank sub-class version is still rejected");
+
+  // --- a component too many -----------------------------------------------------
+  // The header holds four components; the sub-class version holds two. Anything
+  // beyond that was silently truncated, which diverged from
+  // icJsonParseBCDVersionStr -- it hands the whole remainder to a helper that
+  // refuses more than two digits.
+
+  checkVersion("5.10.12.34.56", 0u, "a fifth version component is rejected");
+  checkSubClass("1.2.3", 0u, "a third sub-class component is rejected");
+
+  // A rejected component must say so. iccFromXml only prints the reason when
+  // ParseXml fails, but the string is what carries the explanation either way.
+  {
+    bool bParsed = false;
+    std::string parseStr;
+    parseVersion("5.10", "abc", &bParsed, &parseStr);
+    check(parseStr.find("Cannot parse ProfileSubClassVersion") != std::string::npos,
+          "a rejected sub-class version records a reason");
+  }
+
+  // --- the two elements must not fight over the same header word ---------------
+  // <ProfileVersion>'s four-component form writes all four bytes; a later
+  // <ProfileSubClassVersion> overwrites only the low half.
+  {
+    icUInt32Number v = parseVersion("5.10.12.34", "56.78");
+    check(v == 0x05105678u,
+          "an explicit sub-class version overrides the four-component form");
+  }
+
+  if (g_fail)
+    std::fprintf(stderr, "[xml-version] %d assertion(s) failed\n", g_fail);
+  else
+    std::fprintf(stdout, "[xml-version] all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5137,6 +5137,63 @@ function(iccdev_add_json_bcd_version_test)
   endif()
 endfunction()
 
+# #2387 findings 1 and 2: CIccProfileXml::ParseBasic walked a multi-component version
+# one component at a time, but 889db62b repaired only the first two loops from
+# "ver = *szVer" (assign, keeping the last digit) to "ver += *szVer" (accumulate).
+# The third and fourth loops, and both loops of the separate <ProfileSubClassVersion>
+# element, kept the assigning form, so "5.10.12.34" reached header bytes 8..11 as
+# 05 10 02 04 while iccFromXml reported a correct save. The sub-class block also
+# never stepped over its separator (its minor loop ran zero times) and used atoi()
+# where the header holds BCD -- so accumulating the digits alone would have written
+# 0x0C22, which GetSubClassVersionName rejects as "Invalid BCD subclass version".
+# Both components now use parseVersion, matching icJsonParseBCDVersionStr on the
+# JSON side (see iccdev.json-bcd-version-parse, the twin of this test). Drives the
+# public CIccProfileXml::ParseXml, so it needs IccXML + IccProfLib + libxml2 and is
+# skipped where IccXML is not built.
+function(iccdev_add_xml_version_parse_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccXmlVersionParseTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/xml-version-parse.cpp"
+  )
+  target_compile_features(iccXmlVersionParseTest PRIVATE cxx_std_17)
+  target_include_directories(iccXmlVersionParseTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccXML/IccLibXML"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+    ${LIBXML2_INCLUDE_DIR}
+  )
+  target_link_libraries(iccXmlVersionParseTest PRIVATE
+    ${TARGET_LIB_ICCXML} ${TARGET_LIB_ICCPROFLIB} ${LIBXML2_LIBRARIES})
+  add_dependencies(check iccXmlVersionParseTest)
+
+  add_test(
+    NAME iccdev.xml-version-parse
+    COMMAND "$<TARGET_FILE:iccXmlVersionParseTest>"
+  )
+  set_tests_properties(iccdev.xml-version-parse PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_TEST_OUTDIR}"
+    TIMEOUT 60
+    LABELS "iccdev;xml;header;issue-2387;regression"
+  )
+  if(WIN32)
+    set(_xml_version_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccXmlVersionParseTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCXML}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _xml_version_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.xml-version-parse PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_xml_version_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
+
 # #1911: the JSON writers handed every payload up to the document root by value, so a
 # CLUT-bearing tag's samples were deep-copied and destroyed once per level of the
 # chain (data -> clut -> tagData -> tagObj -> entry -> Tags -> IccProfile). Those
@@ -6951,6 +7008,7 @@ if(WIN32)
   iccdev_add_installed_package_consumer_test()
   iccdev_add_windows_runtime_paths_test()
   iccdev_add_json_bcd_version_test()
+  iccdev_add_xml_version_parse_test()
   iccdev_add_json_writer_move_test()
   iccdev_add_json_fixednum_size_cap_test()
   iccdev_add_json_srng_uf32_test()
@@ -7317,6 +7375,7 @@ iccdev_add_proflib_exported_data_linkage_test()
 iccdev_add_proflib_exported_global_definitions_test()
 iccdev_add_installed_package_consumer_test()
 iccdev_add_json_bcd_version_test()
+iccdev_add_xml_version_parse_test()
 iccdev_add_json_writer_move_test()
 iccdev_add_json_fixednum_size_cap_test()
 iccdev_add_json_srng_uf32_test()

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -410,7 +410,23 @@ static bool parseVersion(const std::string &sPart, unsigned long &rv)
 {
   icUInt32Number v = 0;
 
-  if (!icXmlParseU32(sPart.c_str(), v, 99))
+  // Trim first: a component carries the element's literal text, so a
+  // pretty-printed or hand-edited document indents it ("<ProfileVersion>\n
+  // 5.10\n</ProfileVersion>") or leaves a trailing space. icXmlParseU32 requires
+  // the whole string to be consumed, and strtoull skips leading blanks but not
+  // trailing ones, so "5.10 " was rejected outright and the version reached the
+  // header as 0 -- silently, since ParseBasic still returns true. That has been
+  // true of <ProfileVersion> since the #1845 repair put this helper on that path;
+  // routing <ProfileSubClassVersion> through the same helper would otherwise have
+  // spread it to a field whose atoi() had tolerated the whitespace.
+  std::string sTrimmed = sPart;
+  const char *szBlank = " \t\r\n\f\v";
+  std::string::size_type nFirst = sTrimmed.find_first_not_of(szBlank);
+  if (nFirst == std::string::npos)
+    return false;
+  sTrimmed = sTrimmed.substr(nFirst, sTrimmed.find_last_not_of(szBlank) - nFirst + 1);
+
+  if (!icXmlParseU32(sTrimmed.c_str(), v, 99))
     return false;
 
   rv = ((v / 10) % 10) * 16 + (v % 10);
@@ -471,8 +487,12 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
           szVer++;
 
         if (bVerOk && *szVer) {
+          // Accumulate rather than assign.  889db62b repaired the major and
+          // minor loops above but left these two, so every iteration overwrote
+          // the previous digit and only the last one reached parseVersion:
+          // "5.10.12.34" landed as 05 10 02 04.
           for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
-            ver = *szVer;
+            ver += *szVer;
           }
           bVerOk = parseVersion(ver, verClassMajor);
           ver.clear();
@@ -481,10 +501,17 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
 
           if (bVerOk && *szVer) {
             for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
-              ver = *szVer;
+              ver += *szVer;
             }
             bVerOk = parseVersion(ver, verClassMinor);
             ver.clear();
+
+            // The header holds exactly four components, so anything still
+            // unconsumed is a fifth. Rejecting rather than silently truncating
+            // is what icJsonParseBCDVersionStr does -- it hands the whole
+            // remainder to a helper that refuses more than two digits.
+            if (bVerOk && *szVer)
+              bVerOk = false;
           }
         }
       }
@@ -509,18 +536,51 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
       const char *szVer = (const char*)pNode->children->content;
       std::string ver;
       unsigned long verClassMajor = 0, verClassMinor = 0;
+      // Three defects shared this block and they only cancel out together: the
+      // loops assigned instead of appending, so only the last digit survived;
+      // the major loop never stepped over the separator, so the minor loop ran
+      // zero times and atoi("") supplied 0; and atoi() stored a raw decimal
+      // where the header holds BCD.  Repairing only the first would have put
+      // "12" in the byte as 0x0C, which GetSubClassVersionName then rejects as
+      // "Invalid BCD subclass version".  parseVersion is the strict BCD helper
+      // ProfileVersion already uses, and matches icJsonParseBCDVersionStr on
+      // the JSON side.
+      bool bVerOk = false;
 
-      if (szVer) {
+      for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
+        ver += *szVer;
+      }
+      bVerOk = parseVersion(ver, verClassMajor);
+      ver.clear();
+      if (*szVer)
+        szVer++;
+
+      // A missing minor component stays 0, so "12" means "12.00"; a present but
+      // malformed one rejects the whole subclass version.
+      if (bVerOk && *szVer) {
         for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
-          ver = *szVer;
+          ver += *szVer;
         }
-        verClassMajor = (unsigned char)atoi(ver.c_str());
+        bVerOk = parseVersion(ver, verClassMinor);
         ver.clear();
-        
-        for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
-          ver = *szVer;
-        }
-        verClassMinor = (unsigned char)atoi(ver.c_str());
+
+        // As above: the sub-class version is two components, so a third is a
+        // malformation rather than something to truncate away.
+        if (bVerOk && *szVer)
+          bVerOk = false;
+      }
+
+      if (!bVerOk) {
+        // Malformed input already reached the header as zero via atoi(), so the
+        // stored value is unchanged; what is new is the recorded reason. Note
+        // iccFromXml prints parseStr only when LoadXml fails, and ParseBasic
+        // returns true regardless, so this string is not yet surfaced on the
+        // command line -- that suppression is #2387 finding 4 / #2384, which
+        // needs a ruling on the tool's exit contract before it can move.
+        parseStr += "Cannot parse ProfileSubClassVersion '";
+        parseStr += (const char*)pNode->children->content;
+        parseStr += "'\n";
+        verClassMajor = verClassMinor = 0;
       }
 
       m_Header.version = (m_Header.version & 0xffff0000) | (((verClassMajor << 8) | verClassMinor) & 0x0000ffff);


### PR DESCRIPTION
Part of #2387 — findings 1 and 2. Findings 3, 4 and 5 are left open; see the bottom.

## What it was

Not an original bug — a partial repair. `4628668d` (2019) wrote all four `<ProfileVersion>` component loops as `ver = *szVer`, which **assigns**, so each pass discards the previous digit. `889db62b` (2023) fixed exactly two of them to `ver += *szVer` and stopped. Loops 3 and 4, and both loops of the separate `<ProfileSubClassVersion>` element, kept the broken form.

`<ProfileSubClassVersion>` carried two further defects that only cancel out together with that one:

* its major loop never stepped over the separator, so the minor loop ran zero times and `atoi("")` supplied 0 — `12.34` became `2.00`, not even `2.04`;
* it called `atoi()` directly, storing a raw decimal where header bytes 10–11 hold BCD.

That last one makes a partial repair **worse than none**. I built it to check:

| `<ProfileSubClassVersion>12.34</...>` | bytes 8–11 | `iccDumpProfile` |
|---|---|---|
| master | `05100200` | `SubClass Version: 2.00` |
| digits-only repair | `05100c22` | `SubClass Version: Invalid BCD subclass version 0x0C22` |
| this PR | `05101234` | `SubClass Version: 12.34` |

Both components now go through `parseVersion`, the strict helper the `<ProfileVersion>` path already used and the twin of `icJsonParseBCDVersionStr` on the JSON side.

## Two consequences of that routing, fixed here rather than left to be discovered

**Whitespace.** `parseVersion` rejects a component it cannot consume whole, and `strtoull` skips leading blanks but not trailing ones. So `<ProfileSubClassVersion>2.00 </...>` — an ordinary pretty-printed or hand-edited value — would have reached the header as 0 where `atoi()` had tolerated it. `parseVersion` now trims. That also repairs `<ProfileVersion>`, which has been silently zeroing on `5.10 ` since the #1845 repair put it on this helper:

| input | master | this PR |
|---|---|---|
| `<ProfileSubClassVersion>2.00 </...>` | `0200` ✔ | `0200` ✔ |
| `<ProfileVersion>5.10 </...>` | `0000` ✘ | `0510` ✔ |

**A component too many.** `1.2.3` was silently truncated to `0x0102`, diverging from `icJsonParseBCDVersionStr`, which hands the whole remainder to a helper that refuses more than two digits. Both elements now reject it.

## Verification

* **Corpus swept over every tracked `*.xml`**, not just `Testing/`. No tracked file uses the three- or four-component `<ProfileVersion>` form at all, so finding 1 is byte-neutral repo-wide. Of six distinct `<ProfileSubClassVersion>` values, only the two in the deliberately malformed #1342/#1343 UBSan fixtures parse differently — and both documents are already rejected at a later tag, so **no generated artifact changes bytes**. The two CTests using those fixtures key on UBSan output, not the header.
* New CTest `iccdev.xml-version-parse`, the XML twin of the existing `iccdev.json-bcd-version-parse`, driving the public `ParseXml`.
  * **Red on master: 22 assertions fail**, while every behaviour-neutral pin (`4.30`, `5.10`, `4`, `4.3`, `5.10.1.2`) passes — so it discriminates rather than failing everything.
  * **Red against a digits-only repair: 11 fail**, including the explicit BCD assertions and the `GetSubClassVersionName` round-trip.
  * Both wrong versions were built and measured, not argued.
* Full `check` build **244/245**, zero warnings under `-DICCDEV_ENABLE_STRICT_WARNINGS=ON` (clang) and under a separate GCC `-Wall -Wextra -Wpedantic -Werror` lane. The one failure is `iccdev.spectral-tiff-preview` → `ModuleNotFoundError: No module named 'imagecodecs'`, pre-existing and environmental.
* Clean under ASan+UBSan with `detect_leaks=1`, on a binary confirmed instrumented.
* Pre-PR `ci_scope=source` dispatch: run 33922298658.

## Not addressed here

* **Finding 3** (unknown `RenderingIntent` silently becomes Perceptual) is real — 216 of the 218 tracked `RenderingIntent` values are recognised, and the 2 that are not are the library's own `Unknown Intent '%d'` output inside the already-rejected #1342/#1343 fixtures — but it has **no good standalone fix**, so it is not queued as a follow-up:
  * *Record a reason and continue*, as #1845 did for the version, is invisible here: 0 is a **valid** intent (it is Perceptual), and `parseStr` prints only when `LoadXml` fails while `ParseBasic` returns true regardless. That is finding 4.
  * *`return false`* surfaces it, but `ParseBasic` then aborts before `ParseXml` reaches the tags. Measured on `ub-normalimage-parsexml-1343.xml`: the `Invalid SeamlessIndicator in NormalImage` and `embeddedNormalImageType` diagnostics disappear, so the image-parse path those two fixtures exist to exercise is never entered and **both UBSan regressions would pass while testing nothing**.

  So finding 3's remedy depends on finding 4's ruling.
* **Findings 4 and 5** are in `IccFromXml.cpp`, not the parser, and finding 4 is the iccDEV half of #2384. Both are questions about the tool's exit contract rather than defects with an obvious fix — raised on #2387 for a ruling.
* One limitation of this PR: a rejected sub-class version now records a `Cannot parse ProfileSubClassVersion '…'` reason, but `iccFromXml` prints `parseStr` only when `LoadXml` fails and `ParseBasic` returns true regardless — so it is **not yet surfaced on the command line**. That is exactly finding 4.
* If `<ProfileSubClassVersion>` precedes `<ProfileVersion>`, the latter's whole-word assignment still discards it (`0x05100000`). Pre-existing, the writer never emits that order, and unlike the JSON twin — which masks — distinguishing it needs a component count, so it is left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTQQ6sMWnHkNEA9QedNpMT
