### PR TITLE
CI: Add XNU Build Hardware Targets & CLUT CTest App

### DIFF
--- a/.github/ci/doxygen/Doxyfile
+++ b/.github/ci/doxygen/Doxyfile
@@ -69,8 +69,7 @@ INCLUDE_PATH           = IccProfLib \
                          Tools/CmdLine/IccPawgReport \
                          Tools/CmdLine/IccProfileVisualize \
                          Tools/Winnt/IccIisIsapi \
-                         examples/hello-iccdev \
-                         /usr/include
+                         examples/hello-iccdev
 
 # Extraction settings. Keep file-local anonymous namespaces out of the public
 # hierarchy/UI: they are implementation details and make inherits.html split into

--- a/.github/ci/doxygen/curated-navigation.dox
+++ b/.github/ci/doxygen/curated-navigation.dox
@@ -27,7 +27,7 @@ tabs.
 \subpage md_docs_2documentation-maintenance "Documentation maintenance"
 \subpage md_docs_2label-system "Maintainer label system"
 \subpage md_docs_2label-inventory-audit "Label inventory audit"
-\subpage md_docs_2governance_2UPSTREAM__PR__READINESS "Upstream pull request readiness"
+\subpage upstream-pr-readiness "Upstream pull request readiness"
 */
 
 /**

--- a/.github/instructions/build-system.instructions.md
+++ b/.github/instructions/build-system.instructions.md
@@ -32,6 +32,12 @@ User-facing build details live in `docs/build.md`.
 outputs in the build tree; do not restore the obsolete per-tool Xcode projects
 or copy binaries and TIFF sources into `Testing/` or `Tools/`.
 
+For Unix multi-config CTest, keep the `iccdev_unix_runtime` setup fixture:
+`UnixMultiConfigRuntime.cmake` maps CMake target paths into separate
+`Testing/ctest-runtime/<Config>` directories for the unchanged shell suites.
+Do not replace it with shared flat aliases that can select another
+configuration, or point `cmake --build` at the compatibility directory.
+
 Apple mobile presets build the static core only. `Build/AppleMobile` consumes
 the exported core package in a separate iOS app build; keep its device/simulator
 SDK, architecture, and deployment target aligned with the core archive.

--- a/.github/instructions/build-system.instructions.md
+++ b/.github/instructions/build-system.instructions.md
@@ -35,16 +35,22 @@ or copy binaries and TIFF sources into `Testing/` or `Tools/`.
 For Unix multi-config CTest, keep the `iccdev_unix_runtime` setup fixture:
 `UnixMultiConfigRuntime.cmake` maps CMake target paths into separate
 `Testing/ctest-runtime/<Config>` directories for the unchanged shell suites.
+Expose regular files, not symlinks, because existing scripts use `find -type f`;
+resolve library aliases before hard-linking or copying them into the view.
 Do not replace it with shared flat aliases that can select another
 configuration, or point `cmake --build` at the compatibility directory.
 
 Apple mobile presets build the static core only. `Build/AppleMobile` consumes
-the exported core package in a separate iOS app build; keep its device/simulator
+the exported core package in separate iOS/watchOS app builds; keep each device/simulator
 SDK, architecture, and deployment target aligned with the core archive.
 Physical-device smoke results require both the current `devicectl --console`
 termination exit code and the app's persisted `Documents/results.json`, not
 just successful installation or launch. Keep signing and device identifiers
-local. See `docs/build.md` for the commands.
+local. The UIKit and SwiftUI hosts share the Foundation smoke engine; keep
+Objective-C++ flags off Swift sources. Use
+`.github/scripts/iccdev-apple-simulator-smoke.sh` for fresh-report and
+missing-fixture controls, and `.github/scripts/iccdev-xcode-ctest-smoke.sh` for
+Release/Debug runtime discovery. See `docs/build.md` for the commands.
 
 ## CMake Diagnostics
 

--- a/.github/instructions/build-system.instructions.md
+++ b/.github/instructions/build-system.instructions.md
@@ -22,11 +22,23 @@ Primary build file: `Build/Cmake/CMakeLists.txt`
 | Platform | Configure entry point |
 |----------|-----------------------|
 | Linux | `cd Build && cmake Cmake -DCMAKE_CXX_COMPILER=clang++` |
-| macOS Xcode | `cd Build && cmake -G "Xcode" Cmake` |
+| macOS Xcode | `cmake --preset macos-xcode -S Build/Cmake -B out/macos-xcode` |
 | Windows MSVC/vcpkg | `cmake --preset vs2022-x64 -B Build -S Build/Cmake` |
 | Emscripten/WASM | `cd Build && emcmake cmake Cmake -DENABLE_TESTS=OFF -DENABLE_SHARED_LIBS=OFF` |
 
 User-facing build details live in `docs/build.md`.
+
+`Build/XCode/BuildAll.sh` is a macOS-only wrapper around that preset. Keep
+outputs in the build tree; do not restore the obsolete per-tool Xcode projects
+or copy binaries and TIFF sources into `Testing/` or `Tools/`.
+
+Apple mobile presets build the static core only. `Build/AppleMobile` consumes
+the exported core package in a separate iOS app build; keep its device/simulator
+SDK, architecture, and deployment target aligned with the core archive.
+Physical-device smoke results require both the current `devicectl --console`
+termination exit code and the app's persisted `Documents/results.json`, not
+just successful installation or launch. Keep signing and device identifiers
+local. See `docs/build.md` for the commands.
 
 ## CMake Diagnostics
 

--- a/.github/scripts/iccdev-apple-simulator-smoke.sh
+++ b/.github/scripts/iccdev-apple-simulator-smoke.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 International Color Consortium.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Run the native core host on a disposable iOS/watchOS simulator. A fresh
+# persisted report and console sentinel, not simctl's exit code alone, decide
+# success. The missing-fixture control must fail before restoring a passing run.
+set -euo pipefail
+
+if [[ $# -gt 1 ]]; then
+  echo "Usage: $0 [ios|watchos]" >&2
+  exit 2
+fi
+platform="${1:-ios}"
+case "$platform" in
+  ios) system=iOS; sdk=iphonesimulator; family=iPhone; deployment=17.0 ;;
+  watchos) system=watchOS; sdk=watchsimulator; family='Apple Watch'; deployment=10.0 ;;
+  *) echo "Usage: $0 [ios|watchos]" >&2; exit 2 ;;
+esac
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+core="out/apple-${platform}-simulator-core"
+build="out/apple-${platform}-simulator-smoke"
+mkdir -p "$build"
+
+xcrun simctl list runtimes --json > "$build/runtimes.json"
+if ! jq -e --arg prefix "com.apple.CoreSimulator.SimRuntime.${system}-" \
+    'any(.runtimes[]; .isAvailable and (.identifier | startswith($prefix)))' \
+    "$build/runtimes.json" >/dev/null; then
+  if [[ "${ICCDEV_APPLE_DOWNLOAD_RUNTIME:-0}" != 1 ]]; then
+    echo "No available ${system} simulator runtime. Install it with: xcodebuild -downloadPlatform ${system}" >&2
+    exit 1
+  fi
+  xcodebuild -downloadPlatform "$system"
+  xcrun simctl list runtimes --json > "$build/runtimes.json"
+fi
+selection="$(jq -er --arg prefix "com.apple.CoreSimulator.SimRuntime.${system}-" \
+  --arg family "$family" '
+    [.runtimes[] | select(.isAvailable and (.identifier | startswith($prefix)))]
+    | sort_by(.version | split(".") | map(tonumber)) | last
+    | select(. != null)
+    | [.identifier, (.supportedDeviceTypes | map(select(.productFamily == $family)) | first.identifier)]
+    | select(all(.[]; type == "string" and length > 0)) | @tsv
+  ' "$build/runtimes.json")"
+IFS=$'\t' read -r runtime device_type <<< "$selection"
+
+cmake --preset "apple-${platform}-simulator-core" -S Build/Cmake \
+  -DCMAKE_OSX_ARCHITECTURES="$(uname -m)" -DCMAKE_OSX_DEPLOYMENT_TARGET="$deployment"
+cmake --build "$core" --parallel "$(sysctl -n hw.ncpu)"
+cmake -S Build/AppleMobile -B "$build" -G Xcode \
+  -DCMAKE_SYSTEM_NAME="$system" -DCMAKE_OSX_SYSROOT="$sdk" \
+  -DCMAKE_OSX_ARCHITECTURES="$(uname -m)" -DCMAKE_OSX_DEPLOYMENT_TARGET="$deployment" \
+  -DRefIccMAX_DIR="$repo_root/$core"
+xcodebuild -quiet -project "$build/IccDevCoreSmoke.xcodeproj" \
+  -target IccDevCoreSmoke -configuration Release -sdk "$sdk" CODE_SIGNING_ALLOWED=NO build
+app="$repo_root/$build/Release-${sdk}/IccDevCoreSmoke.app"
+bundle="$(plutil -extract CFBundleIdentifier raw -o - "$app/Info.plist")"
+
+simulator=""
+launch_pid=""
+booted=0
+cleanup() {
+  status=$?
+  trap - EXIT
+  if [[ -n "$launch_pid" ]] && kill -0 "$launch_pid" 2>/dev/null; then
+    if ! kill -TERM "$launch_pid"; then
+      echo "Unable to terminate simulator launch process ${launch_pid}." >&2
+      status=1
+    fi
+  fi
+  if [[ -n "$simulator" ]]; then
+    if [[ "$booted" == 1 ]] && ! xcrun simctl shutdown "$simulator"; then
+      echo "Failed to shut down the test simulator: $simulator" >&2
+      status=1
+    fi
+    if ! xcrun simctl delete "$simulator"; then
+      echo "Failed to delete the test simulator: $simulator" >&2
+      status=1
+    fi
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+simulator="$(xcrun simctl create "iccDEV-${platform}-smoke-$$" "$device_type" "$runtime")"
+xcrun simctl boot "$simulator"
+booted=1
+xcrun simctl bootstatus "$simulator" -b
+xcrun simctl install "$simulator" "$app"
+data="$(xcrun simctl get_app_container "$simulator" "$bundle" data)"
+installed_app="$(xcrun simctl get_app_container "$simulator" "$bundle" app)"
+
+run_case() {
+  local name="$1" expected="$2"
+  local launch_status=0 timed_out=0
+  rm -f "$data/Documents/results.json"
+  xcrun simctl launch --console-pty --terminate-running-process \
+    "$simulator" "$bundle" --exit-after-tests > "$build/${name}.log" 2>&1 &
+  launch_pid=$!
+  for ((second = 0; second < 120; ++second)); do
+    if ! kill -0 "$launch_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 1
+  done
+  if kill -0 "$launch_pid" 2>/dev/null; then
+    timed_out=1
+    kill -TERM "$launch_pid"
+    sleep 1
+    if kill -0 "$launch_pid" 2>/dev/null; then
+      kill -KILL "$launch_pid"
+    fi
+  fi
+  wait "$launch_pid" || launch_status=$?
+  launch_pid=""
+  if [[ "$timed_out" == 1 || ( "$launch_status" != 0 && "$expected" == true ) ]]; then
+    echo "Simulator case ${name} failed (exit=${launch_status}, timeout=${timed_out})." >&2
+    sed -n '1,120p' "$build/${name}.log"
+    return 1
+  fi
+  cp "$data/Documents/results.json" "$build/${name}.json"
+  if ! jq -e --argjson expected "$expected" '
+    .passed == $expected and (.tests | length > 0) and
+    (if $expected then all(.tests[]; .passed == true)
+     else any(.tests[]; .test == "Bundled RGB fixture exists" and .passed == false) end)
+  ' "$build/${name}.json" >/dev/null; then
+    sed -n '1,120p' "$build/${name}.log"
+    return 1
+  fi
+  if [[ "$expected" == true ]]; then
+    grep -F 'ICCDEV_DEVICE_TESTS PASS (' "$build/${name}.log"
+  else
+    grep -F 'ICCDEV_DEVICE_TESTS FAIL (' "$build/${name}.log"
+  fi
+}
+
+run_case positive true
+mv "$installed_app/sRGB_D65_MAT.icc" "$installed_app/sRGB_D65_MAT.icc.disabled"
+run_case missing-fixture false
+mv "$installed_app/sRGB_D65_MAT.icc.disabled" "$installed_app/sRGB_D65_MAT.icc"
+run_case restored true
+printf '%s simulator core smoke passed using %s\n' "$system" "$runtime"

--- a/.github/scripts/iccdev-apple-simulator-smoke.sh
+++ b/.github/scripts/iccdev-apple-simulator-smoke.sh
@@ -88,13 +88,19 @@ xcrun simctl boot "$simulator"
 booted=1
 xcrun simctl bootstatus "$simulator" -b
 xcrun simctl install "$simulator" "$app"
-data="$(xcrun simctl get_app_container "$simulator" "$bundle" data)"
-installed_app="$(xcrun simctl get_app_container "$simulator" "$bundle" app)"
+data=""
+installed_app=""
+refresh_app_containers() {
+  data="$(xcrun simctl get_app_container "$simulator" "$bundle" data)"
+  installed_app="$(xcrun simctl get_app_container "$simulator" "$bundle" app)"
+}
+refresh_app_containers
 
 run_case() {
   local name="$1" expected="$2"
   local launch_status=0 timed_out=0
-  rm -f "$data/Documents/results.json"
+  local result_file="$data/Documents/results.json"
+  rm -f "$result_file"
   xcrun simctl launch --console-pty --terminate-running-process \
     "$simulator" "$bundle" --exit-after-tests > "$build/${name}.log" 2>&1 &
   launch_pid=$!
@@ -119,7 +125,12 @@ run_case() {
     sed -n '1,120p' "$build/${name}.log"
     return 1
   fi
-  cp "$data/Documents/results.json" "$build/${name}.json"
+  if [[ ! -s "$result_file" ]]; then
+    echo "Simulator case ${name} did not persist results at ${result_file}." >&2
+    sed -n '1,120p' "$build/${name}.log"
+    return 1
+  fi
+  cp "$result_file" "$build/${name}.json"
   if ! jq -e --argjson expected "$expected" '
     .passed == $expected and (.tests | length > 0) and
     (if $expected then all(.tests[]; .passed == true)
@@ -138,6 +149,7 @@ run_case() {
 run_case positive true
 mv "$installed_app/sRGB_D65_MAT.icc" "$installed_app/sRGB_D65_MAT.icc.disabled"
 run_case missing-fixture false
-mv "$installed_app/sRGB_D65_MAT.icc.disabled" "$installed_app/sRGB_D65_MAT.icc"
+xcrun simctl install "$simulator" "$app"
+refresh_app_containers
 run_case restored true
 printf '%s simulator core smoke passed using %s\n' "$system" "$runtime"

--- a/.github/scripts/iccdev-xcode-ctest-smoke.sh
+++ b/.github/scripts/iccdev-xcode-ctest-smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Copyright (c) 2026 International Color Consortium.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Dependency-free Xcode coverage of native tests, direct CLI paths, and
+# find -type f discovery in the configuration-specific shell runtime view.
+set -euo pipefail
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$repo_root"
+build="out/xcode-ctest-smoke"
+cmake --preset macos-xcode -S Build/Cmake -B "$build" \
+  -DENABLE_TOOLS=ON -DENABLE_TESTS=ON \
+  -DENABLE_SHARED_LIBS=ON -DENABLE_STATIC_LIBS=ON \
+  -DENABLE_ICCXML=OFF -DENABLE_ICCJSON=OFF -DICC_USE_ZLIB=OFF \
+  -DENABLE_IMAGE_TOOLS=OFF -DENABLE_WXWIDGETS=OFF -DENABLE_CMM_TOOLS=OFF
+for config in Release Debug; do
+  cmake --build "$build" --config "$config" --parallel "$(sysctl -n hw.ncpu)" \
+    --target iccFromCube iccDumpProfile iccProfileWriteFailureTest
+  rm -f "$build/Testing/ctest-output/$config/iccdev-fromcube-cli-args/domain.icc"
+  ctest --test-dir "$build" -C "$config" \
+    -R '^iccdev\.(unix-runtime-layout|profile-write-failure|fromcube-cli-args)$' \
+    --output-on-failure --no-tests=error
+  # A legacy discovery failure is reported as SKIP by this script, so require
+  # the successful operation's output as well as CTest's process status.
+  test -s "$build/Testing/ctest-output/$config/iccdev-fromcube-cli-args/domain.icc"
+done

--- a/.github/workflows/ci-apple-mobile-core.yml
+++ b/.github/workflows/ci-apple-mobile-core.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: apple-core-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Apple mobile static cores
@@ -110,6 +114,48 @@ jobs:
               sanitize_line "$result"
               echo ' |'
             done < "$artifact_manifest"
+          } >> "$GITHUB_STEP_SUMMARY"  # elements-sanitized
+
+      # preflight: allow-pr-script-execution reason=native-apple-host-test-only
+      - name: Exercise iOS and watchOS simulator hosts
+        env:
+          BASH_ENV: /dev/null
+          ICCDEV_APPLE_DOWNLOAD_RUNTIME: '1'
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          bash .github/scripts/iccdev-apple-simulator-smoke.sh ios
+          bash .github/scripts/iccdev-apple-simulator-smoke.sh watchos
+
+      # preflight: allow-pr-script-execution reason=xcode-ctest-runtime-test-only
+      - name: Exercise Xcode CTest runtime layouts
+        env:
+          BASH_ENV: /dev/null
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          bash .github/scripts/iccdev-xcode-ctest-smoke.sh
+
+      - name: Summarize native Apple smoke results
+        env:
+          BASH_ENV: /dev/null
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          # shellcheck source=.github/scripts/sanitize-sed.sh
+          source "$GITHUB_WORKSPACE/base/.github/scripts/sanitize-sed.sh"
+          {
+            for platform in ios watchos; do
+              report="out/apple-${platform}-simulator-smoke/restored.json"
+              count="$(jq -er '.tests | length' "$report")"
+              sanitize_line "${platform}: ${count} core checks; missing-fixture failure control passed."
+              printf '\n'
+            done
+            sanitize_line "Xcode Release and Debug CTest runtime gates passed."
+            printf '\n'
           } >> "$GITHUB_STEP_SUMMARY"  # elements-sanitized
 
       - name: Upload Apple mobile core libraries

--- a/.github/workflows/ci-apple-platform-smoke.yml
+++ b/.github/workflows/ci-apple-platform-smoke.yml
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 International Color Consortium.
+# SPDX-License-Identifier: BSD-3-Clause
+name: Apple platform smoke
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - 'IccProfLib/**'
+      - 'Build/AppleMobile/**'
+      - 'Build/Cmake/**'
+      - 'Build/XCode/**'
+      - 'Testing/AppleMobile/**'
+      - 'Testing/**/sRGB_D65_MAT.icc'
+      - 'Tools/CmdLine/IccFromCube/**'
+      - 'Tools/CmdLine/IccDumpProfile/**'
+      - '.github/ci/regression/profile-write-failure.cpp'
+      - '.github/scripts/iccdev-fromcube-cli-args-regression.sh'
+      - '.github/scripts/iccdev-apple-simulator-smoke.sh'
+      - '.github/scripts/iccdev-xcode-ctest-smoke.sh'
+      - '.github/workflows/ci-apple-platform-smoke.yml'
+      - '.github/workflows/ci-apple-mobile-core.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: apple-smoke-${{ github.event_name }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+jobs:
+  smoke:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: macos-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        shell: bash --noprofile --norc {0}
+    steps:
+      - name: Checkout test sources
+        uses: actions/checkout@c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5
+        with:
+          persist-credentials: false
+
+      - name: Checkout trusted summary helpers
+        uses: actions/checkout@c2d88d3ecc89a9ef08eebf45d9637801dcee7eb5
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: base
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      # preflight: allow-pr-script-execution reason=native-apple-host-test-only
+      - name: Exercise native simulator and Xcode CTest hosts
+        env:
+          BASH_ENV: /dev/null
+          ICCDEV_APPLE_DOWNLOAD_RUNTIME: '1'
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          bash .github/scripts/iccdev-apple-simulator-smoke.sh ios
+          bash .github/scripts/iccdev-apple-simulator-smoke.sh watchos
+          bash .github/scripts/iccdev-xcode-ctest-smoke.sh
+
+      - name: Summarize Apple smoke results
+        env:
+          BASH_ENV: /dev/null
+        run: |
+          set -euo pipefail
+          git config --global credential.helper ""
+          unset GITHUB_TOKEN || true
+          # shellcheck source=.github/scripts/sanitize-sed.sh
+          source "$GITHUB_WORKSPACE/base/.github/scripts/sanitize-sed.sh"
+          {
+            for platform in ios watchos; do
+              report="out/apple-${platform}-simulator-smoke/restored.json"
+              count="$(jq -er '.tests | length' "$report")"
+              sanitize_line "${platform}: ${count} core checks; missing-fixture failure control passed."
+              printf '\n'
+            done
+            sanitize_line "Xcode Release and Debug CTest runtime gates passed."
+            printf '\n'
+          } >> "$GITHUB_STEP_SUMMARY"  # elements-sanitized

