### PR TITLE
fix(#2386): name an ExtraSamples count libtiff repaired, and refuse a zero bits-per-sample

### DIFF
--- a/.github/ci/regression/tiff-create-bytesperline-overflow.cpp
+++ b/.github/ci/regression/tiff-create-bytesperline-overflow.cpp
@@ -340,6 +340,82 @@ int main()
     }
   }
 
+  // --- 10. A zero bits-per-sample is not a depth.
+  //
+  // Zero passes Create()'s "nBPS % 8" guard, and libtiff accepts
+  // TIFFSetField(BITSPERSAMPLE, 0) with rc=1, so neither the modulus nor the
+  // write-status check added for #2386 catches it. The pre-fix path therefore
+  // authored the directory with BitsPerSample 0 and only gave up once
+  // TIFFStripSize() returned 0 and the "stripSize <= 0" test refused it -- by which
+  // point TIFFOpen had created the destination, leaving a ~140-byte stub on disk.
+  // (Not calcBytesPerLine(): the contiguous branch this case exercises never calls
+  // it, and on the separated branch "stripSize <= 0" fires first.) Open() has
+  // always refused m_nBitsPerSample == 0 on the way in, so this makes the two
+  // symmetric.
+  //
+  // Red/green: against the pre-fix TiffImg.cpp the first assertion passes by
+  // accident -- Create() does return false, just far too late -- and the second
+  // fails, because a file is left on disk. That second assertion is what pins the
+  // fix, so exit status alone is not the test here.
+  //
+  // Not reachable from either tool caller: their depth comes back out of Open(),
+  // which rejects zero. This guards the public API, like case 9 above.
+  {
+    // bCompress MUST be passed as false. It defaults to true, and the guard just
+    // below the modulus -- "bCompress && nBPS != 8 && != 16 && != 32" -- then
+    // rejects a zero depth before TIFFOpen() is ever reached. Written with the
+    // default, this case passes against the unfixed library while never once
+    // exercising the zero-depth path; measured, and it is why this reads
+    // explicitly rather than relying on the signature.
+    cleanup();
+    CTiffImg img;
+    const bool ok = img.Create(kOutPath, 64u, 4u, /*nBPS=*/0u, PHOTO_MINISBLACK,
+                               3u, 0u, 72.0f, 72.0f, /*bCompress=*/false,
+                               /*bSep=*/false);
+    check(!ok, "Create() rejects a zero bits-per-sample");
+    img.Close();
+
+    std::FILE *left = std::fopen(kOutPath, "rb");
+    check(left == NULL,
+          "Create() writes no file when it rejects a zero bits-per-sample");
+    if (left)
+      std::fclose(left);
+    cleanup();
+  }
+
+  // --- 11. A written image knows its own ExtraSamples count.
+  //
+  // Create() sets the ExtraSamples observers for an output image so a Create()d
+  // object does not report "tag 338 was not present" while having just written it.
+  // The stored-count pair added for #2386 has to be set in the same place: without
+  // it, HasStoredExtraSamplesCount() answers false for a directory this object just
+  // authored, and false is defined as "could not determine -- unreadable, non-TIFF,
+  // or BigTIFF", none of which is true here. Nothing repairs a directory we write,
+  // so the stored count is exactly the one we were handed.
+  //
+  // No production caller reads these off an output image today, which is precisely
+  // why the gap survived into review -- so it is asserted here.
+  {
+    cleanup();
+    CTiffImg img;
+    const bool ok = img.Create(kOutPath, 64u, 4u, 8u, PHOTO_MINISBLACK, 6u,
+                               /*nExtraSamples=*/5u, 72.0f, 72.0f,
+                               /*bCompress=*/false, /*bSep=*/false);
+    check(ok, "Create() accepts a 6-sample image declaring 5 extra samples");
+    if (ok) {
+      check(img.HasStoredExtraSamples(),
+            "a written image reports tag 338 as stored");
+      check(img.HasStoredExtraSamplesCount(),
+            "a written image knows the ExtraSamples count it stored");
+      check(img.GetStoredExtraSamplesCount() == 5u,
+            "the stored count on a written image is the one Create() was given");
+      check(img.GetEffectiveExtraSamples() == 5u,
+            "nothing repairs a directory we author, so effective == stored");
+    }
+    img.Close();
+    cleanup();
+  }
+
   if (g_fail)
     std::fprintf(stderr, "[tiff-create-overflow] %d assertion(s) failed\n", g_fail);
   else

