### PR TITLE
fix(#2383): read a one-digit version minor as tenths, in both the XML and JSON parsers

### DIFF
--- a/.github/ci/regression/json-bcd-version-parse.cpp
+++ b/.github/ci/regression/json-bcd-version-parse.cpp
@@ -100,12 +100,29 @@ int main()
   checkVersion("5.00", 0x05000000u, "\"5.00\" encodes as 0x0500");
   checkVersion("2.20", 0x02200000u, "\"2.20\" encodes as 0x0220");
 
-  // A missing minor component keeps its previous meaning ("4" == "4.0"), and a
-  // single-digit minor keeps its previous (quirky but unchanged) encoding: atoi("3")
-  // was 3, giving 0x03 rather than 0x30. Pinned so this fix stays behaviour-neutral
-  // for input that already parsed.
+  // A missing minor component keeps its previous meaning ("4" == "4.0").
   checkVersion("4", 0x04000000u, "\"4\" encodes as 0x0400");
-  checkVersion("4.3", 0x04030000u, "\"4.3\" encodes as 0x0403 (unchanged quirk)");
+
+  // --- #2383: a one-digit minor is a TENTHS digit ------------------------------
+  // Inverted from the assertion #1830 left here, which pinned 0x0403 as a
+  // "quirky but unchanged" encoding.  It is the defect: a minor is the fractional
+  // part of a decimal version, so "4.3" is four-and-three-TENTHS and must encode
+  // exactly as the canonical "4.30" that CIccInfo::GetVersionName writes.
+  //
+  // The XML twin (parseVersion in IccProfileXml.cpp) carries the identical rule
+  // and the mirror of these assertions.  The two MUST agree: the same document is
+  // convertible either way, and a disagreement would make a JSON->XML round trip
+  // change the profile version.
+  checkVersion("4.3", 0x04300000u, "\"4.3\" encodes as 0x0430, same as \"4.30\" (#2383)");
+  checkVersion("5.1", 0x05100000u, "\"5.1\" encodes as 0x0510, same as \"5.10\" (#2383)");
+  check(parseVersion("5.1", NULL) == parseVersion("5.10", NULL),
+        "\"5.1\" and \"5.10\" are the same version");
+
+  // Keyed on the digit count, not the value, so an explicit two-digit minor is
+  // already in hundredths and is not scaled again.
+  checkVersion("4.05", 0x04050000u, "\"4.05\" stays 0x0405 -- two digits are not scaled");
+  checkVersion("4.5", 0x04500000u, "\"4.5\" encodes as 0x0450");
+  checkVersion("4.0", 0x04000000u, "\"4.0\" still encodes as 0x0400");
 
   // --- the #1830 cases ---------------------------------------------------------
 
@@ -138,6 +155,17 @@ int main()
   v = parseVersion("4.30", "-1");
   check(v == 0x04300000u, "negative subclass version rejected, major preserved (#1830)");
   check((v & 0x0000ffffu) == 0u, "rejected subclass version leaves the low half zero");
+
+  // #2383 reaches the subclass through the same helper, so it scales here too.
+  // Mirrors the XML twin's checkSubClass cases deliberately: the subclass minor is
+  // the axis this change moved, and covering it on only one side would let a later
+  // one-sided edit drift the two encoders apart without any test noticing.
+  v = parseVersion("4.30", "1.2");
+  check(v == 0x04300120u, "a one-digit subclass minor scales to tenths (#2383)");
+  check(v == parseVersion("4.30", "1.20"),
+        "subclass \"1.2\" and \"1.20\" are the same version");
+  v = parseVersion("4.30", "1.02");
+  check(v == 0x04300102u, "a two-digit subclass minor is not scaled");
 
   if (g_fail)
     std::fprintf(stderr, "[json-bcd-version] %d assertion(s) failed\n", g_fail);

--- a/.github/ci/regression/xml-version-parse.cpp
+++ b/.github/ci/regression/xml-version-parse.cpp
@@ -158,11 +158,42 @@ int main()
   checkVersion("5.10", 0x05100000u, "\"5.10\" encodes as 0x0510");
   checkVersion("2.20", 0x02200000u, "\"2.20\" encodes as 0x0220");
 
-  // A missing minor component keeps its previous meaning ("4" == "4.0"), and a
-  // single-digit minor keeps its previous encoding: parseVersion maps 3 to 0x03
-  // rather than 0x30, matching icJsonParseBCDByte on the JSON side.
+  // A missing minor component keeps its previous meaning ("4" == "4.0").
   checkVersion("4", 0x04000000u, "\"4\" encodes as 0x0400");
-  checkVersion("4.3", 0x04030000u, "\"4.3\" encodes as 0x0403 (unchanged quirk)");
+
+  // --- #2383: a one-digit minor is a TENTHS digit ------------------------------
+  // This assertion is inverted from #2387, which pinned 0x0403 as an "unchanged
+  // quirk" while repairing the neighbouring loops.  It is the defect: a minor is
+  // the fractional part of a decimal version, so "4.3" is four-and-three-TENTHS
+  // and must encode exactly as the canonical "4.30" does.  The old 0x0403 read
+  // back as 4.03, and for "5.1" gave #2383's 0x05010100 -- below the library's
+  // 5.10 threshold, which is what made a v5.1 profile report its zero-step
+  // observer and illuminant encodings as noncompliant.
+  checkVersion("4.3", 0x04300000u, "\"4.3\" encodes as 0x0430, same as \"4.30\" (#2383)");
+  checkVersion("5.1", 0x05100000u, "\"5.1\" encodes as 0x0510, same as \"5.10\" (#2383)");
+  check(parseVersion("5.1", NULL) == parseVersion("5.10", NULL),
+        "\"5.1\" and \"5.10\" are the same version");
+
+  // Keyed on the digit count, not the value: an explicit two-digit minor is
+  // already in hundredths and must NOT be scaled again.
+  checkVersion("4.05", 0x04050000u, "\"4.05\" stays 0x0405 -- two digits are not scaled");
+
+  // The scaling test counts DIGITS, so the component must be digits-only and at
+  // most two of them -- icJsonParseBCDByte's contract on the JSON side.  Without
+  // that, strtoull's tolerance of '+' and of leading zeros let "5.+1" and "5.001"
+  // past the length test and encode as 0x01 while "5.1" encoded as 0x10, and the
+  // JSON twin rejected both outright: one version text, two header words,
+  // depending on the importer.
+  checkVersion("5.+1", 0u, "a signed minor is rejected, as on the JSON side");
+  checkVersion("5.001", 0u, "a three-digit minor is rejected, as on the JSON side");
+  checkVersion("+5.10", 0u, "a signed major is rejected");
+  checkVersion("4.50", 0x04500000u, "\"4.50\" stays 0x0450");
+  checkVersion("4.5", 0x04500000u, "\"4.5\" encodes as 0x0450");
+  checkVersion("4.0", 0x04000000u, "\"4.0\" still encodes as 0x0400");
+
+  // The rule reaches the class minor too, the fourth component.
+  checkVersion("5.10.12.3", 0x05101230u, "a one-digit class minor scales to tenths");
+  checkVersion("5.10.12.03", 0x05101203u, "a two-digit class minor is not scaled");
 
   // --- finding 1: the third and fourth components lost their leading digit ------
   // The issue's own fixture. Before the repair this gave 0x05100204.
@@ -171,8 +202,10 @@ int main()
                "four-component version keeps every digit (#2387 finding 1)");
   checkVersion("5.10.12", 0x05101200u,
                "three-component version keeps the class major's leading digit");
