### PR TITLE
codeql: fix argv-unchecked-index scope and its same-line guard

### DIFF
--- a/.github/codeql-queries/argv-unchecked-index.ql
+++ b/.github/codeql-queries/argv-unchecked-index.ql
@@ -19,10 +19,25 @@
 
 import cpp
 
-/** A `main`-style argv parameter (char** or char*[] named argv). */
+/**
+ * A `main`-style argv parameter (char** or char*[] named argv).
+ *
+ * Both spellings have to be accepted, as this comment has always said.  A
+ * parameter written `char* argv[]` decays to a pointer at the call, but the
+ * extractor keeps the *declared* type, so its unspecified type is an
+ * `ArrayType` -- `char *[]` -- and never a `PointerType`.  Testing only for
+ * `PointerType` therefore matched `char** argv` alone.  Measured on a database
+ * of this tree, 19 functions under Tools/ take an (argc, argv) pair and 17 of
+ * them spell argv as an array, so `takesArgcArgv` was false for those 17 and
+ * the query reported clean over almost its entire stated scope
+ * (code-scanning alert 2366).
+ */
 predicate isArgv(Parameter p) {
   p.getName() = "argv" and
-  p.getType().getUnspecifiedType() instanceof PointerType
+  exists(Type t |
+    t = p.getType().getUnspecifiedType() and
+    (t instanceof PointerType or t instanceof ArrayType)
+  )
 }
 
 /** Function on the argc/argv path (main, or any function taking argc+argv). */
