### PR TITLE
fix(#2401): give every spelling of an XML array one conversion

### DIFF
--- a/.github/scripts/iccdev-issue-2401-xml-array-element-form-regression.sh
+++ b/.github/scripts/iccdev-issue-2401-xml-array-element-form-regression.sh
@@ -1,0 +1,344 @@
+#!/bin/bash
+###############################################################################
+# #2401 -- the two spellings of an XML array body must parse identically
+###############################################################################
+#
+# An <Array>/<Data> body may be written as text ("256 255 300 -1") or as a run
+# of <n> elements.  They were parsed by two different conversions:
+# CIccXmlArrayType::ParseText() used clipTypeRange<T>(atof(...)) while
+# ParseArray()'s element branch cast atol() straight to T.  So one array had two
+# meanings depending only on how it was spelled, and each conversion was wrong
+# somewhere the other was right.  Measured on f186948c:
+#
+#   uInt8Array      input  256   300   -1
+#     element <n>          0     44    255     (wrapped)
+#     text                 255   255   0       (clipped)
+#
+#   float32Array    input  0.5   -2.25
+#     element <n>          0.0   -2.0          (atol() dropped the fraction)
+#     text                 0.5   -2.25
+#
+#   float32Array    input  nan   1.5
+#     element <n>          0.0   1.0
+#     text                 nan   1.5
+#
+#   uInt64Array     input  2^53+1              UINT64_MAX
+#     element <n>          exact               9223372036854775807 (atol saturates at LLONG_MAX)
+#     text                 9007199254740992    exact
+#
+# Note the last row: the element form was NOT simply the worse of the two.  Each
+# spelling was exact where the other lost data, which is why the fix is a single
+# shared conversion (icParseArrayValue) rather than making one call the other's
+# old code -- that would have fixed one column and regressed the other.
+#
+# Assertions are made on the RAW TAG BYTES in the .icc, not on a round-trip
+# through iccToXml.  That matters: DumpArray() has
+# "case icSigUInt64ArrayType: // unused" and zeroes non-finite floats, so a
+# round-trip cannot observe the uInt64 or the NaN case at all -- a test written
+# against the XML dump is structurally blind to exactly the two rows above that
+# were hardest to get right.
+#
+# Each case asserts BOTH that the two spellings agree AND what they equal.
+# Agreement alone would stay green if both paths regressed the same way; the
+# absolute values alone would not express the invariant.
+#
+# Red/green: all four cases fail against f186948c.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-xml-array-element-form-regression}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+fail_case() { echo "  [FAIL] $1 -- $2"; FAIL=$((FAIL + 1)); }
+pass_case() { echo "  [PASS] $1 -- $2"; PASS=$((PASS + 1)); }
+
+if [ ! -x "$FROMXML" ]; then
+  echo "iccFromXml not found at $FROMXML -- skipping (build Tools first)"
+  exit 77
+fi
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not available -- skipping (needed to read tag bytes out of the .icc)"
+  exit 77
+fi
+
+# Decode one tag's payload from a profile.  Walks the tag table rather than
+# assuming an offset, skips the 8-byte type signature + reserved header, and
+# prints the values space-separated so the caller can compare them as a string.
+read_tag_values() {
+  python3 - "$1" "$2" "$3" "$4" <<'PYEOF'
+import struct, sys, math
+path, want, fmt, count = sys.argv[1], sys.argv[2].encode(), sys.argv[3], int(sys.argv[4])
+data = open(path, 'rb').read()
+ntags = struct.unpack('>I', data[128:132])[0]
+for i in range(ntags):
+    sig, off, size = struct.unpack('>4sII', data[132 + i * 12:144 + i * 12])
+    if sig == want:
+        vals = struct.unpack('>%d%s' % (count, fmt), data[off + 8:off + 8 + count * struct.calcsize('>' + fmt)])
+        print(' '.join('nan' if isinstance(v, float) and math.isnan(v) else
+                       ('%g' % v if isinstance(v, float) else str(v)) for v in vals))
+        sys.exit(0)
+sys.exit('tag %s not found' % want.decode())
+PYEOF
+}
+
+# Raw payload of one tag, as hex, for cases whose values are buried in a
+# structure (the MPE matrix below) rather than a flat array.
+read_tag_hex() {
+  python3 - "$1" "$2" <<'PYEOF2'
+import struct, sys
+data = open(sys.argv[1], 'rb').read()
+want = sys.argv[2].encode()
+ntags = struct.unpack('>I', data[128:132])[0]
+for i in range(ntags):
+    sig, off, size = struct.unpack('>4sII', data[132 + i * 12:144 + i * 12])
+    if sig == want:
+        print(data[off:off + size].hex())
+        sys.exit(0)
+sys.exit('tag %s not found' % want.decode())
+PYEOF2
+}
+
+emit_profile() {
+  local out="$1" type="$2" container="$3" elem_body="$4" text_body="$5"
+  cat > "$out" <<XMLEOF
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.30</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>GRAY</DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>2026-08-20T00:00:00</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Perceptual</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/>
+    </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+  </Header>
+  <Tags>
+    <PrivateTag TagSignature="ELEM"> <$type>
+      <$container>$elem_body</$container>
+    </$type> </PrivateTag>
+    <PrivateTag TagSignature="TEXT"> <$type>
+      <$container>$text_body</$container>
+    </$type> </PrivateTag>
+    <grayTRCTag> <curveType>
+      <Curve>563</Curve>
+    </curveType> </grayTRCTag>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS">#2401 element-form array fixture</LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS">ICC regression fixture</LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/>
+    </XYZArrayType> </mediaWhitePointTag>
+  </Tags>
+</IccProfile>
+XMLEOF
+}
+
+# name | xml type | container | struct fmt | value count | expected | element body | text body
+run_case() {
+  local name="$1" type="$2" container="$3" fmt="$4" count="$5" expected="$6" elem_body="$7" text_body="$8"
+  TOTAL=$((TOTAL + 1))
+
+  local xml="$OUTDIR/$name.xml" icc="$OUTDIR/$name.icc" log="$OUTDIR/$name.log"
+  local rc=0
+
+  emit_profile "$xml" "$type" "$container" "$elem_body" "$text_body"
+
+  rm -f "$icc"
+  # rc captured explicitly: inside "if ! cmd" the value of $? is the status of
+  # the negation, which is always 0 when the command failed, so a diagnostic
+  # built from it would report a nonsense status.
+  timeout 25 "$FROMXML" "$xml" "$icc" > "$log" 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_case "$name" "iccFromXml refused the fixture (exit=$rc)"
+    sed -n '1,10p' "$log"
+    return
+  fi
+
+  local elem text
+  elem="$(read_tag_values "$icc" ELEM "$fmt" "$count")" || {
+    fail_case "$name" "could not read the element-form tag: $elem"; return; }
+  text="$(read_tag_values "$icc" TEXT "$fmt" "$count")" || {
+    fail_case "$name" "could not read the text-form tag: $text"; return; }
+
+  if [ "$elem" != "$text" ]; then
+    fail_case "$name" "element form '$elem' disagrees with text form '$text'"
+    return
+  fi
+  # Agreement alone would survive both paths regressing identically, so pin the
+  # value too.
+  if [ "$elem" != "$expected" ]; then
+    fail_case "$name" "both spellings agree on '$elem' but expected '$expected'"
+    return
+  fi
+
+  pass_case "$name" "both spellings gave '$elem'"
+}
+
+echo "=== XML array element-form parity regression (#2401) ==="
+
+# uInt8: above, at and below the 0..255 range.  Clipped, not wrapped.
+run_case uint8-range uInt8NumberType Array B 4 "255 255 255 0" \
+  "<n>256</n><n>255</n><n>300</n><n>-1</n>" "256 255 300 -1"
+
+# float32: fractions atol() discarded.  The float types accept only <Data>:
+# CIccTagXmlFloatNum::ParseXml looks for "Data" and does not fall back to
+# "Array" the way CIccTagXmlNum::ParseXml does.
+run_case float32-fraction float32NumberType Data f 3 "0.5 -2.25 3.75" \
+  "<n>0.5</n><n>-2.25</n><n>3.75</n>" "0.5 -2.25 3.75"
+
+# float32 NaN: the text form has always stored a real NaN for floating-point
+# types; the element form must too.
+run_case float32-nan float32NumberType Data f 2 "nan 1.5" \
+  "<n>nan</n><n>1.5</n>" "nan 1.5"
+
+# uInt64: the row where each spelling was exact where the other was not, so it
+# pins both directions at once.
+run_case uint64-exact uInt64NumberType Array Q 3 \
+  "9007199254740993 1234567890123456789 18446744073709551615" \
+  "<n>9007199254740993</n><n>1234567890123456789</n><n>18446744073709551615</n>" \
+  "9007199254740993 1234567890123456789 18446744073709551615"
+
+# Indented NaN.  Pretty-printed XML puts whitespace inside the element, and the
+# NaN literal test must see past it -- when the whitespace skip lived inside the
+# integer branch, "<n>\n  nan\n</n>" in a float array flushed to 0 while the
+# unindented spelling gave a real NaN.
+run_case float32-nan-indented float32NumberType Data f 2 "nan 1.5" \
+  "<n>
+      nan
+    </n><n>1.5</n>" "nan 1.5"
+
+# A float-shaped token in an integer array takes the atof() fallback.  It must
+# saturate rather than convert out of range -- (double)UINT64_MAX rounds up to
+# 2^64, so the bound has to be compared inclusively.
+run_case uint64-float-token uInt64NumberType Array Q 2 \
+  "18446744073709551615 1000" "<n>1.8446744073709552e19</n><n>1e3</n>" \
+  "1.8446744073709552e19 1e3"
+
+# The <f> spelling is the third way to write a float array body, and it had its
+# own unchecked conversion: no clamp, so <f>1e50</f> stored +inf (0x7f800000)
+# into an MPE matrix coefficient where the identical text array clipped to
+# FLT_MAX (0x7f7fffff), and a non-finite coefficient propagates into transform
+# output.  Only icSigFloatArrayType scans for "f" elements, and that type is not
+# a tag type -- it backs MPE matrices, curves and CLUTs -- so this case needs a
+# multiProcessElementType rather than the PrivateTag shape above.  The two tags
+# are identical apart from the spelling, so their payloads must be byte-equal.
+TOTAL=$((TOTAL + 1))
+MPE="$OUTDIR/mpe-f-element.xml"
+cat > "$MPE" <<'XMLEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>5.00</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>2026-08-20T00:00:00</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Perceptual</RenderingIntent>
+    <PCSIlluminant>
+      <XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/>
+    </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+  </Header>
+  <Tags>
+    <AToB0Tag> <multiProcessElementType>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+        <MatrixElement InputChannels="3" OutputChannels="3">
+          <MatrixData><f>1e50</f><f>0</f><f>0</f><f>0</f><f>0.25</f><f>0</f><f>0</f><f>0</f><f>1</f></MatrixData>
+        </MatrixElement>
+      </MultiProcessElements>
+    </multiProcessElementType> </AToB0Tag>
+    <AToB1Tag> <multiProcessElementType>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+        <MatrixElement InputChannels="3" OutputChannels="3">
+          <MatrixData>1e50 0 0 0 0.25 0 0 0 1</MatrixData>
+        </MatrixElement>
+      </MultiProcessElements>
+    </multiProcessElementType> </AToB1Tag>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS">#2401 f-element fixture</LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS">ICC regression fixture</LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/>
+    </XYZArrayType> </mediaWhitePointTag>
+  </Tags>
+</IccProfile>
+XMLEOF
+mpe_rc=0
+timeout 25 "$FROMXML" "$MPE" "$OUTDIR/mpe-f-element.icc" > "$OUTDIR/mpe-f-element.log" 2>&1 || mpe_rc=$?
+if [ "$mpe_rc" -ne 0 ]; then
+  fail_case "floatarray-f-element" "iccFromXml refused the fixture (exit=$mpe_rc)"
+  sed -n '1,10p' "$OUTDIR/mpe-f-element.log"
+else
+  f_hex="$(read_tag_hex "$OUTDIR/mpe-f-element.icc" 'A2B0')" || f_hex=""
+  t_hex="$(read_tag_hex "$OUTDIR/mpe-f-element.icc" 'A2B1')" || t_hex=""
+  if [ -z "$f_hex" ] || [ -z "$t_hex" ]; then
+    fail_case "floatarray-f-element" "could not read both MPE tags back"
+  elif [ "$f_hex" != "$t_hex" ]; then
+    # 7f800000 is +inf, 7f7fffff is FLT_MAX -- name which one turned up so the
+    # failure says what happened rather than dumping two hex blobs.
+    case "$f_hex" in
+      *7f800000*) fail_case "floatarray-f-element" "<f> spelling stored +inf where the text spelling clipped" ;;
+      *)          fail_case "floatarray-f-element" "<f> and text spellings produced different MPE payloads" ;;
+    esac
+  elif [ "${f_hex#*7f7fffff}" = "$f_hex" ]; then
+    fail_case "floatarray-f-element" "neither spelling clipped 1e50 to FLT_MAX"
+  else
+    pass_case "floatarray-f-element" "<f> and text spellings both clipped 1e50 to FLT_MAX"
+  fi
+fi
+
+echo "=== summary: $PASS passed, $FAIL failed, $TOTAL total ==="
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+if [ "$PASS" -eq 0 ]; then
+  echo "no case was measured -- treating as skipped rather than passed"
+  exit 77
+fi
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7628,6 +7628,25 @@ if(TARGET iccFromXml)
     SKIP_RETURN_CODE 77)
 endif()
 
