### PR TITLE
IccApplySearch: drop the dead argc clamp the -threads shift created

### DIFF
--- a/.github/scripts/iccdev-issue-2405-apply-usage-exit-code-regression.sh
+++ b/.github/scripts/iccdev-issue-2405-apply-usage-exit-code-regression.sh
@@ -28,7 +28,7 @@
 # is why every case below asserts the quiet stream is EMPTY -- an implementation
 # that printed usage to both would satisfy a status-only test.
 #
-# Red/green, measured against master f186948c: 22 of the 26 cases below fail.
+# Red/green, measured against master f186948c: 24 of the 28 cases below fail.
 # All thirteen too-few-operand forms fail, each reporting exit=0.  The five
 # "clears minargs but still malformed" cases fail because master answers them on
 # stdout.  Of the eight help cases, the four on iccApplyProfiles and
@@ -43,6 +43,16 @@
 # the malformed cases, not the help cases, are what red/green this change.
 # Those four assertions still earn their place: they pin the help path against
 # a future regression once it is the only route to Usage() on stdout.
+#
+# The two "threads-then-*" cases were added later, with code-scanning alert
+# 2365 (cpp/constant-comparison), and they fail
+# against f186948c too -- which is why the count above is 24 of 28 rather than
+# 22 of 26.  There the post-"-threads" guard is a bare "Usage(); return
+# EXIT_FAILURE;" and Usage() takes no stream argument, so the screen lands on
+# stdout and there is no "Missing arguments after -threads" line to match.
+# They fail on the stdout assertion first, and would fail on the message one
+# too.  That alert itself is not what they red/green -- see the note on
+# run_threads_operand_count() below.
 #
 # Anti-vacuity: assert_usage_screen() pins a row that this change does not
 # touch, so a truncated or empty capture cannot satisfy the stream assertions
