### PR TITLE
fix(#2442): bound what iccFromCube's line reader consumes, not only what it keeps

### DIFF
--- a/.github/scripts/iccdev-issue-2442-fromcube-endless-stream-tests.sh
+++ b/.github/scripts/iccdev-issue-2442-fromcube-endless-stream-tests.sh
@@ -1,0 +1,387 @@
+#!/bin/bash
+###############################################################################
+# #2442 -- iccFromCube spins forever on an endless readable stream
+###############################################################################
+#
+# CubeFile::getNextLine() read with
+#
+#   while ((c = fgetc(m_f)) != EOF && c != '\n')
+#
+# which ends on EOF or a newline and consults nothing else.  On a stream that is
+# endlessly readable and never yields a newline, neither ever arrives, so the
+# loop spins inside a SINGLE getNextLine() call.  Measured on 5bbe773f: exit 124
+# under any timeout at a flat RSS -- CPU exhaustion, not an allocation blow-up
+# (CWE-835).
+#
+# This is the sibling of #2414, not a duplicate of it.  #2414 repaired isEOF()
+# so the three `while (!isEOF())` loops terminate on a FAILED read; this loop
+# never reaches isEOF() at all, so /dev/zero measured 124 both before and after
+# that fix.  MAX_LINE_LEN does not bound it either: that caps what is STORED,
+# and characters past it are deliberately still consumed so the tail of an
+# over-long line is not returned as the next call's "line" (#1843).
+#
+# The fix bounds what is CONSUMED at MAX_LINE_CONSUME_LEN (8 * MAX_LINE_LEN =
+# 65536) and marks the stream unusable, which routes the case into the same
+# `while (!isEOF())` loops #2414 already terminates.
+#
+# WHAT IS REACHABLE, measured rather than assumed.  The stream must be SEEKABLE
+# as well as endless: parseHeader() calls ftell() at the top of every iteration
+# and refuses with "header parsing error" when it returns -1, so a pipe never
+# gets as far as this loop.  An endlessly-fed FIFO (`tr -dc a < /dev/zero > p`)
+# exits 254 on the UNFIXED build.  That leaves seekable character devices --
+# /dev/zero and /dev/full, both covered below.  /dev/urandom is deliberately NOT
+# a case: random bytes contain 0x0A, so it terminates on its own and would be a
+# fixture that passes against the unfixed build.
+#
+# Anti-vacuity, which is most of this file.  A cap is trivially satisfied by a
+# tool that refuses more than it should, and that failure would be INVISIBLE to
+# the two defect cases -- so eight of the eleven cases are controls that must
+# pass on BOTH builds, and three of them pin the cap's boundary from the other
+# side:
+#
+#   * a 20000-character comment -- over MAX_LINE_LEN, far under the consume cap
+#   * a line of 65535 consumed characters -- one below the cap
+#   * an over-long TABLE ROW, which must still be rejected by parse3DTable() as
+#     "Invalid 3DLUT entry" and NOT silently misread (#1843)
+#
+# The trailing-junk pair is there because the cap DID cost a validation once:
+# the "Too many 3DLUT entries" loop accepts empty lines, so a discarded
+# over-long line read as a blank one and the parse returned success on a file
+# master rejects.  Neither build may accept it.
+#
+# The /dev/null case is here for the same reason it is in the #2414 suite, and
+# it is the argument against "just require a regular file": /dev/null is a
+# character device, so an S_ISREG guard would refuse it before the parser saw
+# it, and the contract is that it reaches the parser and is refused THERE.
+#
+# Red/green against 5bbe773f: devzero-terminates and devfull-terminates fail
+# with rc=124, devzero-names-cause finds no diagnostic, and over-cap-refused
+# fails because the unfixed build ACCEPTS the file (rc=0).  The other five cases
+# pass on both builds -- that is what they are for.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# An explicit ICCDEV_TOOLS_DIR is never second-guessed: resolving past it would
+# measure a DIFFERENT build than the caller meant, which is how a stale tree
+# fakes a result.
+if [ -n "${ICCDEV_TOOLS_DIR:-}" ]; then
+  TOOLS_DIR="$ICCDEV_TOOLS_DIR"
+  TOOLS_DIR_EXPLICIT=1
+else
+  TOOLS_DIR="$REPO_ROOT/Build/Tools"
+  TOOLS_DIR_EXPLICIT=0
+fi
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-2442-fromcube-endless-stream}"
+mkdir -p "$OUTDIR"
+
+# Resolve on the BINARY, not on the directory.  Build/Tools exists in a
+# configured tree as CMake scaffolding with nothing built under it, so a
+# directory test picks a path where every case skips -- and the suite would
+# still exit 0.  A green run that skipped every case covering the defect is the
+# failure mode this accounting exists to prevent (#2414 hit exactly that).
+if [ "$TOOLS_DIR_EXPLICIT" -eq 0 ] && [ ! -x "$TOOLS_DIR/IccFromCube/iccFromCube" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/out/build/Tools"; do
+    if [ -x "$candidate/IccFromCube/iccFromCube" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+FROMCUBE="$TOOLS_DIR/IccFromCube/iccFromCube"
+CUBE_OK="$REPO_ROOT/.github/ci/test-data/test-identity.cube"
+
+# Must track MAX_LINE_CONSUME_LEN in iccFromCube.cpp.  Asserted rather than
+# assumed: the over/under pair below is only a boundary test if this is the
+# boundary, so a change to the constant that is not mirrored here turns two
+# cases into noise.
+CAP=65536
+
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+# Counted separately: the endless-stream cases are the ones that cover the
+# defect, so the suite must not be able to report success without them.
+DEFECT_MEASURED=0
+
+fail_case() { echo "  [FAIL] $1 -- $2"; FAIL=$((FAIL + 1)); }
+pass_case() { echo "  [PASS] $1 -- $2"; PASS=$((PASS + 1)); }
+skip_case() { echo "  [SKIP] $1 -- $2"; SKIP=$((SKIP + 1)); }
+
+if [ ! -x "$FROMCUBE" ]; then
+  echo "iccFromCube not built at $FROMCUBE -- nothing measured"
+  echo "=== summary: 0 passed, 0 failed, 11 skipped, 0 total ==="
+  exit 77
+fi
+if [ ! -f "$CUBE_OK" ]; then
+  echo "fixture missing: $CUBE_OK -- nothing measured"
+  echo "=== summary: 0 passed, 0 failed, 11 skipped, 0 total ==="
+  exit 77
+fi
+
+# --- fixtures -------------------------------------------------------------
+# Generated rather than tracked: three of them are 64 KB of one repeated
+# character, which is corpus bloat for no reading benefit, and generating them
+# keeps the sizes visibly tied to $CAP above.
+#
+# awk rather than reading /dev/zero, deliberately.  This suite uses that device
+# as INPUT UNDER TEST, and iccdev_add_script_test has no WIN32 guard, so on a
+# lane where it is absent the fixtures would come out short and the cap cases
+# would fail for a reason that has nothing to do with the fix.  The device cases
+# skip cleanly there; the fixture cases must not depend on it.
+# Doubling rather than appending one character at a time: 70000 single-character
+# concatenations is quadratic in some awks, ~17 doublings is not.
+repeat_char() { # $1 = count, $2 = character
+  awk -v n="$1" -v c="$2" 'BEGIN { s = c; while (length(s) < n) s = s s; printf "%s", substr(s, 1, n) }'
+}
+
+make_long_line_cube() { # $1 = consumed chars on the first line, $2 = output
+  {
+    printf '# '
+    repeat_char "$(( $1 - 2 ))" 'y'
+    printf '\n'
+    cat "$CUBE_OK"
+  } > "$2"
+}
+
+make_long_line_cube 20000        "$OUTDIR/long-comment.cube"
+make_long_line_cube "$((CAP-1))" "$OUTDIR/just-under.cube"
+make_long_line_cube "$((CAP+1))" "$OUTDIR/just-over.cube"
+
+# Trailing junk AFTER a complete table, in two lengths.  The long one is the
+# case that caught a regression in this very fix: the trailing
+# "Too many 3DLUT entries" loop treats an empty line as legal, so a DISCARDED
+# over-long line looked identical to a blank one and the parse returned success
+# -- printing the cap diagnostic and then "successfully created" at rc=0, on a
+# file master rejects.  The short one pins that the ordinary trailing-garbage
+# check still works, so the long case cannot be satisfied by breaking both.
+{ cat "$CUBE_OK"; repeat_char 100 'z'; printf '\n'; } \
+  > "$OUTDIR/trailing-short.cube"
+{ cat "$CUBE_OK"; repeat_char 70000 'z'; printf '\n'; } \
+  > "$OUTDIR/trailing-long.cube"
+
+# An over-long TABLE ROW rather than a comment: this is the #1843 shape, where
+# the tail past MAX_LINE_LEN is dropped from the returned text and the row is
+# then short of its three floats and rejected explicitly.
+{
+  head -4 "$CUBE_OK"
+  printf '0.0 0.0 0.0 '
+  repeat_char 20000 '9'
+  printf '\n'
+  tail -n +6 "$CUBE_OK"
+} > "$OUTDIR/long-row.cube"
+
+# --- (1) the defect: /dev/zero --------------------------------------------
+# 15s against a ~0.1s real conversion, so a timeout here is the loop, not a
+# slow machine.
+if [ ! -c /dev/zero ]; then
+  skip_case devzero-terminates "/dev/zero is not a character device here"
+  skip_case devzero-names-cause "/dev/zero is not a character device here"
+else
+  LOG="$OUTDIR/devzero.log"
+  rc=0
+  timeout 15 "$FROMCUBE" /dev/zero "$OUTDIR/devzero.icc" > "$LOG" 2>&1 || rc=$?
+  TOTAL=$((TOTAL + 1)); DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+  if [ "$rc" -eq 124 ]; then
+    fail_case devzero-terminates "timed out (rc=124) -- the getNextLine() spin is back"
+  elif [ "$rc" -eq 0 ]; then
+    fail_case devzero-terminates "reported success on /dev/zero (rc=0)"
+  else
+    pass_case devzero-terminates "refused with rc=$rc"
+  fi
+
+  # (2) Anti-vacuity for (1).  "Did not hang" is satisfied by a tool that fails
+  # for some unrelated reason, so the refusal has to be THIS refusal: the cap
+  # naming itself, and the parse failure naming the file.
+  TOTAL=$((TOTAL + 1))
+  if ! grep -q "Line longer than $CAP characters" "$LOG" 2>/dev/null; then
+    fail_case devzero-names-cause "no cap diagnostic -- terminated for some other reason"
+    sed -n '1,10p' "$LOG"
+  elif ! grep -q "Unable to parse .*/dev/zero" "$LOG" 2>/dev/null; then
+    fail_case devzero-names-cause "cap diagnostic present but the parse did not fail naming the file"
+    sed -n '1,10p' "$LOG"
+  else
+    pass_case devzero-names-cause "named the cap and failed the parse"
+  fi
+fi
+
+# --- (3) the same defect through a second device --------------------------
+# /dev/full is not a duplicate of /dev/zero here: it is the check that the fix
+# is a property of the READ loop rather than a special case for one path.
+if [ ! -c /dev/full ]; then
+  skip_case devfull-terminates "/dev/full not present on this platform"
+else
+  rc=0
+  timeout 15 "$FROMCUBE" /dev/full "$OUTDIR/devfull.icc" > "$OUTDIR/devfull.log" 2>&1 || rc=$?
+  TOTAL=$((TOTAL + 1)); DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+  if [ "$rc" -eq 124 ]; then
+    fail_case devfull-terminates "timed out (rc=124)"
+  elif [ "$rc" -eq 0 ]; then
+    fail_case devfull-terminates "reported success on /dev/full (rc=0)"
+  else
+    pass_case devfull-terminates "refused with rc=$rc"
+  fi
+fi
+
+# --- (4) the cap's upper side ---------------------------------------------
+TOTAL=$((TOTAL + 1)); DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+rc=0
+timeout 30 "$FROMCUBE" "$OUTDIR/just-over.cube" "$OUTDIR/just-over.icc" \
+  > "$OUTDIR/just-over.log" 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+  fail_case over-cap-refused "accepted a $((CAP+1))-character line (rc=0) -- the cap is not in effect"
+elif [ "$rc" -eq 124 ]; then
+  fail_case over-cap-refused "timed out (rc=124)"
+elif grep -q "Line longer than $CAP characters" "$OUTDIR/just-over.log" 2>/dev/null; then
+  pass_case over-cap-refused "refused at the cap with rc=$rc"
+else
+  fail_case over-cap-refused "rc=$rc but not the cap's diagnostic"
+  sed -n '1,10p' "$OUTDIR/just-over.log"
+fi
+
+# --- (5) the cap's lower side: ONE character below it must still convert ---
+# This is the case that would catch an off-by-one or a cap applied to the
+# stored text rather than the consumed text.
+TOTAL=$((TOTAL + 1))
+rm -f "$OUTDIR/just-under.icc"
+rc=0
+timeout 30 "$FROMCUBE" "$OUTDIR/just-under.cube" "$OUTDIR/just-under.icc" \
+  > "$OUTDIR/just-under.log" 2>&1 || rc=$?
+if [ "$rc" -eq 0 ] && [ -s "$OUTDIR/just-under.icc" ]; then
+  pass_case under-cap-converts "$((CAP-1))-character line converted, $(wc -c < "$OUTDIR/just-under.icc") bytes"
+else
+  fail_case under-cap-converts "rc=$rc -- the cap bites one character early"
+  sed -n '1,10p' "$OUTDIR/just-under.log"
+fi
+
+# --- (6) control: a long comment, over MAX_LINE_LEN but far under the cap --
+TOTAL=$((TOTAL + 1))
+rm -f "$OUTDIR/long-comment.icc"
+rc=0
+timeout 30 "$FROMCUBE" "$OUTDIR/long-comment.cube" "$OUTDIR/long-comment.icc" \
+  > "$OUTDIR/long-comment.log" 2>&1 || rc=$?
+if [ "$rc" -eq 0 ] && [ -s "$OUTDIR/long-comment.icc" ]; then
+  pass_case long-comment-converts "20000-character comment converted"
+else
+  fail_case long-comment-converts "rc=$rc -- a legal over-MAX_LINE_LEN line was refused"
+  sed -n '1,10p' "$OUTDIR/long-comment.log"
+fi
+
+# --- (7) control: #1843 must stay fixed -----------------------------------
+# An over-long table row is short of its three floats once the tail is dropped,
+# and must be rejected AS a bad entry rather than resumed mid-line and misread
+# as a row of its own.
+TOTAL=$((TOTAL + 1))
+rc=0
+timeout 30 "$FROMCUBE" "$OUTDIR/long-row.cube" "$OUTDIR/long-row.icc" \
+  > "$OUTDIR/long-row.log" 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+  fail_case long-row-rejected "accepted a truncated 3DLUT row (rc=0)"
+elif grep -q "Invalid 3DLUT entry" "$OUTDIR/long-row.log" 2>/dev/null; then
+  pass_case long-row-rejected "rejected as a bad entry, rc=$rc (#1843 intact)"
+else
+  fail_case long-row-rejected "rc=$rc but not the parser's entry error -- the line was resumed or misread"
+  sed -n '1,10p' "$OUTDIR/long-row.log"
+fi
+
+# --- (7b) the regression this fix introduced once: trailing junk ----------
+# Both are controls in the sense that they must pass on master too -- the point
+# is that the cap must not COST a validation.  rc alone is the assertion for the
+# long one: which message comes back legitimately differs between builds (master
+# still has the line's text and says "Too many 3DLUT entries"; with the cap the
+# text is gone, so the honest answer is that the file was not read), but neither
+# build may accept the file.
+TOTAL=$((TOTAL + 1))
+rm -f "$OUTDIR/trailing-long.icc"
+rc=0
+timeout 30 "$FROMCUBE" "$OUTDIR/trailing-long.cube" "$OUTDIR/trailing-long.icc" \
+  > "$OUTDIR/trailing-long.log" 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+  fail_case trailing-long-rejected "accepted a $((CAP+4464))-character line after a complete table (rc=0) -- the cap dropped a validation"
+  sed -n '1,10p' "$OUTDIR/trailing-long.log"
+elif [ -s "$OUTDIR/trailing-long.icc" ]; then
+  fail_case trailing-long-rejected "rc=$rc but a profile was still written"
+else
+  pass_case trailing-long-rejected "refused with rc=$rc and wrote nothing"
+fi
+
+TOTAL=$((TOTAL + 1))
+rc=0
+timeout 30 "$FROMCUBE" "$OUTDIR/trailing-short.cube" "$OUTDIR/trailing-short.icc" \
+  > "$OUTDIR/trailing-short.log" 2>&1 || rc=$?
+if grep -q "Too many 3DLUT entries" "$OUTDIR/trailing-short.log" 2>/dev/null && [ "$rc" -ne 0 ]; then
+  pass_case trailing-short-rejected "ordinary trailing garbage still refused, rc=$rc"
+else
+  fail_case trailing-short-rejected "rc=$rc -- the ordinary trailing-garbage check is gone"
+  sed -n '1,10p' "$OUTDIR/trailing-short.log"
+fi
+
+# --- (8) control: /dev/null must still reach the PARSER --------------------
+# The argument against "require a regular file": /dev/null is a character
+# device, so an S_ISREG guard refuses it before the parse.  rc alone cannot
+# tell the two apart -- both are non-zero -- so the discriminator is WHICH
+# message comes back.
+if [ ! -c /dev/null ]; then
+  skip_case devnull-reaches-parser "/dev/null is not a character device here"
+else
+  TOTAL=$((TOTAL + 1))
+  rc=0
+  timeout 20 "$FROMCUBE" /dev/null "$OUTDIR/devnull.icc" > "$OUTDIR/devnull.log" 2>&1 || rc=$?
+  if [ "$rc" -eq 0 ] || [ "$rc" -eq 124 ]; then
+    fail_case devnull-reaches-parser "rc=$rc"
+    sed -n '1,10p' "$OUTDIR/devnull.log"
+  elif grep -q "Line longer than" "$OUTDIR/devnull.log" 2>/dev/null; then
+    fail_case devnull-reaches-parser "the consume cap fired on an EMPTY stream"
+    sed -n '1,10p' "$OUTDIR/devnull.log"
+  elif grep -q "Unable to parse .*/dev/null" "$OUTDIR/devnull.log" 2>/dev/null; then
+    pass_case devnull-reaches-parser "reached the parser and was refused there, rc=$rc"
+  else
+    fail_case devnull-reaches-parser "rc=$rc but not the parser's refusal -- a guard rejected it first"
+    sed -n '1,10p' "$OUTDIR/devnull.log"
+  fi
+fi
+
+# --- (9) control: a real .cube still converts ------------------------------
+TOTAL=$((TOTAL + 1))
+rm -f "$OUTDIR/identity.icc"
+rc=0
+timeout 60 "$FROMCUBE" "$CUBE_OK" "$OUTDIR/identity.icc" > "$OUTDIR/identity.log" 2>&1 || rc=$?
+if [ "$rc" -eq 0 ] && [ -s "$OUTDIR/identity.icc" ]; then
+  pass_case regular-file-converts "converted, $(wc -c < "$OUTDIR/identity.icc") bytes"
+else
+  fail_case regular-file-converts "rc=$rc"
+  sed -n '1,10p' "$OUTDIR/identity.log"
+fi
+
+echo "=== summary: $PASS passed, $FAIL failed, $SKIP skipped, $TOTAL total ==="
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+if [ "$PASS" -eq 0 ]; then
+  echo "no case was measured -- treating as skipped rather than passed"
+  exit 77
+fi
+# The endless-stream and over-cap cases are the ones that cover the defect.
+# Passing on the controls alone is not evidence about this fix.
+if [ "$DEFECT_MEASURED" -eq 0 ]; then
+  echo "no endless-stream case ran (tools dir: $TOOLS_DIR) -- treating as skipped rather than passed"
+  exit 77
+fi
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7766,6 +7766,39 @@ if(TARGET iccFromCube AND TARGET iccFromXml)
     SKIP_RETURN_CODE 77)
 endif()
 
+# #2442: the sibling of #2414 in the same tool, and the reason it is a separate
+# registration rather than another case in that script -- it is a different loop
+# with a different termination route.  #2414 repaired isEOF() so the three
+# `while (!isEOF())` loops end on a FAILED read; getNextLine()'s own fgetc loop
+# never consults isEOF(), so an endlessly readable stream that never emits a
+# newline spun inside one call and /dev/zero measured 124 both before and after
+# that fix (CWE-835).
+#
+# Guarded on iccFromCube alone: unlike the #2414 suite this measures one tool,
+# so a partial build has nothing to hide.
+#
+# Deliberately NOT labelled "slow", so it runs on the pull_request path:
+# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+#
+# 400s for a 290s worst case (10 spawns: 15+15+30+30+30+30+30+30+20+60).  As
+# with the registration above, the budget is set over the SUM of the per-case
+# timeouts rather than over the ~0.1s a healthy run takes: a tighter one risks
+# CTest killing the script instead of letting it fail, which would replace
+# eleven per-case verdicts and their log tails with a bare "Timeout" for exactly
+# the regression this suite exists to diagnose.
+if(TARGET iccFromCube)
+  iccdev_add_script_test(
+    iccdev.fromcube-endless-stream-regression
+    400
+    "iccdev;tools;cli;fromcube;endless;issue-2442;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2442-fromcube-endless-stream-tests.sh"
+  )
+  # Exits 77 when iccFromCube is not built or no endless-stream case was measured.
+  set_tests_properties(iccdev.fromcube-endless-stream-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # The iccApply* half of the same CLI-contract family (#2405).  Guarded on all
 # four targets because the script measures all four and its "nothing measured"
 # guard would otherwise turn a partial build into a skip that hides real cases.

--- a/Tools/CmdLine/IccFromCube/iccFromCube.cpp
+++ b/Tools/CmdLine/IccFromCube/iccFromCube.cpp
@@ -325,7 +325,22 @@ public:
       }
     }
 