+# #2401: the element (<n>) and text spellings of one XML array must agree.  Not
+# labelled "slow", so it runs on the pull_request path (ci-pr-action.yml pins
+# ctest_mode=fast, which drops the slow label).
+if(TARGET iccFromXml)
+  iccdev_add_script_test(
+    iccdev.xml-array-element-form-regression
+    300
+    "iccdev;xml;array;parser;issue-2401;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2401-xml-array-element-form-regression.sh"
+  )
+  # Exits 77 when iccFromXml or python3 is absent, or nothing was measured.
+  # Seven cases x one invocation x "timeout 25" is a 175s worst case, so the
+  # registered budget has to exceed it: if CTest kills the test first, the
+  # script's own per-case diagnostic and log tail are never produced.
+  set_tests_properties(iccdev.xml-array-element-form-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # Guarded on the target, like iccdev.tiff-resolution-unit-regression below.
 # Both scripts exit 2 when iccSpecSepToTiff is missing rather than skipping the
 # way the older sibling suites do, so an unguarded registration turns a

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -1084,6 +1084,92 @@ float clipTypeRange( const float &input )
   return input;
 }
 
+// #2401: ONE conversion, shared by both spellings of an array body.
+//
+// An <Array>/<Data> body may be written as text ("256 255 300 -1") or as a run
+// of <n> elements.  ParseText() clipped with clipTypeRange<T>(atof(...)) while
+// ParseArray()'s element branch cast atol() straight to T, so <n>256</n> in a
+// uInt8Array wrapped to 0 where the identical text array clipped to 255.  Two
+// implementations that merely happen to agree drift again, so they now have
+// one: agreement is structural here, not a coincidence the tests have to keep
+// re-checking.
+//
+// Integers are parsed integrally rather than through atof().  atol() was exact
+// for the whole uInt64 range on LP64, and routing those values through a
+// double's 53-bit mantissa would have LOST fidelity that the element form
+// already had -- 9007199254740993 landing as ...92.  It also avoids
+// clipTypeRange()'s (long double)max() comparison, which on a platform where
+// long double == double rounds UINT64_MAX up to 2^64, so the saturation test
+// fails and the cast is undefined.  Every integer instantiation of this
+// template is unsigned, which is why "below the range" is simply zero.
+template<typename T>
+static T icParseArrayValue(const char *num)
+{
+  // Skipped once, before anything else looks at the token.  Keeping this inside
+  // the integer branch would make the NaN literal test below whitespace
+  // sensitive: a pretty-printed "<n>\n  nan\n</n>" would miss strncmp() and
+  // fall through to clipTypeRange(), which flushes NaN to zero, while the
+  // unindented spelling produced a real NaN.
+  const char *p = num;
+  while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+    p++;
+
+  // Long-standing special case kept from ParseText(): a real NaN for floating
+  // point, zero for integers, which cannot represent one.
+  if (!strncmp(p, "nan", 3) || !strncmp(p, "-nan", 4)) {
+    if (std::is_floating_point<T>())
+      return (T)nanf(p);
+    return (T)0;
+  }
+
+  if constexpr (std::numeric_limits<T>::is_integer) {
+    static_assert(!std::numeric_limits<T>::is_signed,
+                  "negative values are clipped to zero here, which is only the "
+                  "right lower bound while every integer instantiation of "
+                  "CIccXmlArrayType is unsigned");
+
+    // A token carrying a decimal point or an exponent is not an integer
+    // literal, and strtoull() would stop at the '.' and read "1e300" as 1.
+    bool bFloatToken = false;
+    for (const char *q = p; *q; q++) {
+      if (*q == '.' || *q == 'e' || *q == 'E') {
+        bFloatToken = true;
+        break;
+      }
+    }
+
+    if (!bFloatToken) {
+      if (*p == '-')
+        return (T)0;    // clip below the range, as clipTypeRange() did
+
+      errno = 0;
+      char *end = nullptr;
+      unsigned long long v = strtoull(p, &end, 10);
+      if (errno == ERANGE ||
+          v > (unsigned long long)std::numeric_limits<T>::max())
+        return std::numeric_limits<T>::max();
+      return (T)v;
+    }
+
+    // Float-shaped token in an integer array.  Saturate in double space rather
+    // than deferring to clipTypeRange(): its bound is (long double)max(), and
+    // where long double == double (MSVC x64/ARM64) that rounds UINT64_MAX up to
+    // 2^64, so "1.8446744073709552e19" fails the > test and the cast to
+    // uint64_t is undefined.  Comparing >= against the same rounded-up bound
+    // saturates instead.  atol() was defined here before this change, so this
+    // path must not be the one that introduces UB.
+    double d = atof(p);
+    if (std::isnan(d) || d <= 0.0)
+      return (T)0;
+    if (d >= (double)std::numeric_limits<T>::max())
+      return std::numeric_limits<T>::max();
+    return (T)d;
+  }
+  else {
+    return clipTypeRange<T>(atof(p));
+  }
+}
+
 template <class T, icTagTypeSignature Tsig>
 icUInt32Number CIccXmlArrayType<T, Tsig>::ParseText(T* pBuf, icUInt32Number nSize, const char *szText)
 {	
@@ -1104,15 +1190,7 @@ icUInt32Number CIccXmlArrayType<T, Tsig>::ParseText(T* pBuf, icUInt32Number nSiz
     }
     else if (bInNum) {
       num[b] = 0;
-      if (!strncmp(num, "nan", 3) || !strncmp(num, "-nan", 4)) {
-        if (std::is_floating_point<T>())        // compile type constant for each type
-          pBuf[n] = (T)nanf(num);
-        else
-          pBuf[n] = 0;  // flush nan to zero for integers
-      }
-      else {
-        pBuf[n] = clipTypeRange<T>(atof(num));  // clip input to valid output range
-      }
+      pBuf[n] = icParseArrayValue<T>(num);
       n++;
       bInNum = false;
     }
@@ -1120,15 +1198,7 @@ icUInt32Number CIccXmlArrayType<T, Tsig>::ParseText(T* pBuf, icUInt32Number nSiz
   }
   if ( bInNum && (n < nSize) ) {
     num[b] = 0;
-    if (!strncmp(num, "nan", 3) || !strncmp(num, "-nan", 4)) {
-        if (std::is_floating_point<T>())        // compile type constant for each type
-          pBuf[n] = (T)nanf(num);
-        else
-          pBuf[n] = 0;  // flush nan to zero for integers
-    }
-    else {
-      pBuf[n] = clipTypeRange<T>(atof(num));  // clip input to valid output range
-    }
+    pBuf[n] = icParseArrayValue<T>(num);
     n++;
   } 
 
@@ -1166,9 +1236,14 @@ bool CIccXmlArrayType<T, Tsig>::ParseArray(T* pBuf, icUInt32Number nSize, xmlNod
           !icXmlStrCmp(pNode->name, "f") &&
           pNode->children &&
           pNode->children->content) {
-            float f = 0.0f;
-            sscanf((const char *)(pNode->children->content), "%f", &f);
-            pBuf[i] = (T)f;
+            // #2401: was an unchecked sscanf("%f") straight into a cast, which
+            // made this a THIRD conversion: no clamp, so <f>1e50</f> stored
+            // +inf into an MPE matrix where the identical text array clipped to
+            // FLT_MAX, and no "nan" literal case.  Same helper as the other two
+            // spellings.  (What still differs is acceptance, not conversion: a
+            // non-numeric <f> body counts as a value here while the text form
+            // rejects the array in ParseTextCount().)
+            pBuf[i] = icParseArrayValue<T>((const char *)(pNode->children->content));
             i++;
         }
       }
