### PR TITLE
fix(#2439): encode a legacy config name for the file that reads it back

### DIFF
--- a/.github/scripts/iccdev-issue-2439-config-name-roundtrip-tests.sh
+++ b/.github/scripts/iccdev-issue-2439-config-name-roundtrip-tests.sh
@@ -1,0 +1,518 @@
+#!/bin/bash
+###############################################################################
+# #2439 -- the legacy config writer hands a name token to the CONSOLE sanitizer,
+#          so the only text fromLegacy() reads back is encoded for a terminal
+###############################################################################
+#
+# #2420 asked what a file-safe encoder should look like at IccCmmConfig.cpp:2393
+# and :2403. Measuring it turned up two defects, not one.
+#
+# 1. The round trip does not close. icSanitizeConsoleText() is written for a
+#    terminal and is deliberately lossy -- every non-ASCII codepoint becomes an
+#    escape and a literal backslash is left alone. A profile colour named
+#    Gr<U+00FC>n went out as { "Gr\u00FCn" } and came back as the eight
+#    characters G r \ u 0 0 F C n, which matches no colour. Measured on
+#    764fc176: exit 0 on the way out, "Profile application failed." on the way
+#    back in. This dates from #1683 (d59c072d), which introduced the sanitize
+#    call, NOT from #2419 -- worth stating because the sub-issue that spawned
+#    this suite says #2419.
+#
+# 2. That encoding made a stack-buffer-overflow reachable from the tool's own
+#    output. ParseName() strncpy()'d the token into a caller-supplied char[256]
+#    using a length read straight out of the token, with nothing bounding it
+#    (CWE-787). It is not a sanitizer-only finding: on a stock Release build
+#    glibc's _FORTIFY_SOURCE catches the strncpy and the tool ABORTS, exit 134,
+#    "*** buffer overflow detected ***". A colour name of 43 accented characters
+#    is 86 bytes going in and 258 characters coming back out at six characters
+#    per escape -- so the crash is reachable by round-tripping a legitimate
+#    profile, not only by hand-writing a long name.
+#
+# The fix splits the sink instead of widening the escape set. A named file gets
+# EncodeCfgName(), which escapes only \ " and control codepoints and writes every
+# printable codepoint as its own bytes; stdout keeps icSanitizeConsoleText(),
+# because stdout may be a terminal and #2406/#2420 put that escaping there.
+#
+# Anti-vacuity. The three CONTROL cases carry as much weight as the defect cases
+# and MUST pass on both builds:
+#
+#   stdout-console-escaping-kept  The cheap way to "fix" the round trip is to
+#       drop the escaping. That re-opens #2406 and #2420 -- U+202E and the C1
+#       controls would reach a terminal again -- and every defect case here
+#       would still go green. This case is the only thing standing between the
+#       two.
+#   ascii-corpus-unchanged  All three tracked legacy fixtures must produce the
+#       output they always did. Verified byte-for-byte across builds while
+#       developing the fix (96KB over the three); asserted here on the token
+#       shape, which is what a future encoder change would move.
+#   backslash-name-preserved  Adding a decoder is an acceptance change: a name
+#       that already contained a backslash must not start decoding. The escape
+#       set is deliberately small ({ \\ \" \xNN }) and unknown escapes are kept
+#       verbatim, so C:\temp still reads as C:\temp -- \t is NOT an escape this
+#       writer emits. Zero tracked corpus files carry a backslash or a non-ASCII
+#       byte in a name token (git ls-files '*.txt', 3 files), so this case is the
+#       only cover for the acceptance change.
+#
+# Both profiles are built here from tracked XML rather than taken from Testing/,
+# where every .icc is generated and may not exist yet.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# An explicit ICCDEV_TOOLS_DIR is never second-guessed: resolving past it would
+# measure a different build than the caller meant, which is how a stale tree
+# fakes a result.
+if [ -n "${ICCDEV_TOOLS_DIR:-}" ]; then
+  TOOLS_DIR="$ICCDEV_TOOLS_DIR"
+  TOOLS_DIR_EXPLICIT=1
+else
+  TOOLS_DIR="$REPO_ROOT/Build/Tools"
+  TOOLS_DIR_EXPLICIT=0
+fi
+
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-2439-config-name-roundtrip}"
+rm -rf "$OUTDIR"
+mkdir -p "$OUTDIR"
+
+# Resolve on the BINARIES. Build/Tools exists in a configured tree as CMake
+# scaffolding with no executables under it, and a directory test would resolve
+# to a path where nothing is built, skip every case and still exit 0.
+tools_dir_ok() {
+  [ -x "$1/IccApplyNamedCmm/iccApplyNamedCmm" ] && [ -x "$1/IccFromXml/iccFromXml" ]
+}
+
+if [ "$TOOLS_DIR_EXPLICIT" -eq 0 ] && ! tools_dir_ok "$TOOLS_DIR"; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/out/build/Tools"; do
+    if tools_dir_ok "$candidate"; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+APPLY="$TOOLS_DIR/IccApplyNamedCmm/iccApplyNamedCmm"
+SEARCH="$TOOLS_DIR/IccApplySearch/iccApplySearch"
+FROMXML="$TOOLS_DIR/IccFromXml/iccFromXml"
+NAMED_XML="$REPO_ROOT/Testing/Named/NamedColor.xml"
+
+PASS=0
+FAIL=0
+SKIP=0
+
+# Counted separately: the overflow and round-trip cases are the ones that cover
+# the defect, so the suite must not be able to report success without them.
+DEFECT_MEASURED=0
+
+fail_case() { echo "  [FAIL] $1 -- $2"; FAIL=$((FAIL + 1)); }
+pass_case() { echo "  [PASS] $1 -- $2"; PASS=$((PASS + 1)); }
+skip_case() { echo "  [SKIP] $1 -- $2"; SKIP=$((SKIP + 1)); }
+
+echo "=== #2439 legacy config name encoding ==="
+
+if [ ! -x "$FROMXML" ] || [ ! -x "$APPLY" ] || [ ! -f "$NAMED_XML" ]; then
+  echo "  [SKIP] iccFromXml/iccApplyNamedCmm not built, or $NAMED_XML missing"
+  exit 77
+fi
+
+# --------------------------------------------------------------------------
+# Fixtures, built here so the suite does not depend on generated Testing/*.icc
+# --------------------------------------------------------------------------
+# U+00FC as its two UTF-8 bytes. Written with printf rather than as a literal so
+# this file stays pure ASCII and cannot be mangled by an editor or a checkout.
+UCH="$(printf '\303\274')"
+UNAME="Gr${UCH}n"
+# 43 codepoints: 86 bytes in, 258 characters out under the console escaping --
+# just past the 256-byte buffer, which is the point.
+WIDENAME="$(printf '\303\274%.0s' $(seq 1 43))"
+BSNAME='C:\temp'
+
+make_profile() {  # $1 = colour name to substitute for "Gray", $2 = output .icc
+  local name="$1" out="$2"
+  # The name goes through the environment, not the command line: BSNAME is
+  # C:\temp and an argument would have to survive two layers of quoting.
+  if ! NEWNAME="$name" python3 - "$NAMED_XML" "$OUTDIR/tmp.xml" <<'PY'
+import os, sys
+src = open(sys.argv[1], encoding='utf-8').read()
+open(sys.argv[2], 'w', encoding='utf-8').write(
+    src.replace('CDATA[Gray]', 'CDATA[%s]' % os.environ['NEWNAME']))
+PY
+  then
+    return 1
+  fi
+  timeout 120 "$FROMXML" "$OUTDIR/tmp.xml" "$out" > "$OUTDIR/fromxml.log" 2>&1
+  [ -f "$out" ]
+}
+
+make_legacy() {  # $1 = name token contents, $2 = output .txt
+  printf "'nmcl'\t; Data Format\nicEncodeValue\t; Encoding\n\n{ \"%s\" } 1.0\n" "$1" > "$2"
+}
+
+if ! command -v python3 > /dev/null 2>&1; then
+  echo "  [SKIP] python3 unavailable; every case needs a generated profile"
+  exit 77
+fi
+
+# Called one at a time on purpose. Packing "$name:$path" into a loop variable
+# and splitting on ':' silently built the backslash profile under the name "C",
+# because BSNAME is C:\temp -- the control then failed for a reason that had
+# nothing to do with the code under test.
+build_or_skip() {
+  if ! make_profile "$1" "$2"; then
+    echo "  [SKIP] could not build $2 from $NAMED_XML"
+    sed -n '1,20p' "$OUTDIR/fromxml.log" 2>/dev/null
+    exit 77
+  fi
+}
+
+build_or_skip "$UNAME"    "$OUTDIR/utf8.icc"
+build_or_skip "$BSNAME"   "$OUTDIR/bslash.icc"
+build_or_skip "$WIDENAME" "$OUTDIR/wide.icc"
+
+# --------------------------------------------------------------------------
+# 1/2. The overflow, on iccApplyNamedCmm and iccApplySearch
+#
+# 400 'A' characters. Deliberately past 256 rather than exactly at it: at
+# exactly 256 the strncpy still fits and only the trailing NUL store is out of
+# bounds, which _FORTIFY_SOURCE does not see -- ASan does, but this case has to
+# be red on an uninstrumented build too. Exit 134 (SIGABRT) on 764fc176.
+# --------------------------------------------------------------------------
+make_legacy "$(printf 'A%.0s' $(seq 1 400))" "$OUTDIR/long.txt"
+
+check_no_crash() {  # $1 = case, $2 = log, $3 = rc
+  local name="$1" log="$2" rc="$3"
+
+  if grep -qE "ERROR: AddressSanitizer|buffer overflow detected|stack smashing" "$log" 2>/dev/null; then
+    fail_case "$name" "overflow reported: $(grep -m1 -oE 'ERROR: AddressSanitizer[^ ]*|buffer overflow detected|stack smashing' "$log")"
+    return 1
+  fi
+  # 134 = SIGABRT, 139 = SIGSEGV. A tool that dies without a message still died.
+  # Bounded above at 192: iccApplySearch answers a refused profile chain with
+  # `return -1`, which the shell reports as 255, and an unbounded test read that
+  # as a signal.
+  if [ "$rc" -ge 128 ] && [ "$rc" -le 192 ]; then
+    fail_case "$name" "killed by signal $((rc - 128)) (rc=$rc)"
+    return 1
+  fi
+  pass_case "$name" "parsed a 400-character name without an out-of-bounds write (rc=$rc)"
+  return 0
+}
+
+timeout 60 "$APPLY" "$OUTDIR/long.txt" 0 0 "$OUTDIR/utf8.icc" 1 > "$OUTDIR/long-apply.log" 2>&1
+check_no_crash overflow-longname-namedcmm "$OUTDIR/long-apply.log" $?
+DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+
+if [ -x "$SEARCH" ]; then
+  # Usage 2 of iccApplySearch needs two profiles and an -INIT intent; with one
+  # profile it rejects the command line before it ever reads the data file, and
+  # the case would pass against the unfixed build.
+  timeout 60 "$SEARCH" "$OUTDIR/long.txt" 0 0 "$OUTDIR/utf8.icc" 1 "$OUTDIR/utf8.icc" 1 -INIT 1 \
+    > "$OUTDIR/long-search.log" 2>&1
+  rc=$?
+  # The chain of two named-colour profiles is refused at AddXform, which is fine
+  # -- that happens AFTER fromLegacy. What would make this case vacuous is an
+  # exit BEFORE the data file is read, so those two diagnostics are disqualifying.
+  if grep -qE "Unable to parse legacy data file|Unable to parse profile sequence arguments" \
+       "$OUTDIR/long-search.log" 2>/dev/null; then
+    skip_case overflow-longname-applysearch "the run exited before it read the data file"
+  else
+    check_no_crash overflow-longname-applysearch "$OUTDIR/long-search.log" "$rc"
+    DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+  fi
+else
+  skip_case overflow-longname-applysearch "iccApplySearch not built"
+fi
+
+# --------------------------------------------------------------------------
+# 3. The tool's own output, fed back in
+#
+# 43 accented characters: legal, unremarkable, 86 bytes. Under the console
+# escaping the token comes back 258 characters long and the re-read aborts.
+# --------------------------------------------------------------------------
+make_legacy "$WIDENAME" "$OUTDIR/wide-in.txt"
+timeout 60 "$APPLY" "$OUTDIR/wide-in.txt" 0 0 "$OUTDIR/wide.icc" 1 > "$OUTDIR/wide-1.log" 2>&1
+WIDE_TOKEN="$(grep -o '{ "[^"]*" }' "$OUTDIR/wide-1.log" | head -1)"
+
+if [ -z "$WIDE_TOKEN" ]; then
+  skip_case overflow-self-output "first pass emitted no name token"
+else
+  printf "'nmcl'\t; Data Format\nicEncodeValue\t; Encoding\n\n%s 1.0\n" "$WIDE_TOKEN" > "$OUTDIR/wide-in2.txt"
+  timeout 60 "$APPLY" "$OUTDIR/wide-in2.txt" 0 0 "$OUTDIR/wide.icc" 1 > "$OUTDIR/wide-2.log" 2>&1
+  rc=$?
+  if grep -qE "ERROR: AddressSanitizer|buffer overflow detected|stack smashing" "$OUTDIR/wide-2.log" 2>/dev/null \
+     || { [ "$rc" -ge 128 ] && [ "$rc" -le 192 ]; }; then
+    fail_case overflow-self-output "re-reading the tool's own 43-codepoint name token crashed it (rc=$rc)"
+  else
+    pass_case overflow-self-output "the tool's own name token re-reads without an out-of-bounds write (rc=$rc)"
+  fi
+  DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+fi
+
+# --------------------------------------------------------------------------
+# 4. The round trip, through a named destination FILE
+#
+# This is the sink the fix is about: a config file iccApplyNamedCmm writes and
+# then reads back. Two assertions, because either alone is weak -- the token
+# must hold the name's own bytes, AND the re-read must find the colour.
+# --------------------------------------------------------------------------
+make_legacy "$UNAME" "$OUTDIR/utf8-in.txt"
+cat > "$OUTDIR/rt.json" <<EOF_CFG
+{
+  "dataFiles": {
+    "srcType": "legacy",
+    "srcFile": "$OUTDIR/utf8-in.txt",
+    "dstType": "legacy",
+    "dstFile": "$OUTDIR/rt-out.txt",
+    "dstEncoding": "value"
+  },
+  "profileSequence": [
+    { "iccFile": "$OUTDIR/utf8.icc", "intent": "relative" }
+  ]
+}
+EOF_CFG
+
+timeout 60 "$APPLY" -cfg "$OUTDIR/rt.json" > "$OUTDIR/rt.log" 2>&1
+if [ ! -f "$OUTDIR/rt-out.txt" ]; then
+  skip_case roundtrip-nonascii-file "the tool wrote no destination file"
+  skip_case roundtrip-nonascii-reread "the tool wrote no destination file"
+else
+  FILE_TOKEN="$(grep -o '{ "[^"]*" }' "$OUTDIR/rt-out.txt" | head -1)"
+
+  if [ "$FILE_TOKEN" = "{ \"$UNAME\" }" ]; then
+    pass_case roundtrip-nonascii-file "the config file carries the name's own UTF-8 bytes"
+  else
+    fail_case roundtrip-nonascii-file "config file token is '$FILE_TOKEN', expected '{ \"$UNAME\" }'"
+  fi
+  DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+
+  printf "'nmcl'\t; Data Format\nicEncodeValue\t; Encoding\n\n%s 1.0\n" "$FILE_TOKEN" > "$OUTDIR/rt-back.txt"
+  timeout 60 "$APPLY" "$OUTDIR/rt-back.txt" 0 0 "$OUTDIR/utf8.icc" 1 > "$OUTDIR/rt-back.log" 2>&1
+  if grep -q "Profile application failed" "$OUTDIR/rt-back.log"; then
+    fail_case roundtrip-nonascii-reread "the colour written to the config file no longer matches the profile"
+  else
+    pass_case roundtrip-nonascii-reread "the name written to a config file reads back and applies"
+  fi
+  DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+fi
+
+# --------------------------------------------------------------------------
+# 4b. A name containing the terminator sequence itself
+#
+# ParseName() finds the end of the token with strstr(..., '" }'), which knows
+# nothing about escapes. The first cut of this fix spelled a quote \" and a name
+# holding '" }' matched at its OWN escaped quote: A" }B went out as A\" }B and
+# came back as A\. The quote is written \x22 for exactly this reason, so no raw
+# '"' byte survives inside a token and the scan has only one thing it can match.
+#
+# Red against that first cut, and against 764fc176 for a different reason -- the
+# console encoder left the quote raw, so the name truncated at 'A' there too.
+# --------------------------------------------------------------------------
+QNAME='A" }B'
+if make_profile "$QNAME" "$OUTDIR/quote.icc"; then
+  cat > "$OUTDIR/q.json" <<EOF_QCFG
+{
+  "dataFiles": {
+    "srcType": "legacy",
+    "srcFile": "$OUTDIR/qin.txt",
+    "dstType": "legacy",
+    "dstFile": "$OUTDIR/qout.txt",
+    "dstEncoding": "value"
+  },
+  "profileSequence": [
+    { "iccFile": "$OUTDIR/quote.icc", "intent": "relative" }
+  ]
+}
+EOF_QCFG
+  # The source name is spelled with the escape the writer itself emits, so the
+  # reader has to decode it to find the colour at all.
+  make_legacy 'A\x22 }B' "$OUTDIR/qin.txt"
+  timeout 60 "$APPLY" -cfg "$OUTDIR/q.json" > "$OUTDIR/q.log" 2>&1
+
+  if [ ! -f "$OUTDIR/qout.txt" ]; then
+    fail_case terminator-in-name "no destination file: the name holding '\" }' was not matched"
+  else
+    Q_TOKEN="$(grep -o '{ "[^"]*" }' "$OUTDIR/qout.txt" | head -1)"
+    if [ "$Q_TOKEN" = '{ "A\x22 }B" }' ]; then
+      pass_case terminator-in-name "a name containing the token terminator survives the round trip"
+    else
+      fail_case terminator-in-name "token '$Q_TOKEN', expected '{ \"A\\x22 }B\" }' -- a raw quote lets the terminator scan match inside the name"
+    fi
+  fi
+  DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+else
+  skip_case terminator-in-name "could not build the quote fixture"
+fi
+
+# --------------------------------------------------------------------------
+# 5. CONTROL -- stdout must KEEP the #2420 codepoint escaping.
+#
+# Passes on both builds. Without it, deleting the escaping altogether would turn
+# every case above green while re-opening #2406/#2420 on the terminal.
+# --------------------------------------------------------------------------
+timeout 60 "$APPLY" "$OUTDIR/utf8-in.txt" 0 0 "$OUTDIR/utf8.icc" 1 > "$OUTDIR/stdout.log" 2>&1
+STDOUT_TOKEN="$(grep -o '{ "[^"]*" }' "$OUTDIR/stdout.log" | head -1)"
+if [ "$STDOUT_TOKEN" = '{ "Gr\u00FCn" }' ]; then
+  pass_case stdout-console-escaping-kept "stdout still escapes U+00FC by codepoint"
+else
+  fail_case stdout-console-escaping-kept "stdout token is '$STDOUT_TOKEN', expected '{ \"Gr\\u00FCn\" }' -- console escaping must not be dropped to close the round trip"
+fi
+
+# --------------------------------------------------------------------------
+# 6. CONTROL -- the tracked ASCII corpus is untouched. Passes on both builds.
+# --------------------------------------------------------------------------
+CORPUS="$REPO_ROOT/Testing/Named/NamedColorTest.txt"
+CORPUS_ICC="$OUTDIR/corpus.icc"
+if [ -f "$CORPUS" ] && make_profile "Gray" "$CORPUS_ICC"; then
+  timeout 60 "$APPLY" "$CORPUS" 0 0 "$CORPUS_ICC" 1 > "$OUTDIR/corpus.log" 2>&1
+  missing=""
+  for n in Black Gray Blue Red Green; do
+    grep -Fq "{ \"$n\" }" "$OUTDIR/corpus.log" || missing="$missing $n"
+  done
+  if [ -z "$missing" ]; then
+    pass_case ascii-corpus-unchanged "every tracked ASCII name still round-trips verbatim"
+  else
+    fail_case ascii-corpus-unchanged "missing name tokens:$missing"
+  fi
+else
+  skip_case ascii-corpus-unchanged "$CORPUS or its profile unavailable"
+fi
+
+# --------------------------------------------------------------------------
+# 7a. CONTROL -- an UNKNOWN escape must not start decoding. Passes on both builds.
+#
+# C:\temp contains \t, which the writer never emits, so the decoder keeps both
+# characters and the name is untouched. This is the bulk of the acceptance
+# surface: every escape except \\ and \xNN behaves exactly as it did before.
+# --------------------------------------------------------------------------
+make_legacy 'C:\temp' "$OUTDIR/bslash-in.txt"
+timeout 60 "$APPLY" "$OUTDIR/bslash-in.txt" 0 0 "$OUTDIR/bslash.icc" 1 > "$OUTDIR/bslash.log" 2>&1
+BS_TOKEN="$(grep -o '{ "[^"]*" }' "$OUTDIR/bslash.log" | head -1)"
+if [ "$BS_TOKEN" = '{ "C:\temp" }' ] && ! grep -q "Profile application failed" "$OUTDIR/bslash.log"; then
+  pass_case backslash-unknown-escape-preserved "an escape the writer never emits is kept verbatim"
+else
+  fail_case backslash-unknown-escape-preserved "token '$BS_TOKEN' -- \\t must not be decoded"
+fi
+
+# --------------------------------------------------------------------------
+# 7b. ACCEPTANCE CHANGE, asserted rather than assumed.
+#
+# \\ and \xNN are the ONLY two spellings that move, and they DO move: a
+# hand-written name C:\x41rt used to match a profile colour spelled literally
+# C:\x41rt and now matches one spelled C:Art. An earlier draft of this suite
+# claimed "a backslash reads exactly as it did before", which is false for these
+# two -- the claim is narrowed here and pinned by measurement. Red pre-fix by
+# design: this case documents the intended change, it does not guard against it.
+# --------------------------------------------------------------------------
+if make_profile 'C:Art' "$OUTDIR/decoded.icc"; then
+  make_legacy 'C:\x41rt' "$OUTDIR/esc-in.txt"
+  timeout 60 "$APPLY" "$OUTDIR/esc-in.txt" 0 0 "$OUTDIR/decoded.icc" 1 > "$OUTDIR/esc.log" 2>&1
+  if grep -q "Profile application failed" "$OUTDIR/esc.log"; then
+    fail_case hex-escape-decodes "C:\\x41rt did not resolve to the colour named C:Art"
+  else
+    pass_case hex-escape-decodes "\\xNN decodes -- the acceptance change is exactly this and \\\\"
+  fi
+  DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+else
+  skip_case hex-escape-decodes "could not build the C:Art fixture"
+fi
+
+# --------------------------------------------------------------------------
+# 8. A name that BEGINS with the terminator's tail
+#
+# ParseName() used to look for '" }' from the start of the line, where the '{ "'
+# prefix supplies a quote of its own. A colour named ' }B' therefore "ended"
+# before it began -- ptr < p, the decode loop never ran, and fromLegacy() dropped
+# the row with no diagnostic at all. Red on 764fc176, where the row vanishes.
+# --------------------------------------------------------------------------
+if make_profile ' }B' "$OUTDIR/brace.icc"; then
+  make_legacy ' }B' "$OUTDIR/brace-in.txt"
+  timeout 60 "$APPLY" "$OUTDIR/brace-in.txt" 0 0 "$OUTDIR/brace.icc" 1 > "$OUTDIR/brace.log" 2>&1
+  BR_TOKEN="$(grep -o '{ "[^"]*" }' "$OUTDIR/brace.log" | head -1)"
+  if [ "$BR_TOKEN" = '{ " }B" }' ]; then
+    pass_case leading-terminator-name "a name beginning with ' }' is parsed rather than dropped"
+  else
+    fail_case leading-terminator-name "token '$BR_TOKEN', expected '{ \" }B\" }' -- the row was dropped silently"
+  fi
+  DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+else
+  skip_case leading-terminator-name "could not build the ' }B' fixture"
+fi
+
+# --------------------------------------------------------------------------
+# 9. A line longer than the reader's own buffer must END the read, not spin
+#
+# getline() sets failbit without reaching eof when the line does not fit, and
+# failbit is sticky: every later getline() returns immediately having extracted
+# nothing, so `while (!eof())` never terminates. Measured on 764fc176 as exit 124
+# under any timeout (CWE-835) -- the same shape as #2414 and #2442 in the sibling
+# tools. 30000 characters against a 20000-byte buffer.
+#
+# The 15s timeout is deliberately well under the 60s used elsewhere: this case
+# distinguishes "terminated" from "spinning", and a slow lane still finishes a
+# single refused parse in far less.
+# --------------------------------------------------------------------------
+make_legacy "$(printf 'A%.0s' $(seq 1 30000))" "$OUTDIR/huge.txt"
+timeout 15 "$APPLY" "$OUTDIR/huge.txt" 0 0 "$OUTDIR/utf8.icc" 1 > "$OUTDIR/huge.log" 2>&1
+rc=$?
+if [ "$rc" -eq 124 ]; then
+  fail_case overlong-line-terminates "a 30000-character line did not terminate the read (rc=124)"
+else
+  pass_case overlong-line-terminates "a line longer than the read buffer ends the parse (rc=$rc)"
+fi
+DEFECT_MEASURED=$((DEFECT_MEASURED + 1))
+
+# --------------------------------------------------------------------------
+# 10. CONTROL -- the break added for case 9 must not eat a final row.
+#
+# A last line with no trailing newline leaves eofbit set but NOT failbit, because
+# getline() did extract characters. Passes on both builds; this is the off-by-one
+# that a naive `if (!InputData) break;` would introduce.
+# --------------------------------------------------------------------------
+printf "'nmcl'\t; Data Format\nicEncodeValue\t; Encoding\n\n{ \"Black\" } 1.0\n{ \"Gray\" } 1.0" \
+  > "$OUTDIR/nonl.txt"
+# corpus.icc is the unmodified NamedColor.xml, so it carries both Black and Gray.
+# Case 6 builds it; guard rather than assume, or a skip there turns this into a
+# failure that says nothing about the break.
+if [ ! -f "$OUTDIR/corpus.icc" ]; then
+  make_profile "Gray" "$OUTDIR/corpus.icc" || true
+fi
+timeout 60 "$APPLY" "$OUTDIR/nonl.txt" 0 0 "$OUTDIR/corpus.icc" 1 > "$OUTDIR/nonl.log" 2>&1
+NONL_ROWS="$(grep -c '{ "' "$OUTDIR/nonl.log")"
+if [ ! -f "$OUTDIR/corpus.icc" ]; then
+  skip_case final-row-without-newline "corpus profile unavailable"
+elif [ "$NONL_ROWS" -eq 2 ]; then
+  pass_case final-row-without-newline "a last line with no trailing newline is still read"
+else
+  fail_case final-row-without-newline "expected 2 rows, got $NONL_ROWS -- the overlong-line break ate the final row"
+fi
+
+# --------------------------------------------------------------------------
+echo
+echo "  pass=$PASS fail=$FAIL skip=$SKIP"
+
+if [ "$FAIL" -ne 0 ]; then
+  echo "  [FAIL] iccdev-issue-2439-config-name-roundtrip"
+  exit 1
+fi
+
+# A green run that measured none of the defect cases is the failure mode this
+# accounting exists to prevent.
+if [ "$DEFECT_MEASURED" -eq 0 ]; then
+  echo "  [SKIP] no defect case was measured"
+  exit 77
+fi
+
+echo "  [PASS] iccdev-issue-2439-config-name-roundtrip ($DEFECT_MEASURED defect cases measured)"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7862,6 +7862,39 @@ if(TARGET iccFromCube)
     SKIP_RETURN_CODE 77)
 endif()
 