--- a/Build/AppleMobile/CMakeLists.txt
+++ b/Build/AppleMobile/CMakeLists.txt
@@ -4,32 +4,63 @@
 cmake_minimum_required(VERSION 3.21)
 project(IccDevCoreSmoke LANGUAGES CXX OBJCXX)
 
-if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS" OR NOT CMAKE_GENERATOR STREQUAL "Xcode")
-  message(FATAL_ERROR "Use the Xcode generator with -DCMAKE_SYSTEM_NAME=iOS")
+if(NOT CMAKE_SYSTEM_NAME MATCHES "^(iOS|watchOS)$" OR NOT CMAKE_GENERATOR STREQUAL "Xcode")
+  message(FATAL_ERROR "Use the Xcode generator with -DCMAKE_SYSTEM_NAME=iOS or watchOS")
 endif()
 
 find_package(RefIccMAX CONFIG REQUIRED)
 if(NOT TARGET RefIccMAX::IccProfLib2-static)
-  message(FATAL_ERROR "Build the matching apple-ios-*-core static library first")
+  message(FATAL_ERROR "Build the matching apple-*-core static library first")
 endif()
 
 set(ICCDEV_IOS_BUNDLE_IDENTIFIER "org.color.iccdev.CoreSmoke" CACHE STRING
-  "Bundle identifier registered with your Apple development team")
+  "Legacy iOS bundle identifier (used unless ICCDEV_APPLE_BUNDLE_IDENTIFIER is set)")
+if(CMAKE_SYSTEM_NAME STREQUAL "watchOS")
+  enable_language(Swift)
+  set(_bundle_default "org.color.iccdev.CoreSmoke.watch")
+else()
+  set(_bundle_default "${ICCDEV_IOS_BUNDLE_IDENTIFIER}")
+endif()
+set(ICCDEV_APPLE_BUNDLE_IDENTIFIER "" CACHE STRING
+  "Override the platform default bundle identifier registered with your Apple development team")
+if(ICCDEV_APPLE_BUNDLE_IDENTIFIER)
+  set(_bundle_identifier "${ICCDEV_APPLE_BUNDLE_IDENTIFIER}")
+else()
+  set(_bundle_identifier "${_bundle_default}")
+endif()
 set(_source "${CMAKE_CURRENT_SOURCE_DIR}/../../Testing/AppleMobile")
 set(_profile "${CMAKE_CURRENT_SOURCE_DIR}/../../Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc")
 set_source_files_properties("${_profile}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
 
-add_executable(IccDevCoreSmoke MACOSX_BUNDLE "${_source}/main.mm" "${_profile}")
+add_executable(IccDevCoreSmoke MACOSX_BUNDLE
+  "${_source}/SmokeTests.mm" "${_source}/SmokeTests.h" "${_profile}")
 target_link_libraries(IccDevCoreSmoke PRIVATE
-  RefIccMAX::IccProfLib2-static "-framework UIKit" "-framework Foundation")
+  RefIccMAX::IccProfLib2-static "-framework Foundation")
 target_compile_features(IccDevCoreSmoke PRIVATE cxx_std_17)
-target_compile_options(IccDevCoreSmoke PRIVATE -fobjc-arc -Wall -Wextra -Werror)
+target_compile_options(IccDevCoreSmoke PRIVATE
+  "$<$<COMPILE_LANGUAGE:CXX,OBJCXX>:-Wall;-Wextra;-Werror>"
+  "$<$<COMPILE_LANGUAGE:Swift>:-warnings-as-errors>")
+if(CMAKE_SYSTEM_NAME STREQUAL "watchOS")
+  target_sources(IccDevCoreSmoke PRIVATE "${_source}/WatchApp.swift")
+  target_link_libraries(IccDevCoreSmoke PRIVATE "-framework SwiftUI")
+  set_target_properties(IccDevCoreSmoke PROPERTIES
+    Swift_LANGUAGE_VERSION 5
+    XCODE_ATTRIBUTE_SWIFT_OBJC_BRIDGING_HEADER "${_source}/SmokeTests.h"
+    XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "4"
+    XCODE_ATTRIBUTE_LD_RUNPATH_SEARCH_PATHS "$(inherited) @executable_path/Frameworks"
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/WatchInfo.plist.in")
+else()
+  target_sources(IccDevCoreSmoke PRIVATE "${_source}/main.mm")
+  target_link_libraries(IccDevCoreSmoke PRIVATE "-framework UIKit")
+  set_target_properties(IccDevCoreSmoke PROPERTIES
+    XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
+    XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in")
+endif()
 set_target_properties(IccDevCoreSmoke PROPERTIES
   OBJCXX_STANDARD 17
   OBJCXX_STANDARD_REQUIRED YES
-  MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
   XCODE_GENERATE_SCHEME YES
-  XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${ICCDEV_IOS_BUNDLE_IDENTIFIER}"
-  XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic
-  XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
-  XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO)
+  XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES
+  XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${_bundle_identifier}"
+  XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic)

--- a/Build/AppleMobile/CMakeLists.txt
+++ b/Build/AppleMobile/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Copyright (c) 2026 International Color Consortium.
+# SPDX-License-Identifier: BSD-3-Clause
+
+cmake_minimum_required(VERSION 3.21)
+project(IccDevCoreSmoke LANGUAGES CXX OBJCXX)
+
+if(NOT CMAKE_SYSTEM_NAME STREQUAL "iOS" OR NOT CMAKE_GENERATOR STREQUAL "Xcode")
+  message(FATAL_ERROR "Use the Xcode generator with -DCMAKE_SYSTEM_NAME=iOS")
+endif()
+
+find_package(RefIccMAX CONFIG REQUIRED)
+if(NOT TARGET RefIccMAX::IccProfLib2-static)
+  message(FATAL_ERROR "Build the matching apple-ios-*-core static library first")
+endif()
+
+set(ICCDEV_IOS_BUNDLE_IDENTIFIER "org.color.iccdev.CoreSmoke" CACHE STRING
+  "Bundle identifier registered with your Apple development team")
+set(_source "${CMAKE_CURRENT_SOURCE_DIR}/../../Testing/AppleMobile")
+set(_profile "${CMAKE_CURRENT_SOURCE_DIR}/../../Testing/ApplyDataFiles/test-profiles/sRGB_D65_MAT.icc")
+set_source_files_properties("${_profile}" PROPERTIES MACOSX_PACKAGE_LOCATION Resources)
+
+add_executable(IccDevCoreSmoke MACOSX_BUNDLE "${_source}/main.mm" "${_profile}")
+target_link_libraries(IccDevCoreSmoke PRIVATE
+  RefIccMAX::IccProfLib2-static "-framework UIKit" "-framework Foundation")
+target_compile_features(IccDevCoreSmoke PRIVATE cxx_std_17)
+target_compile_options(IccDevCoreSmoke PRIVATE -fobjc-arc -Wall -Wextra -Werror)
+set_target_properties(IccDevCoreSmoke PROPERTIES
+  OBJCXX_STANDARD 17
+  OBJCXX_STANDARD_REQUIRED YES
+  MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_SOURCE_DIR}/Info.plist.in"
+  XCODE_GENERATE_SCHEME YES
+  XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER "${ICCDEV_IOS_BUNDLE_IDENTIFIER}"
+  XCODE_ATTRIBUTE_CODE_SIGN_STYLE Automatic
+  XCODE_ATTRIBUTE_TARGETED_DEVICE_FAMILY "1,2"
+  XCODE_ATTRIBUTE_SUPPORTS_MACCATALYST NO)

