### PR TITLE
fix(#2406): stop file paths carrying terminal control sequences into diagnostics

### DIFF
--- a/.github/scripts/iccdev-issue-2406-apply-console-injection-regression.sh
+++ b/.github/scripts/iccdev-issue-2406-apply-console-injection-regression.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+###############################################################################
+# #2406 -- ICC profile paths could inject terminal control sequences
+###############################################################################
+#
+# CWE-150 / CWE-117.  The four iccApply* tools printed profile paths, data-file
+# paths and raw argv straight into their diagnostics, so a path containing ESC
+# reproduced CSI colour and OSC title payloads on the operator's terminal and in
+# any log that captured them.  Measured on f186948c, all four emit raw 0x1b:
+#
+#   iccApplyProfiles / iccApplySearch / iccApplyNamedCmm print the shared
+#   sConnectError, whose text is assembled with the raw path in
+#   IccConnect.cpp; iccApplyToLink prints argv directly.
+#
+# The library already had the helper -- icSanitizeConsoleText() in
+# IccProfLib/IccFileUtil.h, which escapes C0/C1 and anything >= 0x7f as \xHH.
+# iccSpecSepToTiff routes its OWN prints through it, which is why these four
+# tools looked like the whole story; measured, it still emitted 4 raw ESC bytes
+# on f186948c, because the leak it shares with iccApplyProfiles is not in either
+# tool's prints.  TiffImg.cpp passes the file PATH to TIFFError() as libtiff's
+# "module" string, and libtiff raises its own "TIFFOpen: <path>: ..." the same
+# way, so both went out through libtiff's default handler untouched.  Sanitizing
+# the call-site argument would not have covered libtiff's internal message; the
+# handler is the one place both meet, and it is installed in TiffImg.cpp so
+# iccTiffDump and iccSpecSepToTiff get it too.
+#
+# That also means the payload is reachable through the SOURCE and DESTINATION
+# image arguments, not only the profile argument -- the first version of this
+# test passed a valid source TIFF and put the payload only in the profile, so it
+# reported 4/4 PASS while the tool still injected on its most common error path.
+#
+# The predicate is the raw byte, not the rendered text: a test that grepped for
+# "ESC[31m" would pass on output that still contained 0x1b written another way.
+# Each case counts 0x1b in BOTH streams and requires zero.
+#
+# Anti-vacuity matters more than usual here, because "no ESC in the output" is
+# trivially satisfied by no output at all.  Every case therefore also requires
+# (a) the marker text that only appears inside the path, proving the diagnostic
+# naming the path was actually produced, and (b) the escaped form \x1B, proving
+# the sanitizer ran rather than the payload being dropped.
+#
+# Red/green: all four cases fail against f186948c, each with 2 raw ESC bytes.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-apply-console-injection-regression}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+PROFILES="$TOOLS_DIR/IccApplyProfiles/iccApplyProfiles"
+SEARCH="$TOOLS_DIR/IccApplySearch/iccApplySearch"
+NAMEDCMM="$TOOLS_DIR/IccApplyNamedCmm/iccApplyNamedCmm"
+TOLINK="$TOOLS_DIR/IccApplyToLink/iccApplyToLink"
+SPECSEP="$TOOLS_DIR/IccSpecSepToTiff/iccSpecSepToTiff"
+
+SRC_TIFF="$REPO_ROOT/Testing/ApplyDataFiles/seed-tiff-none-rgb-8x8.tif"
+SRC_DATA="$REPO_ROOT/Testing/ApplyDataFiles/DarkRed-CMYK.txt"
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+
+fail_case() { echo "  [FAIL] $1 -- $2"; FAIL=$((FAIL + 1)); }
+pass_case() { echo "  [PASS] $1 -- $2"; PASS=$((PASS + 1)); }
+skip_case() { echo "  [SKIP] $1 -- $2"; SKIP=$((SKIP + 1)); }
+
+# A path that does not exist, carrying a CSI colour payload.  The tools fail to
+# open it and name it in the diagnostic, which is the path under test.
+ESC=$(printf '\033')
+PWN_PATH="$OUTDIR/missing-${ESC}[31mICC-PWN${ESC}[0m.icc"
+
+count_esc() {
+  # Count raw 0x1b bytes.  od + grep on a byte column rather than grep -c on the
+  # text, so a payload split across lines is still counted.
+  od -An -tx1 -v "$1" | tr ' ' '\n' | grep -c '^1b$' || true
+}
+
+run_case() {
+  local name="$1" tool="$2"; shift 2
+  if [ ! -x "$tool" ]; then
+    skip_case "$name" "not built at $tool"
+    return
+  fi
+  TOTAL=$((TOTAL + 1))
+
+  local log="$OUTDIR/$name.log"
+  local rc=0
+  : > "$log"
+  timeout 60 "$tool" "$@" > "$log" 2>&1 || rc=$?
+
+  if [ "$rc" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+
+  local esc
+  esc="$(count_esc "$log")"
+
+  # (a) the diagnostic that names the path was produced at all
+  if ! grep -q -- '-PWN' "$log" 2>/dev/null; then
+    fail_case "$name" "no diagnostic naming the profile path -- nothing was measured"
+    sed -n '1,10p' "$log"
+    return
+  fi
+  # the defect itself, reported before the backstop below so a failure says what
+  # actually went wrong
+  if [ "$esc" -ne 0 ]; then
+    fail_case "$name" "$esc raw ESC byte(s) reached the output"
+    return
+  fi
+  # (b) the sanitizer ran, rather than the payload simply being dropped
+  if ! grep -q 'x1B\|x1b' "$log" 2>/dev/null; then
+    fail_case "$name" "path is named and carries no ESC, but the escape was not rendered as \\xHH"
+    sed -n '1,10p' "$log"
+    return
+  fi
+
+  pass_case "$name" "path reported with the escape neutralised, no raw ESC"
+}
+
+if [ ! -x "$PROFILES" ] && [ ! -x "$SEARCH" ] && [ ! -x "$NAMEDCMM" ] && [ ! -x "$TOLINK" ]; then
+  echo "no iccApply* tool found under $TOOLS_DIR -- skipping"
+  exit 77
+fi
+if [ ! -f "$SRC_TIFF" ] || [ ! -f "$SRC_DATA" ]; then
+  echo "apply data files missing -- skipping"
+  exit 77
+fi
+
+echo "=== iccApply* console injection regression (#2406) ==="
+
+run_case iccapplyprofiles-connect-error "$PROFILES" \
+  "$SRC_TIFF" "$OUTDIR/out.tif" 0 0 0 0 1 "$PWN_PATH" 1
+run_case iccapplynamedcmm-connect-error "$NAMEDCMM" \
+  "$SRC_DATA" 0 0 "$PWN_PATH" 1
+run_case iccapplysearch-connect-error "$SEARCH" \
+  "$SRC_DATA" 0 0 "$PWN_PATH" 1 "$PWN_PATH" 1 -INIT 1
+run_case iccapplytolink-argv "$TOLINK" \
+  "$OUTDIR/link.icc" 0 33 0 title 0 1 0 0 "$PWN_PATH" 1
+
+# The image arguments, not the profile argument.  A bad source or destination
+# path is iccApplyProfiles' most common failure and it goes out through
+# libtiff's handler, so these two are what cover the TiffImg.cpp half.
+PWN_TIFF="$OUTDIR/missing-${ESC}[31mTIFF-PWN${ESC}[0m.tif"
+PWN_DST="$OUTDIR/no-such-dir/${ESC}[31mDST-PWN${ESC}[0m.tif"
+SRGB="$REPO_ROOT/Testing/sRGB_v4_ICC_preference.icc"
+
+if [ -f "$SRGB" ]; then
+  run_case iccapplyprofiles-source-tiff "$PROFILES" \
+    "$PWN_TIFF" "$OUTDIR/out2.tif" 0 0 0 0 1 "$SRGB" 1
+  run_case iccapplyprofiles-dest-tiff "$PROFILES" \
+    "$SRC_TIFF" "$PWN_DST" 0 0 0 0 1 "$SRGB" 1
+else
+  skip_case iccapplyprofiles-image-paths "sRGB reference profile missing"
+fi
+
+# iccSpecSepToTiff shares TiffImg.cpp, so it inherits both the defect and the
+# fix.  Included because the header used to claim this tool was already clean
+# and measurement said otherwise.
+if [ -x "$SPECSEP" ]; then
+  run_case iccspecseptotiff-prefix "$SPECSEP" \
+    "$OUTDIR/specsep-out.tif" 0 0 "$OUTDIR/missing-${ESC}[31mSEP-PWN${ESC}[0m-" 400 700 10
+else
+  skip_case iccspecseptotiff-prefix "not built"
+fi
+
+echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total ==="
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+if [ "$PASS" -eq 0 ]; then
+  echo "no case was measured -- treating as skipped rather than passed"
+  exit 77
+fi
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7647,6 +7647,25 @@ if(TARGET iccFromXml)
     SKIP_RETURN_CODE 77)
 endif()
 
+# #2406: profile and data-file paths must not carry terminal control sequences
+# into the tools' diagnostics (CWE-150/CWE-117).  Not labelled "slow", so it
+# runs on the pull_request path (ci-pr-action.yml pins ctest_mode=fast, which
+# drops the slow label).  Four cases x "timeout 60" is a 240s worst case.
+if(TARGET iccApplyProfiles AND TARGET iccApplySearch
+   AND TARGET iccApplyNamedCmm AND TARGET iccApplyToLink)
+  iccdev_add_script_test(
+    iccdev.apply-console-injection-regression
+    300
+    "iccdev;apply;security;console;injection;issue-2406;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2406-apply-console-injection-regression.sh"
+  )
+  # Exits 77 when no tool is built, the apply data files are missing, or nothing
+  # was measured.
+  set_tests_properties(iccdev.apply-console-injection-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # Guarded on the target, like iccdev.tiff-resolution-unit-regression below.
 # Both scripts exit 2 when iccSpecSepToTiff is missing rather than skipping the
 # way the older sibling suites do, so an unguarded registration turns a

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -397,31 +397,31 @@ int main(int argc, const char* argv[])
 
     json cfg;
     if (!loadJsonFrom(cfg, argv[2]) || !cfg.is_object()) {
-      printf("Unable to read configuration from '%s'\n", argv[2]);
+      printf("Unable to read configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return EXIT_FAILURE;
     }
 
     if (cfg.find("dataFiles") == cfg.end() || !cfgApply.fromJson(cfg["dataFiles"])) {
-      printf("Unable to parse dataFile configuration from '%s'\n", argv[2]);
+      printf("Unable to parse dataFile configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return EXIT_FAILURE;
     }
 
     if (cfg.find("profileSequence") == cfg.end() || !cfgProfiles.fromJson(cfg["profileSequence"])) {
-      printf("Unable to parse profileSequence configuration from '%s'\n", argv[2]);
+      printf("Unable to parse profileSequence configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return EXIT_FAILURE;
     }
 
     if (cfgApply.m_srcType == icCfgColorData) {
       if (cfgApply.m_srcFile.empty()) {
         if (!cfgData.fromJson(cfg["colorData"])) {
-          printf("Unable to parse colorData configuration from '%s'\n", argv[2]);
+          printf("Unable to parse colorData configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
           return EXIT_FAILURE;
         }
       }
       else {
         json data;
         if (!loadJsonFrom(data, cfgApply.m_srcFile.c_str()) || !cfgData.fromJson(data)) {
-          printf("Unable to load color data from '%s'\n", cfgApply.m_srcFile.c_str());
+          printf("Unable to load color data from '%s'\n", icSanitizeConsoleText(cfgApply.m_srcFile.c_str()).c_str());
           return EXIT_FAILURE;
         }
       }
@@ -429,13 +429,13 @@ int main(int argc, const char* argv[])
     else if (cfgApply.m_srcType == icCfgIt8) {
       cfgData.m_srcSpace = cfgApply.m_srcSpace;
       if (cfgApply.m_srcFile.empty() || !cfgData.fromIt8(cfgApply.m_srcFile.c_str())) {
-        printf("Unable to parse IT8 data file '%s'\n", cfgApply.m_srcFile.c_str());
+        printf("Unable to parse IT8 data file '%s'\n", icSanitizeConsoleText(cfgApply.m_srcFile.c_str()).c_str());
         return EXIT_FAILURE;
       }
     }
     else if (cfgApply.m_srcType == icCfgLegacy) {
       if (!cfgData.fromLegacy(cfgApply.m_srcFile.c_str())) {
-        printf("Unable to parse legacy data file '%s'\n", cfgApply.m_srcFile.c_str());
+        printf("Unable to parse legacy data file '%s'\n", icSanitizeConsoleText(cfgApply.m_srcFile.c_str()).c_str());
         return EXIT_FAILURE;
       }
     }
@@ -492,7 +492,7 @@ int main(int argc, const char* argv[])
     }
 
     if (cfgApply.m_srcType != icCfgLegacy || !cfgData.fromLegacy(cfgApply.m_srcFile.c_str())) {
-      printf("Unable to parse legacy data file '%s'\n", cfgApply.m_srcFile.c_str());
+      printf("Unable to parse legacy data file '%s'\n", icSanitizeConsoleText(cfgApply.m_srcFile.c_str()).c_str());
       return EXIT_FAILURE;
     }
 
@@ -521,17 +521,17 @@ int main(int argc, const char* argv[])
         std::string jsonText = cfgJson.dump(1);
         size_t n = fwrite(jsonText.c_str(), 1, jsonText.size(), f);
         if (n != jsonText.size()) {
-          printf("Error writing json config file '%s'\n", exportFile.c_str());
+          printf("Error writing json config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
           fclose(f);
           return EXIT_FAILURE;
         }
         if (!icFlushAndClose(f)) {
-          printf("Error closing json config file '%s'\n", exportFile.c_str());
+          printf("Error closing json config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
           return EXIT_FAILURE;
         }
       }
       else {
-        printf("Unable to export config file '%s'\n", exportFile.c_str());
+        printf("Unable to export config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
         return EXIT_FAILURE;
       }
     }
@@ -588,7 +588,7 @@ int main(int argc, const char* argv[])
 
   if (!pConnect) {
     if (!sConnectError.empty())
-      printf("Error - %s\n", sConnectError.c_str());
+      printf("Error - %s\n", icSanitizeConsoleText(sConnectError.c_str()).c_str());
     else
       printf("Error - Unable to begin profile application - Possibly invalid or incompatible profiles\n");
     return EXIT_FAILURE;

--- a/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/TiffImg.cpp
@@ -75,6 +75,57 @@
 #include <limits>
 #include <climits>   // LONG_MAX, for the IFD-offset bound in readStoredExtraSamplesCount()
 #include "TiffImg.h"
+#include "IccFileUtil.h"  // icSanitizeConsoleText - #2406
+#include <cstdarg>
+
+// #2406: libtiff routes every diagnostic through a handler that prints the
+// "module" string and the formatted message straight to stderr.  Every
+// TIFFError() call in this file passes the FILE PATH as that module string, and
+// libtiff raises its own "TIFFOpen: <path>: No such file or directory." the same
+// way -- so a path carrying ESC reproduced CSI/OSC payloads on the terminal.
+// Sanitizing the argument at each call site would have left libtiff's internal
+// message raw; the handler is the one place both meet.
+//
+// The format mirrors libtiff's own unix handlers exactly ("module: ", the
+// message, then ".\n", with "Warning, " prefixed for warnings), so output is
+// unchanged for the ASCII paths every existing test uses -- only control and
+// non-ASCII bytes render differently, which is the defect.
+//
+// Installed for every consumer of this file rather than in one tool's main():
+// iccApplyProfiles, iccSpecSepToTiff and iccTiffDump all compile TiffImg.cpp and
+// all three leaked through these same sites.
+static void icTiffSanitizedErrorHandler(const char* module, const char* fmt, va_list ap)
+{
+  char msg[1024];
+  vsnprintf(msg, sizeof(msg), fmt, ap);
+  if (module != NULL)
+    fprintf(stderr, "%s: ", icSanitizeConsoleText(module).c_str());
+  fprintf(stderr, "%s.\n", icSanitizeConsoleText(msg).c_str());
+}
+
+static void icTiffSanitizedWarningHandler(const char* module, const char* fmt, va_list ap)
+{
+  char msg[1024];
+  vsnprintf(msg, sizeof(msg), fmt, ap);
+  if (module != NULL)
+    fprintf(stderr, "%s: ", icSanitizeConsoleText(module).c_str());
+  fprintf(stderr, "Warning, %s.\n", icSanitizeConsoleText(msg).c_str());
+}
+
+namespace {
+// A file-scope object so the handlers are in place before main() runs, whichever
+// of the three tools is linking this file.  TIFFSetErrorHandler is a plain
+// function-pointer assignment, so there is no static-initialisation-order
+// dependency here.
+struct IccTiffSanitizedHandlers {
+  IccTiffSanitizedHandlers()
+  {
+    TIFFSetErrorHandler(icTiffSanitizedErrorHandler);
+    TIFFSetWarningHandler(icTiffSanitizedWarningHandler);
+  }
+};
+const IccTiffSanitizedHandlers g_icTiffSanitizedHandlers;
+}
 
 // The output-destination check below needs GetFileAttributesA() on Windows and
 // lstat()/errno on POSIX (#2242).  <windows.h> is pulled in here, in the shared

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -292,7 +292,7 @@ int main(int argc, const char** argv)
     long parsed = strtol(argv[2], &end, 10);
     if (errno || end == argv[2] || *end || parsed < 0 ||
         parsed > CIccThreadedCmm::GetMaxThreads()) {
-      printf("Invalid thread count '%s': expected 0..%d\n", argv[2],
+      printf("Invalid thread count '%s': expected 0..%d\n", icSanitizeConsoleText(argv[2]).c_str(),
              CIccThreadedCmm::GetMaxThreads());
       return EXIT_FAILURE;
     }
@@ -319,23 +319,23 @@ int main(int argc, const char** argv)
 
     json cfg;
     if (!loadJsonFrom(cfg, argv[2]) || !cfg.is_object()) {
-      printf("Unable to read configuration from '%s'\n", argv[2]);
+      printf("Unable to read configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return -1;
     }
 
     if (cfg.find("imageFiles") == cfg.end() || !cfgApply.fromJson(cfg["imageFiles"])) {
-      printf("Unable to parse imageFiles configuration from '%s'\n", argv[2]);
+      printf("Unable to parse imageFiles configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return -1;
     }
 
     if (cfg.find("profileSequence") == cfg.end() || !cfgProfiles.fromJson(cfg["profileSequence"])) {
-      printf("Unable to parse profileSequence configuration from '%s'\n", argv[2]);
+      printf("Unable to parse profileSequence configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return -1;
     }
 
     auto connectOptions = cfg.find("connect");
     if (connectOptions != cfg.end() && !cfgConnect.fromJson(*connectOptions)) {
-      printf("Unable to parse connect configuration from '%s'\n", argv[2]);
+      printf("Unable to parse connect configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return -1;
     }
   }
@@ -409,17 +409,17 @@ int main(int argc, const char** argv)
 
         std::string jsonText = cfgJson.dump(1);
         if (fwrite(jsonText.c_str(), 1, jsonText.size(), f) != jsonText.size()) {
-          printf("Unable to write complete config file '%s'\n", exportFile.c_str());
+          printf("Unable to write complete config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
           fclose(f);
           return -1;
         }
         if (!icFlushAndClose(f)) {
-          printf("Unable to close config file '%s'\n", exportFile.c_str());
+          printf("Unable to close config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
           return -1;
         }
       }
       else {
-        printf("Unable to export config file '%s'\n", exportFile.c_str());
+        printf("Unable to export config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
         return -1;
       }
     }
@@ -436,7 +436,7 @@ int main(int argc, const char** argv)
 
   //Open source image file and get information from it
   if (!SrcImg.Open(cfgApply.m_srcImgFile.c_str())) {
-    printf("\nFile [%s] cannot be opened.\n", cfgApply.m_srcImgFile.c_str());
+    printf("\nFile [%s] cannot be opened.\n", icSanitizeConsoleText(cfgApply.m_srcImgFile.c_str()).c_str());
     return -1;
   }
   sn = SrcImg.GetSamples();
@@ -520,7 +520,7 @@ int main(int argc, const char** argv)
 
   if (!pConnect) {
     if (!sConnectError.empty())
-      printf("Error - %s\n", sConnectError.c_str());
+      printf("Error - %s\n", icSanitizeConsoleText(sConnectError.c_str()).c_str());
     else
       printf("Error - Unable to begin profile application - Possibly invalid or incompatible profiles\n");
     return -1;
@@ -542,14 +542,14 @@ int main(int argc, const char** argv)
     //Allow color management to ignore extra samples when non extra samples match samples in profile
     if (sen != 0) {
       if (nSrcSamples != (int)(sn - sen)) {
-        printf("Number of non-extra samples %u in image[%s] doesn't match device samples %d in first profile\n", sn - sen, cfgApply.m_srcImgFile.c_str(), nSrcSamples);
+        printf("Number of non-extra samples %u in image[%s] doesn't match device samples %d in first profile\n", sn - sen, icSanitizeConsoleText(cfgApply.m_srcImgFile.c_str()).c_str(), nSrcSamples);
         return -1;
       }
       else
         nSrcSamples = sn;
     }
     else {
-      printf("Number of samples %u in image[%s] doesn't match device samples %d in first profile\n", sn, cfgApply.m_srcImgFile.c_str(), nSrcSamples);
+      printf("Number of samples %u in image[%s] doesn't match device samples %d in first profile\n", sn, icSanitizeConsoleText(cfgApply.m_srcImgFile.c_str()).c_str(), nSrcSamples);
       return -1;
     }
   }
@@ -605,7 +605,7 @@ int main(int argc, const char** argv)
   // and the physical size shifted by 2.54x.  Same defect as iccSpecSepToTiff, because
   // both tools reach it through the same shared CTiffImg::Create() (#2220).
   if (!DstImg.Create(cfgApply.m_dstImgFile.c_str(), SrcImg.GetWidth(), SrcImg.GetHeight(), dbps, photo, nDestSamples, nExtraSamples, SrcImg.GetXRes(), SrcImg.GetYRes(), bCompress, bSeparation, SrcImg.GetResolutionUnit())) {
-    printf("Unable to create Tiff file - '%s'\n", cfgApply.m_dstImgFile.c_str());
+    printf("Unable to create Tiff file - '%s'\n", icSanitizeConsoleText(cfgApply.m_dstImgFile.c_str()).c_str());
     return -1;
   }
 
@@ -787,7 +787,7 @@ int main(int argc, const char** argv)
       for (unsigned int nRow = 0; nRow < nBatchRows; nRow++) {
         if (!SrcImg.ReadLine(pSBuf)) {
           printf("Error reading line %u from Tiff file - '%s'\n",
-                 (unsigned int)i + nRow, cfgApply.m_srcImgFile.c_str());
+                 (unsigned int)i + nRow, icSanitizeConsoleText(cfgApply.m_srcImgFile.c_str()).c_str());
           bApplySuccess = false;
           break;
         }
@@ -833,7 +833,7 @@ int main(int argc, const char** argv)
 
         if (!DstImg.WriteLine(pDBuf)) {
           printf("Error writing line %u to Tiff file - '%s'\n",
-                 (unsigned int)i + nRow, cfgApply.m_dstImgFile.c_str());
+                 (unsigned int)i + nRow, icSanitizeConsoleText(cfgApply.m_dstImgFile.c_str()).c_str());
           bApplySuccess = false;
           break;
         }
@@ -854,7 +854,7 @@ int main(int argc, const char** argv)
     else {
       if (!SrcImg.ReadLine(pSBuf)) {
         printf("Error reading line %d from Tiff file - '%s'\n", i,
-               cfgApply.m_srcImgFile.c_str());
+               icSanitizeConsoleText(cfgApply.m_srcImgFile.c_str()).c_str());
         bApplySuccess = false;
         break;
       }
@@ -892,7 +892,7 @@ int main(int argc, const char** argv)
 
     //Output the converted pixels to the destination image
     if (!DstImg.WriteLine(pDBuf)) {
-      printf("Error writing line %d to Tiff file - '%s'\n", i, cfgApply.m_dstImgFile.c_str());
+      printf("Error writing line %d to Tiff file - '%s'\n", i, icSanitizeConsoleText(cfgApply.m_dstImgFile.c_str()).c_str());
       bApplySuccess = false;
       break;
     }

--- a/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
+++ b/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
@@ -269,7 +269,7 @@ int main(int argc, const char* argv[])
     long parsed = strtol(argv[2], &end, 10);
     if (errno || !end || end == argv[2] || *end || parsed < 0 ||
         parsed > CIccThreadedCmm::GetMaxThreads()) {
-      printf("Invalid thread count '%s': expected 0..%d\n", argv[2],
+      printf("Invalid thread count '%s': expected 0..%d\n", icSanitizeConsoleText(argv[2]).c_str(),
              CIccThreadedCmm::GetMaxThreads());
       return EXIT_FAILURE;
     }
@@ -299,31 +299,31 @@ int main(int argc, const char* argv[])
 
     json cfg;
     if (!loadJsonFrom(cfg, argv[2]) || !cfg.is_object()) {
-      printf("Unable to read configuration from '%s'\n", argv[2]);
+      printf("Unable to read configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return -1;
     }
 
     if (cfg.find("dataFiles") == cfg.end() || !cfgApply.fromJson(cfg["dataFiles"])) {
-      printf("Unable to parse dataFile configuration from '%s'\n", argv[2]);
+      printf("Unable to parse dataFile configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return -1;
     }
 
     if (cfg.find("searchApply") == cfg.end() || !cfgSearchApply.fromJson(cfg["searchApply"])) {
-      printf("Unable to parse profileSequence configuration from '%s'\n", argv[2]);
+      printf("Unable to parse profileSequence configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
       return -1;
     }
 
     if (cfgApply.m_srcType == icCfgColorData) {
       if (cfgApply.m_srcFile.empty()) {
         if (!cfgData.fromJson(cfg["colorData"])) {
-          printf("Unable to parse colorData configuration from '%s'\n", argv[2]);
+          printf("Unable to parse colorData configuration from '%s'\n", icSanitizeConsoleText(argv[2]).c_str());
           return -1;
         }
       }
       else {
         json data;
         if (!loadJsonFrom(data, cfgApply.m_srcFile.c_str()) || !cfgData.fromJson(data)) {
-          printf("Unable to load color data from '%s'\n", cfgApply.m_srcFile.c_str());
+          printf("Unable to load color data from '%s'\n", icSanitizeConsoleText(cfgApply.m_srcFile.c_str()).c_str());
           return -1;
         }
       }
@@ -331,13 +331,13 @@ int main(int argc, const char* argv[])
     else if (cfgApply.m_srcType == icCfgIt8) {
       cfgData.m_srcSpace = cfgApply.m_srcSpace;
       if (cfgApply.m_srcFile.empty() || !cfgData.fromIt8(cfgApply.m_srcFile.c_str())) {
-        printf("Unable to parse IT8 data file '%s'\n", cfgApply.m_srcFile.c_str());
+        printf("Unable to parse IT8 data file '%s'\n", icSanitizeConsoleText(cfgApply.m_srcFile.c_str()).c_str());
         return -1;
       }
     }
     else if (cfgApply.m_srcType == icCfgLegacy) {
       if (!cfgData.fromLegacy(cfgApply.m_srcFile.c_str())) {
-        printf("Unable to parse legacy data file '%s'\n", cfgApply.m_srcFile.c_str());
+        printf("Unable to parse legacy data file '%s'\n", icSanitizeConsoleText(cfgApply.m_srcFile.c_str()).c_str());
         return -1;
       }
     }
@@ -381,7 +381,7 @@ int main(int argc, const char* argv[])
     }
 
     if (cfgApply.m_srcType != icCfgLegacy || !cfgData.fromLegacy(cfgApply.m_srcFile.c_str())) {
-      printf("Unable to parse legacy data file '%s'\n", cfgApply.m_srcFile.c_str());
+      printf("Unable to parse legacy data file '%s'\n", icSanitizeConsoleText(cfgApply.m_srcFile.c_str()).c_str());
       return -1;
     }
 
@@ -411,17 +411,17 @@ int main(int argc, const char* argv[])
         std::string jsonText = cfgJson.dump(1);
         size_t n = fwrite(jsonText.c_str(), 1, jsonText.size(), f);
         if (n != jsonText.size()) {
-          printf("Error writing json config file '%s'\n", exportFile.c_str());
+          printf("Error writing json config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
           fclose(f);
           return -1;
         }
         if (!icFlushAndClose(f)) {
-          printf("Error closing json config file '%s'\n", exportFile.c_str());
+          printf("Error closing json config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
           return -1;
         }
       }
       else {
-        printf("Unable to export config file '%s'\n", exportFile.c_str());
+        printf("Unable to export config file '%s'\n", icSanitizeConsoleText(exportFile.c_str()).c_str());
         return -1;
       }
     }
@@ -460,7 +460,7 @@ int main(int argc, const char* argv[])
 
   if (!pConnect) {
     if (!sConnectError.empty())
-      printf("Error - %s\n", sConnectError.c_str());
+      printf("Error - %s\n", icSanitizeConsoleText(sConnectError.c_str()).c_str());
     printf("Unable to begin profile application - Possibly invalid or incompatible profiles\n");
     return -1;
   }

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -272,7 +272,7 @@ public:
 
     m_f = icOpenRegularWriteBinaryFile(m_filename.c_str());
     if (!m_f) {
-      printf("Unable to open '%s'\n", m_filename.c_str());
+      printf("Unable to open '%s'\n", icSanitizeConsoleText(m_filename.c_str()).c_str());
       return false;
     }
 
@@ -933,7 +933,7 @@ int main(int argc, icChar* argv[])
 
   int nLinkType = 0;
   if (!ParseIntArg(argv[2], 0, 1, nLinkType)) {
-    printf("Invalid link_type '%s': expected 0 (Device Link) or 1 (.cube text file)\n", argv[2]);
+    printf("Invalid link_type '%s': expected 0 (Device Link) or 1 (.cube text file)\n", icSanitizeConsoleText(argv[2]).c_str());
     return 1;
   }
 
@@ -956,7 +956,7 @@ int main(int argc, icChar* argv[])
 
   int nLutSize = 0;
   if (!ParseIntArg(argv[3], 2, 255, nLutSize)) {
-    printf("Invalid LUT size '%s': expected an integer between 2 and 255\n", argv[3]);
+    printf("Invalid LUT size '%s': expected an integer between 2 and 255\n", icSanitizeConsoleText(argv[3]).c_str());
     return EXIT_FAILURE;
   }
   
@@ -965,13 +965,13 @@ int main(int argc, icChar* argv[])
   int nOption = 0;
   if (nLinkType == 0) {
     if (!ParseIntArg(argv[4], 0, 1, nOption)) {
-      printf("Invalid option '%s': DeviceLink option must be 0 (v4) or 1 (v5)\n", argv[4]);
+      printf("Invalid option '%s': DeviceLink option must be 0 (v4) or 1 (v5)\n", icSanitizeConsoleText(argv[4]).c_str());
       return 1;
     }
   }
   else {
     if (!ParseIntArg(argv[4], 0, 20, nOption)) {
-      printf("Invalid option '%s': .cube precision must be between 0 and 20\n", argv[4]);
+      printf("Invalid option '%s': .cube precision must be between 0 and 20\n", icSanitizeConsoleText(argv[4]).c_str());
       return 1;
     }
   }
@@ -1036,13 +1036,13 @@ int main(int argc, icChar* argv[])
   //Retrieve command line arguments
   int nFirstTransform = 0;
   if (!ParseIntArg(argv[8], 0, 1, nFirstTransform)) {
-    printf("Invalid first_transform '%s': expected 0 or 1\n", argv[8]);
+    printf("Invalid first_transform '%s': expected 0 or 1\n", icSanitizeConsoleText(argv[8]).c_str());
     return 1;
   }
   bool bFirstTransform = nFirstTransform != 0;
   int nInterpVal = 0;
   if (!ParseIntArg(argv[9], 0, 1, nInterpVal)) {
-    printf("Invalid interp '%s': expected 0 (linear) or 1 (tetrahedral)\n", argv[9]);
+    printf("Invalid interp '%s': expected 0 (linear) or 1 (tetrahedral)\n", icSanitizeConsoleText(argv[9]).c_str());
     return 1;
   }
   icXformInterp nInterp = (nInterpVal == 0) ? icInterpLinear : icInterpTetrahedral;
@@ -1075,7 +1075,7 @@ int main(int argc, icChar* argv[])
       icSignature sig = icGetSigVal(argv[nCount]+5);
       icFloatNumber val;
       if (!ParseFloatArg(argv[nCount+1], val)) {
-        printf("Invalid environment value '%s' for %s: expected a finite number\n", argv[nCount+1], argv[nCount]);
+        printf("Invalid environment value '%s' for %s: expected a finite number\n", icSanitizeConsoleText(argv[nCount+1]).c_str(), icSanitizeConsoleText(argv[nCount]).c_str());
         releasePccList(pccList);
         return 1;
       }
@@ -1085,7 +1085,7 @@ int main(int argc, icChar* argv[])
     else if (stricmp(argv[nCount], "-PCC")) { //Attach profile while ignoring -PCC (this are handled below as profiles are attached)
       bUseD2BxB2DxTags = true;
       if (!ParseIntArg(argv[nCount+1], INT_MIN, INT_MAX, nIntent)) {
-        printf("Invalid rendering intent '%s': expected an integer code\n", argv[nCount+1]);
+        printf("Invalid rendering intent '%s': expected an integer code\n", icSanitizeConsoleText(argv[nCount+1]).c_str());
         releasePccList(pccList);
         return 1;
       }
@@ -1099,7 +1099,7 @@ int main(int argc, icChar* argv[])
       // (IccCmmConfig.cpp, #2190); refused here so the two tools agree (#2268).
       if (nIntent < 0) {
         printf("Invalid rendering intent '%s': a negative intent code is not a"
-               " valid form\n", argv[nCount+1]);
+               " valid form\n", icSanitizeConsoleText(argv[nCount+1]).c_str());
         releasePccList(pccList);
         return 1;
       }
@@ -1134,7 +1134,7 @@ int main(int argc, icChar* argv[])
       // guard there, removed in #2267; adding the guard here without removing
       // this term would file the alert a second time (#2268).
       if (nIntent > (int)icAbsoluteColorimetric) {
-        printf("Invalid rendering intent '%s': decoded intent is out of range\n", argv[nCount+1]);
+        printf("Invalid rendering intent '%s': decoded intent is out of range\n", icSanitizeConsoleText(argv[nCount+1]).c_str());
         releasePccList(pccList);
         return 1;
       }
@@ -1164,7 +1164,7 @@ int main(int argc, icChar* argv[])
       if (i+1<nNumProfiles && !stricmp(argv[nCount+2], "-PCC")) {  
         pPccProfile = OpenIccProfile(argv[nCount+3]);
         if (!pPccProfile) {
-          printf("Unable to open Profile Connections Conditions from '%s'\n", argv[nCount+3]);
+          printf("Unable to open Profile Connections Conditions from '%s'\n", icSanitizeConsoleText(argv[nCount+3]).c_str());
           // Free any -PCC profiles opened on earlier loop iterations (#1336).
           releasePccList(pccList);
           return -1;
@@ -1199,7 +1199,7 @@ int main(int argc, icChar* argv[])
         // profile, which misled users when a structurally valid profile was
         // simply chained incompatibly - see issue #1322.  Decode the status
         // with CIccCmm::GetStatusText so the real cause is visible.
-        printf("Error - Unable to add '%s' to transform chain (status %d: %s)\n", argv[nCount], stat, CIccCmm::GetStatusText(stat));
+        printf("Error - Unable to add '%s' to transform chain (status %d: %s)\n", icSanitizeConsoleText(argv[nCount]).c_str(), stat, CIccCmm::GetStatusText(stat));
         if (stat == icCmmStatBadSpaceLink) {
           printf("The profile's color spaces do not connect with the previous transform in the chain.\n");
         }
@@ -1326,10 +1326,10 @@ int main(int argc, icChar* argv[])
   }
 
   if (pWriter->finish()) {
-    printf("\nLUT successfully written to '%s'\n", argv[1]);
+    printf("\nLUT successfully written to '%s'\n", icSanitizeConsoleText(argv[1]).c_str());
   }
   else {
-    printf("\nUnable to write LUT to '%s'\n", argv[1]);
+    printf("\nUnable to write LUT to '%s'\n", icSanitizeConsoleText(argv[1]).c_str());
     return -1;
   }
 


### PR DESCRIPTION
Part of #2406.

## Two routes, not one

CWE-150 / CWE-117. A path containing ESC reproduced CSI colour and OSC title payloads on the
operator's terminal and in any log that captured it. There are two distinct routes, and only
the first is in the report:

**1. The tools' own prints.** iccApplyProfiles, iccApplySearch and iccApplyNamedCmm print the
shared `sConnectError`, assembled with the unfiltered path in `IccConnect.cpp`;
iccApplyToLink prints `argv` directly. 2 raw `0x1b` bytes each.

**2. libtiff's handler.** `TiffImg.cpp` passes the file **path** to `TIFFError()` as libtiff's
`module` string, and libtiff raises its own `TIFFOpen: <path>: No such file or directory.`
the same way — so both went out through libtiff's default handler untouched. **6 raw bytes**
for a bad source or destination image, which is iccApplyProfiles' most common failure.

## The fix

The helper already existed: `icSanitizeConsoleText()` in `IccFileUtil.h`, escaping C0/C1 and
`>= 0x7f` as `\xHH`. It is reachable in all four tools via `IccCmdLineUtil.h`, so no include
changes there.

**Route 1** is sanitized at the print sites rather than where the message is built: that is
where the string reaches a terminal, ten separate sites in `IccConnect.cpp` embed a path into
`sErrorMsg`, and the boundary covers messages added later. 58 arguments across the four tools
— every `argv[]`, `m_srcFile`, `m_srcImgFile`, `m_dstImgFile`, `m_iccFile`, `m_pccFile`,
`exportFile` and `sConnectError` that reaches a `printf`. Format strings are untouched and
non-string arguments are left alone.

**Route 2** is fixed with a sanitizing `TIFFSetErrorHandler`/`TIFFSetWarningHandler` installed
in `TiffImg.cpp`. Sanitizing the argument at each `TIFFError()` call site would **not** have
covered libtiff's own message; the handler is the one place both meet. The format mirrors
libtiff's unix handlers exactly, so output is unchanged for ASCII paths. It is installed in
`TiffImg.cpp` rather than one tool's `main()` because iccApplyProfiles, iccSpecSepToTiff and
iccTiffDump all compile it and all three leaked — `iccSpecSepToTiff` sanitizes its own prints,
which is why it looked clean, but measured **4 raw ESC bytes** on `f186948c` through these
sites.

No output changes for any existing test: the helper passes printable ASCII through unaltered,
and there is no non-ASCII filename anywhere in the tree (`git ls-files` matches none, and no
script creates one). All 13 other TIFF and specsep CTests pass unchanged, including the
warning-text assertions in `iccdev.tiffdump-output-hardening` and
`iccdev.tiff-extrasamples-diagnostics`.

## One trade-off for a maintainer's eye

`icSanitizeConsoleText` escapes **every** byte `>= 0x7f`, so a legitimate UTF-8 path now
renders as `'\xC3\xA9cran-Profil.icc'` — in success output as well as errors, and no longer
copy-pasteable. Left as-is here because C1 bytes (`0x80`-`0x9f`) are terminal-active, and
because the alternative is changing a shared helper that `iccSpecSepToTiff` and
`IccCmmConfig` already depend on. A UTF-8-aware variant that escapes only C0/C1 is a
reasonable follow-up, but it is a library decision rather than part of this fix — happy to
take it either way.

## Test

`iccdev.apply-console-injection-regression` — 7 cases, **all red against `f186948c`** at 2, 2,
2, 2, 6, 6 and 4 raw ESC bytes: the profile argument on all four tools, the source and
destination image arguments on iccApplyProfiles, and the prefix argument on iccSpecSepToTiff.

The predicate is the **byte**, not the rendered text — grepping for `ESC[31m` would pass on
output that still contained `0x1b` written another way. And because "no ESC" is trivially
satisfied by *no output at all*, each case also requires the marker text from inside the path
(proving the diagnostic naming it was produced) and the escaped `\xHH` form (proving the
sanitizer ran rather than the payload being dropped). An earlier version of this suite covered
only the profile argument and so reported 4/4 PASS while the tool still injected on its image
paths.

```
ctest -R iccdev.apply-console-injection-regression
```

## Scope

The `iccApply*` tools plus the `TiffImg.cpp` sites their siblings share. The wider sweep of
the remaining CLI tooling is tracked separately in #2414.

## Pre-flight

- gcc 15.2.0 container, `-Wall -Wextra -Wpedantic -Werror` + LTO: **0 warnings, 0 errors**.
- Full `ctest -LE slow`: green; slow TIFF/specsep lane green; `shellcheck` clean.

## Note on ordering

This touches the same four tool sources as the #2405 branch, in different hunks. Both are cut
from `master` rather than stacked so each gets real CI, but they should land one at a time
with a rebase between.
