### PR TITLE
fix(#2414): sanitize the operands the remaining CLI tools echo

### DIFF
--- a/.github/scripts/iccdev-issue-2414-console-sanitize-sweep-tests.sh
+++ b/.github/scripts/iccdev-issue-2414-console-sanitize-sweep-tests.sh
@@ -1,0 +1,239 @@
+#!/bin/bash
+###############################################################################
+# #2414 -- the ANSI-injection half: CLI tools that echo a user-supplied path
+#          to the console without sanitizing it
+###############################################################################
+#
+# #2406 established the mechanism and #2419 fixed the four iccApply* tools;
+# #2437 changed the helper to escape by CODEPOINT rather than by byte.  The
+# helper, icSanitizeConsoleText(), lives in IccProfLib/IccFileUtil.h.
+#
+# #2414's QA task is the rest of the tooling.  Measured on 764fc176, EIGHT more
+# tools printed an operand verbatim, so a profile named with a CSI sequence
+# repainted the terminal of anyone who ran them:
+#
+#   iccDumpProfile iccPngDump iccFromCube iccRoundTrip
+#   iccPawgReport  iccToXml   iccBenchApply iccFromXml
+#
+#   iccProfilePlot  iccV5DspObsToV4Dsp
+#
+# The count in the issue thread said six, and that was wrong in both directions:
+# it counted only tools that ALSO call fopen(), which dropped iccToXml,
+# iccFromXml, iccRoundTrip and iccPawgReport.
+#
+# It also cleared iccProfilePlot, and an earlier draft of THIS header repeated
+# that.  Both were wrong for the same reason: the probe invocation was rejected
+# by argument validation before any path was printed, and "no escape in the
+# output" was read as "no path is printed here".  iccProfilePlot needs its
+# `list` subcommand to reach iccProfilePlot.cpp:248, and iccV5DspObsToV4Dsp
+# needs all three operands to reach its twelve diagnostics; both leak once you
+# get there.  An early reject is not evidence of a clean tool -- which is why
+# every case below asserts the ESCAPED form is PRESENT, not merely that the raw
+# one is absent.  iccJpegDump and iccProfileVisualize did check out:
+# iccJpegDump prints no operand on any accepted invocation, and
+# iccProfileVisualize substitutes "_".
+#
+# Twelve tools have no sanitization at all; TEN of them were measured to leak.
+#
+# What each defect case asserts, and why it is two assertions rather than one:
+# a raw ESC must not survive to the console, AND the escaped spelling must be
+# present.  "No raw ESC" alone is satisfied by a tool that fails earlier for an
+# unrelated reason and prints nothing at all -- which is exactly what the first
+# draft of this suite did for iccJpegDump and iccBenchApply, whose argument
+# validation rejected the invocation before any path was printed.  Requiring
+# the \x1B spelling pins that the path really was echoed, through the helper.
+#
+# The controls carry as much weight as the defect cases.  An over-eager fix --
+# sanitizing a string that is not a path, or double-escaping -- would be
+# invisible to every case above, so ascii-path-unchanged asserts that an
+# ordinary ASCII path still prints with NO backslash escapes at all, and
+# valid-conversion-still-works asserts iccToXml still produces its profile.
+# Both pass on the unpatched build; that is what they are for.
+#
+# Red/green against 764fc176: all eight defect cases fail (raw ESC present,
+# escaped form absent).  Both controls pass on BOTH builds.
+#
+# NOT labelled "slow": ci-pr-action.yml pins ctest_mode=fast, which drops the
+# slow label, and this suite needs to run on the pull_request path (#2412).
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# An explicit ICCDEV_TOOLS_DIR is never second-guessed: resolving past it would
+# measure a DIFFERENT build than the caller meant, which is how a stale tree
+# fakes a result.
+if [ -n "${ICCDEV_TOOLS_DIR:-}" ]; then
+  TOOLS_DIR="$ICCDEV_TOOLS_DIR"
+  TOOLS_DIR_EXPLICIT=1
+else
+  TOOLS_DIR="$REPO_ROOT/Build/Tools"
+  TOOLS_DIR_EXPLICIT=0
+fi
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-2414-console-sanitize-sweep}"
+mkdir -p "$OUTDIR"
+
+# Resolve on a BINARY, not on the directory: Build/Tools exists in a configured
+# tree as CMake scaffolding with no executables under it, and a directory test
+# would resolve to a path where nothing is built (see the sibling
+# directory-read-guard script, where that produced a green run that measured
+# nothing).
+tools_dir_has_any() {
+  [ -x "$1/IccDumpProfile/iccDumpProfile" ] || [ -x "$1/IccToXml/iccToXml" ]
+}
+if [ "$TOOLS_DIR_EXPLICIT" -eq 0 ] && ! tools_dir_has_any "$TOOLS_DIR"; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools" "$REPO_ROOT/out/build/Tools"; do
+    if tools_dir_has_any "$candidate"; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON:$BUILD_ROOT/IccConnect${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-halt_on_error=0,detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0,print_stacktrace=1}"
+
+PASS=0; FAIL=0; SKIP=0; MEASURED=0
+
+# A CSI colour sequence is the payload: it is what a terminal ACTS on, and it
+# is the shape CVE-2021-42574-style attacks use to hide text.  Built with
+# printf rather than written literally so the escape cannot be lost by an
+# editor or a diff tool that strips control characters.
+ESC=$(printf '\033')
+CSI="${ESC}[31m"
+
+VALID_PROFILE="$REPO_ROOT/Testing/sRGB_v4_ICC_preference.icc"
+
+# Cases are driven through a shared runner so every one of them applies the
+# SAME pair of assertions; a per-case hand-rolled grep is how one case ends up
+# weaker than the others without anyone noticing.
+run_case() {
+  local name="$1"; shift
+  local bin="$1"; shift
+  if [ ! -x "$bin" ]; then
+    echo "[SKIP] $name (not built: $bin)"
+    SKIP=$((SKIP+1))
+    return
+  fi
+  MEASURED=$((MEASURED+1))
+  local out
+  # 20s, not 60: the CTest TIMEOUT is 300s and this suite now makes 13
+  # spawns.  At 60s each, three hung tools would exhaust the budget and CTest
+  # would kill the script before it printed a single [FAIL] line -- the failure
+  # mode the sibling directory-guard suite sized its own budget to avoid.
+  out=$(timeout 20 "$bin" "$@" 2>&1)
+  local raw=0 escaped=0
+  case "$out" in *"$CSI"*) raw=1 ;; esac
+  case "$out" in *'\x1B[31m'*) escaped=1 ;; esac
+  if [ "$raw" -eq 0 ] && [ "$escaped" -eq 1 ]; then
+    echo "[PASS] $name"
+    PASS=$((PASS+1))
+  else
+    echo "[FAIL] $name (raw_esc=$raw escaped_present=$escaped)"
+    printf '%s\n' "$out" | head -5 | cat -v | sed 's/^/         /'
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "=== #2414 console-sanitize sweep: TOOLS_DIR=$TOOLS_DIR ==="
+
+# --- defect cases: a path whose NAME carries a CSI sequence ------------------
+EVIL_ICC="$OUTDIR/ev${CSI}il.icc"
+EVIL_XML="$OUTDIR/ev${CSI}il.xml"
+EVIL_BAD="$OUTDIR/bad-ev${CSI}il.icc"
+rm -f "$EVIL_ICC" "$EVIL_XML" "$EVIL_BAD"
+if [ -r "$VALID_PROFILE" ]; then
+  cp "$VALID_PROFILE" "$EVIL_ICC"
+fi
+printf 'not a profile\n' > "$EVIL_BAD"
+printf '<not-icc/>\n'    > "$EVIL_XML"
+
+run_case "dumpprofile-escapes-path"  "$TOOLS_DIR/IccDumpProfile/iccDumpProfile"   "$EVIL_ICC"
+run_case "pngdump-escapes-path"      "$TOOLS_DIR/IccPngDump/iccPngDump"           "$EVIL_ICC"
+run_case "roundtrip-escapes-path"    "$TOOLS_DIR/IccRoundTrip/iccRoundTrip"       "$EVIL_ICC"
+run_case "pawgreport-escapes-path"   "$TOOLS_DIR/IccPawgReport/iccPawgReport"     "$EVIL_ICC"
+run_case "fromcube-escapes-path"     "$TOOLS_DIR/IccFromCube/iccFromCube"         "$EVIL_BAD" "$OUTDIR/out.icc"
+run_case "toxml-escapes-path"        "$TOOLS_DIR/IccToXml/iccToXml"               "$EVIL_BAD" "$OUTDIR/out.xml"
+run_case "fromxml-escapes-path"      "$TOOLS_DIR/IccFromXml/iccFromXml"           "$EVIL_XML" "$OUTDIR/out2.icc"
+run_case "benchapply-escapes-path"   "$TOOLS_DIR/IccBenchApply/iccBenchApply"     1 "$EVIL_BAD" 0
+
+# iccProfilePlot needs its subcommand, and iccV5DspObsToV4Dsp needs all three
+# operands, to reach a print site at all.  Both were wrongly cleared once; see
+# the header.
+run_case "profileplot-escapes-path"  "$TOOLS_DIR/IccProfilePlot/iccProfilePlot"   "$EVIL_BAD" list
+run_case "v5dspobs-escapes-path"     "$TOOLS_DIR/IccV5DspObsToV4Dsp/iccV5DspObsToV4Dsp" \
+                                     "$EVIL_BAD" "$EVIL_BAD" "$OUTDIR/v5out.icc"
+
+# The stronger vector of the two: a line of the .cube FILE, not an operand the
+# caller typed.  A downloaded LUT carries whatever its author put in it, and
+# iccFromCube echoed the offending line verbatim.  Nothing else here covers
+# content-derived output -- every case above is argv-derived.
+EVIL_CUBE="$OUTDIR/evil-content.cube"
+printf 'TITLE ok\nev%sil_keyword 1 2 3\n' "$CSI" > "$EVIL_CUBE"
+run_case "fromcube-escapes-content"  "$TOOLS_DIR/IccFromCube/iccFromCube"         "$EVIL_CUBE" "$OUTDIR/out4.icc"
+
+# --- controls: these must pass on the UNPATCHED build too --------------------
+# An ordinary ASCII path must print with no backslash escaping at all.  This is
+# what an over-eager or double-escaping fix would break, and no defect case
+# above would notice.
+ASCII_BAD="$OUTDIR/plain-ascii-bad.icc"
+printf 'not a profile\n' > "$ASCII_BAD"
+TOXML="$TOOLS_DIR/IccToXml/iccToXml"
+if [ -x "$TOXML" ]; then
+  MEASURED=$((MEASURED+1))
+  out=$(timeout 20 "$TOXML" "$ASCII_BAD" "$OUTDIR/out3.xml" 2>&1)
+  case "$out" in
+    *'\x'*|*'\u'*)
+      echo "[FAIL] ascii-path-unchanged (an ASCII path was escaped)"
+      printf '%s\n' "$out" | head -3 | sed 's/^/         /'
+      FAIL=$((FAIL+1)) ;;
+    *"$ASCII_BAD"*)
+      echo "[PASS] ascii-path-unchanged"
+      PASS=$((PASS+1)) ;;
+    *)
+      echo "[FAIL] ascii-path-unchanged (path not echoed at all)"
+      printf '%s\n' "$out" | head -3 | sed 's/^/         /'
+      FAIL=$((FAIL+1)) ;;
+  esac
+
+  # And the tool must still do its job: sanitizing a diagnostic must not touch
+  # the path actually handed to the profile reader.
+  if [ -r "$VALID_PROFILE" ]; then
+    MEASURED=$((MEASURED+1))
+    if timeout 20 "$TOXML" "$VALID_PROFILE" "$OUTDIR/valid.xml" >/dev/null 2>&1 \
+       && [ -s "$OUTDIR/valid.xml" ]; then
+      echo "[PASS] valid-conversion-still-works"
+      PASS=$((PASS+1))
+    else
+      echo "[FAIL] valid-conversion-still-works"
+      FAIL=$((FAIL+1))
+    fi
+  else
+    echo "[SKIP] valid-conversion-still-works (no $VALID_PROFILE)"
+    SKIP=$((SKIP+1))
+  fi
+else
+  echo "[SKIP] controls (iccToXml not built)"
+  SKIP=$((SKIP+2))
+fi
+
+echo "=== Result: PASS=$PASS FAIL=$FAIL SKIP=$SKIP MEASURED=$MEASURED ==="
+
+# A suite that measured nothing must SKIP, not pass.  Exit 0 with every case
+# skipped is a green light for a defect that was never exercised.
+if [ "$MEASURED" -eq 0 ]; then
+  echo "No case was measured -- reporting SKIP rather than success."
+  exit 77
+fi
+[ "$FAIL" -eq 0 ] || exit 1
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7895,6 +7895,39 @@ if(TARGET iccApplyNamedCmm AND TARGET iccApplySearch AND TARGET iccFromXml)
     SKIP_RETURN_CODE 77)
 endif()
 