--- a/Build/AppleMobile/Info.plist.in
+++ b/Build/AppleMobile/Info.plist.in
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Copyright (c) 2026 International Color Consortium.
+     SPDX-License-Identifier: BSD-3-Clause -->
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleName</key>
+  <string>iccDEV Core Smoke</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>LSRequiresIPhoneOS</key>
+  <true/>
+  <key>UILaunchScreen</key>
+  <dict/>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+  <key>UISupportedInterfaceOrientations~ipad</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+  </array>
+</dict>
+</plist>

--- a/Build/AppleMobile/WatchInfo.plist.in
+++ b/Build/AppleMobile/WatchInfo.plist.in
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!-- Copyright (c) 2026 International Color Consortium.
+     SPDX-License-Identifier: BSD-3-Clause -->
+<plist version="1.0">
+<dict>
+  <key>CFBundleExecutable</key>
+  <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+  <key>CFBundleIdentifier</key>
+  <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+  <key>CFBundleName</key>
+  <string>iccDEV Core Smoke</string>
+  <key>CFBundleDisplayName</key>
+  <string>iccDEV Smoke</string>
+  <key>CFBundlePackageType</key>
+  <string>APPL</string>
+  <key>CFBundleShortVersionString</key>
+  <string>1.0</string>
+  <key>CFBundleVersion</key>
+  <string>1</string>
+  <key>WKApplication</key>
+  <true/>
+  <key>WKWatchOnly</key>
+  <true/>
+  <key>UISupportedInterfaceOrientations</key>
+  <array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationPortraitUpsideDown</string>
+  </array>
+</dict>
+</plist>

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -9321,7 +9321,10 @@ if(TARGET iccDescribeSinkTest)
   )
 endif()
 
-if(ICCDEV_IS_MULTI_CONFIG)
+# UnixMultiConfigRuntime.cmake bails out on WIN32 without defining the
+# iccdev_unix_runtime fixture, so this wiring must be skipped there too or
+# Windows multi-config (Visual Studio) CTest runs get unsatisfied fixtures.
+if(ICCDEV_IS_MULTI_CONFIG AND NOT WIN32)
   get_property(_iccdev_runtime_tests DIRECTORY PROPERTY TESTS)
   foreach(_test IN LISTS _iccdev_runtime_tests)
     if(NOT _test MATCHES "^iccdev\\.(unix-multi-config-runtime|unix-runtime-layout)$")

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7343,6 +7343,8 @@ exit "$status"
   endif()
 endif()
 
+include("${CMAKE_CURRENT_LIST_DIR}/UnixMultiConfigRuntime.cmake")
+
 set(ICCDEV_TOOL_PATHS
   "${ICCDEV_TOOLS_DIR}/IccApplyNamedCmm"
   "${ICCDEV_TOOLS_DIR}/IccApplyProfiles"
@@ -7369,7 +7371,7 @@ endif()
 
 list(JOIN ICCDEV_TOOL_PATHS ":" ICCDEV_TOOL_PATH)
 set(ICCDEV_SHARED_LIBRARY_PATH
-    "${CMAKE_BINARY_DIR}/IccProfLib:${CMAKE_BINARY_DIR}/IccXML:${CMAKE_BINARY_DIR}/IccJSON:${CMAKE_BINARY_DIR}/IccConnect")
+    "${ICCDEV_SCRIPT_BUILD_DIR}/IccProfLib:${ICCDEV_SCRIPT_BUILD_DIR}/IccXML:${ICCDEV_SCRIPT_BUILD_DIR}/IccJSON:${ICCDEV_SCRIPT_BUILD_DIR}/IccConnect")
 
 set(ICCDEV_REQUIRE_JSON_ROUNDTRIP 0)
 if(TARGET iccToJson AND TARGET iccFromJson)
@@ -7454,7 +7456,7 @@ set(ICCDEV_TEST_ENV
   "LLVM_PROFILE_FILE=/dev/null"
   "ICCDEV_TOOLS_DIR=${ICCDEV_TOOLS_DIR}"
   "ICCDEV_TESTING_DIR=${ICCDEV_TESTING_DIR}"
-  "ICCDEV_BUILD_DIR=${CMAKE_BINARY_DIR}"
+  "ICCDEV_BUILD_DIR=${ICCDEV_SCRIPT_BUILD_DIR}"
   "ICCDEV_REQUIRE_JSON_ROUNDTRIP=${ICCDEV_REQUIRE_JSON_ROUNDTRIP}"
   # Issue #1856. The JSON size bound is configurable, so a test that asserts on
   # a document size has to know which limit the readers were actually built
@@ -9317,4 +9319,13 @@ if(TARGET iccDescribeSinkTest)
     TIMEOUT 60
     LABELS  "iccdev;describe;api;sink;options"
   )
+endif()
+
+if(ICCDEV_IS_MULTI_CONFIG)
+  get_property(_iccdev_runtime_tests DIRECTORY PROPERTY TESTS)
+  foreach(_test IN LISTS _iccdev_runtime_tests)
+    if(NOT _test MATCHES "^iccdev\\.(unix-multi-config-runtime|unix-runtime-layout)$")
+      set_property(TEST "${_test}" APPEND PROPERTY FIXTURES_REQUIRED iccdev_unix_runtime)
+    endif()
+  endforeach()
 endif()

--- a/Build/Cmake/Testing/StageUnixTestRuntime.cmake
+++ b/Build/Cmake/Testing/StageUnixTestRuntime.cmake
@@ -51,7 +51,12 @@ while(_source_count GREATER 0)
   if(EXISTS "${_source}")
     get_filename_component(_directory "${_root}/${_destination}" DIRECTORY)
     file(MAKE_DIRECTORY "${_directory}")
-    file(CREATE_LINK "${_source}" "${_root}/${_destination}" SYMBOLIC RESULT _result)
+    # Several shell suites discover tools with find -type f, which excludes symlinks.
+    # Resolve library aliases too, then expose regular files without duplicating
+    # data on the usual same-filesystem build tree.
+    file(REAL_PATH "${_source}" _resolved_source)
+    file(CREATE_LINK "${_resolved_source}" "${_root}/${_destination}"
+      COPY_ON_ERROR RESULT _result)
     if(NOT _result STREQUAL "0")
       message(FATAL_ERROR "Cannot stage ${_destination}: ${_result}")
     endif()

--- a/Build/Cmake/Testing/StageUnixTestRuntime.cmake
+++ b/Build/Cmake/Testing/StageUnixTestRuntime.cmake
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 International Color Consortium.
+# SPDX-License-Identifier: BSD-3-Clause
+
+if(NOT IS_ABSOLUTE "${ICCDEV_BINARY_DIR}" OR
+    NOT EXISTS "${ICCDEV_BINARY_DIR}/CMakeCache.txt")
+  message(FATAL_ERROR "ICCDEV_BINARY_DIR must identify the configured build tree")
+endif()
+if(NOT ICCDEV_CONFIG MATCHES "^[A-Za-z0-9_+-][A-Za-z0-9_.+-]*$")
+  message(FATAL_ERROR "ICCDEV_CONFIG must identify one configuration")
+endif()
+list(LENGTH ICCDEV_RUNTIME_SOURCES _source_count)
+list(LENGTH ICCDEV_RUNTIME_DESTINATIONS _destination_count)
+if(NOT _source_count EQUAL _destination_count)
+  message(FATAL_ERROR "Runtime source/destination manifest lengths differ")
+endif()
+foreach(_destination IN LISTS ICCDEV_RUNTIME_DESTINATIONS)
+  if(IS_ABSOLUTE "${_destination}" OR
+      _destination MATCHES "(^|/)\\.\\.(/|$)" OR _destination STREQUAL "")
+    message(FATAL_ERROR "Invalid runtime destination: ${_destination}")
+  endif()
+endforeach()
+
+# Only this dedicated, marked view is replaced; actual build outputs are never moved.
+set(_parent "${ICCDEV_BINARY_DIR}/Testing/ctest-runtime")
+set(_root "${_parent}/${ICCDEV_CONFIG}")
+if(IS_SYMLINK "${ICCDEV_BINARY_DIR}/Testing" OR
+    IS_SYMLINK "${_parent}" OR IS_SYMLINK "${_root}")
+  message(FATAL_ERROR "Refusing a symlinked CTest runtime directory")
+endif()
+file(MAKE_DIRECTORY "${_parent}")
+file(LOCK "${_parent}/${ICCDEV_CONFIG}.lock" GUARD PROCESS TIMEOUT 30)
+if(EXISTS "${_root}")
+  if(NOT EXISTS "${_root}/.iccdev-runtime")
+    message(FATAL_ERROR "Refusing to replace an unmarked CTest runtime directory: ${_root}")
+  endif()
+  file(READ "${_root}/.iccdev-runtime" _marker)
+  if(NOT _marker STREQUAL "iccdev CTest runtime\n")
+    message(FATAL_ERROR "Invalid CTest runtime ownership marker")
+  endif()
+  file(REMOVE_RECURSE "${_root}")
+endif()
+file(MAKE_DIRECTORY "${_root}/Tools")
+file(WRITE "${_root}/.iccdev-runtime" "iccdev CTest runtime\n")
+
+while(_source_count GREATER 0)
+  math(EXPR _source_count "${_source_count} - 1")
+  list(GET ICCDEV_RUNTIME_SOURCES ${_source_count} _source)
+  list(GET ICCDEV_RUNTIME_DESTINATIONS ${_source_count} _destination)
+  # A focused build need not build every configured target. Do not expose dangling
+  # aliases that shell library discovery could mistake for a linkable archive.
+  if(EXISTS "${_source}")
+    get_filename_component(_directory "${_root}/${_destination}" DIRECTORY)
+    file(MAKE_DIRECTORY "${_directory}")
+    file(CREATE_LINK "${_source}" "${_root}/${_destination}" SYMBOLIC RESULT _result)
+    if(NOT _result STREQUAL "0")
+      message(FATAL_ERROR "Cannot stage ${_destination}: ${_result}")
+    endif()
+  endif()
+endwhile()

--- a/Build/Cmake/Testing/TestUnixTestRuntime.cmake
+++ b/Build/Cmake/Testing/TestUnixTestRuntime.cmake
@@ -32,15 +32,28 @@ foreach(_config IN ITEMS Release Debug)
 endforeach()
 foreach(_config IN ITEMS Release Debug)
   set(_view "${_build}/Testing/ctest-runtime/${_config}")
-  if(NOT IS_SYMLINK "${_view}/Tools/Probe/probe" OR
-      NOT IS_SYMLINK "${_view}/CMakeCache.txt")
-    message(FATAL_ERROR "Runtime view did not preserve artifact/cache links")
+  if(NOT EXISTS "${_view}/Tools/Probe/probe" OR
+      NOT EXISTS "${_view}/CMakeCache.txt" OR
+      IS_SYMLINK "${_view}/Tools/Probe/probe" OR
+      IS_SYMLINK "${_view}/CMakeCache.txt")
+    message(FATAL_ERROR "Runtime view must expose regular artifact/cache files")
+  endif()
+  execute_process(COMMAND find "${_view}/Tools" -maxdepth 2 -name probe -type f
+    RESULT_VARIABLE _find_result OUTPUT_VARIABLE _found OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT _find_result STREQUAL "0" OR NOT _found STREQUAL "${_view}/Tools/Probe/probe")
+    message(FATAL_ERROR "Shell find -type f cannot discover the staged tool")
   endif()
   file(READ "${_view}/Tools/Probe/probe" _content)
   if(NOT _content STREQUAL "${_config}\n")
     message(FATAL_ERROR "Runtime view selected the wrong configuration")
   endif()
 endforeach()
