### PR TITLE
fix(#2401): give the element form of an XML array the text form's acceptance

### DIFF
--- a/.github/scripts/iccdev-issue-2401-xml-array-element-form-regression.sh
+++ b/.github/scripts/iccdev-issue-2401-xml-array-element-form-regression.sh
@@ -332,6 +332,161 @@ else
   fi
 fi
 
+###############################################################################
+# Acceptance parity (#2401 follow-up)
+#
+# The conversion was unified above; what stayed different was ACCEPTANCE.  The
+# text form decides a body has values in it with ParseTextCount(), and rejects
+# the whole array when it counts none.  The element form applied no such test:
+# any <n>/<f> body was taken as a value.  Both spellings now go through
+# ParseTextCount(), so the pairs below must agree on accept-vs-reject.
+#
+# The empty-element case is the sharp one, and it is a defect rather than an
+# inconsistency.  icXmlNodeCount() counted <n></n>, the write loop's
+# `children && content` guard skipped it, and SetSize()'s buffer comes from
+# malloc() with no zeroing -- so the slot it stood for was serialized into the
+# .icc never having been written, and the parse still reported success.  Under
+# MALLOC_PERTURB_=42 glibc fills fresh allocations with 0xd5, which is what the
+# assertion looks for: on the unfixed build a 48-element array with 47 empty
+# elements writes 47 bytes of 0xd5 to disk.
+#
+# Deliberately NOT tightened past parity: "abc" and "Silver" contain characters
+# icIsNumChar() accepts ('a', 'e'), so the text form takes them as one token
+# worth 0 and the element form must too.  Testing/hybrid's three Overprint
+# profiles carry <n>Silver</n> and <n>ProcessBlack</n> in a colorantOrderTag,
+# which reaches this same CIccUInt8Array::ParseArray -- rejecting non-numeric
+# bodies outright would refuse three tracked corpus profiles.  Those two cases
+# are here to hold that line.
+###############################################################################
+
+emit_single() {
+  # Both tags carry the same body, so a rejection is attributable to that body
+  # rather than to whichever of the two spellings happened to be paired with it.
+  emit_profile "$1" uInt8NumberType Array "$2" "$2"
+}
+
+# name | body | expected: "accept" or "reject" -- asserted for BOTH spellings
+run_acceptance_case() {
+  local name="$1" elem_body="$2" text_body="$3" want="$4"
+  TOTAL=$((TOTAL + 1))
+
+  local e_rc=0 t_rc=0
+  emit_single "$OUTDIR/$name-elem.xml" "$elem_body"
+  emit_single "$OUTDIR/$name-text.xml" "$text_body"
+  rm -f "$OUTDIR/$name-elem.icc" "$OUTDIR/$name-text.icc"
+  timeout 25 "$FROMXML" "$OUTDIR/$name-elem.xml" "$OUTDIR/$name-elem.icc" \
+    > "$OUTDIR/$name-elem.log" 2>&1 || e_rc=$?
+  timeout 25 "$FROMXML" "$OUTDIR/$name-text.xml" "$OUTDIR/$name-text.icc" \
+    > "$OUTDIR/$name-text.log" 2>&1 || t_rc=$?
+
+  local e_got t_got
+  [ "$e_rc" -eq 0 ] && e_got=accept || e_got=reject
+  [ "$t_rc" -eq 0 ] && t_got=accept || t_got=reject
+
+  if [ "$e_got" != "$t_got" ]; then
+    fail_case "$name" "element form $e_got(s) while text form $t_got(s) -- the parity this fixes"
+    return
+  fi
+  # Agreement alone would be satisfied by both spellings regressing together, so
+  # pin which side of the line the body falls on.
+  if [ "$e_got" != "$want" ]; then
+    fail_case "$name" "both spellings $e_got, expected both to $want"
+    return
+  fi
+  pass_case "$name" "both spellings $want -- agreed"
+}
+
+# Element-form-only assertion.  Used where the two spellings are NOT twins: a
+# multi-token element body has no text equivalent with the same array length, so
+# parity is the wrong question -- the contract is that the element form refuses
+# rather than filling one slot and dropping the rest.
+run_element_reject_case() {
+  local name="$1" elem_body="$2"
+  TOTAL=$((TOTAL + 1))
+
+  local rc=0
+  emit_single "$OUTDIR/$name-elem.xml" "$elem_body"
+  rm -f "$OUTDIR/$name-elem.icc"
+  timeout 25 "$FROMXML" "$OUTDIR/$name-elem.xml" "$OUTDIR/$name-elem.icc" \
+    > "$OUTDIR/$name-elem.log" 2>&1 || rc=$?
+
+  if [ "$rc" -eq 0 ]; then
+    fail_case "$name" "element form accepted a body carrying more than one value"
+    return
+  fi
+  pass_case "$name" "element form refused a multi-value body (exit=$rc)"
+}
+
+echo "--- acceptance parity ---"
+
+# No character icIsNumChar() accepts anywhere in the body: the text form has
+# always refused these, and the element form now does too.
+#
+# The bodies compared here are single-token on purpose.  A MIXED body such as
+# "zz 2" is not a like-for-like twin: ParseTextCount() does not reject it, it
+# simply produces no token for the "zz" run, so the text form yields a
+# one-element array while <n>zz</n><n>2</n> is a two-element array with one bad
+# element.  Those are different inputs, not the same input parsed two ways.
+run_acceptance_case nonnumeric-zz  "<n>zz</n>"          "zz"     reject
+run_acceptance_case nonnumeric-pun "<n>!!!</n>"         "!!!"    reject
+
+# Parity is the rule, not "reject anything that is not a number": both of these
+# carry a character icIsNumChar() accepts, so both spellings take them as a
+# token worth 0.  Testing/hybrid's colorantOrderTag depends on this.
+run_acceptance_case numchar-abc    "<n>abc</n>"         "abc"    accept
+run_acceptance_case numchar-silver "<n>Silver</n>"      "Silver" accept
+
+# One element is one slot.  icParseArrayValue() converts the first token in a
+# body and ignores the rest, so <n>10 20 30</n> filled one slot and dropped two
+# values -- the array came out SHORTER than the identical text spelling, which is
+# the same count-vs-values mismatch the empty element produces at the other end.
+# Measured before the fix: <n>10 20 30</n><n>40</n> gave [10, 40] where the text
+# body "10 20 30 40" gave [10, 20, 30, 40], and iccFromXml exited 0.
+#
+# The test for this is whitespace tokens, NOT ParseTextCount()==1: that counter
+# treats 'a', 'e' and 'n' as numeric so "nan" survives, which makes
+# "ProcessBlack" two tokens and "ProcessMagenta" four -- and Testing/hybrid's
+# three Overprint profiles put exactly those in a colorantOrderTag.  Counting
+# with it here would refuse tracked corpus profiles; the last case below pins
+# that.
+run_element_reject_case multi-token     "<n>10 20 30</n><n>40</n>"
+run_element_reject_case multi-token-one "<n>10 20</n>"
+run_acceptance_case     corpus-colorant "<n>ProcessBlack</n>" "ProcessBlack" accept
+
+# An empty element is counted but yields nothing, so it must reject rather than
+# leave the slot it reserved unwritten.
+run_acceptance_case empty-element  "<n></n><n>2</n>"    ""       reject
+run_acceptance_case selfclosing    "<n/><n>2</n>"       ""       reject
+
+# The uninitialised read itself, observed rather than inferred.  47 empty
+# elements and one real value: on the unfixed build this is accepted and the 47
+# unwritten bytes reach the file as MALLOC_PERTURB_'s fill pattern.
+TOTAL=$((TOTAL + 1))
+perturb_body=""
+i=0
+while [ "$i" -lt 47 ]; do perturb_body="$perturb_body<n></n>"; i=$((i + 1)); done
+perturb_body="$perturb_body<n>170</n>"
+emit_single "$OUTDIR/perturb.xml" "$perturb_body"
+rm -f "$OUTDIR/perturb.icc"
+perturb_rc=0
+MALLOC_PERTURB_=42 timeout 25 "$FROMXML" "$OUTDIR/perturb.xml" "$OUTDIR/perturb.icc" \
+  > "$OUTDIR/perturb.log" 2>&1 || perturb_rc=$?
+if [ "$perturb_rc" -ne 0 ]; then
+  pass_case "uninitialised-slots" "array with unwritten slots refused (exit=$perturb_rc)"
+elif [ ! -f "$OUTDIR/perturb.icc" ]; then
+  fail_case "uninitialised-slots" "iccFromXml reported success but wrote no profile"
+else
+  perturb_hex="$(read_tag_values "$OUTDIR/perturb.icc" ELEM B 48)" || perturb_hex=""
+  # 0xd5 == 42 ^ 0xff, glibc's fill for a freshly malloc()ed block.
+  if printf '%s\n' "$perturb_hex" | grep -qw 213; then
+    fail_case "uninitialised-slots" \
+      "accepted, and unwritten slots reached the .icc as MALLOC_PERTURB_ fill: $perturb_hex"
+  else
+    fail_case "uninitialised-slots" \
+      "accepted an array whose slots were never all written: $perturb_hex"
+  fi
+fi
+
 echo "=== summary: $PASS passed, $FAIL failed, $TOTAL total ==="
 
 if [ "$FAIL" -ne 0 ]; then

--- a/IccXML/IccLibXML/IccUtilXml.cpp
+++ b/IccXML/IccLibXML/IccUtilXml.cpp
@@ -1205,6 +1205,36 @@ icUInt32Number CIccXmlArrayType<T, Tsig>::ParseText(T* pBuf, icUInt32Number nSiz
   return n;
 }
 
+// True when szText carries exactly one whitespace-delimited token.
+//
+// An <n>/<f> element stands for exactly one array slot, and icParseArrayValue()
+// converts the first token in the body and ignores anything after it.  So a body
+// like "10 20 30" would fill one slot and silently drop two values, leaving the
+// array shorter than the count that reserved the slots -- the same mismatch the
+// empty-element case produces at the other end.
+//
+// This is deliberately NOT ParseTextCount()==1.  That counter treats 'a', 'e' and
+// 'n' as numeric characters so "nan" survives, which makes "ProcessBlack" two
+// tokens and "ProcessMagenta" four; Testing/hybrid's three Overprint profiles put
+// exactly those in a colorantOrderTag, so counting with it here would refuse
+// tracked corpus profiles.  Whitespace is the right delimiter for "one value".
+static bool icXmlIsSingleToken(const char *szText)
+{
+  int nTokens = 0;
+
+  for (const char *p = szText; *p; ) {
+    while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+      p++;
+    if (!*p)
+      break;
+    nTokens++;
+    while (*p && *p != ' ' && *p != '\t' && *p != '\n' && *p != '\r')
+      p++;
+  }
+
+  return nTokens == 1;
+}
+
 template <class T, icTagTypeSignature Tsig>
 bool CIccXmlArrayType<T, Tsig>::ParseArray(T* pBuf, icUInt32Number nSize, xmlNode *pNode)
 {
@@ -1233,17 +1263,35 @@ bool CIccXmlArrayType<T, Tsig>::ParseArray(T* pBuf, icUInt32Number nSize, xmlNod
       icUInt32Number i;
       for (i=0; i<nSize && pNode; pNode = pNode->next) {
         if (pNode->type == XML_ELEMENT_NODE &&
-          !icXmlStrCmp(pNode->name, "f") &&
-          pNode->children &&
-          pNode->children->content) {
+          !icXmlStrCmp(pNode->name, "f")) {
             // #2401: was an unchecked sscanf("%f") straight into a cast, which
             // made this a THIRD conversion: no clamp, so <f>1e50</f> stored
             // +inf into an MPE matrix where the identical text array clipped to
             // FLT_MAX, and no "nan" literal case.  Same helper as the other two
-            // spellings.  (What still differs is acceptance, not conversion: a
-            // non-numeric <f> body counts as a value here while the text form
-            // rejects the array in ParseTextCount().)
-            pBuf[i] = icParseArrayValue<T>((const char *)(pNode->children->content));
+            // spellings.
+
+            // A counted element must actually carry a value.  An empty
+            // <f/> was skipped by the old `children && content` guard while
+            // icXmlNodeCount() still counted it, so the slot it stood for was
+            // never written and SetSize()'s malloc()ed buffer was serialized
+            // uninitialised -- MALLOC_PERTURB_=42 writes 0xd5 through to the
+            // .icc, and the parse still reported success.
+            if (!pNode->children || !pNode->children->content)
+              return false;
+
+            // Acceptance now matches the text form, which is the parity #2401
+            // was about: ParseTextCount() is what decides a text body has a
+            // value in it, so the element body is admitted on the same test
+            // rather than on a second rule that can drift from it.
+            const char *szValue = (const char *)(pNode->children->content);
+            if (!ParseTextCount(szValue))
+              return false;
+
+            // One element is one slot, so its body must be one value.
+            if (!icXmlIsSingleToken(szValue))
+              return false;
+
+            pBuf[i] = icParseArrayValue<T>(szValue);
             i++;
         }
       }
@@ -1269,9 +1317,7 @@ bool CIccXmlArrayType<T, Tsig>::ParseArray(T* pBuf, icUInt32Number nSize, xmlNod
       icUInt32Number i;
       for (i=0; i<nSize && pNode; pNode = pNode->next) {
         if (pNode->type == XML_ELEMENT_NODE &&
-          !icXmlStrCmp(pNode->name, "n") &&
-          pNode->children &&
-          pNode->children->content) {
+          !icXmlStrCmp(pNode->name, "n")) {
             // #2401: this was (T)atol(...), an unchecked narrowing cast, so
             // <n>256</n> in a uInt8Array wrapped to 0 and <n>300</n> to 44
             // while the identical text-form array clipped both to 255.  atol()
@@ -1281,7 +1327,29 @@ bool CIccXmlArrayType<T, Tsig>::ParseArray(T* pBuf, icUInt32Number nSize, xmlNod
             // wrapper's scanType), so <n>0.5</n> in a float32Array stored 0.
             // Both are the same defect -- this branch had its own conversion --
             // so it now calls the one ParseText() uses.
-            pBuf[i] = icParseArrayValue<T>((const char *)(pNode->children->content));
+
+            // A counted element must actually carry a value.  An empty
+            // <n/> was skipped by the old `children && content` guard while
+            // icXmlNodeCount() still counted it, so the slot it stood for was
+            // never written and SetSize()'s malloc()ed buffer was serialized
+            // uninitialised -- MALLOC_PERTURB_=42 writes 0xd5 through to the
+            // .icc, and the parse still reported success.
+            if (!pNode->children || !pNode->children->content)
+              return false;
+
+            // Acceptance now matches the text form, which is the parity #2401
+            // was about: ParseTextCount() is what decides a text body has a
+            // value in it, so the element body is admitted on the same test
+            // rather than on a second rule that can drift from it.
+            const char *szValue = (const char *)(pNode->children->content);
+            if (!ParseTextCount(szValue))
+              return false;
+
+            // One element is one slot, so its body must be one value.
+            if (!icXmlIsSingleToken(szValue))
+              return false;
+
+            pBuf[i] = icParseArrayValue<T>(szValue);
             i++;
         }
       }


### PR DESCRIPTION
Part of #2401 — the Pending item, plus two defects underneath it.

## The reported half

PR #2418 gave the three spellings of an `<Array>`/`<Data>` body one conversion. What it left differing was **acceptance**: the text form decides a body carries values with `ParseTextCount()` and refuses the whole array when it counts none, while the element branches applied no such test — any `<n>`/`<f>` body was taken as a value. Both now go through `ParseTextCount()`.

The gap was in **both** element branches, not only `<f>`.

## What was underneath it

Two ways an element could disagree with the count that reserved its slot, in opposite directions:

| body | counted | values written |
|---|---|---|
| `<n></n>` | 1 | 0 — slot never written |
| `<n>10 20 30</n>` | 1 | 1 — two values dropped |

**The empty element is the sharp one.** `icXmlNodeCount()` counted it, the write loop's `children && content` guard skipped it, `SetSize()` allocates with `malloc()` and no zeroing, and `ParseArray()` compared *counted* elements against the size rather than *written* ones — so the slot went into the `.icc` never having been written and the parse still returned true.

Measured: a 48-element array with 47 empty elements, built under `MALLOC_PERTURB_=42` (glibc fills fresh allocations with `0xd5`):

```
clro/array payload: aa d5 d5 d5 ... d5      iccFromXml exit 0
```

47 bytes of uninitialised heap in the output profile, reported as success.

**The multi-token body is quieter.** `icParseArrayValue()` converts the first token and ignores the rest, so `<n>10 20 30</n><n>40</n>` produced `[10, 40]` where the text body `10 20 30 40` produced `[10, 20, 30, 40]` — the array came out shorter than its twin, at exit 0.

An element body must now be exactly one whitespace-delimited token, and must be one `ParseTextCount()` would count.

## Why not `ParseTextCount() == 1`

That is the obvious one-character spelling and it is wrong here. `icIsNumChar()` treats `'a'`, `'e'` and `'n'` as numeric so `"nan"` survives — which makes `"ProcessBlack"` **two** tokens and `"ProcessMagenta"` **four**.

`Testing/hybrid`'s three Overprint profiles put exactly those in a `colorantOrderTag`, and `CIccTagXmlColorantOrder::ParseXml` calls this same `CIccUInt8Array::ParseArray`. Swept over all tracked `*.xml`: `ParseTextCount() != 1` would refuse **12 of the 15** `<n>`/`<f>` elements in the corpus.

So whitespace is the delimiter for "one value"; `ParseTextCount()` stays the test for "a value at all". Three cases pin that line and pass on both builds.

## Not changed

`<n>Silver</n>` still parses to `0`, as it always has — `ToXml` only ever writes `<n>%d</n>`, so a name in a `colorantOrder` is a reader/writer mismatch rather than an acceptance one, and tightening it here would refuse tracked corpus profiles. Noted on the issue.

## Test

Ten cases added to `iccdev.xml-array-element-form-regression`. Red/green against master at `5dfafa80`: **7 fail**, and the three corpus-guard cases pass on both builds.

Local: 251/251 CTests, one pre-existing unrelated failure (`iccdev.spectral-tiff-preview`, missing Python `imagecodecs`).
