### PR TITLE
fix(#2384): stop iccFromXml/iccFromJson reporting success for a profile they call invalid

### DIFF
--- a/.github/scripts/iccdev-hextext-compression-ab-regression.sh
+++ b/.github/scripts/iccdev-hextext-compression-ab-regression.sh
@@ -246,12 +246,39 @@ run_compressed_import()
   TOTAL=$((TOTAL + 1))
   rm -f "$icc" "$roundtrip_xml" "$dump_log" "$log"
 
-  "$FROMXML" "$xml" "$icc" > "$log" 2>&1 || exit_code=$?
+  # Bounded: the guard below no longer keys off the status, so without a timeout
+  # a post-write hang would wedge the run rather than fail this case.
+  timeout 60 "$FROMXML" "$xml" "$icc" > "$log" 2>&1 || exit_code=$?
   check_sanitizers "$name" "$log" || return
 
+  # Status still matters for the outcomes it is the ONLY witness to.  Relaxing
+  # the guard below to the artifact must not also stop this case noticing that
+  # iccFromXml wrote the profile and then died in teardown, or hung: a SIGSEGV
+  # in a tag destructor leaves a complete .icc on disk and, on the ordinary
+  # uninstrumented lanes, no sanitizer text for check_sanitizers to
+  # find -- so an artifact-only assertion would report PASS for a crash.  The
+  # #2384 suite excludes the same range for the same reason.
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "iccFromXml timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ] && [ "$exit_code" -le 192 ]; then
+    fail_case "$name" "iccFromXml died on signal $((exit_code - 128))"
+    sed -n '1,40p' "$log"
+    return
+  fi
+
   if [ "$expect_zlib" = "ON" ]; then
-    if [ "$exit_code" -ne 0 ] || [ ! -s "$icc" ]; then
-      fail_case "$name" "zlib-enabled build rejected generated HexCompressedData"
+    # The artifact, not the status.  This fixture REPLACES profileDescriptionTag
+    # with a utf8ZipType carrying HexCompressedData -- the thing under test --
+    # and Validate() calls that "profileDescriptionTag utf8ZipType: Invalid tag
+    # type", so the profile is non-conformant BY CONSTRUCTION and cannot be made
+    # otherwise without deleting what this case exists to measure.  Since #2384
+    # iccFromXml exits non-zero for such a profile while still writing it, so
+    # "the zlib build imported the stream" is the file plus the absence of a
+    # parse error, exactly as the #1898/#1845 fixtures already assert it.
+    if [ ! -s "$icc" ] || grep -q "Unable to Parse" "$log"; then
+      fail_case "$name" "zlib-enabled build rejected generated HexCompressedData (exit=$exit_code)"
       sed -n '1,80p' "$log"
       return
     fi

--- a/.github/scripts/iccdev-issue-2089-jab-operators-regression.sh
+++ b/.github/scripts/iccdev-issue-2089-jab-operators-regression.sh
@@ -241,8 +241,33 @@ run_case() {
   if ! check_log "$name/fromxml" "$fromxml_log"; then
     return
   fi
-  if [ "$exit_code" -ne 0 ] || [ ! -s "$icc" ]; then
-    fail_case "$name" "iccFromXml failed with exit=$exit_code"
+  # Status still matters for the outcomes it is the ONLY witness to.  Relaxing
+  # the guard below to the artifact must not also stop this case noticing that
+  # iccFromXml wrote the profile and then died in teardown, or hung: a SIGSEGV
+  # in a tag destructor leaves a complete .icc on disk and, on the ordinary
+  # uninstrumented lanes, no sanitizer text for check_log/check_sanitizers to
+  # find -- so an artifact-only assertion would report PASS for a crash.  The
+  # #2384 suite excludes the same range for the same reason.
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "iccFromXml timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ] && [ "$exit_code" -le 192 ]; then
+    fail_case "$name" "iccFromXml died on signal $((exit_code - 128))"
+    sed -n '1,20p' "$fromxml_log"
+    return
+  fi
+  # The artifact, not the status.  These probes are minimal v5 "spac" documents
+  # carrying just desc and an A2B1 calculator: enough to exercise the Jab
+  # operators, never a conformant profile (Validate reports "Critical tag(s)
+  # missing" for the class), and adding the tags that would silence it means
+  # carrying a full colorimetric transform that has nothing to do with what is
+  # measured here.  Since #2384 iccFromXml exits non-zero for a profile it
+  # declares invalid while still writing it, so the signal that the document
+  # was ACCEPTED is the file plus the absence of a parse error -- the same way
+  # the #1898/#1845 fixtures assert it.
+  if [ ! -s "$icc" ] || grep -q "Unable to Parse" "$fromxml_log"; then
+    fail_case "$name" "iccFromXml produced no profile (exit=$exit_code)"
     sed -n '1,20p' "$fromxml_log"
     return
   fi

--- a/.github/scripts/iccdev-issue-2384-invalid-profile-exit-code-regression.sh
+++ b/.github/scripts/iccdev-issue-2384-invalid-profile-exit-code-regression.sh
@@ -1,0 +1,283 @@
+#!/bin/bash
+###############################################################################
+# #2384 -- iccFromXml / iccFromJson reported success for a profile they had
+#          just declared invalid
+###############################################################################
+#
+# Both converters validate the profile they built and then take one of two
+# branches.  The above-warning branch printed
+#
+#   Profile parsed.  Profile is invalid, but saved correctly
+#
+# followed by the whole validation report, ON STDOUT, and then fell through to
+# "return EXIT_SUCCESS".  So an invalid profile was indistinguishable from a
+# conformant one to any caller that checks $?, and a caller that separates the
+# streams saw a silent stderr as well.  #2384 found one reaching three TIFFs and
+# package generation that way.
+#
+# The contract applied here is the one this tree already uses for every other
+# failing exit in these two main()s, and which #1514/#2387 settled for the
+# usage paths:
+#
+#   nothing was produced, or what was produced is invalid
+#                                -> diagnostics on STDERR, non-zero status
+#   a conformant profile         -> message on STDOUT, exit 0, stderr empty
+#
+# What deliberately does NOT change: the invalid profile is still WRITTEN.  That
+# is what lets a caller inspect or repair it, and this tree's own #1898/#1901/
+# #1902/#1845 fixtures depend on the artifact appearing -- they gate on the file
+# existing and never on $?, which is why they still pass.  Every "invalid" case
+# below therefore asserts the file IS there as well as that the status is
+# non-zero; a fix that simply refused to write would satisfy the status half and
+# break five fixtures.
+#
+# Red/green, measured against master 2fd99a03: 4 of the 6 cases below fail.
+# Both "invalid" cases fail twice over (exit 0, and the report on stdout), and
+# both "parse-failure" cases fail on the stream alone -- those already returned
+# EXIT_FAILURE but answered on stdout.  The two "valid" controls PASS against
+# master and must keep passing: they are what separates "reports invalid
+# profiles" from "started failing on everything", which a status-only test on
+# the invalid cases alone could not tell apart.
+#
+# Scope note: #2384 also reports the SpectralEncoding BuildAndTest.sh/.bat
+# wrappers converting a non-zero iccTiffDump into a warning.  Those live in the
+# ICS-POC repository, not here; the in-tree Testing/hybrid/BuildAndTest.sh does
+# not mask, and runs under "set -eu" against 18 XML documents that all validate
+# clean, so it is unaffected by this change.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-invalid-profile-exit-code-regression}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+FROMJSON="$TOOLS_DIR/IccFromJson/iccFromJson"
+
+STDOUT_LOG="$OUTDIR/invalid-profile.stdout.log"
+STDERR_LOG="$OUTDIR/invalid-profile.stderr.log"
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+
+fail_case() { echo "  [FAIL] $1 -- $2"; FAIL=$((FAIL + 1)); }
+pass_case() { echo "  [PASS] $1 -- $2"; PASS=$((PASS + 1)); }
+skip_case() { echo "  [SKIP] $1 -- $2"; SKIP=$((SKIP + 1)); }
+
+check_sanitizers() {
+  local name="$1" log="$2"
+  if grep -Eq "ERROR: AddressSanitizer|LeakSanitizer: detected memory leaks|runtime error:" "$log" 2>/dev/null; then
+    fail_case "$name" "sanitizer finding in tool output"
+    return 1
+  fi
+  return 0
+}
+
+###############################################################################
+# Fixtures.  A minimal but complete v4 GRAY profile, and the same document with
+# mediaWhitePointTag removed -- which CIccProfile::Validate reports as
+# "Error! - Media white point tag missing." (above icValidateWarning) while the
+# document still parses, so the tool reaches the branch under test rather than
+# failing earlier.
+###############################################################################
+cat > "$OUTDIR/valid.xml" <<'XMLEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<IccProfile>
+  <Header>
+    <ProfileVersion>4.30</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>GRAY</DataColourSpace>
+    <PCS>XYZ </PCS>
+    <RenderingIntent>Perceptual</RenderingIntent>
+  </Header>
+  <Tags>
+    <grayTRCTag> <curveType><Curve>563</Curve></curveType> </grayTRCTag>
+    <profileDescriptionTag> <textDescriptionType><TextData>2384 CLI contract fixture</TextData></textDescriptionType> </profileDescriptionTag>
+    <copyrightTag> <textType><TextData>ICC regression fixture</TextData></textType> </copyrightTag>
+    <mediaWhitePointTag> <XYZArrayType><XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/></XYZArrayType> </mediaWhitePointTag>
+  </Tags>
+</IccProfile>
+XMLEOF
+
+# The same profile without mediaWhitePointTag.
+grep -v 'mediaWhitePointTag' "$OUTDIR/valid.xml" > "$OUTDIR/invalid.xml"
+
+# Well-formed XML that is not a profile: LoadXml fails, so this exercises the
+# parse-failure exit rather than the validation one.
+cat > "$OUTDIR/unparseable.xml" <<'XMLEOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<NotAProfile><Nothing/></NotAProfile>
+XMLEOF
+
+cat > "$OUTDIR/valid.json" <<'JSONEOF'
+{
+  "IccProfile": {
+    "Header": {
+      "ProfileVersion": "4.30",
+      "ProfileDeviceClass": "mntr",
+      "DataColourSpace": "GRAY",
+      "PCS": "XYZ ",
+      "RenderingIntent": "Perceptual"
+    },
+    "Tags": [
+      { "mediaWhitePointTag": { "data": { "type": "XYZArrayType", "XYZ": [ [ 0.964202880859375, 1.0, 0.8249053955078125 ] ] } } },
+      { "grayTRCTag": { "data": { "type": "curveType", "curveType": "gamma", "gamma": 2.19921880909169 } } },
+      { "profileDescriptionTag": { "data": { "type": "multiLocalizedUnicodeType",
+          "localizedStrings": [ { "country": "US", "language": "en", "text": "2384 CLI contract fixture" } ] } } },
+      { "copyrightTag": { "data": { "type": "multiLocalizedUnicodeType",
+          "localizedStrings": [ { "country": "US", "language": "en", "text": "ICC regression fixture" } ] } } }
+    ]
+  }
+}
+JSONEOF
+
+# The same profile without mediaWhitePointTag, by whole-line delete -- the same
+# shape as the XML twin above.
+#
+# The tag is written on ONE line, and is deliberately the FIRST entry, so the
+# delete leaves the array valid: dropping a trailing entry would strand the
+# previous one's comma.  Do not reach for `sed '/x/,+1d'` to span two lines --
+# `addr,+N` is a GNU extension that BSD sed (macOS) rejects outright, leaving a
+# zero-byte file, and the case would then exercise the parse-failure path
+# instead of the validation branch it is about.
+#
+# CI would not have told us: no lane runs this suite on macOS.  The only ctest
+# gate in _build-test-unix.yml is the step literally named "Run Linux CTest
+# gate", guarded by `inputs.run-full-tests`, which _build-matrix.yml sets from
+# `matrix.os == 'ubuntu-latest'`; ci-pr-action's two macOS legs go through
+# ci-pr-unix.yml, which runs no ctest at all.  So this would have stayed green
+# in CI and failed only for someone running the suite on a Mac.
+grep -v 'mediaWhitePointTag' "$OUTDIR/valid.json" > "$OUTDIR/invalid.json"
+
+cat > "$OUTDIR/unparseable.json" <<'JSONEOF'
+{ "NotAProfile": { } }
+JSONEOF
+
+###############################################################################
+# run <name> <tool> <input> <want-exit: zero|nonzero> <want-stream: out|err>
+#     <want-artifact: file|nofile> <needle>
+###############################################################################
+run_case() {
+  local name="$1" tool="$2" input="$3" want_exit="$4" want_stream="$5" want_file="$6" needle="$7"
+  TOTAL=$((TOTAL + 1))
+  local exit_code=0
+  local icc="$OUTDIR/$name.icc"
+
+  rm -f "$icc"
+  : > "$STDOUT_LOG"; : > "$STDERR_LOG"
+  timeout 60 "$tool" "$input" "$icc" > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
+
+  check_sanitizers "$name" "$STDOUT_LOG" || return
+  check_sanitizers "$name" "$STDERR_LOG" || return
+
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  # A crash is also non-zero, so exclude the signal range rather than accepting
+  # any non-zero as proof the guard fired.
+  if [ "$exit_code" -ge 128 ] && [ "$exit_code" -le 192 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    return
+  fi
+
+  if [ "$want_exit" = "zero" ] && [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "expected exit=0, got exit=$exit_code"
+    sed -n '1,5p' "$STDERR_LOG"
+    return
+  fi
+  if [ "$want_exit" = "nonzero" ] && [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "reported success (exit=0) for a run that did not produce a conformant profile"
+    sed -n '1,5p' "$STDOUT_LOG"
+    return
+  fi
+
+  # The stream is the discriminator: both branches print a full report, so a
+  # status-only assertion would accept an implementation that answered on both.
+  local loud quiet
+  if [ "$want_stream" = "err" ]; then
+    loud="$STDERR_LOG"; quiet="$STDOUT_LOG"
+  else
+    loud="$STDOUT_LOG"; quiet="$STDERR_LOG"
+  fi
+  if [ -s "$quiet" ]; then
+    fail_case "$name" "wrote $(wc -c < "$quiet") bytes to the wrong stream (wanted $want_stream only)"
+    sed -n '1,5p' "$quiet"
+    return
+  fi
+  if ! grep -Fq "$needle" "$loud" 2>/dev/null; then
+    fail_case "$name" "no \"$needle\" on $want_stream"
+    sed -n '1,5p' "$loud"
+    return
+  fi
+
+  # The artifact half.  An invalid profile is still written -- see the header.
+  if [ "$want_file" = "file" ] && [ ! -f "$icc" ]; then
+    fail_case "$name" "no profile written; the artifact must survive a non-zero status"
+    return
+  fi
+  if [ "$want_file" = "nofile" ] && [ -f "$icc" ]; then
+    fail_case "$name" "a run that parsed nothing still wrote $(wc -c < "$icc") bytes"
+    return
+  fi
+
+  pass_case "$name" "exit=$exit_code, $want_stream only, $want_file"
+}
+
+echo "=== iccFromXml/iccFromJson invalid-profile exit-code regression (#2384) ==="
+
+if [ -x "$FROMXML" ]; then
+  run_case "xml-invalid"     "$FROMXML"  "$OUTDIR/invalid.xml"     nonzero err file   "Profile is invalid"
+  run_case "xml-valid"       "$FROMXML"  "$OUTDIR/valid.xml"       zero    out file   "Profile parsed and saved correctly"
+  run_case "xml-unparseable" "$FROMXML"  "$OUTDIR/unparseable.xml" nonzero err nofile "Unable to Parse"
+else
+  skip_case "iccFromXml" "not built at $FROMXML"
+fi
+
+if [ -x "$FROMJSON" ]; then
+  run_case "json-invalid"     "$FROMJSON" "$OUTDIR/invalid.json"     nonzero err file   "Profile is invalid"
+  run_case "json-valid"       "$FROMJSON" "$OUTDIR/valid.json"       zero    out file   "Profile parsed and saved correctly"
+  run_case "json-unparseable" "$FROMJSON" "$OUTDIR/unparseable.json" nonzero err nofile "Unable to Parse"
+else
+  skip_case "iccFromJson" "not built at $FROMJSON"
+fi
+
+echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total ==="
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+
+# A run that measured nothing must not report green -- the same defect class
+# this suite exists to pin.
+if [ "$PASS" -eq 0 ]; then
+  echo "no case was measured -- treating as skipped rather than passed"
+  exit 77
+fi
+
+exit 0

--- a/.github/scripts/iccdev-json-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-json-parser-regression-tests.sh
@@ -778,6 +778,19 @@ raise SystemExit("namedColor2 tag not found")
 # profile.  Generating it would make these cases depend on the resp tag's READ path,
 # and when that path was broken (#2399) they would have gone green by skipping rather
 # than red -- the failure mode this file's own reject helper exists to prevent.
+# Every document carries the four tags a v2 GRAY mntr profile must have, so the
+# CONTROL converts with exit 0.  They were omitted while iccFromJson returned
+# EXIT_SUCCESS for a profile it had just declared invalid; #2384 made that an
+# EXIT_FAILURE, so a control asserting exit 0 now means what it always claimed.
+# The outputResponseTag under test -- its CountOfChannels and DeviceCode -- is
+# unchanged, and the overflow cases are still refused by the parser before
+# validation is reached.  Mirrors the same change in the XML sibling suite.
+#
+# The tag TYPES are the v2 ones -- textDescriptionType and textType, not
+# multiLocalizedUnicodeType -- because these documents declare ProfileVersion
+# 2.10.  Validate() rejects the v4 spellings here as "Invalid tag type (Might
+# be critical!)", so the v4 forms would leave the control failing for a second,
+# unrelated reason.
 write_responsecurve_json() {
   # write_responsecurve_json <path> <count> <device-code>
   cat > "$1" <<JSONEOF
@@ -808,7 +821,13 @@ write_responsecurve_json() {
           ]
         }
       }
-    }
+    },
+    { "grayTRCTag": { "data": { "type": "curveType", "curveType": "gamma", "gamma": 2.19921880909169 } } },
+    { "profileDescriptionTag": { "data": { "type": "textDescriptionType",
+        "description": "responseCurveSet16 regression fixture" } } },
+    { "copyrightTag": { "data": { "type": "textType", "text": "ICC regression fixture" } } },
+    { "mediaWhitePointTag": { "data": { "type": "XYZArrayType",
+        "XYZ": [ [ 0.964202880859375, 1.0, 0.8249053955078125 ] ] } } }
   ]
 }
 JSONEOF