+
+file(CREATE_LINK "${_build}/Tools/Probe/Release/probe" "${_build}/probe-alias" SYMBOLIC)
+stage("Alias" "${_build}/probe-alias" "Tools/Probe/probe" TRUE)
+if(IS_SYMLINK "${_build}/Testing/ctest-runtime/Alias/Tools/Probe/probe")
+  message(FATAL_ERROR "A symlinked source was not resolved to a regular runtime file")
+endif()
 
 stage("Release" "${_build}/not-built;${_build}/CMakeCache.txt"
   "Tools/Probe/probe;CMakeCache.txt" TRUE)

--- a/Build/Cmake/Testing/TestUnixTestRuntime.cmake
+++ b/Build/Cmake/Testing/TestUnixTestRuntime.cmake
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 International Color Consortium.
+# SPDX-License-Identifier: BSD-3-Clause
+
+if(NOT IS_ABSOLUTE "${ICCDEV_TEST_OUTDIR}")
+  message(FATAL_ERROR "ICCDEV_TEST_OUTDIR must be absolute")
+endif()
+set(_build "${ICCDEV_TEST_OUTDIR}/build with spaces")
+file(MAKE_DIRECTORY "${_build}/Tools/Probe/Release" "${_build}/Tools/Probe/Debug")
+file(WRITE "${_build}/CMakeCache.txt" "runtime-layout-test\n")
+file(WRITE "${_build}/Tools/Probe/Release/probe" "Release\n")
+file(WRITE "${_build}/Tools/Probe/Debug/probe" "Debug\n")
+
+function(stage CONFIG SOURCE DESTINATION EXPECT_SUCCESS)
+  execute_process(
+    COMMAND "${CMAKE_COMMAND}"
+      "-DICCDEV_BINARY_DIR=${_build}" "-DICCDEV_CONFIG=${CONFIG}"
+      "-DICCDEV_RUNTIME_SOURCES=${SOURCE}"
+      "-DICCDEV_RUNTIME_DESTINATIONS=${DESTINATION}"
+      -P "${CMAKE_CURRENT_LIST_DIR}/StageUnixTestRuntime.cmake"
+    RESULT_VARIABLE _result OUTPUT_VARIABLE _stdout ERROR_VARIABLE _stderr)
+  if(EXPECT_SUCCESS AND NOT _result STREQUAL "0")
+    message(FATAL_ERROR "Runtime staging failed: ${_stdout}${_stderr}")
+  elseif(NOT EXPECT_SUCCESS AND _result STREQUAL "0")
+    message(FATAL_ERROR "Invalid runtime staging unexpectedly succeeded")
+  endif()
+endfunction()
+
+foreach(_config IN ITEMS Release Debug)
+  stage("${_config}"
+    "${_build}/Tools/Probe/${_config}/probe;${_build}/CMakeCache.txt"
+    "Tools/Probe/probe;CMakeCache.txt" TRUE)
+endforeach()
+foreach(_config IN ITEMS Release Debug)
+  set(_view "${_build}/Testing/ctest-runtime/${_config}")
+  if(NOT IS_SYMLINK "${_view}/Tools/Probe/probe" OR
+      NOT IS_SYMLINK "${_view}/CMakeCache.txt")
+    message(FATAL_ERROR "Runtime view did not preserve artifact/cache links")
+  endif()
+  file(READ "${_view}/Tools/Probe/probe" _content)
+  if(NOT _content STREQUAL "${_config}\n")
+    message(FATAL_ERROR "Runtime view selected the wrong configuration")
+  endif()
+endforeach()
+
+stage("Release" "${_build}/not-built;${_build}/CMakeCache.txt"
+  "Tools/Probe/probe;CMakeCache.txt" TRUE)
+if(EXISTS "${_build}/Testing/ctest-runtime/Release/Tools/Probe/probe" OR
+    IS_SYMLINK "${_build}/Testing/ctest-runtime/Release/Tools/Probe/probe")
+  message(FATAL_ERROR "Missing artifact retained a stale or dangling alias")
+endif()
+file(READ "${_build}/Testing/ctest-runtime/Debug/Tools/Probe/probe" _debug)
+if(NOT _debug STREQUAL "Debug\n")
+  message(FATAL_ERROR "Refreshing Release modified the Debug view")
+endif()
+file(READ "${_build}/Tools/Probe/Release/probe" _release)
+if(NOT _release STREQUAL "Release\n")
+  message(FATAL_ERROR "Refreshing the view modified an actual build artifact")
+endif()
+
+stage("../outside" "${_build}/CMakeCache.txt" "CMakeCache.txt" FALSE)
+stage("Release" "${_build}/CMakeCache.txt" "../outside" FALSE)
+stage("Release" "${_build}/CMakeCache.txt" "one;two" FALSE)
+file(MAKE_DIRECTORY "${_build}/Testing/ctest-runtime/Unmanaged")
+stage("Unmanaged" "${_build}/CMakeCache.txt" "CMakeCache.txt" FALSE)
+file(CREATE_LINK "${_build}/Tools" "${_build}/Testing/ctest-runtime/Linked" SYMBOLIC)
+stage("Linked" "${_build}/CMakeCache.txt" "CMakeCache.txt" FALSE)
+message(STATUS "Unix runtime layout: configuration isolation and failure controls passed")

--- a/Build/Cmake/Testing/UnixMultiConfigRuntime.cmake
+++ b/Build/Cmake/Testing/UnixMultiConfigRuntime.cmake
@@ -1,10 +1,16 @@
 # Copyright (c) 2026 International Color Consortium.
 # SPDX-License-Identifier: BSD-3-Clause
 
+# CMakeLists.txt uses ICCDEV_SCRIPT_BUILD_DIR (via ICCDEV_BUILD_DIR and
+# ICCDEV_SHARED_LIBRARY_PATH) for every platform, so the default must be set
+# before any early return below.
+set(ICCDEV_SCRIPT_BUILD_DIR "${CMAKE_BINARY_DIR}")
+
 # This runtime view and its layout regression rely on POSIX semantics (hard
 # links, `find -type f`) that Windows multi-config generators (Visual Studio)
 # do not provide. Bail out early so Windows CTest runs neither register an
-# unsatisfiable iccdev_unix_runtime fixture nor the Unix-only layout test.
+# unsatisfiable iccdev_unix_runtime fixture nor the Unix-only layout test,
+# while still leaving ICCDEV_SCRIPT_BUILD_DIR defined above.
 if(WIN32)
   return()
 endif()
@@ -26,7 +32,6 @@ function(iccdev_append_runtime_entry SOURCE_PATH DESTINATION_PATH)
   set(_iccdev_runtime_manifest "${_iccdev_runtime_manifest}" PARENT_SCOPE)
 endfunction()
 
-set(ICCDEV_SCRIPT_BUILD_DIR "${CMAKE_BINARY_DIR}")
 if(ICCDEV_IS_MULTI_CONFIG)
   foreach(_config IN LISTS CMAKE_CONFIGURATION_TYPES)
     if(NOT _config MATCHES "^[A-Za-z0-9_+-][A-Za-z0-9_.+-]*$")

--- a/Build/Cmake/Testing/UnixMultiConfigRuntime.cmake
+++ b/Build/Cmake/Testing/UnixMultiConfigRuntime.cmake
@@ -1,6 +1,14 @@
 # Copyright (c) 2026 International Color Consortium.
 # SPDX-License-Identifier: BSD-3-Clause
 
+# This runtime view and its layout regression rely on POSIX semantics (hard
+# links, `find -type f`) that Windows multi-config generators (Visual Studio)
+# do not provide. Bail out early so Windows CTest runs neither register an
+# unsatisfiable iccdev_unix_runtime fixture nor the Unix-only layout test.
+if(WIN32)
+  return()
+endif()
+
 function(iccdev_collect_runtime_targets DIRECTORY_PATH OUTPUT_VAR)
   get_property(_targets DIRECTORY "${DIRECTORY_PATH}" PROPERTY BUILDSYSTEM_TARGETS)
   get_property(_children DIRECTORY "${DIRECTORY_PATH}" PROPERTY SUBDIRECTORIES)

--- a/Build/Cmake/Testing/UnixMultiConfigRuntime.cmake
+++ b/Build/Cmake/Testing/UnixMultiConfigRuntime.cmake
@@ -1,0 +1,83 @@
+# Copyright (c) 2026 International Color Consortium.
+# SPDX-License-Identifier: BSD-3-Clause
+
+function(iccdev_collect_runtime_targets DIRECTORY_PATH OUTPUT_VAR)
+  get_property(_targets DIRECTORY "${DIRECTORY_PATH}" PROPERTY BUILDSYSTEM_TARGETS)
+  get_property(_children DIRECTORY "${DIRECTORY_PATH}" PROPERTY SUBDIRECTORIES)
+  foreach(_child IN LISTS _children)
+    iccdev_collect_runtime_targets("${_child}" _child_targets)
+    list(APPEND _targets ${_child_targets})
+  endforeach()
+  set("${OUTPUT_VAR}" "${_targets}" PARENT_SCOPE)
+endfunction()
+
+function(iccdev_append_runtime_entry SOURCE_PATH DESTINATION_PATH)
+  string(APPEND _iccdev_runtime_manifest
+    "list(APPEND ICCDEV_RUNTIME_SOURCES [==[${SOURCE_PATH}]==])\n"
+    "list(APPEND ICCDEV_RUNTIME_DESTINATIONS [==[${DESTINATION_PATH}]==])\n")
+  set(_iccdev_runtime_manifest "${_iccdev_runtime_manifest}" PARENT_SCOPE)
+endfunction()
+
+set(ICCDEV_SCRIPT_BUILD_DIR "${CMAKE_BINARY_DIR}")
+if(ICCDEV_IS_MULTI_CONFIG)
+  foreach(_config IN LISTS CMAKE_CONFIGURATION_TYPES)
+    if(NOT _config MATCHES "^[A-Za-z0-9_+-][A-Za-z0-9_.+-]*$")
+      message(FATAL_ERROR "Unsupported CTest runtime configuration: ${_config}")
+    endif()
+    file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/ctest-output/${_config}")
+  endforeach()
+  set(ICCDEV_SCRIPT_BUILD_DIR "${CMAKE_CURRENT_BINARY_DIR}/ctest-runtime/$<CONFIG>")
+  set(ICCDEV_TOOLS_DIR "${ICCDEV_SCRIPT_BUILD_DIR}/Tools")
+  set(ICCDEV_TEST_OUTDIR "${CMAKE_CURRENT_BINARY_DIR}/ctest-output/$<CONFIG>")
+
+  set(_iccdev_runtime_manifest
+    "set(ICCDEV_BINARY_DIR [==[${CMAKE_BINARY_DIR}]==])\nset(ICCDEV_CONFIG [==[$<CONFIG>]==])\n")
+  iccdev_append_runtime_entry("${CMAKE_BINARY_DIR}/CMakeCache.txt" "CMakeCache.txt")
+  foreach(_header IN ITEMS
+      IccProfLib/IccProfLibVer.h IccXML/IccLibXMLVer.h
+      IccJSON/IccLibJSONVer.h IccConnect/IccLibConnectVer.h)
+    if(EXISTS "${CMAKE_BINARY_DIR}/${_header}")
+      iccdev_append_runtime_entry("${CMAKE_BINARY_DIR}/${_header}" "${_header}")
+    endif()
+  endforeach()
+
+  iccdev_collect_runtime_targets("${CMAKE_SOURCE_DIR}" _runtime_targets)
+  foreach(_target IN LISTS _runtime_targets)
+    get_target_property(_type "${_target}" TYPE)
+    get_target_property(_binary_dir "${_target}" BINARY_DIR)
+    file(RELATIVE_PATH _relative_dir "${CMAKE_BINARY_DIR}" "${_binary_dir}")
+    if(NOT _relative_dir MATCHES "^(Tools/|IccProfLib$|IccXML$|IccJSON$|IccConnect$)")
+      continue()
+    endif()
+    if(_type STREQUAL "EXECUTABLE" OR
+        _type STREQUAL "STATIC_LIBRARY" OR _type STREQUAL "SHARED_LIBRARY")
+      iccdev_append_runtime_entry("$<TARGET_FILE:${_target}>"
+        "${_relative_dir}/$<TARGET_FILE_NAME:${_target}>")
+    endif()
+    if(_type STREQUAL "SHARED_LIBRARY")
+      iccdev_append_runtime_entry("$<TARGET_LINKER_FILE:${_target}>"
+        "${_relative_dir}/$<TARGET_LINKER_FILE_NAME:${_target}>")
+      iccdev_append_runtime_entry("$<TARGET_SONAME_FILE:${_target}>"
+        "${_relative_dir}/$<TARGET_SONAME_FILE_NAME:${_target}>")
+    endif()
+  endforeach()
+  string(APPEND _iccdev_runtime_manifest
+    "include([==[${CMAKE_CURRENT_LIST_DIR}/StageUnixTestRuntime.cmake]==])\n")
+  file(GENERATE
+    OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/ctest-runtime-$<CONFIG>.cmake"
+    CONTENT "${_iccdev_runtime_manifest}")
+  add_test(NAME iccdev.unix-multi-config-runtime
+    COMMAND "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/ctest-runtime-$<CONFIG>.cmake")
+  set_tests_properties(iccdev.unix-multi-config-runtime PROPERTIES
+    FIXTURES_SETUP iccdev_unix_runtime
+    LABELS "iccdev;build;fixture"
+    TIMEOUT 30)
+endif()
+
+add_test(NAME iccdev.unix-runtime-layout
+  COMMAND "${CMAKE_COMMAND}"
+    "-DICCDEV_TEST_OUTDIR=${ICCDEV_TEST_OUTDIR}/unix-runtime-layout"
+    -P "${CMAKE_CURRENT_LIST_DIR}/TestUnixTestRuntime.cmake")
+set_tests_properties(iccdev.unix-runtime-layout PROPERTIES
+  LABELS "iccdev;build;regression"
+  TIMEOUT 30)

