### PR TITLE
fix(#2420): escape console text by codepoint, not by byte

### DIFF
--- a/.github/ci/regression/console-sanitize-codepoint.cpp
+++ b/.github/ci/regression/console-sanitize-codepoint.cpp
@@ -1,0 +1,213 @@
+// #2420 -- icSanitizeConsoleText() escapes by codepoint, not by byte.
+//
+// #2419 routed the four iccApply* tools' diagnostics through the library helper
+// icSanitizeConsoleText() (IccProfLib/IccFileUtil.h).  The pre-merge note on that PR
+// raised the cost: the helper escaped every byte >= 0x7f, so a legitimate UTF-8 path
+// rendered as '\xC3\xA9cran-Profil.icc' -- two hex escapes for one character, in
+// success output as well as errors.
+//
+// The obvious fix -- pass valid UTF-8 through -- is a net regression, and this test
+// exists mostly to keep that from being re-tried:
+//
+//   * U+202E RIGHT-TO-LEFT OVERRIDE is itself valid UTF-8.  A name carrying it renders
+//     reversed from that point, so 'gnp.<RLO>cci' displays as 'icc.png' -- Trojan
+//     Source, CVE-2021-42574.  The byte bound blocked that by accident.
+//   * U+0080..U+009F are the C1 controls, which a terminal still acts on, and which
+//     UTF-8 spells as the perfectly valid two-byte sequences C2 80..C2 9F.  U+009B is
+//     CSI: the same escape the #2406 fix was written to neutralise, wearing UTF-8.
+//   * Nothing in this tree sets a console code page, so raw UTF-8 is mojibake on the
+//     four Windows legs.
+//
+// So the whitelist is kept -- everything that is not printable ASCII is still escaped --
+// and only the SPELLING of the escape changes: one \uXXXX (or \UXXXXXXXX above the BMP)
+// per codepoint instead of one \xHH per byte.  Malformed UTF-8 has no codepoint to name
+// and keeps the per-byte form, one byte at a time, so an invalid lead byte cannot
+// swallow the bytes after it.
+//
+// Two properties matter more than any single expected string, and both are checked over
+// the whole range rather than sampled:
+//
+//   1. ASCII in, identical ASCII out.  Only bytes >= 0x80 reach the new path, so every
+//      existing caller and every existing assertion about ASCII output is untouched --
+//      including iccdev.apply-console-injection-regression, which greps for \x1B.
+//      Checked for all 255 single-byte inputs.
+//   2. The output is always printable ASCII.  That is the security invariant the helper
+//      exists for, and it is what a blacklist could never guarantee.  Checked on every
+//      case below, including the malformed ones.
+//
+// Red/green: built against master at 5dfafa80 the ten well-formed-UTF-8 cases fail, each
+// reporting the \xHH run the helper used to emit, and the 255 single-byte, malformed and
+// edge cases pass on BOTH builds -- which is what makes property 1 a measurement rather
+// than a claim.
+//
+// Returns 0 on success; the number of failed assertions otherwise (each printed).
+
+#include "IccFileUtil.h"
+
+#include <string>
+
+#include <cstdio>
+#include <cstring>
+
+namespace {
+
+int g_fail = 0;
+
+void fail(const char *what, const std::string &got, const char *want)
+{
+  ++g_fail;
+  std::fprintf(stderr, "[console-sanitize-codepoint] FAIL: %s (got \"%s\", want \"%s\")\n",
+               what, got.c_str(), want);
+}
+
+// Every case also has to satisfy property 2, so it is enforced here rather than in a
+// separate pass that a new case could be added without.
+void checkEscape(const char *what, const char *in, const char *want)
+{
+  std::string got = icSanitizeConsoleText(in);
+
+  if (got != want) {
+    fail(what, got, want);
+    return;
+  }
+
+  for (std::string::size_type i = 0; i < got.size(); i++) {
+    unsigned char ch = (unsigned char)got[i];
+    if (ch < 0x20 || ch >= 0x7f) {
+      ++g_fail;
+      std::fprintf(stderr,
+                   "[console-sanitize-codepoint] FAIL: %s left byte 0x%02X at offset %u "
+                   "in the sanitized output\n",
+                   what, ch, (unsigned)i);
+      return;
+    }
+  }
+}
+
+// Property 1: ASCII input is passed through exactly as the byte-wise helper did.  Stated
+// as an independent expectation rather than by calling the helper twice, so a change to
+// the ASCII branch cannot satisfy this by agreeing with itself.
+void testAsciiUnchanged()
+{
+  for (int b = 0x01; b <= 0xff; b++) {
+    char in[2];
+    char want[8];
+
+    in[0] = (char)b;
+    in[1] = '\0';
+
+    if (b == '\n')      std::snprintf(want, sizeof(want), "\\n");
+    else if (b == '\r') std::snprintf(want, sizeof(want), "\\r");
+    else if (b == '\t') std::snprintf(want, sizeof(want), "\\t");
+    else if (b >= 0x20 && b < 0x7f) { want[0] = (char)b; want[1] = '\0'; }
+    else                std::snprintf(want, sizeof(want), "\\x%02X", b);
+
+    // A lone byte >= 0x80 is never a well-formed UTF-8 sequence, so the whole range
+    // stays on the per-byte form here -- that is the malformed case, not a counterexample
+    // to the codepoint spelling, which needs a complete sequence.
+    std::string got = icSanitizeConsoleText(in);
+    if (got != want) {
+      char what[64];
+      std::snprintf(what, sizeof(what), "single byte 0x%02X", b);
+      fail(what, got, want);
+    }
+  }
+}
+
+// The issue's own case, plus the widths either side of it.
+void testCodepointSpelling()
+{
+  checkEscape("U+00E9 in a filename",  "\xC3\xA9" "cran-Profil.icc", "\\u00E9cran-Profil.icc");
+  checkEscape("U+00A0 no-break space", "\xC2\xA0",                   "\\u00A0");
+  checkEscape("U+8272 three-byte",     "\xE8\x89\xB2",               "\\u8272");
+  checkEscape("U+1F600 four-byte",     "\xF0\x9F\x98\x80",           "\\U0001F600");
+  checkEscape("U+10FFFF upper bound",  "\xF4\x8F\xBF\xBF",           "\\U0010FFFF");
+  checkEscape("mixed run",             "a\xC3\xA9" "b\xE8\x89\xB2" "c",
+                                       "a\\u00E9b\\u8272c");
+}
+
+// The reason passthrough was rejected.  Each of these is well-formed UTF-8 and must
+// still come out escaped.
+void testTerminalActiveCodepointsStillEscaped()
+{
+  checkEscape("U+009B CSI as UTF-8",   "x\xC2\x9B" "[31my",          "x\\u009B[31my");
+  checkEscape("U+202E RLO",            "gnp.\xE2\x80\xAE" "cci",     "gnp.\\u202Ecci");
+  checkEscape("U+FEFF BOM",            "\xEF\xBB\xBF" "a",           "\\uFEFFa");
+  checkEscape("U+200B zero width",     "a\xE2\x80\x8B" "b",          "a\\u200Bb");
+  // The ASCII ESC the #2406 fix targeted is unchanged by all of this.
+  checkEscape("ASCII ESC unchanged",   "a\x1b" "[31mb",              "a\\x1B[31mb");
+}
+
+// RFC 3629 rejects these, so there is no codepoint to name and the per-byte form stands.
+// Each also proves the invalid lead advanced by exactly one byte.
+void testMalformedFallsBackPerByte()
+{
+  checkEscape("lone continuation",     "a\x80" "b",                  "a\\x80b");
+  checkEscape("overlong two-byte",     "\xC0\xAF",                   "\\xC0\\xAF");
+  checkEscape("overlong three-byte",   "\xE0\x80\xAF",               "\\xE0\\x80\\xAF");
+  checkEscape("overlong four-byte",    "\xF0\x80\x80\xAF",           "\\xF0\\x80\\x80\\xAF");
+  checkEscape("UTF-8 surrogate D800",  "\xED\xA0\x80",               "\\xED\\xA0\\x80");
+  checkEscape("above U+10FFFF",        "\xF4\x90\x80\x80",           "\\xF4\\x90\\x80\\x80");
+  checkEscape("F5 lead",               "\xF5\x80\x80\x80",           "\\xF5\\x80\\x80\\x80");
+  checkEscape("FF is never a lead",    "\xFF",                       "\\xFF");
+  checkEscape("truncated two-byte",    "\xC3",                       "\\xC3");
+  checkEscape("truncated three-byte",  "\xE8\x89",                   "\\xE8\\x89");
+  // The lead is escaped alone and the ASCII after it survives: a greedy fallback would
+  // have consumed the 'A' as though it were a continuation byte.
+  checkEscape("bad lead then ASCII",   "\xC3" "A",                   "\\xC3A");
+}
+
+// The escape names the codepoint, so two encodings that a terminal renders identically
+// stay distinguishable -- the concrete cost of rendering raw UTF-8.
+void testDistinctFormsStayDistinct()
+{
+  std::string precomposed = icSanitizeConsoleText("\xC3\xA9");         // U+00E9
+  std::string decomposed  = icSanitizeConsoleText("e\xCC\x81");        // e + U+0301
+
+  if (precomposed == decomposed) {
+    ++g_fail;
+    std::fprintf(stderr,
+                 "[console-sanitize-codepoint] FAIL: precomposed and decomposed forms "
+                 "both rendered as \"%s\"\n", precomposed.c_str());
+  }
+}
+
+void testEdges()
+{
+  checkEscape("empty string", "", "");
+
+  if (!icSanitizeConsoleText((const char *)0).empty()) {
+    ++g_fail;
+    std::fprintf(stderr, "[console-sanitize-codepoint] FAIL: null input was not empty\n");
+  }
+
+  // The std::string overload must agree with the char* one.
+  std::string s = "\xC3\xA9" "cran";
+  if (icSanitizeConsoleText(s) != icSanitizeConsoleText(s.c_str())) {
+    ++g_fail;
+    std::fprintf(stderr,
+                 "[console-sanitize-codepoint] FAIL: std::string overload disagrees\n");
+  }
+}
+
+} // namespace
+
+int main()
+{
+  testAsciiUnchanged();
+  testCodepointSpelling();
+  testTerminalActiveCodepointsStillEscaped();
+  testMalformedFallsBackPerByte();
+  testDistinctFormsStayDistinct();
+  testEdges();
+
+  if (g_fail)
+    std::fprintf(stderr, "[console-sanitize-codepoint] %d assertion(s) failed\n", g_fail);
+  else
+    std::printf("[console-sanitize-codepoint] all assertions passed\n");
+
+  // Not `return g_fail`: the exit status is truncated to 8 bits, and
+  // testAsciiUnchanged() alone can contribute 255 failures, so a count landing on
+  // a multiple of 256 would exit 0 and report this test green.
+  return g_fail ? 1 : 0;
+}

--- a/.github/scripts/iccdev-issue-2406-apply-console-injection-regression.sh
+++ b/.github/scripts/iccdev-issue-2406-apply-console-injection-regression.sh
@@ -13,7 +13,10 @@
 #   IccConnect.cpp; iccApplyToLink prints argv directly.
 #
 # The library already had the helper -- icSanitizeConsoleText() in
-# IccProfLib/IccFileUtil.h, which escapes C0/C1 and anything >= 0x7f as \xHH.
+# IccProfLib/IccFileUtil.h.  It escapes everything that is not printable ASCII:
+# ASCII controls, 0x7F and malformed bytes as \xHH, and -- since #2420 -- each
+# non-ASCII codepoint as one \uXXXX (\UXXXXXXXX above the BMP) rather than one
+# \xHH per byte.  The cases below are all ASCII ESC, which is unaffected.
 # iccSpecSepToTiff routes its OWN prints through it, which is why these four
 # tools looked like the whole story; measured, it still emitted 4 raw ESC bytes
 # on f186948c, because the leak it shares with iccApplyProfiles is not in either

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4632,6 +4632,52 @@ function(iccdev_add_tiff_separated_strips_test)
   endif()
 endfunction()
 
+function(iccdev_add_console_sanitize_codepoint_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccConsoleSanitizeCodepointTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/console-sanitize-codepoint.cpp"
+  )
+  target_compile_features(iccConsoleSanitizeCodepointTest PRIVATE cxx_std_17)
+
+  target_include_directories(iccConsoleSanitizeCodepointTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  # IccFileUtil.h is header-only, so this target links nothing and needs no runtime
+  # search path -- hence no ENVIRONMENT_MODIFICATION block on Windows, unlike the
+  # neighbouring regression tests.  It also makes the test the header's only standalone
+  # consumer: the four iccApply* tools reach it through IccProfLib, so without this the
+  # header is never compiled on its own and an include it forgot to make would surface
+  # as a tool build break instead of here.
+  add_dependencies(check iccConsoleSanitizeCodepointTest)
+
+  # Needing no library path is not a reason to drop ICCDEV_TEST_ENV: it also carries
+  # ASAN_OPTIONS/UBSAN_OPTIONS and the empty DEBUGINFOD_URLS.  Without it this test
+  # would inherit the container's Ubuntu default for the last of those, and one
+  # symbolized sanitizer report would spend ~90s in llvm-symbolizer against the
+  # TIMEOUT below -- the #1928 stall documented further down this file.
+  if(WIN32)
+    add_test(
+      NAME iccdev.console-sanitize-codepoint
+      COMMAND "$<TARGET_FILE:iccConsoleSanitizeCodepointTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.console-sanitize-codepoint
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccConsoleSanitizeCodepointTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.console-sanitize-codepoint PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;security;console;sanitize;issue-2420;regression"
+  )
+endfunction()
+
 function(iccdev_add_signature_utils_contract_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -6999,6 +7045,7 @@ if(WIN32)
   iccdev_add_struct_name_spelling_test()
   iccdev_add_mcs_colorspace_name_test()
   iccdev_add_signature_utils_contract_test()
+  iccdev_add_console_sanitize_codepoint_test()
   iccdev_add_tiff_create_overflow_test()
   iccdev_add_tiff_separated_strips_test()
   iccdev_add_mpexml_unknown_reserved_test()
@@ -7367,6 +7414,7 @@ iccdev_add_tag_name_spelling_test()
 iccdev_add_struct_name_spelling_test()
 iccdev_add_mcs_colorspace_name_test()
 iccdev_add_signature_utils_contract_test()
+iccdev_add_console_sanitize_codepoint_test()
 iccdev_add_tiff_create_overflow_test()
 iccdev_add_tiff_separated_strips_test()
 iccdev_add_mpexml_unknown_reserved_test()

--- a/IccProfLib/IccFileUtil.h
+++ b/IccProfLib/IccFileUtil.h
@@ -71,6 +71,79 @@
 #include <unistd.h>
 #endif
 
+// Decodes one UTF-8 sequence at p per RFC 3629, rejecting overlong forms, the
+// surrogate range and anything above U+10FFFF.  Returns the sequence length and
+// stores the codepoint, or 0 when p does not begin a well-formed sequence.  p is
+// NUL-terminated, so a truncated sequence fails a continuation-byte test rather
+// than reading past the end.
+//
+// Why this is not icConvertUTF8toUTF32() from IccConvertUTF.h.  Two reasons, the
+// second measured:
+//
+//   1. That entry point is ICCPROFLIB_API, and this header is header-only by
+//      design -- a sanitizer that every tool's error path calls should not drag
+//      in a link dependency.
+//   2. Its strictConversion mode is not strict enough for this use.  isLegalUTF8()
+//      (IccConvertUTF.cpp:450) tests the second byte in an inner switch whose
+//      0xED and 0xF4 arms check only an upper bound -- `a > 0x9F` and `a > 0x8F`
+//      -- and so never reach the `default:` arm's lower-bound test `a < 0x80`.
+//      Both leads therefore accept all 127 second bytes in 0x01..0x7F: ED 01 80
+//      decodes as U+B040, and F4 01 80 80 as U+81000, which is not a codepoint at
+//      all.  Compared exhaustively over every 1-3 byte sequence and every
+//      F0..F5-led 4-byte sequence (116,134,905 in total), this function accepts
+//      nothing that one rejects and agrees on every codepoint and length where
+//      both accept; the converter accepts 528,320 sequences this one refuses.
+//      Reusing it would let a malformed path be reported under a fabricated
+//      codepoint -- still ASCII, so not an injection, but the wrong name for the
+//      file.  The converter's own behaviour is a separate defect and is not
+//      changed here.
+inline int icDecodeUtf8(const unsigned char* p, unsigned int* pCp)
+{
+  unsigned char c0 = p[0];
+  unsigned char lo, hi;
+  unsigned int cp;
+  int len, i;
+
+  if (c0 < 0x80) {
+    *pCp = c0;
+    return 1;
+  }
+
+  if (c0 >= 0xc2 && c0 <= 0xdf) {
+    // C0 and C1 are excluded above: they can only spell an overlong 2-byte form.
+    len = 2; cp = c0 & 0x1fu; lo = 0x80; hi = 0xbf;
+  }
+  else if (c0 >= 0xe0 && c0 <= 0xef) {
+    len = 3; cp = c0 & 0x0fu;
+    // E0 A0..BF rejects the overlong 3-byte forms; ED 80..9F rejects
+    // U+D800..U+DFFF, which UTF-8 must not encode.
+    lo = (c0 == 0xe0) ? 0xa0 : 0x80;
+    hi = (c0 == 0xed) ? 0x9f : 0xbf;
+  }
+  else if (c0 >= 0xf0 && c0 <= 0xf4) {
+    len = 4; cp = c0 & 0x07u;
+    // F0 90..BF rejects the overlong 4-byte forms; F4 80..8F caps at U+10FFFF.
+    lo = (c0 == 0xf0) ? 0x90 : 0x80;
+    hi = (c0 == 0xf4) ? 0x8f : 0xbf;
+  }
+  else {
+    // A lone continuation byte (80..BF), an overlong lead (C0/C1), or F5..FF.
+    return 0;
+  }
+
+  for (i = 1; i < len; i++) {
+    // The tighter bound applies to the second byte only; the rest are 80..BF.
+    unsigned char ch = p[i];
+    if (ch < ((i == 1) ? lo : (unsigned char)0x80) ||
+        ch > ((i == 1) ? hi : (unsigned char)0xbf))
+      return 0;
+    cp = (cp << 6) | (ch & 0x3fu);
+  }
+
+  *pCp = cp;
+  return len;
+}
+
 inline std::string icSanitizeConsoleText(const char* szText)
 {
   static const char hex[] = "0123456789ABCDEF";
@@ -79,30 +152,48 @@ inline std::string icSanitizeConsoleText(const char* szText)
   if (!szText)
     return result;
 
-  for (const unsigned char *p = (const unsigned char*)szText; *p; p++) {
+  for (const unsigned char *p = (const unsigned char*)szText; *p; ) {
     unsigned char ch = *p;
 
-    switch (ch) {
-    case '\n':
-      result += "\\n";
-      break;
-    case '\r':
-      result += "\\r";
-      break;
-    case '\t':
-      result += "\\t";
-      break;
-    default:
-      if (ch < 0x20 || ch >= 0x7f) {
-        result += "\\x";
-        result += hex[(ch >> 4) & 0xf];
-        result += hex[ch & 0xf];
-      }
-      else {
-        result += (char)ch;
-      }
-      break;
+    if (ch == '\n') { result += "\\n"; p++; continue; }
+    if (ch == '\r') { result += "\\r"; p++; continue; }
+    if (ch == '\t') { result += "\\t"; p++; continue; }
+
+    if (ch >= 0x20 && ch < 0x7f) {
+      result += (char)ch;
+      p++;
+      continue;
     }
+
+    if (ch >= 0x80) {
+      // #2420: escape non-ASCII by codepoint rather than per byte, so an
+      // accented name reads as one U+00E9 escape instead of \xC3\xA9.  The whitelist
+      // itself is unchanged -- every non-ASCII codepoint is still escaped,
+      // including the C1 controls U+0080..U+009F, which UTF-8 spells as
+      // C2 80..C2 9F and a terminal still acts on, and U+202E RIGHT-TO-LEFT
+      // OVERRIDE (CVE-2021-42574).  Passing valid UTF-8 through would admit
+      // both.  ASCII input is unaffected: only bytes >= 0x80 come through here.
+      unsigned int cp = 0;
+      int len = icDecodeUtf8(p, &cp);
+
+      if (len > 1) {
+        int digits = (cp > 0xffffu) ? 8 : 4;
+        int shift;
+
+        result += (digits == 8) ? "\\U" : "\\u";
+        for (shift = (digits - 1) * 4; shift >= 0; shift -= 4)
+          result += hex[(cp >> shift) & 0xfu];
+        p += len;
+        continue;
+      }
+      // Not well-formed UTF-8.  Fall through to the per-byte escape and advance
+      // a single byte, so an invalid lead cannot consume the bytes after it.
+    }
+
+    result += "\\x";
+    result += hex[(ch >> 4) & 0xf];
+    result += hex[ch & 0xf];
+    p++;
   }
 
   return result;


### PR DESCRIPTION
Part of #2420 — the escape half. The `IccCmmConfig.cpp` call site noted at the end is a separate ruling, so this does not close the issue.

## What the pre-merge note asked

#2419 routed the four `iccApply*` tools' diagnostics through `icSanitizeConsoleText()`, which escaped every byte `>= 0x7f`. A legitimate UTF-8 path then rendered as `\xC3\xA9cran-Profil.icc` — two hex escapes for one character, in success output as well as errors.

## Why passing valid UTF-8 through would be a net regression

The byte bound was blocking three things by accident, and all three are valid UTF-8:

| input | codepoint | why it matters |
|---|---|---|
| `E2 80 AE` | U+202E RIGHT-TO-LEFT OVERRIDE | `gnp.<RLO>cci` renders as `icc.png` — Trojan Source, CVE-2021-42574 |
| `C2 9B` | U+009B CSI | the same escape #2406 was written to neutralise, wearing UTF-8 |
| `EF BB BF` | U+FEFF | zero-width, invisible in a path |

Nothing in this tree sets a console code page either, so raw UTF-8 is mojibake on the four Windows legs.

## What this does instead

The whitelist is unchanged — everything that is not printable ASCII is still escaped. Only the **spelling** changes: one `\uXXXX` (or `\UXXXXXXXX` above the BMP) per codepoint instead of one `\xHH` per byte. Malformed UTF-8 has no codepoint to name and keeps the per-byte form, advancing a single byte so an invalid lead cannot swallow the ASCII after it.

```
before: unable to open ICC profile 'gnp.\xE2\x80\xAEcci'
after:  unable to open ICC profile 'gnp.\u202Ecci'
```

Only bytes `>= 0x80` reach the new path, so ASCII output is byte-identical for every caller — including `iccdev.apply-console-injection-regression`, which asserts on `\x1B`.

## Why not `icConvertUTF8toUTF32()`

Two reasons, the second measured. It is `ICCPROFLIB_API` and this header is header-only; and its `strictConversion` mode is not strict enough for this use. `isLegalUTF8()`'s `0xED` and `0xF4` arms check only an upper bound on the second byte and never apply the lower one, so both leads accept all 127 second bytes in `0x01..0x7F` — `ED 01 80` decodes as U+B040, `F4 01 80 80` as U+81000, which is not a Unicode scalar value.

Compared exhaustively over every 1–3 byte sequence and every `F0..F5`-led 4-byte sequence — 116,134,905 in total:

| | count |
|---|---|
| accepted here, rejected by `icConvertUTF8toUTF32` | **0** |
| accepted by `icConvertUTF8toUTF32`, rejected here | **528,320** |
| both accept, disagree on codepoint or length | **0** |

That converter defect is untouched here and is filed separately as #2435.

## Test

New CTest `iccdev.console-sanitize-codepoint` — a compiled regression, so unlike the script tests it also runs on Windows, and it is the header's only standalone consumer.

Red/green against master at `5dfafa80`: the **10** well-formed-UTF-8 cases fail, and the 255 single-byte, malformed and edge cases pass on **both** builds. That second half is what makes "ASCII output unchanged" a measurement rather than a claim.

Local: 252/252 CTests, one pre-existing unrelated failure (`iccdev.spectral-tiff-preview`, missing Python `imagecodecs`).