--- a/.github/scripts/iccdev-xml-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-xml-parser-regression-tests.sh
@@ -545,6 +545,18 @@ xyz_array_at_cap
 # No tracked document uses responseCurveSet16Type, which is why neither survived
 # into a fixture; these three are written here.
 
+# The four tags a v2 GRAY mntr profile must carry to be conformant, carried by
+# every document below so that the CONTROLS convert with exit 0.
+#
+# They used to be omitted: a resp tag on a bare header parses, so the documents
+# reached the parser this suite is about, and iccFromXml returned EXIT_SUCCESS
+# for the resulting profile even though it validated above icValidateWarning.
+# #2384 made that an EXIT_FAILURE, which is what a control asserting "exit 0"
+# should have meant all along -- the old fixtures were testing "the parser
+# accepted it", never "a usable profile came out".  Adding the required tags
+# keeps the strong exit-0 assertion instead of relaxing it, and does not touch
+# what is under test: the resp tag, its CountOfChannels and its Measurement
+# rows are unchanged, and the round-trip cases only look for the resp tag.
 write_countofchannels_document() {
   # write_countofchannels_document <path> <count-element>
   cat > "$1" <<XMLEOF
@@ -566,6 +578,10 @@ write_countofchannels_document() {
         </ChannelResponses>
       </ResponseCurve>
     </responseCurveSet16Type>
+    <grayTRCTag> <curveType><Curve>563</Curve></curveType> </grayTRCTag>
+    <profileDescriptionTag> <textDescriptionType><TextData>responseCurveSet16 regression fixture</TextData></textDescriptionType> </profileDescriptionTag>
+    <copyrightTag> <textType><TextData>ICC regression fixture</TextData></textType> </copyrightTag>
+    <mediaWhitePointTag> <XYZArrayType><XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/></XYZArrayType> </mediaWhitePointTag>
   </Tags>
 </IccProfile>
 XMLEOF
@@ -867,6 +883,10 @@ measurement_reserved_not_inherited() {
         </ChannelResponses>
       </ResponseCurve>
     </responseCurveSet16Type>
+    <grayTRCTag> <curveType><Curve>563</Curve></curveType> </grayTRCTag>
+    <profileDescriptionTag> <textDescriptionType><TextData>responseCurveSet16 regression fixture</TextData></textDescriptionType> </profileDescriptionTag>
+    <copyrightTag> <textType><TextData>ICC regression fixture</TextData></textType> </copyrightTag>
+    <mediaWhitePointTag> <XYZArrayType><XYZNumber X="0.964202880859" Y="1.000000000000" Z="0.824905395508"/></XYZArrayType> </mediaWhitePointTag>
   </Tags>
 </IccProfile>
 XMLEOF

--- a/.github/workflows/ci-json-roundtrip.yml
+++ b/.github/workflows/ci-json-roundtrip.yml
@@ -290,7 +290,17 @@ jobs:
             echo "[JSON-RT] TOJSON_OK profile=${safe_rel} json_bytes=${json_size} json=${json_out}"
             echo "[JSON-RT] COMMAND iccFromJson source=${json_out} output=${rt_out} log=${fromjson_log}"
 
-            if ! timeout 30 "$FROMJSON" "$json_out" "$rt_out" >"$fromjson_log" 2>&1; then
+            # A non-zero iccFromJson no longer means "no profile": since #2384 the
+            # tool exits non-zero for a profile validating above icValidateWarning
+            # while still WRITING it, and four generated profiles round-trip that
+            # way (Named/SparseMatrixNamedColor.icc and
+            # CalcTest/calcOverMem_t{get,put,sav}.icc).  Keying the skip off the
+            # status moved them out of byte-parity coverage while this job stayed
+            # green.  Gate on the artifact, as Testing/RunJsonTests.sh now does.
+            fromjson_rc=0
+            rm -f "$rt_out"
+            timeout 30 "$FROMJSON" "$json_out" "$rt_out" >"$fromjson_log" 2>&1 || fromjson_rc=$?
+            if [ ! -s "$rt_out" ]; then
               if is_expected_fromjson_failure "$rel"; then
                 XFAIL=$((XFAIL+1))
                 profile_status="XFAIL_FROMJSON"
@@ -312,9 +322,9 @@ jobs:
               if [ "$profile_status" = "XFAIL_FROMJSON" ]; then
                 echo "| [XFAIL] | ${safe_rel} | $(sanitize_line "${orig_size}") | $(sanitize_line "${json_size}") | - | expected invalid calculator profile |" >> "$GITHUB_STEP_SUMMARY"
               else
-                echo "| [SKIP] | ${safe_rel} | $(sanitize_line "${orig_size}") | $(sanitize_line "${json_size}") | - | iccFromJson failed |" >> "$GITHUB_STEP_SUMMARY"
+                echo "| [SKIP] | ${safe_rel} | $(sanitize_line "${orig_size}") | $(sanitize_line "${json_size}") | - | iccFromJson wrote no profile (exit $(sanitize_line "${fromjson_rc}")) |" >> "$GITHUB_STEP_SUMMARY"
               fi
-              echo "[JSON-RT] ${profile_status} profile=${safe_rel} original=${original_record} json=${json_record} roundtrip=${rt_record} log=${fromjson_log}"
+              echo "[JSON-RT] ${profile_status} profile=${safe_rel} fromjson_exit=${fromjson_rc} original=${original_record} json=${json_record} roundtrip=${rt_record} log=${fromjson_log}"
               sanitize_tool_log "[JSON-RT][iccFromJson]" "$fromjson_log"
               if [ "$rel" = "Display/LCDDisplay.icc" ]; then
                 LCDDISPLAY_STATUS="$profile_status"

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7686,6 +7686,26 @@ if(TARGET iccApplyProfiles AND TARGET iccApplySearch
     SKIP_RETURN_CODE 77)
 endif()
 
+# The converter half of the same CLI-contract family (#2384): iccFromXml and
+# iccFromJson reported success for a profile they had just declared invalid.
+# Guarded on both targets because the suite measures both and its "nothing
+# measured" guard would otherwise turn a partial build into a skip that hides
+# the half that did build.
+#
+# Deliberately NOT labelled "slow", for the same reason as the sibling above --
+# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+if(TARGET iccFromXml AND TARGET iccFromJson)
+  iccdev_add_script_test(
+    iccdev.invalid-profile-exit-code-regression
+    120
+    "iccdev;fromxml;fromjson;cli;validate;exitcode;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2384-invalid-profile-exit-code-regression.sh"
+  )
+  set_tests_properties(iccdev.invalid-profile-exit-code-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # Guarded on the target, like iccdev.tiff-resolution-unit-regression below.
 # Both scripts exit 2 when iccSpecSepToTiff is missing rather than skipping the
 # way the older sibling suites do, so an unguarded registration turns a

--- a/IccJSON/CmdLine/IccFromJson/IccFromJson.cpp
+++ b/IccJSON/CmdLine/IccFromJson/IccFromJson.cpp
@@ -39,9 +39,11 @@ int main(int argc, char* argv[])
       bNoId = true;
   }
 
+  // On stderr, like the XML twin: this returned EXIT_FAILURE already but answered
+  // on stdout, so a caller that separates the streams saw nothing (#2384).
   if (!profile.LoadJson(argv[1], &reason)) {
-    printf("%s", reason.c_str());
-    printf("Unable to Parse '%s'\n", argv[1]);
+    fprintf(stderr, "%s", reason.c_str());
+    fprintf(stderr, "Unable to Parse '%s'\n", argv[1]);
     return EXIT_FAILURE;
   }
 
@@ -57,24 +59,32 @@ int main(int argc, char* argv[])
       printf("Profile parsed and saved correctly\n");
     }
     else {
-      printf("Unable to save profile as '%s'\n", argv[2]);
+      fprintf(stderr, "Unable to save profile as '%s'\n", argv[2]);
       return EXIT_FAILURE;
     }
   }
   else {
+    // The same contract as the XML twin, changed in the same commit rather than
+    // left to drift: an above-warning profile is still written, but the report
+    // goes to stderr and the status is EXIT_FAILURE instead of EXIT_SUCCESS
+    // (#2384).  See IccFromXml.cpp for the reasoning.  Fixing only one of the two
+    // parsers is what makes a defect like this outlive its fix -- the JSON side
+    // has its own control fixtures (#1901/#1902) and its own callers.
     int i;
     for (i = 0; i < 16; i++) {
       if (profile.m_Header.profileID.ID8[i])
         break;
     }
     if (SaveIccProfile(argv[2], &profile, bNoId ? icNeverWriteID : (i < 16 ? icAlwaysWriteID : icVersionBasedID))) {
-      printf("Profile parsed. Profile is invalid, but saved correctly\n");
+      fprintf(stderr, "Profile parsed. Profile is invalid, but saved correctly\n");
     }
     else {
-      printf("Unable to save profile - profile is invalid!\n");
+      fprintf(stderr, "Unable to save profile - profile is invalid!\n");
       return EXIT_FAILURE;
     }
-    printf("%s", valid_report.c_str());
+    fprintf(stderr, "%s", valid_report.c_str());
+    fprintf(stderr, "\n");
+    return EXIT_FAILURE;
   }
 
   printf("\n");

--- a/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
+++ b/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
@@ -247,12 +247,16 @@ int main(int argc, char* argv[])
   // Re-indented to match its block.  The stray four-space indent was harmless while
   // nothing preceded it, but it now follows an if-statement and -Wmisleading-indentation
   // rejects it outright on the strict lanes.
+  // On stderr, like every other failing exit in this main().  This one returned
+  // EXIT_FAILURE already but answered on stdout, so a caller that separates the
+  // streams -- the discriminator this file's Usage() comment relies on -- saw a
+  // silent stderr for a run that parsed nothing (#2384).
   if (!profile.LoadXml(argv[1], szRelaxNGDir.c_str(), &reason)) {
-    printf("%s", reason.c_str());
+    fprintf(stderr, "%s", reason.c_str());
 #ifndef WIN32
-    printf("\n");
+    fprintf(stderr, "\n");
 #endif
-    printf("Unable to Parse '%s'\n", argv[1]);
+    fprintf(stderr, "Unable to Parse '%s'\n", argv[1]);
     return EXIT_FAILURE;
   }
 
@@ -282,23 +286,41 @@ int main(int argc, char* argv[])
       printf("Profile parsed and saved correctly\n");
     }
     else {
-      printf("Unable to save profile as '%s'\n", argv[2]);
+      fprintf(stderr, "Unable to save profile as '%s'\n", argv[2]);
       return EXIT_FAILURE;
     }
   }
   else {
+    // A profile that validates above icValidateWarning is still WRITTEN -- that is
+    // deliberate and is kept: the file is what lets a caller inspect or repair what
+    // it asked for, and this tree's own #1898/#1901/#1845 fixtures depend on the
+    // artifact appearing.  What changes is that the run no longer REPORTS success.
+    //
+    // It used to print "Profile is invalid, but saved correctly" and the whole
+    // validation report on stdout and then return EXIT_SUCCESS, so an invalid
+    // profile was indistinguishable from a conformant one to any caller that checks
+    // $? -- which is how one reached three TIFFs and package generation before
+    // anyone noticed (#2384).  Both signals now say the same thing: the report goes
+    // to stderr with the rest of this main()'s diagnostics, and the status is
+    // EXIT_FAILURE, matching every other non-success exit here.
+    //
+    // The artifact still exists, so a caller that WANTS a deliberately invalid
+    // profile keeps working by ignoring the status -- which is exactly what the
+    // fixtures above do; they gate on the file, never on $?.
     for (i=0; i<16; i++) {
       if (profile.m_Header.profileID.ID8[i])
         break;
     }
     if (SaveIccProfile(argv[2], &profile, bNoId ? icNeverWriteID : (i<16 ? icAlwaysWriteID : icVersionBasedID))) {
-      printf("Profile parsed.  Profile is invalid, but saved correctly\n");
+      fprintf(stderr, "Profile parsed.  Profile is invalid, but saved correctly\n");
     }
     else {
-      printf("Unable to save profile - profile is invalid!\n");
+      fprintf(stderr, "Unable to save profile - profile is invalid!\n");
       return EXIT_FAILURE;
     }
-    printf("%s", valid_report.c_str());
+    fprintf(stderr, "%s", valid_report.c_str());
+    fprintf(stderr, "\n");
+    return EXIT_FAILURE;
   }
 
   printf("\n");