--- a/.github/scripts/iccdev-tiff-extrasamples-diagnostics-tests.sh
+++ b/.github/scripts/iccdev-tiff-extrasamples-diagnostics-tests.sh
@@ -20,11 +20,14 @@
 # extra sample, and feeding 80 to iccApplyProfiles would reclassify an 81-band
 # spectral image's bands as alpha.  Case 4 pins that separation.
 #
-# Only the ABSENT-tag half of the gap is closed.  Where tag 338 is present and
-# libtiff still repairs, it overwrites the stored count in place while leaving the
-# field marked present, so the plain getter returns the repaired figure and the
-# original is unrecoverable through libtiff.  Case 2 pins that limit deliberately,
-# with a fixture whose stored and repaired counts disagree.
+# The PRESENT-and-repaired half is closed too.  Where tag 338 is present and libtiff
+# still repairs, it overwrites the stored count in place while leaving the field
+# marked present, so every libtiff getter returns the repaired figure -- a 6-sample
+# MinIsBlack file storing one extra and an honest five-extra file produced
+# byte-identical dumps.  CTiffImg::Open() now reads tag 338's own count field out of
+# the IFD, which is the only way to recover it, and iccTiffDump reports both numbers
+# when they disagree.  Case 2 pins that, and carries an honest-directory control so an
+# unconditional annotation cannot satisfy it.
 #
 # Fixtures are written byte by byte rather than through an encoder so the tag
 # under test is exactly what the test intends, and tag presence is read back out
@@ -320,7 +323,7 @@ case_absent_tag_is_explained() {
 }
 
 ###############################################################################
-# Case 2 -- a stored tag prints the plain count and is not relabelled as repaired.
+# Case 2 -- a repaired tag names BOTH counts; an honest one prints the plain count.
 #
 # The fixture is deliberately the shape where stored and repaired DISAGREE: 6
 # samples, MinIsBlack (one colour channel), tag 338 storing a single value.  One
@@ -330,10 +333,17 @@ case_absent_tag_is_explained() {
 # returns 5, not the 1 the IFD holds, and libtiff offers no way to read the
 # original back.
 #
-# So this case pins the documented limit of the #2386 fix rather than an
-# aspiration: the tag-present half of the gap is NOT closed, and the number
-# printed is libtiff's.  A well-formed fixture (5 stored extras) would have made
-# stored and repaired identical and pinned nothing.
+# This case previously pinned that as a documented LIMIT, asserting a bare "5".
+# The limit is now lifted: CTiffImg::Open() reads tag 338's own count field out
+# of the IFD, which is the only way to recover it, so the dump can name both
+# numbers.  The assertion below is therefore the reverse of what it once was --
+# a bare "5" for this fixture is now a FAILURE, because it means a repaired
+# directory is again indistinguishable from an honest one.
+#
+# The honest 5-extra control at the end is what gives that teeth.  An
+# implementation appending the wording unconditionally would satisfy the first
+# assertion; case 3's well-formed fixture does not cover it, because that file
+# carries no tag 338 at all and so never reaches this branch.
 ###############################################################################
 case_stored_tag_prints_count() {
   local name="stored-tag-prints-count"
@@ -354,18 +364,53 @@ case_stored_tag_prints_count() {
     return
   fi
 
+  # UPDATED for the second half of #2386. This case previously asserted a bare "5" and
+  # carried a failure arm reading "if that is now recoverable, this case and the header
+  # comment both need updating" -- the stored count IS now recoverable, because Open()
+  # reads tag 338's count field straight out of the IFD rather than asking libtiff,
+  # which cannot answer once it has repaired the directory in place.
+  #
+  # Both numbers are required. The effective count leads, because it is the layout the
+  # rest of libtiff is using; the stored count follows, because it is what tells the
+  # reader the file is malformed at all.
   local line
   line="$(dump_extrasamples_line "$f")"
   case "$line" in
+    "5 (file stores 1"*) ;;
     "5")
-      pass_case "$name" "a present tag prints libtiff's plain count (5), with no repair wording" ;;
-    "1")
-      fail_case "$name" "dump printed the stored count 1 -- if that is now recoverable, this case and the header comment both need updating" ;;
+      fail_case "$name" "dump printed a bare 5 -- the repaired directory is again indistinguishable from an honest one"
+      return ;;
     *"not stored"*)