+# #2439: the legacy config writer handed its name tokens to the CONSOLE
+# sanitizer, so the only text fromLegacy() reads back was encoded for a terminal.
+# Two defects fell out: the round trip does not close for a non-ASCII colour
+# name, and the six-characters-per-codepoint expansion made ParseName()'s
+# unbounded strncpy into a char[256] reachable from the tool's OWN output -- a
+# 43-character name is 86 bytes in and 258 characters back out.  On a stock
+# Release build _FORTIFY_SOURCE turns that into SIGABRT, so the suite is red on
+# an uninstrumented lane too and needs no sanitizer to be worth running.
+#
+# Guarded on iccFromXml as well as the two apply tools: the script builds all
+# three of its named-colour profiles from tracked XML rather than from
+# Testing/*.icc, every one of which is generated.
+#
+# Deliberately NOT labelled "slow", so it runs on the pull_request path --
+# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+#
+# 300s for a ~200s worst case: 3 iccFromXml profile builds at 120s each is the
+# ceiling, but they complete in well under a second on every lane measured, and
+# the 10 tool spawns are 60s apiece.
+if(TARGET iccApplyNamedCmm AND TARGET iccApplySearch AND TARGET iccFromXml)
+  iccdev_add_script_test(
+    iccdev.config-name-roundtrip-regression
+    300
+    "iccdev;tools;cli;applynamedcmm;applysearch;config;named;issue-2439;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2439-config-name-roundtrip-tests.sh"
+  )
+  # Exits 77 when a tool or python3 is unavailable, when a fixture profile
+  # cannot be built, or when no defect case was measured.
+  set_tests_properties(iccdev.config-name-roundtrip-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # The iccApply* half of the same CLI-contract family (#2405).  Guarded on all
 # four targets because the script measures all four and its "nothing measured"
 # guard would otherwise turn a partial build into a skip that hides real cases.

--- a/IccConnect/IccLibConnect/IccCmmConfig.cpp
+++ b/IccConnect/IccLibConnect/IccCmmConfig.cpp
@@ -1858,25 +1858,164 @@ static bool ParseNextNumber(icFloatNumber& num, icChar** text)
 
 //===================================================
 
-static bool ParseName(icChar* pName, icChar* pString)
+static int HexDigit(icChar c)
+{
+  if (c >= '0' && c <= '9') return c - '0';
+  if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+  if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+  return -1;
+}
+
+// #2439: the '{ "name" }' tokens are the only text toLegacy() writes that
+// fromLegacy() reads back, so what lands in a config *file* has to survive the
+// trip. icSanitizeConsoleText() cannot carry it: that helper is deliberately
+// lossy because it is written for a terminal -- it escapes every non-ASCII
+// codepoint and leaves a literal backslash alone, so a name holding U+00FC and
+// the six characters \u00FC both encode to the same six characters, and neither
+// reads back. Measured on 764fc176: a profile colour named Gr<U+00FC>n applied
+// through iccApplyNamedCmm wrote { "Gr\u00FCn" }, and feeding that token back
+// in failed the lookup with "Profile application failed."
+//
+// This encoder escapes only what the format or the written file cannot take:
+//
+//   \ and "     framing. The backslash has to be spelled for any escape to be
+//               decodable; the quote goes out as \x22 so that ParseName()'s
+//               terminator scan cannot match inside the name.
+//   C0, DEL, C1 control codepoints. #2406 keeps these out of text iccDEV emits
+//               and no colour name legitimately carries one. C1 is escaped as
+//               its two UTF-8 bytes, which re-form the codepoint exactly.
+//   ill-formed  UTF-8, one byte at a time, so a mangled name cannot leave a
+//               file whose meaning depends on the reader.
+//
+// Everything else -- printable ASCII and every printable non-ASCII codepoint --
+// is written as its own bytes. An ordinary ASCII name is therefore byte-for-byte
+// what it is today, and a non-ASCII one now round-trips exactly.
+static std::string EncodeCfgName(const std::string& name)
+{
+  static const icChar hex[] = "0123456789ABCDEF";
+  std::string out;
+  // Walked by length, not to the first NUL. m_name reaches toLegacy() from
+  // readers other than fromLegacy() -- the JSON and IT8 paths -- and one of
+  // those can hand over a name with an embedded NUL, which c_str() would end the
+  // token at. It is escaped like any other C0 byte instead. icDecodeUtf8() below
+  // still reads through a NUL-terminated buffer, so a truncated sequence at the
+  // end of the string fails validation rather than running off it.
+  const unsigned char* base = (const unsigned char*)name.c_str();
+  const unsigned char* end = base + name.size();
+  const unsigned char* p = base;
+
+  while (p < end) {
+    unsigned char ch = *p;
+    int nEscape = 0;
+
+    if (ch == '\\') {
+      out += "\\\\";
+      p++;
+      continue;
+    }
+
+    // A double quote falls through to the \xNN escape below rather than being
+    // spelled \", so that no raw '"' byte can appear inside a token at all.
+    // ParseName() finds the end of the token with strstr(..., "\" }"), which
+    // knows nothing about escapes: with a \" spelling, a colour name containing
+    // '" }' matched at its OWN escaped quote and came back truncated. Measured
+    // on the first cut of this fix -- A" }B encoded to A\" }B and decoded to A\.
+    // \x22 leaves the terminator scan only one thing it can match.
+    if (ch != '"' && ch >= 0x20 && ch < 0x7f) {
+      out += (icChar)ch;
+      p++;
+      continue;
+    }
+
+    if (ch >= 0x80) {
+      unsigned int cp = 0;
+      int len = icDecodeUtf8(p, &cp);
+
+      if (len > 1 && p + len <= end) {
+        // C1 is spelled C2 80..C2 9F in UTF-8 and a terminal still acts on it,
+        // so it is escaped like C0. Every other well-formed codepoint keeps its
+        // own bytes -- that is what makes the round trip exact.
+        if (cp < 0x80u || cp > 0x9fu) {
+          out.append((const icChar*)p, (size_t)len);
+          p += len;
+          continue;
+        }
+        nEscape = len;
+      }
+      // A byte that is not a well-formed lead, or a sequence that would run past
+      // the end. Fall through and escape a single byte, so an invalid lead
+      // cannot swallow what follows.
+    }
+
+    if (!nEscape)
+      nEscape = 1;
+
+    while (nEscape--) {
+      out += "\\x";
+      out += hex[(*p >> 4) & 0xf];
+      out += hex[*p & 0xf];
+      p++;
+    }
+  }
+
+  return out;
+}
+
+static bool ParseName(std::string& name, const icChar* pString)
 {
   if (strncmp(pString, "{ \"", 3))
     return false;
 
-  const icChar* ptr = strstr(pString, "\" }");
+  // #2439: search from past the opening quote, not from the start of the line.
+  // strstr() from pString matches the '{ "' prefix's OWN quote whenever the name
+  // begins with ' }' -- the terminator was then found BEFORE the name started,
+  // ptr < p, the decode loop never ran and fromLegacy() dropped the row with no
+  // diagnostic. Measured on 764fc176 with a colour named ' }B'.
+  const icChar* p = pString + 3;
+  const icChar* ptr = strstr(p, "\" }");
 
   if (!ptr)
     return false;
 
-  icUInt32Number nNameLen = (icUInt32Number)(ptr - (pString + 3));
+  // #2439: decode into a std::string. This used to strncpy() the token into a
+  // caller-supplied icChar[256] with a length taken straight from the token, so
+  // any legacy config file carrying a name of 256 characters or more wrote past
+  // that buffer: ASan reports a stack-buffer-overflow in ParseName for both
+  // `iccApplyNamedCmm <file> 0 0 <profile> 1` and the iccApplySearch equivalent
+  // (CWE-787). It was reachable from the tool's own output -- a colour named
+  // with 43 accented characters is 86 bytes in, but 258 characters back out
+  // under the console escaping this function used to be handed. A larger buffer
+  // would only move the boundary, so there is no buffer.
+  name.clear();
 
-  if (!nNameLen)
-    return false;
+  while (p < ptr) {
+    if (*p == '\\' && p + 1 < ptr) {
+      icChar esc = p[1];
 
-  strncpy(pName, pString + 3, nNameLen);
-  pName[nNameLen] = '\0';
+      if (esc == '\\') {
+        name += esc;
+        p += 2;
+        continue;
+      }
 
-  return true;
+      if (esc == 'x' && p + 3 < ptr) {
+        int hi = HexDigit(p[2]), lo = HexDigit(p[3]);
+
+        if (hi >= 0 && lo >= 0) {
+          name += (icChar)((hi << 4) | lo);
+          p += 4;
+          continue;
+        }
+      }
+      // Not an escape EncodeCfgName() emits. Keep both characters, so a name
+      // that already contained a backslash -- a path spelled into a colour name,
+      // say -- reads exactly as it did before #2439.
+    }
+
+    name += *p++;
+  }
+
+  return !name.empty();
 }
 
 
@@ -1929,22 +2068,35 @@ bool CIccCfgColorData::fromLegacy(const char* filename, bool bReset)
     delete[] tempBuf;
     return false;
   }