@@ -1197,7 +1272,16 @@ bool CIccXmlArrayType<T, Tsig>::ParseArray(T* pBuf, icUInt32Number nSize, xmlNod
           !icXmlStrCmp(pNode->name, "n") &&
           pNode->children &&
           pNode->children->content) {
-            pBuf[i] = (T)atol((const char *)(pNode->children->content));
+            // #2401: this was (T)atol(...), an unchecked narrowing cast, so
+            // <n>256</n> in a uInt8Array wrapped to 0 and <n>300</n> to 44
+            // while the identical text-form array clipped both to 255.  atol()
+            // also discarded the fractional part outright for the
+            // float32/float64/float16 arrays, which reach this branch too:
+            // only icSigFloatArrayType scans for "f" elements (see the
+            // wrapper's scanType), so <n>0.5</n> in a float32Array stored 0.
+            // Both are the same defect -- this branch had its own conversion --
+            // so it now calls the one ParseText() uses.
+            pBuf[i] = icParseArrayValue<T>((const char *)(pNode->children->content));
             i++;
         }
       }


### PR DESCRIPTION
Part of #2401.

## The defect

An `<Array>`/`<Data>` body can be written three ways, and each had its own conversion:

| spelling | conversion |
|---|---|
| text (`256 255 300 -1`) | `clipTypeRange<T>(atof(...))` |
| `<n>` elements | `(T)atol(...)` — unchecked narrowing cast |
| `<f>` elements (`icSigFloatArrayType` only) | unchecked `sscanf("%f")` into a cast |