--- a/Testing/RunJsonTests.sh
+++ b/Testing/RunJsonTests.sh
@@ -67,13 +67,25 @@ while IFS= read -r icc; do
     continue
   fi
   # FromJson
-  if ! timeout 30 "$FROMJSON" /tmp/json-rt-test.json /tmp/json-rt-test.icc >/dev/null 2>&1; then
+  # A non-zero iccFromJson no longer means "no profile".  Since #2384 the tool
+  # exits non-zero for a profile that validates above icValidateWarning while
+  # still WRITING it, and four generated profiles round-trip that way --
+  # Named/SparseMatrixNamedColor.icc plus CalcTest/calcOverMem_t{get,put,sav}.icc.
+  # Treating status as the gate silently moved them from "byte-parity compared"
+  # to SKIP: the harness stayed green while covering less, and
+  # SparseMatrixNamedColor is a NON-CalcTest profile that had been counting
+  # toward the non-calc failure gate.  Gate on the artifact instead, so a written
+  # profile is always size-compared and only a genuinely absent one skips.
+  rm -f /tmp/json-rt-test.icc
+  fromjson_rc=0
+  timeout 30 "$FROMJSON" /tmp/json-rt-test.json /tmp/json-rt-test.icc >/dev/null 2>&1 || fromjson_rc=$?
+  if [ ! -s /tmp/json-rt-test.icc ]; then
     if is_expected_fromjson_failure "$relpath"; then
       XFAIL=$((XFAIL + 1))
       echo "[XFAIL] $relpath (expected invalid calculator profile)"
     else
       SKIP=$((SKIP + 1))