--- a/Build/XCode/BuildAll.sh
+++ b/Build/XCode/BuildAll.sh
@@ -14,8 +14,8 @@ if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
   exit 0
 fi
 
-script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
-repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+script_dir=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH='' cd -- "$script_dir/../.." && pwd)
 build_dir=${ICCDEV_XCODE_BUILD_DIR:-out/macos-xcode}
 config=${ICCDEV_XCODE_CONFIG:-Release}
 case "$build_dir" in

--- a/Build/XCode/BuildAll.sh
+++ b/Build/XCode/BuildAll.sh
@@ -1,50 +1,40 @@
 #!/bin/sh
-config="Release"
+# Copyright (c) 2026 International Color Consortium.
+# SPDX-License-Identifier: BSD-3-Clause
+set -eu
 
-cd ../../IccProfLib
-xcodebuild -target IccProfLib-macOS -configuration "$config"
-cp Build/$config/* ../Build/XCode/lib
+if [ "${1:-}" = "--help" ] || [ "${1:-}" = "-h" ]; then
+  printf '%s\n' \
+    'Usage: BuildAll.sh [CMake configure options...]' \
+    'Builds macOS with the macos-xcode preset; no files are copied into Testing/.' \
+    'ICCDEV_XCODE_BUILD_DIR: build directory (default: out/macos-xcode, relative to repo)' \
+    'ICCDEV_XCODE_CONFIG: Debug, Release (default), RelWithDebInfo, or MinSizeRel' \
+    'CMAKE_BUILD_PARALLEL_LEVEL: positive build job count (default: available CPUs)' \
+    'For iOS device tests, see docs/build.md and Build/AppleMobile.'
+  exit 0
+fi
 
-cd ../IccXML/IccLibXML
-xcodebuild -target IccLibXML-macOS -configuration "$config"
-cp build/$config/* ../../Build/XCode/lib
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+repo_root=$(CDPATH= cd -- "$script_dir/../.." && pwd)
+build_dir=${ICCDEV_XCODE_BUILD_DIR:-out/macos-xcode}
+config=${ICCDEV_XCODE_CONFIG:-Release}
+case "$build_dir" in
+  /*) ;;
+  *) build_dir="$repo_root/$build_dir" ;;
+esac
+case "$config" in
+  Debug|Release|RelWithDebInfo|MinSizeRel) ;;
+  *) printf 'Unsupported ICCDEV_XCODE_CONFIG: %s\n' "$config" >&2; exit 2 ;;
+esac
 
-cd ../../Tools/CmdLine/IccApplyNamedCmm
-xcodebuild -target IccApplyNamedCMM -configuration "$config"
-cp build/$config/IccApplyNamedCmm ../../../Testing
+jobs=${CMAKE_BUILD_PARALLEL_LEVEL:-$(sysctl -n hw.ncpu)}
+case "$jobs" in
+  ''|*[!0-9]*) printf 'Build job count must be a positive integer\n' >&2; exit 2 ;;
+esac
+if [ "$jobs" -eq 0 ]; then
+  printf 'Build job count must be a positive integer\n' >&2
+  exit 2
+fi
 
-cd ../IccApplyProfiles
-xcodebuild -target iccApplyProfiles -configuration "$config"
-cp build/$config/IccApplyProfiles ../../../Testing
-
-cd ../IccDumpProfile
-xcodebuild -target IccDumpProfile -configuration "$config"
-cp build/$config/IccDumpProfile ../../../Testing
-
-cd ../IccRoundTrip
-xcodebuild -target IccRoundTrip -configuration "$config"
-cp build/$config/IccRoundTrip ../../../Testing
-
-cd ../IccSpecSepToTiff
-cp ../IccApplyProfiles/TiffImg.* .
-xcodebuild -target IccSpecSepToTiff -configuration "$config"
-cp build/$config/IccSpecSepToTiff ../../../Testing
-
-cd ../IccTiffDump
-cp ../IccApplyProfiles/TiffImg.* .
-xcodebuild -target IccTiffDump -configuration "$config"
-cp build/$config/IccTiffDump ../../../Testing
-
-cd ../../../IccXML/CmdLine/IccFromXml
-xcodebuild -target IccFromXml -configuration "$config"
-cp build/$config/IccFromXml ../../../Testing
-
-cd ../../../IccXML/CmdLine/IccToXml
-xcodebuild -target IccToXML -configuration "$config"
-cp build/$config/IccToXml ../../../Testing
-
-cd ../../../Tools/MacOS-X/RefIccMAXCmm
-xcodebuild -target RefIccMAXCmm -configuration "$config"
-
-cd ../../wxWidget/wxProfileDump/
-xcodebuild -target wxProfileDump -configuration "$config"
+cmake --preset macos-xcode -S "$repo_root/Build/Cmake" -B "$build_dir" "$@"
+cmake --build "$build_dir" --config "$config" --parallel "$jobs"

--- a/Testing/AppleMobile/SmokeTests.h
+++ b/Testing/AppleMobile/SmokeTests.h
@@ -47,40 +47,16 @@
  *
  */
 
-#import <UIKit/UIKit.h>
-#import "SmokeTests.h"
+#pragma once
 
-@interface IccDevAppDelegate : UIResponder <UIApplicationDelegate>
-@property(nonatomic, strong) UIWindow *window;
-@end
+#import <Foundation/Foundation.h>
 
-@implementation IccDevAppDelegate
-- (BOOL)application:(UIApplication *)application
-    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
-{
-  (void)application;
-  (void)launchOptions;
-  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
-  UIViewController *controller = [[UIViewController alloc] init];
-  UITextView *text = [[UITextView alloc] initWithFrame:self.window.bounds];
-  text.editable = NO;
-  text.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-  text.font = [UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightRegular];
-  text.text = @"iccDEV core device tests running...";
-  controller.view = text;
-  self.window.rootViewController = controller;
-  [self.window makeKeyAndVisible];
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-  dispatch_async(dispatch_get_main_queue(), ^{
-    text.text = IccDevRunCoreSmoke();
-  });
-  return YES;
+NSString * _Nonnull IccDevRunCoreSmoke(void);
+
+#ifdef __cplusplus
 }
-@end
-
-int main(int argc, char *argv[])
-{
-  @autoreleasepool {
-    return UIApplicationMain(argc, argv, nil, NSStringFromClass([IccDevAppDelegate class]));
-  }
-}
+#endif

--- a/Testing/AppleMobile/SmokeTests.mm
+++ b/Testing/AppleMobile/SmokeTests.mm
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and "The
+ *    International Color Consortium" must not be used to imply that the
+ *    ICC organization endorses or promotes products derived from this
+ *    software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR
+ * ITS CONTRIBUTING MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the The International Color Consortium.
+ *
+ *
+ * Membership in the ICC is encouraged when this software is used for
+ * commercial purposes.
+ *
+ *
+ * For more information on The International Color Consortium, please
+ * see <http://www.color.org/>.
+ *
+ *
+ */
+
+#import "SmokeTests.h"
+#include "IccCmm.h"
+#include "IccIO.h"
+#include "IccProfLibVer.h"
+#include "IccProfile.h"
+#include "IccTagLut.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+
+namespace {
+
+bool Check(NSMutableArray<NSDictionary *> *results, bool ok, NSString *name)
+{
+  [results addObject:@{@"test": name, @"passed": @(ok)}];
+  std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name.UTF8String);
+  return ok;
+}
+
+bool Near(icFloatNumber value, icFloatNumber expected, double tolerance)
+{
+  return std::isfinite(value) && std::fabs(value - expected) <= tolerance;
+}
+
+void TestProfiles(NSMutableArray<NSDictionary *> *results, NSURL *documents)
+{
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"sRGB_D65_MAT" ofType:@"icc"];
+  if (!Check(results, path != nil, @"Bundled RGB fixture exists"))
+    return;
+  std::unique_ptr<CIccProfile> profile(ReadIccProfile(path.fileSystemRepresentation));
+  if (!Check(results, profile && profile->m_Header.colorSpace == icSigRgbData,
+             @"Read bundled RGB profile"))
+    return;
+
+  CIccMemIO memory;
+  if (!Check(results, memory.Alloc(1024 * 1024, true) &&
+             profile->Write(&memory, icNeverWriteID), @"Serialize profile to memory"))
+    return;
+  const size_t length = memory.GetLength();
+  std::unique_ptr<CIccProfile> restored(
+    ReadIccProfile(memory.GetData(), static_cast<icUInt32Number>(length)));
+  if (!Check(results, restored != nullptr, @"Read serialized profile"))
+    return;
+  std::unique_ptr<CIccProfile> truncated(ReadIccProfile(memory.GetData(), 64));
+  Check(results, !truncated, @"Reject truncated profile header");
+
+  NSURL *saved = [documents URLByAppendingPathComponent:@"roundtrip.icc"];
+  bool savedOk = SaveIccProfile(saved.fileSystemRepresentation, restored.get(), icNeverWriteID);
+  std::unique_ptr<CIccProfile> fromFile(
+    savedOk ? ReadIccProfile(saved.fileSystemRepresentation) : nullptr);
+  Check(results, fromFile != nullptr, @"Write and reopen profile inside app sandbox");
+  if (savedOk) {
+    NSError *error = nil;
+    Check(results, [[NSFileManager defaultManager] removeItemAtURL:saved error:&error],
+          @"Remove sandbox round-trip file");
+    if (error)
+      std::fprintf(stderr, "%s\n", error.localizedDescription.UTF8String);
+  }
+
+  CIccCmm cmm(icSigRgbData, icSigRgbData, true);
+  if (!Check(results,
+             cmm.AddXform(*profile, icRelativeColorimetric) == icCmmStatOk &&
+             cmm.AddXform(*restored, icRelativeColorimetric) == icCmmStatOk &&
+             cmm.Begin() == icCmmStatOk, @"Begin original/serialized RGB round-trip CMM"))
+    return;
+
+  icFloatNumber input[81] = {}, output[81] = {};
+  size_t offset = 0;
+  for (int r = 0; r < 3; ++r) {
+    for (int g = 0; g < 3; ++g) {
+      for (int b = 0; b < 3; ++b) {
+        input[offset++] = r * 0.5f;
+        input[offset++] = g * 0.5f;
+        input[offset++] = b * 0.5f;
+      }
+    }
+  }
+  if (!Check(results, cmm.Apply(output, input, 27) == icCmmStatOk,
+             @"Apply 27 RGB pixels in one batch"))
+    return;
+  bool roundTrip = true, singleMatches = true;
+  for (size_t pixel = 0; pixel < 27; ++pixel) {
+    icFloatNumber single[3] = {};
+    singleMatches &= cmm.Apply(single, input + pixel * 3) == icCmmStatOk;
+    for (size_t channel = 0; channel < 3; ++channel) {
+      size_t index = pixel * 3 + channel;
+      roundTrip &= Near(output[index], input[index], 0.005);
+      singleMatches &= Near(single[channel], output[index], 1e-6);
+    }
+  }
+  Check(results, roundTrip, @"RGB round-trip error <= 0.005 for all 81 channels");
+  Check(results, singleMatches, @"Single-pixel and batch CMM results agree");
+}
+
+void TestClut(NSMutableArray<NSDictionary *> *results)
+{
+  for (icUInt16Number channels : {3, 8, 15, 16}) {
+    CIccCLUT clut(3, channels);
+    if (!Check(results, clut.Init(static_cast<icUInt8Number>(2)),
+               [NSString stringWithFormat:@"Allocate 3D CLUT with %u outputs", channels]))
+      continue;
+    icFloatNumber *data = clut.GetData(0);
+    for (icUInt32Number point = 0; point < 8; ++point) {
+      for (icUInt16Number channel = 0; channel < channels; ++channel)
+        data[point * channels + channel] = point * 0.08f + channel * 0.01f;
+    }
+    if (!Check(results, clut.Begin(), @"Initialize CLUT interpolation"))
+      continue;
+    bool matches = true;
+    const icFloatNumber probes[][3] = {
+      {0, 0, 0}, {1, 1, 1}, {0.5f, 0.25f, 0.75f}, {0.1f, 0.9f, 0.3f}
+    };
+    for (const auto &input : probes) {
+      icFloatNumber tri[16], tetra[16];
+      for (int i = 0; i < 16; ++i)
+        tri[i] = tetra[i] = -100;
+      clut.Interp3d(tri, input);
+      clut.Interp3dTetra(tetra, input);
+      for (icUInt16Number channel = 0; channel < channels; ++channel) {
+        const icFloatNumber expected =
+          input[0] * 0.32f + input[1] * 0.16f + input[2] * 0.08f + channel * 0.01f;
+        matches &= Near(tri[channel], expected, 1e-6) &&
+                   Near(tetra[channel], expected, 1e-6);
+      }
+    }
+    Check(results, matches,
+          [NSString stringWithFormat:@"Trilinear/tetrahedral %u-output CLUT matches analytic ramp",
+                                     channels]);
+  }
+}
+
+} // namespace
+
+NSString *IccDevRunCoreSmoke(void)
+{
+  @autoreleasepool {
+    NSMutableArray<NSDictionary *> *results = [NSMutableArray array];
+    NSURL *documents = [[[NSFileManager defaultManager]
+      URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] firstObject];
+    if (Check(results, documents != nil, @"Locate app sandbox"))
+      TestProfiles(results, documents);
+    TestClut(results);
+    bool passed = results.count > 0;
+    for (NSDictionary *result in results)
+      passed &= [result[@"passed"] boolValue];
+    NSOperatingSystemVersion os = [NSProcessInfo processInfo].operatingSystemVersion;
+    NSDictionary *report = @{
+      @"passed": @(passed), @"tests": results,
+      @"libraryVersion": @ICCPROFLIBVER,
+      @"osVersion": [NSString stringWithFormat:@"%ld.%ld.%ld",
+                    static_cast<long>(os.majorVersion), static_cast<long>(os.minorVersion),
+                    static_cast<long>(os.patchVersion)]
+    };
+    NSError *error = nil;
+    NSData *json = [NSJSONSerialization dataWithJSONObject:report
+                      options:NSJSONWritingPrettyPrinted error:&error];
+    bool written = json && documents &&
+      [json writeToURL:[documents URLByAppendingPathComponent:@"results.json"]
+              options:NSDataWritingAtomic error:&error];
+    if (!written) {
+      passed = false;
+      std::fprintf(stderr, "Cannot persist device results: %s\n",
+                   error ? error.localizedDescription.UTF8String : "no output location");
+    }
+    NSMutableString *summary = [NSMutableString stringWithFormat:
+      @"iccDEV %s\n%@\n\n", ICCPROFLIBVER, passed ? @"PASS" : @"FAIL"];
+    for (NSDictionary *result in results)
+      [summary appendFormat:@"%@ %@\n", [result[@"passed"] boolValue] ? @"PASS" : @"FAIL",
+                            result[@"test"]];
+    if (!written)
+      [summary appendString:@"FAIL Persist device results\n"];
+    std::printf("ICCDEV_DEVICE_TESTS %s (%lu checks)\n", passed ? "PASS" : "FAIL",
+                static_cast<unsigned long>(results.count));
+    std::fflush(stdout);
+    std::fflush(stderr);
+    // Explicit opt-in for devicectl automation; a normal launch keeps the report visible.
+    if ([[NSProcessInfo processInfo].arguments containsObject:@"--exit-after-tests"])
+      std::exit(passed ? 0 : 1);
+    return summary;
+  }
+}

