### PR TITLE
fix(#2414): terminate the CLI tools on a stream they cannot read

### DIFF
--- a/.github/scripts/iccdev-issue-2414-directory-read-guard-tests.sh
+++ b/.github/scripts/iccdev-issue-2414-directory-read-guard-tests.sh
@@ -1,0 +1,361 @@
+#!/bin/bash
+###############################################################################
+# #2414 -- fopen() succeeds on a directory, so a directory argument is not
+#          rejected where the tool believes it opened a file
+###############################################################################
+#
+# #2411 found this in iccFromXml: -v=<some-directory> slipped past an openability
+# guard, because fopen(dir, "r") succeeds on glibc, and produced a four-line
+# libxml2 cascade naming the XML file instead of the one-line schema error.  The
+# fix was a read-a-byte discriminator -- a directory fails the read with EISDIR,
+# a legitimately empty file reports EOF with no error.  It was static in
+# IccFromXml.cpp, so no other tool could reach it; it now lives in
+# IccProfLib/IccFileUtil.h as icIsReadableFile(), beside the write-side
+# icOpenRegularWriteFile().
+#
+# Sweeping the other tools for the same shape turned up a worse instance than
+# the one that started it.  iccFromCube HUNG on a directory:
+#
+#   isEOF() tested feof(m_f) alone.  A read that FAILS -- EISDIR here -- makes
+#   fgetc() return EOF while leaving feof() FALSE and setting ferror() instead,
+#   so getNextLine() returned an empty string forever and the three
+#   `while (!isEOF())` loops never advanced.  Measured on ee14d031, exit 124
+#   under any timeout, spinning with no allocation growth (CWE-835).
+#
+# The fix is the ferror() arm alone.  The tidier-looking version -- probe the
+# path with icIsReadableFile() before open() -- is a REGRESSION, which is why
+# case (6) exists: the probe opens, reads and closes, so the second fopen() of a
+# single-reader FIFO blocks on a writer that has already been consumed.  That
+# guard took a FIFO from 254 to 124, trading one hang for another.  Validate the
+# stream you are holding, not the path you are about to open again.
+#
+# Anti-vacuity, in two places.  "Did not hang" is trivially satisfied by a tool
+# that fails for an unrelated reason, so the directory cases also require the
+# diagnostic that names the path.  And a guard that is too eager would be
+# invisible to every defect case, so the controls carry as much weight: a real
+# .cube must still convert, and /dev/null must still be ACCEPTED and then
+# refused by the PARSER, which is the case an S_ISREG guard would have broken.
+# Nothing else pins that: iccdev.issue-1178-fromcube-devnull passes /dev/null as
+# the OUTPUT profile path (`iccFromCube "$POC" /dev/null`), never as the input
+# .cube, so case (5) here is the only cover for the input side.
+#
+# The suite ALSO has to be able to report that it measured nothing.  Resolving
+# TOOLS_DIR on the directory rather than on the binaries let a configured tree
+# with no executables under Build/Tools skip all five iccFromCube cases and
+# still exit 0, carried by the single iccFromXml case.  Hence tools_dir_has_both
+# below, and the FROMCUBE_MEASURED gate at the end.
+#
+# Red/green against ee14d031: fromcube-directory-terminates and
+# fromxml-schema-fifo fail with rc=124, and fromcube-directory-names-path finds
+# no diagnostic.  The other five cases pass on BOTH builds -- that is what they
+# are for.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Whether the caller named the tree.  An explicit ICCDEV_TOOLS_DIR is never
+# second-guessed below: silently resolving past it would measure a DIFFERENT
+# build than the one the caller meant, which is how a stale tree fakes a result.
+if [ -n "${ICCDEV_TOOLS_DIR:-}" ]; then
+  TOOLS_DIR="$ICCDEV_TOOLS_DIR"
+  TOOLS_DIR_EXPLICIT=1
+else
+  TOOLS_DIR="$REPO_ROOT/Build/Tools"
+  TOOLS_DIR_EXPLICIT=0
+fi
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-2414-directory-read-guard}"
+mkdir -p "$OUTDIR"
+
+# Resolve on the BINARIES, not on the directory.  Build/Tools exists in a
+# configured tree as CMake scaffolding with no executables under it, so a
+# directory test resolved TOOLS_DIR to a path where nothing is built and every
+# case below skipped -- and the suite still exited 0, because the "nothing was
+# measured" guard was satisfied by the one iccFromXml case.  A green run that
+# skipped every case covering the defect is the failure mode this whole file
+# exists to prevent, so the probe has to be for the thing it will execute.
+tools_dir_has_both() {
+  [ -x "$1/IccFromCube/iccFromCube" ] && [ -x "$1/IccFromXml/iccFromXml" ]
+}
+tools_dir_has_any() {
+  [ -x "$1/IccFromCube/iccFromCube" ] || [ -x "$1/IccFromXml/iccFromXml" ]
+}
+
+# Two passes, and the order matters.  A tree can hold one tool and not the other
+# -- Build/Tools in a working checkout often has stale binaries for some tools
+# only -- and settling for it would skip the cases that cover the defect while
+# another tree next to it has everything.  Prefer a complete tree, and fall back
+# to a partial one only so the skip accounting at the end can report what was
+# missing.
+if [ "$TOOLS_DIR_EXPLICIT" -eq 0 ] && ! tools_dir_has_both "$TOOLS_DIR"; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/out/build/Tools"; do
+    if tools_dir_has_both "$candidate"; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+if [ "$TOOLS_DIR_EXPLICIT" -eq 0 ] && ! tools_dir_has_any "$TOOLS_DIR"; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/out/build/Tools"; do
+    if tools_dir_has_any "$candidate"; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+FROMCUBE="$TOOLS_DIR/IccFromCube/iccFromCube"
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+
+CUBE_OK="$REPO_ROOT/.github/ci/test-data/test-identity.cube"
+XML_OK="$REPO_ROOT/Testing/Calc/CameraModel.xml"
+
+# The directory every case is pointed at.  Named so it cannot be mistaken for a
+# fixture that was meant to exist.
+ADIR="$OUTDIR/a-directory-not-a-file"
+rm -rf "$ADIR"
+mkdir -p "$ADIR"
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+
+# Counted separately from TOTAL: the iccFromCube cases are the ones that cover
+# the defect, so the suite must not be able to report success without them.
+FROMCUBE_MEASURED=0
+
+fail_case() { echo "  [FAIL] $1 -- $2"; FAIL=$((FAIL + 1)); }
+pass_case() { echo "  [PASS] $1 -- $2"; PASS=$((PASS + 1)); }
+skip_case() { echo "  [SKIP] $1 -- $2"; SKIP=$((SKIP + 1)); }
+
+# ---------------------------------------------------------------------------
+# iccFromCube
+# ---------------------------------------------------------------------------
+if [ ! -x "$FROMCUBE" ]; then
+  skip_case fromcube-directory-terminates "not built at $FROMCUBE"
+  skip_case fromcube-directory-names-path "not built"
+  skip_case fromcube-regular-file-converts "not built"
+  skip_case fromcube-missing-file-unchanged "not built"
+  skip_case fromcube-devnull-unchanged "not built"
+else
+  # (1) The defect: a directory must not spin.  20s is far above the ~0.1s a
+  # real conversion of this fixture takes, so a timeout here means the loop,
+  # not a slow machine.
+  LOG="$OUTDIR/fromcube-directory.log"
+  rc=0
+  timeout 20 "$FROMCUBE" "$ADIR" "$OUTDIR/from-directory.icc" > "$LOG" 2>&1 || rc=$?
+  TOTAL=$((TOTAL + 1)); FROMCUBE_MEASURED=$((FROMCUBE_MEASURED + 1))
+  if [ "$rc" -eq 124 ]; then
+    fail_case fromcube-directory-terminates "timed out (rc=124) -- the isEOF() spin is back"
+  elif [ "$rc" -eq 0 ]; then
+    fail_case fromcube-directory-terminates "reported success on a directory (rc=0)"
+  else
+    pass_case fromcube-directory-terminates "refused with rc=$rc"
+  fi
+
+  # (2) Anti-vacuity for (1): the refusal must be the tool naming the path, not
+  # some earlier unrelated failure.
+  TOTAL=$((TOTAL + 1))
+  if grep -q -- "$ADIR" "$LOG" 2>/dev/null; then
+    pass_case fromcube-directory-names-path "diagnostic names the directory"
+  else
+    fail_case fromcube-directory-names-path "no diagnostic naming the path -- nothing was measured"
+    sed -n '1,10p' "$LOG"
+  fi
+
+  # (3) Control: the guard must not refuse a real .cube.
+  if [ -f "$CUBE_OK" ]; then
+    TOTAL=$((TOTAL + 1))
+    OUT_ICC="$OUTDIR/identity.icc"
+    rm -f "$OUT_ICC"
+    rc=0
+    timeout 60 "$FROMCUBE" "$CUBE_OK" "$OUT_ICC" > "$OUTDIR/fromcube-ok.log" 2>&1 || rc=$?
+    if [ "$rc" -eq 0 ] && [ -s "$OUT_ICC" ]; then
+      pass_case fromcube-regular-file-converts "converted, $(wc -c < "$OUT_ICC") bytes"
+    else
+      fail_case fromcube-regular-file-converts "rc=$rc, output $( [ -s "$OUT_ICC" ] && echo present || echo "missing/empty")"
+      sed -n '1,10p' "$OUTDIR/fromcube-ok.log"
+    fi
+  else
+    skip_case fromcube-regular-file-converts "fixture missing: $CUBE_OK"
+  fi
+
+  # (4) Control: a missing file was already refused cleanly and must stay that
+  # way -- the guard returns false for it too, by a different route.
+  TOTAL=$((TOTAL + 1))
+  MISSING="$OUTDIR/no-such-file.cube"
+  rm -f "$MISSING"
+  rc=0
+  timeout 20 "$FROMCUBE" "$MISSING" "$OUTDIR/missing.icc" > "$OUTDIR/fromcube-missing.log" 2>&1 || rc=$?
+  if [ "$rc" -ne 0 ] && [ "$rc" -ne 124 ] && grep -q -- "$MISSING" "$OUTDIR/fromcube-missing.log" 2>/dev/null; then
+    pass_case fromcube-missing-file-unchanged "refused with rc=$rc and named the path"
+  else
+    fail_case fromcube-missing-file-unchanged "rc=$rc"
+    sed -n '1,10p' "$OUTDIR/fromcube-missing.log"
+  fi
+
+  # (5) Control: /dev/null reads EOF with no error, so the guard must ACCEPT it
+  # and leave it to the parser to refuse.  A guard written as S_ISREG would fail
+  # this case, which is why it is here.
+  if [ -c /dev/null ]; then
+    TOTAL=$((TOTAL + 1))
+    rc=0
+    timeout 20 "$FROMCUBE" /dev/null "$OUTDIR/devnull.icc" > "$OUTDIR/fromcube-devnull.log" 2>&1 || rc=$?
+    # rc alone cannot tell the two apart: a guard that refused /dev/null outright
+    # would also exit non-zero, so this case would pass against exactly the
+    # implementation it exists to rule out.  The discriminator is WHICH message
+    # comes back -- the parser's, naming the file it tried to read.
+    if [ "$rc" -eq 0 ] || [ "$rc" -eq 124 ]; then
+      fail_case fromcube-devnull-unchanged "rc=$rc"
+      sed -n '1,10p' "$OUTDIR/fromcube-devnull.log"
+    elif grep -q "Unable to parse .*/dev/null" "$OUTDIR/fromcube-devnull.log" 2>/dev/null; then
+      pass_case fromcube-devnull-unchanged "reached the parser and was refused there, rc=$rc"
+    else
+      fail_case fromcube-devnull-unchanged "rc=$rc but not the parser's refusal -- a guard rejected it before the parse"
+      sed -n '1,10p' "$OUTDIR/fromcube-devnull.log"
+    fi
+  else
+    skip_case fromcube-devnull-unchanged "/dev/null is not a character device here"
+  fi
+
+  # (6) Regression guard for the FIX ITSELF, not for the defect.
+  #
+  # The tidier-looking version of this fix probed the path with
+  # icIsReadableFile() before open() -- open, read a byte, close, then fopen()
+  # again.  On a single-reader FIFO the probe consumes the writer's rendezvous
+  # and the SECOND open blocks forever, so that guard turned a directory fix
+  # into a pipe hang: 254 before it, 124 with it.  A named pipe is the cheapest
+  # input that tells a path probe apart from a handle check, which is why it is
+  # a case here rather than a comment.
+  # Remove any leftover first.  mkfifo FAILS when the path exists, and OUTDIR
+  # persists across runs, so one interrupted run (a CTest TIMEOUT kill, Ctrl-C)
+  # left a stale FIFO that skipped this case on every later run -- permanently
+  # disabling the guard that protects the fix, while the suite still exited 0.
+  rm -f "$OUTDIR/fifo-probe"
+  if ! command -v mkfifo > /dev/null 2>&1; then
+    skip_case fromcube-fifo-terminates "mkfifo not available on this platform"
+  elif ! mkfifo "$OUTDIR/fifo-probe" 2>/dev/null; then
+    skip_case fromcube-fifo-terminates "mkfifo failed in $OUTDIR (filesystem does not support FIFOs?)"
+  else
+    TOTAL=$((TOTAL + 1)); FROMCUBE_MEASURED=$((FROMCUBE_MEASURED + 1))
+    if [ -f "$CUBE_OK" ]; then
+      ( cat "$CUBE_OK" > "$OUTDIR/fifo-probe" 2>/dev/null ) &
+      WRITER=$!
+      rc=0
+      timeout 20 "$FROMCUBE" "$OUTDIR/fifo-probe" "$OUTDIR/fifo.icc" \
+        > "$OUTDIR/fromcube-fifo.log" 2>&1 || rc=$?
+      kill "$WRITER" 2>/dev/null
+      wait "$WRITER" 2>/dev/null
+      if [ "$rc" -eq 124 ]; then
+        fail_case fromcube-fifo-terminates "timed out (rc=124) -- a path probe was reintroduced before open()"
+      else
+        pass_case fromcube-fifo-terminates "terminated with rc=$rc"
+      fi
+    else
+      skip_case fromcube-fifo-terminates "fixture missing: $CUBE_OK"
+      TOTAL=$((TOTAL - 1)); FROMCUBE_MEASURED=$((FROMCUBE_MEASURED - 1))
+    fi
+    rm -f "$OUTDIR/fifo-probe"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# iccFromXml -- the #2411 case, now going through the promoted helper.  This is
+# a no-behaviour-change assertion: it must still be the one-line schema error.
+# ---------------------------------------------------------------------------
+if [ ! -x "$FROMXML" ]; then
+  skip_case fromxml-schema-directory "not built at $FROMXML"
+elif [ ! -f "$XML_OK" ]; then
+  skip_case fromxml-schema-directory "fixture missing: $XML_OK"
+else
+  TOTAL=$((TOTAL + 1))
+  LOG="$OUTDIR/fromxml-schema-directory.log"
+  rc=0
+  timeout 60 "$FROMXML" "$XML_OK" "$OUTDIR/fromxml.icc" "-v=$ADIR" > "$LOG" 2>&1 || rc=$?
+
+  # The libxml2 cascade this replaced was four lines naming the XML file; the
+  # contract is one line naming the SCHEMA.  Counting lines is what tells the
+  # two apart, so both halves are asserted.
+  LINES=$(wc -l < "$LOG" | tr -d ' ')
+  if [ "$rc" -eq 0 ]; then
+    fail_case fromxml-schema-directory "accepted a directory as a schema (rc=0)"
+  elif ! grep -q "schema" "$LOG" 2>/dev/null; then
+    fail_case fromxml-schema-directory "refused with rc=$rc but did not name the schema"
+    sed -n '1,10p' "$LOG"
+  elif [ "$LINES" -gt 2 ]; then
+    fail_case fromxml-schema-directory "$LINES lines of output -- the libxml2 cascade is back"
+    sed -n '1,10p' "$LOG"
+  else
+    pass_case fromxml-schema-directory "one-line schema error, rc=$rc"
+  fi
+
+  # A FIFO as the schema, which is the other half of the same defect and the one
+  # the promoted helper had to grow an S_ISREG arm for.  iccFromXml DOES probe
+  # the path before handing it to libxml2, so it hung both ways: with no writer
+  # the probe's own open blocks, and with a single writer the probe eats the
+  # rendezvous and libxml2's reopen blocks.  Measured at 00b91b56: rc=124 for
+  # both.  Only the writer-less case is exercised here -- it needs no background
+  # process, so there is nothing to leak if the tool hangs and the case fails.
+  #
+  # The writer-less case is enough to pin the S_ISREG arm, which is the part of
+  # icIsReadableFile() that is easiest to delete believing it redundant.  Deleting
+  # it and keeping O_NONBLOCK does NOT make this case pass: read() on a
+  # writer-less FIFO returns 0, not EAGAIN, so the guard accepts the path and
+  # libxml2's own blocking reopen then hangs.  Measured: rc=1 with the arm, 124
+  # without it.
+  rm -f "$OUTDIR/schema-fifo"
+  if ! command -v mkfifo > /dev/null 2>&1; then
+    skip_case fromxml-schema-fifo "mkfifo not available on this platform"
+  elif ! mkfifo "$OUTDIR/schema-fifo" 2>/dev/null; then
+    skip_case fromxml-schema-fifo "mkfifo failed in $OUTDIR (filesystem does not support FIFOs?)"
+  else
+    TOTAL=$((TOTAL + 1))
+    rc=0
+    timeout 20 "$FROMXML" "$XML_OK" "$OUTDIR/fromxml-fifo.icc" "-v=$OUTDIR/schema-fifo" \
+      > "$OUTDIR/fromxml-schema-fifo.log" 2>&1 || rc=$?
+    if [ "$rc" -eq 124 ]; then
+      fail_case fromxml-schema-fifo "timed out (rc=124) -- a writer-less FIFO reached a blocking open, in the guard or in libxml2 after it"
+    elif [ "$rc" -eq 0 ]; then
+      fail_case fromxml-schema-fifo "accepted a FIFO as a schema (rc=0)"
+    elif grep -q "schema" "$OUTDIR/fromxml-schema-fifo.log" 2>/dev/null; then
+      pass_case fromxml-schema-fifo "refused with rc=$rc, naming the schema"
+    else
+      fail_case fromxml-schema-fifo "refused with rc=$rc but did not name the schema"
+      sed -n '1,10p' "$OUTDIR/fromxml-schema-fifo.log"
+    fi
+    rm -f "$OUTDIR/schema-fifo"
+  fi
+fi
+
+echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total ==="
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+if [ "$PASS" -eq 0 ]; then
+  echo "no case was measured -- treating as skipped rather than passed"
+  exit 77
+fi
+# The iccFromCube cases are the ones that cover the defect.  Passing on the
+# iccFromXml case alone is not evidence about this fix, so report a skip rather
+# than a pass -- a green tick with every relevant case skipped is worse than no
+# tick at all.
+if [ "$FROMCUBE_MEASURED" -eq 0 ]; then
+  echo "no iccFromCube case ran (tools dir: $TOOLS_DIR) -- treating as skipped rather than passed"
+  exit 77
+fi
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7714,6 +7714,38 @@ if(TARGET iccApplyProfiles AND TARGET iccApplySearch
     SKIP_RETURN_CODE 77)
 endif()
 