-      fail_case "$name" "a file that DOES store tag 338 was reported as not stored: $line" ;;
+      fail_case "$name" "a file that DOES store tag 338 was reported as not stored: $line"
+      return ;;
     *)
-      fail_case "$name" "expected a plain count, got: '${line:-<no line>}'" ;;
+      fail_case "$name" "expected the effective count then the stored one, got: '${line:-<no line>}'"
+      return ;;
   esac
+
+  # The control that makes the assertion above mean something: a file whose stored
+  # count is honest must NOT be annotated. Without this, an implementation that
+  # appended the wording unconditionally would pass. case_wellformed_file_is_silent
+  # does not cover it -- that fixture has no tag 338 at all, so it never reaches this
+  # branch; this one stores five extras and is annotation-eligible.
+  local honest="$WORKDIR/minisblack-6ch-338-five.tif"
+  generate_tiff "$honest" 4 4 6 1 0 0 0 0 0
+
+  local honest_stored
+  honest_stored="$(read_stored_extrasamples_count "$honest")"
+  if [ "$honest_stored" != "5" ]; then
+    fail_case "$name" "control fixture should store 5 extras, IFD says '$honest_stored'"
+    return
+  fi
+
+  local honest_line
+  honest_line="$(dump_extrasamples_line "$honest")"
+  if [ "$honest_line" != "5" ]; then
+    fail_case "$name" "an honest 5-extra file must print a bare '5', got '${honest_line:-<no line>}'"
+    return
+  fi
+
+  pass_case "$name" "a repaired tag names both counts; an honest one prints a bare 5"
 }
 
 ###############################################################################

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -73,6 +73,7 @@
 #include <cstring>
 #include <algorithm>
 #include <limits>
+#include <climits>   // LONG_MAX, for the IFD-offset bound in readStoredExtraSamplesCount()
 #include "TiffImg.h"
 
 // The output-destination check below needs GetFileAttributesA() on Windows and
@@ -292,6 +293,113 @@ bool calcBytesPerLine(unsigned int width, unsigned int bitsPerSample,
   return checkedUInt32(bytes, bytesPerLine);
 }
 