+# The ANSI-injection half of #2414's QA task -- the counterpart to the directory
+# guard above.  #2419 sanitized the four iccApply* tools and #2437 moved the
+# helper to per-codepoint escaping; this covers the eight further tools measured
+# to echo an operand verbatim on 764fc176, plus iccProfilePlot and
+# iccV5DspObsToV4Dsp, which a first pass wrongly cleared.
+#
+# Guarded on iccDumpProfile AND iccToXml rather than on all ten: the script
+# skips per-tool and reports what it could not measure, but iccToXml carries
+# BOTH controls, and a run with the controls skipped could pass while an
+# over-eager fix went unnoticed.
+#
+# The 300 s budget is the sibling's, and the per-case timeout was cut to 20 s to
+# stay inside it: 13 spawns at the sibling's 60 s would be a 780 s worst case,
+# and CTest killing the script means no [FAIL] line and a bare "Timeout" for
+# precisely the regression this suite exists to diagnose.
+#
+# Deliberately NOT labelled "slow", for the same reason as the apply-usage suite
+# below: ci-pr-action.yml pins ctest_mode=fast, which drops the slow label, and
+# a console-injection regression that runs on no PR leg is not a regression test
+# (#2412).
+if(TARGET iccDumpProfile AND TARGET iccToXml)
+  iccdev_add_script_test(
+    iccdev.console-sanitize-sweep-regression
+    300
+    "iccdev;tools;cli;console;sanitize;issue-2414;issue-2406;regression"
+    "${ICCDEV_REPO_ROOT}"
+    "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2414-console-sanitize-sweep-tests.sh"
+  )
+  # Exits 77 when no tool was found and no case ran.
+  set_tests_properties(iccdev.console-sanitize-sweep-regression PROPERTIES
+    SKIP_RETURN_CODE 77)
+endif()
+
 # The iccApply* half of the same CLI-contract family (#2405).  Guarded on all
 # four targets because the script measures all four and its "nothing measured"
 # guard would otherwise turn a partial build into a skip that hides real cases.