@@ -55,7 +70,33 @@ predicate hasArgcGuard(Function f, ArrayExpr access) {
   exists(ComparisonOperation cmp |
     cmp.getEnclosingFunction() = f and
     cmp.getAnOperand().(VariableAccess).getTarget().(Parameter).getName() = "argc" and
-    cmp.getLocation().getStartLine() < access.getLocation().getStartLine()
+    // The guard and the access sit on the *same* line in the short-circuit
+    // idiom every CmdLine tool spells its help screen with --
+    //   if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
+    // -- where `argv[1]` is read only because `argc == 2` already held.  A
+    // strict `<` on lines could not see that guard and reported the read twice,
+    // once per `argv[1]`: that is code-scanning alerts 2366 and 2367.
+    //
+    // Same line is not on its own enough, though.  Relaxing this to `<=` also
+    // swallows the case the line test exists to catch,
+    //   if (!strcmp(argv[1], "-x") && argc > 2)
+    // where argv[1] is read *before* argc is compared and is out of bounds at
+    // argc == 1.  So on a shared line, compare columns: the comparison has to
+    // start left of the access, which the help idiom satisfies and this one
+    // does not.
+    //
+    // Columns are still only an ordering approximation.  A guard written
+    // entirely on one line but inverted relative to the access -- `if (argc > 5)
+    // { ... } else { ... argv[3] ... }` -- reads left to right and is missed.
+    // `GuardCondition.controls()` is the sound way to do this and would replace
+    // the whole predicate; that is a much larger change than these alerts
+    // need.
+    (
+      cmp.getLocation().getStartLine() < access.getLocation().getStartLine()
+      or
+      cmp.getLocation().getStartLine() = access.getLocation().getStartLine() and
+      cmp.getLocation().getStartColumn() < access.getLocation().getStartColumn()
+    )
   )
   or
   // assert/return-on-bad-argc earlier

--- a/.github/codeql-queries/test/argv-unchecked-index/ArgvUncheckedIndex.expected
+++ b/.github/codeql-queries/test/argv-unchecked-index/ArgvUncheckedIndex.expected
@@ -1,0 +1,4 @@
+| Tools/CmdLine/case.h:26:15:26:21 | access to array | Access argv[1] in 'arraySpellingUnguarded' without a prior comparison against argc. Add `if (argc <= N) usage();` before this read. |
+| Tools/CmdLine/case.h:32:15:32:21 | access to array | Access argv[2] in 'constArraySpellingUnguarded' without a prior comparison against argc. Add `if (argc <= N) usage();` before this read. |
+| Tools/CmdLine/case.h:38:15:38:21 | access to array | Access argv[1] in 'pointerUnguarded' without a prior comparison against argc. Add `if (argc <= N) usage();` before this read. |
+| Tools/CmdLine/case.h:83:15:83:21 | access to array | Access argv[1] in 'readBeforeGuardSameLine' without a prior comparison against argc. Add `if (argc <= N) usage();` before this read. |

--- a/.github/codeql-queries/test/argv-unchecked-index/ArgvUncheckedIndex.qlref
+++ b/.github/codeql-queries/test/argv-unchecked-index/ArgvUncheckedIndex.qlref
@@ -1,0 +1,1 @@
+query: argv-unchecked-index.ql

--- a/.github/codeql-queries/test/argv-unchecked-index/Tools/CmdLine/case.h
+++ b/.github/codeql-queries/test/argv-unchecked-index/Tools/CmdLine/case.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the conditions in the
+ * ICC Software License are met.
+ */
+
+int strcmp(const char *a, const char *b);
+int puts(const char *s);
+
+// --- A. same-line short-circuit guard: the `-h`/`--help` idiom every
+//        Tools/CmdLine main() uses.  argv[1] is read only when argc == 2.
+//        MUST NOT be reported.
+int helpGuardSameLine(int argc, char **argv)
+{
+  if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
+    return 0;
+  return 1;
+}
+
+// --- B. array-spelled parameter, genuinely unguarded.  MUST be reported.
+int arraySpellingUnguarded(int argc, char *argv[])
+{
+  return puts(argv[1]);
+}
+
+// --- C. array-spelled, const-qualified, genuinely unguarded.  MUST be reported.
+int constArraySpellingUnguarded(int argc, const char *argv[])
+{
+  return puts(argv[2]);
+}
+
+// --- D. pointer-spelled, genuinely unguarded.  MUST be reported (existing TP).
+int pointerUnguarded(int argc, char **argv)
+{
+  return puts(argv[1]);
+}
+
+// --- E. pointer-spelled, guarded on an earlier line.  MUST NOT be reported.
+int pointerGuardedEarlier(int argc, char **argv)
+{
+  if (argc < 2)
+    return 1;
+  return puts(argv[1]);
+}
+
+// --- F. array-spelled, guarded on an earlier line.  MUST NOT be reported.
+int arrayGuardedEarlier(int argc, char *argv[])
+{
+  if (argc < 3)
+    return 1;
+  return puts(argv[2]);
+}
+
+// --- G. argv[0] is always valid.  MUST NOT be reported.
+int programName(int argc, char *argv[])
+{
+  return puts(argv[0]);
+}
+
+// --- H. the combination that actually occurs: array-spelled parameter *and*
+//        the same-line help guard.  Four of the five iccApply* tools are
+//        written this way, so widening isArgv() without also relaxing the
+//        line test would have turned one false positive into nine.
+//        MUST NOT be reported.
+int arrayHelpGuardSameLine(int argc, char *argv[])
+{
+  if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help")))
+    return 0;
+  return 1;
+}
+
+// --- I. the same-line case that is NOT a guard: argv[1] is read before argc
+//        is ever compared, so at argc == 1 this reads out of bounds.  Without
+//        this case the suite cannot tell a correct same-line relaxation from
+//        one that simply stops looking at the line -- every other MUST-NOT
+//        case here is one where the comparison really does dominate.
+//        MUST be reported.
+int readBeforeGuardSameLine(int argc, char *argv[])
+{
+  if (!strcmp(argv[1], "-x") && argc > 2)
+    return 0;
+  return 1;
+}

--- a/.github/codeql-queries/test/argv-unchecked-index/case.cpp
+++ b/.github/codeql-queries/test/argv-unchecked-index/case.cpp
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026 International Color Consortium.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the conditions in the
+ * ICC Software License are met.
+ */
+
+/*
+ * The cases live in Tools/CmdLine/case.h, not here, because
+ * argv-unchecked-index.ql restricts itself to files whose relative path
+ * begins "Tools/" -- a case compiled at this directory's root is outside the
+ * query's scope and the test passes while asserting nothing.  The qltest cpp
+ * extractor does not descend into subdirectories on its own, so the header is
+ * pulled in from a root-level .cpp it will compile; the functions' getFile()
+ * is then the header, whose relative path is Tools/CmdLine/case.h.
+ */
+#include "Tools/CmdLine/case.h"

--- a/.github/workflows/ci-codeql-query-tests.yml
+++ b/.github/workflows/ci-codeql-query-tests.yml
@@ -1,0 +1,147 @@
+###############################################################
+#
+# Copyright (c) 2025-2026 International Color Consortium.
+#                 All rights reserved.
+#                 https://color.org
+#
+## Intent: Run the CodeQL query unit tests under .github/codeql-queries/test
+##
+## Why this is a separate workflow rather than a job in
+## ci-codeql-security.yml: that workflow's pull_request trigger is
+## types:[labeled] and its analyze job additionally requires the
+## 'codeql-ready' label, because it builds the whole tree to make a
+## database.  These tests need no database and no build -- the qltest
+## extractor compiles the fixture itself -- so they can and should run on
+## every PR that edits a query.  Adding them there would have meant
+## widening that workflow's triggers for every PR.
+##
+## NOTE: CODEQL_VER/CODEQL_SHA256 below are a THIRD pin site for the CodeQL
+## bundle, alongside ci-codeql-security.yml and ci-preflight-safety.yml.
+## Bump all three together; docs/codeql.md lists them.
+#
+###############################################################
+
+name: "ci-codeql-query-tests"
+
+# Pinned SHAs and CodeQL command strings exceed line length.
+# yamllint disable rule:line-length
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - '.github/codeql-queries/**'
+      - '.github/workflows/ci-codeql-query-tests.yml'
+  push:
+    branches:
+      - master
+    paths:
+      - '.github/codeql-queries/**'
+      - '.github/workflows/ci-codeql-query-tests.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: "codeql-query-tests-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}"
+  cancel-in-progress: true
+
+jobs:
+  query-tests:
+    name: CodeQL Query Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5  # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Install CodeQL CLI
+        shell: bash --noprofile --norc {0}
+        env:
+          BASH_ENV: /dev/null
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          # Unlike the sibling workflows this does NOT fall back to a codeql
+          # already on PATH.  Query-test output carries extractor line/column
+          # locations that .expected files assert exactly, so an unpinned CLI
+          # could flip these tests PASS/FAIL for reasons unrelated to the diff.
+          # CODEQL_SHA256 is the release asset digest for this exact bundle, so the
+          # two values below must always be refreshed together:
+          #   gh api repos/github/codeql-action/releases/tags/codeql-bundle-v"$CODEQL_VER" \
+          #     --jq '.assets[]|select(.name=="codeql-bundle-linux64.tar.gz").digest'
+          CODEQL_VER="2.26.4"
+          CODEQL_ARCHIVE="/tmp/codeql-bundle-linux64.tar.gz"
+          CODEQL_SHA256="48e1ab8b874d57bd6fd7c90fefee75addc5a45e9bd063982df9beb45a62dd5d3"
+          CODEQL_URL="https://github.com/github/codeql-action/releases/download"
+          curl -fsSL --retry 3 \
+            -o "${CODEQL_ARCHIVE}" \
+            "${CODEQL_URL}/codeql-bundle-v${CODEQL_VER}/codeql-bundle-linux64.tar.gz"
+          printf '%s  %s\n' "${CODEQL_SHA256}" "${CODEQL_ARCHIVE}" | sha256sum -c -
+          tar xzf "${CODEQL_ARCHIVE}" -C /opt
+          # Prepend, so a codeql already on the runner image cannot win.
+          echo "/opt/codeql" >> "$GITHUB_PATH"
+
+      - name: Install CodeQL pack dependencies
+        shell: bash --noprofile --norc {0}
+        env:
+          BASH_ENV: /dev/null
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          # Both installs, as .github/codeql-queries/README.md prescribes.
+          # With the pinned bundle above these mostly resolve from the bundle's
+          # own qlpacks (it rewrites the lock files to an empty dependency set
+          # in the process -- harmless here, but do not commit that churn).
+          # They matter for a standalone CLI, where the query pack's lock
+          # supplies codeql/cpp-all 8.0.3 and the test pack pins that same
+          # version; the second install is what keeps the two in step if the
+          # query pack's lock is ever regenerated against a newer cpp-all.
+          codeql pack install .github/codeql-queries
+          codeql pack install .github/codeql-queries/test \
+            --additional-packs=.github/codeql-queries
+
+      - name: Run query unit tests
+        shell: bash --noprofile --norc {0}
+        env:
+          BASH_ENV: /dev/null
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+
+          # A qltest whose sources the extractor cannot see still reports
+          # PASSED, against an empty database -- the argv-unchecked-index
+          # fixture did exactly that twice while it was being written, once
+          # printing "found nothing to extract".  The cpp extractor does not
+          # descend into subdirectories, so require a source file beside every
+          # .qlref.  This checks the necessary condition only: it says the
+          # extractor has something to compile, not that compiling it produced
+          # a non-empty database.  A suite with a non-empty .expected already
+          # proves that itself; this is the backstop for all-negative suites,
+          # which cannot.
+          missing=0
+          while IFS= read -r ref; do
+            d="$(dirname "$ref")"
+            # find, not `ls a b c`: ls exits non-zero when *any* glob is
+            # unmatched, so absent .cc/.cxx would fail a directory that has a
+            # perfectly good .cpp.
+            if [ -z "$(find "$d" -maxdepth 1 -type f \
+                        \( -name '*.c' -o -name '*.cpp' \
+                           -o -name '*.cc' -o -name '*.cxx' \) -print -quit)" ]; then
+              echo "[FAIL] $d has $(basename "$ref") but no source file beside it" >&2
+              missing=1
+            fi
+          done < <(find .github/codeql-queries/test -name '*.qlref' -print)
+          [ "$missing" -eq 0 ] || exit 1
+
+          codeql test run .github/codeql-queries/test \
+            --additional-packs=.github/codeql-queries \
+            --threads=0

--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,8 @@ build-cfl-smoke/
 **/RefIccMAXTargets.cmake
 **/compile_commands.json
 codeql-results/
+# Databases `codeql test run` extracts next to each test directory.
+*.testproj/
 
 # Built tool binaries (no extension on Linux)
 # DANGER - this line overfilters and removes the ability to add or change CMakeList.txt files in the tools directory

--- a/docs/codeql.md
+++ b/docs/codeql.md
@@ -17,10 +17,17 @@ Run local analysis with:
 .github/scripts/run-codeql-local.sh
 ```
 
-The bootstrap path in `ci-codeql-security.yml` and
-`ci-preflight-safety.yml` is pinned to CodeQL bundle 2.26.4 and verifies the
+The bootstrap path in `ci-codeql-security.yml`, `ci-preflight-safety.yml` and
+`ci-codeql-query-tests.yml` is pinned to CodeQL bundle 2.26.4 and verifies the
 official Linux release-asset SHA-256 before extraction. Update the version and
-digest together in both workflows.
+digest together in all three workflows -- a bump applied to only some of them
+fails the others at their next `sha256sum -c`.
+
+`ci-codeql-query-tests.yml` runs the checked-in query unit tests under
+`.github/codeql-queries/test` on any PR touching `.github/codeql-queries/**`.
+It builds no database. Unlike the other two it never falls back to a `codeql`
+already on the runner's PATH, because `.expected` files assert extractor
+line/column locations exactly and an unpinned CLI can flip them.
 
 The GitHub Actions CodeQL workflow uploads only the standard
 `cpp-security-and-quality` SARIF. Run custom iccDEV query suites locally and


### PR DESCRIPTION
Closes the two open `iccdev/argv-unchecked-index` code-scanning alerts on
`iccApplyProfiles.cpp:279`, and fixes the reason the query produced them.

- [alert 2366](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/2366)
- [alert 2367](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/2367)

## The alerts

Line 279 is the help-screen guard:

```cpp
if (argc == 2 && (!strcmp(argv[1], "-h") || !strcmp(argv[1], "--help"))) {
```

`argv[1]` is read only because `argc == 2` already held. Two alerts rather
than one because the line reads `argv[1]` twice — they are not duplicates of
each other, they are columns 29 and 55.

## Two defects, which have to be fixed together

**1. `hasArgcGuard()` required the guard on a strictly earlier line.**
`cmp.getStartLine() < access.getStartLine()` cannot see a guard that
short-circuits on the same line, which is how every `Tools/CmdLine` tool
spells its help screen.

Same line is not on its own enough, though. A plain `<=` also swallows the
case the ordering test exists for — `if (!strcmp(argv[1], "-x") && argc > 2)`,
where `argv[1]` is read *before* `argc` is compared and is out of bounds at
`argc == 1`. On a shared line the fix therefore compares **columns**: the
comparison has to start left of the access.

| line test | `helpGuard` (must not fire) | `readBeforeGuard` (must fire) |
|---|---|---|
| `<` (today) | fires — the two alerts | fires |
| `<=` | silent | **missed** |
| column-ordering | silent | fires |

Still an approximation: a one-line guard inverted relative to its access
(`if (argc > 5) { … } else { … argv[3] … }`) reads left to right and is
missed. `GuardCondition.controls()` is the sound replacement for the whole
predicate and is much more than these alerts need.

**2. `isArgv()` required the parameter's unspecified type to be a
`PointerType`.** A parameter written `char* argv[]` keeps its declared type in
the extractor, so it is an `ArrayType` and never matched — even though the
predicate's own comment has always said "char** or char*[]".

Fixing (2) alone makes things worse: four of the five `iccApply*` tools use
the array spelling *and* the same-line guard, so widening `isArgv()` without
relaxing the line test takes the tree from 2 false positives to 10. The
`arrayHelpGuardSameLine` case pins that.

## Measured, on a database built from this tree

| | before | after |
|---|---|---|
| `argv[N>0]` reads under `Tools/` in query scope | 13 / 229 (5.7%) | 229 / 229 |
| findings | 2 (both false) | 0 |

The `0` is a real result, not a silent one: every one of the 229 reads now in
scope carries an `argc` comparison ordered before it. `hasArgcGuard()` remains
an ordering approximation rather than control-flow dominance, so that means
"an `argc` comparison precedes this read", not "this read is provably guarded".

## Tests

Adds the red/green test the fix was developed against. It discriminates three
ways — it fails on the unfixed query (the two same-line false positives
present, the array-spelled true positives missing) **and** on a plain `<=`
relaxation, which drops `readBeforeGuardSameLine`. Without that last case the
suite could not tell a correct same-line rule from one that merely stops
looking at the line.

The cases live in `Tools/CmdLine/case.h` rather than beside the `.qlref`
because the query filters on a `Tools/` path prefix and the qltest cpp
extractor does not descend into subdirectories: a case compiled at the test
root is out of the query's scope and the test passes having asserted nothing.
That is not hypothetical — the fixture did exactly that twice while it was
being written, once printing `found nothing to extract` and still `PASSED`.

## Nothing was running these tests

`ci-codeql-security.yml` builds a database and its `analyze` job is gated
behind the `codeql-ready` label, so the existing `unbounded-profile-loop` test
had never run in CI either. `ci-codeql-query-tests.yml` runs them on any PR
touching `.github/codeql-queries/**`; it needs no database and no build
(~3 min, dominated by query compilation). It is a separate workflow rather
than a job in `ci-codeql-security.yml` because that workflow's `pull_request`
trigger is `types:[labeled]`; adding the tests there would have meant widening
its triggers for every PR.

Two deliberate differences from the sibling workflows:

- it asserts every test directory has a source file beside its `.qlref`, so
  the extract-nothing failure cannot pass silently again;
- it always installs the SHA-pinned bundle instead of accepting a `codeql`
  already on the runner, because `.expected` asserts extractor line/column
  locations exactly and an unpinned CLI could flip these tests for reasons
  unrelated to the diff.

`docs/codeql.md` named two bundle pin sites; this makes three, so the doc and
the new workflow's header now name all three.

Also gitignores `*.testproj/`, the databases `codeql test run` extracts beside
each test directory. They were never ignored, so running the tests left
untracked directories behind.

## Verification

- Red/green confirmed three ways (unfixed / `<=` / shipped).
- Full suite passes on CodeQL 2.25.6 and on the CI-pinned bundle 2.26.4, so
  the `.expected` locations are version-stable.
- Pack resolution checked from an emptied package cache, not a warm one.
- `preflight-safety-checks.sh`: 0 failures. `yamllint` on the new workflow
  reports the same two warnings `ci-codeql-security.yml` reports
  (`document-start`, `truthy`) and nothing else.