-  checkVersion("5.10.1.2", 0x05100102u,
-               "single-digit class components are unaffected");
+  // The class MAJOR is a whole number and stays unscaled; only the minor beside
+  // it moves (0x02 -> 0x20), which is the #2383 rule applied to this component.
+  checkVersion("5.10.1.2", 0x05100120u,
+               "a single-digit class major stays whole, its minor scales to tenths");
 
   // The strictness of the shared helper reaches the later components too: a
   // malformed one rejects the whole version rather than landing partly parsed.
@@ -189,6 +222,13 @@ int main()
                 "explicit sub-class version keeps both components (#2387 finding 2)");
   checkSubClass("1.20", 0x0120u, "single-digit sub-class major is unaffected");
   checkSubClass("12", 0x1200u, "a missing sub-class minor stays 0 (\"12\" == \"12.00\")");
+
+  // #2383 through the separate element, which is its own parse site rather than
+  // the fourth component of <ProfileVersion> covered above.
+  checkSubClass("1.2", 0x0120u, "a one-digit sub-class minor scales to tenths (#2383)");
+  checkSubClass("1.02", 0x0102u, "a two-digit sub-class minor is not scaled");
+  check(parseVersion("5.10", "1.2") == parseVersion("5.10", "1.20"),
+        "sub-class \"1.2\" and \"1.20\" are the same version");
 
   // These are the assertions a digits-only repair fails. atoi() would store "12" as
   // decimal 12 == 0x0C and "34" as 0x22, giving 0x0C22 -- a value

