### PR TITLE
fix(#2387): make iccFromXml's CLI contract honest about what it did

### DIFF
--- a/.github/scripts/iccdev-issue-2387-fromxml-cli-contract-regression.sh
+++ b/.github/scripts/iccdev-issue-2387-fromxml-cli-contract-regression.sh
@@ -1,0 +1,387 @@
+#!/bin/bash
+###############################################################################
+# iccFromXml CLI-contract regression (#2387)
+###############################################################################
+#
+# Four defects in IccFromXml.cpp's argument handling, all reported against the
+# same tool and all of them silent -- each one exits 0 while doing something
+# other than what it was asked.
+#
+#   1. -noid preserved an existing profile ID.  CIccProfile::Write() emits
+#      m_Header.profileID unconditionally; icNeverWriteID only suppresses the
+#      RECALCULATION and rewrite at offset 84.  So a document already carrying a
+#      <ProfileID> -- which is what iccToXml emits for any v4 profile -- kept its
+#      original ID straight through `iccFromXml ... -noid`.
+#   2. Bare -v failed OPEN.  The lookup left the schema string empty when it
+#      found nothing, and LoadXml validates only against a non-empty string, so
+#      -v was behaviourally identical to passing nothing.  The lookup also only
+#      ever derived the path from argv[0] while the README documents the CURRENT
+#      directory, so the documented invocation never found the schema at all.
+#   3. A missing output path returned success.  `iccFromXml foo.xml` printed
+#      usage and exited 0, so automation saw success for a run that converted
+#      nothing.
+#   4. Unknown options were ignored in silence.  An ordinary "-no-id" typo left
+#      bNoId false, wrote a profile with an ID, and still exited 0.
+#
+# The help/error split follows the ruling already applied to iccSpecSepToTiff for
+# this same defect class (#1514): a help request prints to stdout and succeeds, a
+# malformed invocation prints to stderr and fails.  The STREAM is what separates
+# them -- a shared stdout cannot express the difference whatever the status says.
+# The status here is 1 rather than #1514's 255 because that is what every other
+# error exit in this tool's main() already returns.
+#
+# Every rejection case is paired with a control that must still SUCCEED, because
+# a change that refused everything would satisfy the rejections on its own.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-fromxml-cli-contract}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+TOOLS_DIR="$(cd "$TOOLS_DIR" 2>/dev/null && pwd -P)"
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+TOXML="$TOOLS_DIR/IccToXml/iccToXml"
+
+WORKDIR="$OUTDIR/fromxml-cli-contract"
+STDOUT_LOG="$OUTDIR/fromxml-cli.stdout.log"
+STDERR_LOG="$OUTDIR/fromxml-cli.stderr.log"
+rm -rf "$WORKDIR"
+mkdir -p "$WORKDIR"
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+
+pass_case() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  [PASS] $1 -- $2"; }
+fail_case() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  [FAIL] $1 -- $2"; }
+skip_case() { SKIP=$((SKIP + 1)); TOTAL=$((TOTAL + 1)); echo "  [SKIP] $1 -- $2"; }
+
+check_sanitizers() {
+  local name="$1" log="$2"
+  if grep -Eq "ERROR: AddressSanitizer|LeakSanitizer: detected memory leaks|runtime error:" "$log" 2>/dev/null; then
+    fail_case "$name" "sanitizer finding in tool output"
+    return 1
+  fi
+  return 0
+}
+
+if [ ! -x "$FROMXML" ]; then
+  echo "=== iccFromXml CLI-contract regression (#2387) ==="
+  skip_case "fromxml-cli-contract" "iccFromXml not built at $FROMXML"
+  echo ""
+  echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total ==="
+  exit 77
+fi
+
+# A minimal but complete v4 profile, so iccFromXml writes a real profile ID for it
+# and the -noid case below has something to suppress.
+cat > "$WORKDIR/base.xml" <<'XMLEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>4.30</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>GRAY</DataColourSpace>
+    <PCS>XYZ </PCS>
+    <RenderingIntent>Perceptual</RenderingIntent>
+  </Header>
+  <Tags>
+    <grayTRCTag> <curveType><Curve>563</Curve></curveType> </grayTRCTag>
+    <profileDescriptionTag> <textDescriptionType><TextData>2387 CLI contract fixture</TextData></textDescriptionType> </profileDescriptionTag>
+    <copyrightTag> <textType><TextData>ICC regression fixture</TextData></textType> </copyrightTag>
+    <mediaWhitePointTag> <XYZArrayType><XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/></XYZArrayType> </mediaWhitePointTag>
+  </Tags>
+</IccProfile>
+XMLEOF
+
+# Permissive RelaxNG: accepts any well-formed document.  Used as the "validation
+# still works" control, so a fix that simply refused every -v cannot pass.
+cat > "$WORKDIR/permissive.rng" <<'RNGEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<grammar xmlns="http://relaxng.org/ns/structure/1.0">
+  <start><ref name="anyElement"/></start>
+  <define name="anyElement">
+    <element><anyName/>
+      <zeroOrMore>
+        <choice>
+          <attribute><anyName/></attribute>
+          <text/>
+          <ref name="anyElement"/>
+        </choice>
+      </zeroOrMore>
+    </element>
+  </define>
+</grammar>
+RNGEOF
+
+# Reject-all RelaxNG.  This is what proves the schema is APPLIED rather than merely
+# located: a fix that found the file and then ignored it would pass every other
+# -v case here.
+cat > "$WORKDIR/reject.rng" <<'RNGEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<element name="ThisWillNeverMatch" xmlns="http://relaxng.org/ns/structure/1.0"><empty/></element>
+RNGEOF
+
+# run <name> <expected-exit> <stream: out|err> <description> -- <args...>
+# Asserts the status AND which stream carried the output AND that the other one is
+# empty.  Exit status alone cannot separate a help request from a malformed
+# invocation once both are non-silent, which is the distinction #1514 established.
+run_case() {
+  local name="$1" want_exit="$2" want_stream="$3" desc="$4"
+  shift 5   # drop the "--" too
+  local exit_code=0
+
+  ( cd "$WORKDIR" && timeout 60 "$FROMXML" "$@" ) > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
+
+  check_sanitizers "$name" "$STDOUT_LOG" || return
+  check_sanitizers "$name" "$STDERR_LOG" || return
+
+  if [ "$exit_code" -ge 128 ]; then
+    fail_case "$name" "iccFromXml died on a signal (exit $exit_code)"
+    return
+  fi
+  if [ "$exit_code" -ne "$want_exit" ]; then
+    fail_case "$name" "expected exit=$want_exit, got exit=$exit_code ($desc)"
+    sed -n '1,6p' "$STDERR_LOG"
+    return
+  fi
+
+  if [ "$want_stream" = "err" ]; then
+    if [ ! -s "$STDERR_LOG" ]; then
+      fail_case "$name" "expected a diagnostic on stderr, got none"
+      return
+    fi
+    if [ -s "$STDOUT_LOG" ]; then
+      fail_case "$name" "a failed invocation wrote to stdout"
+      sed -n '1,6p' "$STDOUT_LOG"
+      return
+    fi
+  elif [ "$want_stream" = "out" ]; then
+    if [ ! -s "$STDOUT_LOG" ]; then
+      fail_case "$name" "expected output on stdout, got none"
+      return
+    fi
+    if [ -s "$STDERR_LOG" ]; then
+      fail_case "$name" "a successful invocation wrote to stderr"
+      sed -n '1,6p' "$STDERR_LOG"
+      return
+    fi
+  fi
+
+  pass_case "$name" "$desc"
+}
+
+echo "=== iccFromXml CLI-contract regression (#2387) ==="
+echo "tools: $TOOLS_DIR"
+
+###############################################################################
+# Finding 3 -- incomplete invocations must not report success, and a real help
+# request must not report failure.
+###############################################################################
+run_case "no-operands"   1 err "a bare invocation is a malformed conversion, not a help request" --
+run_case "one-operand"   1 err "an input with no output path converts nothing" -- base.xml
+run_case "help-short"    0 out "-h is an explicit help request and succeeds" -- -h
+run_case "help-long"     0 out "--help is an explicit help request and succeeds" -- --help
+
+###############################################################################
+# Finding 4 -- an unrecognised option is an error, not something to skip.
+###############################################################################
+run_case "typo-no-id"    1 err "the '-no-id' typo is refused instead of silently ignored" -- base.xml out.icc -no-id
+# -verbose additionally pins the tightening of the option match itself: the old
+# test was strncmp(argv[i], "-v", 2), so this string was accepted AS a validation
+# request. It must now be refused as unknown rather than turning validation on.
+run_case "unknown-dash-v-prefix" 1 err "'-verbose' is not accepted as a '-v' prefix match" -- base.xml out.icc -verbose
+
+# A help flag mixed into a real conversion is a malformed invocation, not a help
+# request. Caught in review: scanning every argv position for -h made
+# "iccFromXml in.xml out.icc -h" return 0 having written no profile -- the exact
+# "exit 0 while doing something else" defect this suite exists to pin, reintroduced
+# one argument to the right. Before that regression the tool ignored the flag and
+# converted, so silence here is not an option either way.
+run_case "help-flag-after-operands" 1 err "a help flag mixed into a conversion is refused, not silently obeyed" -- base.xml out-h.icc -h
+if [ -f "$WORKDIR/out-h.icc" ]; then
+  fail_case "help-flag-after-operands-no-output" "a refused invocation still wrote a profile"
+else
+  pass_case "help-flag-after-operands-no-output" "the refused invocation wrote no profile"
+fi
+
+###############################################################################
+# Finding 2 -- -v must fail CLOSED, and must honour the documented location.
+###############################################################################
+# Precondition: neither lookup location may hold the schema, or this case proves
+# nothing. Assert it rather than assume it.
+if [ -f "$WORKDIR/SampleIccRELAX.rng" ] || [ -f "$TOOLS_DIR/IccFromXml/SampleIccRELAX.rng" ]; then
+  skip_case "bare-v-fails-closed" "SampleIccRELAX.rng is present in a lookup location"
+else
+  run_case "bare-v-fails-closed" 1 err "bare -v with no schema found fails closed instead of validating nothing" -- base.xml out.icc -v
+fi
+run_case "v-equals-missing"  1 err "an explicitly named schema that cannot be opened is an error" -- base.xml out.icc -v=definitely-not-here.rng
+run_case "v-equals-empty"    1 err "-v= with no path is an error" -- base.xml out.icc -v=
+
+# The documented behaviour: README says SampleIccRELAX.rng is taken from the CURRENT
+# directory. run_case cds into WORKDIR, so placing it there is exactly the invocation
+# the README describes -- which never worked, because the lookup only ever derived the
+# path from argv[0].
+#
+# The schema planted here REJECTS everything, and that choice is load-bearing. With a
+# permissive one this case asserts only "exit 0", which the unfixed tool satisfies by
+# failing open and validating nothing -- measured: it passed against master. Requiring
+# a REFUSAL means the case can only pass if the schema was both found in the documented
+# location and actually applied.
+cp "$WORKDIR/reject.rng" "$WORKDIR/SampleIccRELAX.rng"
+bare_v_exit=0
+( cd "$WORKDIR" && timeout 60 "$FROMXML" base.xml out-barev.icc -v ) \
+  > "$STDOUT_LOG" 2> "$STDERR_LOG" || bare_v_exit=$?
+if [ "$bare_v_exit" -eq 0 ]; then
+  fail_case "bare-v-current-dir" "bare -v accepted the document against a reject-all schema in the current directory -- the documented lookup still fails open"
+elif ! grep -qi "relax-ng\|validity error" "$STDOUT_LOG" "$STDERR_LOG" 2>/dev/null; then
+  fail_case "bare-v-current-dir" "bare -v refused, but with no RelaxNG diagnostic -- refused for some other reason"
+  sed -n '1,6p' "$STDOUT_LOG"
+else
+  pass_case "bare-v-current-dir" "bare -v finds and APPLIES SampleIccRELAX.rng from the current directory, as documented"
+fi
+rm -f "$WORKDIR/SampleIccRELAX.rng"
+
+###############################################################################
+# Controls -- validation must still RUN, not merely be located.
+###############################################################################
+run_case "v-equals-permissive" 0 out "an explicit schema that accepts the document still converts" -- base.xml out-v.icc -v=permissive.rng
+
+# The sharp one: a schema that rejects everything must actually reject. Without
+# this, a fix that located the schema and then never applied it passes every case
+# above.
+reject_exit=0
+( cd "$WORKDIR" && timeout 60 "$FROMXML" base.xml out-reject.icc -v=reject.rng ) \
+  > "$STDOUT_LOG" 2> "$STDERR_LOG" || reject_exit=$?
+if [ "$reject_exit" -eq 0 ]; then
+  fail_case "reject-all-schema" "a reject-all schema was accepted -- the schema is located but not applied"
+elif ! grep -qi "relax-ng\|validity error" "$STDOUT_LOG" "$STDERR_LOG" 2>/dev/null; then
+  fail_case "reject-all-schema" "refused, but with no RelaxNG validity diagnostic -- refused for some other reason"
+  sed -n '1,6p' "$STDOUT_LOG"
+else
+  pass_case "reject-all-schema" "a reject-all schema produces a RelaxNG validity error, so validation runs"
+fi
+
+###############################################################################
+# Finding 1 -- -noid must leave no profile ID behind.
+###############################################################################
+# Built through a round trip on purpose: iccToXml emits <ProfileID> for a v4
+# profile, and that emitted ID is what -noid used to carry straight through. A
+# fixture written by hand without a <ProfileID> would have nothing to suppress and
+# the case would pass against the unfixed tool.
+profile_id_bytes() {
+  python3 - "$1" <<'PY'
+import pathlib, sys
+d = pathlib.Path(sys.argv[1]).read_bytes()
+print(d[84:100].hex() if len(d) >= 100 else "short")
+PY
+}
+
+if [ ! -x "$TOXML" ]; then
+  skip_case "noid-clears-profile-id" "iccToXml not built, cannot build a fixture carrying an ID"
+else
+  ( cd "$WORKDIR" && "$FROMXML" base.xml with-id.icc >/dev/null 2>&1 )
+  ( cd "$WORKDIR" && "$TOXML" with-id.icc with-id.xml >/dev/null 2>&1 )
+
+  if ! grep -q "<ProfileID>" "$WORKDIR/with-id.xml" 2>/dev/null; then
+    skip_case "noid-clears-profile-id" "round-trip XML carries no <ProfileID>, nothing to suppress"
+  else
+    ( cd "$WORKDIR" && "$FROMXML" with-id.xml noid.icc -noid >/dev/null 2>&1 )
+    ( cd "$WORKDIR" && "$FROMXML" with-id.xml withid.icc >/dev/null 2>&1 )
+
+    noid_id="$(profile_id_bytes "$WORKDIR/noid.icc")"
+    withid_id="$(profile_id_bytes "$WORKDIR/withid.icc")"
+
+    if [ "$withid_id" = "00000000000000000000000000000000" ]; then
+      # The control must carry an ID, or "-noid produced zeroes" proves nothing.
+      fail_case "noid-clears-profile-id" "the control without -noid also has a zero ID -- fixture proves nothing"
+    elif [ "$noid_id" != "00000000000000000000000000000000" ]; then
+      fail_case "noid-clears-profile-id" "-noid left profile ID bytes 84-99 as $noid_id"
+    else
+      pass_case "noid-clears-profile-id" "-noid zeroes the ID while the same document without it keeps $withid_id"
+    fi
+  fi
+fi
+
+###############################################################################
+# The executable-directory fallback has to actually work.
+###############################################################################
+#
+# Caught in review. The retained argv[0] derivation could not resolve a PATH-found
+# invocation: it compared a 1-character substring with the 2-character literal "./"
+# (always true) and then took substr(0, find_last_of("//")), which for a bare
+# basename returns the basename itself -- so the candidate was
+# "iccFromXml//SampleIccRELAX.rng". Harmless while a failed lookup silently disabled
+# validation; once -v fails CLOSED it turned an installation that ships the schema
+# beside the binary into a hard refusal. Measured: exit 1 via PATH, exit 0 via an
+# absolute path, same files.
+if command -v cp >/dev/null 2>&1; then
+  BINDIR="$WORKDIR/bin"
+  mkdir -p "$BINDIR"
+  cp "$FROMXML" "$BINDIR/iccFromXml" 2>/dev/null
+  cp "$WORKDIR/permissive.rng" "$BINDIR/SampleIccRELAX.rng" 2>/dev/null
+  if [ -x "$BINDIR/iccFromXml" ] && [ -f "$BINDIR/SampleIccRELAX.rng" ]; then
+    path_exit=0
+    # No SampleIccRELAX.rng in the working directory, so only the executable-directory
+    # lookup can satisfy this -- which is the point.
+    rm -f "$WORKDIR/SampleIccRELAX.rng"
+    ( cd "$WORKDIR" && PATH="$BINDIR:$PATH" timeout 60 iccFromXml base.xml out-path.icc -v ) \
+      > "$STDOUT_LOG" 2> "$STDERR_LOG" || path_exit=$?
+    if [ "$path_exit" -ne 0 ]; then
+      fail_case "path-resolved-schema-lookup" "a PATH-found tool could not locate the schema installed beside it (exit $path_exit)"
+      sed -n '1,4p' "$STDERR_LOG"
+    elif ! grep -q "$BINDIR/SampleIccRELAX.rng" "$STDOUT_LOG" 2>/dev/null; then
+      fail_case "path-resolved-schema-lookup" "converted, but did not report using the schema beside the executable"
+      sed -n '1,4p' "$STDOUT_LOG"
+    else
+      pass_case "path-resolved-schema-lookup" "a PATH-found tool resolves the schema installed beside it"
+    fi
+  else
+    skip_case "path-resolved-schema-lookup" "could not stage a PATH-resolved copy of the tool"
+  fi
+fi
+
+###############################################################################
+# Control -- an ordinary conversion is untouched by all of the above.
+###############################################################################
+run_case "plain-conversion" 0 out "an ordinary two-operand conversion still succeeds" -- base.xml plain.icc
+
+echo ""
+echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total ==="
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi
+
+# Every case skipped means nothing was measured. Report that as a skip rather than
+# success: a script CTest that exits 0 having asserted nothing reports GREEN.
+if [ "$PASS" -eq 0 ]; then
+  exit 77
+fi
+
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7605,6 +7605,29 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-specsep-cli-args-regression-tests.sh"
 )
 
