### PR TITLE
fix(#2386): report an ExtraSamples tag libtiff repaired, and keep Create()'s write status

### DIFF
--- a/.github/scripts/iccdev-tiff-extrasamples-diagnostics-tests.sh
+++ b/.github/scripts/iccdev-tiff-extrasamples-diagnostics-tests.sh
@@ -1,0 +1,498 @@
+#!/bin/bash
+###############################################################################
+# ExtraSamples diagnostic-fidelity regression (#2386)
+###############################################################################
+#
+# CTiffImg::Open() discarded the return of its TIFFGetField(TIFFTAG_EXTRASAMPLES)
+# call, so nothing downstream could tell "tag 338 absent" from "tag 338 stored".
+# iccTiffDump then printed its ExtraSamples line only when the count was nonzero
+# and said nothing at all about a directory libtiff had repaired.
+#
+# libtiff repairs a file whose photometric model plus stored ExtraSamples do not
+# account for SamplesPerPixel, warns on stderr ("Defining non-color channels as
+# ExtraSamples") and names no count.  It publishes the repaired figure ONLY
+# through TIFFGetFieldDefaulted; the plain Get still fails.  So the dump reported
+# SamplesPerPixel 81 against a one-channel photometric model and left the other
+# 80 channels unmentioned.
+#
+# The count colour management uses -- CTiffImg::GetExtraSamples() -- is
+# deliberately NOT changed by the fix: libtiff calls every unaccounted channel an
+# extra sample, and feeding 80 to iccApplyProfiles would reclassify an 81-band
+# spectral image's bands as alpha.  Case 4 pins that separation.
+#
+# Only the ABSENT-tag half of the gap is closed.  Where tag 338 is present and
+# libtiff still repairs, it overwrites the stored count in place while leaving the
+# field marked present, so the plain getter returns the repaired figure and the
+# original is unrecoverable through libtiff.  Case 2 pins that limit deliberately,
+# with a fixture whose stored and repaired counts disagree.
+#
+# Fixtures are written byte by byte rather than through an encoder so the tag
+# under test is exactly what the test intends, and tag presence is read back out
+# of the IFD directly rather than through a tool, so a tool reporting presence
+# wrongly cannot make a case pass for the wrong reason.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-tiff-extrasamples-diagnostics}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+TIFFDUMP="$TOOLS_DIR/IccTiffDump/iccTiffDump"
+# Tracked, and the file the report was filed against: 81 bands, MinIsBlack, no
+# tag 338.  Every Testing/*.icc is generated, but this .tif is in the repo.
+TRACKED_SPECTRAL="$REPO_ROOT/Testing/hybrid/Data/smCows380_5_780.tif"
+
+WORKDIR="$OUTDIR/tiff-extrasamples-diagnostics"
+LOGFILE="$OUTDIR/tiff-extrasamples-diagnostics.log"
+rm -rf "$WORKDIR"
+mkdir -p "$WORKDIR"
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+
+pass_case() {
+  PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1))
+  printf '[PASS] %s -- %s\n' "$1" "$2" | tee -a "$LOGFILE"
+}
+
+fail_case() {
+  FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1))
+  printf '[FAIL] %s -- %s\n' "$1" "$2" | tee -a "$LOGFILE"
+}
+
+skip_case() {
+  SKIP=$((SKIP + 1)); TOTAL=$((TOTAL + 1))
+  printf '[SKIP] %s -- %s\n' "$1" "$2" | tee -a "$LOGFILE"
+}
+
+# generate_tiff <path> <width> <height> <samples> <photometric> <extrasamples...>
+# Writes a minimal single-strip 8-bit TIFF.  Tag 338 is emitted only when extra
+# sample values are supplied, so "no trailing arguments" produces exactly the
+# malformed shape this issue is about: a photometric model that accounts for
+# fewer channels than SamplesPerPixel, with nothing to explain the difference.
+generate_tiff() {
+  python3 - "$@" <<'PY'
+import pathlib
+import struct
+import sys
+
+path = pathlib.Path(sys.argv[1])
+width = int(sys.argv[2])
+height = int(sys.argv[3])
+samples = int(sys.argv[4])
+photometric = int(sys.argv[5])
+extras = [int(a) for a in sys.argv[6:]]
+path.parent.mkdir(parents=True, exist_ok=True)
+
+pixel_data = bytes([0x40]) * (width * height * samples)
+
+data_offset = 8
+strip_bytes = len(pixel_data)
+cursor = data_offset + strip_bytes
+if cursor % 2:
+    # Pad only to keep the following IFD word-aligned; StripByteCounts stays the
+    # unpadded length so libtiff does not read past the pixel data.
+    pixel_data += b"\0"
+    cursor += 1
+
+# A SHORT array of two or fewer values fits in the entry's own 4-byte value field,
+# and libtiff reads it from there (TIFFReadDirEntryArrayWithLimit memcpys out of
+# tdir_offset when datasize <= 4).  Writing an offset instead made a 2-sample
+# fixture decode BitsPerSample as the offset's two halves.  Tag 338 below already
+# had this case; tag 258 needs it too.
+bps_inline = samples <= 2
+
+bps_offset = cursor
+if samples > 1 and not bps_inline:
+    cursor += 2 * samples
+
+# ExtraSamples needs an out-of-line array once it carries more than two values.
+extras_offset = cursor
+extras_inline = len(extras) <= 2
+if extras and not extras_inline:
+    cursor += 2 * len(extras)
+    if cursor % 2:
+        cursor += 1
+
+ifd_offset = cursor
+
+entries = [
+    (256, 4, 1, width),
+    (257, 4, 1, height),
+    (258, 3, samples, 8 if samples == 1 else (0 if bps_inline else bps_offset)),
+    (259, 3, 1, 1),
+    (262, 3, 1, photometric),
+    (273, 4, 1, data_offset),
+    (277, 3, 1, samples),
+    (278, 4, 1, height),
+    (279, 4, 1, strip_bytes),
+    (284, 3, 1, 1),
+    (296, 3, 1, 2),
+]
+if extras:
+    entries.append((338, 3, len(extras), extras[0] if extras_inline else extras_offset))
+entries.sort()
+
+data = bytearray(b"II" + struct.pack("<H", 42) + struct.pack("<I", ifd_offset))
+data.extend(pixel_data)
+if samples > 1 and not bps_inline:
+    data.extend(struct.pack("<H", 8) * samples)
+if extras and not extras_inline:
+    for value in extras:
+        data.extend(struct.pack("<H", value))
+    if len(data) % 2:
+        data.extend(b"\0")
+
+data.extend(struct.pack("<H", len(entries)))
+for tag, kind, count, value in entries:
+    data.extend(struct.pack("<HHI", tag, kind, count))
+    if kind == 3 and count == 1:
+        data.extend(struct.pack("<H", value))
+        data.extend(b"\0\0")
+    elif tag == 258 and bps_inline:
+        data.extend(struct.pack("<H", 8) * samples)
+        data.extend(b"\0\0" * (2 - samples))
+    elif tag == 338 and extras_inline:
+        for v in extras:
+            data.extend(struct.pack("<H", v))
+        data.extend(b"\0\0" * (2 - len(extras)))
+    else:
+        data.extend(struct.pack("<I", value))
+data.extend(struct.pack("<I", 0))
+path.write_bytes(data)
+PY
+}
+
+# Print the value count stored for tag 338 in a TIFF's first IFD, or "absent".
+# Read from the bytes so the assertion does not depend on the tool under test.
+read_stored_extrasamples_count() {
+  python3 - "$1" <<'PY'
+import pathlib
+import struct
+import sys
+
+data = pathlib.Path(sys.argv[1]).read_bytes()
+if len(data) < 8 or data[:2] not in (b"II", b"MM"):
+    print("unreadable")
+    sys.exit(0)
+
+endian = "<" if data[:2] == b"II" else ">"
+offset = struct.unpack_from(endian + "I", data, 4)[0]
+if offset + 2 > len(data):
+    print("unreadable")
+    sys.exit(0)
+
+count = struct.unpack_from(endian + "H", data, offset)[0]
+for index in range(count):
+    entry = offset + 2 + 12 * index
+    if entry + 12 > len(data):
+        break
+    tag, kind, values = struct.unpack_from(endian + "HHI", data, entry)
+    if tag == 338:
+        print(values)
+        sys.exit(0)
+
+print("absent")
+PY
+}
+
+# Print the BitsPerSample values stored in a TIFF's first IFD, space separated.
+# Resolves the inline-vs-offset distinction the same way libtiff does, so it can
+# tell a correctly built fixture from one whose values are really an offset.
+read_bits_per_sample() {
+  python3 - "$1" <<'PY'
+import pathlib
+import struct
+import sys
+
+data = pathlib.Path(sys.argv[1]).read_bytes()
+if len(data) < 8 or data[:2] not in (b"II", b"MM"):
+    print("unreadable")
+    sys.exit(0)
+
+endian = "<" if data[:2] == b"II" else ">"
+offset = struct.unpack_from(endian + "I", data, 4)[0]
+count = struct.unpack_from(endian + "H", data, offset)[0]
+for index in range(count):
+    entry = offset + 2 + 12 * index
+    if entry + 12 > len(data):
+        break
+    tag, kind, values = struct.unpack_from(endian + "HHI", data, entry)
+    if tag != 258:
+        continue
+    # A SHORT array of 4 bytes or fewer lives in the entry's value field.
+    base = entry + 8 if values * 2 <= 4 else struct.unpack_from(endian + "I", data, entry + 8)[0]
+    print(" ".join(str(struct.unpack_from(endian + "H", data, base + 2 * i)[0])
+                   for i in range(values)))
+    sys.exit(0)
+
+print("absent")
+PY
+}
+
+# The ExtraSamples line iccTiffDump prints, empty when it prints no such line.
+dump_extrasamples_line() {
+  "$TIFFDUMP" "$1" 2>/dev/null | sed -n 's/^ExtraSamples: *//p' | head -1
+}
+
+# Assertions about an ABSENT line cannot stand on their own: a tool that fails
+# outright prints nothing, so "no ExtraSamples line" is satisfied by a broken
+# iccTiffDump -- including an ASan abort, on a test carrying the asan label.
+# Require the dump to have succeeded and produced the line that must always be
+# there before any such assertion is trusted.
+dump_succeeded() {
+  local f="$1" expected_samples="$2" out
+  out="$("$TIFFDUMP" "$f" 2>/dev/null)" || return 1
+  printf '%s\n' "$out" | grep -q "^SamplesPerPixel: *${expected_samples}\$"
+}
+
+require_tools() {
+  local name="$1"
+  if [ ! -x "$TIFFDUMP" ]; then
+    skip_case "$name" "iccTiffDump not built at $TIFFDUMP"
+    return 1
+  fi
+  if ! command -v python3 >/dev/null 2>&1; then
+    skip_case "$name" "python3 unavailable, cannot build or inspect TIFF fixtures"
+    return 1
+  fi
+  return 0
+}
+
+###############################################################################
+# Case 1 -- the defect itself, on a synthetic 6-channel MinIsBlack file.
+# MinIsBlack accounts for one channel, SamplesPerPixel is 6, tag 338 is absent.
+# libtiff repairs the directory to 5 extra samples and warns; before the fix the
+# dump printed no ExtraSamples line at all, so the report never accounted for
+# five of the six channels.
+###############################################################################
+case_absent_tag_is_explained() {
+  local name="absent-tag-is-explained"
+  require_tools "$name" || return
+
+  local f="$WORKDIR/minisblack-6ch-no-338.tif"
+  generate_tiff "$f" 4 4 6 1
+
+  local stored
+  stored="$(read_stored_extrasamples_count "$f")"
+  if [ "$stored" != "absent" ]; then
+    fail_case "$name" "fixture is wrong: tag 338 should be absent, IFD says '$stored'"
+    return
+  fi
+
+  local line
+  line="$(dump_extrasamples_line "$f")"
+  if [ -z "$line" ]; then
+    fail_case "$name" "iccTiffDump reported no ExtraSamples line for a 6-sample MinIsBlack file with no tag 338"
+    return
+  fi
+  case "$line" in
+    *"not stored"*"5 of 6"*)
+      pass_case "$name" "dump explains the repaired layout: $line" ;;
+    *)
+      fail_case "$name" "expected a 'not stored ... 5 of 6' explanation, got: $line" ;;
+  esac
+}
+
+###############################################################################
+# Case 2 -- a stored tag prints the plain count and is not relabelled as repaired.
+#
+# The fixture is deliberately the shape where stored and repaired DISAGREE: 6
+# samples, MinIsBlack (one colour channel), tag 338 storing a single value.  One
+# colour plus one extra does not account for six samples, so libtiff repairs --
+# and because the tag IS present it overwrites the stored count in place while
+# leaving the field marked present.  The plain getter therefore succeeds and
+# returns 5, not the 1 the IFD holds, and libtiff offers no way to read the
+# original back.
+#
+# So this case pins the documented limit of the #2386 fix rather than an
+# aspiration: the tag-present half of the gap is NOT closed, and the number
+# printed is libtiff's.  A well-formed fixture (5 stored extras) would have made
+# stored and repaired identical and pinned nothing.
+###############################################################################
+case_stored_tag_prints_count() {
+  local name="stored-tag-prints-count"
+  require_tools "$name" || return
+
+  local f="$WORKDIR/minisblack-6ch-338-one.tif"
+  generate_tiff "$f" 4 4 6 1 2
+
+  local stored
+  stored="$(read_stored_extrasamples_count "$f")"
+  if [ "$stored" != "1" ]; then
+    fail_case "$name" "fixture is wrong: tag 338 should store 1 value, IFD says '$stored'"
+    return
+  fi
+
+  if ! dump_succeeded "$f" 6; then
+    fail_case "$name" "iccTiffDump did not report SamplesPerPixel 6 for the fixture"
+    return
+  fi
+
+  local line
+  line="$(dump_extrasamples_line "$f")"
+  case "$line" in
+    "5")
+      pass_case "$name" "a present tag prints libtiff's plain count (5), with no repair wording" ;;
+    "1")
+      fail_case "$name" "dump printed the stored count 1 -- if that is now recoverable, this case and the header comment both need updating" ;;
+    *"not stored"*)
+      fail_case "$name" "a file that DOES store tag 338 was reported as not stored: $line" ;;
+    *)
+      fail_case "$name" "expected a plain count, got: '${line:-<no line>}'" ;;
+  esac
+}
+
+###############################################################################
+# Case 3 -- a well-formed file gains no line.  RGB accounts for all three of its
+# channels, so there is nothing to explain and the dump must stay silent.  This
+# fails against a fix that prints the new wording unconditionally.
+###############################################################################
+case_wellformed_file_is_silent() {
+  local name="wellformed-file-is-silent"
+  require_tools "$name" || return
+
+  local f="$WORKDIR/rgb-3ch.tif"
+  generate_tiff "$f" 4 4 3 2
+
+  local stored
+  stored="$(read_stored_extrasamples_count "$f")"
+  if [ "$stored" != "absent" ]; then
+    fail_case "$name" "fixture is wrong: tag 338 should be absent, IFD says '$stored'"
+    return
+  fi
+
+  # Before trusting an absence, require the dump to have actually run: an empty
+  # ExtraSamples line is also what a crashed or rejecting iccTiffDump produces.
+  if ! dump_succeeded "$f" 3; then
+    fail_case "$name" "iccTiffDump did not report SamplesPerPixel 3 for a well-formed RGB file"
+    return
+  fi
+
+  local line
+  line="$(dump_extrasamples_line "$f")"
+  if [ -n "$line" ]; then
+    fail_case "$name" "a well-formed RGB file gained an ExtraSamples line: $line"
+    return
+  fi
+
+  pass_case "$name" "no ExtraSamples line for a file whose photometric model accounts for every channel"
+}
+
+###############################################################################
+# Case 4 -- the tracked 81-band spectral file the report was filed against, and
+# the separation that matters: the dump names 80 of 81, while iccApplyProfiles
+# still sees a stored count of 0.  Reading them from one invocation would not
+# prove that, so the stored count is read from the IFD and the effective count
+# from the tool, and the two are required to DISAGREE.
+###############################################################################
+case_tracked_spectral_file() {
+  local name="tracked-spectral-file"
+  require_tools "$name" || return
+
+  if [ ! -f "$TRACKED_SPECTRAL" ]; then
+    skip_case "$name" "tracked fixture missing: $TRACKED_SPECTRAL"
+    return
+  fi
+
+  local stored
+  stored="$(read_stored_extrasamples_count "$TRACKED_SPECTRAL")"
+  if [ "$stored" != "absent" ]; then
+    fail_case "$name" "tracked fixture changed: tag 338 should be absent, IFD says '$stored'"
+    return
+  fi
+
+  local line
+  line="$(dump_extrasamples_line "$TRACKED_SPECTRAL")"
+  case "$line" in
+    *"not stored"*"80 of 81"*)
+      pass_case "$name" "dump explains libtiff's repair without adopting it: $line" ;;
+    "")
+      fail_case "$name" "iccTiffDump reported no ExtraSamples line for the tracked 81-band file" ;;
+    *)
+      fail_case "$name" "expected a 'not stored ... 80 of 81' explanation, got: $line" ;;
+  esac
+}
+
+###############################################################################
+# Case 5 -- the fixture generator itself, at the sample count where TIFF switches
+# a SHORT array from an out-of-line offset to the entry's own value field.  Two
+# 16-bit values are exactly 4 bytes, so BitsPerSample must be written inline;
+# emitting an offset instead made libtiff decode it as the offset's two halves,
+# and the fixture -- not the tool -- would have been what a future case measured.
+# Read back through the IFD parser rather than the tool, for the same reason.
+###############################################################################
+case_generator_two_sample_bitspersample() {
+  local name="generator-two-sample-bitspersample"
+  require_tools "$name" || return
+
+  local f="$WORKDIR/minisblack-2ch.tif"
+  generate_tiff "$f" 4 4 2 1
+
+  local bps
+  bps="$(read_bits_per_sample "$f")"
+  if [ "$bps" != "8 8" ]; then
+    fail_case "$name" "2-sample fixture decodes BitsPerSample as '$bps', expected '8 8'"
+    return
+  fi
+
+  if ! dump_succeeded "$f" 2; then
+    fail_case "$name" "iccTiffDump could not read the 2-sample fixture"
+    return
+  fi
+
+  pass_case "$name" "a 2-sample fixture stores BitsPerSample inline and reads back as 8 8"
+}
+
+###############################################################################
+
+: > "$LOGFILE"
+printf '=== ExtraSamples diagnostic-fidelity regression (#2386) ===\n' | tee -a "$LOGFILE"
+printf 'tools: %s\n' "$TOOLS_DIR" | tee -a "$LOGFILE"
+
+case_absent_tag_is_explained
+case_stored_tag_prints_count
+case_wellformed_file_is_silent
+case_tracked_spectral_file
+case_generator_two_sample_bitspersample
+
+printf '\n=== summary: %d passed, %d failed, %d skipped, %d total ===\n' \
+  "$PASS" "$FAIL" "$SKIP" "$TOTAL" | tee -a "$LOGFILE"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+# Every case skipped means nothing was measured.  Report that as a skip rather
+# than success: a script CTest that exits 0 having asserted nothing reports GREEN
+# and hides the gap.
+if [ "$PASS" -eq 0 ]; then
+  exit 77
+fi
+
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7679,6 +7679,26 @@ if(TARGET iccSpecSepToTiff AND TARGET iccApplyProfiles AND TARGET iccTiffDump)
   )
 endif()
 
