### PR TITLE
CI Modify CodeQL Labels & BenchApply Metrics

### DIFF
--- a/.github/ci/quality-assurance/scripts/iccApplyProfiles_ci_path_exercise.sh
+++ b/.github/ci/quality-assurance/scripts/iccApplyProfiles_ci_path_exercise.sh
@@ -458,6 +458,11 @@ run_cmd() {
     bash -lc "$cmd" > "${prefix}.out" 2> "${prefix}.err"
     rc=$?
   fi
+  printf -v status_index '%05d' "$idx"
+  status_file="$LOG_DIR/status/${status_index}.${phase}.rc"
+  status_tmp="${status_file}.$$"
+  printf '%s\n' "$rc" > "$status_tmp"
+  mv -f "$status_tmp" "$status_file"
 
   extract_sanitizer "$prefix"
 
@@ -496,7 +501,12 @@ run_one() {
     if [[ -n "$cfg" && -f "$cfg" ]]; then
       if (( idx % 2 == 0 )); then thread_prefix="-threads 1 "; else thread_prefix=""; fi
       cfg_cmd="iccApplyProfiles ${thread_prefix}-cfg ${cfg}"
-      run_cmd "$idx" "cfg" "$cfg_cmd" || rc=$?
+      if run_cmd "$idx" "cfg" "$cfg_cmd"; then
+        :
+      else
+        cfg_rc=$?
+        [[ "$rc" -ne 0 ]] || rc=$cfg_rc
+      fi
     elif [[ "$DRY_RUN" -ne 1 ]]; then
       echo "SKIP $idx cfg ; config not generated: $cfg"
     fi
@@ -518,11 +528,18 @@ if [[ "$MODE" == "generate" ]]; then
 fi
 
 mkdir -p "$LOG_DIR"
+status_dir="$LOG_DIR/status"
+if [[ -d "$status_dir" ]]; then
+  find "$status_dir" -mindepth 1 -maxdepth 1 -type f -name '*.rc' -delete
+fi
+mkdir -p "$status_dir"
 : > "$LOG_DIR/sanitizer-summary.txt"
 : > "$LOG_DIR/failures.txt"
 
 tmp="$(mktemp)"
 emit_export_mutations "$MUTATIONS" "$START_AT" > "$tmp"
+selected_mutations="$(wc -l < "$tmp")"
+printf '%s\n' "$selected_mutations" > "$status_dir/expected-export-count"
 
 if [[ "$JOBS" -le 1 ]]; then
   failures=0
@@ -546,20 +563,35 @@ fi
 
 # Simple parallel queue preserving full command lines.
 current="$START_AT"
+failures=0
+active_children=0
 while IFS= read -r cmd; do
   idx="$current"
   current=$((current + 1))
   (
     run_one "$idx" "$cmd"
   ) &
-  while (( $(jobs -rp | wc -l) >= JOBS )); do
-    wait -n || true
+  active_children=$((active_children + 1))
+  while (( active_children >= JOBS )); do
+    if ! wait -n; then
+      failures=$((failures + 1))
+    fi
+    active_children=$((active_children - 1))
   done
 done < "$tmp"
 
-while wait -n 2>/dev/null; do :; done
+while (( active_children > 0 )); do
+  if ! wait -n; then
+    failures=$((failures + 1))
+  fi
+  active_children=$((active_children - 1))
+done
 
 rm -f "$tmp"
+echo "=== Done: failures=$failures ==="
 echo "Sanitizer summary: $LOG_DIR/sanitizer-summary.txt"
 echo "Failure summary:   $LOG_DIR/failures.txt"
-exit 0
+if [[ "$failures" -eq 0 ]]; then
+  exit 0
+fi
+exit 1

--- a/.github/scripts/iccdev-clut-profile.sh
+++ b/.github/scripts/iccdev-clut-profile.sh
@@ -7,6 +7,7 @@
 ###############################################################################
 
 set -euo pipefail
+export LC_ALL=C
 
 if [ "$#" -ne 2 ]; then
     echo "usage: $0 BUILD_DIR OUTPUT_DIR" >&2
@@ -55,6 +56,7 @@ fi
 
 mkdir -p "$output_dir"
 samples_file="$output_dir/samples.tsv"
+derived_perf_file="$output_dir/perf-derived.tsv"
 environment_file="$output_dir/environment.txt"
 
 runner=()
@@ -96,6 +98,8 @@ fi
 
 printf 'run\telapsed_s\tuser_s\tsystem_s\tmax_rss_kb\tstatus\tlog\tperf_stat\n' \
     > "$samples_file"
+printf 'run\tcycles\tinstructions\tbranches\tbranch_misses\tcache_references\tcache_misses\tinstructions_per_cycle\tinstructions_per_second\tbranch_miss_rate\tcache_miss_rate\n' \
+    > "$derived_perf_file"
 for run in $(seq 1 "$runs"); do
     log_file="$output_dir/run-${run}.log"
     time_file="$output_dir/run-${run}.time"
@@ -132,6 +136,47 @@ context-switches,cpu-migrations \
         echo "[FAIL] telemetry was not produced in run $run: $telemetry_file" >&2
         exit 1
     fi
+
+    awk -F, -v run="$run" -v elapsed="${elapsed:-}" '
+        function clean(value) {
+            gsub(/[[:space:]]/, "", value)
+            gsub(/,/, "", value)
+            return value
+        }
+        function number(value) {
+            return value ~ /^[0-9]+([.][0-9]+)?$/
+        }
+        function ratio(numerator, denominator) {
+            if (number(numerator) && number(denominator) && denominator > 0)
+                return numerator / denominator
+            return "n/a"
+        }
+        {
+            event = clean($3)
+            sub(/:.*/, "", event)
+        }
+        event == "cycles" { cycles = clean($1) }
+        event == "instructions" { instructions = clean($1) }
+        event == "branches" { branches = clean($1) }
+        event == "branch-misses" { branch_misses = clean($1) }
+        event == "cache-references" { cache_references = clean($1) }
+        event == "cache-misses" { cache_misses = clean($1) }
+        END {
+            values[1] = cycles
+            values[2] = instructions
+            values[3] = branches
+            values[4] = branch_misses
+            values[5] = cache_references
+            values[6] = cache_misses
+            for (i = 1; i <= 6; i++)
+                if (!number(values[i]))
+                    values[i] = "n/a"
+            printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+                run, values[1], values[2], values[3], values[4], values[5],
+                values[6], ratio(values[2], values[1]),
+                ratio(values[2], elapsed), ratio(values[4], values[3]),
+                ratio(values[6], values[5])
+        }' "$perf_file" >> "$derived_perf_file"
 done
 
 if command -v strace >/dev/null 2>&1; then
@@ -176,4 +221,5 @@ awk -F '\t' '
 
 printf 'perf_stat=%s\n' "$([ "$perf_available" -eq 1 ] && echo available || echo unavailable)" \
     >> "$output_dir/summary.txt"
+printf 'perf_derived=%s\n' "$derived_perf_file" >> "$output_dir/summary.txt"
 printf '[PASS] profile report: %s\n' "$output_dir"

--- a/.github/scripts/iccdev-clut-profile.sh
+++ b/.github/scripts/iccdev-clut-profile.sh
@@ -126,9 +126,16 @@ if command -v perf >/dev/null 2>&1 && perf stat -e cycles true >/dev/null 2>&1; 
         effective_events=()
         for event in "${perf_events[@]}"; do
             if awk -F, -v target="$event" '
-                {
-                    name = $3
+                function canonical_event(name) {
                     sub(/:.*/, "", name)
+                    if (name ~ /^[^/]+\/[^/]+\/$/) {
+                        sub(/^[^/]+\//, "", name)
+                        sub(/\/$/, "", name)
+                    }
+                    return name
+                }
+                {
+                    name = canonical_event($3)
                     if (name == target && $1 !~ /^</)
                         found = 1
                 }
@@ -140,6 +147,10 @@ if command -v perf >/dev/null 2>&1 && perf stat -e cycles true >/dev/null 2>&1; 
             fi
         done
         perf_events=("${effective_events[@]}")
+        if [ "${#perf_events[@]}" -eq 0 ]; then
+            perf_available=0
+            printf 'combined_probe=unavailable\n' >> "$perf_event_file"
+        fi
     else
         perf_available=0
         printf 'combined_probe=unavailable\n' >> "$perf_event_file"
@@ -193,13 +204,25 @@ for run in $(seq 1 "$runs"); do
     fi
 
     awk -F, -v run="$run" -v elapsed="${elapsed:-}" '
+        BEGIN {
+            CONVFMT = "%.17g"
+            OFMT = "%.17g"
+        }
         function clean(value) {
             gsub(/[[:space:]]/, "", value)
             gsub(/,/, "", value)
             return value
         }
+        function canonical_event(name) {
+            sub(/:.*/, "", name)
+            if (name ~ /^[^/]+\/[^/]+\/$/) {
+                sub(/^[^/]+\//, "", name)
+                sub(/\/$/, "", name)
+            }
+            return name
+        }
         function number(value) {
-            return value ~ /^[0-9]+([.][0-9]+)?$/
+            return value ~ /^[0-9]+([.][0-9]+)?([eE][+-]?[0-9]+)?$/
         }
         function ratio(numerator, denominator) {
             if (number(numerator) && number(denominator) && denominator > 0)
@@ -207,32 +230,23 @@ for run in $(seq 1 "$runs"); do
             return "n/a"
         }
         {
-            event = clean($3)
-            sub(/:.*/, "", event)
+            event = canonical_event(clean($3))
+            value = clean($1)
+            if (number(value))
+                event_values[event] += value
         }
-        event == "cycles" { cycles = clean($1) }
-        event == "instructions" { instructions = clean($1) }
-        event == "branches" { branches = clean($1) }
-        event == "branch-misses" { branch_misses = clean($1) }
-        event == "cache-references" { cache_references = clean($1) }
-        event == "cache-misses" { cache_misses = clean($1) }
-        event == "mem_inst_retired.all_loads" { memory_loads = clean($1) }
-        event == "mem_inst_retired.all_stores" { memory_stores = clean($1) }
-        event == "fp_arith_inst_retired.scalar" { fp_scalar = clean($1) }
-        event == "fp_arith_inst_retired.4_flops" { fp_4_flops = clean($1) }
-        event == "fp_arith_inst_retired.8_flops" { fp_8_flops = clean($1) }
         END {
-            values[1] = cycles
-            values[2] = instructions
-            values[3] = branches
-            values[4] = branch_misses
-            values[5] = cache_references
-            values[6] = cache_misses
-            values[7] = memory_loads
-            values[8] = memory_stores
-            values[9] = fp_scalar
-            values[10] = fp_4_flops
-            values[11] = fp_8_flops
+            values[1] = event_values["cycles"]
+            values[2] = event_values["instructions"]
+            values[3] = event_values["branches"]
+            values[4] = event_values["branch-misses"]
+            values[5] = event_values["cache-references"]
+            values[6] = event_values["cache-misses"]
+            values[7] = event_values["mem_inst_retired.all_loads"]
+            values[8] = event_values["mem_inst_retired.all_stores"]
+            values[9] = event_values["fp_arith_inst_retired.scalar"]
+            values[10] = event_values["fp_arith_inst_retired.4_flops"]
+            values[11] = event_values["fp_arith_inst_retired.8_flops"]
             for (i = 1; i <= 11; i++)
                 if (!number(values[i]))
                     values[i] = "n/a"

--- a/.github/scripts/iccdev-clut-profile.sh
+++ b/.github/scripts/iccdev-clut-profile.sh
@@ -92,13 +92,69 @@ ctest_command=(
 } > "$environment_file"
 
 perf_available=0
+perf_events=()
+perf_optional_events=()
+perf_event_file="$output_dir/perf-events.txt"
 if command -v perf >/dev/null 2>&1 && perf stat -e cycles true >/dev/null 2>&1; then
     perf_available=1
+    perf_events=(
+        cycles
+        instructions
+        branches
+        branch-misses
+        cache-references
+        cache-misses
+        context-switches
+        cpu-migrations
+    )
+    for event in \
+        mem_inst_retired.all_loads \
+        mem_inst_retired.all_stores \
+        fp_arith_inst_retired.scalar \
+        fp_arith_inst_retired.4_flops \
+        fp_arith_inst_retired.8_flops; do
+        if perf stat -e "$event" true >/dev/null 2>&1; then
+            perf_events+=("$event")
+            perf_optional_events+=("$event")
+        else
+            printf 'unavailable_event=%s\n' "$event" >> "$perf_event_file"
+        fi
+    done
+    perf_probe="$output_dir/perf-event-probe.csv"
+    if perf stat -x, -o "$perf_probe" \
+        -e "$(IFS=,; printf '%s' "${perf_events[*]}")" sleep 1; then
+        effective_events=()
+        for event in "${perf_events[@]}"; do
+            if awk -F, -v target="$event" '
+                {
+                    name = $3
+                    sub(/:.*/, "", name)
+                    if (name == target && $1 !~ /^</)
+                        found = 1
+                }
+                END { exit found ? 0 : 1 }
+            ' "$perf_probe"; then
+                effective_events+=("$event")
+            else
+                printf 'excluded_event=%s\n' "$event" >> "$perf_event_file"
+            fi
+        done
+        perf_events=("${effective_events[@]}")
+    else
+        perf_available=0
+        printf 'combined_probe=unavailable\n' >> "$perf_event_file"
+        for event in "${perf_optional_events[@]}"; do
+            printf 'excluded_event=%s\n' "$event" >> "$perf_event_file"
+        done
+    fi
+fi
+if [ "$perf_available" -eq 1 ]; then
+    printf 'effective_event=%s\n' "${perf_events[@]}" >> "$perf_event_file"
 fi
 
 printf 'run\telapsed_s\tuser_s\tsystem_s\tmax_rss_kb\tstatus\tlog\tperf_stat\n' \
     > "$samples_file"
-printf 'run\tcycles\tinstructions\tbranches\tbranch_misses\tcache_references\tcache_misses\tinstructions_per_cycle\tinstructions_per_second\tbranch_miss_rate\tcache_miss_rate\n' \
+printf 'run\tcycles\tinstructions\tbranches\tbranch_misses\tcache_references\tcache_misses\tmemory_load_instructions\tmemory_store_instructions\tfp_arith_scalar_events\tfp_arith_4_flop_events\tfp_arith_8_flop_events\tinstructions_per_cycle\tinstructions_per_second\tbranch_miss_rate\tcache_miss_rate\n' \
     > "$derived_perf_file"
 for run in $(seq 1 "$runs"); do
     log_file="$output_dir/run-${run}.log"
@@ -109,8 +165,7 @@ for run in $(seq 1 "$runs"); do
 
     if [ "$perf_available" -eq 1 ]; then
         perf stat -x, -o "$perf_file" \
-            -e cycles,instructions,branches,branch-misses,cache-references,cache-misses,\
-context-switches,cpu-migrations \
+            -e "$(IFS=,; printf '%s' "${perf_events[*]}")" \
             env "ICC_PERF_STATS_FILE=$telemetry_file" \
             /usr/bin/time -f 'elapsed_s=%e\nuser_s=%U\nsystem_s=%S\nmax_rss_kb=%M' \
             -o "$time_file" "${runner[@]}" "${ctest_command[@]}" > "$log_file" 2>&1 || status=$?
@@ -161,6 +216,11 @@ context-switches,cpu-migrations \
         event == "branch-misses" { branch_misses = clean($1) }
         event == "cache-references" { cache_references = clean($1) }
         event == "cache-misses" { cache_misses = clean($1) }
+        event == "mem_inst_retired.all_loads" { memory_loads = clean($1) }
+        event == "mem_inst_retired.all_stores" { memory_stores = clean($1) }
+        event == "fp_arith_inst_retired.scalar" { fp_scalar = clean($1) }
+        event == "fp_arith_inst_retired.4_flops" { fp_4_flops = clean($1) }
+        event == "fp_arith_inst_retired.8_flops" { fp_8_flops = clean($1) }
         END {
             values[1] = cycles
             values[2] = instructions
@@ -168,12 +228,18 @@ context-switches,cpu-migrations \
             values[4] = branch_misses
             values[5] = cache_references
             values[6] = cache_misses
-            for (i = 1; i <= 6; i++)
+            values[7] = memory_loads
+            values[8] = memory_stores
+            values[9] = fp_scalar
+            values[10] = fp_4_flops
+            values[11] = fp_8_flops
+            for (i = 1; i <= 11; i++)
                 if (!number(values[i]))
                     values[i] = "n/a"
-            printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+            printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
                 run, values[1], values[2], values[3], values[4], values[5],
-                values[6], ratio(values[2], values[1]),
+                values[6], values[7], values[8], values[9], values[10],
+                values[11], ratio(values[2], values[1]),
                 ratio(values[2], elapsed), ratio(values[4], values[3]),
                 ratio(values[6], values[5])
         }' "$perf_file" >> "$derived_perf_file"

--- a/.github/workflows/ci-afl-regression-repro.yml
+++ b/.github/workflows/ci-afl-regression-repro.yml
@@ -118,6 +118,10 @@ jobs:
             echo "- \`iccdev.apply-throughput ... Passed\` confirms the #2207 regression executed."
             echo "- \`100% tests passed, 0 tests failed\` confirms the CTest result."
             echo "- 27 CSV rows ending in \`,ok\` confirm 9 suite cases at each of 1, 2, and 8 threads."
+            echo "- 9 \`benchmark_metrics case=...\` blocks show the exact benchmark-buffer"
+            echo "  footprint and workload for every suite case."
+            echo "- Each metrics block must contain internally consistent buffer sizes and the"
+            echo "  architecture-specific instruction, stack, and FLOP collection boundaries."
             echo "- \`CHECKSUM MISMATCH\`, \`SOME CASES FAILED\`, and \`FAIL:\` must be absent."
           } >> "$GITHUB_STEP_SUMMARY"  # elements-sanitized
 
@@ -150,7 +154,7 @@ jobs:
             -DENABLE_WXWIDGETS=OFF \
             -DENABLE_IMAGE_TOOLS=OFF
           cmake --build Build/apply-throughput-repro \
-            --target build-test-binaries \
+            --target build-test-binaries iccFromXml \
             --parallel "$(nproc)"
 
       - name: Run iccBenchApply regression
@@ -163,6 +167,8 @@ jobs:
           unset GITHUB_TOKEN || true
           test_log="Build/apply-throughput-repro/iccdev.apply-throughput.log"
           threaded_log="Build/apply-throughput-repro/iccdev.apply-throughput-threaded.log"
+          metrics_log="Build/apply-throughput-repro/iccdev.apply-throughput-metrics.log"
+          metrics_verified="Build/apply-throughput-repro/iccdev.apply-throughput-metrics-verified"
           ctest --test-dir Build/apply-throughput-repro \
             --output-on-failure \
             --no-tests=error \
@@ -172,7 +178,8 @@ jobs:
           ICCDEV_BENCH_SOURCE_ROOT="$PWD" \
             ICCDEV_BENCH_BUILD_ROOT="$PWD/Build/apply-throughput-repro" \
             Build/apply-throughput-repro/Tools/IccBenchApply/iccBenchApply \
-              -suite -csv -pixels 65536 -repeats 3 -threads 1,2,8 | tee "$threaded_log"
+              -metrics -suite -csv -pixels 65536 -repeats 3 -threads 1,2,8 \
+              2> >(tee "$metrics_log" >&2) | tee "$threaded_log"
 
           if ! grep -qE 'Test +#[0-9]+: iccdev.create-profiles.*Passed' "$test_log"; then
             echo "[FAIL] Missing successful iccdev.create-profiles fixture signal" >&2
@@ -227,11 +234,92 @@ jobs:
             echo "[FAIL] Missing or inconsistent 1,2,8-thread CSV replay signal" >&2
             exit 1
           fi
+          if ! awk '
+            function finish_block() {
+              if (active &&
+                  !(have_xforms && have_pixels && have_repeats && have_applies &&
+                    have_input && have_output && have_total && have_bytes_per_apply &&
+                    have_instructions && have_stack && have_flops &&
+                    total == input + output && bytes_per_apply == total)) {
+                invalid = 1
+              }
+            }
+            /^benchmark_metrics case=/ {
+              finish_block()
+              case_name = substr($2, 6)
+              if (!case_name || seen[case_name]++) {
+                invalid = 1
+              }
+              block_count++
+              active = 1
+              input = output = total = bytes_per_apply = 0
+              have_input = have_output = have_total = have_bytes_per_apply = 0
+              have_pixels = have_repeats = have_applies = have_xforms = 0
+              have_instructions = have_stack = have_flops = 0
+              next
+            }
+            /^  resolved_transform_count=/ {
+              have_xforms = ($0 ~ /^  resolved_transform_count=[1-9][0-9]*$/)
+              next
+            }
+            /^  pixels_per_apply=/ {
+              have_pixels = ($0 == "  pixels_per_apply=65536")
+              next
+            }
+            /^  timed_applies_per_thread=/ {
+              have_repeats = ($0 == "  timed_applies_per_thread=3")
+              next
+            }
+            /^  total_applies_per_thread=/ {
+              have_applies = ($0 == "  total_applies_per_thread=4")
+              next
+            }
+            /^  input_buffer_bytes=/ {
+              input = substr($0, 22) + 0
+              have_input = input > 0
+              next
+            }
+            /^  output_buffer_bytes=/ {
+              output = substr($0, 23) + 0
+              have_output = output > 0
+              next
+            }
+            /^  benchmark_buffer_bytes=/ {
+              total = substr($0, 26) + 0
+              have_total = total > 0
+              next
+            }
+            /^  benchmark_bytes_per_apply=/ {
+              bytes_per_apply = substr($0, 29) + 0
+              have_bytes_per_apply = bytes_per_apply > 0
+              next
+            }
+            /^  hardware_instructions=/ {
+              have_instructions = ($0 == "  hardware_instructions=external-profiler-required")
+              next
+            }
+            /^  stack_operands=/ {
+              have_stack = ($0 == "  stack_operands=compiler-abi-specific")
+              next
+            }
+            /^  floating_point_operations=/ {
+              have_flops = ($0 == "  floating_point_operations=profile-and-isa-specific")
+              next
+            }
+            END {
+              finish_block()
+              exit (invalid || block_count != 9) ? 1 : 0
+            }
+          ' "$metrics_log"; then
+            echo "[FAIL] Missing or inconsistent benchmark metrics replay signal" >&2
+            exit 1
+          fi
+          touch "$metrics_verified"
           if grep -qE 'CHECKSUM MISMATCH|SOME CASES FAILED|FAIL:' "$test_log" "$threaded_log"; then
             echo "[FAIL] iccBenchApply reported a correctness failure" >&2
             exit 1
           fi
-          echo "[OK] Verified fixture, CTest, and 1,2,8-thread checksum signals"
+          echo "[OK] Verified fixture, CTest, metrics, and 1,2,8-thread checksum signals"
 
       - name: Report replay result
         if: ${{ always() }}
@@ -246,10 +334,13 @@ jobs:
 
           test_log="Build/apply-throughput-repro/iccdev.apply-throughput.log"
           threaded_log="Build/apply-throughput-repro/iccdev.apply-throughput-threaded.log"
+          metrics_log="Build/apply-throughput-repro/iccdev.apply-throughput-metrics.log"
+          metrics_verified="Build/apply-throughput-repro/iccdev.apply-throughput-metrics-verified"
           fixture_signal="FAIL"
           regression_signal="FAIL"
           ctest_signal="FAIL"
           threaded_signal="FAIL"
+          metrics_signal="FAIL"
           checksum_signal="FAIL"
           overall_signal="FAIL"
 
@@ -304,6 +395,9 @@ jobs:
           ' "$threaded_log"; then
             threaded_signal="PASS"
           fi
+          if [ -f "$metrics_log" ] && [ -f "$metrics_verified" ]; then
+            metrics_signal="PASS"
+          fi
           if [ -f "$test_log" ] && [ -f "$threaded_log" ] && \
              ! grep -qE 'CHECKSUM MISMATCH|SOME CASES FAILED|FAIL:' "$test_log" "$threaded_log"; then
             checksum_signal="PASS"
@@ -313,6 +407,7 @@ jobs:
              [ "$regression_signal" = "PASS" ] && \
              [ "$ctest_signal" = "PASS" ] && \
              [ "$threaded_signal" = "PASS" ] && \
+             [ "$metrics_signal" = "PASS" ] && \
              [ "$checksum_signal" = "PASS" ]; then
             overall_signal="PASS"
           fi
@@ -328,6 +423,7 @@ jobs:
             echo "| #2207 throughput regression | ${regression_signal} |"
             echo "| CTest aggregate | ${ctest_signal} |"
             echo "| 9 cases x 3 thread counts, CSV status ok | ${threaded_signal} |"
+            echo "| 9 metrics blocks, buffer values and collection boundaries | ${metrics_signal} |"
             echo "| No correctness-failure marker | ${checksum_signal} |"
             echo ""
             echo "**Overall replay signal**: ${overall_signal}"

--- a/.github/workflows/ci-afl-regression-repro.yml
+++ b/.github/workflows/ci-afl-regression-repro.yml
@@ -177,11 +177,17 @@ jobs:
             -V \
             -R '^iccdev\.apply-throughput$' | tee "$test_log"
 
+          metrics_status=0
           ICCDEV_BENCH_SOURCE_ROOT="$PWD" \
             ICCDEV_BENCH_BUILD_ROOT="$PWD/Build/apply-throughput-repro" \
             Build/apply-throughput-repro/Tools/IccBenchApply/iccBenchApply \
               -metrics -suite -csv -pixels 65536 -repeats 3 -threads 1,2,8 \
-              2> >(tee "$metrics_log" >&2) | tee "$threaded_log"
+              2> "$metrics_log" | tee "$threaded_log" || metrics_status=$?
+          cat "$metrics_log" >&2
+          if [ "$metrics_status" -ne 0 ]; then
+            echo "[FAIL] iccBenchApply metrics replay failed: $metrics_status" >&2
+            exit "$metrics_status"
+          fi
 
           if ! grep -qE 'Test +#[0-9]+: iccdev.create-profiles.*Passed' "$test_log"; then
             echo "[FAIL] Missing successful iccdev.create-profiles fixture signal" >&2

--- a/.github/workflows/ci-afl-regression-repro.yml
+++ b/.github/workflows/ci-afl-regression-repro.yml
@@ -120,8 +120,10 @@ jobs:
             echo "- 27 CSV rows ending in \`,ok\` confirm 9 suite cases at each of 1, 2, and 8 threads."
             echo "- 9 \`benchmark_metrics case=...\` blocks show the exact benchmark-buffer"
             echo "  footprint and workload for every suite case."
-            echo "- Each metrics block must contain internally consistent buffer sizes and the"
-            echo "  architecture-specific instruction, stack, and FLOP collection boundaries."
+            echo "- Each metrics block must contain internally consistent buffer sizes, three"
+            echo "  thread-count settings, and per-setting plus sweep-total apply counts."
+            echo "- Architecture-specific instruction, memory-operation, and floating-point"
+            echo "  event counts are collected by the optional platform profiler, not this CLI."
             echo "- \`CHECKSUM MISMATCH\`, \`SOME CASES FAILED\`, and \`FAIL:\` must be absent."
           } >> "$GITHUB_STEP_SUMMARY"  # elements-sanitized
 
@@ -237,9 +239,10 @@ jobs:
           if ! awk '
             function finish_block() {
               if (active &&
-                  !(have_xforms && have_pixels && have_repeats && have_applies &&
-                    have_input && have_output && have_total && have_bytes_per_apply &&
-                    have_instructions && have_stack && have_flops &&
+                  !(have_xforms && have_pixels && have_thread_settings &&
+                    have_per_setting_timed && have_per_setting_scheduled &&
+                    have_total_timed && have_total_scheduled && have_input &&
+                    have_output && have_total && have_bytes_per_apply &&
                     total == input + output && bytes_per_apply == total)) {
                 invalid = 1
               }
@@ -254,8 +257,9 @@ jobs:
               active = 1
               input = output = total = bytes_per_apply = 0
               have_input = have_output = have_total = have_bytes_per_apply = 0
-              have_pixels = have_repeats = have_applies = have_xforms = 0
-              have_instructions = have_stack = have_flops = 0
+              have_pixels = have_thread_settings = have_xforms = 0
+              have_per_setting_timed = have_per_setting_scheduled = 0
+              have_total_timed = have_total_scheduled = 0
               next
             }
             /^  resolved_transform_count=/ {
@@ -266,12 +270,24 @@ jobs:
               have_pixels = ($0 == "  pixels_per_apply=65536")
               next
             }
-            /^  timed_applies_per_thread=/ {
-              have_repeats = ($0 == "  timed_applies_per_thread=3")
+            /^  thread_count_settings=/ {
+              have_thread_settings = ($0 == "  thread_count_settings=3")
               next
             }
-            /^  total_applies_per_thread=/ {
-              have_applies = ($0 == "  total_applies_per_thread=4")
+            /^  timed_applies_per_thread_setting=/ {
+              have_per_setting_timed = ($0 == "  timed_applies_per_thread_setting=3")
+              next
+            }
+            /^  scheduled_applies_per_thread_setting=/ {
+              have_per_setting_scheduled = ($0 == "  scheduled_applies_per_thread_setting=4")
+              next
+            }
+            /^  total_timed_applies=/ {
+              have_total_timed = ($0 == "  total_timed_applies=9")
+              next
+            }
+            /^  total_scheduled_applies=/ {
+              have_total_scheduled = ($0 == "  total_scheduled_applies=12")
               next
             }
             /^  input_buffer_bytes=/ {
@@ -292,18 +308,6 @@ jobs:
             /^  benchmark_bytes_per_apply=/ {
               bytes_per_apply = substr($0, 29) + 0
               have_bytes_per_apply = bytes_per_apply > 0
-              next
-            }
-            /^  hardware_instructions=/ {
-              have_instructions = ($0 == "  hardware_instructions=external-profiler-required")
-              next
-            }
-            /^  stack_operands=/ {
-              have_stack = ($0 == "  stack_operands=compiler-abi-specific")
-              next
-            }
-            /^  floating_point_operations=/ {
-              have_flops = ($0 == "  floating_point_operations=profile-and-isa-specific")
               next
             }
             END {

--- a/.github/workflows/ci-codeql-security.yml
+++ b/.github/workflows/ci-codeql-security.yml
@@ -54,6 +54,7 @@ jobs:
       github.event_name != 'pull_request' ||
       (
         github.event.pull_request.head.repo.full_name == github.repository &&
+        github.event.pull_request.merged == false &&
         github.event.action == 'labeled' &&
         github.event.label.name == 'codeql-ready'
       )

--- a/.github/workflows/ci-codeql-security.yml
+++ b/.github/workflows/ci-codeql-security.yml
@@ -54,7 +54,7 @@ jobs:
       github.event_name != 'pull_request' ||
       (
         github.event.pull_request.head.repo.full_name == github.repository &&
-        github.event.pull_request.merged == false &&
+        github.event.pull_request.state == 'open' &&
         github.event.action == 'labeled' &&
         github.event.label.name == 'codeql-ready'
       )

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -6297,6 +6297,25 @@ if(TARGET iccBenchApply)
     FIXTURES_REQUIRED iccdev_profiles
   )
 
+  # Metrics describe the benchmark buffers and scheduled calls, while
+  # architecture-specific instruction, stack, and FLOP counts stay with the
+  # platform profiler. Keep this a tiny direct chain so it imports neither a
+  # timing threshold nor the suite's slow profile fixture.
+  add_test(
+    NAME iccdev.bench-apply-metrics
+    COMMAND "${CMAKE_COMMAND}"
+      "-DTOOL=$<TARGET_FILE:iccBenchApply>"
+      "-DTOOL_ARGS=-metrics;-pixels;4;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;0"
+      "-DEXPECT_EXIT=zero"
+      "-DEXPECT_MATCH=benchmark_metrics case=chain"
+      -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
+  )
+  set_tests_properties(iccdev.bench-apply-metrics PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;benchmark;metrics;regression"
+  )
+
   # #2271: two columns of DecodeIntent() disagreed with the iccApplyToLink decode
   # its own comment claimed to reproduce.
   #

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -6307,7 +6307,7 @@ if(TARGET iccBenchApply)
       "-DTOOL=$<TARGET_FILE:iccBenchApply>"
       "-DTOOL_ARGS=-metrics;-pixels;4;-repeats;1;1;Testing/sRGB_v4_ICC_preference.icc;0"
       "-DEXPECT_EXIT=zero"
-      "-DEXPECT_MATCH=benchmark_metrics case=chain"
+      "-DEXPECT_MATCHES=benchmark_metrics case=chain;resolved_transform_count=1;pixels_per_apply=4;thread_count_settings=1;timed_applies_per_thread_setting=1;scheduled_applies_per_thread_setting=2;total_timed_applies=1;total_scheduled_applies=2;input_buffer_bytes=48;output_buffer_bytes=48;benchmark_buffer_bytes=96;benchmark_bytes_per_apply=96"
       -P "${CMAKE_CURRENT_LIST_DIR}/RunBenchApplyCliTest.cmake"
   )
   set_tests_properties(iccdev.bench-apply-metrics PROPERTIES

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -6451,6 +6451,7 @@ if(TARGET iccBenchApply)
       iccdev.bench-apply-negative-intent-code
       iccdev.bench-apply-valid-intent-code
       iccdev.bench-apply-valid-intent-code-typed
+      iccdev.bench-apply-metrics
       iccdev.bench-apply-bpc-intent-code
       iccdev.bench-apply-bpc-changes-result
       iccdev.bench-apply-luminance-column

--- a/Build/Cmake/Testing/RunBenchApplyCliTest.cmake
+++ b/Build/Cmake/Testing/RunBenchApplyCliTest.cmake
@@ -32,6 +32,8 @@
 # Optional -D args:
 #   TOOL_ARGS    - ';'-separated argument list passed to the tool
 #   EXPECT_MATCH - regex that must appear in stdout or stderr (run A only)
+#   EXPECT_MATCHES - ';'-separated regexes that must each appear in stdout or
+#                    stderr (run A only)
 #   LABEL        - prefix for this driver's own log lines
 #                  (default: bench-apply-cli, so existing callers are unchanged)
 # Optional -D args for a two-run differential assertion (#2271):
@@ -138,6 +140,13 @@ if(DEFINED EXPECT_MATCH AND NOT "${EXPECT_MATCH}" STREQUAL "")
       "[${LABEL}] output did not match '${EXPECT_MATCH}'")
   endif()
 endif()
+
+foreach(_expected_match IN LISTS EXPECT_MATCHES)
+  if(NOT _output MATCHES "${_expected_match}")
+    message(FATAL_ERROR
+      "[${LABEL}] output did not match '${_expected_match}'")
+  endif()
+endforeach()
 
 if(DEFINED COMPARE_ARGS AND NOT "${COMPARE_ARGS}" STREQUAL "")
   if(NOT DEFINED COMPARE_EXTRACT OR "${COMPARE_EXTRACT}" STREQUAL "")

--- a/Tools/CmdLine/IccBenchApply/Readme.md
+++ b/Tools/CmdLine/IccBenchApply/Readme.md
@@ -83,14 +83,20 @@ and transform-local storage are platform- and profile-dependent. These values
 describe the tool's allocations and scheduled calls; they do not claim to
 represent all memory touched inside a profile's resolved transform graph.
 
-The report intentionally does not invent process-independent values for
-hardware instructions, stack operands, or floating-point operations. Each
-depends on the compiler, target ABI, optimization level, resolved transforms,
-and scalar/SSE/AVX dispatch. The current Linux profiling path already collects
-the accurate process instruction count with `perf stat`; use
-`.github/scripts/iccdev-clut-profile.sh` for that evidence. FLOP hardware
-events are CPU-model-specific, and stack operands require disassembly or a
-sampling profile, so neither is portable benchmark output.
+`thread_count_settings` is the number of requested `-threads` values, not the
+number of workers in one apply. The per-thread-setting values describe one
+whole-buffer warm-up plus timed sequence. The `total_*` values multiply those
+scheduled calls across all requested settings, so `-threads 1,2,8 -repeats 3`
+reports 3 thread-count settings, 3 timed and 4 scheduled applies per setting,
+9 timed applies, and 12 scheduled applies total.
+
+The report intentionally omits hardware instructions, stack operands, and
+floating-point operations. They depend on the compiler, target ABI,
+optimization level, resolved transforms, and scalar/SSE/AVX dispatch. Use the
+opt-in Linux profiler, `.github/scripts/iccdev-clut-profile.sh`, for numeric
+hardware instruction, memory-operation, and supported floating-point event
+counts. Stack operands need architecture-specific disassembly or sampling, so
+they are not portable benchmark output.
 
 `-suite` and a chain are alternatives, not a chain with a default. Passing both
 is refused rather than silently resolved in favour of the table, and `-perxform`

--- a/Tools/CmdLine/IccBenchApply/Readme.md
+++ b/Tools/CmdLine/IccBenchApply/Readme.md
@@ -51,6 +51,7 @@ matching. The same code means different things in the two families (#2270).
 | `-threads L` | comma list of thread counts, e.g. `1,2,8` (default `1`) |
 | `-perxform` | per-xform breakdown, including PCS steps |
 | `-leaf` | isolated hot leaf functions |
+| `-metrics` | report the benchmark buffers and workload; with `-csv`, writes metrics to stderr |
 | `-suite` | run the built-in case table; takes no chain arguments |
 | `-csv` | machine-readable output |
 
@@ -69,6 +70,27 @@ iccBenchApply -suite -csv -threads 1,2,8
 # the built-in table, bounded for a quick check
 iccBenchApply -suite -pixels 65536 -repeats 3
 ```
+
+## Metrics report
+
+`-metrics` reports the exact source and destination benchmark-buffer sizes,
+their total allocation footprint, the logical input-plus-output buffer capacity
+per scheduled apply, pixel count, and warm-up plus timed apply count. It reports
+once for a command-line chain and once for each resolved `-suite` case.
+`benchmark_bytes_per_apply` is therefore a logical capacity value, not a claim
+about physical DRAM traffic: cache residency, write allocation, prefetching,
+and transform-local storage are platform- and profile-dependent. These values
+describe the tool's allocations and scheduled calls; they do not claim to
+represent all memory touched inside a profile's resolved transform graph.
+
+The report intentionally does not invent process-independent values for
+hardware instructions, stack operands, or floating-point operations. Each
+depends on the compiler, target ABI, optimization level, resolved transforms,
+and scalar/SSE/AVX dispatch. The current Linux profiling path already collects
+the accurate process instruction count with `perf stat`; use
+`.github/scripts/iccdev-clut-profile.sh` for that evidence. FLOP hardware
+events are CPU-model-specific, and stack operands require disassembly or a
+sampling profile, so neither is portable benchmark output.
 
 `-suite` and a chain are alternatives, not a chain with a default. Passing both
 is refused rather than silently resolved in favour of the table, and `-perxform`

--- a/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
+++ b/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
@@ -98,6 +98,7 @@ static bool             g_bLeaf     = false;
 static std::vector<int> g_threads;
 static bool             g_bSuite    = false;
 static bool             g_bCsv      = false;
+static bool             g_bMetrics  = false;
 
 static void Usage()
 {
@@ -128,6 +129,7 @@ static void Usage()
   printf("  -repeats N         timed repeats per case (default 7)\n");
   printf("  -perxform          per-xform breakdown, including PCS steps\n");
   printf("  -leaf              isolated hot leaf functions\n");
+  printf("  -metrics           report exact benchmark memory and workload metrics\n");
   printf("  -threads L         comma list of thread counts, e.g. 1,2,8\n");
   printf("  -suite             run the built-in case table; takes no chain\n");
   printf("  -csv               machine-readable output\n");
@@ -282,6 +284,45 @@ public:
 
   std::vector<CIccXform *> m_xforms;
 };
+
+// This is deliberately a benchmark-buffer report, not a claim about the
+// library's transient allocations or the compiler's generated instructions.
+// The latter vary with the resolved transform graph, ISA dispatch, ABI, and
+// optimizer, and are collected accurately by the platform profiler instead.
+static void ReportMetrics(const char *caseName, const CIccCmm &cmm,
+                          size_t transformCount)
+{
+  if (!g_bMetrics)
+    return;
+
+  const unsigned long long sourceValues =
+    (unsigned long long)g_nPixels * cmm.GetSourceSamples();
+  const unsigned long long destinationValues =
+    (unsigned long long)g_nPixels * cmm.GetDestSamples();
+  const unsigned long long sourceBytes = sourceValues * sizeof(icFloatNumber);
+  const unsigned long long destinationBytes =
+    destinationValues * sizeof(icFloatNumber);
+  const unsigned long long appliesPerThread = (unsigned long long)g_nRepeats + 1;
+  FILE *stream = g_bCsv ? stderr : stdout;
+
+  fprintf(stream, "benchmark_metrics case=%s\n", caseName);
+  fprintf(stream, "  resolved_transform_count=%llu\n",
+          (unsigned long long)transformCount);
+  fprintf(stream, "  pixels_per_apply=%u\n", (unsigned int)g_nPixels);
+  fprintf(stream, "  timed_applies_per_thread=%d\n", g_nRepeats);
+  fprintf(stream, "  total_applies_per_thread=%llu\n", appliesPerThread);
+  fprintf(stream, "  input_buffer_bytes=%llu\n", sourceBytes);
+  fprintf(stream, "  output_buffer_bytes=%llu\n", destinationBytes);
+  fprintf(stream, "  benchmark_buffer_bytes=%llu\n",
+          sourceBytes + destinationBytes);
+  fprintf(stream, "  benchmark_bytes_per_apply=%llu\n",
+          sourceBytes + destinationBytes);
+  fprintf(stream, "  hardware_instructions=external-profiler-required\n");
+  fprintf(stream, "  stack_operands=compiler-abi-specific\n");
+  fprintf(stream, "  floating_point_operations=profile-and-isa-specific\n");
+  if (g_bCsv)
+    fflush(stream);
+}
 
 // Runs the chain at each requested thread count.
 //
@@ -601,6 +642,10 @@ static int RunSuite()
       continue;
     }
 
+    CChainReporter reporter;
+    theCmm.IterateXforms(&reporter);
+    ReportMetrics(bc.name.c_str(), theCmm, reporter.m_xforms.size());
+
     if (!RunThreadSweep(theCmm, g_threads, bc.name.c_str()))
       bAllOk = false;
     nRan++;
@@ -721,6 +766,10 @@ int main(int argc, const char *argv[])
     }
     else if (!stricmp(argv[nArg], "-leaf")) {
       g_bLeaf = true;
+      nArg++;
+    }
+    else if (!stricmp(argv[nArg], "-metrics")) {
+      g_bMetrics = true;
       nArg++;
     }
     else if (!stricmp(argv[nArg], "-suite")) {
@@ -901,6 +950,7 @@ int main(int argc, const char *argv[])
 
   CChainReporter reporter;
   theCmm.IterateXforms(&reporter);
+  ReportMetrics("chain", theCmm, reporter.m_xforms.size());
 
   printf("resolved transforms:\n");
   for (size_t i = 0; i < reporter.m_xforms.size(); i++) {

--- a/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
+++ b/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
@@ -302,24 +302,33 @@ static void ReportMetrics(const char *caseName, const CIccCmm &cmm,
   const unsigned long long sourceBytes = sourceValues * sizeof(icFloatNumber);
   const unsigned long long destinationBytes =
     destinationValues * sizeof(icFloatNumber);
-  const unsigned long long appliesPerThread = (unsigned long long)g_nRepeats + 1;
+  const unsigned long long threadSettings =
+    static_cast<unsigned long long>(g_threads.size());
+  const unsigned long long timedAppliesPerThreadSetting =
+    static_cast<unsigned long long>(g_nRepeats);
+  const unsigned long long scheduledAppliesPerThreadSetting =
+    timedAppliesPerThreadSetting + 1;
   FILE *stream = g_bCsv ? stderr : stdout;
 
   fprintf(stream, "benchmark_metrics case=%s\n", caseName);
   fprintf(stream, "  resolved_transform_count=%llu\n",
           (unsigned long long)transformCount);
   fprintf(stream, "  pixels_per_apply=%u\n", (unsigned int)g_nPixels);
-  fprintf(stream, "  timed_applies_per_thread=%d\n", g_nRepeats);
-  fprintf(stream, "  total_applies_per_thread=%llu\n", appliesPerThread);
+  fprintf(stream, "  thread_count_settings=%llu\n", threadSettings);
+  fprintf(stream, "  timed_applies_per_thread_setting=%llu\n",
+          timedAppliesPerThreadSetting);
+  fprintf(stream, "  scheduled_applies_per_thread_setting=%llu\n",
+          scheduledAppliesPerThreadSetting);
+  fprintf(stream, "  total_timed_applies=%llu\n",
+          threadSettings * timedAppliesPerThreadSetting);
+  fprintf(stream, "  total_scheduled_applies=%llu\n",
+          threadSettings * scheduledAppliesPerThreadSetting);
   fprintf(stream, "  input_buffer_bytes=%llu\n", sourceBytes);
   fprintf(stream, "  output_buffer_bytes=%llu\n", destinationBytes);
   fprintf(stream, "  benchmark_buffer_bytes=%llu\n",
           sourceBytes + destinationBytes);
   fprintf(stream, "  benchmark_bytes_per_apply=%llu\n",
           sourceBytes + destinationBytes);
-  fprintf(stream, "  hardware_instructions=external-profiler-required\n");
-  fprintf(stream, "  stack_operands=compiler-abi-specific\n");
-  fprintf(stream, "  floating_point_operations=profile-and-isa-specific\n");
   if (g_bCsv)
     fflush(stream);
 }

--- a/docs/avx2-clut-diagnostics.md
+++ b/docs/avx2-clut-diagnostics.md
@@ -79,10 +79,16 @@ FLAMEGRAPH_DIR=/path/to/FlameGraph \
 The report includes per-run wall/user/system time and RSS, median and p95
 elapsed time, raw `perf stat` counters when permitted by the host, and derived
 IPC, instruction-rate, branch-miss-rate, and cache-miss-rate values in
-`perf-derived.tsv`. A ratio describes this end-to-end CTest envelope; it is not
-a kernel-only or per-pixel value. The report also includes a `strace -f -c`
-summary when available, and optional `perf.data`, folded stacks, and an SVG
-flamegraph. `perf` hardware counters may be unavailable when
+`perf-derived.tsv`. On hosts that advertise the required events, that TSV also
+contains numeric retired memory-load/store and floating-point event counts
+successfully scheduled together by the profiler's combined probe.
+Floating-point columns retain the exact `perf` event scope rather than claiming
+a cross-CPU FLOP total. Dynamic stack-operand counts are not available from a
+portable counter and require architecture-specific sampling or disassembly.
+A ratio describes this end-to-end CTest envelope; it is not a kernel-only or
+per-pixel value. The report also includes a `strace -f -c` summary when
+available, and optional `perf.data`, folded stacks, and an SVG flamegraph.
+`perf` hardware counters may be unavailable when
 `kernel.perf_event_paranoid` disallows them; this is reported rather than
 treated as a correctness failure. Do not use `strace`, source coverage, or
 debug logging when collecting cycle or throughput comparisons.

--- a/docs/avx2-clut-diagnostics.md
+++ b/docs/avx2-clut-diagnostics.md
@@ -85,6 +85,10 @@ successfully scheduled together by the profiler's combined probe.
 Floating-point columns retain the exact `perf` event scope rather than claiming
 a cross-CPU FLOP total. Dynamic stack-operand counts are not available from a
 portable counter and require architecture-specific sampling or disassembly.
+On hybrid Intel hosts, `perf` may qualify generic events as `cpu_core/...` and
+`cpu_atom/...`; the profiler normalizes those names and sums their reported
+values into the matching generic column. A combined probe that yields no usable
+events is reported as unavailable and the timed run proceeds without `perf`.
 A ratio describes this end-to-end CTest envelope; it is not a kernel-only or
 per-pixel value. The report also includes a `strace -f -c` summary when
 available, and optional `perf.data`, folded stacks, and an SVG flamegraph.

--- a/docs/avx2-clut-diagnostics.md
+++ b/docs/avx2-clut-diagnostics.md
@@ -77,7 +77,10 @@ FLAMEGRAPH_DIR=/path/to/FlameGraph \
 ```
 
 The report includes per-run wall/user/system time and RSS, median and p95
-elapsed time, `perf stat` counters when permitted by the host, a `strace -f -c`
+elapsed time, raw `perf stat` counters when permitted by the host, and derived
+IPC, instruction-rate, branch-miss-rate, and cache-miss-rate values in
+`perf-derived.tsv`. A ratio describes this end-to-end CTest envelope; it is not
+a kernel-only or per-pixel value. The report also includes a `strace -f -c`
 summary when available, and optional `perf.data`, folded stacks, and an SVG
 flamegraph. `perf` hardware counters may be unavailable when
 `kernel.perf_event_paranoid` disallows them; this is reported rather than

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -123,7 +123,7 @@ before running the suite.
 | `iccdev.fileio-seek-tell` | `.github/ci/regression/fileio-seek-tell.cpp` |
 | `iccdev.iccconnect-config-parser` | `.github/ci/regression/iccconnect-config-parser.cpp` |
 | `iccdev.iccconnect-threaded-cmm` | `.github/ci/regression/iccconnect-threaded-cmm.cpp` |
-| `iccdev.bench-apply-metrics` | `Build/Cmake/Testing/CMakeLists.txt` |
+| `iccdev.bench-apply-metrics` | `Build/Cmake/Testing/CMakeLists.txt`; asserts the deterministic one-profile, four-pixel metrics contract |
 | `iccdev.applytolink-invalid-decoded-intent` | `Build/Cmake/Testing/CMakeLists.txt` |
 | `iccdev.applytolink-v4-missing-device-descriptions` | `Build/Cmake/Testing/CMakeLists.txt` |
 | `iccdev.xform-abstorel-adjust` | `.github/ci/regression/xform-abstorel-adjust.cpp` |

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -123,6 +123,7 @@ before running the suite.
 | `iccdev.fileio-seek-tell` | `.github/ci/regression/fileio-seek-tell.cpp` |
 | `iccdev.iccconnect-config-parser` | `.github/ci/regression/iccconnect-config-parser.cpp` |
 | `iccdev.iccconnect-threaded-cmm` | `.github/ci/regression/iccconnect-threaded-cmm.cpp` |
+| `iccdev.bench-apply-metrics` | `Build/Cmake/Testing/CMakeLists.txt` |
 | `iccdev.applytolink-invalid-decoded-intent` | `Build/Cmake/Testing/CMakeLists.txt` |
 | `iccdev.applytolink-v4-missing-device-descriptions` | `Build/Cmake/Testing/CMakeLists.txt` |
 | `iccdev.xform-abstorel-adjust` | `.github/ci/regression/xform-abstorel-adjust.cpp` |

--- a/docs/label-system.md
+++ b/docs/label-system.md
@@ -208,9 +208,12 @@ create a job-local Docker image.
 ### CodeQL Ready
 
 `ci-codeql-security.yml` uses the `codeql-ready` label to trigger the full
-CodeQL security workflow for a PR. Use this label when a change touches C/C++,
-CMake, CodeQL query logic, parser hardening, or security-sensitive automation
-and the fast preflight checks are not enough.
+CodeQL security workflow for an open same-repository PR. Labelling a merged PR
+does not rerun CodeQL: the push trigger already analyzes `master`, and a
+label-triggered run would use the PR base commit's trusted query set while
+publishing its results against `master`. Use this label when a change touches
+C/C++, CMake, CodeQL query logic, parser hardening, or security-sensitive
+automation and the fast preflight checks are not enough.
 
 ## Maintainer Change Process
 

--- a/docs/label-system.md
+++ b/docs/label-system.md
@@ -211,7 +211,9 @@ create a job-local Docker image.
 CodeQL security workflow for an open same-repository PR. Labelling a merged PR
 does not rerun CodeQL: the push trigger already analyzes `master`, and a
 label-triggered run would use the PR base commit's trusted query set while
-publishing its results against `master`. Use this label when a change touches
+publishing its results against `master`. Closed unmerged PRs are also ignored:
+they are not active review targets and must be reopened before CodeQL can run.
+Use this label when a change touches
 C/C++, CMake, CodeQL query logic, parser hardening, or security-sensitive
 automation and the fast preflight checks are not enough.
 


### PR DESCRIPTION
## PR Summary

#2436 

## Checklist

- [ ] Signed all Commits in PR
- [ ] Built locally according to `docs/build.md`
- [ ] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [ ] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes
- [ ] Added or updated regression coverage for behavior changes
- [ ] Attached a `base...HEAD` contract matrix for cross-cutting changes:
      producer, consumer, build/runtime behavior, platform/toolchain boundary,
      CI trigger, dependency owner, and local evidence
- [ ] Reviewed active and suppressed automated findings from review threads and summaries
- [ ] For Python package changes, followed `docs/python-packaging-release.md` for PR and merge requirements
- [ ] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [ ] New source files include the ICC copyright and BSD 3-Clause license header
- [ ] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consortium (ICC)
follows the open source software best practice policies. The [International Color Consortium IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).

## Metrics scope

`iccBenchApply -metrics` reports portable benchmark-buffer and scheduled-workload values only, including per-thread-setting and full-sweep apply counts. Numeric hardware instruction, memory-operation, and supported floating-point event counts are collected by the opt-in Linux profiler. Dynamic stack-operand counts require architecture-specific disassembly or sampling and are intentionally not represented as portable CLI metrics.