+// The ExtraSamples count as the FILE stores it, read straight out of the IFD.
+//
+// libtiff cannot answer this.  When the photometric model plus the stored
+// ExtraSamples do not account for SamplesPerPixel it repairs the directory in memory
+// and overwrites the count IN PLACE, leaving the field marked present, so every
+// libtiff getter -- plain or Defaulted -- returns the repaired figure and the stored
+// one is gone.  Measured on a 6-sample MinIsBlack file storing ExtraSamples [0]:
+// tiffdump shows "ExtraSamples (338) SHORT (3) 1<0>" while tiffinfo and iccTiffDump
+// both report 5, so a repaired file and an honest 5-extra file produced byte-identical
+// dumps (#2386).
+//
+// Reading tag 338's own count field is the only way to tell them apart, and it needs
+// nothing but the 12-byte IFD entry: for ExtraSamples the entry's count IS the number
+// of extra samples.  Opened separately from libtiff's handle so nothing here can
+// disturb the decoder's file position.
+//
+// Reporting only.  A false return means "could not determine" -- not "absent" -- and
+// the caller must keep the two apart: BigTIFF (magic 43) lays its IFD out differently
+// and is deliberately not parsed here rather than guessed at.
+bool readStoredExtraSamplesCount(const char *szFname, icUInt16Number &nStored)
+{
+  if (!szFname)
+    return false;
+
+  FILE *f = fopen(szFname, "rb");
+  if (!f)
+    return false;
+
+  unsigned char hdr[8];
+  if (fread(hdr, 1, sizeof(hdr), f) != sizeof(hdr)) {
+    fclose(f);
+    return false;
+  }
+
+  bool bLittle;
+  if (hdr[0] == 'I' && hdr[1] == 'I')
+    bLittle = true;
+  else if (hdr[0] == 'M' && hdr[1] == 'M')
+    bLittle = false;
+  else {
+    fclose(f);
+    return false;
+  }
+
+  struct Get {
+    bool little;
+    icUInt32Number u16(const unsigned char *p) const {
+      return little ? (icUInt32Number)(p[0] | (p[1] << 8))
+                    : (icUInt32Number)(p[1] | (p[0] << 8));
+    }
+    icUInt32Number u32(const unsigned char *p) const {
+      return little ? ((icUInt32Number)p[0] | ((icUInt32Number)p[1] << 8) |
+                       ((icUInt32Number)p[2] << 16) | ((icUInt32Number)p[3] << 24))
+                    : ((icUInt32Number)p[3] | ((icUInt32Number)p[2] << 8) |
+                       ((icUInt32Number)p[1] << 16) | ((icUInt32Number)p[0] << 24));
+    }
+  } get{bLittle};
+
+  // 42 is classic TIFF. 43 is BigTIFF, whose IFD carries 8-byte counts and 20-byte
+  // entries; parsing it as classic would read garbage, so refuse instead.
+  if (get.u16(hdr + 2) != 42) {
+    fclose(f);
+    return false;
+  }
+
+  // The offset is a TIFF uint32, but fseek() takes a long, which is 32-bit on LLP64 --
+  // the MSVC lane.  A classic TIFF larger than 2 GiB may legally place its first IFD at
+  // or above 0x80000000, which would cast to a negative offset there and fail, so the
+  // same file would report its stored count on Linux and silently decline to on
+  // Windows.  Refuse the out-of-range offset explicitly instead, so "could not
+  // determine" means the same thing on every lane rather than depending on sizeof(long).
+  icUInt32Number nIfdOffset = get.u32(hdr + 4);
+  if (nIfdOffset < 8 || nIfdOffset > (icUInt32Number)LONG_MAX ||
+      fseek(f, (long)nIfdOffset, SEEK_SET) != 0) {
+    fclose(f);
+    return false;
+  }
+
+  unsigned char count[2];
+  if (fread(count, 1, sizeof(count), f) != sizeof(count)) {
+    fclose(f);
+    return false;
+  }
+
+  icUInt32Number nEntries = get.u16(count);
+  for (icUInt32Number i = 0; i < nEntries; i++) {
+    unsigned char entry[12];
+    if (fread(entry, 1, sizeof(entry), f) != sizeof(entry)) {
+      fclose(f);
+      return false;
+    }
+    if (get.u16(entry) == TIFFTAG_EXTRASAMPLES) {
+      icUInt32Number nCount = get.u32(entry + 4);
+      fclose(f);
+      // The count is what is being reported, so it has to fit the field it is
+      // compared against; a value this large is a malformed directory either way.
+      if (nCount > kMaxTiffSamples)
+        return false;
+      nStored = (icUInt16Number)nCount;
+      return true;
+    }
+  }
+
+  fclose(f);
+  return false;
+}
+
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -311,6 +419,8 @@ CTiffImg::CTiffImg()
     m_nExtraSamples(0),
     m_bExtraSamplesStored(false),
     m_nEffectiveExtraSamples(0),