+# CTiffImg::Open() discarded the TIFFGetField(TIFFTAG_EXTRASAMPLES) return, so no
+# caller could tell an absent tag 338 from a stored one, and iccTiffDump reported
+# nothing at all for a directory libtiff had silently repaired (#2386).  Only
+# iccTiffDump is exercised -- the fix deliberately leaves the count colour
+# management reads alone -- so it is the only target guarded on.  Three of the
+# four fixtures are written by the script; the fourth is the tracked
+# Testing/hybrid/Data/smCows380_5_780.tif, which needs no generated profile.
+if(TARGET iccTiffDump)
+  iccdev_add_script_test(
+    iccdev.tiff-extrasamples-diagnostics
+    120
+    "iccdev;tools;tiff;tiffdump;extrasamples;regression;asan"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-tiff-extrasamples-diagnostics-tests.sh"
+  )
+  set_tests_properties(iccdev.tiff-extrasamples-diagnostics PROPERTIES
+    SKIP_RETURN_CODE 77
+  )
+endif()
+
 iccdev_add_script_test(
   iccdev.dump-profile-header-regression
   120

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -309,6 +309,8 @@ CTiffImg::CTiffImg()
     m_nPhoto(0),
     m_nSamples(0),
     m_nExtraSamples(0),
+    m_bExtraSamplesStored(false),
+    m_nEffectiveExtraSamples(0),
     m_nPlanar(0),
     m_nCompress(0),
     m_nSampleFormat(SAMPLEFORMAT_UINT),
@@ -383,6 +385,8 @@ void CTiffImg::Close()
   m_nPhoto = 0;
   m_nSamples = 0;
   m_nExtraSamples = 0;
+  m_bExtraSamplesStored = false;
+  m_nEffectiveExtraSamples = 0;
   m_nPlanar = 0;
   m_nCompress = 0;
   m_nSampleFormat = SAMPLEFORMAT_UINT;
@@ -499,11 +503,42 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
     TIFFError(szFname,"Can not open output image");
     return false;
   }