--- a/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
+++ b/IccXML/CmdLine/IccFromXml/IccFromXml.cpp
@@ -133,6 +133,13 @@ int main(int argc, char* argv[])
     return EXIT_FAILURE;
   }
 
+  // #2414: every failure path below echoes one of the two operands, so a path
+  // carrying terminal control sequences reached the console verbatim (#2406).
+  // Sanitized once here rather than at each print site; the paths handed to
+  // LoadXml()/SaveIccProfile() stay untouched.
+  std::string srcName = icSanitizeConsoleText(argv[1]);
+  std::string dstName = icSanitizeConsoleText(argv[2]);
+
   // Profile XML on the CLI tool's filesystem is trusted by the invoking
   // user (same trust boundary as the XML file itself), so opt in to
   // <tag File="..."/> / <tag Filename="..."/> loaders. Library/WASM
@@ -175,7 +182,8 @@ int main(int argc, char* argv[])
           return EXIT_FAILURE;
         }
         if (!icIsReadableFile(szRelaxNGDir.c_str())) {
-          fprintf(stderr, "Error: cannot read RelaxNG schema '%s'\n", szRelaxNGDir.c_str());
+          fprintf(stderr, "Error: cannot read RelaxNG schema '%s'\n",
+                  icSanitizeConsoleText(szRelaxNGDir).c_str());
           return EXIT_FAILURE;
         }
       }
@@ -203,7 +211,8 @@ int main(int argc, char* argv[])
       // silence: an ordinary "-no-id" typo left bNoId false, produced a profile with
       // an ID, and still exited 0, reporting success for a run that ignored what it
       // was told to do.
-      fprintf(stderr, "Error: unrecognized option '%s'\n", argv[i]);
+      fprintf(stderr, "Error: unrecognized option '%s'\n",
+              icSanitizeConsoleText(argv[i]).c_str());
       Usage(stderr);
       return EXIT_FAILURE;
     }
@@ -228,7 +237,8 @@ int main(int argc, char* argv[])
   // what the README documents, so it stays; the silence about which file was used is
   // the part worth fixing.
   if (bValidateRequested)
-    printf("Validating against RelaxNG schema '%s'\n", szRelaxNGDir.c_str());
+    printf("Validating against RelaxNG schema '%s'\n",
+           icSanitizeConsoleText(szRelaxNGDir).c_str());
 
   // Re-indented to match its block.  The stray four-space indent was harmless while
   // nothing preceded it, but it now follows an if-statement and -Wmisleading-indentation
@@ -242,7 +252,7 @@ int main(int argc, char* argv[])
 #ifndef WIN32
     fprintf(stderr, "\n");
 #endif
-    fprintf(stderr, "Unable to Parse '%s'\n", argv[1]);
+    fprintf(stderr, "Unable to Parse '%s'\n", srcName.c_str());
     return EXIT_FAILURE;
   }
 
@@ -272,7 +282,7 @@ int main(int argc, char* argv[])
       printf("Profile parsed and saved correctly\n");
     }
     else {
-      fprintf(stderr, "Unable to save profile as '%s'\n", argv[2]);
+      fprintf(stderr, "Unable to save profile as '%s'\n", dstName.c_str());
       return EXIT_FAILURE;
     }
   }

--- a/IccXML/CmdLine/IccToXml/IccToXml.cpp
+++ b/IccXML/CmdLine/IccToXml/IccToXml.cpp
@@ -8,6 +8,7 @@
 #include "IccIO.h"
 #include "IccProfLibVer.h"
 #include "IccLibXMLVer.h"
+#include "IccFileUtil.h"
 #include <cstdlib>
 
 int main(int argc, char* argv[])
@@ -24,13 +25,20 @@ int main(int argc, char* argv[])
   CIccProfileXml profile;
   CIccFileIO srcIO, dstIO;
 
+  // #2414: both operands are echoed by every failure path below, so a path carrying
+  // terminal control sequences reached the console verbatim (#2406).  Sanitized once
+  // here rather than at each printf so a message added later cannot reintroduce the
+  // raw form; the paths handed to Open() stay untouched.
+  std::string srcName = icSanitizeConsoleText(argv[1]);
+  std::string dstName = icSanitizeConsoleText(argv[2]);
+
   if (!srcIO.Open(argv[1], "r")) {
-    printf("Unable to open '%s'\n", argv[1]);
+    printf("Unable to open '%s'\n", srcName.c_str());
     return EXIT_FAILURE;
   }
 
   if (!profile.Read(&srcIO)) {
-    printf("Unable to read '%s'\n", argv[1]);
+    printf("Unable to read '%s'\n", srcName.c_str());
     return EXIT_FAILURE;
   }
 