--- a/IccJSON/IccLibJSON/IccProfileJson.cpp
+++ b/IccJSON/IccLibJSON/IccProfileJson.cpp
@@ -301,7 +301,22 @@ bool CIccProfileJson::ToJson(std::string &jsonString, int indent)
 // represented in type icUInt32Number". atoi() is also undefined on an
 // out-of-range input, which a digit-by-digit parse of at most two digits cannot
 // hit.
-static bool icJsonParseBCDByte(const std::string &sPart, icUInt32Number &nOut)
+// bFractional marks the minor component, whose digits are positional: "5.1" is
+// five-and-one-TENTH, so the digit belongs in the high nibble as 0x10, matching
+// the canonical "5.10" that CIccInfo::GetVersionName writes.  Encoding it as the
+// integer 1 gave 0x01 -- 5.01 -- which is #2383.  The XML twin (parseVersion in
+// IccProfileXml.cpp) carries the identical SCALING rule and the same one-or-two
+// digit contract, so a version the two both accept encodes to the same header
+// word.  That is the guarantee -- NOT that the two accept the same inputs.  The
+// XML side is deliberately the more tolerant of the pair, and measurably so:
+//   - it trims surrounding whitespace, because element text is subject to
+//     pretty-printing ("<ProfileVersion>\n  5.10\n</ProfileVersion>");
+//   - it accepts ',' as a component separator, so "5,1" parses there and not here;
+//   - it accepts third and fourth components ("5.10.12.34"), which this parser
+//     hands to a single byte helper that refuses more than two characters.
+// Each of those yields 0 here, which GetVersionName renders as a plain "0.00".
+static bool icJsonParseBCDByte(const std::string &sPart, icUInt32Number &nOut,
+                               bool bFractional)
 {
   if (sPart.empty() || sPart.size() > 2)
     return false;
@@ -312,6 +327,11 @@ static bool icJsonParseBCDByte(const std::string &sPart, icUInt32Number &nOut)
       return false;
     v = v * 10 + (unsigned int)(sPart[i] - '0');
   }
+
+  // Keyed on the digit COUNT, not the value, so an explicit "05" still means
+  // five hundredths and stays 0x05 while a bare "5" becomes 0x50.
+  if (bFractional && sPart.size() == 1)
+    v *= 10;
 
   nOut = (icUInt32Number)(((v / 10) % 10) * 16 + (v % 10));
   return true;
@@ -332,7 +352,7 @@ static icUInt32Number icJsonParseBCDVersionStr(const char *szVer)
   for (; *szVer && *szVer != '.'; szVer++) part += *szVer;
 
   icUInt32Number hi = 0, lo = 0;