--- a/Testing/AppleMobile/WatchApp.swift
+++ b/Testing/AppleMobile/WatchApp.swift
@@ -1,0 +1,26 @@
+// Copyright (c) 2026 International Color Consortium.
+// SPDX-License-Identifier: BSD-3-Clause
+
+import SwiftUI
+
+@main
+struct IccDevWatchApp: App {
+  @State private var summary = "iccDEV core device tests running..."
+  @State private var hasRun = false
+
+  var body: some Scene {
+    WindowGroup {
+      ScrollView {
+        Text(summary)
+          .font(.system(.caption2, design: .monospaced))
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding()
+      }
+      .task {
+        guard !hasRun else { return }
+        hasRun = true
+        summary = IccDevRunCoreSmoke()
+      }
+    }
+  }
+}

--- a/Testing/AppleMobile/main.mm
+++ b/Testing/AppleMobile/main.mm
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) International Color Consortium.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * 3. In the absence of prior written permission, the names "ICC" and "The
+ *    International Color Consortium" must not be used to imply that the
+ *    ICC organization endorses or promotes products derived from this
+ *    software.
+ *
+ *
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESSED OR IMPLIED
+ * WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED.  IN NO EVENT SHALL THE INTERNATIONAL COLOR CONSORTIUM OR
+ * ITS CONTRIBUTING MEMBERS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+ * USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ * ====================================================================
+ *
+ * This software consists of voluntary contributions made by many
+ * individuals on behalf of the The International Color Consortium.
+ *
+ *
+ * Membership in the ICC is encouraged when this software is used for
+ * commercial purposes.
+ *
+ *
+ * For more information on The International Color Consortium, please
+ * see <http://www.color.org/>.
+ *
+ *
+ */
+
+#import <UIKit/UIKit.h>
+#include "IccCmm.h"
+#include "IccIO.h"
+#include "IccProfLibVer.h"
+#include "IccProfile.h"
+#include "IccTagLut.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+
+namespace {
+
+bool Check(NSMutableArray<NSDictionary *> *results, bool ok, NSString *name)
+{
+  [results addObject:@{@"test": name, @"passed": @(ok)}];
+  std::printf("[%s] %s\n", ok ? "PASS" : "FAIL", name.UTF8String);
+  return ok;
+}
+
+bool Near(icFloatNumber value, icFloatNumber expected, double tolerance)
+{
+  return std::isfinite(value) && std::fabs(value - expected) <= tolerance;
+}
+
+void TestProfiles(NSMutableArray<NSDictionary *> *results, NSURL *documents)
+{
+  NSString *path = [[NSBundle mainBundle] pathForResource:@"sRGB_D65_MAT" ofType:@"icc"];
+  if (!Check(results, path != nil, @"Bundled RGB fixture exists"))
+    return;
+  std::unique_ptr<CIccProfile> profile(ReadIccProfile(path.fileSystemRepresentation));
+  if (!Check(results, profile && profile->m_Header.colorSpace == icSigRgbData,
+             @"Read bundled RGB profile"))
+    return;
+
+  CIccMemIO memory;
+  if (!Check(results, memory.Alloc(1024 * 1024, true) &&
+             profile->Write(&memory, icNeverWriteID), @"Serialize profile to memory"))
+    return;
+  const size_t length = memory.GetLength();
+  std::unique_ptr<CIccProfile> restored(
+    ReadIccProfile(memory.GetData(), static_cast<icUInt32Number>(length)));
+  if (!Check(results, restored != nullptr, @"Read serialized profile"))
+    return;
+  std::unique_ptr<CIccProfile> truncated(ReadIccProfile(memory.GetData(), 64));
+  Check(results, !truncated, @"Reject truncated profile header");
+
+  NSURL *saved = [documents URLByAppendingPathComponent:@"roundtrip.icc"];
+  bool savedOk = SaveIccProfile(saved.fileSystemRepresentation, restored.get(), icNeverWriteID);
+  std::unique_ptr<CIccProfile> fromFile(
+    savedOk ? ReadIccProfile(saved.fileSystemRepresentation) : nullptr);
+  Check(results, fromFile != nullptr, @"Write and reopen profile inside app sandbox");
+  if (savedOk) {
+    NSError *error = nil;
+    Check(results, [[NSFileManager defaultManager] removeItemAtURL:saved error:&error],
+          @"Remove sandbox round-trip file");
+    if (error)
+      std::fprintf(stderr, "%s\n", error.localizedDescription.UTF8String);
+  }
+
+  CIccCmm cmm(icSigRgbData, icSigRgbData, true);
+  if (!Check(results,
+             cmm.AddXform(*profile, icRelativeColorimetric) == icCmmStatOk &&
+             cmm.AddXform(*restored, icRelativeColorimetric) == icCmmStatOk &&
+             cmm.Begin() == icCmmStatOk, @"Begin original/serialized RGB round-trip CMM"))
+    return;
+
+  icFloatNumber input[81] = {}, output[81] = {};
+  size_t offset = 0;
+  for (int r = 0; r < 3; ++r) {
+    for (int g = 0; g < 3; ++g) {
+      for (int b = 0; b < 3; ++b) {
+        input[offset++] = r * 0.5f;
+        input[offset++] = g * 0.5f;
+        input[offset++] = b * 0.5f;
+      }
+    }
+  }
+  if (!Check(results, cmm.Apply(output, input, 27) == icCmmStatOk,
+             @"Apply 27 RGB pixels in one batch"))
+    return;
+  bool roundTrip = true, singleMatches = true;
+  for (size_t pixel = 0; pixel < 27; ++pixel) {
+    icFloatNumber single[3] = {};
+    singleMatches &= cmm.Apply(single, input + pixel * 3) == icCmmStatOk;
+    for (size_t channel = 0; channel < 3; ++channel) {
+      size_t index = pixel * 3 + channel;
+      roundTrip &= Near(output[index], input[index], 0.005);
+      singleMatches &= Near(single[channel], output[index], 1e-6);
+    }
+  }
+  Check(results, roundTrip, @"RGB round-trip error <= 0.005 for all 81 channels");
+  Check(results, singleMatches, @"Single-pixel and batch CMM results agree");
+}
+
+void TestClut(NSMutableArray<NSDictionary *> *results)
+{
+  for (icUInt16Number channels : {3, 8, 15, 16}) {
+    CIccCLUT clut(3, channels);
+    if (!Check(results, clut.Init(static_cast<icUInt8Number>(2)),
+               [NSString stringWithFormat:@"Allocate 3D CLUT with %u outputs", channels]))
+      continue;
+    icFloatNumber *data = clut.GetData(0);
+    for (icUInt32Number point = 0; point < 8; ++point) {
+      for (icUInt16Number channel = 0; channel < channels; ++channel)
+        data[point * channels + channel] = point * 0.08f + channel * 0.01f;
+    }
+    if (!Check(results, clut.Begin(), @"Initialize CLUT interpolation"))
+      continue;
+    bool matches = true;
+    const icFloatNumber probes[][3] = {
+      {0, 0, 0}, {1, 1, 1}, {0.5f, 0.25f, 0.75f}, {0.1f, 0.9f, 0.3f}
+    };
+    for (const auto &input : probes) {
+      icFloatNumber tri[16], tetra[16];
+      for (int i = 0; i < 16; ++i)
+        tri[i] = tetra[i] = -100;
+      clut.Interp3d(tri, input);
+      clut.Interp3dTetra(tetra, input);
+      for (icUInt16Number channel = 0; channel < channels; ++channel) {
+        const icFloatNumber expected =
+          input[0] * 0.32f + input[1] * 0.16f + input[2] * 0.08f + channel * 0.01f;
+        matches &= Near(tri[channel], expected, 1e-6) &&
+                   Near(tetra[channel], expected, 1e-6);
+      }
+    }
+    Check(results, matches,
+          [NSString stringWithFormat:@"Trilinear/tetrahedral %u-output CLUT matches analytic ramp",
+                                     channels]);
+  }
+}
+
+} // namespace
+
+@interface IccDevAppDelegate : UIResponder <UIApplicationDelegate>
+@property(nonatomic, strong) UIWindow *window;
+@end
+
+@implementation IccDevAppDelegate
+- (BOOL)application:(UIApplication *)application
+    didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
+{
+  (void)application;
+  (void)launchOptions;
+  self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
+  UIViewController *controller = [[UIViewController alloc] init];
+  UITextView *text = [[UITextView alloc] initWithFrame:self.window.bounds];
+  text.editable = NO;
+  text.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+  text.font = [UIFont monospacedSystemFontOfSize:14 weight:UIFontWeightRegular];
+  text.text = @"iccDEV core device tests running...";
+  controller.view = text;
+  self.window.rootViewController = controller;
+  [self.window makeKeyAndVisible];
+
+  dispatch_async(dispatch_get_main_queue(), ^{
+    NSMutableArray<NSDictionary *> *results = [NSMutableArray array];
+    NSURL *documents = [[[NSFileManager defaultManager]
+      URLsForDirectory:NSDocumentDirectory inDomains:NSUserDomainMask] firstObject];
+    if (Check(results, documents != nil, @"Locate app sandbox"))
+      TestProfiles(results, documents);
+    TestClut(results);
+    bool passed = results.count > 0;
+    for (NSDictionary *result in results)
+      passed &= [result[@"passed"] boolValue];
+    NSDictionary *report = @{
+      @"passed": @(passed), @"tests": results,
+      @"libraryVersion": @ICCPROFLIBVER,
+      @"osVersion": [UIDevice currentDevice].systemVersion
+    };
+    NSError *error = nil;
+    NSData *json = [NSJSONSerialization dataWithJSONObject:report
+                      options:NSJSONWritingPrettyPrinted error:&error];
+    bool written = json && documents &&
+      [json writeToURL:[documents URLByAppendingPathComponent:@"results.json"]
+              options:NSDataWritingAtomic error:&error];
+    if (!written) {
+      passed = false;
+      std::fprintf(stderr, "Cannot persist device results: %s\n",
+                   error ? error.localizedDescription.UTF8String : "no output location");
+    }
+    NSMutableString *summary = [NSMutableString stringWithFormat:
+      @"iccDEV %s\n%@\n\n", ICCPROFLIBVER, passed ? @"PASS" : @"FAIL"];
+    for (NSDictionary *result in results)
+      [summary appendFormat:@"%@ %@\n", [result[@"passed"] boolValue] ? @"PASS" : @"FAIL",
+                            result[@"test"]];
+    if (!written)
+      [summary appendString:@"FAIL Persist device results\n"];
+    text.text = summary;
+    std::printf("ICCDEV_DEVICE_TESTS %s (%lu checks)\n", passed ? "PASS" : "FAIL",
+                static_cast<unsigned long>(results.count));
+    std::fflush(stdout);
+    std::fflush(stderr);
+    // Explicit opt-in for devicectl automation; a normal launch keeps the report visible.
+    if ([[NSProcessInfo processInfo].arguments containsObject:@"--exit-after-tests"])
+      std::exit(passed ? 0 : 1);
+  });
+  return YES;
+}
+@end
+
+int main(int argc, char *argv[])
+{
+  @autoreleasepool {
+    return UIApplicationMain(argc, argv, nil, NSStringFromClass([IccDevAppDelegate class]));
+  }
+}