-      echo "[SKIP] $relpath (FromJson failed)"
+      echo "[SKIP] $relpath (FromJson wrote no profile, exit=$fromjson_rc)"
     fi
     rm -f /tmp/json-rt-test.json
     continue


### PR DESCRIPTION
Part of #2384.

## What

`iccFromXml` and `iccFromJson` validated the profile they had just built and, when the
status was above `icValidateWarning`, printed

```
Profile parsed.  Profile is invalid, but saved correctly
```

plus the whole validation report **on stdout**, then fell through to `return EXIT_SUCCESS`.
An invalid profile was therefore indistinguishable from a conformant one to any caller that
checks `$?`, and a caller that separates the streams saw a silent stderr as well. #2384
found one generated, embedded into three TIFFs, and passed through package generation that
way.

Both signals now agree, matching every other failing exit in these two `main()`s and the
contract #1514 / #2387 settled for the usage paths: the notice and the report go to
**stderr**, and the status is **EXIT_FAILURE**. The parse-failure exit above it moves to
stderr for the same reason — it already returned `EXIT_FAILURE` but answered on stdout.

**The profile is still written.** That is deliberate: it is what lets a caller inspect or
repair what it asked for, and five in-tree fixtures depend on the artifact appearing.

Fixed in **both** parsers in one commit — `IccFromJson.cpp` carried the identical branch.