-  if (!icJsonParseBCDByte(part, hi))
+  if (!icJsonParseBCDByte(part, hi, false))
     return 0;
 
   part.clear();
@@ -341,7 +361,7 @@ static icUInt32Number icJsonParseBCDVersionStr(const char *szVer)
 
   // A missing minor component stays 0 ("4" == "4.0"), matching the previous
   // behaviour; a present but malformed one rejects the whole version.
-  if (!part.empty() && !icJsonParseBCDByte(part, lo))
+  if (!part.empty() && !icJsonParseBCDByte(part, lo, true))
     return 0;
 
   return (hi << 8) | lo;

--- a/IccXML/IccLibXML/IccProfileXml.cpp
+++ b/IccXML/IccLibXML/IccProfileXml.cpp
@@ -406,7 +406,22 @@ bool CIccProfileXml::ToXmlWithBlanks(std::string &xml, std::string blanks)
 // performs the range check.  This is the XML twin of the JSON defect fixed for
 // #1830, whose icJsonParseBCDByte in IccProfileJson.cpp now carries the same
 // contract.
-static bool parseVersion(const std::string &sPart, unsigned long &rv)
+// bFractional distinguishes the two kinds of component this helper encodes.  A
+// major is a whole number, so "5" is 0x05.  A minor is the fractional part of a
+// decimal version, so its digits are positional: "5.1" is five-and-one-TENTH and
+// must reach the header as 0x10, exactly as the canonical "5.10" does.  Encoding
+// the digit as the integer 1 instead gave 0x01, i.e. 5.01, which is #2383's
+// `0x05010100` -- and, being below the library's 5.10 threshold, is what made a
+// v5.1 profile report its zero-step observer and illuminant encodings as
+// noncompliant.
+//
+// #2387's test pinned this as an "unchanged quirk" while that PR repaired the
+// neighbouring loops; it is the defect itself, so that assertion is inverted here
+// rather than preserved.  Rejecting a one-digit minor instead was not an option:
+// 28 tracked documents use the short form (19x "5.0", 9x "1.0"), all with a zero
+// minor, which is why the corpus never exposed this.
+static bool parseVersion(const std::string &sPart, unsigned long &rv,
+                         bool bFractional)
 {
   icUInt32Number v = 0;
 
@@ -426,8 +441,29 @@ static bool parseVersion(const std::string &sPart, unsigned long &rv)
     return false;
   sTrimmed = sTrimmed.substr(nFirst, sTrimmed.find_last_not_of(szBlank) - nFirst + 1);
 
+  // Require one or two DIGITS, which is icJsonParseBCDByte's contract on the JSON
+  // side.  icXmlParseU32 alone is not enough here: it rejects a leading '-' but
+  // strtoull still accepts '+', and it accepts any number of leading zeros while
+  // the value stays <= 99.  Both slipped past the length test below, so "5.+1"
+  // and "5.001" scaled differently from "5.1" -- and, since the JSON twin refuses
+  // them outright, the same version text produced two different header words
+  // depending on which importer was used.  Checking digits here makes the length
+  // test below a true digit count and closes that divergence.
+  if (sTrimmed.size() < 1 || sTrimmed.size() > 2)
+    return false;
+  for (std::string::size_type i = 0; i < sTrimmed.size(); i++) {
+    if (sTrimmed[i] < '0' || sTrimmed[i] > '9')
+      return false;
+  }
+
   if (!icXmlParseU32(sTrimmed.c_str(), v, 99))
     return false;
+
+  // Scale a one-digit fractional component to its tenths place, so "1" and "10"
+  // both encode as 0x10.  Keyed on the digit COUNT rather than the value, so a
+  // written-out "05" still means five hundredths and is left at 0x05.
+  if (bFractional && sTrimmed.size() == 1)
+    v *= 10;
 
   rv = ((v / 10) % 10) * 16 + (v % 10);
   return true;
@@ -472,7 +508,7 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
       for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
         ver += *szVer;
       }