+    m_nStoredExtraSamplesCount(0),
+    m_bStoredExtraSamplesKnown(false),
     m_nPlanar(0),
     m_nCompress(0),
     m_nSampleFormat(SAMPLEFORMAT_UINT),
@@ -387,6 +497,8 @@ void CTiffImg::Close()
   m_nExtraSamples = 0;
   m_bExtraSamplesStored = false;
   m_nEffectiveExtraSamples = 0;
+  m_nStoredExtraSamplesCount = 0;
+  m_bStoredExtraSamplesKnown = false;
   m_nPlanar = 0;
   m_nCompress = 0;
   m_nSampleFormat = SAMPLEFORMAT_UINT;
@@ -415,7 +527,19 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
   m_bRead = false;
   m_bOutputOpened = false;
 
-  if (nBPS % 8)
+  // Zero is rejected explicitly: it passes "% 8" and libtiff accepts
+  // TIFFSetField(BITSPERSAMPLE, 0) with rc=1, so neither the modulus nor the write
+  // status catches it.  The directory was therefore authored with BitsPerSample 0 and
+  // only abandoned much further down, once TIFFStripSize() returned 0 ("Computed
+  // scanline size is zero") and the "stripSize <= 0" test refused it -- on BOTH the
+  // separated and contiguous branches, and note it is that test rather than
+  // calcBytesPerLine(), which the contiguous branch never calls.  By then TIFFOpen had
+  // created the destination, so a ~140-byte stub was left on disk.  Open() has always
+  // refused m_nBitsPerSample == 0 on the way in; this makes Create() symmetric with it
+  // and refuses before the destination is touched (#2386).  Neither tool caller can
+  // reach it -- their depth comes back out of Open() -- so this guards the public API,
+  // as the ResolutionUnit check below does.
+  if (!nBPS || nBPS % 8)
     return false;
 
   if (bCompress && nBPS != 8 && nBPS != 16 && nBPS != 32)
@@ -562,6 +686,14 @@ bool CTiffImg::Create(const char *szFname, unsigned int nWidth, unsigned int nHe
   // the effective count is the requested one.
   m_bExtraSamplesStored = (m_nExtraSamples != 0);
   m_nEffectiveExtraSamples = m_nExtraSamples;
+  // The stored-count pair belongs here for the same reason, and leaving it out would
+  // have re-opened exactly the trap this block exists to close: a Create()d object
+  // would answer HasStoredExtraSamplesCount() == false, which the header defines as
+  // "could not determine -- unreadable, non-TIFF, or BigTIFF".  None of those is true
+  // of a directory we just authored from a count we were handed.  Nothing repairs a
+  // directory we write, so the stored count IS the requested one.
+  m_bStoredExtraSamplesKnown = true;
+  m_nStoredExtraSamplesCount = m_nExtraSamples;
   bFieldsSet &= TIFFSetField(m_hTif, TIFFTAG_BITSPERSAMPLE, m_nBitsPerSample) == 1;
   if (m_nBitsPerSample >= 32) {
     m_nSampleFormat = SAMPLEFORMAT_IEEEFP;
@@ -742,6 +874,15 @@ bool CTiffImg::Open(const char *szFname)
         nEffective <= m_nSamples)
       m_nEffectiveExtraSamples = nEffective;
   }
+
+  // The count the file itself stores, which no libtiff getter can report once the
+  // directory has been repaired in place.  Read from the IFD so that a repaired file
+  // is distinguishable from an honest one: without it a 6-sample MinIsBlack image
+  // storing ExtraSamples [0] and one honestly storing five produced identical dumps
+  // (#2386).  Failure here means "could not determine", so the flag is what gates
+  // reporting -- a 0 count is a legitimate stored value, not a sentinel.
+  m_bStoredExtraSamplesKnown =
+    readStoredExtraSamplesCount(szFname, m_nStoredExtraSamplesCount);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_SAMPLEFORMAT, &m_nSampleFormat);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_ROWSPERSTRIP, &m_nRowsPerStrip);
   TIFFGetFieldDefaulted(m_hTif, TIFFTAG_ORIENTATION, &m_nOrientation);

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.h
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.h
@@ -149,7 +149,9 @@ public:
   // present, so the plain TIFFGetField() in Open() succeeds and hands back the
   // repaired figure.  Measured on libtiff 4.5.1 and 4.7.2 with a 6-sample MinIsBlack
   // file storing ExtraSamples [2]: the IFD carries 1, this answers 5.  libtiff