-  TIFFSetField(m_hTif, TIFFTAG_IMAGEWIDTH, (uint32_t) m_nWidth);
-  TIFFSetField(m_hTif, TIFFTAG_IMAGELENGTH, (uint32_t) m_nHeight);
-  TIFFSetField(m_hTif, TIFFTAG_PHOTOMETRIC, m_nPhoto);
-  TIFFSetField(m_hTif, TIFFTAG_PLANARCONFIG, m_nPlanar);
-  TIFFSetField(m_hTif, TIFFTAG_SAMPLESPERPIXEL, m_nSamples);
+  // Required directory state, written through a helper that keeps the result.  The
+  // EXTRASAMPLES arm below already closed and failed on a rejected write while every
+  // other tag here discarded its status, so the writer could believe libtiff had
+  // accepted a directory it had refused; this makes the whole block consistent (#2386).
+  //
+  // No input Create() permits can currently produce a rejection: measured against
+  // libtiff 4.5.1 and 4.7.2, every tag below returns 1 for every value that gets past
+  // the entry guards, and the one set-time failure available at all -- SamplesPerPixel
+  // of 0, "Bad value 0" -- is already refused above.  Codec validity is NOT checked
+  // here either way, because libtiff defers it to write time (COMPRESSION 9999 and an
+  // unconfigured JBIG both return 1), so this guard is not a substitute for the
+  // write-time diagnostics.  It exists so a stricter libtiff fails at the tag that
+  // was rejected rather than somewhere downstream.
+  //
+  // Checked in two stages rather than once at the end: libtiff validates an
+  // ExtraSamples count against SamplesPerPixel, so the EXTRASAMPLES arm below must
+  // not run on a directory that did not accept SamplesPerPixel -- it would fail for
+  // the second reason and report the wrong tag.  The remaining writes are collected
+  // and checked together after the last of them.
+  //
+  // The accumulation is `&=`, never `&&=`/`&&`: it must NOT short-circuit.  Every
+  // TIFFSetField below has to run whatever an earlier one returned, because the
+  // directory being written is the product of all of them -- switching to a
+  // short-circuiting operator would silently stop writing tags after the first
+  // rejection and produce a file missing required state rather than an error.
+  bool bFieldsSet = true;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_IMAGEWIDTH, (uint32_t) m_nWidth) == 1;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_IMAGELENGTH, (uint32_t) m_nHeight) == 1;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_PHOTOMETRIC, m_nPhoto) == 1;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_PLANARCONFIG, m_nPlanar) == 1;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_SAMPLESPERPIXEL, m_nSamples) == 1;
+  if (!bFieldsSet) {
+    TIFFError(szFname, "Can not set required TIFF directory fields");
+    Close();
+    return false;
+  }
   if (m_nExtraSamples) {
     unsigned short* extrasamplevalues = static_cast<unsigned short*>(calloc(m_nExtraSamples, sizeof(unsigned short)));
     if (!extrasamplevalues) {
@@ -517,21 +552,31 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
       return false;
     }
   }