So one array had three meanings depending only on how it was spelled. Measured on `f186948c`:

| type | input | element | text |
|---|---|---|---|
| uInt8Array | 256 / 300 / -1 | 0 / 44 / 255 (wrapped) | 255 / 255 / 0 (clipped) |
| float32Array | 0.5 / -2.25 | 0.0 / -2.0 | 0.5 / -2.25 |
| float32Array | nan | 0.0 | nan |
| uInt64Array | 2^53+1 | exact | 9007199254740992 |
| uInt64Array | UINT64_MAX | 9223372036854775807 | exact |
| floatArray | 1e50 (`<f>`) | +inf | FLT_MAX |

The report covers the first row. The float rows follow from the same line: only
`icSigFloatArrayType` scans for `"f"` elements (the `scanType` in `ParseArray(xmlNode*)`),
so float16/float32/float64 arrays reach the `<n>` branch too, where `atol()` discarded the
fraction outright.

## Why it is one shared helper rather than a redirect

**Neither spelling was simply the worse one** — each was exact where another lost data.
`atof()` routes through a double's 53-bit mantissa; `atol()` is 64-bit but **saturates at
`LLONG_MAX`**, so it is not exact at the top of the unsigned range either. Pointing the
element form at the text form's conversion — the obvious fix — measurably regressed uInt64.