+# #2414: fopen() succeeds on a directory, so a directory argument reaches code
+# that believes it opened a file.  #2411 hit this in iccFromXml's schema lookup;
+# the same shape HANGS iccFromCube (isEOF() tested feof() alone, while a failed
+# read sets ferror() and leaves feof() false) and hangs iccFromXml on a FIFO
+# schema -- all CWE-835.  Three defect cases fail against ee14d031, two of them
+# with rc=124; the five controls pass on BOTH builds, which is what proves the
+# guard is not too eager.  One control is a FIFO into iccFromCube, guarding the
+# FIX rather than the defect: a path probe before open() takes a named pipe from
+# 254 to 124, which is why iccFromCube does not use the shared guard.
+#
+# Deliberately NOT labelled "slow", so it runs on the pull_request path:
+# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+#
+# 300s for a 220s worst case (7 spawns: 20+60+20+20+20+60+20), matching the two
+# registrations above.  240 would leave 20s for eight process spawns, and on a
+# sanitizer or loaded leg a run where two cases genuinely time out overshoots it
+# -- CTest then kills the script, so none of its per-case [FAIL] lines or log
+# tails are produced and the lane reports a bare "Timeout" for precisely the
+# regression this suite exists to diagnose.
+if(TARGET iccFromCube AND TARGET iccFromXml)
+  iccdev_add_script_test(
+    iccdev.directory-read-guard-regression
+    300
+    "iccdev;tools;cli;fromcube;fromxml;directory;issue-2414;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2414-directory-read-guard-tests.sh"
+  )
+  # Exits 77 when neither tool is built or no case was measured.
+  set_tests_properties(iccdev.directory-read-guard-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # The iccApply* half of the same CLI-contract family (#2405).  Guarded on all
 # four targets because the script measures all four and its "nothing measured"
 # guard would otherwise turn a partial build into a skip that hides real cases.

--- a/IccProfLib/IccFileUtil.h
+++ b/IccProfLib/IccFileUtil.h
@@ -65,9 +65,14 @@
 #include <cstdio>
 #include <string>
 
+// sys/types.h + sys/stat.h are needed on BOTH arms now: icIsReadableFile() tests for a
+// regular file on Windows too, via _stat/_S_IFREG.  They were POSIX-guarded while only
+// the POSIX arm used them.
+#include <sys/types.h>
+#include <sys/stat.h>
+
 #if !defined(_WIN32)
 #include <fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h>
 #endif
 
@@ -202,6 +207,104 @@ inline std::string icSanitizeConsoleText(const char* szText)
 inline std::string icSanitizeConsoleText(const std::string& text)
 {
   return icSanitizeConsoleText(text.c_str());
+}
+
+// True when szPath names a regular file a byte can actually be read from.
+//
+// fopen(dir, "r") SUCCEEDS on glibc, so "it opened" does not mean "it is a file":
+// iccFromXml's -v=<some-directory> slipped past an openability guard and produced a
+// four-line libxml2 cascade naming the XML file instead of the one-line schema error
+// the guard existed to give (#2411).
+//
+// BOTH tests are needed, and each covers what the other misses -- measured, not assumed.
+//
+// The regular-file test alone is not enough: it says nothing about whether the file can
+// actually be read, which is the case #2411 was about.
+//
+// The read alone is not enough either.  With this function's O_NONBLOCK open, read() on
+// a writer-less FIFO returns 0 -- end-of-file, indistinguishable from an empty regular
+// file -- so the read arm ACCEPTS it, and the caller's own blocking reopen then hangs.
+// Deleting the S_ISREG line and keeping everything else makes exactly that happen:
+// the suite's fromxml-schema-fifo case goes from rc=1 to a 124 timeout.  (An earlier
+// note here claimed read() failed with EAGAIN in that case.  It does not; it returns 0.)
+//
+// ANSWERS ONE QUESTION: "is this a REGULAR file I can read a byte from".  It is for a
+// caller that will open the path AGAIN afterwards -- a schema handed to libxml2, a
+// candidate probed while walking PATH -- so anything that cannot survive being opened
+// twice must be refused here rather than accepted.  Hence the S_ISREG test: a FIFO
+// passes a naive read-a-byte probe and then HANGS the caller's reopen, because the
+// probe has already consumed the single writer's rendezvous.  Measured on 00b91b56,
+// before this arm existed: `iccFromXml x.xml o.icc -v=<a fifo>` sat at exit 124 both
+// with a writer and without one (a read-open of a writer-less FIFO blocks on its own).
+//
+// O_NONBLOCK is what makes the refusal cheap rather than another hang: it lets the
+// open of a writer-less FIFO return immediately so fstat() can reject it.  It has no
+// effect on a regular file, which never blocks.
+//
+// A caller whose input may LEGITIMATELY be a pipe or a device must not use this at all
+// -- it would refuse valid input.  Validate the HANDLE you are holding instead: test
+// ferror() on the stream you already opened.  That is what iccFromCube does, and why
+// it does not call this.
+//
+// An empty regular file is READABLE: read() returns 0 with no error, which is why the
+// test is n >= 0 rather than n == 1.
+//
+// Still a diagnostic guard, not a security boundary -- it answers the question at one
+// instant and the caller opens the path again.  Where the identity of the opened object
+// matters, keep the validated handle instead: see icWriteDocumentAndClose() in
+// Tools/CmdLine/IccCmdLineUtil.h.
+inline bool icIsReadableFile(const char* szPath)
+{
+  if (!szPath || !szPath[0])
+    return false;
+
+#if !defined(_WIN32)
+  int fd = open(szPath, O_RDONLY | O_NONBLOCK);
+  if (fd < 0)
+    return false;
+
+  struct stat st;
+  if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode)) {
+    close(fd);
+    return false;
+  }
+
+  char ch;
+  ssize_t nRead = read(fd, &ch, 1);
+  close(fd);
+  return nRead >= 0;
+#else
+  // The regular-file test is needed HERE TOO, and read-a-byte cannot stand in for it.
+  // Win32 resolves the reserved DOS device names (NUL, CON, AUX, COM1-9, LPT1-9)
+  // anywhere on a path, with any extension: fopen("NUL", "rb") SUCCEEDS and fread()
+  // then reports EOF with no error -- exactly what an empty regular file looks like.
+  // So a read-only test returns TRUE for NUL, and `iccFromXml in.xml out.icc -v=NUL`
+  // would pass this guard, leaving validation silently skipped at exit 0: the very
+  // failure the caller added the guard to remove (#2411).  _S_IFREG rejects it.
+  //
+  // _S_IFMT/_S_IFREG rather than S_ISREG(): MSVC's <sys/stat.h> defines the former
+  // pair but not the macro, and IccIO.cpp guards its S_ISREG() helpers out of the
+  // Windows build for that reason.  A path that does not exist yet cannot be stat()ed
+  // at all -- Tools/CmdLine/IccApplyProfiles/TiffImg.cpp:isWindowsDevicePath() solves
+  // that neighbouring problem name-first, for the WRITE side.
+  //
+  // No O_NONBLOCK equivalent here, and none is needed: the writer-less-FIFO block this
+  // guard avoids on POSIX is not reachable through a Win32 path a schema is spelled
+  // with.  Read-a-byte otherwise means the same thing: stdio fills a whole buffer, so
+  // this remains a test for seekable inputs.
+  struct _stat st;
+  if (_stat(szPath, &st) != 0 || (st.st_mode & _S_IFMT) != _S_IFREG)
+    return false;
+
+  FILE* f = fopen(szPath, "rb");
+  if (!f)
+    return false;
+
+  char ch;
+  bool bReadable = (fread(&ch, 1, 1, f) == 1) || (feof(f) && !ferror(f));
+  fclose(f);
+  return bReadable;
+#endif
 }
 
 inline FILE* icOpenRegularWriteFile(const char* szFname, const char* szMode)