-  TIFFSetField(m_hTif, TIFFTAG_BITSPERSAMPLE, m_nBitsPerSample);
+  // Keep the two ExtraSamples observers true for a written image as well as a read
+  // one.  Close() resets them and only Open() set them, so a Create()d object
+  // reported "tag 338 was not present" while having just written it, contradicting
+  // the unconditional promise on HasStoredExtraSamples().  No caller reads them off
+  // an output image today; setting them here keeps that from becoming a trap.  This
+  // is the one place the write path knows the answer: the tag is written exactly
+  // when m_nExtraSamples is nonzero, and nothing repairs a directory we author, so
+  // the effective count is the requested one.
+  m_bExtraSamplesStored = (m_nExtraSamples != 0);
+  m_nEffectiveExtraSamples = m_nExtraSamples;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_BITSPERSAMPLE, m_nBitsPerSample) == 1;
   if (m_nBitsPerSample >= 32) {
     m_nSampleFormat = SAMPLEFORMAT_IEEEFP;
-    TIFFSetField(m_hTif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP);
+    bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_SAMPLEFORMAT, SAMPLEFORMAT_IEEEFP) == 1;
   }
-  TIFFSetField(m_hTif, TIFFTAG_ROWSPERSTRIP, m_nRowsPerStrip);
-  TIFFSetField(m_hTif, TIFFTAG_COMPRESSION, m_nCompress);
-  TIFFSetField(m_hTif, TIFFTAG_ORIENTATION, m_nOrientation);
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_ROWSPERSTRIP, m_nRowsPerStrip) == 1;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_COMPRESSION, m_nCompress) == 1;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_ORIENTATION, m_nOrientation) == 1;
   // Written unconditionally, next to the values it qualifies.  libtiff omits the tag
   // unless it is set and readers then fall back to their own default, so an output
   // converted from a centimetre-based source came out silently claiming inches and
   // its physical size shifted by 2.54x (#2220).  Stating the unit even when it is
   // RESUNIT_INCH costs one IFD entry and makes the file say what it means instead of
   // depending on the reader agreeing about the default.