-      bVerOk = parseVersion(ver, verMajor);
+      bVerOk = parseVersion(ver, verMajor, false);
       ver.clear();
       if (*szVer)
         szVer++;
@@ -481,7 +517,7 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
         for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
           ver += *szVer;
         }
-        bVerOk = parseVersion(ver, verMinor);
+        bVerOk = parseVersion(ver, verMinor, true);
         ver.clear();
         if (*szVer)
           szVer++;
@@ -494,7 +530,7 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
           for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
             ver += *szVer;
           }
-          bVerOk = parseVersion(ver, verClassMajor);
+          bVerOk = parseVersion(ver, verClassMajor, false);
           ver.clear();
           if (*szVer)
             szVer++;
@@ -503,7 +539,7 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
             for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
               ver += *szVer;
             }
-            bVerOk = parseVersion(ver, verClassMinor);
+            bVerOk = parseVersion(ver, verClassMinor, true);
             ver.clear();
 
             // The header holds exactly four components, so anything still
@@ -550,7 +586,7 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
       for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
         ver += *szVer;
       }
-      bVerOk = parseVersion(ver, verClassMajor);
+      bVerOk = parseVersion(ver, verClassMajor, false);
       ver.clear();
       if (*szVer)
         szVer++;
@@ -561,7 +597,7 @@ bool CIccProfileXml::ParseBasic(xmlNode *pNode, std::string &parseStr)
         for (; *szVer && *szVer != '.' && *szVer != ','; szVer++) {
           ver += *szVer;
         }
-        bVerOk = parseVersion(ver, verClassMinor);
+        bVerOk = parseVersion(ver, verClassMinor, true);
         ver.clear();
 
         // As above: the sub-class version is two components, so a third is a


### PR DESCRIPTION
Closes #2383.

## The defect

A version's minor component is the fractional part of a decimal number, so its digits are positional: `5.1` is five-and-one-**tenth** and must reach the header as `0x10`, exactly as the canonical `5.10` that `CIccInfo::GetVersionName` writes. Both parsers instead encoded the digit as the integer 1, giving `0x01`:

| `ProfileVersion` | before | after |
|---|---|---|
| `5.10` | `05100100` | `05100100` |
| **`5.1`** | **`05010100`** — 5.01 | **`05100100`** |
| `4.30` | `04300100` | `04300100` |
| **`4.3`** | **`04030100`** — 4.03 | **`04300100`** |

`0x05010100` is the value the issue reports. Being below the library's 5.10 threshold is what made a v5.1 profile report its zero-step observer and illuminant encodings as noncompliant.

## #2387/#2396 did not close this — measured

I built `4daaba4c` (pre) and `ac738b70` (post) and compared: **byte-identical on every version input**. That PR's reach was the neighbouring loops and the sub-class element's `atoi()`. Its own test then pinned `0x0403` as an *"unchanged quirk"*, and the JSON twin carried the same pin from #1830. That is the defect, so **both assertions are inverted here rather than preserved** — flagged explicitly rather than quietly flipped.

## Both paths, because they are the only two

XML and JSON share the identical arithmetic (`IccProfileXml.cpp:432`, `IccProfileJson.cpp:316`). The JSON path was verified by constructing input through `iccFromJson`, not by reading. Every other `m_Header.version` assignment in the tree is a compile-time constant, so these are the only two string entry points.

The scale keys on the digit **count**, not the value, so an explicit `4.05` is already in hundredths and stays `0x0405` while a bare `4.5` becomes `0x0450`. It reaches `ProfileSubClassVersion` in both parsers too (`1.1` → `0x0110`).

Rejecting the short form instead was never an option: **28 tracked documents use it** (19× `5.0`, 9× `1.0`). All have a zero minor, which encodes the same either way — exactly why the corpus never exposed this.

## A deliberate behaviour change, stated plainly