## Scope

The other half of #2384 — the SpectralEncoding `BuildAndTest.sh` / `.bat` wrappers turning a
non-zero `iccTiffDump` into a warning — lives in the **ICS-POC** repository, not here, so it
is untouched. The in-tree `Testing/hybrid/BuildAndTest.sh` does not mask, and runs under
`set -eu` against 18 XML documents that all validate clean. Hence `Part of`, not a closing
keyword; the routing of that half is yours to call.

## Blast radius, measured

Every tracked document swept through the matching converter:

| | XML (221) | JSON (23) |
|---|---|---|
| converts clean, untouched | 200 | 1 |
| already exited non-zero | 18 | 20 |
| **flips 0 → 1** | **3** | **2** |

All five are `.github/ci/test-data/` fixtures consumed by the #1898 / #1845 suites, which
gate on the profile **file** appearing and never on `$?` — both still pass unchanged.
`CreateAllProfiles.sh` checks no exit codes, and no workflow touches the five.

**That sweep was necessary and not sufficient.** A full `ctest` run then found four more
suites whose fixtures are synthesized at test time and so appear in no `git ls-files`
listing. Two remedies, by cause:

- **`xml-parser-regressions`, `json-parser-regressions`** — the responseCurveSet16 documents
  were headers carrying only the tag under test, so their *controls* asserted `exit 0` for
  profiles that were never conformant. They now carry the four tags a v2 GRAY `mntr` profile
  needs, which **keeps** the strong `exit 0` assertion instead of relaxing it, and leaves the
  `resp` tag, its `CountOfChannels` and its `Measurement` rows untouched. The JSON copies use
  the **v2** tag types (`textDescriptionType` / `textType`); the v4 spellings are rejected at
  ProfileVersion 2.10 as *"Invalid tag type"* and would have left the control red for a
  second, unrelated reason.