-  char SrcNameBuf[256];
   int nSrcSamples = icGetSpaceSamples(m_srcSpace);
   CIccPixelBuf Pixel(nSrcSamples + 16);
 
+  // #2439: a line longer than tempBufSize makes getline() set failbit without
+  // reaching eof, and failbit is sticky -- every later getline() then returns
+  // immediately having extracted nothing, so `while (!eof())` spins forever.
+  // Measured on 764fc176: a 30000-character name is exit 124 under any timeout
+  // (CWE-835), the same shape as #2414 and #2442 in the sibling tools. Reading
+  // the stream state after each getline() ends the loop instead; a clean EOF sets
+  // failbit too, on the final zero-character read, so this also covers the
+  // ordinary exit and does not need eof() to be consulted separately.
   while (!InputData.eof()) {
     CIccCfgDataEntryPtr data(new CIccCfgDataEntry());
 
     //Are names coming is as an input?
     if (m_srcSpace == icSigNamedData) {
       InputData.getline(tempBuf, tempBufSize);
-      if (!ParseName(SrcNameBuf, tempBuf))
+      if (InputData.fail())
+        break;
+
+      // #2439: the fixed icChar[256] this used to fill is gone -- the token
+      // carries its own length and nothing bounded it.
+      if (!ParseName(data->m_name, tempBuf))
         continue;
 
-      data->m_name = SrcNameBuf;
-
-      icChar* numptr = strstr(tempBuf, "\" }");
+      // #2439: from tempBuf + 3 for the same reason ParseName() does -- these two
+      // scans have to agree on where the name ended, or the tint is read out of
+      // the middle of the name.
+      icChar* numptr = strstr(tempBuf + 3, "\" }");
       if (numptr)
         numptr += 3;
 
@@ -1956,6 +2108,9 @@ bool CIccCfgColorData::fromLegacy(const char* filename, bool bReset)
     else { //pixel sample data coming in as input
 
       InputData.getline(tempBuf, tempBufSize);
+      if (InputData.fail())
+        break;
+
       if (!ParseNumbers(Pixel, tempBuf, nSamples))
         continue;
 
@@ -2341,6 +2496,19 @@ bool CIccCfgColorData::toLegacy(const char* filename, const CIccCfgProfileArray 
            icWriteString(f, tempBuf);
   };
 
+  // #2439: same text, two sinks, two encoders. A named file is read back by
+  // fromLegacy(), so its name tokens need EncodeCfgName(), which is reversible.
+  // icOpenRegularWriteFile() hands back stdout for an empty filename, and stdout
+  // may be a terminal, so that case stays on the console escaping #2406/#2420
+  // put there. A redirected stdout keeps the console spelling too: the FILE* is
+  // still stdout, and guessing from isatty() would make the bytes iccDEV writes
+  // depend on how the caller invoked it. Ask for a file if you want to read it
+  // back.
+  const bool bToFile = (f != stdout);
+  auto nameToken = [bToFile](const std::string& sName)->std::string {
+    return bToFile ? EncodeCfgName(sName) : icSanitizeConsoleText(sName);
+  };
+
   std::string out;
   snprintf(tempBuf, tempSize, "%s\t; ", icGetColorSig(tempBuf2, tempSize, m_space, false));
   out = tempBuf;
@@ -2364,6 +2532,10 @@ bool CIccCfgColorData::toLegacy(const char* filename, const CIccCfgProfileArray 
 
   fprintf(f, ";Source data is after semicolon\n");
   
+  // #2439: the ';' lines below stay on icSanitizeConsoleText() on purpose.
+  // ParseName() rejects them and fromLegacy() skips them, so they are comments
+  // no reader decodes -- lossy-but-safe is the right trade for text whose only
+  // consumer is a person looking at the file.
   fprintf(f, "\n;Profiles applied\n");
   for (auto pIter = profiles.begin(); pIter != profiles.end(); pIter++) {
     CIccCfgProfile* pProf = pIter->get();
@@ -2390,7 +2562,7 @@ bool CIccCfgColorData::toLegacy(const char* filename, const CIccCfgProfileArray 
     }
 
     if (pData->m_name.size() != size_t(0)) {
-      fprintf(f, "{ \"%s\" }\t;", icSanitizeConsoleText(pData->m_name).c_str() );
+      fprintf(f, "{ \"%s\" }\t;", nameToken(pData->m_name).c_str() );
     }
     else {
       for (size_t i = 0; i < pData->m_values.size(); i++) {
@@ -2400,7 +2572,7 @@ bool CIccCfgColorData::toLegacy(const char* filename, const CIccCfgProfileArray 
     }
 
     if (pData->m_srcName.size() != size_t(0)) {
-      fprintf(f,"{ \"%s\" }", icSanitizeConsoleText(pData->m_srcName).c_str());
+      fprintf(f,"{ \"%s\" }", nameToken(pData->m_srcName).c_str());
       // Echo the tint the caller supplied (m_srcValues[0]).  We used to
       // suppress this when the tint was exactly 1.0, but that hid a
       // value the caller had explicitly written -- the


### PR DESCRIPTION
Closes #2439.

#2420 asked for a file-safe encoder at `IccCmmConfig.cpp:2393` and `:2403`. Measuring it turned up more than the encoder.

Those two `{ "name" }` tokens are the only text `toLegacy()` writes that `fromLegacy()` reads back, and they were handed to `icSanitizeConsoleText()` — a helper written for a terminal, which escapes every non-ASCII codepoint and leaves a literal backslash alone. It is not reversible, by design.

## 1. The round trip does not close

Measured on `764fc176`, a profile colour named `Gr<U+00FC>n` applied through `iccApplyNamedCmm` wrote `{ "Gr\u00FCn" }`; feeding that token back in answered `Profile application failed.`

**This dates from #1683 (`d59c072d`), which introduced the sanitize call — not from #2419.** The sub-issue says #2419 and so did my own comment on #2420; `git log -L` on the call site settles it.

## 2. A stack-buffer-overflow, reachable from the tool's own output

`ParseName()` `strncpy`'d the token into a caller-supplied `char[256]` using a length read straight out of the token, with nothing bounding it (CWE-787).

**Not a sanitizer-only finding.** On a stock Release build glibc's `_FORTIFY_SOURCE` catches the `strncpy` and the tool aborts:

```
$ iccApplyNamedCmm <400-char-name file> 0 0 nc.icc 1
*** buffer overflow detected ***: terminated
exit 134
```

A colour name of **43 accented characters** is 86 bytes going in and 258 characters coming back out at six characters per escape — so the crash is reachable by round-tripping a legitimate profile, not only by hand-writing a long name. `iccApplySearch` reaches the same call. Boundary: at exactly 256 only the trailing NUL store is out of bounds (ASan sees it, FORTIFY does not); at 257+ the `strncpy` itself overflows.

## The fix: split the sink, don't widen the escape set

`icOpenRegularWriteFile()` returns `stdout` for an empty filename, so `toLegacy()` writes to a terminal *and* to files. One function, two sinks:

- **named file** → `EncodeCfgName()`, reversible: escapes `\` and control codepoints, writes every printable codepoint as its own bytes.
- **stdout** → unchanged `icSanitizeConsoleText()`, because stdout may be a terminal and #2406/#2420 put that escaping there.

`ParseName()` decodes into a `std::string`, so there is no buffer to bound — a larger one would only move the boundary. The `;` comment lines stay on the console helper: nothing parses them.

## Three more defects, found in review of the first cut

- **A quote is written `\x22`, not `\"`.** `ParseName()` finds the end of the token with `strstr(..., '" }')`, which is escape-blind, so a `\"` spelling let a name containing `" }` match at its *own* escaped quote — `A" }B` decoded to `A\`, and the caller then read the tint out of the middle of the name.
- **That scan now starts at `pString + 3`.** From the start of the line it matched the `{ "` prefix's own quote whenever a name began with `" }"`, so the terminator was found *before* the name started and `fromLegacy()` dropped the row with no diagnostic. `fromLegacy()`'s own tint scan had the same bug and moves with it — the two have to agree on where the name ended.
- **A line longer than the 20000-byte read buffer hung the tool** (CWE-835). `getline()` sets failbit without reaching eof and failbit is sticky, so `while (!eof())` spun forever.

### Why the hang is in this PR rather than its own

It is pre-existing, but it is **not cleanly separable from the overflow fix**, and shipping the overflow fix alone would look like a regression. Measured across three builds, exit codes:

| build | terminator lost past the buffer | terminator survives, 19000-char name |
|---|---|---|
| `764fc176` — neither fix | **124** hang | **134** abort |
| overflow fix only | **124** hang | **124** hang |
| this PR | 0 | 0 |

For the second input the overflow was *masking* the hang: fixing the overflow alone turns an abort into a hang. Happy to split if you would rather — but then the hang fix has to land **first**, not second.

## Acceptance change, stated precisely

Adding a decoder moves exactly two spellings: `\\` and `\xNN`. Everything else — `\t` included — is an escape this writer never emits and is kept verbatim, so `C:\temp` still reads as `C:\temp`. But `C:\x41rt` now reads as `C:Art`, where it was literal before. An earlier draft of this claimed a backslash "reads exactly as it did before", which is false for those two; both are now asserted by name in the suite.

Zero tracked files carry a backslash or a non-ASCII byte in a name token (3 legacy fixtures, `git ls-files '*.txt'`), and all three produce **byte-identical** output across the change — 96KB over the three.

## Known trade

Printable non-ASCII now lands raw in a config *file*, so U+202E is no longer escaped there. Deliberate, and narrower than it sounds: ESC and the C1 controls are still escaped on both sinks, so terminal control-sequence injection — the actual #2406/#2420 mechanism — stays closed; on POSIX the file sink is provably never a terminal (`icOpenRegularWriteFile` refuses anything that is not `S_ISREG`); and the sibling file sinks `toIt8()` and `toJson()` write `m_name` with **no** escaping at all, so this is strictly safer than its own neighbours. The residual exposure is a person opening the config file in an editor and seeing a reordered name. Flagging it rather than burying it — say the word and I will escape by codepoint on the file sink too, at the cost of the round trip.

## Test

`ctest -R iccdev.config-name-roundtrip-regression` — **9 defect cases red on `764fc176`, 13 green after.**

The **4 control cases pass on both builds**: stdout must keep escaping U+00FC; the tracked ASCII corpus must be unchanged; an unknown escape must not decode; and a final row with no trailing newline must survive the break added for the hang. Without the first, deleting the escaping outright would turn every defect case green while re-opening #2406 and #2420.

Both fixture profiles are built from tracked XML rather than `Testing/*.icc`, every one of which is generated.

## CI

Dispatched `ci_scope=source` on the branch before opening this PR, per the suggested workflow — run [34091352381](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34091352381).

Locally: strict clang `-Wall -Wextra -Wpedantic -Werror` clean over a full clean build (148 TUs, 0 warnings), ASan+UBSan clean, `shellcheck` rc=0, full `ctest` with no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTQQ6sMWnHkNEA9QedNpMT