@@ -106,16 +116,19 @@ check_sanitizers() {
 # row assumed common to all, which is what a first version of this test assumed
 # and got wrong.
 #
+# Passed in by each caller rather than read from a global: as a global it was
+# assigned by the per-tool table loop and any case running outside that loop
+# silently inherited the last entry's row (found while fixing alert 2365).
+#
 # Matched as a whole line with -F against a leading-whitespace-stripped copy:
 # every anchor below contains "+", "(", ")" or "/", all ERE metacharacters, so a
 # regex would quietly stop meaning what it reads as (the same reasoning as the
 # #2262 row assertions).  The tools indent these rows differently.
-ANCHOR=""
 assert_usage_screen() {
-  local name="$1" log="$2" where="$3"
+  local name="$1" log="$2" where="$3" anchor="$4"
   sed 's/^[[:space:]]*//' "$log" > "$log.stripped"
-  if ! grep -Fqx "$ANCHOR" "$log.stripped" 2>/dev/null; then
-    fail_case "$name" "no complete usage screen on $where (last row \"$ANCHOR\" absent)"
+  if ! grep -Fqx "$anchor" "$log.stripped" 2>/dev/null; then
+    fail_case "$name" "no complete usage screen on $where (last row \"$anchor\" absent)"
     sed -n '1,10p' "$log"
     return 1
   fi
@@ -124,7 +137,7 @@ assert_usage_screen() {
 
 # A malformed invocation: non-zero status, usage on stderr, stdout untouched.
 run_malformed() {
-  local name="$1" tool="$2"; shift 2
+  local name="$1" tool="$2" anchor="$3"; shift 3
   TOTAL=$((TOTAL + 1))
   local exit_code=0
 
@@ -158,7 +171,7 @@ run_malformed() {
     sed -n '1,5p' "$STDERR_LOG"
     return
   fi
-  assert_usage_screen "$name" "$STDERR_LOG" "stderr" || return
+  assert_usage_screen "$name" "$STDERR_LOG" "stderr" "$anchor" || return
 
   pass_case "$name" "rejected with exit=$exit_code, usage on stderr, stdout empty"
 }
@@ -206,9 +219,66 @@ run_malformed_no_usage() {
   pass_case "$name" "rejected with exit=$exit_code, diagnostic on stderr, stdout empty"
 }
 
+# The operand-count guard that runs AFTER "-threads N" has been consumed.
+# iccApplySearch shifts its vector ("argv += 2; argc -= 2") and then repeats the
+# minargs test, so the count in that second message comes from a different
+# expression than the one the sweep above covers -- and nothing reached it: the
+# "threads-no-count" case below stops at the earlier "Missing thread count"
+# guard, which returns before the shift.
+#
+# These cases do not red/green alert 2365.  That change removed an "argc > 0 ?" clamp
+# whose else branch was already unreachable -- the minargs test has established
+# argc >= 3 before the shift, so argc >= 1 after it -- and the output is
+# identical before and after it (verified on all five reachable forms).  What
+# they pin is the arithmetic the clamp was standing in front of: "-threads 4"
+# leaves argc == 1, the smallest value that can reach the line, so a rewrite
+# that dropped the "- 1" or clamped on the wrong side would print 1 or 0 here
+# rather than 0 and 1.  Asserts the whole line with -F: the message has no
+# regex metacharacters but the count is the point, and a substring match on
+# "received" would accept any number.
+run_threads_operand_count() {
+  local name="$1" tool="$2" anchor="$3" expected="$4"; shift 4
+  TOTAL=$((TOTAL + 1))
+  local exit_code=0
+
+  : > "$STDOUT_LOG"; : > "$STDERR_LOG"
+  timeout 60 "$tool" "$@" > "$STDOUT_LOG" 2> "$STDERR_LOG" || exit_code=$?
+
+  check_sanitizers "$name" "$STDOUT_LOG" || return
+  check_sanitizers "$name" "$STDERR_LOG" || return
+
+  if [ "$exit_code" -eq 124 ]; then
+    fail_case "$name" "timed out"
+    return
+  fi
+  if [ "$exit_code" -ge 128 ] && [ "$exit_code" -le 192 ]; then
+    fail_case "$name" "crashed with signal $((exit_code - 128))"
+    return
+  fi
+  if [ "$exit_code" -eq 0 ]; then
+    fail_case "$name" "incomplete invocation reported success (exit=0)"
+    return
+  fi
+  if [ -s "$STDOUT_LOG" ]; then
+    fail_case "$name" "malformed invocation wrote $(wc -c < "$STDOUT_LOG") bytes to stdout"
+    sed -n '1,5p' "$STDOUT_LOG"
+    return
+  fi
+
+  local want="Missing arguments after -threads: expected at least 2, received ${expected}."
+  if ! grep -Fqx "$want" "$STDERR_LOG" 2>/dev/null; then
+    fail_case "$name" "stderr does not carry \"$want\""
+    sed -n '1,5p' "$STDERR_LOG"
+    return
+  fi
+  assert_usage_screen "$name" "$STDERR_LOG" "stderr" "$anchor" || return
+
+  pass_case "$name" "reported received=$expected, usage on stderr, stdout empty"
+}
+
 # A help request: exit 0, usage on stdout, stderr untouched.
 run_help() {
-  local name="$1" tool="$2" flag="$3"
+  local name="$1" tool="$2" anchor="$3" flag="$4"
   TOTAL=$((TOTAL + 1))
   local exit_code=0
 
@@ -228,7 +298,7 @@ run_help() {
     sed -n '1,5p' "$STDERR_LOG"
     return
   fi
-  assert_usage_screen "$name" "$STDOUT_LOG" "stdout" || return
+  assert_usage_screen "$name" "$STDOUT_LOG" "stdout" "$anchor" || return
 
   pass_case "$name" "$flag printed usage on stdout and exited 0"
 }
@@ -249,7 +319,7 @@ for entry in "iccApplyProfiles|$PROFILES|0|+10000 - Use V5 sub-profile if presen
              "iccApplyNamedCmm|$NAMEDCMM|0|only one of +1000000 / +2000000 may be given)" \
              "iccApplySearch|$SEARCH|1|+10000 - Use V5 sub-profile if present" \
              "iccApplyToLink|$TOLINK|8|+1000 - Use V5 sub-profile if present"; do
-  IFS='|' read -r name tool maxops ANCHOR <<< "$entry"
+  IFS='|' read -r name tool maxops anchor <<< "$entry"
 
   if [ ! -x "$tool" ]; then
     skip_case "$name" "not built at $tool"
@@ -260,11 +330,11 @@ for entry in "iccApplyProfiles|$PROFILES|0|+10000 - Use V5 sub-profile if presen
   # iccApplyToLink accepted nine of them and iccApplySearch two, so a test that
   # only ran the tool with no operands would leave most of the defect uncovered.
   for n in $(seq 0 "$maxops"); do
-    run_malformed "$name $n-operand" "$tool" "${ARGS[@]:0:$n}"
+    run_malformed "$name $n-operand" "$tool" "$anchor" "${ARGS[@]:0:$n}"
   done
 
-  run_help "$name short help" "$tool" -h
-  run_help "$name long help" "$tool" --help
+  run_help "$name short help" "$tool" "$anchor" -h
+  run_help "$name long help" "$tool" "$anchor" --help
 done
 
 # Forms that clear minargs but are still malformed.  One operand is a complete
@@ -285,6 +355,19 @@ fi
 if [ -x "$SEARCH" ]; then
   run_malformed_no_usage "iccApplySearch unparseable-args" "$SEARCH" "$DATA" 0
   run_malformed_no_usage "iccApplySearch threads-no-count" "$SEARCH" -threads
+  # argc == 1 and argc == 2 after the shift: the only two values that reach the
+  # post-"-threads" guard (a third operand clears minargs and goes to the parser).
+  #
+  # The anchor is passed in rather than inherited: it used to be a global that
+  # the per-tool table loop above assigned, so out here it still held whichever
+  # row the LAST entry set -- iccApplyToLink's "+1000", not iccApplySearch's
+  # "+10000" -- and assert_usage_screen() looked for a row this tool never
+  # prints and failed for the wrong reason.  It is now a parameter, so a case
+  # added anywhere has to name the screen it expects.
+  run_threads_operand_count "iccApplySearch threads-then-nothing" "$SEARCH" \
+    "+10000 - Use V5 sub-profile if present" 0 -threads 4
+  run_threads_operand_count "iccApplySearch threads-then-one-operand" "$SEARCH" \
+    "+10000 - Use V5 sub-profile if present" 1 -threads 4 -cfg
 fi
 
 echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total ==="

--- a/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
+++ b/Tools/CmdLine/IccApplySearch/iccApplySearch.cpp
@@ -295,8 +295,16 @@ int main(int argc, const char* argv[])
     argc -= 2;
 
     if (argc < minargs) {
+      // No `argc > 0 ?` clamp here, unlike the sibling message at the top of main().
+      // That guard runs before any adjustment, where argc is only bounded from above,
+      // so a process entered with argc == 0 would reach it and report "received -1" --
+      // well-defined arithmetic, just a nonsensical count -- and the clamp earns its
+      // place.  This copy runs after the minargs test has established argc >= 3 and
+      // after `argc -= 2`, so argc >= 1 on every path that reaches this line and the
+      // clamp's else branch was unreachable -- a dead bound the -threads shift created
+      // (code-scanning alert 2365, cpp/constant-comparison).
       fprintf(stderr, "Missing arguments after -threads: expected at least %d, received %d.\n",
-              minargs - 1, argc > 0 ? argc - 1 : 0);
+              minargs - 1, argc - 1);
       Usage(stderr);
       return EXIT_FAILURE;
     }


### PR DESCRIPTION
## What

Code-scanning alert **2365** (`cpp/constant-comparison`) on
`Tools/CmdLine/IccApplySearch/iccApplySearch.cpp` — *"Comparison is always true because
argc >= 1."*

> Referred to by number, not as `#2365`: on this repo that number is an already-merged
> pull request, and GitHub resolves a bare `#N` to an issue or PR, never to a
> code-scanning alert. The usual `fix(#N):` title shape would have cross-linked
> unrelated work permanently.

The alert is on code this repo merged **13 minutes earlier** in #2421 — the `-threads`
argument shift I added there created its own dead bound.

## Mechanism

Reaching the post-`-threads` message requires:

1. passing `if (argc < minargs)` at the top of `main()`, which establishes `argc >= 3`;
2. then `argv += 2; argc -= 2`.

So `argc >= 1` on every path that gets there, and the `argc > 0 ? argc - 1 : 0` clamp can
never take its else branch. `iccApplySearch -threads 4` is the tightest reachable form and
leaves `argc == 1`.

**Only the shifted copy is removed.** The identical shape at the top of `main()` — in all
four apply tools — runs *before* any adjustment, where `argc` is only bounded from above,
so a process entered with `argc == 0` would reach it and print `received -1`. That clamp is
load-bearing and stays. CodeQL flagged exactly one site, for exactly this reason.

## No behaviour change

Every reachable form produces identical status and diagnostics before and after:

| invocation | `argc` at the line | exit | message |
|---|---|---|---|
| `-threads 4` | 1 | 1 | `Missing arguments after -threads: expected at least 2, received 0.` |
| `-threads 4 -cfg` | 2 | 1 | `… received 1.` |
| *(bare)* | — | 1 | `Missing arguments: expected at least 2, received 0.` |
| `-threads` | — | 1 | `Missing thread count for -threads` |
| `-threads 4 -cfg x y` | — | 1 | *(parser diagnostic)* |

## Test

That guard had **no** coverage. The #2405 suite's `threads-no-count` case stops at the
earlier `Missing thread count` guard, which returns *before* the shift, so nothing
exercised the second message or the count it computes. Two cases now pin it at `argc == 1`
and `argc == 2` — the only two values that can reach it.

They do **not** red/green the clamp removal, and the suite says so: nothing can, because the
else branch was already unreachable. What they pin is the arithmetic the clamp stood in
front of — drop the `- 1` and both fail, reporting 1 and 2 where 0 and 1 are correct, with
no other case in the suite moving.

## Also: the ANCHOR global is retired

`assert_usage_screen()` read `ANCHOR` as a global assigned by the per-tool table loop, so
any case running outside that loop silently inherited the **last** entry's row. The two new
cases looked for iccApplyToLink's `+1000` in an iccApplySearch screen that prints `+10000`
and failed for the wrong reason. It is now a parameter, so a case added anywhere has to name
the screen it expects. Verified live: feeding a row no tool prints reds 9 cases rather than
passing silently.

The suite's red/green ledger was stale as a consequence — it claimed 22 of 26 where the file
now runs 28. Measured against `f186948c`, both new cases fail there too (the guard is a bare
`Usage(); return EXIT_FAILURE;` with no stream argument, so the screen lands on stdout and
there is no `Missing arguments after -threads` line at all). Corrected to 24 of 28.

## Pre-flight

- `iccdev.apply-usage-exit-code-regression` — **28/28**.
- Full `ctest` (251 tests) diffed against a control build of the same tree with master's
  sources: **zero new failures**.
- CI's warning gate (`grep -cE 'warning:' build.log` = 0) on both strict profiles:
  **clang 21.1.3** and, in the CI container, **GCC 15.2.0** with `strict warnings ENABLED`
  (`-Wall -Wextra -Wpedantic -Werror`). 148 objects each, including the changed TU.
- `shellcheck` clean; pre-flight safety gate matches master exactly.

Dispatched before opening this PR, per the reduced-check workflow:
**run `33997771987`, `ci_scope=source` — 13 success / 3 skipped.**
Verified in that run's `Tool Smoke Tests (ASAN+UBSAN, Debug)` job rather than inferred from
the green tick: `iccdev.apply-usage-exit-code-regression .... Passed`, in a job reporting
`100% tests passed, 0 tests failed out of 246`.

## Sibling alerts 2366 / 2367 — not fixed here, and why

Both sit on `iccApplyProfiles.cpp:279`, the `-h` guard from #2421:

```c
if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
```

They are **false positives** — `argc == 2` fully guards both `argv[1]` reads (two alerts
because there are two reads on the one line). The cause is in
`.github/codeql-queries/argv-unchecked-index.ql`: `hasArgcGuard` requires the guard's start
line to be *strictly less* than the access line, so a same-line guard is invisible.

Worth raising separately — that query has produced **exactly two alerts in its entire
history**, both on the only file under `Tools/CmdLine/` that spells `const char** argv`. The
other 16 `main()` definitions there use the `argv[]` array form, which `isArgv()`'s
`getUnspecifiedType() instanceof PointerType` test does not match, so the rule effectively
covers 1 of 17 tools. Happy to file that if useful.