-  TIFFSetField(m_hTif, TIFFTAG_RESOLUTIONUNIT, m_nResolutionUnit);
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_RESOLUTIONUNIT, m_nResolutionUnit) == 1;
   // m_fXRes/m_fYRes, not the raw parameters: a non-positive resolution was clamped to
   // 96 above, and writing the unclamped argument put the file at odds with the object
   // that produced it -- GetXRes() answered 96 while the file declared 0.  Harmless
@@ -540,15 +585,21 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
   // is corrected here.  Neither tool caller is affected: iccSpecSepToTiff substitutes
   // its own value below 1, and iccApplyProfiles takes an already-clamped resolution out
   // of Open(), so for both m_fXRes == fXRes.
-  TIFFSetField(m_hTif, TIFFTAG_XRESOLUTION, m_fXRes);
-  TIFFSetField(m_hTif, TIFFTAG_YRESOLUTION, m_fYRes);
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_XRESOLUTION, m_fXRes) == 1;
+  bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_YRESOLUTION, m_fYRes) == 1;
   if (bCompress) {
     if (m_nBitsPerSample >= 32) {
-      TIFFSetField(m_hTif, TIFFTAG_PREDICTOR, PREDICTOR_FLOATINGPOINT);
+      bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_PREDICTOR, PREDICTOR_FLOATINGPOINT) == 1;
     }
     else {
-      TIFFSetField(m_hTif, TIFFTAG_PREDICTOR, PREDICTOR_HORIZONTAL);
+      bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_PREDICTOR, PREDICTOR_HORIZONTAL) == 1;
     }