-  // exposes no way to recover the stored count once that has happened.
+  // exposes no way to recover the stored count once that has happened -- so Open()
+  // reads it out of the IFD directly instead; see GetStoredExtraSamplesCount() below
+  // when you need the count the file actually carries.
   //
   // That matters because colour management keys off this value:
   // iccApplyProfiles.cpp:541-547 lets a profile match sn-sen instead of sn, so on
@@ -171,6 +173,24 @@ public:
   // the image as 1 colour channel plus 80 non-colour.  Reporting only -- feeding it
   // to colour management would reclassify those spectral bands as alpha.
   unsigned int GetEffectiveExtraSamples() const { return m_nEffectiveExtraSamples; }
+  // Whether the ExtraSamples count the FILE stores could be recovered, and what it is.
+  //
+  // This is the one thing GetExtraSamples() cannot give you on a repaired file, and it
+  // does not come from libtiff at all: Open() reads tag 338's count field straight out
+  // of the IFD, because libtiff overwrites the stored count in place and then reports
+  // the repaired figure through every getter it has.  On a 6-sample MinIsBlack image
+  // storing ExtraSamples [0] this answers 1 while GetExtraSamples() answers 5.
+  //
+  // False means "could not determine" -- an unreadable file, a non-TIFF, or BigTIFF,
+  // whose directory layout is deliberately not parsed -- and NOT "tag 338 absent",
+  // which is HasStoredExtraSamples(). Keep the two apart: a stored count of 0 is a
+  // legitimate value, so the flag is what gates use of the number.
+  //
+  // Reporting only, like GetEffectiveExtraSamples(). Which count colour management
+  // should key off is the carrier-contract question open on #2379/#2385 and is not
+  // decided here; iccApplyProfiles still uses GetExtraSamples().
+  bool HasStoredExtraSamplesCount() const { return m_bStoredExtraSamplesKnown; }
+  unsigned int GetStoredExtraSamplesCount() const { return m_nStoredExtraSamplesCount; }
   unsigned int GetCompress() { return m_nCompress; }
   unsigned int GetPlanar() { return m_nPlanar; }
   unsigned int GetSampleFormat() { return m_nSampleFormat; }
@@ -218,6 +238,8 @@ protected:
   icUInt16Number m_nExtraSamples;
   bool m_bExtraSamplesStored;
   icUInt16Number m_nEffectiveExtraSamples;
+  icUInt16Number m_nStoredExtraSamplesCount;
+  bool m_bStoredExtraSamplesKnown;
   icUInt16Number m_nPlanar;
   icUInt16Number m_nCompress;
   icUInt16Number m_nSampleFormat;

--- a/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
+++ b/Tools/CmdLine/IccTiffDump/iccTiffDump.cpp
@@ -492,17 +492,34 @@ int main(int argc, icChar* argv[])
   // and say it was not stored, rather than leave the reader to reconcile the two
   // numbers themselves (#2386).
   //