@@ -38,19 +46,19 @@ int main(int argc, char* argv[])
   xml.reserve(40000000);
 
   if (!profile.ToXml(xml)) {
-    printf("Unable to convert '%s' to xml\n", argv[1]);
+    printf("Unable to convert '%s' to xml\n", srcName.c_str());
     return EXIT_FAILURE;
   }
 
   if (!dstIO.Open(argv[2], "wb")) {
-    printf("unable to open '%s'\n", argv[2]);
+    printf("unable to open '%s'\n", dstName.c_str());
     return EXIT_FAILURE;
   }
 
   if (dstIO.Write8((char*)xml.c_str(), xml.size()) != xml.size() ||
       !dstIO.Flush() ||
       !dstIO.CloseFile()) {
-    printf("Unable to write '%s'\n", argv[2]);
+    printf("Unable to write '%s'\n", dstName.c_str());
     return EXIT_FAILURE;
   }
 

--- a/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
+++ b/Tools/CmdLine/IccBenchApply/iccBenchApply.cpp
@@ -87,6 +87,7 @@
 #include "IccProfile.h"
 #include "IccTagLut.h"
 #include "IccUtil.h"
+#include "IccFileUtil.h"
 
 #include "BenchCases.h"
 #include "BenchTimer.h"
@@ -458,11 +459,15 @@ static void RunLeaf(const char *szProfilePath)
 {
   CIccProfile *pProfile = ReadIccProfile(szProfilePath);
   if (!pProfile) {
-    printf("  (leaf: cannot read '%s')\n", szProfilePath);
+    // #2414: a profile path reaching the console verbatim carries whatever
+    // terminal control sequences its name holds (#2406).
+    printf("  (leaf: cannot read '%s')\n",
+           icSanitizeConsoleText(szProfilePath).c_str());
     return;
   }
 
-  printf("\n  isolated leaf functions (%s):\n", szProfilePath);
+  printf("\n  isolated leaf functions (%s):\n",
+         icSanitizeConsoleText(szProfilePath).c_str());
   printf("  %-28s %9s\n", "function", "Mval/s");
 
   // A2B0 is where a LUT-based profile keeps its device-to-PCS transform.
@@ -801,7 +806,8 @@ int main(int argc, const char *argv[])
         if (*p == ',' || *p == '\0') {
           int n;
           if (!ParseIntArg(tok.c_str(), 1, 1024, n)) {
-            printf("Invalid thread count '%s': expected 1..1024\n", tok.c_str());
+            printf("Invalid thread count '%s': expected 1..1024\n",
+                   icSanitizeConsoleText(tok).c_str());
             return 1;
           }
           g_threads.push_back(n);
@@ -817,7 +823,8 @@ int main(int argc, const char *argv[])
       nArg += 2;
     }
     else {
-      printf("Unknown option '%s'\n", argv[nArg]);
+      printf("Unknown option '%s'\n",
+             icSanitizeConsoleText(argv[nArg]).c_str());
       Usage();
       return 1;
     }
@@ -835,7 +842,8 @@ int main(int argc, const char *argv[])
   if (g_bSuite && nArg < argc) {
     printf("-suite runs the built-in case table and takes no chain;"
            " '%s' and everything after it would be ignored.\n"
-           "Drop them, or drop -suite to benchmark that chain.\n", argv[nArg]);
+           "Drop them, or drop -suite to benchmark that chain.\n",
+           icSanitizeConsoleText(argv[nArg]).c_str());
     return 1;
   }
 
@@ -883,14 +891,15 @@ int main(int argc, const char *argv[])
     const char *szProfile = argv[nArg];
 
     if (nArg + 1 >= argc) {
-      printf("Profile '%s' has no rendering intent\n", szProfile);
+      printf("Profile '%s' has no rendering intent\n",
+             icSanitizeConsoleText(szProfile).c_str());
       return 1;
     }
 
     int nEncoded;
     if (!ParseIntArg(argv[nArg + 1], INT_MIN, INT_MAX, nEncoded)) {
       printf("Invalid rendering intent '%s': expected an integer code\n",
-             argv[nArg + 1]);
+             icSanitizeConsoleText(argv[nArg + 1]).c_str());
       return 1;
     }
     nArg += 2;
@@ -907,11 +916,11 @@ int main(int argc, const char *argv[])
       // would describe a digit the caller can see is in range (#2268).
       if (nEncoded < 0) {
         printf("Invalid rendering intent '%s': a negative intent code is not a"
-               " valid form\n", argv[nArg - 1]);
+               " valid form\n", icSanitizeConsoleText(argv[nArg - 1]).c_str());
       }
       else {
         printf("Invalid rendering intent '%s': decoded intent out of range\n",
-               argv[nArg - 1]);
+               icSanitizeConsoleText(argv[nArg - 1]).c_str());
       }
       return 1;
     }
@@ -920,7 +929,8 @@ int main(int argc, const char *argv[])
     if (nArg + 1 < argc && !stricmp(argv[nArg], "-PCC")) {
       pPccProfile.reset(ReadIccProfile(argv[nArg + 1]));
       if (!pPccProfile) {
-        printf("Unable to read PCC profile '%s'\n", argv[nArg + 1]);
+        printf("Unable to read PCC profile '%s'\n",
+               icSanitizeConsoleText(argv[nArg + 1]).c_str());
         return 1;
       }
       nArg += 2;
@@ -937,7 +947,8 @@ int main(int argc, const char *argv[])
                                        bUseSubProfile);
     if (stat != icCmmStatOk) {
       printf("Unable to add '%s' to the chain: %s\n",
-             szProfile, CIccCmm::GetStatusText(stat));
+             icSanitizeConsoleText(szProfile).c_str(),
+             CIccCmm::GetStatusText(stat));
       return 1;
     }
     if (pPccProfile)

--- a/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
+++ b/Tools/CmdLine/IccDumpProfile/iccDumpProfile.cpp
@@ -85,6 +85,7 @@
 #include "IccUtil.h"
 #include "IccProfLibVer.h"
 #include "IccCmdLineUtil.h"
+#include "IccFileUtil.h"
 
 // #define MEMORY_LEAK_CHECK to enable C RTL memory leak checking (slow!)
 #define MEMORY_LEAK_CHECK
@@ -700,9 +701,15 @@ int main(int argc, char* argv[])
   icHeader* pHdr = NULL;
 
   // Precondition: nArg is argument of ICC profile filename