+  }
+
+  if (!bFieldsSet) {
+    TIFFError(szFname, "Can not set required TIFF directory fields");
+    Close();
+    return false;
   }
 
   m_nCurLine = 0;
@@ -658,7 +709,39 @@ bool CTiffImg::Open(const char *szFname)
 
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_PLANARCONFIG, &m_nPlanar);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_SAMPLESPERPIXEL, &m_nSamples);
-  TIFFGetField(m_hTif, TIFFTAG_EXTRASAMPLES, &m_nExtraSamples, &nSampleInfo);
+  // Plain Get, and its return is now kept: unlike its neighbours this one must
+  // report what the file STORES, because colour management sizes the image from
+  // it (iccApplyProfiles.cpp:543 lets a profile match sn-sen instead of sn).  A
+  // failed Get leaves the destination untouched, so m_nExtraSamples would silently
+  // keep whatever it held; Close() zeroes it at the top of Open() so that was 0 by
+  // luck rather than by contract.  Assign it explicitly and record whether tag 338
+  // was there at all -- 0 otherwise means "absent", not "stored as zero" (#2386).
+  m_bExtraSamplesStored =
+    (TIFFGetField(m_hTif, TIFFTAG_EXTRASAMPLES, &m_nExtraSamples, &nSampleInfo) == 1);
+  if (!m_bExtraSamplesStored)
+    m_nExtraSamples = 0;
+
+  // The reporting-only companion.  When the photometric model plus the stored
+  // ExtraSamples do not add up to SamplesPerPixel, libtiff repairs the directory
+  // in memory and warns ("Defining non-color channels as ExtraSamples"), but it
+  // publishes the repaired count ONLY through the Defaulted getter -- the plain
+  // Get above still fails.  Measured on libtiff 4.5.1 and 4.7.2 against the tracked
+  // 81-band Testing/hybrid/Data/smCows380_5_780.tif: Get returns 0 and writes
+  // nothing, Defaulted returns 1 with 80.  Keep that figure for iccTiffDump to
+  // explain the layout the rest of libtiff is actually using, and keep it away from
+  // m_nExtraSamples, which must stay the stored count (see the header).
+  m_nEffectiveExtraSamples = m_nExtraSamples;
+  {
+    icUInt16Number nEffective = 0;
+    icUInt16Number *pEffectiveInfo = NULL;
+    // m_nSamples is already read above, so the count can be bounded here.  libtiff
+    // derives it as SamplesPerPixel minus the photometric model's colour channels
+    // and cannot exceed it, but this value is printed rather than validated, and the
+    // check below rejects only m_nExtraSamples -- so clamp instead of trusting it.
+    if (TIFFGetFieldDefaulted(m_hTif, TIFFTAG_EXTRASAMPLES, &nEffective, &pEffectiveInfo) == 1 &&
+        nEffective <= m_nSamples)
+      m_nEffectiveExtraSamples = nEffective;
+  }
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_SAMPLEFORMAT, &m_nSampleFormat);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_ROWSPERSTRIP, &m_nRowsPerStrip);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_ORIENTATION, &m_nOrientation);

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.h
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.h
@@ -140,7 +140,37 @@ public:
   unsigned int GetBitsPerSample() { return m_nBitsPerSample;}
   unsigned int GetPhoto();
   unsigned int GetSamples() { return m_nSamples;}
+  // libtiff's ExtraSamples count for the open image, and 0 when tag 338 is absent.
+  //
+  // This is NOT reliably the count the file stores, and callers must not read it as
+  // such.  When the photometric model plus the stored ExtraSamples do not account
+  // for SamplesPerPixel, libtiff repairs the directory -- and where tag 338 IS
+  // present it overwrites the stored count IN PLACE while leaving the field marked
+  // present, so the plain TIFFGetField() in Open() succeeds and hands back the
+  // repaired figure.  Measured on libtiff 4.5.1 and 4.7.2 with a 6-sample MinIsBlack
+  // file storing ExtraSamples [2]: the IFD carries 1, this answers 5.  libtiff
+  // exposes no way to recover the stored count once that has happened.
+  //
+  // That matters because colour management keys off this value:
+  // iccApplyProfiles.cpp:541-547 lets a profile match sn-sen instead of sn, so on
+  // such a file a profile is matched against the repaired channel split rather than
+  // the file's own.  The behaviour predates #2386 and is unchanged by it -- which
+  // split is correct is the carrier-contract question open on #2379/#2385, so it is
+  // deliberately not decided here.
   unsigned int GetExtraSamples() { return m_nExtraSamples; }