- **`hextext-compression-ab`, `issue-2089-jab-operators`** — non-conformance is *inherent*.
  The first **replaces** `profileDescriptionTag` with the `utf8ZipType` under test, which
  `Validate()` calls an invalid tag type; the second uses minimal v5 `spac` calculator probes
  that cannot satisfy the class's critical-tag rule without a full colorimetric transform
  irrelevant to the Jab operators. Neither can be made conformant without deleting what it
  measures, so both assert on the artifact plus the absence of a parse error — the signal
  they actually meant, and the one #1898 / #1845 already use.

  Those two keep an explicit **signal/timeout check** beside the artifact test. Dropping the
  status entirely would have made them report PASS for a converter that wrote the profile and
  then died in teardown: on the ordinary uninstrumented lanes a SIGSEGV leaves a complete
  `.icc` and no sanitizer text. Measured with a stub that runs the real tool then raises
  SIGSEGV — all four jab cases **PASS** without the check and fail with *"died on signal 11"*
  with it. `iccFromXml` in the hextext case had no timeout at all and now has one.

## Two round-trip harnesses were losing coverage while staying green

`Testing/RunJsonTests.sh` and `ci-json-roundtrip.yml` both classified a non-zero
`iccFromJson` as *"FromJson failed → SKIP"* and never reached the byte-parity comparison. So
four profiles left coverage **without either harness going red**:

- `Testing/Named/SparseMatrixNamedColor.icc` — a **non-CalcTest** profile that had been
  counting toward the non-calc failure gate
- `Testing/CalcTest/calcOverMem_t{get,put,sav}.icc`

none of which `is_expected_fromjson_failure` matches. Both now gate on the artifact.
Measured: skip count goes **5 → 1** and all four are size-compared again.

## Test

New `iccdev.invalid-profile-exit-code-regression` covers both tools — invalid (non-zero,
stderr, profile still written), a valid control (exit 0, stdout, stderr empty), and parse
failure (non-zero, stderr, no profile).

**4 of its 6 cases fail against master `2fd99a03`.** The two valid controls pass on both,
which is what separates this change from one that simply started failing on everything.

Its invalid-JSON fixture is derived with `grep -v` on a one-line tag, not `sed '/x/,+1d'` —
`addr,+N` is a GNU extension that BSD sed rejects, leaving a zero-byte document and turning
the case into a parse-failure test. CI would not have caught that: the only ctest gate in
`_build-test-unix.yml` is the step named *"Run Linux CTest gate"*, guarded by
`run-full-tests`, which `_build-matrix.yml` sets from `matrix.os == 'ubuntu-latest'`; and
`ci-pr-action`'s two macOS legs use `ci-pr-unix.yml`, which runs no ctest at all.