Counting digits only works if the component *is* digits, so `parseVersion` now enforces the one-or-two-digit contract `icJsonParseBCDByte` already applied. `icXmlParseU32` alone was not enough — it rejects a leading `-`, but `strtoull` still accepts `+`, and leading zeros pass while the value stays ≤ 99. Both slipped past the length test, so `5.+1` and `5.001` encoded as `0x01` while `5.1` encoded as `0x10`, **and the JSON twin refused them outright — one version text, two different header words depending on the importer.**

Consequently `+5.10`, `005.10` and `5.010` used to reach the header as `0x0510` and now reject to 0. That follows the policy #1830 and #2387 already set here — refuse a malformed component rather than let a partly-parsed value through — and matches what JSON has always done. **No tracked document is affected.** A rejected version is not silent to a reader: the validator prints `Major version number (0) is unexpected` and `iccFromXml` reports the profile invalid. It still exits 0, but that is the separate contract #2384 covers, not something introduced here.

`bFractional` takes **no default argument**. The safe-looking default would be `false` — the defect's own behaviour — so a future minor-component caller would silently reproduce #2383. Requiring it at all eight call sites makes a forgotten flag a compile error instead.

## Parity: what is actually guaranteed

The guarantee is that a version **both** parsers accept encodes to the same header word — *not* that they accept the same inputs. XML stays the more tolerant of the pair, measurably so, and the comment now enumerates all three differences rather than claiming whitespace is the only one:

- whitespace trimming (element text is subject to pretty-printing; a JSON string is not),
- `,` accepted as a component separator (`5,1` parses in XML, rejects in JSON),
- third and fourth components (`5.10.12.34` parses in XML, rejects in JSON).

## Verification

- **Corpus, measured not derived:** every one of the **188** tracked XML documents that converts produces a byte-identical version word against a clean `origin/master` build — **0 differ, 0 newly rejected** by the tightened contract. Re-run after the tightening, since hardening a parser is exactly where load-bearing slack gets removed.
- **Round trip is now a stable fixed point:** `5.1` → `0x0510` → writer emits `5.10` → reparses to `0x0510`. The old encoding was self-consistent too, just not the version the author wrote.
- **Red/green:** reverting only the library fix turns **12 assertions** red across the two twins, re-checked after each restructuring.
- 0 warnings under `-Wall -Wextra -Wpedantic -Werror` on strict clang 21.1.3 **and** in the GCC 15.2.0 CI container with LTO, both reporting `strict warnings ENABLED`.
- **236/236** fast CTests. Both tests clean under ASAN/UBSAN with `detect_leaks=1` — on binaries verified to carry `__asan_` symbols rather than trusting the label.
- `iccdev.spectral-tiff-preview` fails identically on clean master (no python `imagecodecs` locally), i.e. pre-existing and environmental.

## Tests

Both existing regression twins gain the new cases, including the `ProfileSubClassVersion` element — a separate parse site from the fourth component of `ProfileVersion`. The JSON twin mirrors the XML sub-class assertions so a one-sided future edit cannot drift the two encoders apart unnoticed.

## One verified pre-existing gap, deliberately not fixed here

Element **order** changes the header word. `ProfileVersion` then `ProfileSubClassVersion` gives `0x05100120`; the same two elements reversed give `0x05100000` — the sub-class version is silently wiped. The `ProfileVersion` branch does a full assignment while the sub-class branch does a masked merge; `CIccProfileJson::ParseBasic` masks on both sides and is order-independent.

Not introduced here, and the writer always emits version first, so only hand-written or reordered documents hit it. The fix is not a one-liner — the 2-component and 4-component forms need different merge behaviour — so it is out of scope for this change. Happy to file it or fold it in, whichever you prefer.

## Pre-PR dispatched run

`ci_scope=source` on `9ab3d16f`, dispatched before this PR was opened per the suggested PR workflow: [33942643573](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/33942643573) — **14 success, 2 skipped**. Engaged GCC 15.2 Strict Release LTO, Windows MSVC + ClangCL, MinGW UCRT64, macOS Clang Debug + Release, and Tool Smoke Tests ASAN+UBSAN.