-  // Only the absent-tag half of that gap is closed here.  Where tag 338 IS present
-  // and libtiff still repairs, it overwrites the stored count in place and exposes
-  // no way to read the original back, so the plain figure printed below is libtiff's
-  // and may not be the file's -- a 6-sample MinIsBlack image storing [2] prints 5.
-  // Recovering the stored count would mean parsing the IFD independently of libtiff;
-  // that is not done here because the same repaired count is what colour management
-  // consumes, and which of the two is correct is the open question on #2379/#2385.
+  // The present-and-repaired half is now covered too.  Where tag 338 IS present and
+  // libtiff repairs anyway, it overwrites the stored count in place and reports the
+  // repaired figure through every getter it has, so this line used to be libtiff's
+  // number presented as the file's: a 6-sample MinIsBlack image storing ExtraSamples
+  // [0] printed "ExtraSamples: 5", byte-identical to an honest five-extra file.  Two
+  // materially different directories were indistinguishable in the dump, which is the
+  // half of #2386 left open by #2402.
+  //
+  // CTiffImg::Open() now reads tag 338's count field straight out of the IFD, so the
+  // stored figure is available to compare -- see HasStoredExtraSamplesCount().  When
+  // the two disagree, print both and name the repair; the reader needs the stored one
+  // to know the file is malformed and the effective one to understand the layout the
+  // rest of libtiff is using.  Reporting only: iccApplyProfiles still consumes the
+  // repaired count, and which of the two SHOULD drive colour management is the
+  // carrier-contract question open on #2379/#2385, deliberately not decided here.
   unsigned int nExtra = SrcImg.GetExtraSamples();
   unsigned int nEffectiveExtra = SrcImg.GetEffectiveExtraSamples();
-  if (SrcImg.HasStoredExtraSamples())
-    printf("ExtraSamples:      %u\n", nExtra);
+  if (SrcImg.HasStoredExtraSamples()) {
+    // Gated on the flag, not on a nonzero count: a stored 0 is a legitimate value, and
+    // a false flag means the count could not be determined (BigTIFF, or an unreadable
+    // file) rather than that the tag was absent.
+    if (SrcImg.HasStoredExtraSamplesCount() &&
+        SrcImg.GetStoredExtraSamplesCount() != nExtra)
+      printf("ExtraSamples:      %u (file stores %u; libtiff repaired the layout)\n",
+        nExtra, SrcImg.GetStoredExtraSamplesCount());
+    else
+      printf("ExtraSamples:      %u\n", nExtra);
+  }
   else if (nEffectiveExtra)
     printf("ExtraSamples:      not stored; libtiff treats %u of %u samples as non-color\n",
       nEffectiveExtra, SrcImg.GetSamples());


### PR DESCRIPTION
Part of #2386 — items 1 and 2, the two left open when #2402 closed the absent-tag half.

## Item 1 — a repaired directory was indistinguishable from an honest one

Where tag 338 is present but its count does not account for `SamplesPerPixel`, libtiff repairs the directory and overwrites the stored count **in place**, leaving the field marked present. Every libtiff getter then returns the repaired figure, so `iccTiffDump` printed libtiff's number as though it were the file's.

Measured — a 6-sample MinIsBlack file storing `ExtraSamples [0]` and an honest five-extra file produced **byte-identical output**:

```
$ tiffdump repaired.tif | grep ExtraSamples
  ExtraSamples (338) SHORT (3) 1<0>          <- the file stores ONE

$ iccTiffDump repaired.tif | grep ExtraSamples
ExtraSamples:      5                          <- before
$ iccTiffDump honest.tif   | grep ExtraSamples
ExtraSamples:      5                          <- identical
```

Two materially different directories, one dump. libtiff has no API for the stored count once it has repaired — which is exactly what the #2402 header comment recorded as a limitation — so `CTiffImg::Open()` now reads tag 338's own count field straight out of the IFD. For ExtraSamples the entry's count *is* the number of extra samples, so this needs the 12-byte directory entry and nothing else. It uses a separate `FILE*` so it cannot disturb libtiff's handle, and BigTIFF (magic 43) is refused rather than parsed as classic.

```
ExtraSamples:      5 (file stores 1; libtiff repaired the layout)
```

The effective count leads because it is the layout the rest of libtiff is using; the stored count follows because it is what tells the reader the file is malformed at all.