All three spellings now call one `icParseArrayValue<T>()`, so agreement is structural
instead of two implementations that have to keep re-earning it.

The helper parses integers integrally rather than through `atof()`, which also fixes the
text form's own 2^53 truncation. Where a token is float-shaped (`.`, `e`, `E`) it saturates
in double space rather than deferring to `clipTypeRange()`: that bound is
`(long double)max()`, and where `long double == double` (MSVC x64 and ARM64) it rounds
`UINT64_MAX` **up** to 2^64, so the saturation test fails and the cast to `uint64_t` is
undefined. `atol()` was defined here before, so this change must not be what introduces UB.
Whitespace is skipped once, before the NaN literal test, so an indented
`<n>\n  nan\n</n>` is not treated differently from `<n>nan</n>`. A `static_assert` pins the
unsigned assumption behind clipping a negative to zero, which was previously only a comment.

## Not addressed

A non-numeric `<f>` body still counts as a value where the text spelling rejects the whole
array in `ParseTextCount()`. That is an acceptance difference rather than a conversion one,
and is left alone here.

## Test

`iccdev.xml-array-element-form-regression` — 7 cases, all red against `f186948c`.

It asserts **both** that the spellings agree **and** what they equal: agreement alone would
survive both paths regressing identically.

It reads the **raw tag bytes** out of the `.icc` rather than round-tripping through
`iccToXml`, which matters — `DumpArray()` has `case icSigUInt64ArrayType: // unused` and
zeroes non-finite floats, so a round-trip is structurally blind to the uInt64, NaN and `<f>`
rows, i.e. the three that were hardest to get right. The `<f>` case needs a
`multiProcessElementType` because `icSigFloatArrayType` is not a tag type — it backs MPE
matrices, curves and CLUTs, which is what makes a `+inf` coefficient there worth pinning.

```
ctest -R iccdev.xml-array-element-form-regression
```

## Pre-flight

- gcc 15.2.0 container, `-Wall -Wextra -Wpedantic -Werror` + LTO: **0 warnings, 0 errors**
  (`strict warnings ENABLED (GNU 15.2.0)` confirmed in the configure log).
- Full `ctest -LE slow`: green.
- `shellcheck`: clean on the new script.
- Corpus: all 221 tracked `.xml` converted under both builds, twice, because this touches
  `ParseText`, which every array uses. 18 do not convert standalone either way. Every file
  that ever differed carries `<CreationDateTime>now` and differed only in the header dateTime
  and profile ID, in the embedded profile as well as the outer one — the differing set is not
  even stable between sweeps, and a single build run twice differs at the same offsets.
  Nothing value-bearing changed.
