### PR TITLE
fix(#2397,#2398,#2399): repair the responseCurveSet16 tag end to end

### DIFF
--- a/.github/scripts/iccdev-json-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-json-parser-regression-tests.sh
@@ -761,6 +761,64 @@ for idx in range(tag_count):
 raise SystemExit("namedColor2 tag not found")
 ' "$NAMED_PROFILE" "$NAMED_INVALID_ASCII"
 
+###############################################################################
+# responseCurveSet16Type measurement/channel counts (#2398)
+###############################################################################
+#
+# CIccTagJsonResponseCurveSet16::ParseJson read CountOfChannels, DeviceCode and
+# Reserved into an int and cast each to the icUInt16Number that actually stores it,
+# so a value above the field's ceiling was truncated and the parser wrote a profile
+# for a document it had not been given.  Measured against the unfixed parser:
+# "CountOfChannels": 65537 produced a file byte-identical to the count-of-1 control,
+# "DeviceCode": 65537 one byte-identical to DeviceCode 1, and -1 one byte-identical
+# to 65535 -- all three at exit 0.  This is the JSON half of #2398; the XML twin is
+# pinned in iccdev-xml-parser-regression-tests.sh.
+#
+# The fixture is written here in full rather than produced by iccToJson from an ICC
+# profile.  Generating it would make these cases depend on the resp tag's READ path,
+# and when that path was broken (#2399) they would have gone green by skipping rather
+# than red -- the failure mode this file's own reject helper exists to prevent.
+write_responsecurve_json() {
+  # write_responsecurve_json <path> <count> <device-code>
+  cat > "$1" <<JSONEOF
+{
+  "Header": {
+    "ProfileVersion": "2.10.0",
+    "ProfileDeviceClass": "mntr",
+    "DataColourSpace": "GRAY",
+    "PCS": "XYZ ",
+    "RenderingIntent": "Perceptual"
+  },
+  "Tags": [
+    {
+      "outputResponseTag": {
+        "data": {
+          "type": "responseCurveSet16Type",
+          "CountOfChannels": $2,
+          "ResponseCurves": [
+            {
+              "MeasurementUnit": "Status A",
+              "Channels": [
+                {
+                  "MaxColorantXYZ": [ 0.0, 0.0, 0.0 ],
+                  "Measurements": [ { "DeviceCode": $3, "MeasValue": 0.0 } ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+JSONEOF
+}
+
+write_responsecurve_json "$OUTDIR/responsecurve-control.json" 1 1
+write_responsecurve_json "$OUTDIR/responsecurve-count-overflow.json" 65537 1
+write_responsecurve_json "$OUTDIR/responsecurve-devicecode-overflow.json" 1 65537
+write_responsecurve_json "$OUTDIR/responsecurve-devicecode-negative.json" 1 -1
+
 echo "Using base profile: $PROFILE"
 echo "Using XML profile:  $XML_PROFILE"
 echo "Tools dir: $TOOLS_DIR"
@@ -778,6 +836,14 @@ run_reject_test "spectral-offset-short" "$OUTDIR/spectral-offset-short.json" "of
 run_reject_test "struct-bad-member" "$OUTDIR/struct-bad-member.json" "MemberTag 'badMember' missing 'type' field"
 run_fromjson_success_test "utf16-short-text" "$OUTDIR/utf16-short-text.json"
 run_reject_test "empty-tag-name" "$OUTDIR/empty-tag-name.json" "Tag entry has empty name"
+
+# The control runs first and must convert: without it, a change that refused every
+# responseCurveSet16Type document would satisfy all three reject cases below while
+# removing the guards they exist to pin.
+run_fromjson_success_test "responsecurve-control" "$OUTDIR/responsecurve-control.json"
+run_reject_test "responsecurve-count-overflow" "$OUTDIR/responsecurve-count-overflow.json" "Missing or invalid CountOfChannels in ResponseCurveSet16"
+run_reject_test "responsecurve-devicecode-overflow" "$OUTDIR/responsecurve-devicecode-overflow.json" "Invalid Measurement DeviceCode in ResponseCurveSet16"
+run_reject_test "responsecurve-devicecode-negative" "$OUTDIR/responsecurve-devicecode-negative.json" "Invalid Measurement DeviceCode in ResponseCurveSet16"
 run_reject_test "struct-empty-member-name" "$OUTDIR/struct-empty-member-name.json" "MemberTag entry has empty name"
 run_xml_reject_test "xml-matrix-huge-channels" "$XML_MATRIX_HUGE" "Invalid InputChannels or OutputChannels In MatrixElement"
 run_xml_reject_test "xml-empty-private-type" "$XML_EMPTY_PRIVATE_TYPE" "Invalid private tag type attribute"

--- a/.github/scripts/iccdev-xml-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-xml-parser-regression-tests.sh
@@ -220,6 +220,20 @@ echo "=== Parser hardening still armed ==="
 # expected to use.
 PARSER_DIAG='parser error|exceeds the parser'"'"'s nesting-depth or name-length limit'
 
+# What the responseCurveSet16Type parser says when it refuses the count itself, as
+# opposed to iccFromXml refusing the profile for some later reason.
+#
+# Anchored on the diagnostics the fix actually emits.  The first version of this
+# pattern carried a bare "responseCurveSet16Type" alternative, which subsumed the
+# specific one and matched CIccProfileXml::ParseTag's generic
+#   Unable to Parse "responseCurveSet16Type" (responseCurveSet16Type) Tag on line N
+# -- a line printed for ANY failure inside the tag.  Measured against a document whose
+# only defect is a channel-count mismatch: the generic line matched, so the attribution
+# asserted nothing beyond "the tag failed" and a change that refused every
+# responseCurveSet16Type would have passed all of these cases while the guards under
+# test were gone.
+RESP_TAG_DIAG='(Empty|Invalid) CountOfChannels in responseCurveSet16Type|Invalid Measurement (DeviceCode|Reserved) in responseCurveSet16Type'
+
 # Proves the assertion in reject_case() is worth something: a well-formed
 # document that violates no parser limit must be refused WITHOUT any parser
 # diagnostic, because it fails later as an invalid profile. If this ever starts
@@ -509,6 +523,453 @@ xyz_array_at_cap() {
 
 xyz_array_over_cap
 xyz_array_at_cap
+
+###############################################################################
+# 5. responseCurveSet16Type CountOfChannels (#2397 null deref, #2398 wrap)
+###############################################################################
+#
+# CIccTagXmlResponseCurveSet16::ParseXml checked that icXmlFindNode located the
+# <CountOfChannels> element and then read pNode->children->content without
+# checking the child.  An empty <CountOfChannels/> is well-formed XML with no
+# text child, so libxml2 leaves children NULL: UBSan reported "member access
+# within null pointer of type 'struct _xmlNode'" and a release build took a
+# SIGSEGV (#2397).
+#
+# The same line used atoi() and stored into an icUInt32Number, while
+# SetNumChannels takes an icUInt16Number.  "4294967297" is 0x100000001 --
+# undefined for atoi() to begin with -- and truncated to 1, so the tool wrote a
+# profile byte-identical to the one a count of 1 produces and reported success
+# (#2398).  That equality is the assertion below, because exit status alone
+# cannot distinguish "refused the count" from "refused the profile".
+#
+# No tracked document uses responseCurveSet16Type, which is why neither survived
+# into a fixture; these three are written here.
+
+write_countofchannels_document() {
+  # write_countofchannels_document <path> <count-element>
+  cat > "$1" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>2.10</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>GRAY</DataColourSpace>
+    <PCS>XYZ </PCS>
+  </Header>
+  <Tags>
+    <responseCurveSet16Type>
+      <TagSignature>resp</TagSignature>
+      $2
+      <ResponseCurve MeasUnitSignature="Status A">
+        <ChannelResponses X="0" Y="0" Z="0">
+          <Measurement DeviceCode="0" MeasValue="0"/>
+        </ChannelResponses>
+      </ResponseCurve>
+    </responseCurveSet16Type>
+  </Tags>
+</IccProfile>
+XMLEOF
+}
+
+countofchannels_empty_element() {
+  local name="xml-responsecurve-empty-count"
+  local file="$OUTDIR/resp-empty.xml" logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  write_countofchannels_document "$file" "<CountOfChannels/>"
+
+  "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1
+  local status=$?
+
+  # The defect was a crash, so the assertion is on HOW it exits, not merely that
+  # it does. A signal death surfaces as 128+signum through the shell (139 for
+  # SIGSEGV), which is what this fixture produced before the child guard.
+  if [ "$status" -ge 128 ]; then
+    fail "$name" "iccFromXml died on a signal (exit $status) -- the null deref is back"
+    return
+  fi
+  if [ "$status" -eq 0 ]; then
+    fail "$name" "an empty CountOfChannels was accepted"
+    return
+  fi
+  # Section 4's rule applies here: exit status alone is not attribution, because
+  # every fixture in this script exits non-zero. Require the parser to name the tag
+  # it refused, so a change that rejects this document earlier -- during header
+  # parsing, or by refusing every responseCurveSet16Type -- goes red instead of
+  # passing while the guard under test is gone.
+  if ! grep -qE "$RESP_TAG_DIAG" "$logfile"; then
+    fail "$name" "refused, but not by the responseCurveSet16Type parser"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || return
+  pass "$name (empty element refused by the tag parser, exit $status, no signal)"
+}
+
+countofchannels_overflow_is_not_one() {
+  local name="xml-responsecurve-count-overflow"
+  local over="$OUTDIR/resp-over.xml" ctrl="$OUTDIR/resp-ctrl.xml"
+  local logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  write_countofchannels_document "$over" "<CountOfChannels>4294967297</CountOfChannels>"
+  write_countofchannels_document "$ctrl" "<CountOfChannels>1</CountOfChannels>"
+
+  rm -f "$OUTDIR/${name}-over.icc" "$OUTDIR/${name}-ctrl.icc"
+  "$FROMXML" "$over" "$OUTDIR/${name}-over.icc" >"$logfile" 2>&1
+  local over_status=$?
+  "$FROMXML" "$ctrl" "$OUTDIR/${name}-ctrl.icc" >"$OUTDIR/${name}-ctrl.log" 2>&1
+  local ctrl_status=$?
+
+  # The control must still convert. Without it a fix that refuses every
+  # responseCurveSet16Type document would pass this case while breaking the tag.
+  if [ "$ctrl_status" -ne 0 ] || [ ! -s "$OUTDIR/${name}-ctrl.icc" ]; then
+    fail "$name" "the count-of-1 control no longer converts (exit $ctrl_status)"
+    return
+  fi
+
+  if [ "$over_status" -eq 0 ]; then
+    # This is the shape the issue measured: both documents produced the same
+    # bytes, so the tool silently agreed to a different document than the one
+    # supplied. Name that explicitly rather than reporting a bare "accepted".
+    if cmp -s "$OUTDIR/${name}-over.icc" "$OUTDIR/${name}-ctrl.icc"; then
+      fail "$name" "4294967297 truncated to 1 -- output is byte-identical to the control"
+    else
+      fail "$name" "an out-of-range CountOfChannels was accepted"
+    fi
+    return
+  fi
+
+  if [ -s "$OUTDIR/${name}-over.icc" ]; then
+    fail "$name" "a rejected count still left a profile behind"
+    return
+  fi
+
+  if ! grep -qE "$RESP_TAG_DIAG" "$logfile"; then
+    fail "$name" "refused, but not by the responseCurveSet16Type parser"
+    return
+  fi
+
+  # Scan BOTH logs. The control is the run that actually reaches SetNumChannels and
+  # allocates per-channel storage, so it is the interesting memory path; scanning
+  # only the rejected run would let a finding on the accepted one sit unread while
+  # this case reports PASS on the sanitizer lanes.
+  check_sanitizers "$name" "$logfile" || return
+  check_sanitizers "$name (control)" "$OUTDIR/${name}-ctrl.log" || return
+  pass "$name (out-of-range count refused, control still converts)"
+}
+
+countofchannels_indented_is_accepted() {
+  local name="xml-responsecurve-count-indented"
+  local file="$OUTDIR/resp-indent.xml" logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  # Element text carries the document's own indentation. atoi() skipped it; a strict
+  # helper that requires the whole string consumed does not, so tightening this parse
+  # without trimming first would refuse an ordinary pretty-printed document -- the
+  # same trap #2387 fixed for <ProfileVersion>. This case is the guard for that, and
+  # it is the ONLY one here that asserts acceptance.
+  write_countofchannels_document "$file" "$(printf '<CountOfChannels>\n        1\n      </CountOfChannels>')"
+
+  if ! "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1; then
+    fail "$name" "a pretty-printed CountOfChannels was refused"
+    return
+  fi
+  if [ ! -s "$OUTDIR/${name}.icc" ]; then
+    fail "$name" "accepted but wrote no profile, so nothing proves it reached the tag"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || return
+  pass "$name (indented element text still parses)"
+}
+
+countofchannels_zero_refused() {
+  local name="xml-responsecurve-count-zero"
+  local file="$OUTDIR/resp-zero.xml" logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  # The JSON twin rejects CountOfChannels <= 0 and docs/icc-profile.schema.json
+  # declares "minimum": 1, so the XML path accepting 0 was the odd one out.
+  #
+  # This fixture deliberately carries NO ResponseCurve element. With one present the
+  # later "nChannels != icXmlNodeCount(...)" mismatch refuses the document anyway, so
+  # a zero-count fixture that includes a curve passes even against the unfixed
+  # library -- measured, and it made the first version of this case vacuous. With no
+  # curve that check cannot fire, and the old parser accepted the document and wrote
+  # a profile for a tag claiming zero channels.
+  cat > "$file" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>2.10</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>GRAY</DataColourSpace>
+    <PCS>XYZ </PCS>
+  </Header>
+  <Tags>
+    <responseCurveSet16Type>
+      <TagSignature>resp</TagSignature>
+      <CountOfChannels>0</CountOfChannels>
+    </responseCurveSet16Type>
+  </Tags>
+</IccProfile>
+XMLEOF
+
+  if "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1; then
+    fail "$name" "a zero CountOfChannels was accepted and a profile written, unlike the JSON twin"
+    return
+  fi
+  if ! grep -qE "$RESP_TAG_DIAG" "$logfile"; then
+    fail "$name" "refused, but not by the responseCurveSet16Type parser"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || return
+  pass "$name (zero count refused, matching the JSON twin and the schema)"
+}
+
+measurement_devicecode_overflow() {
+  local name="xml-responsecurve-devicecode-overflow"
+  local over="$OUTDIR/resp-dev-over.xml" ctrl="$OUTDIR/resp-dev-ctrl.xml"
+  local logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  # icResponse16Number::deviceCode is an icUInt16Number and was filled by atoi(), so
+  # DeviceCode="65537" truncated to 1 exactly as CountOfChannels did -- same tag, same
+  # function, 45 lines apart. Asserted the same way: the two documents must not
+  # produce the same bytes.
+  #
+  # Both documents are written from the helper rather than sed-ed out of another case's
+  # output.  The previous version read $OUTDIR/resp-ctrl.xml, which only exists once
+  # countofchannels_overflow_is_not_one() has run; its fallback arm wrote "$ctrl" and the
+  # unconditional redirect on the following line then truncated that same file to zero
+  # bytes before sed failed, with "|| true" swallowing the failure -- so the case reported
+  # a false "the DeviceCode=1 control no longer converts" instead of testing anything.
+  write_countofchannels_document "$ctrl" "<CountOfChannels>1</CountOfChannels>"
+  write_countofchannels_document "$over" "<CountOfChannels>1</CountOfChannels>"
+  sed -i 's|DeviceCode="0"|DeviceCode="1"|' "$ctrl"
+  sed -i 's|DeviceCode="0"|DeviceCode="65537"|' "$over"
+
+  rm -f "$OUTDIR/${name}-over.icc" "$OUTDIR/${name}-ctrl.icc"
+  "$FROMXML" "$over" "$OUTDIR/${name}-over.icc" >"$logfile" 2>&1
+  local over_status=$?
+  "$FROMXML" "$ctrl" "$OUTDIR/${name}-ctrl.icc" >"$OUTDIR/${name}-ctrl.log" 2>&1
+  local ctrl_status=$?
+
+  if [ "$ctrl_status" -ne 0 ] || [ ! -s "$OUTDIR/${name}-ctrl.icc" ]; then
+    fail "$name" "the DeviceCode=1 control no longer converts (exit $ctrl_status)"
+    return
+  fi
+
+  if [ "$over_status" -eq 0 ]; then
+    if cmp -s "$OUTDIR/${name}-over.icc" "$OUTDIR/${name}-ctrl.icc"; then
+      fail "$name" "DeviceCode 65537 truncated to 1 -- output is byte-identical to the control"
+    else
+      fail "$name" "an out-of-range DeviceCode was accepted"
+    fi
+    return
+  fi
+
+  check_sanitizers "$name" "$logfile" || return
+  check_sanitizers "$name (control)" "$OUTDIR/${name}-ctrl.log" || return
+  pass "$name (out-of-range DeviceCode refused, control still converts)"
+}
+
+responsecurve_profile_reads_back() {
+  local name="xml-responsecurve-reads-back"
+  local file="$OUTDIR/resp-readback.xml" logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ] || [ ! -x "$TOXML" ]; then
+    skip "$name" "iccFromXml or iccToXml not built"
+    return
+  fi
+
+  # CIccTagResponseCurveSet16::Read bounded the curve offset twice: once tag-relative
+  # against the tag length (correct), then again as an ABSOLUTE file position against
+  # that same tag length. A 44-byte resp tag at file offset 396 with curve offset 16
+  # computed 412 > 44, so Read returned false and NO profile carrying this tag could be
+  # read back -- iccToXml and iccToJson both said "Unable to read" and iccDumpProfile
+  # reported the tag missing, for bytes that are correct (#2399).
+  #
+  # This is section 1's read-back-what-you-wrote invariant applied to this tag: without
+  # it every other case here asserts only on documents the toolchain cannot consume, and
+  # all four would stay green while the tag remained unreadable.
+  write_countofchannels_document "$file" "<CountOfChannels>1</CountOfChannels>"
+
+  if ! "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1; then
+    fail "$name" "the control document no longer converts"
+    return
+  fi
+  if ! "$TOXML" "$OUTDIR/${name}.icc" "$OUTDIR/${name}-back.xml" >>"$logfile" 2>&1; then
+    fail "$name" "iccToXml cannot read back the profile it just wrote -- the resp tag offset bound is back"
+    return
+  fi
+  if ! grep -q "responseCurveSet16Type" "$OUTDIR/${name}-back.xml"; then
+    fail "$name" "round-tripped, but the resp tag did not survive"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || return
+  pass "$name (profile with a resp tag reads back and keeps the tag)"
+}
+
+measurement_reserved_not_inherited() {
+  local name="xml-responsecurve-reserved-not-inherited"
+  local file="$OUTDIR/resp-reserved.xml" logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ] || [ ! -x "$TOXML" ]; then
+    skip "$name" "iccFromXml or iccToXml not built"
+    return
+  fi
+
+  # icResponse16Number was declared once per <ChannelResponses> and reused for every
+  # <Measurement> sibling. deviceCode and measurementValue are assigned every iteration,
+  # but reserved only when the attribute is present, so a bare <Measurement> following
+  # Reserved="7" inherited the 7 -- a field ICC requires to be 0 (#2399).
+  #
+  # Asserted through a round trip rather than on the bytes: ToXml emits Reserved only
+  # when it is nonzero, so the count of Reserved="7" in the regenerated document is
+  # exactly the number of measurements that carry it. Two means the second inherited.
+  cat > "$file" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>2.10</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>GRAY</DataColourSpace>
+    <PCS>XYZ </PCS>
+  </Header>
+  <Tags>
+    <responseCurveSet16Type>
+      <TagSignature>resp</TagSignature>
+      <CountOfChannels>1</CountOfChannels>
+      <ResponseCurve MeasUnitSignature="Status A">
+        <ChannelResponses X="0" Y="0" Z="0">
+          <Measurement DeviceCode="1" MeasValue="0" Reserved="7"/>
+          <Measurement DeviceCode="2" MeasValue="0"/>
+        </ChannelResponses>
+      </ResponseCurve>
+    </responseCurveSet16Type>
+  </Tags>
+</IccProfile>
+XMLEOF
+
+  if ! "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1; then
+    fail "$name" "the two-measurement document no longer converts"
+    return
+  fi
+  if ! "$TOXML" "$OUTDIR/${name}.icc" "$OUTDIR/${name}-back.xml" >>"$logfile" 2>&1; then
+    fail "$name" "iccToXml cannot read the profile back, so the field cannot be checked"
+    return
+  fi
+
+  local nReserved
+  nReserved=$(grep -c 'Reserved="7"' "$OUTDIR/${name}-back.xml")
+  if [ "$nReserved" -ne 1 ]; then
+    fail "$name" "Reserved=\"7\" appears $nReserved time(s); the measurement that omitted it inherited the previous value"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || return
+  pass "$name (an omitted Reserved stays 0 instead of inheriting)"
+}
+
+countofchannels_65536_channel_write() {
+  local name="xml-responsecurve-count-65536-oob"
+  local file="$OUTDIR/resp-65536.xml" logfile="$OUTDIR/${name}.log"
+
+  if [ ! -x "$FROMXML" ]; then
+    skip "$name" "iccFromXml not built"
+    return
+  fi
+
+  # The narrowing in #2398 was not only a wrong value -- at exactly 65536 it was a heap
+  # out-of-bounds WRITE, and a second crash distinct from #2397's null deref.
+  #
+  # CountOfChannels was parsed into an icUInt32Number, so 65536 survived intact in
+  # nChannels.  CIccResponseCurveStruct's constructor takes an icUInt16Number, so the
+  # struct was built with 65536 truncated to 0 and calloc'd nothing -- while the
+  # "nChannels != icXmlNodeCount(...)" gate compared the UNtruncated 65536 and therefore
+  # passed for a document carrying 65536 <ChannelResponses>.  The loop then wrote through
+  # curves.GetXYZ(i) (IccTagBasic.h:1704, an unchecked &m_maxColorantXYZ[index]) for i up
+  # to 65535: roughly 768 KiB written past a zero-sized allocation.  Measured on the
+  # unfixed parser: SIGSEGV, core dumped, exit 139.
+  #
+  # The fixture MUST carry all 65536 elements.  With fewer, the count gate refuses the
+  # document before the write and the unfixed parser exits non-zero all by itself, so the
+  # case would pass against the very defect it exists to pin -- the same vacuity that the
+  # zero-count fixture above had to be rebuilt to avoid.
+  if ! python3 - "$file" <<'PY'
+import sys
+n = 65536
+chan = ('        <ChannelResponses X="0" Y="0" Z="0">\n'
+        '          <Measurement DeviceCode="0" MeasValue="0"/>\n'
+        '        </ChannelResponses>\n')
+with open(sys.argv[1], "w") as f:
+    f.write('<?xml version="1.0" encoding="UTF-8"?>\n<IccProfile>\n  <Header>\n'
+            '    <ProfileVersion>2.10</ProfileVersion>\n'
+            '    <ProfileDeviceClass>mntr</ProfileDeviceClass>\n'
+            '    <DataColourSpace>GRAY</DataColourSpace>\n'
+            '    <PCS>XYZ </PCS>\n  </Header>\n  <Tags>\n'
+            '    <responseCurveSet16Type>\n      <TagSignature>resp</TagSignature>\n'
+            f'      <CountOfChannels>{n}</CountOfChannels>\n'
+            '      <ResponseCurve MeasUnitSignature="Status A">\n')
+    f.write(chan * n)
+    f.write('      </ResponseCurve>\n    </responseCurveSet16Type>\n  </Tags>\n</IccProfile>\n')
+PY
+  then
+    skip "$name" "could not generate the 65536-channel document"
+    return
+  fi
+
+  "$FROMXML" "$file" "$OUTDIR/${name}.icc" >"$logfile" 2>&1
+  local status=$?
+
+  # Asserted on HOW it exits, like the empty-element case: this defect's signature is a
+  # signal death (128+signum), which a bare "exit != 0" would have accepted.
+  if [ "$status" -ge 128 ]; then
+    fail "$name" "iccFromXml died on a signal (exit $status) -- the 65536-channel OOB write is back"
+    return
+  fi
+  if [ "$status" -eq 0 ]; then
+    fail "$name" "a CountOfChannels of 65536 was accepted"
+    return
+  fi
+  if ! grep -qE "$RESP_TAG_DIAG" "$logfile"; then
+    fail "$name" "refused, but not by the responseCurveSet16Type parser"
+    return
+  fi
+  check_sanitizers "$name" "$logfile" || return
+  pass "$name (65536 channels refused at the count, no signal)"
+}
+
+echo
+echo "=== responseCurveSet16 CountOfChannels (issues #2397, #2398, #2399) ==="
+
+countofchannels_empty_element
+countofchannels_overflow_is_not_one
+countofchannels_indented_is_accepted
+countofchannels_zero_refused
+measurement_devicecode_overflow
+responsecurve_profile_reads_back
+measurement_reserved_not_inherited
+countofchannels_65536_channel_write
 
 ###############################################################################
 

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -1891,8 +1891,15 @@ bool CIccTagJsonResponseCurveSet16::ToJson(IccJson &j)
 
 bool CIccTagJsonResponseCurveSet16::ParseJson(const IccJson &j, std::string &parseStr)
 {
+  // The upper bound matters as much as the lower one: SetNumChannels takes an
+  // icUInt16Number, so 65537 was cast down to 1 and this parser accepted a document
+  // it then wrote as a different one -- the JSON half of #2398, which the XML twin
+  // (CIccTagXmlResponseCurveSet16::ParseXml) carried in the same shape.  The
+  // "< 0 || > 0xffff" guard is the idiom this file already uses before narrowing a
+  // JSON integer to a channel count (see the SparseMatrixArray case above).
   int nChannels = 0;
-  if (!jGetValue(j, "CountOfChannels", nChannels) || nChannels <= 0) {
+  if (!jGetValue(j, "CountOfChannels", nChannels) || nChannels <= 0 ||
+      nChannels > 0xffff) {
     parseStr += "Missing or invalid CountOfChannels in ResponseCurveSet16\n";
     return false;
   }
@@ -1942,9 +1949,26 @@ bool CIccTagJsonResponseCurveSet16::ParseJson(const IccJson &j, std::string &par
           icResponse16Number resp = {};
           int dc = 0, res = 0;
           double mv = 0.0;
-          jGetValue(jm, "DeviceCode", dc);
+
+          // Both fields are icUInt16Number in icResponse16Number and were read into an
+          // int and cast unchecked, so "DeviceCode": 65537 stored 1 and -1 stored 65535 --
+          // the same narrowing CountOfChannels carried above and that the XML twin
+          // (CIccTagXmlResponseCurveSet16::ParseXml) fixes in the same tag (#2398).  The
+          // jGetValue result was discarded too, so "DeviceCode": "abc" silently yielded 0.
+          // Range-tested with this file's own "< 0 || > 0xffff" idiom; a field that is
+          // absent keeps its zero default, as the XML path allows for Reserved.
+          if (jsonExistsField(jm, "DeviceCode") &&
+              (!jGetValue(jm, "DeviceCode", dc) || dc < 0 || dc > 0xffff)) {
+            parseStr += "Invalid Measurement DeviceCode in ResponseCurveSet16\n";
+            return false;
+          }
+          if (jsonExistsField(jm, "Reserved") &&
+              (!jGetValue(jm, "Reserved", res) || res < 0 || res > 0xffff)) {
+            parseStr += "Invalid Measurement Reserved in ResponseCurveSet16\n";
+            return false;
+          }
           jGetValue(jm, "MeasValue",  mv);
-          jGetValue(jm, "Reserved",   res);
+
           resp.deviceCode       = (icUInt16Number)dc;
           resp.measurementValue = icDtoF((icFloatNumber)mv);
           resp.reserved         = (icUInt16Number)res;

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -11494,8 +11494,17 @@ bool CIccTagResponseCurveSet16::Read(icUInt32Number size, CIccIO *pIO)
       delete[] nOffset;
       return false;
     }
+    // nOffset[i] is TAG-RELATIVE and is already bounded against the tag length by the
+    // check above.  offsetCalc is an ABSOLUTE file position, so the only thing left to
+    // bound it against is what the IO layer can address; comparing it with `size` -- the
+    // tag's byte length -- rejected every ordinary profile carrying this tag.  The resp
+    // tag iccFromXml writes sits at file offset 396 with size 44 and curve offset 16, so
+    // this computed 412 > 44 and returned false: iccToXml and iccToJson both reported
+    // "Unable to read" and iccDumpProfile reported the tag "not found", for a tag whose
+    // bytes are correct (#2399).  A tag can only fail this way when its own file offset
+    // exceeds its length, which is true of essentially every real tag.
     size_t offsetCalc = startPos + nOffset[i];
-    if (offsetCalc > size || offsetCalc > 0xFFFFFFFFULL) {
+    if (offsetCalc > 0xFFFFFFFFULL) {
       delete[] nOffset;
       return false;
     }

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -3054,14 +3054,63 @@ bool CIccTagXmlResponseCurveSet16::ToXml(std::string &xml, std::string blanks/* 
 }
 
 
-bool CIccTagXmlResponseCurveSet16::ParseXml(xmlNode *pNode, std::string & /*parseStr*/)
+bool CIccTagXmlResponseCurveSet16::ParseXml(xmlNode *pNode, std::string &parseStr)
 {
-  pNode = icXmlFindNode(pNode, "CountOfChannels"); 
+  pNode = icXmlFindNode(pNode, "CountOfChannels");
 
   if(!pNode)
     return false;
 
-  icUInt32Number nChannels = (icUInt32Number)atoi((const char*)pNode->children->content);
+  // An empty <CountOfChannels/> is a well-formed element with NO text child, so
+  // libxml2 leaves pNode->children NULL and the old read of children->content
+  // dereferenced it: "member access within null pointer of type 'struct _xmlNode'",
+  // and a SIGSEGV in a release build (#2397).  The pNode test above is not the same
+  // check -- icXmlFindNode found the element, it simply has no content.  Every other
+  // ->children->content read in the XML parsers guards the child first; this was the
+  // one site that did not.
+  if (!pNode->children || !pNode->children->content) {
+    parseStr += "Empty CountOfChannels in responseCurveSet16Type\n";
+    return false;
+  }
+
+  // icXmlParseU16, not atoi(), and sized to the setter rather than to icUInt32Number.
+  // SetNumChannels takes an icUInt16Number, so the old u32 value was narrowed on the
+  // way in: "4294967297" is 0x100000001, which atoi() has undefined behaviour on to
+  // begin with, and which truncated to 1 -- producing a profile byte-identical to the
+  // one a count of 1 produces, reported as "parsed and saved correctly" (#2398).
+  // Parsing straight into the setter's own type refuses the value instead of
+  // silently agreeing to a different document than the one supplied.
+  //
+  // TRIM FIRST.  Every other icXmlParseU16 caller passes an attribute value; this is
+  // the first to pass ELEMENT text, which carries the document's own indentation.
+  // The helper requires the whole string to be consumed and strtoul skips leading
+  // blanks but not trailing ones, so a pretty-printed
+  // "<CountOfChannels>\n  1\n</CountOfChannels>" would be refused outright -- a
+  // document atoi() read as 1.  That is the same trap #2387 fixed for
+  // <ProfileVersion> (see parseVersion in IccProfileXml.cpp, which trims for exactly
+  // this reason); applying the strict helper without the trim would have reproduced
+  // it here.  The two trims are deliberately not shared yet: parseVersion is
+  // file-static in a translation unit with an open change against it.
+  std::string sCount((const char*)pNode->children->content);
+  const char *szBlank = " \t\r\n\f\v";
+  std::string::size_type nFirst = sCount.find_first_not_of(szBlank);
+  if (nFirst == std::string::npos) {
+    parseStr += "Empty CountOfChannels in responseCurveSet16Type\n";
+    return false;
+  }
+  sCount = sCount.substr(nFirst, sCount.find_last_not_of(szBlank) - nFirst + 1);
+
+  icUInt16Number nChannels = 0;
+  if (!icXmlParseU16(sCount.c_str(), nChannels) || !nChannels) {
+    // Zero is refused as well as out-of-range: the JSON twin already rejects
+    // "CountOfChannels" <= 0 (IccTagJson.cpp:1895) and
+    // docs/icc-profile.schema.json declares "minimum": 1, so accepting it here was
+    // the odd one out.  A zero count sizes no channels while the tag still claims
+    // response curves.
+    parseStr += "Invalid CountOfChannels in responseCurveSet16Type\n";
+    return false;
+  }
+
   SetNumChannels(nChannels);
 
   if (!m_ResponseCurves)
@@ -3085,8 +3134,6 @@ bool CIccTagXmlResponseCurveSet16::ParseXml(xmlNode *pNode, std::string & /*pars
         if (pChild->type == XML_ELEMENT_NODE && !icXmlStrCmp(pChild->name, "ChannelResponses")) {
           CIccResponse16List *pResponseList = curves.GetResponseList(i);
           icXYZNumber *pXYZ = curves.GetXYZ(i);
-          icResponse16Number response{};  // zero-init (.reserved is conditionally set; ICC spec requires it be 0)
-
           const icChar *szX = icXmlAttrValue(pChild, "X");
           const icChar *szY = icXmlAttrValue(pChild, "Y");
           const icChar *szZ = icXmlAttrValue(pChild, "Z");
@@ -3100,6 +3147,16 @@ bool CIccTagXmlResponseCurveSet16::ParseXml(xmlNode *pNode, std::string & /*pars
 
           for (pMeasurement = pChild->children; pMeasurement; pMeasurement = pMeasurement->next) {
             if (pMeasurement->type == XML_ELEMENT_NODE && !icXmlStrCmp(pMeasurement->name, "Measurement")) {
+              // Declared per <Measurement>, not per <ChannelResponses>.  deviceCode and
+              // measurementValue are assigned unconditionally below, but `reserved` is set
+              // only when the attribute is present, so one object reused across siblings
+              // carried the previous measurement's value into a measurement that omitted
+              // it: Reserved="7" followed by a bare <Measurement> wrote 0001 0007 and
+              // 0002 0007, giving the second a nonzero field ICC requires to be 0 (#2399).
+              // Scoping it here makes that structural rather than a comment on a
+              // conditional assignment.
+              icResponse16Number response{};
+
               const icChar *szDeviceCode = icXmlAttrValue(pMeasurement, "DeviceCode");
               const icChar *szValue = icXmlAttrValue(pMeasurement, "MeasValue");
               const icChar *szReserved = icXmlAttrValue(pMeasurement, "Reserved");
@@ -3107,11 +3164,25 @@ bool CIccTagXmlResponseCurveSet16::ParseXml(xmlNode *pNode, std::string & /*pars
               if (!szDeviceCode || !szValue || !*szDeviceCode || !*szValue)
                 return false;
 
-              response.deviceCode = (icUInt16Number)atoi(szDeviceCode);
+              // Same narrowing as CountOfChannels above, in the same tag: both fields
+              // are icUInt16Number in icResponse16Number, and atoi() returns an int,
+              // so DeviceCode="65537" stored 1 and produced a file byte-identical to
+              // DeviceCode="1" -- measured, both hashed to df884791948f... "-1"
+              // likewise landed as 65535.  These are attributes rather than element
+              // text, so they need no trim; icXmlParseU16 rejects the sign, non-digits
+              // and anything above the field's own ceiling (#2398).
+              if (!icXmlParseU16(szDeviceCode, response.deviceCode)) {
+                parseStr += "Invalid Measurement DeviceCode in responseCurveSet16Type\n";
+                return false;
+              }
               response.measurementValue = icDtoF((icFloatNumber)atof(szValue));
 
-              if (szReserved && *szReserved)
-                response.reserved = atoi(szReserved);
+              if (szReserved && *szReserved) {
+                if (!icXmlParseU16(szReserved, response.reserved)) {
+                  parseStr += "Invalid Measurement Reserved in responseCurveSet16Type\n";
+                  return false;
+                }
+              }
 
               pResponseList->push_back(response);
             }


### PR DESCRIPTION
Part of #2397, part of #2398, part of #2399.

Four defects in `responseCurveSet16Type`, three of them in one function. They interlock, so they ship together: the read-back defect masked the other three, and each is verified against a build carrying only the other fixes.

## What was wrong

| # | Defect | Symptom |
|---|---|---|
| #2397 | `ParseXml` read `pNode->children->content` without checking the child | `<CountOfChannels/>` is well-formed with no text child → UBSan null deref, SIGSEGV, exit 139 |
| #2398 | `atoi()` into a wider type than the setter accepts, at four sites (XML + JSON) | `4294967297` truncated to 1 and the tool reported "parsed and saved correctly" |
| #2399 (a) | `Read` compared an **absolute file position** against the **tag's byte length** | no profile carrying this tag could be read back at all |
| #2399 (b) | `icResponse16Number` reused across `<Measurement>` siblings | a bare `<Measurement>` after `Reserved="7"` inherited the 7 |

On (a): the check computed `startPos + nOffset[i] > size`. The tag `iccFromXml` writes sits at file offset 396 with size 44 and curve offset 16, so it computed `412 > 44` and returned false. `iccToXml` and `iccToJson` both said `Unable to read` and `iccDumpProfile` reported the tag missing — for bytes that are correct. A tag fails this way whenever its own file offset exceeds its length, which is true of essentially every real tag. The line above it already bounds the tag-relative offset correctly; the absolute position is still bounded against what the IO layer can address.

On #2398, every truncation is asserted by byte-identity rather than exit status, because exit status cannot distinguish "refused the value" from "refused the profile":

- XML `DeviceCode="65537"` wrote the `DeviceCode="1"` file; `"-1"` landed as 65535.
- JSON `"CountOfChannels": 65537` wrote the count-of-1 file.
- JSON `"DeviceCode": 65537` wrote the DeviceCode-1 file, `-1` the 65535 file, and `"abc"` silently yielded 0 — the `jGetValue` result was discarded.

A zero count is now refused on the XML path too: the JSON twin already rejects `<= 0` and `docs/icc-profile.schema.json` declares `"minimum": 1`.

### The narrowing carried a second crash, not reported in either issue

`/security-review` flagged it and measurement confirms it. At **exactly 65536** the #2398 narrowing was a heap out-of-bounds **write**, distinct from #2397's null deref.

`CountOfChannels` was parsed into an `icUInt32Number`, so 65536 survived intact. `CIccResponseCurveStruct`'s constructor takes an `icUInt16Number` (`IccTagBasic.h:1690`), so the struct was built with 65536 truncated to 0 and allocated nothing — while the `nChannels != icXmlNodeCount(...)` gate compared the **untruncated** 65536 and so passed for a document carrying 65536 `<ChannelResponses>`. The loop then wrote through `curves.GetXYZ(i)` (`IccTagBasic.h:1704`, an unchecked `&m_maxColorantXYZ[index]`) for `i` up to 65535 — roughly 768 KiB past a zero-sized allocation.

Measured on `c1ec46b2`: SIGSEGV, core dumped, exit 139. On the fixed parser the value is refused at the count. The strict `icUInt16Number` parse already closes it, so the third commit adds only the regression — whose fixture must carry all 65536 elements, because with fewer the count gate refuses the document first and the case would pass against the defect it exists to pin.

## Trim before the strict parse

Every other `icXmlParseU16` caller passes an attribute value; this is the first to pass **element text**, which carries the document's own indentation. The helper requires the whole string consumed and `strtoul` skips leading blanks but not trailing ones, so a pretty-printed `<CountOfChannels>\n  1\n</CountOfChannels>` would be refused — a document `atoi()` read as 1. That is the trap #2387 dealt with for `<ProfileVersion>`. Applying the strict helper without the trim reproduced it here; it is now pinned by the one case in this section that asserts *acceptance*.

## Tests

Eight cases in the XML script, four in the JSON one, extending the existing scripts rather than adding targets. `/code-review` found three problems with the first version of them, all since corrected and all worth naming:

- The XML attribution pattern carried a bare `responseCurveSet16Type` alternative, which subsumed the specific one and matched `ParseTag`'s generic `Unable to Parse "responseCurveSet16Type" ... Tag on line N` — printed for *any* failure in the tag. Checked against a document whose only defect is a channel-count mismatch: it matched. So the attribution asserted nothing beyond "the tag failed". Now anchored on the specific diagnostics.
- `measurement_devicecode_overflow` built its documents by `sed`-ing another case's output, then truncated that same file to zero bytes on the fallback path with `|| true` swallowing the failure.
- The JSON fixtures are written in full rather than generated by `iccToJson`, so they cannot depend on the resp **read** path — while (a) was broken they would have gone green by *skipping* instead of red.

The first JSON case is a control that must convert; without it, a change refusing every `responseCurveSet16Type` document would satisfy the three reject cases while removing the guards they pin.

## Red/green

Each defect measured against a build carrying only the other fixes:

- `c1ec46b2` with both tools built — 7 of 8 XML cases red, including **two distinct** `died on a signal (exit 139)` reports from two different defects, and two `byte-identical to the control`. The indented case passes on both sides by design: it guards the trim trap, not a defect.
- (b) alone reverted, read-back working — 14/15, the single red reporting `Reserved="7" appears 2 time(s)`, so that case pins (b) and not (a).
- Unfixed JSON parser — control converts, all three reject cases red as `malformed JSON parsed successfully`.
- Fixed — XML 16/16, JSON 25/25, 236/236 fast CTests.

0 warnings under `-Wall -Wextra -Wpedantic -Werror` on clang 21.1.3, clang 18 and g++ 13.3.0. No tracked document uses `responseCurveSet16Type`, which is why none of these ever reached a fixture.

## Two things deliberately not done

1. `ToXml` emits `<CountOfChannels>0</CountOfChannels>` for a zero-channel tag while the new parse refuses 0, which would be a read-back asymmetry — but no zero-channel resp tag could be constructed that `Read` accepts, so the writer has no demonstrated way to emit one. Recorded as unproven rather than acted on.
2. `iccdev.xml-parser-regressions` carries the `slow` label, and `ci-pr-action.yml` pins `ctest_mode=fast`; the Windows legs never register script tests. These cases therefore execute on no PR leg, exactly as the note above that test records. Worth widening, but that is a lane question rather than part of this fix.