**Reporting only.** `iccApplyProfiles` still consumes `GetExtraSamples()`. Which count *should* drive colour management is the carrier-contract question open on #2379/#2385 and is deliberately not decided here. A false "known" flag means the count could not be determined — **not** that the tag is absent, which stays `HasStoredExtraSamples()`.

## Item 2 — `Create()` accepted a zero bits-per-sample

Zero passes `nBPS % 8`, and libtiff accepts `TIFFSetField(BITSPERSAMPLE, 0)` with `rc=1`, so neither the modulus nor the write-status check added by #2402 caught it. The directory was authored with `BitsPerSample 0` and only abandoned once `TIFFStripSize()` returned 0 and the `stripSize <= 0` test refused it — by which point `TIFFOpen` had created the destination, leaving a ~140-byte stub on disk. `Open()` has always refused `m_nBitsPerSample == 0` on the way in; `Create()` is now symmetric with it and refuses before the destination is touched.

Not reachable from either tool caller — their depth comes back out of `Open()` — so this guards the public API, like the ResolutionUnit and output-destination checks beside it.

## Tests, and two fixtures that had to be rebuilt to mean anything

Item 1 **updates** case 2 of the ExtraSamples suite rather than adding a case: it already used the same 6-sample fixture and carried the failure arm *"if that is now recoverable, this case and the header comment both need updating"*. It now asserts both counts and carries an honest five-extra control, so annotating every file cannot satisfy it — case 3's well-formed fixture does not cover that, having no tag 338 to annotate. The stored count is cross-checked against an independent IFD reader first, so a generator that stopped emitting a 1-count tag 338 fails loudly instead of testing nothing.

Item 2 extends the existing direct-call `Create()` regression, since no tool can reach it. **`bCompress` is passed as `false` explicitly and that is load-bearing:** it defaults to `true`, and `bCompress && nBPS != 8 && != 16 && != 32` then rejects a zero depth before `TIFFOpen` is reached. Written with the default, the case passed against the unfixed library while never once exercising the zero-depth path — measured, and corrected.

## Red/green

Each item against a build carrying only the other fix:

- **Item 1**, raw IFD read disabled — case 2 red as `dump printed a bare 5 -- the repaired directory is again indistinguishable from an honest one`. 5/5 green with it.
- **Item 2**, guard reverted — red on `Create() writes no file when it rejects a zero bits-per-sample`, while `Create() rejects a zero bits-per-sample` passes **either way**: it does return false, just after creating the file. So exit status alone is not the test.
- The new observer case is red on a build with the two `Create()` lines removed.

## `/code-review` found four things, all corrected here

- `Create()` set the two older ExtraSamples observers for a written image but **not** the new stored-count pair, so a `Create()d` object answered `HasStoredExtraSamplesCount() == false` — which the header defines as "could not determine" — for a directory it had just authored. That is the exact trap the block it sits in was added to close. Now set alongside them, and pinned by a new case, since no production caller reads these off an output image and that is why the gap survived.
- My comment named the **wrong mechanism**: I wrote that `calcBytesPerLine()` refused the zero depth. It does not — the contiguous branch never calls it, and on the separated branch `stripSize <= 0` fires first. Corrected in the source, the regression and the commit message.
- The case 2 block comment still described the old behaviour as a documented limit, directly above assertions that now require the opposite. The file-level header had been updated and the per-case one had not, so the script contradicted itself.
- `fseek()` takes a `long`, which is 32-bit on LLP64, so a classic TIFF placing its first IFD at or above `0x80000000` would report its stored count on Linux and silently decline to on the MSVC lane. The offset is now range-checked explicitly.

## Verification

0 warnings under `-Wall -Wextra -Wpedantic -Werror` on clang 21.1.3 and g++ 13.3.0; 236/236 fast CTests; the ExtraSamples suite 5/5 and the `Create()` regression green.

No behaviour change on real files: the tracked 81-band spectral image still reads `not stored; libtiff treats 80 of 81 samples as non-color`, and ordinary 3-sample RGB files still print no ExtraSamples line at all.