--- a/docs/build.md
+++ b/docs/build.md
@@ -142,54 +142,73 @@ App code must use only sandbox-authorized file locations or streams. Native
 Apple test hosts are the appropriate test mechanism for these targets; the
 repository's command-line CTest suites remain macOS-host tools.
 
-The reusable `Apple mobile core libraries` workflow discovers the Apple SDKs
-installed on its macOS runner, builds every matching mobile-core preset, and
-uploads the static libraries, generated version headers, and a build manifest
-as the `iccdev-apple-mobile-core` artifact. Run it manually or call
-`.github/workflows/ci-apple-mobile-core.yml` from another workflow.
+The `Apple mobile core libraries` workflow discovers installed Apple SDKs,
+builds every matching mobile-core preset, and runs the simulator and Xcode
+CTest smoke gates below. Master pushes and manual runs upload the static
+libraries, generated version headers, and build manifest as
+`iccdev-apple-mobile-core`. Dispatch
+`.github/workflows/ci-apple-mobile-core.yml` for this complete Apple gate.
+The separate `Apple platform smoke` workflow runs the same runtime gates for
+affected same-repository pull requests without uploading PR-produced artifacts.
 
-### Run the core smoke app on an iPhone or iPad
+### Run the core smoke app on an iPhone, iPad, or Apple Watch
 
 `Build/AppleMobile` is a standalone Xcode consumer of the core's exported
-CMake package. It does not enable desktop tools or CTest on iOS. The app
+CMake package. UIKit (iOS) and SwiftUI (watchOS) hosts share Foundation-based
+tests; neither enables desktop tools or CTest on the device. The app
 exercises the bundled RGB profile, memory and sandbox-file serialization,
 truncated-header rejection, single/batch RGB transforms, and analytic
 3D CLUT interpolation with 3, 8, 15, and 16 output channels.
 
 Use an unlocked, paired device with Developer Mode enabled and an Apple
 Development signing identity in Xcode. A Developer ID Application certificate
-cannot sign an iOS app. Set your team ID and the device identifier from
+cannot sign a mobile app. Set your team ID and the device identifier from
 `xcrun devicectl list devices`; do not commit signing credentials, provisioning
 profiles, device identifiers, or generated Xcode projects.
+For a watch, also keep its paired iPhone available and confirm Xcode can connect
+to the watch. Developer Mode alone does not establish the CoreDevice network
+tunnel.
 
-Run from the repository root, with `TEAM_ID` and `DEVICE_ID` set in your shell:
+Run from the repository root, with `TEAM_ID` and `DEVICE_ID` set in your shell.
+Set `PLATFORM=watchos` for a watch; the default below targets iPhone/iPad:
 
 ```bash
-cmake --preset apple-ios-device-core -S Build/Cmake \
-  -DCMAKE_OSX_DEPLOYMENT_TARGET=17.0
-cmake --build out/apple-ios-device-core --parallel
-cmake -S Build/AppleMobile -B out/apple-ios-device-smoke -G Xcode \
-  -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos \
-  -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=17.0 \
-  -DRefIccMAX_DIR="$PWD/out/apple-ios-device-core" \
+platform="${PLATFORM:-ios}"
+case "$platform" in
+  ios)
+    system=iOS; sdk=iphoneos; arch=arm64; deployment=17.0
+    bundle=org.color.iccdev.CoreSmoke ;;
+  watchos)
+    system=watchOS; sdk=watchos; arch=arm64_32; deployment=10.0
+    bundle=org.color.iccdev.CoreSmoke.watch ;;
+  *) echo "Set PLATFORM to ios or watchos" >&2; exit 2 ;;
+esac
+core="out/apple-${platform}-device-core"
+build="out/apple-${platform}-device-smoke"
+cmake --preset "apple-${platform}-device-core" -S Build/Cmake \
+  -DCMAKE_OSX_ARCHITECTURES="$arch" -DCMAKE_OSX_DEPLOYMENT_TARGET="$deployment"
+cmake --build "$core" --parallel
+cmake -S Build/AppleMobile -B "$build" -G Xcode \
+  -DCMAKE_SYSTEM_NAME="$system" -DCMAKE_OSX_SYSROOT="$sdk" \
+  -DCMAKE_OSX_ARCHITECTURES="$arch" -DCMAKE_OSX_DEPLOYMENT_TARGET="$deployment" \
+  -DRefIccMAX_DIR="$PWD/$core" \
+  -DICCDEV_APPLE_BUNDLE_IDENTIFIER="$bundle" \
   -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM="$TEAM_ID"
-xcodebuild -project out/apple-ios-device-smoke/IccDevCoreSmoke.xcodeproj \
-  -target IccDevCoreSmoke -configuration Release -sdk iphoneos \
+xcodebuild -project "$build/IccDevCoreSmoke.xcodeproj" \
+  -target IccDevCoreSmoke -configuration Release -sdk "$sdk" \
   -allowProvisioningUpdates -allowProvisioningDeviceRegistration build
 xcrun devicectl device install app --device "$DEVICE_ID" \
-  out/apple-ios-device-smoke/Release-iphoneos/IccDevCoreSmoke.app
+  "$build/Release-${sdk}/IccDevCoreSmoke.app"
 xcrun devicectl device process launch --device "$DEVICE_ID" \
   --console --terminate-existing --timeout 90 \
-  --json-output out/apple-ios-device-smoke/device-launch.json \
-  org.color.iccdev.CoreSmoke --exit-after-tests
+  --json-output "$build/device-launch.json" "$bundle" --exit-after-tests
 jq -e '.info.outcome == "success" and .result.terminationResult.exitCode == 0' \
-  out/apple-ios-device-smoke/device-launch.json
+  "$build/device-launch.json"
 xcrun devicectl device copy from --device "$DEVICE_ID" \
-  --domain-type appDataContainer --domain-identifier org.color.iccdev.CoreSmoke \
-  --source Documents/results.json \
-  --destination out/apple-ios-device-smoke/results.json
+  --domain-type appDataContainer --domain-identifier "$bundle" \
+  --source Documents/results.json --destination "$build/results.json"
 jq -e '.passed == true and (.tests | length > 0) and all(.tests[]; .passed == true)' \
-  out/apple-ios-device-smoke/results.json
+  "$build/results.json"
 ```
 
 Require successful commands, `ICCDEV_DEVICE_TESTS PASS` in the console,
@@ -198,15 +217,35 @@ that run. An installation or launch alone is not a test pass. A normal app
 launch (without `--exit-after-tests`) leaves the report visible on the device.
 This is a core smoke suite, not the desktop regression suite or a benchmark.
 
-Set `ICCDEV_IOS_BUNDLE_IDENTIFIER` at configure time if your team needs a
-different app ID, and use that same ID in the device commands. The 17.0 target
-above is specific to this sample; keep the core and app deployment targets
-aligned. For simulator use, build `apple-ios-simulator-core`, configure the
-app into a separate directory with `CMAKE_OSX_SYSROOT=iphonesimulator` and
-the simulator core's `RefIccMAX_DIR`, then build with `-sdk iphonesimulator
-CODE_SIGNING_ALLOWED=NO`. Use `xcrun simctl install` and `xcrun simctl launch
---console-pty` with a booted simulator. Never link a device archive into a
-simulator app, even when both use arm64.
+Change `bundle` if your team needs a different app ID, and use the same ID in
+the device commands. `ICCDEV_IOS_BUNDLE_IDENTIFIER` remains supported for iOS
+when `ICCDEV_APPLE_BUNDLE_IDENTIFIER` is unset or empty. The deployment targets
+above are specific to this sample; keep the core and app targets aligned.
+Never link a device archive into a simulator app, even when both use arm64.
+Use the simulator helper below to build and exercise matching simulator pairs.
+
+### Run the simulator and Xcode CI gates locally
+
+From the repository root on a Mac with Xcode, CMake, Ninja, and `jq`:
+
+```bash
+bash .github/scripts/iccdev-apple-simulator-smoke.sh ios
+bash .github/scripts/iccdev-apple-simulator-smoke.sh watchos
+bash .github/scripts/iccdev-xcode-ctest-smoke.sh
+```
+
+Each simulator command builds a matching core/app pair and creates a disposable
+simulator. It requires a fresh passing report, then a missing-profile failure
+control, followed by a restored passing run. Reports and console logs remain
+under `out/apple-<platform>-simulator-smoke`; only the simulator created by the
+command is shut down and deleted. No signing identity is needed. An unavailable
+runtime fails with an installation command; set
+`ICCDEV_APPLE_DOWNLOAD_RUNTIME=1` to permit Xcode to download it, as CI does.
+
+The Xcode command builds dependency-free Release and Debug test targets in
+`out/xcode-ctest-smoke`, exercises the configuration-specific CTest runtime
+layout, and requires freshly generated CLI output to catch skipped execution.
+See [CTest tool suites](ctest.md) for broader desktop coverage.
 
 ## Windows MSVC
 

--- a/docs/build.md
+++ b/docs/build.md
@@ -85,11 +85,11 @@ ICCDEV_XCODE_CONFIG=Debug Build/XCode/BuildAll.sh -DENABLE_WXWIDGETS=OFF
 This wrapper builds macOS, not iOS; use the mobile core presets and the
 device smoke app below for an iPhone or iPad.
 
-Xcode places CLI executables in `Tools/<tool>/<configuration>/`. Some Unix
-shell-backed CTest suites still assume the single-configuration
-`Tools/<tool>/` layout; use a Ninja build for those suites rather than copying
-executables into the source tree. Native CMake test targets use `ctest -C`
-to select the Xcode configuration.
+Xcode places CLI executables in `Tools/<tool>/<configuration>/`. Use
+`ctest --test-dir out/macos-xcode -C Release` to select that configuration.
+CTest automatically prepares a configuration-specific compatibility directory
+for the shell-backed suites; no executable copies or manual path overrides
+are needed. See [CTest Tool Suites](ctest.md) for the build and test commands.
 
 For GuardMalloc/libgmalloc crash reproduction, use a non-sanitizer Debug build
 and verify that the built Mach-O tools contain `LC_UUID`. Apple's dynamic loader

--- a/docs/build.md
+++ b/docs/build.md
@@ -69,6 +69,28 @@ To open the generated project:
 open out/macos-xcode/RefIccMAX.xcodeproj
 ```
 
+`Build/XCode/BuildAll.sh` wraps this same configure/build sequence and can be
+invoked from any working directory. It replaces the legacy per-tool Xcode
+projects and source-tree copies; executables remain under the build directory,
+not in `Testing/`. Pass CMake configure options as arguments, or use
+`ICCDEV_XCODE_BUILD_DIR`, `ICCDEV_XCODE_CONFIG`, and
+`CMAKE_BUILD_PARALLEL_LEVEL` to select the output directory, configuration, and
+job count. Relative build directories are resolved from the repository root.
+For example:
+
+```bash
+ICCDEV_XCODE_CONFIG=Debug Build/XCode/BuildAll.sh -DENABLE_WXWIDGETS=OFF
+```
+
+This wrapper builds macOS, not iOS; use the mobile core presets and the
+device smoke app below for an iPhone or iPad.
+
+Xcode places CLI executables in `Tools/<tool>/<configuration>/`. Some Unix
+shell-backed CTest suites still assume the single-configuration
+`Tools/<tool>/` layout; use a Ninja build for those suites rather than copying
+executables into the source tree. Native CMake test targets use `ctest -C`
+to select the Xcode configuration.
+
 For GuardMalloc/libgmalloc crash reproduction, use a non-sanitizer Debug build
 and verify that the built Mach-O tools contain `LC_UUID`. Apple's dynamic loader
 can abort before `main()` when `DYLD_INSERT_LIBRARIES=/usr/lib/libgmalloc.dylib`
@@ -125,6 +147,66 @@ installed on its macOS runner, builds every matching mobile-core preset, and
 uploads the static libraries, generated version headers, and a build manifest
 as the `iccdev-apple-mobile-core` artifact. Run it manually or call
 `.github/workflows/ci-apple-mobile-core.yml` from another workflow.