-    return true;
+    // This loop needs its own arm, and it is the one place the consume cap does
+    // not simply fall out of an existing failure path.  The other two callers
+    // already treat a given-up stream as failure -- parseHeader() through
+    // `return !isEOF()`, and the table loop above through `n != num` -- but here
+    // an empty line is LEGAL, so a discarded over-long line is indistinguishable
+    // from a blank one and the loop would exit and report success.  It did:
+    // a complete table followed by a 70000-character junk line printed the cap
+    // diagnostic and then "successfully created" at rc=0, writing a profile that
+    // master rejects with "Too many 3DLUT entries" -- an error message on a
+    // successful exit, and a validation LOST to a change meant to add one.
+    //
+    // Refuse instead of guessing.  Whether the discarded line was trailing
+    // garbage or a harmless comment is exactly what the cap threw away, so the
+    // only honest answer is that the file was not read, and main() says so with
+    // "Unable to parse LUT from", naming it.
+    return !m_bStreamUnusable;
   }
 
 protected:
@@ -392,6 +407,10 @@ protected:
   
   bool open()
   {
+    // Cleared here and nowhere else: this is the one point that means "start of
+    // stream" for both the first open and the fseek-to-0 re-open below.
+    m_bStreamUnusable = false;
+
     if (!m_f) {
       m_f = fopen(m_sFilename.c_str(), "rb");
     }
@@ -450,14 +469,15 @@ protected:
   // then iccFromCube on p exits 254 here and hung at 124 with that guard in place.
   // Validate the stream you are holding, not the path you are about to open again.
   //
-  // It does NOT terminate every unreadable stream, and the limit is worth naming:
-  // getNextLine()'s own `while ((c = fgetc(m_f)) != EOF && c != '\n')` never consults
-  // isEOF(), so an ENDLESS readable stream still spins -- /dev/zero hangs at 124 both
-  // before and after this change, at a flat RSS, so it is CPU exhaustion rather than an
-  // allocation blow-up.  That is a separate pre-existing defect in the line reader:
-  // filed as #2442, because bounding it changes what a legitimately long line means and
-  // MAX_LINE_LEN below caps what is STORED, not what is CONSUMED.
-  bool isEOF() { return m_f ? (feof(m_f)!=0 || ferror(m_f)!=0) : true; }
+  // m_bStreamUnusable is the second arm, and it comes from the sibling defect (#2442).
+  // The ferror() test above cannot reach an ENDLESSLY READABLE stream: getNextLine()'s
+  // own `while ((c = fgetc(m_f)) != EOF && c != '\n')` never consults isEOF(), so on a
+  // stream that always yields a byte and never a newline neither EOF nor ferror() ever
+  // arrives and the read loop spins inside a single getNextLine() call.  /dev/zero hung
+  // at 124 with a flat RSS -- CPU exhaustion, not an allocation blow-up (CWE-835).
+  // getNextLine() bounds what it CONSUMES and raises this flag, which routes that case
+  // into the same three `while (!isEOF())` loops the ferror() arm already terminates.
+  bool isEOF() { return m_bStreamUnusable || (m_f ? (feof(m_f)!=0 || ferror(m_f)!=0) : true); }
 
 // Longest line iccFromCube keeps the text of.  The .cube format sets no line
 // length limit, but reading a line unbounded would let one pathological line
@@ -466,10 +486,26 @@ protected:
 // above the longest row seen in practice.
 #define MAX_LINE_LEN 8192u
 
+// Longest line iccFromCube will CONSUME, as opposed to keep the text of (#2442).
+// The two caps are separate on purpose.  MAX_LINE_LEN bounds the string that comes
+// back, and characters past it are deliberately still READ so that the tail of an
+// over-long line is not returned as the next call's "line" (#1843) -- which means
+// MAX_LINE_LEN on its own places no bound at all on how long the loop below runs.
+//
+// The .cube format sets no line length limit, so this number is a contract, not an
+// implementation detail, and it is chosen to be unreachable by any real file rather
+// than to be tight: a table row is three floats and roughly thirty characters, and
+// the longest line in the tracked corpus is under 100.  Eight times the store cap
+// leaves that whole margin intact -- every line short of 64 KiB still behaves
+// exactly as it did, tail-dropped and then rejected by the parser -- while still
+// terminating a stream that never emits a newline at all.
+#define MAX_LINE_CONSUME_LEN (8u * MAX_LINE_LEN)
+
   std::string getNextLine()
   {
     std::string rv;
     int c;
+    icUInt32Number nConsumed = 0;
 
     // Consume to the end of the physical line, not merely to MAX_LINE_LEN.  The
     // previous loop stopped once it had taken MAX_LINE_LEN characters *without*
@@ -481,6 +517,29 @@ protected:
     // table row short of its three floats, so it is rejected explicitly by
     // parse3DTable() rather than silently misread as a different row.
     while ((c = fgetc(m_f)) != EOF && c != '\n') {
+      // Counted before the '\r' skip below, because what has to be bounded is the
+      // work this loop does, not the text it keeps -- a stream of bare carriage
+      // returns is exactly as endless as a stream of any other byte.
+      if (++nConsumed > MAX_LINE_CONSUME_LEN) {
+        // Fail the parse rather than resume mid-line.  Returning the truncated text
+        // here would hand a fragment to the caller to be parsed as a keyword or a
+        // table row in its own right, which is the #1843 defect the consume-to-EOL
+        // loop was written to fix; and resuming at the cut point would make the
+        // remainder the next call's line, which is the same thing one call later.
+        // Dropping the text and marking the stream unusable ends the parse instead:
+        // isEOF() now reports true, so parseHeader() returns false through
+        // `return !isEOF()` and parse3DTable()'s table loop stops short of its row
+        // count and reports an incomplete table.  Its TRAILING loop is the
+        // exception and checks m_bStreamUnusable directly -- an empty line is legal
+        // there, so "the stream gave up" and "a blank line" arrive looking alike;
+        // see the comment on that return.  All three routes end in main() printing
+        // "Unable to parse", naming the file.
+        printf("Line longer than %u characters\n", (unsigned int)MAX_LINE_CONSUME_LEN);
+        m_bStreamUnusable = true;
+        rv.clear();
+        return rv;
+      }
+
       if (c == '\r') //skip unsupported carriage returns
         continue;
 
@@ -492,6 +551,12 @@ protected:
   }
 
   FILE* m_f=nullptr;
+
+  // Sticky for the lifetime of the open stream, and cleared by open() rather than
+  // by the caller: parseHeader() and parse3DTable() read the same handle in turn,
+  // so a flag reset between them would let the second pass spin on the stream the
+  // first one just gave up on.
+  bool m_bStreamUnusable=false;
 
   int m_sizeLut3D = 0;
   icFloatNumber m_fMinInput[3] = { 0.0f, 0.0f, 0.0f };


### PR DESCRIPTION
Part of #2442.

`CubeFile::getNextLine()` ended its read on `EOF` or a newline and consulted nothing
else, so a stream that is endlessly readable and never yields a newline spun inside a
single call. Measured on `5bbe773f`:

```
$ timeout 6 iccFromCube /dev/zero out.icc ; echo $?
124
```

Flat RSS while spinning, so this is CPU exhaustion rather than an allocation blow-up
(CWE-835).

## Why #2414 did not cover it

That fix repaired `isEOF()` so the three `while (!isEOF())` loops end on a **failed**
read. This loop never reaches `isEOF()`, so `/dev/zero` measured 124 both before and
after it. `MAX_LINE_LEN` does not bound it either: it caps what is **stored**, and
characters past it are deliberately still consumed so the tail of an over-long line is
not returned as the next call's "line" (#1843).

## The fix

Bound the **consumed** characters at `MAX_LINE_CONSUME_LEN` and mark the stream
unusable. That routes the case into the loops #2414 already terminates:
`parseHeader()` fails through `return !isEOF()`, `parse3DTable()` reports an incomplete
table, and `main()` prints `Unable to parse`, naming the file.

```
$ iccFromCube /dev/zero out.icc ; echo $?
Line longer than 65536 characters
Unable to parse '/dev/zero'
254
```

The over-long line's text is **discarded**, not truncated and returned. Handing back a
fragment to be parsed as a keyword or a table row in its own right is exactly the #1843
defect, and resuming at the cut point is the same thing one call later.

### The trailing loop needs its own arm

Discarding the text costs information, and one caller depends on it. `parse3DTable()`'s
trailing "Too many 3DLUT entries" loop treats an **empty line as legal**, so a discarded
over-long line is indistinguishable from a blank one — the loop exits and returns
success. The first draft of this fix did exactly that:

```
$ iccFromCube <complete table + 70000-char junk line> out.icc ; echo $?
Line longer than 65536 characters
'out.icc' successfully created
0
```

An error diagnostic on a **successful exit**, writing a profile that master rejects with
`Too many 3DLUT entries` — a validation *lost* to a change meant to add one. Caught by
`/code-review`. The loop now ends with `return !m_bStreamUnusable`, so the file is
refused at rc=252 with `Unable to parse LUT from`, naming it.

The other two callers already route correctly: `parseHeader()` through
`return !isEOF()`, and the table loop through its `n != num` row-count check.

**The cap is a contract, so it is named and justified rather than tight:**
`8 * MAX_LINE_LEN = 65536`, against a longest tracked corpus line under 100 characters
and a table row of roughly thirty. Every line short of 64 KiB behaves exactly as before
— measured, not assumed:

| first line | unfixed | fixed |
|---|---|---|
| 20000-char comment (over `MAX_LINE_LEN`) | rc=0, 17216 bytes | rc=0, 17216 bytes |
| 65535 consumed (cap − 1) | rc=0 | rc=0 |
| 65537 consumed (cap + 1) | **rc=0** | rc=254, cap named |

The one behaviour change is the last row: a line longer than 64 KiB is now refused
instead of silently tail-dropped.

## Two corrections to my own issue body

Both were measured while building the fixtures, and both narrow the defect:

1. **The stream must be SEEKABLE as well as endless.** `parseHeader()` calls `ftell()`
   at the top of every iteration and refuses with `header parsing error` when it
   returns −1. So an endlessly-fed FIFO (`tr -dc a < /dev/zero > p`) already exited
   **254 on the unfixed build** — the issue lists it as reachable, and it is not.
2. **A `.cube` through a pipe has never worked at all**, for the same reason. My stated
   argument against option 3 ("a `.cube` arriving through a pipe is legitimate input")
   is therefore wrong.

Option 3 is still the wrong instrument, but for a different reason: `/dev/null` is a
character device, and `iccdev.directory-read-guard-regression` pins that it must reach
the **parser** and be refused there. An `S_ISREG` guard would refuse it first and break
that case.

That leaves seekable character devices as the reachable set: `/dev/zero` and
`/dev/full`, both covered below. `/dev/urandom` is deliberately **not** a case — random
bytes contain `0x0A`, so it terminates on its own and would be a fixture that passes
against the unfixed build.

## What this does not bound, and why it is not reachable

The cap bounds characters **within one line**, not the **number** of lines, so
`parseHeader()`'s `while (!isEOF())` is still unbounded on a stream that endlessly emits
newlines or comment lines. I could not construct a reachable case for it:

* non-seekable streams never get that far — `ftell()` refuses them first (measured:
  `mkfifo p; yes "" > p` exits 254 with `header parsing error`);
* the only seekable endless sources are the character devices, and none emits newlines —
  `/dev/zero` and `/dev/full` emit NULs, which this cap now catches, while `/dev/random`
  and `/dev/urandom` emit random bytes that the header's keyword check rejects
  (`Unknown keyword`, rc=254).

So it needs a device that does not exist on a stock system. Recording it rather than
claiming the loop family is now fully bounded — if that assumption is wrong somewhere I
have not looked, this is the paragraph to correct.

## Test

`iccdev.fromcube-endless-stream-regression`, eleven cases, 400s budget for a 290s worst
case (set over the sum of the per-case timeouts, not the ~0.1s a healthy run takes).
Not labelled `slow`, so it runs on the `pull_request` path.

Against `5bbe773f` — **4 red, 7 green, 0 skipped**:

```
[FAIL] devzero-terminates   -- timed out (rc=124) -- the getNextLine() spin is back
[FAIL] devzero-names-cause  -- no cap diagnostic -- terminated for some other reason
[FAIL] devfull-terminates   -- timed out (rc=124)
[FAIL] over-cap-refused     -- accepted a 65537-character line (rc=0)
[PASS] under-cap-converts       [PASS] long-comment-converts
[PASS] long-row-rejected        [PASS] devnull-reaches-parser
[PASS] trailing-long-rejected   [PASS] trailing-short-rejected
[PASS] regular-file-converts
```

The seven controls pass on **both** builds — that is their job. A cap is trivially
satisfied by a tool that refuses more than it should, and that failure would be
invisible to the two defect cases. Three pin the boundary from the other side (a
20000-char comment, a line one character under the cap, and an over-long **table row**
that must still be rejected as `Invalid 3DLUT entry` so #1843 stays fixed), and
`devnull-reaches-parser` is the one that would catch the `S_ISREG` mistake above.

`trailing-long-rejected` is the case for the regression described earlier, and it is
not vacuous: run against the first draft of this fix it is the **only** case that
fails, and it passes against both master and the corrected build. `trailing-short-rejected`
sits beside it so the long case cannot be satisfied by breaking the ordinary
trailing-garbage check as well.

Fixtures are built using `awk` rather than by reading `/dev/zero`, because this suite
uses that device as *input under test* and `iccdev_add_script_test` has no `WIN32` guard
— the device cases skip cleanly where it is absent, but the fixture cases must not
silently shrink.

Control conversions were confirmed byte-identical to the unfixed build apart from
`dateTime` (bytes 33, 35) and the profile ID (84–99).

Full `tools|cli` label sweep: **74/74 pass**, 2 pre-existing skips. `shellcheck` clean
bare over the new script.

## Out of scope, noted while measuring

`iccFromCube` prints *file content* unsanitized — `/dev/urandom` produces
`Unknown keyword '<raw bytes>'` straight to the terminal. That is the #2406 class on a
content path rather than a path argument, in one of the six tools I listed on #2414 as
having no sanitization at all. Not touched here; happy to fold it into the #2414
remainder.

## CI

`ci-pr-action` dispatched on the branch before opening this PR (run
[34082336695](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34082336695),
`ci_scope=auto`) — **success**, including GCC 15.2 Strict Release LTO, Windows MSVC /
ClangCL / MinGW UCRT64, macOS Clang Debug and Release LTO, and Tools GCC Strict
ASAN+UBSAN.

The new test is confirmed to have **run** there rather than skipped:
`160/251 Test #161: iccdev.fromcube-endless-stream-regression ... Passed 1.09 sec`,
in a job reporting `100% tests passed, 0 tests failed out of 251`.