+# The iccFromXml half of the same CLI-contract family as
+# iccdev.specsep-usage-exit-code-regression above: a malformed invocation must not
+# report success, an unrecognised option must not be skipped in silence, -v must not
+# fail open, and -noid must leave no profile ID behind (#2387).  Deliberately NOT
+# labelled "slow", so it runs on the pull_request path -- ci-pr-action.yml pins
+# ctest_mode=fast, which drops the slow label.
+if(TARGET iccFromXml)
+  iccdev_add_script_test(
+    iccdev.fromxml-cli-contract-regression
+    120
+    "iccdev;xml;fromxml;cli;args;usage;exitcode;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2387-fromxml-cli-contract-regression.sh"
+  )
+  # The script exits 77 when iccFromXml is absent and when nothing was measured.
+  # Without this property CTest reports 77 as a FAILURE, so a lane that simply does
+  # not build the tool would go red rather than skipping -- and the "nothing was
+  # measured" guard, which exists so an empty run cannot report green, would itself
+  # turn every such run into a false failure.
+  set_tests_properties(iccdev.fromxml-cli-contract-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # Guarded on the target, like iccdev.tiff-resolution-unit-regression below.
 # Both scripts exit 2 when iccSpecSepToTiff is missing rather than skipping the
 # way the older sibling suites do, so an unguarded registration turns a

--- a/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
+++ b/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
@@ -13,12 +13,138 @@
 #include <cstdlib>
 #include <cstring> /* C strings strcpy, memcpy ... */
 
+// The usage screen, so the help path and the incomplete-invocation path print the same
+// text and cannot drift apart.
+//
+// The STREAM is what separates the two, following the ruling already applied to
+// iccSpecSepToTiff for this same defect class (#1514): a help request prints to stdout
+// and succeeds, a malformed invocation prints to stderr and fails.  That is what lets a
+// caller tell "the user asked for help" from "this invocation converted nothing", which
+// a shared stdout cannot express whatever the exit status says.  The status itself is
+// EXIT_FAILURE rather than #1514's -1/255, because that is what every other error exit
+// in this main() already returns (#2387).
+static void Usage(FILE *out)
+{
+  fprintf(out, "IccFromXml built with IccProfLib Version " ICCPROFLIBVER ", IccLibXML Version " ICCLIBXMLVER "\n\n");
+  fprintf(out, "Usage: IccFromXml xml_file saved_profile_file {-noid -v{=[relax_ng_schema_file - optional]}}\n");
+  fprintf(out, "       IccFromXml -h | --help\n");
+}
+
+// True for the option forms that ask for the usage screen rather than a conversion.
+static bool isHelpRequest(const char *szArg)
+{
+  return !stricmp(szArg, "-h") || !stricmp(szArg, "--help") ||
+         !stricmp(szArg, "-help") || !stricmp(szArg, "-?");
+}
+
+// Whether szPath names something that can actually be READ as a file.
+//
+// fopen(dir, "r") succeeds on glibc, so "it opened" does not mean "it is a schema":
+// -v=<some-directory> slipped past the openability guard below and produced a
+// four-line libxml2 cascade naming the XML file instead of the one-line schema error
+// the guard exists to give.  Reading a byte is the portable discriminator -- a
+// directory fails the read with EISDIR, while a legitimately empty file reports EOF
+// with no error (#2387).
+static bool isReadableFile(const char *szPath)
+{
+  FILE *f = fopen(szPath, "r");
+  if (!f)
+    return false;
+
+  char ch;
+  bool bReadable = (fread(&ch, 1, 1, f) == 1) || (feof(f) && !ferror(f));
+  fclose(f);
+  return bReadable;
+}
+
+// The directory the running executable lives in, with a trailing separator, or an
+// empty string when it cannot be determined.
+//
+// The derivation this replaces could not work.  It read
+//   if (path.substr(0,1) != "./")   -- one character compared with a two-character
+//                                      literal, so always true
+//   path = path.substr(0, path.find_last_of("//"));
+// and for an argv[0] carrying no separator -- the normal case for a tool found on
+// PATH -- find_last_of returns npos, substr(0, npos) returns the whole basename, and
+// the candidate became "iccFromXml//SampleIccRELAX.rng", which never exists.
+//
+// That was invisible while a failed lookup silently disabled validation.  Once the
+// lookup fails CLOSED it turns a working installation into a hard refusal, so it has
+// to genuinely work: measured, `PATH=<bindir>:$PATH iccFromXml in.xml out.icc -v`
+// with the schema installed beside the binary refused to convert, while the same
+// invocation by absolute path succeeded.  Walking PATH for the no-separator case is
+// also what makes the error message's "alongside the executable" true, rather than
+// naming a directory that was never examined (#2387).
+static std::string executableDir(const char *szArgv0)
+{
+  std::string exe = szArgv0 ? szArgv0 : "";
+  if (exe.empty())
+    return "";
+
+#ifdef WIN32
+  const char *szSeps = "\\/";
+  const char cPathSep = ';';
+#else
+  const char *szSeps = "/";
+  const char cPathSep = ':';
+#endif
+
+  std::string::size_type nSlash = exe.find_last_of(szSeps);
+  if (nSlash != std::string::npos)
+    return exe.substr(0, nSlash + 1);
+
+  const char *szPath = getenv("PATH");
+  if (!szPath)
+    return "";
+
+  std::string path(szPath);
+  std::string::size_type nStart = 0;
+  while (nStart <= path.size()) {
+    std::string::size_type nEnd = path.find(cPathSep, nStart);
+    if (nEnd == std::string::npos)
+      nEnd = path.size();
+
+    std::string dir = path.substr(nStart, nEnd - nStart);
+    if (!dir.empty()) {
+      char cLast = dir[dir.size() - 1];
+      if (cLast != '/' && cLast != '\\')
+        dir += "/";
+      if (isReadableFile((dir + exe).c_str()))
+        return dir;
+    }
+
+    if (nEnd == path.size())
+      break;
+    nStart = nEnd + 1;
+  }
+
+  return "";
+}
+
 int main(int argc, char* argv[])
 {
+  // An explicit help request succeeds; an INCOMPLETE conversion does not.  Both used
+  // to print usage and return 0, so `iccFromXml foo.xml` -- a real invocation missing
+  // its output path -- reported success to automation while converting nothing, and a
+  // bare `iccFromXml` did the same.  Splitting them is what the report asks for: the
+  // screen is identical, the status is not (#2387).
+  //
+  // ONLY the lone-argument form is a help request.  Scanning every argv position for a
+  // help flag looked harmless and was not: `iccFromXml in.xml out.icc -h` then returned
+  // 0 having written no profile at all, where it previously ignored the flag and
+  // converted.  That is the exact "exit 0 while doing something else" contract
+  // violation this change exists to remove, reintroduced one argument to the right.  A
+  // help flag mixed into a conversion now falls through to the option loop below and is
+  // refused as unrecognised, which is a malformed invocation rather than a silent no-op.
+  if (argc == 2 && isHelpRequest(argv[1])) {
+    Usage(stdout);
+    return EXIT_SUCCESS;
+  }
+
   if (argc<=2) {
-    printf("IccFromXml built with IccProfLib Version " ICCPROFLIBVER ", IccLibXML Version " ICCLIBXMLVER "\n\n");
-    printf("Usage: IccFromXml xml_file saved_profile_file {-noid -v{=[relax_ng_schema_file - optional]}}\n");
-    return 0;
+    Usage(stderr);
+    fprintf(stderr, "\nError: an input XML file and an output profile path are both required\n");
+    return EXIT_FAILURE;
   }
 
   // Profile XML on the CLI tool's filesystem is trusted by the invoking
@@ -35,6 +161,10 @@ int main(int argc, char* argv[])
 
   std::string szRelaxNGDir;
   bool bNoId = false;
+  // Whether -v was given at all, kept apart from whether a schema was found.  The two
+  // used to be conflated in szRelaxNGDir, which is why a failed lookup was
+  // indistinguishable from "no validation asked for" (#2387).
+  bool bValidateRequested = false;
 
   const char* szRelaxNGFileName = "SampleIccRELAX.rng";
   int i;
@@ -42,39 +172,82 @@ int main(int argc, char* argv[])
     if (!stricmp(argv[i], "-noid")) {
       bNoId = true;
     }
-    else if (!strncmp(argv[i], "-v", 2) || !strncmp(argv[i], "-V", 2)) {// user specified schema validation
+    // Exact forms only.  This used to be strncmp(argv[i], "-v", 2), which accepted
+    // "-verbose", "-vx" and anything else beginning "-v" as a validation request.
+    else if (!stricmp(argv[i], "-v") ||
+             !strncmp(argv[i], "-v=", 3) || !strncmp(argv[i], "-V=", 3)) {
+      bValidateRequested = true;
+
       if (argv[i][2]=='=') {
         szRelaxNGDir = argv[i]+3;
-      }
-      else  { 
-        std::string path = argv[0]; // current directory where program is called
-
-#ifdef WIN32
-        if (path != "IccFromXml.exe") { //current directory is not path where	program is located  
-          path = path.substr(0,path.find_last_of("\\"));
-          path += "\\"; 		
+        // An explicitly named schema that cannot be opened is a hard error.  Left
+        // unchecked it reached LoadXml, which validates only against a schema it
+        // could load, so a typo in the path silently disabled the validation the
+        // user had just asked for.
+        if (szRelaxNGDir.empty()) {
+          fprintf(stderr, "Error: -v= requires a RelaxNG schema file path\n");
+          return EXIT_FAILURE;
         }
-#else
-        if (path.substr(0,1) != "./"){
-          path = path.substr(0,path.find_last_of("//"));
-          path += "//"; 	
+        if (!isReadableFile(szRelaxNGDir.c_str())) {
+          fprintf(stderr, "Error: cannot read RelaxNG schema '%s'\n", szRelaxNGDir.c_str());
+          return EXIT_FAILURE;
         }
-#endif
-
-        path += szRelaxNGFileName; 
-
-        FILE *f = fopen(path.c_str(), "r");
-
-        if (f) {
-          fclose(f);
-
-          szRelaxNGDir = path; 
-        }	
       }
+      else  {
+        // Bare -v.  The README says SampleIccRELAX.rng is taken "from the current
+        // directory"; the code only ever derived it from argv[0], the directory the
+        // BINARY lives in, so the documented invocation never found it.  Try the
+        // documented location first, then the executable's own directory, so an
+        // installation shipping the schema beside the binary keeps working.
+        if (isReadableFile(szRelaxNGFileName)) {
+          szRelaxNGDir = szRelaxNGFileName;
+        }
+        else {
+          std::string dir = executableDir(argv[0]);
+          if (!dir.empty()) {
+            std::string path = dir + szRelaxNGFileName;
+            if (isReadableFile(path.c_str()))
+              szRelaxNGDir = path;
+          }
+        }
+      }
+    }
+    else {
+      // No rejecting branch existed, so an unrecognised option was skipped in
+      // silence: an ordinary "-no-id" typo left bNoId false, produced a profile with
+      // an ID, and still exited 0, reporting success for a run that ignored what it
+      // was told to do.
+      fprintf(stderr, "Error: unrecognized option '%s'\n", argv[i]);
+      Usage(stderr);
+      return EXIT_FAILURE;
     }
   }
 
-    if (!profile.LoadXml(argv[1], szRelaxNGDir.c_str(), &reason)) {
+  // Validation was requested and no schema could be found: fail CLOSED.  Previously
+  // the lookup simply left the schema string empty, and CIccProfileXml::LoadXml
+  // validates only when that string is non-empty, so bare -v was behaviourally
+  // identical to passing no -v at all -- the option appeared to work while checking
+  // nothing.  SampleIccRELAX.rng is not shipped in this tree, so that was the
+  // outcome for every bare -v invocation here.
+  if (bValidateRequested && szRelaxNGDir.empty()) {
+    fprintf(stderr, "Error: -v requested schema validation but '%s' was not found in "
+            "the current directory or alongside the executable\n", szRelaxNGFileName);
+    return EXIT_FAILURE;
+  }
+
+  // Name the schema that was chosen.  The current directory now wins over the copy
+  // installed beside the binary, so an unrelated file of that name in the invocation
+  // directory becomes the validation authority -- and since the schema decides
+  // accept/reject, a stray or weaker one changes the tool's verdict.  The ordering is
+  // what the README documents, so it stays; the silence about which file was used is
+  // the part worth fixing.
+  if (bValidateRequested)
+    printf("Validating against RelaxNG schema '%s'\n", szRelaxNGDir.c_str());
+
+  // Re-indented to match its block.  The stray four-space indent was harmless while
+  // nothing preceded it, but it now follows an if-statement and -Wmisleading-indentation
+  // rejects it outright on the strict lanes.
+  if (!profile.LoadXml(argv[1], szRelaxNGDir.c_str(), &reason)) {
     printf("%s", reason.c_str());
 #ifndef WIN32
     printf("\n");
@@ -82,6 +255,21 @@ int main(int argc, char* argv[])
     printf("Unable to Parse '%s'\n", argv[1]);
     return EXIT_FAILURE;
   }
+
+  // -noid has to mean the saved profile carries NO profile ID, and passing
+  // icNeverWriteID alone does not achieve that.  CIccProfile::Write() emits
+  // m_Header.profileID unconditionally as part of the header; the nWriteId switch only
+  // decides whether CalcProfileID() then RECALCULATES it and rewrites offset 84.  So an
+  // XML document that already carries a <ProfileID> -- which is exactly what iccToXml
+  // emits for any v4 profile -- kept its original ID through `iccFromXml ... -noid`,
+  // contradicting the README's promise that the option prevents writing one.  Measured
+  // on a round trip: bytes 84-99 came back byte-identical to the source profile's ID.
+  //
+  // Clearing the header field here rather than changing icNeverWriteID's meaning: the
+  // enum is public API used by other callers, and the report asks for library
+  // compatibility to be considered separately (#2387).
+  if (bNoId)
+    memset(&profile.m_Header.profileID, 0, sizeof(profile.m_Header.profileID));
 
   std::string valid_report;
 

--- a/IccXML/CmdLine/IccFromXml/Readme.md
+++ b/IccXML/CmdLine/IccFromXml/Readme.md
@@ -7,13 +7,27 @@ optionally validate input with a RELAX NG schema before saving.
 
 ```sh
 iccFromXml input.xml output.icc {-noid -v[=schema.rng]}
+iccFromXml -h | --help
 ```
 
 - `input.xml`: The ICC profile XML file
 - `output.icc`: The output binary ICC profile
-- `-noid`: Prevents writing a profile ID (optional)
+- `-noid`: Prevents writing a profile ID (optional). The saved profile's ID field
+  is zeroed, including when the input XML carries a `<ProfileID>` of its own
 - `-v[=schema.rng]`: Enables RELAX NG validation, using the supplied schema or
-  `SampleIccRELAX.rng` from the current directory
+  `SampleIccRELAX.rng` taken from the current directory, falling back to the
+  directory holding the executable. The schema actually used is reported on stdout
+- `-h`, `--help`: Prints this usage screen on stdout and exits successfully
+
+## Exit status
+
+- `0`: the conversion completed, or a help screen was requested
+- non-zero: the invocation was malformed, the input could not be parsed, or the
+  profile could not be saved
+
+Both operands are required. An incomplete invocation, an unrecognised option, and a
+`-v` whose schema cannot be found or read are all errors: usage and diagnostics go to
+stderr and the exit status is non-zero. `-v` never silently skips validation.
 
 ## Examples
 


### PR DESCRIPTION
Part of #2387 — the four Additional Findings.

All four are in `IccFromXml.cpp`'s argument handling, and all four are the same shape: **the tool exits 0 while doing something other than what it was asked.**

| # | Defect | Before |
|---|---|---|
| 1 | `-noid` preserved an existing profile ID | ID survives the round trip byte-identical |
| 2 | Bare `-v` failed **open**, and never honoured its documented location | `-v` ≡ no `-v` |
| 3 | Missing output path returned success | `iccFromXml foo.xml` → exit **0** |
| 4 | Unknown options skipped in silence | `-no-id` typo → exit **0**, profile written *with* an ID |

## Finding 1 — `-noid`

`CIccProfile::Write()` emits `m_Header.profileID` unconditionally as part of the header (`IccProfile.cpp:1251`). The `nWriteId` switch at `:1361` only decides whether `CalcProfileID()` **recalculates** it and rewrites offset 84. So `icNeverWriteID` suppressed the recalculation and left the loaded ID in place:

```
$ iccFromXml with-id.xml noid.icc -noid
$ xxd -s 84 -l 16 -p noid.icc
a07c7a7019ee285fedb9a7cf3aec3e8e     <- the source profile's ID, unchanged
```

That document is not contrived — it is what `iccToXml` emits for any v4 profile. Fixed in the CLI by clearing the header field before saving, rather than by changing what `icNeverWriteID` means: the enum is public API with other callers, and the report asks for library compatibility to be considered separately.

## Finding 2 — `-v` failed open

Two separate problems in one lookup. It left `szRelaxNGDir` empty when it found nothing, and `LoadXml` validates only against a non-empty string — so `-v` was behaviourally identical to passing nothing. It also only ever derived the path from `argv[0]`, the directory the **binary** lives in, while the README documents the **current** directory. `SampleIccRELAX.rng` is not shipped in this tree, so that was the outcome for every bare `-v` invocation here.

Now the documented location is tried first, the executable's own directory second — via a dirname that actually works, see the review section — and a requested validation that finds no schema is a hard error. An explicitly named `-v=` schema that cannot be opened is an error too — it used to reach `LoadXml` and silently disable the validation just requested.

## Findings 3 and 4 — the exit-code contract

This follows the ruling **already applied to `iccSpecSepToTiff` for this same defect class in #1514**: a help request prints to stdout and succeeds; a malformed invocation prints to stderr and fails. The *stream* is what separates them — a shared stdout cannot express the difference whatever the status says, which is the point that ruling turned on. The status here is `EXIT_FAILURE` rather than #1514's `-1`/255, because that is what every other error exit in this `main()` already returns. `-h`, `--help`, `-help` and `-?` are added as the successful help path.

Finding 4 also tightens the option match itself: it was `strncmp(argv[i], "-v", 2)`, which accepted `-verbose` and anything else beginning `-v` as a validation request.

## Tests — built to discriminate, not merely to pass

New script CTest `iccdev.fromxml-cli-contract-regression`, modelled on the #1514 suite. It asserts the exit status **and** which stream carried the output **and** that the other stream is empty, because once both paths print, status alone cannot separate them.

Two fixtures needed deliberate construction:

- **The documented-lookup case plants a reject-all schema** as `SampleIccRELAX.rng` in the current directory and requires the conversion to **fail**. Written with a permissive schema it asserts only "exit 0" — which the unfixed tool satisfies by failing open and validating nothing. Measured: that version passed against master. Requiring a refusal means it can only pass if the schema was both found in the documented place *and actually applied*.
- **The `-noid` fixture is built through an `iccToXml` round trip**, because that is what puts a `<ProfileID>` in the document. A hand-written fixture without one has nothing to suppress. Its control asserts the same document *without* `-noid` still carries a nonzero ID, so "`-noid` produced zeroes" cannot pass by the ID being absent for some other reason.

Every rejection case is paired with a control that must still succeed, since a change refusing everything would satisfy the rejections on its own.

**Red/green:** 12 of 17 cases red against `c1ec46b2`, 17/17 green with the fix. The five that pass on both sides are controls by design — an ordinary conversion, an explicit `-v=` schema accepting and a reject-all one refusing (both already worked through the explicit path), and the two help cases, which pass on master only because `argc<=2` happened to return 0 there.

The test is **not** labelled `slow`, so it runs on the pull_request path — `ci-pr-action` pins `ctest_mode=fast`, which drops that label.

## `/code-review` found five things — two were regressions this PR introduced

Both are fixed, and both are now pinned by their own cases:

- **The help scan ran over every argv position**, so `iccFromXml in.xml out.icc -h` returned **0 having written no profile** — the exact "exit 0 while doing something else" violation this PR exists to remove, reintroduced one argument to the right. Before it, that invocation ignored the flag and converted. Only the lone-argument form is a help request now; a help flag mixed into a conversion is refused as unrecognised.
- **The retained `argv[0]` derivation could not resolve a PATH-found invocation.** It compared a 1-character substring with the 2-character literal `"./"` (always true), then took `substr(0, find_last_of("//"))`, which for a bare basename returns the basename — so the candidate was `iccFromXml//SampleIccRELAX.rng`. Harmless while a failed lookup silently disabled validation; combined with the new fail-closed gate it turned an installation shipping the schema beside the binary into a **hard refusal**. Measured: exit 1 via PATH, exit 0 via an absolute path, same files. Replaced with a dirname that works plus a PATH walk for the no-separator case — which is also what makes the error message's "alongside the executable" true rather than naming a directory never examined.

And three smaller ones:

- **The CTest registration set no `SKIP_RETURN_CODE`** while the script exits 77 for skips, so a lane that does not build `iccFromXml` would have gone **red** rather than skipping — and the "nothing was measured" guard, which exists so an empty run cannot report green, would itself have produced a false failure. Now set (`SKIP_RETURN_CODE = 77`, verified on the configured test) and the registration is guarded on the target.
- `fopen()` succeeds on a directory, so `-v=<a-directory>` slipped past the openability check and produced a four-line libxml2 cascade naming the *XML* file instead of the one-line schema error. Replaced with a read-a-byte check.
- The current directory now wins over the copy beside the binary, so a stray file of that name silently becomes the validation authority. The ordering is what the README documents and stays; the tool now **reports which schema it used**.

The Readme is updated too — it documented neither the help forms, nor the non-zero exit for an incomplete invocation, nor that `-v` no longer fails open.

## Scope — two findings deliberately left open

This is the four **Additional Findings** only. Findings 3 and 4 of the issue body — an unknown `RenderingIntent` silently becoming Perceptual, and a malformed `ProfileVersion` being saved while its parse reason is suppressed — were routed to @maxderhak and @ChrisCoxArt for discussion, so they are left to that ruling rather than pre-empted here. Findings 1 and 2 of the body landed in #2396.

## Verification

0 warnings under `-Wall -Wextra -Wpedantic -Werror` on clang 21.1.3 and g++ 13.3.0; 237/237 fast CTests; **53/53 across every xml- and json-labelled suite including the slow ones**. That last one matters here rather than being routine: the option tightening changes what the tool accepts, and roughly forty scripts in this repo drive `iccFromXml`, so they had to be run rather than reasoned about.