## Pre-flight

- Full `ctest` (251 tests) diffed against a control build of the same tree with master's
  sources: **zero new failures**; the only delta is the new suite going red → green.
- CI's warning gate (`grep -cE 'warning:' build.log` = 0) on both strict profiles:
  **clang 21.1.3** and, in the CI container, **GCC 15.2.0** with `strict warnings ENABLED`
  (`-Wall -Wextra -Wpedantic -Werror`), 148 objects each including both changed TUs.
- `shellcheck` and `actionlint` clean; pre-flight safety gate matches master exactly.

Dispatched before opening this PR, per the reduced-check workflow:
**run `33997627405`, `ci_scope=source` — 15 success / 1 skipped.**
Verified in that run's `Tool Smoke Tests (ASAN+UBSAN, Debug)` job rather than inferred from
the green tick: `iccdev.invalid-profile-exit-code-regression .... Passed`, in a job reporting
`100% tests passed, 0 tests failed out of 247`. `xml-parser-regressions`,
`hextext-compression-ab-regression`, `issue-2089-jab-operators` and
`apply-usage-exit-code-regression` all ran and passed there too.

One suite this touches does **not** run on the PR lane: `iccdev.json-parser-regressions`
carries the `pr-extended` label, which `ci-iccdev-tool-tests.yml` excludes and
`ci-pr-action.yml` describes as *"deferred only by the PR caller"* — it appears in the run's
`ctest -N` listing but is not executed, and will run in the regression lane. Its change is
verified locally (18/18, including the `responsecurve-control` case this affects). Flagging
it so the green tick is not read as covering it.

## One open contract question

This makes non-zero the **default**. The alternative is an opt-in `-strict` flag: it breaks
nothing, but leaves the default reporting success for an invalid profile. A third option is a
distinct status for *written-but-invalid* (`2`) versus *could not write* (`1`), which would
keep the two outcomes separable from `$?` alone — note no CmdLine tool uses `2` as a status
today, so that would be a new convention. I took the default because it is what the report
names and what #1514 / #2387 / #2405 established, and because the collateral proved bounded
and fixable — but it is a contract change, so say the word and I will reshape it.