--- a/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
+++ b/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
@@ -8,6 +8,7 @@
 #include "IccIO.h"
 #include "IccUtil.h"
 #include "IccProfLibVer.h"
+#include "IccFileUtil.h"
 #include "IccLibXMLVer.h"
 #include "IccXmlConfig.h"
 #include <cstdlib>
@@ -37,25 +38,10 @@ static bool isHelpRequest(const char *szArg)
          !stricmp(szArg, "-help") || !stricmp(szArg, "-?");
 }
 
-// Whether szPath names something that can actually be READ as a file.
-//
-// fopen(dir, "r") succeeds on glibc, so "it opened" does not mean "it is a schema":
-// -v=<some-directory> slipped past the openability guard below and produced a
-// four-line libxml2 cascade naming the XML file instead of the one-line schema error
-// the guard exists to give.  Reading a byte is the portable discriminator -- a
-// directory fails the read with EISDIR, while a legitimately empty file reports EOF
-// with no error (#2387).
-static bool isReadableFile(const char *szPath)
-{
-  FILE *f = fopen(szPath, "r");
-  if (!f)
-    return false;
-
-  char ch;
-  bool bReadable = (fread(&ch, 1, 1, f) == 1) || (feof(f) && !ferror(f));
-  fclose(f);
-  return bReadable;
-}
+// The read-a-byte discriminator this file introduced in #2411 now lives in
+// IccProfLib/IccFileUtil.h as icIsReadableFile(), beside icOpenRegularWriteFile()'s
+// write-side check, so the other CLI tools can reach it too (#2414).  It was static
+// here, so nothing else could.
 
 // The directory the running executable lives in, with a trailing separator, or an
 // empty string when it cannot be determined.