+  // #2414: the operand is echoed on both the failure and the success path, so a
+  // path carrying terminal control sequences reached the console verbatim (#2406).
+  // The --evidence-json writer above escapes it with icJsonEscape(); this is the
+  // text form's counterpart.
+  std::string srcName = icSanitizeConsoleText(argv[nArg]);
+
   printf("Built with IccProfLib version " ICCPROFLIBVER "\n\n");
   if (!pIcc) {
-    printf("Unable to parse '%s' as ICC profile!\n", argv[nArg]);
+    printf("Unable to parse '%s' as ICC profile!\n", srcName.c_str());
     nStatus = icValidateCriticalError;
   }
   else {
@@ -710,7 +717,7 @@ int main(int argc, char* argv[])
     const size_t bufSize = 64;
     char buf[bufSize];
 
-    printf("Profile:            '%s'\n", argv[nArg]);
+    printf("Profile:            '%s'\n", srcName.c_str());
     if(Fmt.IsProfileIDCalculated(&pHdr->profileID))
       printf("Profile ID:         %s\n", Fmt.GetProfileID(&pHdr->profileID));
     else

--- a/Tools/CmdLine/IccFromCube/iccFromCube.cpp
+++ b/Tools/CmdLine/IccFromCube/iccFromCube.cpp
@@ -82,6 +82,7 @@
 #include "IccTagMPE.h"
 #include "IccMpeBasic.h"
 #include "IccProfLibVer.h"
+#include "IccFileUtil.h"
 #include "IccUtil.h"
 #include "IccCmdLineUtil.h"
 
@@ -227,7 +228,9 @@ public:
       else if (line.substr(0, 19) == "LUT_OUT_VIDEO_RANGE")
         m_bLutOutVideoRange = true;
       else {
-        printf("Unknown keyword '%s'\n", line.c_str());
+        // A line of the .cube FILE, not an argv operand -- the stronger vector of
+        // the two, because a downloaded LUT is not something the caller typed.
+        printf("Unknown keyword '%s'\n", icSanitizeConsoleText(line).c_str());
         return false;
       }
     }
@@ -578,15 +581,22 @@ int main(int argc, char* argv[])
     return argc <= 2 ? 0 : 1;
   }
 
+  // #2414: both operands are echoed by the failure paths below, so a path carrying
+  // terminal control sequences reached the console verbatim (#2406).  Sanitized once
+  // here rather than at each printf; CubeFile and SaveIccProfile still receive the
+  // real path.
+  std::string srcName = icSanitizeConsoleText(argv[1]);
+  std::string dstName = icSanitizeConsoleText(argv[2]);
+
   CubeFile cube(argv[1]);
 
   if (!cube.parseHeader()) {
-    printf("Unable to parse '%s'\n", argv[1]);
+    printf("Unable to parse '%s'\n", srcName.c_str());
     return -2;
   }
 
   if (!cube.sizeLut3D()) {
-    printf("3DLUT not found in '%s'\n", argv[1]);
+    printf("3DLUT not found in '%s'\n", srcName.c_str());
     return -3;
   }
 