+  // Whether tag 338 was present in the IFD at all.  This is the one thing that IS
+  // exact: it comes from the TIFFGetField() return, which tracks the field-present
+  // bit and is unaffected by the in-place repair above.  GetExtraSamples() answers 0
+  // both for "absent" and for a stored zero-length count, and Open() used to discard
+  // the return that separates them (#2386).
+  bool HasStoredExtraSamples() const { return m_bExtraSamplesStored; }
+  // The count libtiff is actually working with, including where tag 338 was absent
+  // and the plain getter therefore returned nothing.  Equal to GetExtraSamples() in
+  // every case except that one, which is exactly the case it exists for: an 81-band
+  // spectral image with no tag 338 leaves GetExtraSamples() at 0 while libtiff sizes
+  // the image as 1 colour channel plus 80 non-colour.  Reporting only -- feeding it
+  // to colour management would reclassify those spectral bands as alpha.
+  unsigned int GetEffectiveExtraSamples() const { return m_nEffectiveExtraSamples; }
   unsigned int GetCompress() { return m_nCompress; }
   unsigned int GetPlanar() { return m_nPlanar; }
   unsigned int GetSampleFormat() { return m_nSampleFormat; }
@@ -186,6 +216,8 @@ protected:
   icUInt16Number m_nPhoto;
   icUInt16Number m_nSamples;
   icUInt16Number m_nExtraSamples;
+  bool m_bExtraSamplesStored;
+  icUInt16Number m_nEffectiveExtraSamples;
   icUInt16Number m_nPlanar;
   icUInt16Number m_nCompress;
   icUInt16Number m_nSampleFormat;

--- a/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
+++ b/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
@@ -482,9 +482,30 @@ int main(int argc, icChar* argv[])
             GetSampleFormatDescription( SrcImg.GetSampleFormat()) );
 
   printf("SamplesPerPixel:   %d\n", SrcImg.GetSamples());