@@ -109,7 +95,7 @@ static std::string executableDir(const char *szArgv0)
       char cLast = dir[dir.size() - 1];
       if (cLast != '/' && cLast != '\\')
         dir += "/";
-      if (isReadableFile((dir + exe).c_str()))
+      if (icIsReadableFile((dir + exe).c_str()))
         return dir;
     }
 
@@ -188,7 +174,7 @@ int main(int argc, char* argv[])
           fprintf(stderr, "Error: -v= requires a RelaxNG schema file path\n");
           return EXIT_FAILURE;
         }
-        if (!isReadableFile(szRelaxNGDir.c_str())) {
+        if (!icIsReadableFile(szRelaxNGDir.c_str())) {
           fprintf(stderr, "Error: cannot read RelaxNG schema '%s'\n", szRelaxNGDir.c_str());
           return EXIT_FAILURE;
         }
@@ -199,14 +185,14 @@ int main(int argc, char* argv[])
         // BINARY lives in, so the documented invocation never found it.  Try the
         // documented location first, then the executable's own directory, so an
         // installation shipping the schema beside the binary keeps working.
-        if (isReadableFile(szRelaxNGFileName)) {
+        if (icIsReadableFile(szRelaxNGFileName)) {
           szRelaxNGDir = szRelaxNGFileName;
         }
         else {
           std::string dir = executableDir(argv[0]);
           if (!dir.empty()) {
             std::string path = dir + szRelaxNGFileName;
-            if (isReadableFile(path.c_str()))
+            if (icIsReadableFile(path.c_str()))
               szRelaxNGDir = path;
           }
         }

--- a/Tools/CmdLine/IccFromCube/iccFromCube.cpp
+++ b/Tools/CmdLine/IccFromCube/iccFromCube.cpp
@@ -437,7 +437,27 @@ protected:
     return rv;
   }
 
-  bool isEOF() { return m_f ? feof(m_f)!=0 : true; }
+  // ferror() belongs in this test as much as feof().  A read that FAILS -- a directory
+  // (EISDIR), an I/O error mid-file -- makes fgetc() return EOF while leaving feof()
+  // FALSE and setting ferror() instead, so getNextLine() returned an empty string and
+  // the three `while (!isEOF())` loops below never advanced: iccFromCube spun forever
+  // on a directory argument, at exit code 124 under any timeout (#2414, CWE-835).
+  //
+  // This is the whole fix, deliberately.  Probing the path with icIsReadableFile()
+  // before opening it looks like the tidier guard and is a REGRESSION: the probe
+  // opens, reads and closes, so a second fopen() of a single-reader FIFO blocks on a
+  // writer that has already been consumed.  Measured -- `mkfifo p; cat x.cube > p &`
+  // then iccFromCube on p exits 254 here and hung at 124 with that guard in place.
+  // Validate the stream you are holding, not the path you are about to open again.
+  //
+  // It does NOT terminate every unreadable stream, and the limit is worth naming:
+  // getNextLine()'s own `while ((c = fgetc(m_f)) != EOF && c != '\n')` never consults
+  // isEOF(), so an ENDLESS readable stream still spins -- /dev/zero hangs at 124 both
+  // before and after this change, at a flat RSS, so it is CPU exhaustion rather than an
+  // allocation blow-up.  That is a separate pre-existing defect in the line reader:
+  // filed as #2442, because bounding it changes what a legitimately long line means and
+  // MAX_LINE_LEN below caps what is STORED, not what is CONSUMED.
+  bool isEOF() { return m_f ? (feof(m_f)!=0 || ferror(m_f)!=0) : true; }
 
 // Longest line iccFromCube keeps the text of.  The .cube format sets no line
 // length limit, but reading a line unbounded would let one pathological line


### PR DESCRIPTION
Part of #2414 — the directory-`fopen()` half. The ANSI-scrub half is not in here.

`fopen(dir, "r")` succeeds on glibc, so "it opened" does not mean "it is a file". #2411 hit
this in `iccFromXml`'s schema lookup, but the guard was `static` in `IccFromXml.cpp`, so
nothing else could reach it. Promoting it turned up **two hangs of the same class**.

## 1. `iccFromCube` hung on a directory

```
isEOF() { return m_f ? feof(m_f)!=0 : true; }
```

A read that **fails** — `EISDIR` — makes `fgetc()` return `EOF` while leaving `feof()`
**false** and setting `ferror()` instead. `getNextLine()` returned an empty string forever and
the three `while (!isEOF())` loops never advanced. On `ee14d031`: **exit 124 under any
timeout**, flat RSS (CWE-835).

The fix is the `ferror()` arm and nothing else. **`iccFromCube` deliberately does not call the
promoted helper** — that was my first version and it is a regression:

| input | `ee14d031` | with a path probe before `open()` | this PR |
|---|---|---|---|
| directory | **124 hang** | 254 | 254 |
| FIFO | 254 | **124 hang** | 254 |

The probe opens, reads and closes, so the caller's second `fopen()` of a single-reader FIFO
blocks on a writer already consumed. A `.cube` may legitimately arrive through a pipe, so the
right move is to validate the stream you hold, not the path you are about to reopen.

## 2. `iccFromXml` hung on a FIFO schema

rc=124 both with a writer and without one (a read-open of a writer-less FIFO blocks on its
own). Pre-existing since #2411. Here the input is *never* legitimately a pipe — a RelaxNG
schema is a file the caller reopens through libxml2 — so the guard is the right place:
`open(O_RDONLY|O_NONBLOCK)` + `fstat`/`S_ISREG`, then read a byte.

**Both tests are needed, measured rather than assumed.** The regular-file test says nothing
about readability, which is what #2411 was about. The read alone accepts a writer-less FIFO,
because under `O_NONBLOCK` `read()` returns **0** — indistinguishable from an empty regular
file — and the caller's blocking reopen then hangs. Deleting only the `S_ISREG` line takes
`fromxml-schema-fifo` from rc=1 to a 124 timeout, so that arm is pinned by the suite.

**The `_WIN32` arm needs the regular-file test too.** Win32 resolves `NUL`, `CON`, `AUX`,
`COM1-9`, `LPT1-9` anywhere on a path; `fopen("NUL","rb")` succeeds and `fread()` reports EOF
with no error — byte-identical to an empty regular file. Without a test,
`iccFromXml in.xml out.icc -v=NUL` passes the guard on all four Windows legs and leaves
validation **silently skipped at exit 0** — the failure #2411 removed. `_stat`/`_S_IFREG`
rejects it (`_S_IFMT`/`_S_IFREG` rather than `S_ISREG()`, since MSVC defines the pair but not
the macro — which is why `IccIO.cpp` guards its `S_ISREG` helpers out of the Windows build).
`TiffImg.cpp:isWindowsDevicePath()` solves the neighbouring write-side problem name-first, for
paths that cannot be `stat()`ed at all.

`accept-any`, `reject-all` and malformed `.rng` schemas are unaffected, as is a conversion
with no `-v`.

## What this does *not* fix

`getNextLine()`'s own `fgetc()` loop never consults `isEOF()`, so an **endless readable**
stream still spins — `/dev/zero` hangs at 124 before *and* after this change, at flat RSS.
Separate pre-existing defect; **filed as #2442** and referenced from the comment rather than
left as a source-only disclosure. Bounding it changes what a legitimately long line means, and
`MAX_LINE_LEN` caps what is *stored*, not what is *consumed* (#1843) — so it wants its own
ruling.

## Test

CTest `iccdev.directory-read-guard-regression`, 8 cases:

| case | `ee14d031` | this branch |
|---|---|---|
| `fromcube-directory-terminates` | **FAIL** rc=124 | PASS rc=254 |
| `fromcube-directory-names-path` | **FAIL** no diagnostic | PASS |
| `fromxml-schema-fifo` | **FAIL** rc=124 | PASS rc=1 |
| `fromcube-regular-file-converts` | PASS | PASS |
| `fromcube-missing-file-unchanged` | PASS | PASS |
| `fromcube-devnull-unchanged` | PASS | PASS |
| `fromcube-fifo-terminates` | PASS | PASS |
| `fromxml-schema-directory` | PASS | PASS |

The five controls passing on **both** builds is the point of them — they prove the guard is
not too eager. `/dev/null` is still accepted and refused by the **parser**, asserted on the
parser's own message: an rc check alone would pass against the S_ISREG-everywhere
implementation it exists to rule out. Nothing else covers `/dev/null` as *input* —
`iccdev.issue-1178-fromcube-devnull` passes it as the **output** path.

Two things about the harness itself, both of which had silently broken it:

- It resolved the tools directory by testing the **directory**, and `Build/Tools` exists as
  CMake scaffolding with no binaries — so all five `iccFromCube` cases skipped and the suite
  **exited 0**, carried by the single `iccFromXml` case. It now probes for the binaries,
  prefers a complete tree, never overrides an explicit `ICCDEV_TOOLS_DIR`, and exits **77**
  rather than 0 when no `iccFromCube` case ran.
- Each FIFO fixture is removed **before** it is created: `mkfifo` fails on an existing path, so
  one interrupted run (a CTest TIMEOUT kill, Ctrl-C) disabled that case permanently while
  still reporting green.

Registered at 300s for a 220s worst case, matching the two sibling script tests; at 240 a run
with two real timeouts overshoots and CTest kills the script before it can print which case
failed.

## CI

`ci-pr-action` dispatched on the branch before opening this PR:
[run 34066181286](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34066181286)
— **success**. All four Windows legs green (MSVC, ClangCL, MinGW UCRT64, Release perf), which
is the real check on the `_stat`/`_S_IFREG` arm. `iccdev.directory-read-guard-regression`
**ran and passed** under GCC Strict ASAN+UBSAN Debug (249 tests, 0 failed) — verified in the
log rather than inferred from a green tick, since the 77 gate would otherwise report a skip.

All existing `fromcube`, `fromxml`, `xml-parser` and `relaxng` CTests pass unchanged.