@@ -647,7 +657,7 @@ int main(int argc, char* argv[])
   CIccCLUT* pCLUT = new CIccCLUT(3, 3);
   
   if (!pCLUT->Init(cube.sizeLut3D()) ) {
-    printf("Unable to create LUT from '%s'\n", argv[1]);
+    printf("Unable to create LUT from '%s'\n", srcName.c_str());
     delete pCLUT;
     delete pMpeCLUT;
     delete pTag;
@@ -656,7 +666,7 @@ int main(int argc, char* argv[])
 
   bool bSuccess = cube.parse3DTable(pCLUT->GetData(0), pCLUT->NumPoints()*3);
   if (!bSuccess) {
-    printf("Unable to parse LUT from '%s'\n", argv[1]);
+    printf("Unable to parse LUT from '%s'\n", srcName.c_str());
     delete pCLUT;
     delete pMpeCLUT;
     delete pTag;
@@ -716,10 +726,10 @@ int main(int argc, char* argv[])
   profile.AttachTag(icSigProfileSequenceDescTag, pSeqTag);
 
   if (SaveIccProfile(argv[2], &profile)) {
-    printf("'%s' successfully created\n", argv[2]);
+    printf("'%s' successfully created\n", dstName.c_str());
   }
   else {
-    printf("Unable to save profile '%s'\n", argv[2]);
+    printf("Unable to save profile '%s'\n", dstName.c_str());
     return 5;
   }
 

--- a/Tools/CmdLine/IccPawgReport/IccPawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/IccPawgReport.cpp
@@ -64,6 +64,7 @@
 #include <string>
 #include <exception>
 #include "IccProfLibVer.h"
+#include "IccFileUtil.h"
 #include "PawgReport.h"
 
 #ifdef _WIN32
@@ -137,7 +138,8 @@ int main(int argc, char *argv[])
       return 0;
     }  else if (argv[k][0] == '-') {
        // unrecognized switch/option, document and return error
-       printf("Unknown option \"%s\"\n\n", argv[k] );
+       printf("Unknown option \"%s\"\n\n",
+               icSanitizeConsoleText(argv[k]).c_str() );
        printUsage();
        return 1;
     } else {
@@ -164,6 +166,13 @@ int main(int argc, char *argv[])
   }
 #endif
 
+  // #2414: built BEFORE the try, not inside the handlers.  std::bad_alloc is a
+  // std::exception, so sanitizing in the catch block would allocate on the one
+  // path where allocation has just failed -- and an exception escaping a handler
+  // leaves main() uncaught, turning a clean diagnostic into a terminate().  This
+  // is also the hoisting pattern the other nine tools in this sweep use.
+  const std::string displayPath = icSanitizeConsoleText(profilePath);
+
   try {
 #if defined(ICCDEV_ENABLE_QA_FLAGS)
     if (bEvidenceJson) {
@@ -173,10 +182,12 @@ int main(int argc, char *argv[])
     return DumpPawgReport(profilePath.c_str(), bJson);
   }
   catch (const std::exception& e) {
-    fprintf(stderr, "ERROR - exception while processing PAWG report for '%s': %s\n", profilePath.c_str(), e.what() );
+    fprintf(stderr, "ERROR - exception while processing PAWG report for '%s': %s\n",
+             displayPath.c_str(), e.what() );
   }
   catch (...) {
-    printf("ERROR - Unknown exception while preparing PAWG report for '%s'\n", profilePath.c_str() );
+    printf("ERROR - Unknown exception while preparing PAWG report for '%s'\n",
+            displayPath.c_str() );
   }
   
   // we only get here if an exception was thrown during report generation

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -79,6 +79,7 @@
 #include "IccTagLut.h"
 #include "IccUtil.h"
 #include "IccProfLibVer.h"
+#include "IccFileUtil.h"
 #include "IccQualityMetrics.h"
 #include "IccSignatureRegistry.h"
 
@@ -2427,7 +2428,18 @@ int DumpPawgReport(const char *szFilename, bool bJson)
   printf("            Goals for profile assessment\n");
   printf("URL:        %s\n", kPawgUrl);
   printf("Tool:       iccPawgReport (IccProfLib " ICCPROFLIBVER ")\n");
-  printf("Profile:    %s\n", szFilename ? szFilename : "(null)");
+  // #2414: the report header echoes the operand, so a path carrying terminal
+  // control sequences reached the console verbatim (#2406).
+  //
+  // The JSON writer above is NOT equivalent cover, and an earlier draft of this
+  // comment claimed it was.  icJsonEscape() (Tools/CmdLine/IccCmdLineUtil.h)
+  // escapes ESC as \u001b but appends well-formed UTF-8 unchanged, so U+202E
+  // RIGHT-TO-LEFT OVERRIDE and the C1 controls -- exactly the codepoints #2437
+  // added the by-codepoint escape for -- still reach a terminal that cats the
+  // --json output.  Widening icJsonEscape() changes a shared helper and the
+  // shape of every JSON consumer's input, so it is filed rather than done here.
+  printf("Profile:    %s\n",
+         szFilename ? icSanitizeConsoleText(szFilename).c_str() : "(null)");
   printf("Size:       %zu bytes\n", raw.data.size());
   printf("Load:       %s\n", pIcc ? "parsed by IccProfLib" : "raw checks only; IccProfLib parse failed");
   printf("\n");

--- a/Tools/CmdLine/IccPngDump/iccPngDump.cpp
+++ b/Tools/CmdLine/IccPngDump/iccPngDump.cpp
@@ -91,6 +91,7 @@
 #include "IccDefs.h"
 #include "IccProfLibVer.h"
 #include "IccCmdLineUtil.h"
+#include "IccFileUtil.h"
 #include <zlib.h>
 #if !defined(_WIN32)
 #include <fcntl.h>
@@ -224,7 +225,11 @@ if (injectIccFile) {
         safe_exit("Missing --output argument for write mode.");
     }
 
-    printf("[INFO] Injecting ICC profile '%s' into PNG: '%s'\n", injectIccFile, outputPngFile);
+    // #2414: the operands are echoed here and below, so a path carrying
+    // terminal control sequences reached the console verbatim (#2406).
+    printf("[INFO] Injecting ICC profile '%s' into PNG: '%s'\n",
+           icSanitizeConsoleText(injectIccFile).c_str(),
+           icSanitizeConsoleText(outputPngFile).c_str());
 
     if (!InjectIccProfile(inputFile, injectIccFile, outputPngFile)) {
         safe_exit("Failed to inject ICC profile.");
@@ -235,7 +240,8 @@ if (injectIccFile) {
 }
 
     // --- Extraction Mode ---
-    printf("[INFO] Opening PNG file: %s\n", inputFile);
+    printf("[INFO] Opening PNG file: %s\n",
+           icSanitizeConsoleText(inputFile).c_str());
     FILE *fp = fopen(inputFile, "rb");
     if (!fp) {
         LOG_ERROR("File cannot be opened.");
@@ -723,7 +729,8 @@ bool PrintIccProfileInfo(const unsigned char *pProfMem, unsigned int nLen, const
             LOG_ERROR("Failed to close ICC profile output file.");
             return false;
         }
-        printf("[INFO] ICC Profile saved to: %s\n", outputFile);
+        printf("[INFO] ICC Profile saved to: %s\n",
+               icSanitizeConsoleText(outputFile).c_str());
     }
     
     printf("--------------------------------------------------------------------\n");

--- a/Tools/CmdLine/IccProfilePlot/iccProfilePlot.cpp
+++ b/Tools/CmdLine/IccProfilePlot/iccProfilePlot.cpp
@@ -75,6 +75,7 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
+#include "IccFileUtil.h"
 
 // -- tiny hand-rolled JSON emitter (no third-party deps, like IccPawgReport) --
 
@@ -245,7 +246,11 @@ int main(int argc, char* argv[]) {
 
   CIccProfile* pIcc = OpenIccProfile(path);
   if (!pIcc) {
-    std::fprintf(stderr, "Unable to parse '%s' as an ICC profile.\n", path);
+    // #2414: the operand is echoed here, so a path carrying terminal control
+    // sequences reached the console verbatim (#2406).  The JSON writer below
+    // uses jstr() for its own sink.
+    std::fprintf(stderr, "Unable to parse '%s' as an ICC profile.\n",
+                 icSanitizeConsoleText(path).c_str());
     return 2;
   }
 

--- a/Tools/CmdLine/IccRoundTrip/iccRoundTrip.cpp
+++ b/Tools/CmdLine/IccRoundTrip/iccRoundTrip.cpp
@@ -79,6 +79,7 @@
 #include "IccEval.h"
 #include "IccPrmg.h"
 #include "IccProfLibVer.h"
+#include "IccFileUtil.h"
 
 class CIccMinMaxEval : public CIccEvalCompare
 {
@@ -190,10 +191,16 @@ int main(int argc, char* argv[])
   }
 
   if (argc > 4) {
-    printf("Unexpected extra argument: '%s'\n", argv[4]);
+    printf("Unexpected extra argument: '%s'\n",
+           icSanitizeConsoleText(argv[4]).c_str());
     PrintUsage();
     return 1;
   }
+
+  // #2414: the profile path is echoed by the failure paths and by the report header,
+  // so a path carrying terminal control sequences reached the console verbatim
+  // (#2406).  EvaluateProfile() still receives the real path.
+  std::string srcName = icSanitizeConsoleText(argv[1]);
 
   icRenderingIntent nIntent = icRelativeColorimetric;
   bool nUseMPE = false;
@@ -201,7 +208,8 @@ int main(int argc, char* argv[])
   if (argc>2) {
     int temp = 0;
     if (!ParseIntArg(argv[2], (int)icPerceptual, (int)icAbsoluteColorimetric, temp)) {
-      printf("Invalid rendering_intent: '%s'\n", argv[2]);
+      printf("Invalid rendering_intent: '%s'\n",
+             icSanitizeConsoleText(argv[2]).c_str());
       PrintUsage();
       return 1;
     }
@@ -210,7 +218,8 @@ int main(int argc, char* argv[])
     if (argc > 3) {
       int tempUseMPE = 0;
       if (!ParseIntArg(argv[3], 0, 1, tempUseMPE)) {
-        printf("Invalid use_mpe: '%s'\n", argv[3]);
+        printf("Invalid use_mpe: '%s'\n",
+               icSanitizeConsoleText(argv[3]).c_str());
         PrintUsage();
         return 1;
       }
@@ -226,7 +235,8 @@ int main(int argc, char* argv[])
     // Decode the status so callers can tell an outright failure (e.g. an
     // unreadable profile) from a deliberate refusal such as "Too many samples
     // used", which guards the round trip against wide device spaces (#1405).
-    printf("Unable to perform round trip on '%s': %s\n", argv[1], CIccCmm::GetStatusText(stat));
+    printf("Unable to perform round trip on '%s': %s\n", srcName.c_str(),
+           CIccCmm::GetStatusText(stat));
     if (stat == icCmmStatTooManySamples) {
       return 0;
     }
@@ -241,7 +251,7 @@ int main(int argc, char* argv[])
 
   CIccInfo info;
 
-  printf("Profile:          '%s'\n", argv[1]);
+  printf("Profile:          '%s'\n", srcName.c_str());
   printf("Rendering Intent: %s\n", info.GetRenderingIntentName(nIntent));
   if (prmgOk) {
     printf("Specified Gamut:  %s\n", prmg.m_bPrmgImplied ? "Perceptual Reference Medium Gamut" : "Not Specified");

--- a/Tools/CmdLine/IccV5DspObsToV4Dsp/IccV5DspObsToV4Dsp.cpp
+++ b/Tools/CmdLine/IccV5DspObsToV4Dsp/IccV5DspObsToV4Dsp.cpp
@@ -79,6 +79,7 @@
 #include "IccMpeSpectral.h"
 #include "IccUtil.h"
 #include "IccProfLibVer.h"
+#include "IccFileUtil.h"
 #include <memory>
 
 
@@ -133,16 +134,24 @@ int main(int argc, char* argv[])
     return 0;
   }
 
+  // #2414: all three operands are echoed by the twelve diagnostics below, so a
+  // path carrying terminal control sequences reached the console verbatim
+  // (#2406).  Sanitized once here; ReadIccProfile/SaveIccProfile still get the
+  // real paths.
+  std::string dspName = icSanitizeConsoleText(argv[1]);
+  std::string pccName = icSanitizeConsoleText(argv[2]);
+  std::string outName = icSanitizeConsoleText(argv[3]);
+
   CIccProfileSharedPtr dspIcc( ReadIccProfile(argv[1], true) );
 
   if (!dspIcc) {
-    printf("Unable to parse '%s'\n", argv[1]);
+    printf("Unable to parse '%s'\n", dspName.c_str());
     return -2;
   }
 
   if (dspIcc->m_Header.version < icVersionNumberV5 ||
     dspIcc->m_Header.deviceClass != icSigDisplayClass) {
-    printf("%s is not a V5 display profile\n", argv[1]);
+    printf("%s is not a V5 display profile\n", dspName.c_str());
     return -2;
   }
 
@@ -150,14 +159,14 @@ int main(int argc, char* argv[])
   // matrix/TRC profile built from three (1,0,0)/(0,1,0)/(0,0,1) primaries below,
   // so a non-RGB data colour space cannot be honoured.
   if (dspIcc->m_Header.colorSpace != icSigRgbData) {
-    printf("%s is not an RGB display profile (data colour space must be 'RGB ')\n", argv[1]);
+    printf("%s is not an RGB display profile (data colour space must be 'RGB ')\n", dspName.c_str());
     return -2;
   }
 
   CIccTagMultiProcessElement* pTagIn = (CIccTagMultiProcessElement*)dspIcc->FindTagOfType(icSigAToB1Tag, icSigMultiProcessElementType);
 
   if (!pTagIn) {
-    printf("%s doesn't have an AToB1Tag of type mulitProcessElementType\n", argv[1]);
+    printf("%s doesn't have an AToB1Tag of type mulitProcessElementType\n", dspName.c_str());
     return -2;
   }
 
@@ -170,14 +179,14 @@ int main(int argc, char* argv[])
         curveMpe->GetType()!= icSigCurveSetElemType ||
       ((matrixMpe = pTagIn->GetElement(1))==nullptr) ||
         matrixMpe->GetType()!=icSigEmissionMatrixElemType) {
-    printf("%s doesn't have a spectral emission AToB1Tag\n", argv[1]);
+    printf("%s doesn't have a spectral emission AToB1Tag\n", dspName.c_str());
     return -2;
   }
 
   CIccProfileSharedPtr pccIcc( ReadIccProfile(argv[2]) );
 
   if (!pccIcc) {
-    printf("Unable to parse '%s'\n", argv[2]);
+    printf("Unable to parse '%s'\n", pccName.c_str());
     return -2;
   }
 
@@ -185,7 +194,7 @@ int main(int argc, char* argv[])
   // ICC spec carries as a ColorSpace-class ('spac') profile (subclass 'pcc ').
   if (pccIcc->m_Header.version < icVersionNumberV5 ||
     pccIcc->m_Header.deviceClass != icSigColorSpaceClass) {
-    printf("%s is not a V5 observer (ColorSpace-class PCC) profile\n", argv[2]);
+    printf("%s is not a V5 observer (ColorSpace-class PCC) profile\n", pccName.c_str());
     return -2;
   }
 
@@ -204,12 +213,12 @@ int main(int argc, char* argv[])
     pTagC2S->NumOutputChannels() != 3 ||
     !pTagSvcn->getObserver(obsRange) ||
     !obsRange.steps) {
-    printf("%s doesn't have Profile Connection Conditions (observer + customToStandardPcc)\n", argv[2]);
+    printf("%s doesn't have Profile Connection Conditions (observer + customToStandardPcc)\n", pccName.c_str());
     return -2;
   }
 
   if (!pTagIn->Begin(icElemInterpLinear, dspIcc.get(), pccIcc.get())) {
-    printf("bad tagIn in %s\n", argv[1]);
+    printf("bad tagIn in %s\n", dspName.c_str());
     return -2;
   }
 
@@ -222,7 +231,7 @@ int main(int argc, char* argv[])
   auto mtxApply = applyIter->ptr;
 
   if (!pTagC2S->Begin(icElemInterpLinear, pccIcc.get())) {
-    printf("bad transform c2s in %s\n", argv[2]);
+    printf("bad transform c2s in %s\n", pccName.c_str());
     return -2;
   }
   
@@ -324,11 +333,11 @@ int main(int argc, char* argv[])
   pIcc->AttachTag(icSigMediaWhitePointTag, whiteXYZ); // pointer ownership is passed to the profile
 
   if (!SaveIccProfile(argv[3], pIcc)) {
-    printf("Unable to create %s\n", argv[3]);
+    printf("Unable to create %s\n", outName.c_str());
     delete pIcc;
     return -1;
   }
-  printf("%s successfully created\n", argv[3]);
+  printf("%s successfully created\n", outName.c_str());
   delete pIcc;
 
   return 0;


### PR DESCRIPTION
Part of #2414.

@xsscx asked for the whole sweep ("Please PR All as time permits"); this is the
**ANSI-injection half**. The directory-`fopen()` half landed as #2443.

## What was measured

On `764fc176`, **ten** tools printed a user-supplied operand to the console
verbatim, so a profile whose *name* carries a CSI sequence repaints the terminal
of anyone who runs them (#2406):

| tool | representative site |
|---|---|
| `iccDumpProfile` | `Unable to parse '%s'`, `Profile: '%s'` |
| `iccPngDump` | `Opening PNG file`, injection + save messages |
| `iccFromCube` | four parse failures, the success line, **and the `.cube` file's own content** |
| `iccRoundTrip` | round-trip failure, report header, three argument errors |
| `iccPawgReport` | report header, both exception handlers, unknown option |
| `iccToXml` | all five failure paths |
| `iccBenchApply` | chain/PCC/leaf failures, `-threads`, `-suite`, three intent branches |
| `iccFromXml` | parse failure, save failure, unrecognized option, `-v=<schema>` |
| `iccProfilePlot` | `Unable to parse '%s' as an ICC profile.` |
| `iccV5DspObsToV4Dsp` | twelve diagnostics across all three operands |

`iccTiffDump` was the control: already sanitized by the #2419 family, it prints
the escaped spelling where these ten printed the live escape.

**The strongest vector is `iccFromCube`'s `Unknown keyword '%s'`**, which echoes a
line of the **`.cube` file** rather than an operand. Every other case here is
something the caller typed; a `.cube` arrives downloaded and carries whatever its
author put in it.

## Corrections to my own scope comment on the issue

I wrote "six with zero sanitization". Both halves of that were wrong, and I want
the record straight since the numbers came from me:

- The real count of tools with **no** sanitization is **twelve** -- I had counted
  only tools that *also* call `fopen()`, which dropped `iccToXml`, `iccFromXml`,
  `iccRoundTrip` and `iccPawgReport`. All four leak.
- It named `iccProfilePlot` as not reaching a path-printing site. **It does** --
  via its `list` subcommand. My probe invocation was rejected by argument
  validation before any path was printed, and I read "no escape in the output" as
  "this tool prints no path". `iccV5DspObsToV4Dsp` I never examined at all; it
  leaks from twelve sites.
- Two of the eight `fopen` "candidates" in that comment were grep hits on
  *comments*, not calls.

`iccJpegDump` and `iccProfileVisualize` do check out: the first prints no operand
on any accepted invocation, the second substitutes an underscore.

## The fix

Sanitized at the print sites. Where a tool echoes the same operand from several
of them, the sanitized string is built once near the top of `main()` rather than
at each `printf`, so a message added later cannot reintroduce the raw form. The
paths handed to the readers and writers are untouched.

## Test

`iccdev.console-sanitize-sweep-regression`, registered beside #2443's
directory-guard suite. **13 cases** -- 11 defect, 2 controls.

Each defect case asserts **both** that no raw ESC survives **and** that the
escaped spelling is present. "No raw ESC" alone is satisfied by a tool that fails
earlier and prints nothing -- which is exactly the mistake that produced the wrong
`iccProfilePlot` verdict above.

The controls carry as much weight: an ASCII path must still print with **no**
escaping at all, and a valid conversion must still succeed. An over-eager or
double-escaping fix would be invisible to all eleven defect cases.

```
against 764fc176 :  PASS=2  FAIL=11   (both controls pass)
against this PR  :  PASS=13 FAIL=0
empty tools dir  :  exit 77 (SKIP, not a green run that measured nothing)
```

Per-case timeout is 20 s, not the sibling suite's 60 s: 13 spawns at 60 s is a
780 s worst case against a 300 s CTest budget, and CTest killing the script means
a bare "Timeout" with none of the per-case `[FAIL]` lines -- the failure mode that
sibling sized its own budget to avoid.

Not labelled `slow`: `ci-pr-action.yml` pins `ctest_mode=fast`, which drops that
label, and a console-injection regression that runs on no PR leg is not a
regression test (#2412).

## ASCII output is unchanged

Master and patched binaries produce byte-identical output for every tool on an
ASCII path, error paths included. The only differences across the whole set are
the commit hash in the version banner and `iccBenchApply`'s timing column, which
varies 27.7-30.2 ms run-to-run *within a single binary* while its checksum stays
`0xdd57cbea`.

Local `ctest`: 254/255. The one failure is `iccdev.spectral-tiff-preview`, which
fails identically on master for a missing Python `imagecodecs` module and touches
no code in this PR.

## Not in this PR -- filed instead

1. **#2453 -- `iccDumpProfile` returns 0 for every failure** unless `-v` is passed.
   A missing file, a directory, garbage and random bytes all exit 0, so success
   and total failure are indistinguishable to any caller checking `$?`. `nValid`
   is initialised to 0 at `:1022` and only ever assigned inside
   `if (bDumpValidation)` at `:1024`, so the `icValidateCriticalError` recorded at
   `:713` is discarded. That is the #2405 class in a tool #2421 did not cover, and
   it is an exit-code contract change, so it should not ride along here.

2. **#2454 -- `icJsonEscape()` is not equivalent cover for the JSON sinks.** An
   earlier commit on this branch claimed it was; the claim was wrong and the
   comment now records the gap instead. `icJsonEscape` escapes the C0 controls but
   appends well-formed UTF-8 unchanged, so U+202E and the C1 controls -- the exact
   codepoints #2437 added by-codepoint escaping for -- still reach a terminal that
   `cat`s the `--json` output. Measured on `iccPawgReport`: the text report prints
   the escaped form, `--json` emits the live bytes.

Also measured and deliberately **not** acted on: six of these tools hang on a
writer-less FIFO. That is pre-existing, and `icIsReadableFile()`'s own header says
a caller whose input may legitimately be a pipe must not use it -- #2443 already
traded one hang for another that way once.

## Pre-flight

Per the contribution SOP, mirroring CI's gate rather than a test run:

| lane | result |
|---|---|
| Clang 21.1.3 strict Release (`-Wall -Wextra -Wpedantic -Werror`) | `grep -cE 'warning:'` = **0**, errors 0 |
| GCC 15.2.0 strict Release LTO, in `ghcr.io/internationalcolorconsortium/iccdev:latest` | `grep -cE 'warning:'` = **0**, errors 0 |
| both, incl. `build-test-binaries` | 0 -- the `EXCLUDE_FROM_ALL` targets that escape a default build |
| `ctest` | 254/255; the one failure is `iccdev.spectral-tiff-preview`, which fails identically on master for a missing Python `imagecodecs` module |
| suite under ASAN+UBSAN, `detect_leaks=1` | 13/13, no leaks, no UB (CI's ctest env sets `detect_leaks=0`) |
| `shellcheck` 0.9.0 (CI's apt pin) on the new script | clean |

Both strict lanes printed "strict warnings ENABLED", so neither silently skipped
the `-Wshadow -Wnull-dereference -Wundef -Wpointer-arith` set that the local
GCC 13.3 is below the floor for.

Dispatched `ci-pr-action` with `ci_scope=source` before opening this PR, per the
suggested workflow: run **34103959610**.
