### PR TITLE
fix(#2405): fail the iccApply* tools when the invocation applied nothing

### DIFF
--- a/.github/scripts/iccdev-issue-2262-brdf-usage-regression.sh
+++ b/.github/scripts/iccdev-issue-2262-brdf-usage-regression.sh
@@ -175,20 +175,32 @@ assert_usage_row() {
 check_usage() {
   local name="$1" tool="$2"
   local log="$OUTDIR/$name.log"
+  local errlog="$OUTDIR/$name.err.log"
   local rc=0
 
-  rm -f "$log"
+  # #2405 changed how this screen is reached.  A bare invocation used to print
+  # it on stdout and exit 0; that is now the malformed path (stderr, non-zero)
+  # and "-h" is the only route to Usage() on stdout.  The rows below are the
+  # same rows either way -- the tools print one screen -- so this test keeps
+  # asserting them, it just asks for them the way a help request now does.
+  # Streams are captured separately rather than merged: "-h" writing anything
+  # to stderr would mean the help path had picked up a diagnostic.
+  rm -f "$log" "$errlog"
   set +e
-  timeout 60 "$tool" > "$log" 2>&1
+  timeout 60 "$tool" -h > "$log" 2> "$errlog"
   rc=$?
   set -e
 
   check_sanitizers "$log" || fail "$name usage emitted sanitizer diagnostics"
+  check_sanitizers "$errlog" || fail "$name usage emitted sanitizer diagnostics on stderr"
   if [ "$rc" -eq 124 ]; then
     fail "$name timed out printing usage"
   fi
   if [ "$rc" -ne 0 ]; then
-    fail "$name did not exit 0 when printing usage (exit=$rc)"
+    fail "$name -h did not exit 0 (exit=$rc)"
+  fi
+  if [ -s "$errlog" ]; then
+    fail "$name -h wrote to stderr"
   fi
 
   sed 's/^[[:space:]]*//' "$log" > "$OUTDIR/$name.stripped"

--- a/.github/scripts/iccdev-issue-2405-apply-usage-exit-code-regression.sh
+++ b/.github/scripts/iccdev-issue-2405-apply-usage-exit-code-regression.sh
@@ -1,0 +1,305 @@
+#!/bin/bash
+###############################################################################
+# #2405 -- the four iccApply* tools reported success for invocations that
+#          applied nothing
+###############################################################################
+#
+# All four tools guarded their operand count with "argc < minargs -> Usage();
+# return 0".  Usage() printed on stdout, so an incomplete invocation was
+# indistinguishable from a successful one to any caller that checks $?: the
+# wrapper saw exit 0, an empty stdout was never produced, and no output file
+# appeared.  Measured on master f186948c, thirteen distinct incomplete forms
+# exited 0:
+#
+#   iccApplyProfiles   0 operands                      (minargs 2)
+#   iccApplyNamedCmm   0 operands                      (minargs 2)
+#   iccApplySearch     0 and 1 operands                (minargs 3)
+#   iccApplyToLink     0,1,2,3,4,5,6,7,8 operands      (minargs 10)
+#
+# The contract applied here is the one #1514 settled for iccSpecSepToTiff (see
+# iccdev-issue-1514-specsep-usage-exit-code-regression-tests.sh), which
+# iccRoundTrip, iccPawgReport and now iccFromXml (#2387) also follow:
+#
+#   malformed / too few operands -> Usage on STDERR, non-zero, stdout empty
+#   -h / --help                  -> Usage on STDOUT, exit 0,   stderr empty
+#
+# The STREAM is the discriminator, not the status: once a help flag exists,
+# both paths print the same screen and only the stream tells them apart.  That
+# is why every case below asserts the quiet stream is EMPTY -- an implementation
+# that printed usage to both would satisfy a status-only test.
+#
+# Red/green, measured against master f186948c: 22 of the 26 cases below fail.
+# All thirteen too-few-operand forms fail, each reporting exit=0.  The five
+# "clears minargs but still malformed" cases fail because master answers them on
+# stdout.  Of the eight help cases, the four on iccApplyProfiles and
+# iccApplyNamedCmm fail (exit 255 and 1 respectively -- minargs is 2 there, so
+# "-h" is a complete operand list and reaches the parser, which rejects it).
+#
+# The other four PASS against master, and the reason is worth stating rather
+# than papering over: iccApplySearch and iccApplyToLink have minargs 3 and 10,
+# so "-h" is *below* their minimum and lands in the very "Usage(); return 0"
+# path this change removes.  Master satisfies the help contract there by
+# accident of the defect, not by supporting a help flag -- which is exactly why
+# the malformed cases, not the help cases, are what red/green this change.
+# Those four assertions still earn their place: they pin the help path against
+# a future regression once it is the only route to Usage() on stdout.
+#
+# Anti-vacuity: assert_usage_screen() pins a row that this change does not
+# touch, so a truncated or empty capture cannot satisfy the stream assertions
+# on its own; and the run exits 77 rather than 0 if no case was measured.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-apply-usage-exit-code-regression}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+STDOUT_LOG="$OUTDIR/apply-usage.stdout.log"
+STDERR_LOG="$OUTDIR/apply-usage.stderr.log"
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+
+fail_case() { echo "  [FAIL] $1 -- $2"; FAIL=$((FAIL + 1)); }
+pass_case() { echo "  [PASS] $1 -- $2"; PASS=$((PASS + 1)); }
+skip_case() { echo "  [SKIP] $1 -- $2"; SKIP=$((SKIP + 1)); }
+
+check_sanitizers() {
+  local name="$1" log="$2"
+  if grep -Eq "ERROR: AddressSanitizer|LeakSanitizer: detected memory leaks|runtime error:" "$log" 2>/dev/null; then
+    fail_case "$name" "sanitizer finding in tool output"
+    return 1
+  fi
+  return 0
+}
+
+# Pin the LAST row of the tool's screen.  Proving the final row arrived proves
+# the capture holds a whole usage screen, not a truncated fragment that would
+# satisfy the "other stream is empty" assertions by being nearly empty itself.
+# The four screens do not end alike -- iccApplySearch has no gamut row at all,
+# and its intent table stops at 100 -- so the anchor is per tool rather than one
+# row assumed common to all, which is what a first version of this test assumed
+# and got wrong.
+#
+# Matched as a whole line with -F against a leading-whitespace-stripped copy:
+# every anchor below contains "+", "(", ")" or "/", all ERE metacharacters, so a
+# regex would quietly stop meaning what it reads as (the same reasoning as the
+# #2262 row assertions).  The tools indent these rows differently.
+ANCHOR=""
+assert_usage_screen() {
+  local name="$1" log="$2" where="$3"
+  sed 's/^[[:space:]]*//' "$log" > "$log.stripped"
+  if ! grep -Fqx "$ANCHOR" "$log.stripped" 2>/dev/null; then
+    fail_case "$name" "no complete usage screen on $where (last row \"$ANCHOR\" absent)"
+    sed -n '1,10p' "$log"
+    return 1
+  fi
+  return 0
+}
+
+# A malformed invocation: non-zero status, usage on stderr, stdout untouched.
+run_malformed() {
+  local name="$1" tool="$2"; shift 2
+  TOTAL=$((TOTAL + 1))
+  local exit_code=0
+
+  : > "$STDOUT_LOG"; : > "$STDERR_LOG"
+  timeout 60 "$tool" "$@" > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
+
+  check_sanitizers "$name" "$STDOUT_LOG" || return
+  check_sanitizers "$name" "$STDERR_LOG" || return
+
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  # A crash also produces a non-zero status, so exclude the signal range rather
+  # than accepting any non-zero as proof the guard fired.
+  if [ "$exit_code" -ge 128 ] && [ "$exit_code" -le 192 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "incomplete invocation reported success (exit=0)"
+    return
+  fi
+  if [ -s "$STDOUT_LOG" ]; then
+    fail_case "$name" "malformed invocation wrote $(wc -c < "$STDOUT_LOG") bytes to stdout"
+    sed -n '1,5p' "$STDOUT_LOG"
+    return
+  fi
+  if ! grep -q "Missing arguments" "$STDERR_LOG" 2>/dev/null; then
+    fail_case "$name" "no 'Missing arguments' diagnostic on stderr"
+    sed -n '1,5p' "$STDERR_LOG"
+    return
+  fi
+  assert_usage_screen "$name" "$STDERR_LOG" "stderr" || return
+
+  pass_case "$name" "rejected with exit=$exit_code, usage on stderr, stdout empty"
+}
+
+# A malformed invocation that is NOT short of minargs, so it is rejected by the
+# argument parser rather than the operand-count guard and prints no usage screen.
+# These exist because the operand-count sweep above cannot reach them, and
+# because this is where the four tools most easily drift apart: the same
+# diagnostic is emitted by all of them, and before #2405 completed the contract
+# iccApplyProfiles printed it on stderr while its two siblings used stdout.
+# Asserts the stream and the status, not the wording.
+run_malformed_no_usage() {
+  local name="$1" tool="$2"; shift 2
+  TOTAL=$((TOTAL + 1))
+  local exit_code=0
+
+  : > "$STDOUT_LOG"; : > "$STDERR_LOG"
+  timeout 60 "$tool" "$@" > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
+
+  check_sanitizers "$name" "$STDOUT_LOG" || return
+  check_sanitizers "$name" "$STDERR_LOG" || return
+
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ] && [ "$exit_code" -le 192 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "malformed invocation reported success (exit=0)"
+    return
+  fi
+  if [ -s "$STDOUT_LOG" ]; then
+    fail_case "$name" "malformed invocation wrote $(wc -c < "$STDOUT_LOG") bytes to stdout"
+    sed -n '1,5p' "$STDOUT_LOG"
+    return
+  fi
+  if [ ! -s "$STDERR_LOG" ]; then
+    fail_case "$name" "malformed invocation produced no diagnostic on stderr"
+    return
+  fi
+
+  pass_case "$name" "rejected with exit=$exit_code, diagnostic on stderr, stdout empty"
+}
+
+# A help request: exit 0, usage on stdout, stderr untouched.
+run_help() {
+  local name="$1" tool="$2" flag="$3"
+  TOTAL=$((TOTAL + 1))
+  local exit_code=0
+
+  : > "$STDOUT_LOG"; : > "$STDERR_LOG"
+  timeout 60 "$tool" "$flag" > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
+
+  check_sanitizers "$name" "$STDOUT_LOG" || return
+  check_sanitizers "$name" "$STDERR_LOG" || return
+
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "expected exit=0 for $flag, got exit=$exit_code"
+    sed -n '1,5p' "$STDERR_LOG"
+    return
+  fi
+  if [ -s "$STDERR_LOG" ]; then
+    fail_case "$name" "$flag wrote $(wc -c < "$STDERR_LOG") bytes to stderr"
+    sed -n '1,5p' "$STDERR_LOG"
+    return
+  fi
+  assert_usage_screen "$name" "$STDOUT_LOG" "stdout" || return
+
+  pass_case "$name" "$flag printed usage on stdout and exited 0"
+}
+
+echo "=== iccApply* usage-path exit-code regression (#2405) ==="
+
+PROFILES="$TOOLS_DIR/IccApplyProfiles/iccApplyProfiles"
+SEARCH="$TOOLS_DIR/IccApplySearch/iccApplySearch"
+NAMEDCMM="$TOOLS_DIR/IccApplyNamedCmm/iccApplyNamedCmm"
+TOLINK="$TOOLS_DIR/IccApplyToLink/iccApplyToLink"
+
+# Operands for the prefix sweep.  They are never consumed -- every form below is
+# short of the tool's minimum -- so they only have to be present and inert.
+ARGS=(out.icc 0 33 0 title 0 1 0 0)
+
+# name | binary | highest incomplete operand count | last row of its screen
+for entry in "iccApplyProfiles|$PROFILES|0|+10000 - Use V5 sub-profile if present" \
+             "iccApplyNamedCmm|$NAMEDCMM|0|only one of +1000000 / +2000000 may be given)" \
+             "iccApplySearch|$SEARCH|1|+10000 - Use V5 sub-profile if present" \
+             "iccApplyToLink|$TOLINK|8|+1000 - Use V5 sub-profile if present"; do
+  IFS='|' read -r name tool maxops ANCHOR <<< "$entry"
+
+  if [ ! -x "$tool" ]; then
+    skip_case "$name" "not built at $tool"
+    continue
+  fi
+
+  # Every incomplete prefix, not just the bare invocation: #2405 found that
+  # iccApplyToLink accepted nine of them and iccApplySearch two, so a test that
+  # only ran the tool with no operands would leave most of the defect uncovered.
+  for n in $(seq 0 "$maxops"); do
+    run_malformed "$name $n-operand" "$tool" "${ARGS[@]:0:$n}"
+  done
+
+  run_help "$name short help" "$tool" -h
+  run_help "$name long help" "$tool" --help
+done
+
+# Forms that clear minargs but are still malformed.  One operand is a complete
+# operand list for iccApplyProfiles and iccApplyNamedCmm (minargs 2), so these
+# reach the configuration parser; "-threads" with no count is the guard whose
+# twin lives in a different tool.  All three tools must answer on the same
+# stream -- that they did not is what this half of the test pins.
+DATA="$OUTDIR/incomplete-operand.txt"
+printf 'data\n' > "$DATA"
+
+if [ -x "$PROFILES" ]; then
+  run_malformed_no_usage "iccApplyProfiles unparseable-args" "$PROFILES" "$DATA"
+  run_malformed_no_usage "iccApplyProfiles threads-no-count" "$PROFILES" -threads
+fi
+if [ -x "$NAMEDCMM" ]; then
+  run_malformed_no_usage "iccApplyNamedCmm unparseable-args" "$NAMEDCMM" "$DATA"
+fi
+if [ -x "$SEARCH" ]; then
+  run_malformed_no_usage "iccApplySearch unparseable-args" "$SEARCH" "$DATA" 0
+  run_malformed_no_usage "iccApplySearch threads-no-count" "$SEARCH" -threads
+fi
+
+echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total ==="
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+# A run that measured nothing must not report green: with all four tools absent
+# every case is skipped and the loops above would otherwise fall through to
+# exit 0, which is the exact "reported success having done nothing" defect this
+# suite exists to pin.
+if [ "$PASS" -eq 0 ]; then
+  echo "no case was measured -- treating as skipped rather than passed"
+  exit 77
+fi
+
+exit 0

--- a/.github/workflows/ci-latest-release.yml
+++ b/.github/workflows/ci-latest-release.yml
@@ -229,9 +229,13 @@ jobs:
             "echo \"Tools directory: \$SCRIPT_DIR\"" \
             > "$stage/path.sh"
           chmod +x "$stage/path.sh"
+          # -h, not a bare invocation: since #2405 an incomplete operand list is a
+          # failure (usage on stderr, non-zero), and this step runs under
+          # "set -euo pipefail", so a bare call would abort the job on the first
+          # tool.  -h is the supported route to the banner and exits 0.
           for tool in iccApplyProfiles iccApplyNamedCmm iccApplySearch; do
             LD_LIBRARY_PATH="$stage${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" \
-              "$stage/$tool" 2>&1 | grep -q "IccLibConnect Version"
+              "$stage/$tool" -h 2>&1 | grep -q "IccLibConnect Version"
           done
           # Summary of staged bundle contents
           total=$(find "$stage" -type f | wc -l)
@@ -442,9 +446,10 @@ jobs:
             done
             install_name_tool -add_rpath "@loader_path" "$target" || true
           done
+          # -h for the same reason as the Linux staging step above (#2405).
           for tool in iccApplyProfiles iccApplyNamedCmm iccApplySearch; do
             DYLD_LIBRARY_PATH="$stage${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}" \
-              "$stage/$tool" 2>&1 | grep -q "IccLibConnect Version"
+              "$stage/$tool" -h 2>&1 | grep -q "IccLibConnect Version"
           done
           # Summary of staged bundle contents
           total=$(find "$stage" -type f | wc -l)

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7666,6 +7666,26 @@ if(TARGET iccApplyProfiles AND TARGET iccApplySearch
     SKIP_RETURN_CODE 77)
 endif()
 
+# The iccApply* half of the same CLI-contract family (#2405).  Guarded on all
+# four targets because the script measures all four and its "nothing measured"
+# guard would otherwise turn a partial build into a skip that hides real cases.
+# Deliberately NOT labelled "slow", so it runs on the pull_request path --
+# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+if(TARGET iccApplyProfiles AND TARGET iccApplySearch
+   AND TARGET iccApplyNamedCmm AND TARGET iccApplyToLink)
+  iccdev_add_script_test(
+    iccdev.apply-usage-exit-code-regression
+    120
+    "iccdev;apply;cli;args;usage;exitcode;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2405-apply-usage-exit-code-regression.sh"
+  )
+  # Exits 77 when no tool was found and no case ran, so a lane that does not
+  # build the Tools skips rather than going red.
+  set_tests_properties(iccdev.apply-usage-exit-code-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # Guarded on the target, like iccdev.tiff-resolution-unit-regression below.
 # Both scripts exit 2 when iccSpecSepToTiff is missing rather than skipping the
 # way the older sibling suites do, so an unguarded registration turns a

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -85,6 +85,7 @@
 #include <unistd.h>
 #endif
 #include <cstdlib>
+#include <cstring>  // strcmp, used by the -h/--help contract guard in main()
 
 
 // ============================================================================
@@ -196,22 +197,22 @@ typedef std::shared_ptr<CIccLogDebugger> LogDebuggerPtr;
 //----------------------------------------------------
 
 
-void Usage()
+void Usage(FILE* stream)
 {
-  printf("iccApplyNamedCmm built with IccProfLib version " ICCPROFLIBVER ", IccLibConnect Version " ICCLIBCONNECTVER "\n\n");
+  fprintf(stream, "iccApplyNamedCmm built with IccProfLib version " ICCPROFLIBVER ", IccLibConnect Version " ICCLIBCONNECTVER "\n\n");
 
-  printf("Usage 1: iccApplyNamedCmm {--evidence-json} -cfg config_file_path\n");
-  printf("  Where config_file_path is a json formatted ICC profile application configuration file\n\n");
-  printf("Usage 2: iccApplyNamedCmm (-exportcfg/-exportcfganddata config_file_path} {-debugcalc} data_file_path final_data_encoding{:FmtPrecision{:FmtDigits}} interpolation {{-ENV:Name value} profile_file_path Rendering_intent {-PCC connection_conditions_path}}\n\n");
+  fprintf(stream, "Usage 1: iccApplyNamedCmm {--evidence-json} -cfg config_file_path\n");
+  fprintf(stream, "  Where config_file_path is a json formatted ICC profile application configuration file\n\n");
+  fprintf(stream, "Usage 2: iccApplyNamedCmm (-exportcfg/-exportcfganddata config_file_path} {-debugcalc} data_file_path final_data_encoding{:FmtPrecision{:FmtDigits}} interpolation {{-ENV:Name value} profile_file_path Rendering_intent {-PCC connection_conditions_path}}\n\n");
   
-  printf("  For final_data_encoding:\n");
-  printf("    0 - icEncodeValue (converts to/from lab encoding when samples=3)\n");
-  printf("    1 - icEncodePercent\n");
-  printf("    2 - icEncodeUnitFloat (may clip to 0.0 to 1.0)\n");
-  printf("    3 - icEncodeFloat\n");
-  printf("    4 - icEncode8Bit\n");
-  printf("    5 - icEncode16Bit\n");
-  printf("    6 - icEncode16BitV2\n\n");
+  fprintf(stream, "  For final_data_encoding:\n");
+  fprintf(stream, "    0 - icEncodeValue (converts to/from lab encoding when samples=3)\n");
+  fprintf(stream, "    1 - icEncodePercent\n");
+  fprintf(stream, "    2 - icEncodeUnitFloat (may clip to 0.0 to 1.0)\n");
+  fprintf(stream, "    3 - icEncodeFloat\n");
+  fprintf(stream, "    4 - icEncode8Bit\n");
+  fprintf(stream, "    5 - icEncode16Bit\n");
+  fprintf(stream, "    6 - icEncode16BitV2\n\n");
 
   // #2124: this list read as though all seven selectors were always available,
   // so a Lab destination refusing icEncodePercent looked like a broken encoding
@@ -229,29 +230,29 @@ void Usage()
   // pointer, not a promise. (It also omitted icEncodeUnitFloat for the two PCS
   // spaces when this note was written; #2146 fixed the source side that
   // omission described and brought the table into line.)
-  printf("    Not every encoding is valid for every colour space: a 'Lab '\n");
-  printf("    destination refuses icEncodePercent and an 'XYZ ' destination\n");
-  printf("    refuses icEncode8Bit, each rejected when the data is converted\n");
-  printf("    rather than here. IccCmm.h's icFloatColorEncoding table lists\n");
-  printf("    the per-space encodings.\n\n");
+  fprintf(stream, "    Not every encoding is valid for every colour space: a 'Lab '\n");
+  fprintf(stream, "    destination refuses icEncodePercent and an 'XYZ ' destination\n");
+  fprintf(stream, "    refuses icEncode8Bit, each rejected when the data is converted\n");
+  fprintf(stream, "    rather than here. IccCmm.h's icFloatColorEncoding table lists\n");
+  fprintf(stream, "    the per-space encodings.\n\n");
 
-  printf("    FmtPrecision - formatting for # of digits after decimal (default=4)\n");
-  printf("    FmtDigits - formatting for total # of digits (default=5+FmtPrecision)\n\n");
+  fprintf(stream, "    FmtPrecision - formatting for # of digits after decimal (default=4)\n");
+  fprintf(stream, "    FmtDigits - formatting for total # of digits (default=5+FmtPrecision)\n\n");
 
-  printf("  For interpolation:\n");
-  printf("    0 - Linear\n");
-  printf("    1 - Tetrahedral\n\n");
+  fprintf(stream, "  For interpolation:\n");
+  fprintf(stream, "    0 - Linear\n");
+  fprintf(stream, "    1 - Tetrahedral\n\n");
 
-  printf("  For Rendering_intent:\n");
-  printf("     0 - Perceptual\n");
-  printf("     1 - Relative\n");
-  printf("     2 - Saturation\n");
-  printf("     3 - Absolute\n");
-  printf("     10 + Intent - without D2Bx/B2Dx\n");
-  printf("     20 + Intent - Preview\n");
-  printf("     30 - Gamut\n");
-  printf("     33 - Gamut Absolute\n");
-  printf("     40 + Intent - with BPC\n");
+  fprintf(stream, "  For Rendering_intent:\n");
+  fprintf(stream, "     0 - Perceptual\n");
+  fprintf(stream, "     1 - Relative\n");
+  fprintf(stream, "     2 - Saturation\n");
+  fprintf(stream, "     3 - Absolute\n");
+  fprintf(stream, "     10 + Intent - without D2Bx/B2Dx\n");
+  fprintf(stream, "     20 + Intent - Preview\n");
+  fprintf(stream, "     30 - Gamut\n");
+  fprintf(stream, "     33 - Gamut Absolute\n");
+  fprintf(stream, "     40 + Intent - with BPC\n");
   // Two corrections, both #2262.
   //
   // (1) The acronym was transposed, B-D-R-F.  ICC.2-2023 9.2.14-17 and 9.2.26-29
@@ -285,22 +286,22 @@ void Usage()
   // "Model"/"Light"/"Output" wording, which matched neither the schema nor the
   // two sibling tools: nothing connected the old row for 60 to the
   // "transform": "brdfDirect" that -exportcfg writes when it is given.
-  printf("     50 + Intent - BRDF Parameters\n");
-  printf("     60 + Intent - BRDF Direct\n");
-  printf("     70 + Intent - BRDF MCS Parameters\n");
-  printf("     80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
-  printf("     90 + Intent - Colorimetric Only\n");
-  printf("    100 + Intent - Spectral Only\n");
-  printf("    +1000 - Use Luminance based PCS adjustment\n");
-  printf("   +10000 - Use V5 sub-profile if present\n");
-  printf("  +100000 - Use HToS tag if present\n");
-  printf(" +1000000 - NamedColor over black (icSigNmclSpectralOverBlackMbr 'spcb')\n");
-  printf(" +2000000 - NamedColor over gray  (icSigNmclSpectralOverGrayMbr 'spcg')\n");
+  fprintf(stream, "     50 + Intent - BRDF Parameters\n");
+  fprintf(stream, "     60 + Intent - BRDF Direct\n");
+  fprintf(stream, "     70 + Intent - BRDF MCS Parameters\n");
+  fprintf(stream, "     80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
+  fprintf(stream, "     90 + Intent - Colorimetric Only\n");
+  fprintf(stream, "    100 + Intent - Spectral Only\n");
+  fprintf(stream, "    +1000 - Use Luminance based PCS adjustment\n");
+  fprintf(stream, "   +10000 - Use V5 sub-profile if present\n");
+  fprintf(stream, "  +100000 - Use HToS tag if present\n");
+  fprintf(stream, " +1000000 - NamedColor over black (icSigNmclSpectralOverBlackMbr 'spcb')\n");
+  fprintf(stream, " +2000000 - NamedColor over gray  (icSigNmclSpectralOverGrayMbr 'spcg')\n");
   // The two overprint codes read as additive flags, and #2190 was filed by a
   // caller who combined them. They select mutually exclusive array members, so
   // say here that only one may be given rather than let "+3000000" look legal.
-  printf("            (over black and over gray are alternatives, not flags:\n");
-  printf("             only one of +1000000 / +2000000 may be given)\n");
+  fprintf(stream, "            (over black and over gray are alternatives, not flags:\n");
+  fprintf(stream, "             only one of +1000000 / +2000000 may be given)\n");
 }
 
 static std::string GetProfileId(const char* profilePath)
@@ -371,6 +372,15 @@ int main(int argc, const char* argv[])
   int minargs = 2;
   bool bEvidenceJson = false;
 
+  // An explicit help request is the one invocation here that is not an error, so
+  // it prints on stdout and exits 0; every malformed form below prints on stderr
+  // and fails.  Once both paths print the same screen the stream is the only
+  // thing that separates them -- status alone cannot (#1514).
+  if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+    Usage(stdout);
+    return 0;
+  }
+
   if (argc > 1 && !stricmp(argv[1], "--evidence-json")) {
     bEvidenceJson = true;
     argv++;
@@ -378,8 +388,15 @@ int main(int argc, const char* argv[])
   }
 
   if (argc < minargs) {
-    Usage();
-    return 0;
+    // #2405: usage on stdout plus exit 0 told a wrapper the apply had succeeded
+    // when no data file or profile had been given.  Fail like every other error
+    // exit in this main(), all of which return EXIT_FAILURE.  argc is counted
+    // after the --evidence-json shift above, so the number reported is the
+    // operand count the tool actually had to work with.
+    fprintf(stderr, "Missing arguments: expected at least %d, received %d.\n",
+            minargs - 1, argc > 0 ? argc - 1 : 0);
+    Usage(stderr);
+    return EXIT_FAILURE;
   }
 
   CIccCfgDataApply cfgApply;
@@ -466,7 +483,11 @@ int main(int argc, const char* argv[])
 
     int nArg = cfgApply.fromArgs(&argv[0], argc);
     if (!nArg) {
-      printf("Unable to parse configuration arguments\n");
+      // #2405: on stderr because this is a malformed-invocation diagnostic and the
+      // sibling tool prints it there.  The rest of this main()'s diagnostics stay
+      // on stdout: they are a pre-existing, and consistent, convention across all
+      // four tools, and moving them is a separate change.
+      fprintf(stderr, "Unable to parse configuration arguments\n");
       return EXIT_FAILURE;
     }
     argv += nArg;
@@ -474,7 +495,7 @@ int main(int argc, const char* argv[])
 
     nArg = cfgProfiles.fromArgs(&argv[0], argc);
     if (!nArg) {
-      printf("Unable to parse profile sequence arguments\n");
+      fprintf(stderr, "Unable to parse profile sequence arguments\n");
       return EXIT_FAILURE;
     }
     // fromArgs() reports how many arguments it consumed and stops at the first it

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -73,6 +73,7 @@
 #include <cstdio>
 #include <cstdlib>  // EXIT_FAILURE, used by the argument-contract guards in main()
 #include <cerrno>
+#include <cstring>  // strcmp, used by the -h/--help contract guard in main()
 #include <memory>
 #include <string>
 #include "IccCmm.h"
@@ -181,59 +182,59 @@ static icUInt16Number UnitClipToUInt16(icFloatNumber v)
 
 
 
-void Usage() 
+void Usage(FILE* stream) 
 {
-  printf("iccApplyProfiles built with IccProfLib version " ICCPROFLIBVER ", IccLibConnect Version " ICCLIBCONNECTVER "\n\n");
+  fprintf(stream, "iccApplyProfiles built with IccProfLib version " ICCPROFLIBVER ", IccLibConnect Version " ICCLIBCONNECTVER "\n\n");
 
-  printf("Usage: iccApplyProfiles {-threads N} -cfg config_file\n\n");
-  printf("  Optional: -threads [N] (use 0..%d worker threads; 0=hardware concurrency, 1=single-threaded)\n",
+  fprintf(stream, "Usage: iccApplyProfiles {-threads N} -cfg config_file\n\n");
+  fprintf(stream, "  Optional: -threads [N] (use 0..%d worker threads; 0=hardware concurrency, 1=single-threaded)\n",
          CIccThreadedCmm::GetMaxThreads());
-  printf("  Optional: -cfg config_file (use JSON formatted configuration file to define apply options)\n\n");
+  fprintf(stream, "  Optional: -cfg config_file (use JSON formatted configuration file to define apply options)\n\n");
 
-  printf("Alt-Usage: iccApplyProfiles {-threads N} {-exportcfg config_file} src_tiff_file dst_tiff_file dst_sample_encoding dst_compression dst_planar dst_embed_icc interpolation {{-ENV:sig value} profile_file_path rendering_intent {-PCC connection_conditions_path}}\n\n");
-  printf("  Optional: -threads [N] (use 0..%d worker threads; 0=hardware concurrency, 1=single-threaded)\n",
+  fprintf(stream, "Alt-Usage: iccApplyProfiles {-threads N} {-exportcfg config_file} src_tiff_file dst_tiff_file dst_sample_encoding dst_compression dst_planar dst_embed_icc interpolation {{-ENV:sig value} profile_file_path rendering_intent {-PCC connection_conditions_path}}\n\n");
+  fprintf(stream, "  Optional: -threads [N] (use 0..%d worker threads; 0=hardware concurrency, 1=single-threaded)\n",
          CIccThreadedCmm::GetMaxThreads());
-  printf("  Optional: -exportcfg config_file (create config_file based on rest of arguments)\n\n");
-  printf("  For dst_sample_encoding:\n");
-  printf("    0 - Same as src\n");
-  printf("    1 - icEncode8Bit\n");
-  printf("    2 - icEncode16Bit\n");
-  printf("    3 - icEncodeFloat\n\n");
+  fprintf(stream, "  Optional: -exportcfg config_file (create config_file based on rest of arguments)\n\n");
+  fprintf(stream, "  For dst_sample_encoding:\n");
+  fprintf(stream, "    0 - Same as src\n");
+  fprintf(stream, "    1 - icEncode8Bit\n");
+  fprintf(stream, "    2 - icEncode16Bit\n");
+  fprintf(stream, "    3 - icEncodeFloat\n\n");
 
-  printf("  For dst_compression:\n");
-  printf("    0 - No compression\n");
-  printf("    1 - LZW compression\n\n");
+  fprintf(stream, "  For dst_compression:\n");
+  fprintf(stream, "    0 - No compression\n");
+  fprintf(stream, "    1 - LZW compression\n\n");
 
-  printf("  For dst_planar:\n");
-  printf("    0 - Contig\n");
-  printf("    1 - Separation\n\n");
+  fprintf(stream, "  For dst_planar:\n");
+  fprintf(stream, "    0 - Contig\n");
+  fprintf(stream, "    1 - Separation\n\n");
 
-  printf("  For dst_embed_icc:\n");
-  printf("    0 - Do not Embed\n");
-  printf("    1 - Embed Last ICC\n\n");
+  fprintf(stream, "  For dst_embed_icc:\n");
+  fprintf(stream, "    0 - Do not Embed\n");
+  fprintf(stream, "    1 - Embed Last ICC\n\n");
 
-  printf("  For interpolation:\n");
-  printf("    0 - Linear\n");
-  printf("    1 - Tetrahedral\n\n");
+  fprintf(stream, "  For interpolation:\n");
+  fprintf(stream, "    0 - Linear\n");
+  fprintf(stream, "    1 - Tetrahedral\n\n");
 
-  printf("  For rendering_intent:\n");
-  printf("    0 - Perceptual\n");
-  printf("    1 - Relative\n");
-  printf("    2 - Saturation\n");
-  printf("    3 - Absolute\n");
-  printf("    10 - Perceptual without D2Bx/B2Dx\n");
-  printf("    11 - Relative without D2Bx/B2Dx\n");
-  printf("    12 - Saturation without D2Bx/B2Dx\n");
-  printf("    13 - Absolute without D2Bx/B2Dx\n");
-  printf("    20 - Preview Perceptual\n");
-  printf("    21 - Preview Relative\n");
-  printf("    22 - Preview Saturation\n");
-  printf("    23 - Preview Absolute\n");
-  printf("    30 - Gamut\n");
-  printf("    33 - Gamut Absolute\n");
-  printf("    40 - Perceptual with BPC\n");
-  printf("    41 - Relative Colorimetric with BPC\n");
-  printf("    42 - Saturation with BPC\n");
+  fprintf(stream, "  For rendering_intent:\n");
+  fprintf(stream, "    0 - Perceptual\n");
+  fprintf(stream, "    1 - Relative\n");
+  fprintf(stream, "    2 - Saturation\n");
+  fprintf(stream, "    3 - Absolute\n");
+  fprintf(stream, "    10 - Perceptual without D2Bx/B2Dx\n");
+  fprintf(stream, "    11 - Relative without D2Bx/B2Dx\n");
+  fprintf(stream, "    12 - Saturation without D2Bx/B2Dx\n");
+  fprintf(stream, "    13 - Absolute without D2Bx/B2Dx\n");
+  fprintf(stream, "    20 - Preview Perceptual\n");
+  fprintf(stream, "    21 - Preview Relative\n");
+  fprintf(stream, "    22 - Preview Saturation\n");
+  fprintf(stream, "    23 - Preview Absolute\n");
+  fprintf(stream, "    30 - Gamut\n");
+  fprintf(stream, "    33 - Gamut Absolute\n");
+  fprintf(stream, "    40 - Perceptual with BPC\n");
+  fprintf(stream, "    41 - Relative Colorimetric with BPC\n");
+  fprintf(stream, "    42 - Saturation with BPC\n");
   // #2262: the acronym was transposed, B-D-R-F -- ICC.2-2023 9.2.14-17 and
   // 9.2.26-29 spell the tags brdfAToB0Tag..brdfDToB3Tag, and the library's own
   // identifiers already agree (icXformLutBRDFParam, icSigBRDFDToB0Tag,
@@ -257,12 +258,12 @@ void Usage()
   // say the same thing, and this way the three tools' BRDF and MCS rows agree
   // line for line -- nothing had ever compared them, which is how the same
   // three transforms came to be named two different ways.
-  printf("    50 + Intent - BRDF Parameters\n");
-  printf("    60 + Intent - BRDF Direct\n");
-  printf("    70 + Intent - BRDF MCS Parameters\n");
-  printf("    80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
-  printf("  +1000 - Use Luminance based PCS adjustment\n");
-  printf(" +10000 - Use V5 sub-profile if present\n");
+  fprintf(stream, "    50 + Intent - BRDF Parameters\n");
+  fprintf(stream, "    60 + Intent - BRDF Direct\n");
+  fprintf(stream, "    70 + Intent - BRDF MCS Parameters\n");
+  fprintf(stream, "    80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
+  fprintf(stream, "  +1000 - Use Luminance based PCS adjustment\n");
+  fprintf(stream, " +10000 - Use V5 sub-profile if present\n");
 }
 
 //===================================================
@@ -270,9 +271,26 @@ void Usage()
 int main(int argc, const char** argv)
 {
   int minargs = 2;
-  if (argc < minargs) {
-    Usage();
+
+  // An explicit help request is the one invocation here that is not an error, so
+  // it prints on stdout and exits 0; every malformed form below prints on stderr
+  // and fails.  Once both paths print the same screen the stream is the only
+  // thing that separates them -- status alone cannot (#1514).
+  if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+    Usage(stdout);
     return 0;
+  }
+
+  if (argc < minargs) {
+    // #2405: this printed the usage screen on stdout and returned success, so a
+    // caller could not tell a real apply from a tool that had done nothing at
+    // all.  Name which way the invocation is malformed before the syntax block --
+    // a bare Usage() dump left the caller to diff their command against it --
+    // and fail like the two other Usage() error exits below, which return -1.
+    fprintf(stderr, "Missing arguments: expected at least %d, received %d.\n",
+            minargs - 1, argc > 0 ? argc - 1 : 0);
+    Usage(stderr);
+    return -1;
   }
 
   CIccCfgImageApply cfgApply;
@@ -283,7 +301,8 @@ int main(int argc, const char** argv)
 
   if (!stricmp(argv[1], "-threads")) {
     if (argc < 3) {
-      printf("Missing thread count for -threads\n");
+      // #2405: stderr, matching the byte-identical guard in iccApplySearch.
+      fprintf(stderr, "Missing thread count for -threads\n");
       return EXIT_FAILURE;
     }
 
@@ -353,8 +372,8 @@ int main(int argc, const char** argv)
 
     int nArg = cfgApply.fromArgs(&argv[0], argc);
     if (!nArg) {
-      printf("Unable to parse configuration arguments\n");
-      Usage();
+      fprintf(stderr, "Unable to parse configuration arguments\n");
+      Usage(stderr);
       return -1;
     }
     argv += nArg;
@@ -362,8 +381,8 @@ int main(int argc, const char** argv)
 
     nArg = cfgProfiles.fromArgs(&argv[0], argc);
     if (!nArg) {
-      printf("Unable to parse profile sequence arguments\n");
-      Usage();
+      fprintf(stderr, "Unable to parse profile sequence arguments\n");
+      Usage(stderr);
       return -1;
     }
     // CIccCfgProfileSequence::fromArgs() consumes the profile group in pairs and

--- a/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
+++ b/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
@@ -80,6 +80,7 @@
 #include "IccConnect.h"
 #include "IccCmdLineUtil.h"
 #include <cerrno>
+#include <cstring>  // strcmp, used by the -h/--help contract guard in main()
 #include <cstdlib>  // EXIT_FAILURE, used by the -cfg argument guard added in #2075
 #include <memory>
 #include <vector>
@@ -205,42 +206,42 @@ bool IsSpacePCS( const icColorSpaceSignature &x )
 }
 
 
-void Usage()
+void Usage(FILE* stream)
 {
-  printf("iccApplySearch built with IccProfLib version " ICCPROFLIBVER ", IccLibConnect Version " ICCLIBCONNECTVER "\n\n");
-  printf("Usage 1: iccApplySearch {-threads N} -cfg config_file_path\n");
-  printf("  Optional: -threads N (0=hardware concurrency, 1=single-threaded)\n");
-  printf("  Where config_file_path is a json formatted ICC profile application configuration file\n\n");
-  printf("Usage 2: iccApplySearch {-threads N} {-debugcalc} data_file_path encoding[:precision[:digits]] interpolation {-ENV:tag value} profile1_path intent1 {{-ENV:tag value} middle_profile_path mid_intent} {-ENV:tag value} profile2_path intent2 -INIT init_intent2 {pcc_path1 weight1 ...}\n");
+  fprintf(stream, "iccApplySearch built with IccProfLib version " ICCPROFLIBVER ", IccLibConnect Version " ICCLIBCONNECTVER "\n\n");
+  fprintf(stream, "Usage 1: iccApplySearch {-threads N} -cfg config_file_path\n");
+  fprintf(stream, "  Optional: -threads N (0=hardware concurrency, 1=single-threaded)\n");
+  fprintf(stream, "  Where config_file_path is a json formatted ICC profile application configuration file\n\n");
+  fprintf(stream, "Usage 2: iccApplySearch {-threads N} {-debugcalc} data_file_path encoding[:precision[:digits]] interpolation {-ENV:tag value} profile1_path intent1 {{-ENV:tag value} middle_profile_path mid_intent} {-ENV:tag value} profile2_path intent2 -INIT init_intent2 {pcc_path1 weight1 ...}\n");
   
-  printf("  For final_data_encoding:\n");
-  printf("    0 - icEncodeValue (converts to/from lab encoding when samples=3)\n");
-  printf("    1 - icEncodePercent\n");
-  printf("    2 - icEncodeUnitFloat (may clip to 0.0 to 1.0)\n");
-  printf("    3 - icEncodeFloat\n");
-  printf("    4 - icEncode8Bit\n");
-  printf("    5 - icEncode16Bit\n");
-  printf("    6 - icEncode16BitV2\n\n");
+  fprintf(stream, "  For final_data_encoding:\n");
+  fprintf(stream, "    0 - icEncodeValue (converts to/from lab encoding when samples=3)\n");
+  fprintf(stream, "    1 - icEncodePercent\n");
+  fprintf(stream, "    2 - icEncodeUnitFloat (may clip to 0.0 to 1.0)\n");
+  fprintf(stream, "    3 - icEncodeFloat\n");
+  fprintf(stream, "    4 - icEncode8Bit\n");
+  fprintf(stream, "    5 - icEncode16Bit\n");
+  fprintf(stream, "    6 - icEncode16BitV2\n\n");
 
-  printf("  FmtPrecision - formatting for # of digits after decimal (default=4)\n");
-  printf("  FmtDigits - formatting for total # of digits (default=5+FmtPrecision)\n\n");
+  fprintf(stream, "  FmtPrecision - formatting for # of digits after decimal (default=4)\n");
+  fprintf(stream, "  FmtDigits - formatting for total # of digits (default=5+FmtPrecision)\n\n");
 
-  printf("  For interpolation:\n");
-  printf("    0 - Linear\n");
-  printf("    1 - Tetrahedral\n\n");
+  fprintf(stream, "  For interpolation:\n");
+  fprintf(stream, "    0 - Linear\n");
+  fprintf(stream, "    1 - Tetrahedral\n\n");
 
-  printf("  For init_intent/intent1/intent2/mid_intent:\n");
-  printf("     0 - Perceptual\n");
-  printf("     1 - Relative\n");
-  printf("     2 - Saturation\n");
-  printf("     3 - Absolute\n");
-  printf("     10 + Intent - without D2Bx/B2Dx\n");
-  printf("     40 + Intent - with BPC\n");
-  printf("     90 + Intent - Colorimetric Only\n");
-  printf("    100 + Intent - Spectral Only\n");
-  printf(" +10000 - Use V5 sub-profile if present\n");
+  fprintf(stream, "  For init_intent/intent1/intent2/mid_intent:\n");
+  fprintf(stream, "     0 - Perceptual\n");
+  fprintf(stream, "     1 - Relative\n");
+  fprintf(stream, "     2 - Saturation\n");
+  fprintf(stream, "     3 - Absolute\n");
+  fprintf(stream, "     10 + Intent - without D2Bx/B2Dx\n");
+  fprintf(stream, "     40 + Intent - with BPC\n");
+  fprintf(stream, "     90 + Intent - Colorimetric Only\n");
+  fprintf(stream, "    100 + Intent - Spectral Only\n");
+  fprintf(stream, " +10000 - Use V5 sub-profile if present\n");
   
-  printf("\n");
+  fprintf(stream, "\n");
 }
 
 
@@ -249,13 +250,29 @@ void Usage()
 int main(int argc, const char* argv[])
 {
   int minargs = 3;  // name -cfg file.json
+
+  // An explicit help request is the one invocation here that is not an error, so
+  // it prints on stdout and exits 0; every malformed form below prints on stderr
+  // and fails.  Once both paths print the same screen the stream is the only
+  // thing that separates them -- status alone cannot (#1514).
+  if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+    Usage(stdout);
+    return 0;
+  }
+
   if (argc > 1 && !stricmp(argv[1], "-threads") && argc < 3) {
-    printf("Missing thread count for -threads\n");
+    fprintf(stderr, "Missing thread count for -threads\n");
     return EXIT_FAILURE;
   }
   if (argc < minargs) {
-    Usage();
-    return 0;
+    // #2405: usage on stdout plus exit 0 reported success for an invocation that
+    // applied nothing.  Fail like the identical post-"-threads" guard below,
+    // which already returned EXIT_FAILURE -- the two disagreed only because the
+    // shifted copy was written later.
+    fprintf(stderr, "Missing arguments: expected at least %d, received %d.\n",
+            minargs - 1, argc > 0 ? argc - 1 : 0);
+    Usage(stderr);
+    return EXIT_FAILURE;
   }
 
   CIccCfgDataApply cfgApply;
@@ -278,7 +295,9 @@ int main(int argc, const char* argv[])
     argc -= 2;
 
     if (argc < minargs) {
-      Usage();
+      fprintf(stderr, "Missing arguments after -threads: expected at least %d, received %d.\n",
+              minargs - 1, argc > 0 ? argc - 1 : 0);
+      Usage(stderr);
       return EXIT_FAILURE;
     }
   }
@@ -368,7 +387,11 @@ int main(int argc, const char* argv[])
 
     int nArg = cfgApply.fromArgs(&argv[0], argc);
     if (!nArg) {
-      printf("Unable to parse configuration arguments\n");
+      // #2405: on stderr because this is a malformed-invocation diagnostic and the
+      // sibling tool prints it there.  The rest of this main()'s diagnostics stay
+      // on stdout: they are a pre-existing, and consistent, convention across all
+      // four tools, and moving them is a separate change.
+      fprintf(stderr, "Unable to parse configuration arguments\n");
       return EXIT_FAILURE;
     }
     argv += nArg;
@@ -376,7 +399,7 @@ int main(int argc, const char* argv[])
 
     nArg = cfgSearchApply.fromArgs(&argv[0], argc);
     if (!nArg) {
-      printf("Unable to parse profile sequence arguments\n");
+      fprintf(stderr, "Unable to parse profile sequence arguments\n");
       return -1;
     }
 

--- a/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
+++ b/Tools/CmdLine/IccApplyToLink/iccApplyToLink.cpp
@@ -74,6 +74,7 @@
 #include <cstdio>
 #include <cmath>
 #include <cstdlib>
+#include <cstring>  // strcmp, used by the -h/--help contract guard in main()
 #include <string>
 #include <vector>
 #include <list>
@@ -770,59 +771,59 @@ protected:
   CIccTagProfileSeqDesc* m_pTagSeq = nullptr;
 };
 
-void Usage() 
+void Usage(FILE* stream) 
 {
-  printf("iccApplyToLink built with IccProfLib version " ICCPROFLIBVER "\n\n");
+  fprintf(stream, "iccApplyToLink built with IccProfLib version " ICCPROFLIBVER "\n\n");
 
-  printf("Usage: iccApplyToLink dst_link_file link_type lut_size option title range_min range_max first_transform interp {{-ENV:sig value} profile_file_path rendering_intent {-PCC connection_conditions_path}}\n\n");
-  printf("  dst_link_file is path of file to create\n\n");
+  fprintf(stream, "Usage: iccApplyToLink dst_link_file link_type lut_size option title range_min range_max first_transform interp {{-ENV:sig value} profile_file_path rendering_intent {-PCC connection_conditions_path}}\n\n");
+  fprintf(stream, "  dst_link_file is path of file to create\n\n");
   
-  printf("  For link_type:\n");
-  printf("    0 - Device Link\n");
-  printf("    1 - .cube text file\n\n");
+  fprintf(stream, "  For link_type:\n");
+  fprintf(stream, "    0 - Device Link\n");
+  fprintf(stream, "    1 - .cube text file\n\n");
   
-  printf("  Where lut_size represents the number of grid entries for each lut dimension.\n\n");
+  fprintf(stream, "  Where lut_size represents the number of grid entries for each lut dimension.\n\n");
   
-  printf("  For option when link_type is 0:\n");
-  printf("    0 - version 4 profile with 16-bit table\n");
-  printf("    1 - version 5 profile\n\n");
-  printf("  For option when link_type is 1:\n");
-  printf("    option represents the digits of precision for lut for .cube files\n\n");
+  fprintf(stream, "  For option when link_type is 0:\n");
+  fprintf(stream, "    0 - version 4 profile with 16-bit table\n");
+  fprintf(stream, "    1 - version 5 profile\n\n");
+  fprintf(stream, "  For option when link_type is 1:\n");
+  fprintf(stream, "    option represents the digits of precision for lut for .cube files\n\n");
 
-  printf("  title is the title/description for the dest_link_file\n\n");
+  fprintf(stream, "  title is the title/description for the dest_link_file\n\n");
 
-  printf("  range_min specifies the minimum input value (usually 0.0)\n");
-  printf("  range_max specifies the maximum input value (usually 1.0)\n");
-  printf("    range_max must be greater than range_min\n");
-  printf("    a range other than 0.0 to 1.0 needs option 1 (v5) or link_type 1 (.cube);\n");
-  printf("    a version 4 device link has nowhere to record it\n\n");
+  fprintf(stream, "  range_min specifies the minimum input value (usually 0.0)\n");
+  fprintf(stream, "  range_max specifies the maximum input value (usually 1.0)\n");
+  fprintf(stream, "    range_max must be greater than range_min\n");
+  fprintf(stream, "    a range other than 0.0 to 1.0 needs option 1 (v5) or link_type 1 (.cube);\n");
+  fprintf(stream, "    a version 4 device link has nowhere to record it\n\n");
 
-  printf("  For first_transform:\n");
-  printf("    0 - use destination transform from first profile\n");
-  printf("    1 - use source transform from first profile\n\n");
+  fprintf(stream, "  For first_transform:\n");
+  fprintf(stream, "    0 - use destination transform from first profile\n");
+  fprintf(stream, "    1 - use source transform from first profile\n\n");
 
-  printf("  For interp:\n");
-  printf("    0 - linear interpolation\n");
-  printf("    1 - tetrahedral interpolation\n\n");
+  fprintf(stream, "  For interp:\n");
+  fprintf(stream, "    0 - linear interpolation\n");
+  fprintf(stream, "    1 - tetrahedral interpolation\n\n");
 
-  printf("  For rendering_intent:\n");
-  printf("    0 - Perceptual\n");
-  printf("    1 - Relative\n");
-  printf("    2 - Saturation\n");
-  printf("    3 - Absolute\n");
-  printf("    10 - Perceptual without D2Bx/B2Dx\n");
-  printf("    11 - Relative without D2Bx/B2Dx\n");
-  printf("    12 - Saturation without D2Bx/B2Dx\n");
-  printf("    13 - Absolute without D2Bx/B2Dx\n");
-  printf("    20 - Preview Perceptual\n");
-  printf("    21 - Preview Relative\n");
-  printf("    22 - Preview Saturation\n");
-  printf("    23 - Preview Absolute\n");
-  printf("    30 - Gamut\n");
-  printf("    33 - Gamut Absolute\n");
-  printf("    40 - Perceptual with BPC\n");
-  printf("    41 - Relative Colorimetric with BPC\n");
-  printf("    42 - Saturation with BPC\n");
+  fprintf(stream, "  For rendering_intent:\n");
+  fprintf(stream, "    0 - Perceptual\n");
+  fprintf(stream, "    1 - Relative\n");
+  fprintf(stream, "    2 - Saturation\n");
+  fprintf(stream, "    3 - Absolute\n");
+  fprintf(stream, "    10 - Perceptual without D2Bx/B2Dx\n");
+  fprintf(stream, "    11 - Relative without D2Bx/B2Dx\n");
+  fprintf(stream, "    12 - Saturation without D2Bx/B2Dx\n");
+  fprintf(stream, "    13 - Absolute without D2Bx/B2Dx\n");
+  fprintf(stream, "    20 - Preview Perceptual\n");
+  fprintf(stream, "    21 - Preview Relative\n");
+  fprintf(stream, "    22 - Preview Saturation\n");
+  fprintf(stream, "    23 - Preview Absolute\n");
+  fprintf(stream, "    30 - Gamut\n");
+  fprintf(stream, "    33 - Gamut Absolute\n");
+  fprintf(stream, "    40 - Perceptual with BPC\n");
+  fprintf(stream, "    41 - Relative Colorimetric with BPC\n");
+  fprintf(stream, "    42 - Saturation with BPC\n");
   // #2262: the acronym was transposed, B-D-R-F -- ICC.2-2023 9.2.14-17 and
   // 9.2.26-29 spell the tags brdfAToB0Tag..brdfDToB3Tag, and the library's own
   // identifiers already agree (icXformLutBRDFParam, icSigBRDFDToB0Tag,
@@ -846,12 +847,12 @@ void Usage()
   // say the same thing, and this way the three tools' BRDF and MCS rows agree
   // line for line -- nothing had ever compared them, which is how the same
   // three transforms came to be named two different ways.
-  printf("    50 + Intent - BRDF Parameters\n");
-  printf("    60 + Intent - BRDF Direct\n");
-  printf("    70 + Intent - BRDF MCS Parameters\n");
-  printf("    80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
-  printf("  +100 - Use Luminance based PCS adjustment\n");
-  printf(" +1000 - Use V5 sub-profile if present\n");
+  fprintf(stream, "    50 + Intent - BRDF Parameters\n");
+  fprintf(stream, "    60 + Intent - BRDF Direct\n");
+  fprintf(stream, "    70 + Intent - BRDF MCS Parameters\n");
+  fprintf(stream, "    80 + Intent - MCS connection (Intent applies to MToS/MToB only)\n");
+  fprintf(stream, "  +100 - Use Luminance based PCS adjustment\n");
+  fprintf(stream, " +1000 - Use V5 sub-profile if present\n");
 }
 
 //===================================================
@@ -914,9 +915,25 @@ static void releasePccList(IccProfilePtrList& pccList)
 int main(int argc, icChar* argv[])
 {
   int minargs = 10; // minimum number of arguments
-  if(argc<minargs) {
-    Usage();
+
+  // An explicit help request is the one invocation here that is not an error, so
+  // it prints on stdout and exits 0; every malformed form below prints on stderr
+  // and fails.  Once both paths print the same screen the stream is the only
+  // thing that separates them -- status alone cannot (#1514).
+  if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
+    Usage(stdout);
     return 0;
+  }
+
+  if(argc<minargs) {
+    // #2405: every prefix of 0..8 operands landed here, printed usage on stdout
+    // and exited 0 -- nine distinct incomplete forms all reporting success.
+    // Fail like the odd-argument guard immediately below, which already paired
+    // its diagnostic with Usage() and returned -1.
+    fprintf(stderr, "Missing arguments: expected at least %d, received %d.\n",
+            minargs - 1, argc > 0 ? argc - 1 : 0);
+    Usage(stderr);
+    return -1;
   }
 
   int nNumProfiles, temp;
@@ -924,8 +941,8 @@ int main(int argc, icChar* argv[])
 
   //remaining arguments must be in pairs
   if(temp%2 != 0) {
-    printf("\nMissing arguments!\n");
-    Usage();
+    fprintf(stderr, "\nMissing arguments!\n");
+    Usage(stderr);
     return -1;
   }
 


### PR DESCRIPTION
Part of #2405.

## The defect

All four tools guarded their operand count with `argc < minargs -> Usage(); return 0`, and
`Usage()` printed on stdout — so an incomplete invocation was indistinguishable from a
successful one to any caller that checks `$?`. Measured on `f186948c`, thirteen distinct
incomplete forms exited 0:

| tool | minargs | forms exiting 0 |
|---|---|---|
| iccApplyProfiles | 2 | 0 operands |
| iccApplyNamedCmm | 2 | 0 operands |
| iccApplySearch | 3 | 0 and 1 operands |
| iccApplyToLink | 10 | 0 through 8 operands |

## The contract

This applies the one #1514 settled for `iccSpecSepToTiff`, which `iccRoundTrip`,
`iccPawgReport` and `iccFromXml` (#2387) already follow:

- malformed / too few operands → Usage on **stderr**, non-zero, stdout empty
- `-h` / `--help` → Usage on **stdout**, exit 0, stderr empty

The **stream** is the discriminator, not the status: once a help flag exists, both paths
print the same screen and status alone cannot separate them.

Two of the four were already internally inconsistent about this, which is what made the
guard look deliberate rather than missed — `iccApplySearch`'s post-`-threads` copy of the
identical argc test returned `EXIT_FAILURE` while the one above it returned 0, and
`iccApplyToLink`'s odd-argument guard paired its diagnostic with `Usage()` and returned -1
while too-few-arguments returned 0. Each tool's new exit follows its own file rather than a
status invented here: -1 in iccApplyProfiles and iccApplyToLink, `EXIT_FAILURE` in
iccApplySearch and iccApplyNamedCmm, matching the `Usage()` error exit already beside it.

`Usage()` takes a `FILE*` so one screen serves both paths. **The usage text is unchanged:**
`-h` output is byte-identical to what a bare invocation printed before this change, verified
for all four tools — which is what keeps the 20 row assertions in the #2262 regression
meaningful.

Five argument-contract diagnostics moved to stderr with it, because this change would
otherwise have split them across two streams: `Missing thread count for -threads`
(iccApplySearch's copy moved, so iccApplyProfiles' byte-identical twin had to) and
`Unable to parse configuration arguments` / `Unable to parse profile sequence arguments`
(moved in iccApplyProfiles, where they are paired with `Usage()`, so moved in the two
siblings, where they are not). Leaving them would have produced a half-applied contract: a
wrapper adopting the rule these tests document would classify one tool correctly and two
incorrectly. **The remaining diagnostics in these files stay on stdout** — they are
consistent across all four tools, and moving them is a separate change.

## CI consequence, worth a look

`.github/workflows/ci-latest-release.yml` smoke-tested the staged bundle by running three of
the tools **bare** and grepping for the version banner, under `set -euo pipefail`. That
relied on the exit-0 usage path this removes and would have aborted both the Linux and macOS
staging steps at the next release cut. Both loops now ask with `-h`. The job is
`workflow_dispatch`-only, so no PR lane would have caught it.

## Test

`iccdev.apply-usage-exit-code-regression` — 26 cases, **22 red against `f186948c`**: all
thirteen too-few-operand forms, five malformed-but-not-short forms, and `-h`/`--help` on each
tool. Every case asserts the quiet stream is empty in both directions, and pins the last row
of each screen so a truncated capture cannot pass.

The four cases that are **not** red on master are stated in the script header rather than
hidden: iccApplySearch and iccApplyToLink have minargs 3 and 10, so on master `-h` is *below*
the minimum and lands in the very `Usage(); return 0` path being removed — they satisfy the
help contract by accident of the defect.

`iccdev-issue-2262-brdf-usage-regression.sh` asked for the screen by invoking the tool bare
and asserting exit 0; it now asks with `-h` and additionally asserts stderr is empty. Its row
assertions are untouched, and it is red against `f186948c` under the new harness, so it
remains a real red/green for this change.

```
ctest -R 'iccdev.apply-usage-exit-code-regression|iccdev.issue-2262-brdf-usage'
```

## Pre-flight

- gcc 15.2.0 container, `-Wall -Wextra -Wpedantic -Werror` + LTO: **0 warnings, 0 errors**.
- Full `ctest -LE slow`: green; `shellcheck` clean on both scripts; `actionlint` clean on the
  workflow.
- Rebased onto `6bc6fd07` after #2418 and #2419 merged. The only conflict was the CTest
  registration block; the four tool sources auto-merged, and the composition was checked by
  hand rather than trusted — #2406's `icSanitizeConsoleText` wrapping and this PR's
  `fprintf(stderr, ...)` routing land on adjacent diagnostics in the same functions. Verified
  both survive (e.g. `Missing thread count` on stderr, `Invalid thread count '%s'` sanitized),
  `Usage(FILE*)` intact in all four tools, and all four regressions green together:
  `iccdev.apply-usage-exit-code-regression`, `iccdev.apply-console-injection-regression`,
  `iccdev.xml-array-element-form-regression`, `iccdev.issue-2262-brdf-usage`.
- gcc 15.2.0 strict re-run on the rebased tree: **0 warnings, 0 errors**.