-  int nExtra = SrcImg.GetExtraSamples();
-  if (nExtra)
-    printf("ExtraSamples:      %d\n", nExtra);
+  // Report on tag PRESENCE, not on a nonzero count.  The old test printed nothing
+  // when tag 338 was absent and nothing when it was stored as zero, and said nothing
+  // at all about a directory libtiff had repaired: the tracked 81-band
+  // Testing/hybrid/Data/smCows380_5_780.tif dumped "SamplesPerPixel: 81" and
+  // "Photometric: Min Is Black" -- one colour channel -- with the other 80 channels
+  // unmentioned, while libtiff's own warning went to stderr and named no count.
+  // GetEffectiveExtraSamples() is what libtiff repaired the layout to, so state it
+  // and say it was not stored, rather than leave the reader to reconcile the two
+  // numbers themselves (#2386).
+  //
+  // Only the absent-tag half of that gap is closed here.  Where tag 338 IS present
+  // and libtiff still repairs, it overwrites the stored count in place and exposes
+  // no way to read the original back, so the plain figure printed below is libtiff's
+  // and may not be the file's -- a 6-sample MinIsBlack image storing [2] prints 5.
+  // Recovering the stored count would mean parsing the IFD independently of libtiff;
+  // that is not done here because the same repaired count is what colour management
+  // consumes, and which of the two is correct is the open question on #2379/#2385.
+  unsigned int nExtra = SrcImg.GetExtraSamples();
+  unsigned int nEffectiveExtra = SrcImg.GetEffectiveExtraSamples();
+  if (SrcImg.HasStoredExtraSamples())
+    printf("ExtraSamples:      %u\n", nExtra);
+  else if (nEffectiveExtra)
+    printf("ExtraSamples:      not stored; libtiff treats %u of %u samples as non-color\n",
+      nEffectiveExtra, SrcImg.GetSamples());
   printf("Photometric:       %s\n", GetId(SrcImg.GetPhoto(), photo_types));
   printf("BytesPerLine:      %d\n", SrcImg.GetBytesPerLine());
   printf("Resolution:        (%lf x %lf) %s\n", SrcImg.GetXRes(), SrcImg.GetYRes(),


### PR DESCRIPTION
Closes #2386.

## The defect

`CTiffImg::Open()` discarded the return of its `TIFFGetField(TIFFTAG_EXTRASAMPLES)` call, so nothing could tell an absent tag 338 from a stored one. A failed `Get` leaves the destination untouched, so `m_nExtraSamples` read 0 only because `Close()` had zeroed it at the top of `Open()` — correct by luck, not by contract. `iccTiffDump` then printed its `ExtraSamples` line only when that count was nonzero, so the tracked 81-band `Testing/hybrid/Data/smCows380_5_780.tif` reported:

```
SamplesPerPixel:   81
Photometric:       Min Is Black      <- one colour channel
```

with the other 80 channels unmentioned. libtiff's own warning goes to stderr and names no count.

## What libtiff actually does — and why it decides the fix

libtiff repairs such a directory, but how it publishes the repaired figure depends on whether tag 338 was present:

| tag 338 | `TIFFGetField` | `TIFFGetFieldDefaulted` |
|---|---|---|
| **absent** (81-band file) | rc=0, writes **nothing** | rc=1, **80** |
| **present** (6-sample file storing `[2]`) | rc=1, **5** — the repaired count | rc=1, 5 |

Measured on libtiff **4.5.1**, **4.7.0** (the CI container) and **4.7.2**. The warning text says "Defining non-color channels as ExtraSamples", which reads as though the field is populated; for the absent case it is not.

So **this PR closes the absent-tag half only**, and says so in the header, in the dump and in the test. Where the tag is present libtiff overwrites the stored count in place and leaves the field marked present, and the original is not recoverable through libtiff — recovering it would mean parsing the IFD independently.

**The repaired count is deliberately kept out of `m_nExtraSamples`.** `iccApplyProfiles.cpp:541-547` lets a profile match `sn - sen` instead of `sn`, so adopting 80 would let a 1-channel profile be applied to an 81-band spectral image with its bands reclassified as alpha. The count colour management reads is byte-for-byte what master computes — including in the tag-present case, which behaves exactly as before. Which channel split is *correct* is the carrier-contract question still open on #2379/#2385, and this PR does not pre-empt it.

## `Create()`

`Create()` checked only its `EXTRASAMPLES` write while every other tag discarded its status; the block is now consistent, and `Create()` also maintains the two new observers so a written image no longer reports "tag 338 was not present" just after writing it.

Stated plainly: **no input `Create()` permits can currently produce a rejection.** Every tag returns 1 for every value that gets past the entry guards, and the only set-time failure available at all — `SamplesPerPixel` of 0, "Bad value 0" — is already refused there. Codec validity is not covered either way, because libtiff defers it to write time (`COMPRESSION 9999` and an unconfigured JBIG both return 1). This is a guard against a stricter libtiff, not a fix for a reachable failure.

## Test — `iccdev.tiff-extrasamples-diagnostics`

5 cases, **2 red on master**:

| case | on master | pins |
|---|---|---|
| `absent-tag-is-explained` | **red** | synthetic 6-channel MinIsBlack, no tag 338 |
| `stored-tag-prints-count` | green | the tag-present limit above, with a fixture whose stored (1) and repaired (5) counts **disagree** |
| `wellformed-file-is-silent` | green | a well-formed RGB file gains no line |
| `tracked-spectral-file` | **red** | the tracked 81-band file |
| `generator-two-sample-bitspersample` | green | the fixture generator itself |

Guards were verified load-bearing rather than assumed:

- `wellformed-file-is-silent` was checked against a build that prints the wording unconditionally, and goes red.
- Every case now anchors on a line that must be present. Against a stub tool that always exits 1, **all five go red**; before that change the two absence-assertions passed a broken tool — which would have included an ASan abort, on a test carrying the `asan` label.
- Fixtures are written byte by byte and tag state is read back out of the IFD, so no case can pass through the tool it is testing. `BitsPerSample` is written inline at two samples, where TIFF puts a 4-byte SHORT array in the entry itself.

## Verification

- **CI's gate, mechanically:** `grep -cE 'warning:' build.log` = **0** on strict clang 21.1.3 (`strict warnings ENABLED`) and on the GCC **15.2.0** CI container `ghcr.io/internationalcolorconsortium/iccdev:latest` with `-Wall -Wextra -Wpedantic -Werror` + LTO (`strict warnings ENABLED (GNU 15.2.0)`).
- **No behaviour change:** `iccTiffDump` output over all 10 tracked TIFFs is byte-identical to master except the one file, which gains the explanatory line.
- **235/235** fast CTests pass. `iccdev.spectral-tiff-preview` fails identically on clean master (no python `imagecodecs` locally), i.e. pre-existing and environmental.
- The 5 cases also pass inside the CI container against libtiff 4.7.0.
- Pre-flight safety checks: 0 failures. `shellcheck` (0.9.0, CI's version) clean on the new script, which lands `100755`.
- Test cost: 0.4s of a 120s budget.

## Notes for review

- Where the new test actually executes: the Linux ASAN+UBSAN lane (evidence below). Script CTests sit behind the `BASH_EXECUTABLE` gate, so the green Windows legs show the target *configures* under MSVC/ClangCL — they are not evidence that this test ran there, and this PR does not claim they are.
- `.github/scripts/**` is owned by @dwtza @ChrisCoxArt @xsscx rather than me; the script accompanies its C++ change in one PR per house style, same shape as #2392 and #2393.
- Two adjacent things found and deliberately **not** fixed here, to keep this a single change — say the word and I will file or fold them in:
  1. The tag-present repair path above is a real gap that feeds `iccApplyProfiles`, and is entangled with the #2379/#2385 ruling.
  2. `Create()` accepts `nBPS = 0` (`0 % 8 == 0` passes the guard) and libtiff accepts `BITSPERSAMPLE 0` with rc=1, so checking the return would not catch it either. Unreachable from either tool caller — same class as the existing `nResolutionUnit` guard's "for direct callers of this public API".

## Pre-PR dispatched run

`ci_scope=source` on `0119f5b9`, dispatched before this PR was opened per the suggested PR workflow: [33934113521](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33934113521) — **13 success, 3 skipped**. Engaged GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL, MinGW UCRT64, macOS Clang Debug + Release, and Tool Smoke Tests ASAN+UBSAN.

The new test **ran** there rather than merely registering — `159/242 Test #160: iccdev.tiff-extrasamples-diagnostics ... Passed 0.52 sec`, in a lane reporting `100% tests passed, 0 tests failed out of 242`.