+
+### Run the core smoke app on an iPhone or iPad
+
+`Build/AppleMobile` is a standalone Xcode consumer of the core's exported
+CMake package. It does not enable desktop tools or CTest on iOS. The app
+exercises the bundled RGB profile, memory and sandbox-file serialization,
+truncated-header rejection, single/batch RGB transforms, and analytic
+3D CLUT interpolation with 3, 8, 15, and 16 output channels.
+
+Use an unlocked, paired device with Developer Mode enabled and an Apple
+Development signing identity in Xcode. A Developer ID Application certificate
+cannot sign an iOS app. Set your team ID and the device identifier from
+`xcrun devicectl list devices`; do not commit signing credentials, provisioning
+profiles, device identifiers, or generated Xcode projects.
+
+Run from the repository root, with `TEAM_ID` and `DEVICE_ID` set in your shell:
+
+```bash
+cmake --preset apple-ios-device-core -S Build/Cmake \
+  -DCMAKE_OSX_DEPLOYMENT_TARGET=17.0
+cmake --build out/apple-ios-device-core --parallel
+cmake -S Build/AppleMobile -B out/apple-ios-device-smoke -G Xcode \
+  -DCMAKE_SYSTEM_NAME=iOS -DCMAKE_OSX_SYSROOT=iphoneos \
+  -DCMAKE_OSX_ARCHITECTURES=arm64 -DCMAKE_OSX_DEPLOYMENT_TARGET=17.0 \
+  -DRefIccMAX_DIR="$PWD/out/apple-ios-device-core" \
+  -DCMAKE_XCODE_ATTRIBUTE_DEVELOPMENT_TEAM="$TEAM_ID"
+xcodebuild -project out/apple-ios-device-smoke/IccDevCoreSmoke.xcodeproj \
+  -target IccDevCoreSmoke -configuration Release -sdk iphoneos \
+  -allowProvisioningUpdates -allowProvisioningDeviceRegistration build
+xcrun devicectl device install app --device "$DEVICE_ID" \
+  out/apple-ios-device-smoke/Release-iphoneos/IccDevCoreSmoke.app
+xcrun devicectl device process launch --device "$DEVICE_ID" \
+  --console --terminate-existing --timeout 90 \
+  --json-output out/apple-ios-device-smoke/device-launch.json \
+  org.color.iccdev.CoreSmoke --exit-after-tests
+jq -e '.info.outcome == "success" and .result.terminationResult.exitCode == 0' \
+  out/apple-ios-device-smoke/device-launch.json
+xcrun devicectl device copy from --device "$DEVICE_ID" \
+  --domain-type appDataContainer --domain-identifier org.color.iccdev.CoreSmoke \
+  --source Documents/results.json \
+  --destination out/apple-ios-device-smoke/results.json
+jq -e '.passed == true and (.tests | length > 0) and all(.tests[]; .passed == true)' \
+  out/apple-ios-device-smoke/results.json
+```
+
+Require successful commands, `ICCDEV_DEVICE_TESTS PASS` in the console,
+exit code zero in the current launch JSON, and a passing report copied from
+that run. An installation or launch alone is not a test pass. A normal app
+launch (without `--exit-after-tests`) leaves the report visible on the device.
+This is a core smoke suite, not the desktop regression suite or a benchmark.
+
+Set `ICCDEV_IOS_BUNDLE_IDENTIFIER` at configure time if your team needs a
+different app ID, and use that same ID in the device commands. The 17.0 target
+above is specific to this sample; keep the core and app deployment targets
+aligned. For simulator use, build `apple-ios-simulator-core`, configure the
+app into a separate directory with `CMAKE_OSX_SYSROOT=iphonesimulator` and
+the simulator core's `RefIccMAX_DIR`, then build with `-sdk iphonesimulator
+CODE_SIGNING_ALLOWED=NO`. Use `xcrun simctl install` and `xcrun simctl launch
+--console-pty` with a booted simulator. Never link a device archive into a
+simulator app, even when both use arm64.
 
 ## Windows MSVC
 

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -71,9 +71,11 @@ ctest --test-dir out/macos-xcode -C Release \
 ```
 
 The `iccdev.unix-multi-config-runtime` setup fixture automatically prepares
-`Testing/ctest-runtime/<Config>/` inside the build tree. It exposes symlinks
+`Testing/ctest-runtime/<Config>/` inside the build tree. It exposes regular files
 to that configuration's built CLI targets, shared/static libraries (including
 linker and SONAME aliases), generated version headers, and the real CMake cache.
+Artifacts use hard links where possible, otherwise copies; library symlinks
+are resolved so legacy `find -type f` discovery cannot silently skip tools.
 CTest points the shell suites' `PATH`, library paths, `ICCDEV_TOOLS_DIR`, and
 `ICCDEV_BUILD_DIR` at this flat compatibility layout. It is a test runtime
 directory, not a second CMake build tree; continue using the original build
@@ -86,6 +88,10 @@ regeneration removes stale aliases without changing actual build artifacts.
 Single-config Unix and Windows runtime layouts are unchanged. Existing
 profile-generation scripts still operate in the source `Testing/` directory;
 do not run those fixtures concurrently against the same checkout.
+
+For the dependency-free Xcode CI reproduction, run
+`bash .github/scripts/iccdev-xcode-ctest-smoke.sh`. It covers Release and Debug
+runtime staging, native profile-write behavior, and fresh `iccFromCube` output.
 
 Windows MinGW single-config generators, `cmd.exe`:
 

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -59,6 +59,34 @@ Windows presets use a unified build-tree runtime directory. Visual Studio tools
 and iccDEV DLLs are under `out\vs2022-x64\bin\<Config>`; MinGW tools are under
 `out\mingw-x64\bin`.
 
+macOS Xcode and Unix Ninja Multi-Config:
+
+```bash
+cmake --preset macos-xcode -S Build/Cmake -B out/macos-xcode
+cmake --build out/macos-xcode --config Release --parallel
+cmake --build out/macos-xcode --config Release --target build-test-binaries --parallel
+ctest --test-dir out/macos-xcode -C Release \
+  -R '^iccdev\.(unix-runtime-layout|clut-eight-output-regression)$' \
+  --output-on-failure --no-tests=error
+```
+
+The `iccdev.unix-multi-config-runtime` setup fixture automatically prepares
+`Testing/ctest-runtime/<Config>/` inside the build tree. It exposes symlinks
+to that configuration's built CLI targets, shared/static libraries (including
+linker and SONAME aliases), generated version headers, and the real CMake cache.
+CTest points the shell suites' `PATH`, library paths, `ICCDEV_TOOLS_DIR`, and
+`ICCDEV_BUILD_DIR` at this flat compatibility layout. It is a test runtime
+directory, not a second CMake build tree; continue using the original build
+directory with `cmake --build`.
+
+Only already-built artifacts are exposed. Build the selected configuration
+first; the runtime view never substitutes Release artifacts for unbuilt Debug targets.
+Each configuration has its own runtime directory and script-output directory;
+regeneration removes stale aliases without changing actual build artifacts.
+Single-config Unix and Windows runtime layouts are unchanged. Existing
+profile-generation scripts still operate in the source `Testing/` directory;
+do not run those fixtures concurrently against the same checkout.
+
 Windows MinGW single-config generators, `cmd.exe`:
 
 ```cmd
@@ -115,6 +143,8 @@ before running the suite.
 
 | Test | Source |
 |------|--------|
+| `iccdev.unix-multi-config-runtime` | `Build/Cmake/Testing/UnixMultiConfigRuntime.cmake`; automatic Unix multi-config runtime setup |
+| `iccdev.unix-runtime-layout` | `Build/Cmake/Testing/TestUnixTestRuntime.cmake`; configuration isolation, stale aliases, spaced paths, and failure controls |
 | `iccdev.create-profiles` | `Testing/CreateAllProfiles.sh` |
 | `iccdev.c-validation-dlopen` | `.github/ci/regression/c-validation-dlopen.c` |
 | `iccdev.embedio-read8-bounds` | `.github/ci/regression/embedio-read8-bounds.cpp` |

--- a/docs/governance/UPSTREAM_PR_READINESS.md
+++ b/docs/governance/UPSTREAM_PR_READINESS.md
@@ -1,4 +1,4 @@
-# Upstream Pull Request Authorization and Readiness
+# Upstream Pull Request Authorization and Readiness {#upstream-pr-readiness}
 
 Use this policy before creating, reopening, or requesting review on an
 upstream pull request.

--- a/docs/regression-workflow-governance.md
+++ b/docs/regression-workflow-governance.md
@@ -24,6 +24,7 @@ new blocker returns the branch to branch-only grooming before another review.
 | Regression PoC inventory | `.github/ci/regression/README.md` | Maps regression inputs and scripts to issues. |
 | Tool test gate | `.github/workflows/ci-iccdev-tool-tests.yml` | ASAN/UBSAN tool coverage, JSON gates, regression scripts, and broad generated-profile CLI coverage. |
 | MATLAB Windows gate | `.github/workflows/ci-matlab.yml` | PowerShell-native MSVC build, MATLAB MEX QA, native focused regressions, and Docker interoperability. |
+| Apple platform gates | `.github/workflows/ci-apple-platform-smoke.yml`, `.github/workflows/ci-apple-mobile-core.yml` | iOS/watchOS simulator hosts and Xcode Release/Debug CTest runtime layouts; [local commands](build.md). |
 | CTest registration | `Build/Cmake/Testing/CMakeLists.txt` | CTest names, labels, fixtures, timeouts, and check target. |
 | CTest process guide | `docs/ctest.md` | Local commands, registered suites, and add-test workflow. |
 | Maintainer CI skill | `.github/skills/maintainer-ci-ctest/SKILL.md` | Repeatable maintainer workflow for CI, CTest, CPack, sanitizer, and release gates. |
@@ -58,6 +59,15 @@ Every new regression gate should state:
 Prefer deterministic invariants over broad diffs. For generated ICC profiles,
 normalize only documented volatile fields when comparing whole files; otherwise
 assert specific tag sizes, offsets, record lengths, or validation messages.
+
+The Apple gates extend #2445's static-core SDK builds with native runtime
+coverage. Both use `iccdev-apple-simulator-smoke.sh` and
+`iccdev-xcode-ctest-smoke.sh`: simulator success requires a fresh report and
+console sentinel, a missing-fixture control must fail, and Xcode CTest must
+produce fresh CLI output in both configurations. The path-filtered PR workflow
+runs only for same-repository heads and keeps outputs in the job workspace.
+The master-push/manual core workflow additionally builds all available SDK
+presets and uploads their archives. A nonzero helper exit fails either gate.
 
 ## Workflow Governance Requirements
 


### PR DESCRIPTION
## PR Summary

#2456 

### Apple mobile core libraries

| Preset | SDK | Result |
|---|---|---|
| apple-ios-device-core | iphoneos | built |
| apple-ios-simulator-core | iphonesimulator | built |
| apple-tvos-device-core | appletvos | built |
| apple-tvos-simulator-core | appletvsimulator | built |
| apple-watchos-device-core | watchos | built |
| apple-watchos-simulator-core | watchsimulator | built |
| apple-visionos-device-core | xros | built |
| apple-visionos-simulator-core | xrsimulator | built |

ios: 24 core checks; missing-fixture failure control passed.
watchos: 24 core checks; missing-fixture failure control passed.
Xcode Release and Debug CTest runtime gates passed.

## Checklist

- [ ] Signed all Commits in PR
- [ ] Built locally according to `docs/build.md`
- [ ] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [ ] Ran relevant CTest/profile tests from `docs/ctest.md`
- [ ] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes
- [ ] Added or updated regression coverage for behavior changes
- [ ] Attached a `base...HEAD` contract matrix for cross-cutting changes:
      producer, consumer, build/runtime behavior, platform/toolchain boundary,
      CI trigger, dependency owner, and local evidence
- [ ] Reviewed active and suppressed automated findings from review threads and summaries
- [ ] For Python package changes, followed `docs/python-packaging-release.md` for PR and merge requirements
- [ ] Did not change maintainer-owned workflow, CTest, CPack, sanitizer, release, or security infrastructure unless requested by an iccDEV maintainer
- [ ] New source files include the ICC copyright and BSD 3-Clause license header
- [ ] Code style matches nearby code: 2-space indent, K&R braces, `m_` members

## Legal Requirements

All official software projects hosted by the International Color Consortium (ICC)
follows the open source software best practice policies. The [International Color Consortium IP policy](https://www.color.org/iccip.xalter) governs ICC specification development and contributions to ICC open source software. Software contributions are also covered by the Contributor License Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion
in ICC software must first complete a **Contributor License Agreement
(CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License Agreement (CLA). Please note that this is different from membership in the International Color Consortium (ICC). If your organization relies on our projects, please become a member. Membership dues are an essential source of funding and investment for these projects.

* If you are an individual writing the code on your own time and you are SURE you are the sole owner of any intellectual property you contribute, you can sign the [CLA as an individual contributor](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

* If you are writing the code as part of your job, or if there is any possibility that your employer might think they own any intellectual property you create, then you should use the [Corporate Contributor Licence Agreement](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md)

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License. Contributions to ICC software projects should abide by that license unless otherwised specified or approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC Copyright notice and include or reference the BSD 3-Clause "New" or "Revised" License.

### INTELLECTUAL PROPERTY & PATENTS

Participation in ICC's development activities is subject to [ICC's Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

If you have questions, contact a listed [Maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
