### PR TITLE
codeql: move the #2435 rationale out of the case it explains

### DIFF
--- a/IccProfLib/IccConvertUTF.cpp
+++ b/IccProfLib/IccConvertUTF.cpp
@@ -445,6 +445,37 @@ icUtfConversionResult icConvertUTF16toUTF8 (const UTF16* source, const UTF16* so
 * available.
 * If presented with a length > 4, this returns false.  The Unicode
 * definition of UTF-8 goes up to 4-byte sequences.
+*
+* #2435: every arm needs BOTH bounds.  The case 2 arm below tests only the
+* upper bound (a > 0xBF); the generic lower bound lives in default:, which the
+* four named arms bypass.  0xE0 and 0xF0 tighten the lower bound to 0xA0 and
+* 0x90, so they imply a >= 0x80 and were correct by accident.  0xED and 0xF4
+* only tightened the UPPER bound and then broke, leaving no lower bound at all
+* -- a second byte of 0x00..0x7F, never a continuation byte, was accepted
+* after either lead.
+*
+* Measured against an RFC 3629 reference over every sequence this function can
+* be asked about: for each of the 256 lead bytes, every combination of the
+* trailing bytes its RFC length implies, 84,942,541 sequences.  Before:
+* 532,480 accepted that RFC 3629 rejects -- 128*64 for ED and 128*64*64 for
+* F4 -- and none rejected that it accepts.  After: zero in both directions.
+*
+* (#2435's issue body says 528,320.  That count came from a harness that
+* builds NUL-terminated strings, so it could not present 0x00 as a second
+* byte and missed 64 ED and 4096 F4 sequences.  This function takes a pointer
+* and a length, and a profile's text tag is a byte range, so the NUL cases are
+* reachable and the larger figure is the right one.)
+*
+* The accepted values were not merely wrong characters: ED 01 80 decoded to
+* U+B040 and F4 01 80 80 to U+81000, which is above U+10FFFF and not a Unicode
+* scalar value at all.  icConvertUTF8toUTF16 emitted it as a surrogate pair,
+* so the OUTPUT was not well-formed UTF-16 either.
+*
+* This rationale lives here rather than beside the code it explains because
+* CodeQL's cpp/long-switch measures a case by the raw line distance to the next
+* case label -- comments and blank lines included -- so 26 lines of it inside
+* case 2 tripped the 30-line threshold on their own, with no code change.
+* (code-scanning alert 2368; not issue #2368, which is unrelated.)
 */
 
 static Boolean isLegalUTF8(const UTF8 *source, int length)
@@ -459,33 +490,8 @@ static Boolean isLegalUTF8(const UTF8 *source, int length)
     case 3: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return false;
       [[fallthrough]];
     case 2: if ((a = (*--srcptr)) > 0xBF) return false;
-
-      /* #2435: every arm needs BOTH bounds.  case 2 above tests only the upper
-       * bound (a > 0xBF); the generic lower bound lives in default:, which the
-       * four named arms bypass.  0xE0 and 0xF0 tighten the lower bound to 0xA0
-       * and 0x90, so they imply a >= 0x80 and were correct by accident.  0xED
-       * and 0xF4 only tightened the UPPER bound and then broke, leaving no
-       * lower bound at all -- a second byte of 0x00..0x7F, never a continuation
-       * byte, was accepted after either lead.
-       *
-       * Measured against an RFC 3629 reference over every sequence this
-       * function can be asked about: for each of the 256 lead bytes, every
-       * combination of the trailing bytes its RFC length implies, 84,942,541
-       * sequences.  Before: 532,480 accepted that RFC 3629 rejects -- 128*64 for
-       * ED and 128*64*64 for F4 -- and none rejected that it accepts.  After:
-       * zero in both directions.
-       *
-       * (#2435's issue body says 528,320.  That count came from a harness that
-       * builds NUL-terminated strings, so it could not present 0x00 as a second
-       * byte and missed 64 ED and 4096 F4 sequences.  This function takes a
-       * pointer and a length, and a profile's text tag is a byte range, so the
-       * NUL cases are reachable and the larger figure is the right one.)
-       *
-       * The accepted values were not merely wrong characters: ED 01 80 decoded
-       * to U+B040 and F4 01 80 80 to U+81000, which is above U+10FFFF and not a
-       * Unicode scalar value at all.  icConvertUTF8toUTF16 emitted it as a
-       * surrogate pair, so the OUTPUT was not well-formed UTF-16 either.
-       */
+      /* #2435: the per-lead arms carry the lower bound this line omits; the
+       * rationale and the measurement are above the function. */
       switch (*source) {
             /* no fall-through in this inner switch */
         case 0xE0: if (a < 0xA0) return false; break;


### PR DESCRIPTION
Fixes the open `cpp/long-switch` code-scanning alert on `IccConvertUTF.cpp:454`:

- [alert 2368](https://github.com/InternationalColorConsortium/iccDEV/security/code-scanning/2368)

Linked by URL rather than as `#2368`: alert numbers and issue numbers are separate
namespaces, and issue #2368 is an unrelated closed technology-signature issue.

## What the alert is

`cpp/long-switch` measures a case by the raw line distance from its label to the
next case label. Comments and blank lines count exactly as code does:

```ql
length = next.getStartLine() - sc.getStartLine() - 1     // threshold: > 30
```

`isLegalUTF8()`'s `case 2:` held 11 lines of code before #2451 and 11 after it. What
changed is the 26-line WHY-comment #2451 added beside the per-lead bound checks,
taking the label-to-label distance from 11 to 37. The alert was created 11 minutes
after that merge. **No code got longer.**

## The change

The rationale moves verbatim into the function's header comment, where it documents
the same contract and sits outside every case span; a two-line pointer stays at the
site. `case 2:` returns to 12 lines.

| | `case 2:` span | max case in file |
|---|---|---|
| `bb172dd9` (master) | **37** | 37 — alerts |
| this branch | **12** | 12 — clean |

## Verification

- **Comment-only, proven twice.** Stripping comments and whitespace from both
  revisions of the file gives byte-identical text; independently, a
  `gcc -fpreprocessed -dD -E -P` diff of the two is empty. No statement moved.
- **Red/green against the query's own formula.** Measured on master, `case 2:`
  computes to 37 — reproducing the figure in the alert text exactly, so the model
  is validated rather than assumed. On this branch it computes to 12. Every other
  case in both switches measures 0 or 1.
- `iccdev.islegalutf8-second-byte-bound` passes; the #2435 fix is untouched, all
  four per-lead arms still carry both bounds.
- Zero warnings compiling the TU under clang 21 and gcc with
  `-Wall -Wextra -Wpedantic -Wcomment -Werror`.
- Pre-PR `ci_scope=source` dispatch
  [34151440479](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34151440479):
  all lanes green, including GCC 15.2 Strict Release LTO. Re-dispatched after the
  reference correction below.

## Not bundled with the other long-switch alert

The other open `cpp/long-switch` alert is on `IccCmm.cpp:585` — a 282-line
`icXformLutColor` case in `CIccXform::Create`, plus five more over-long cases in the
same switch. That is a genuine refactor and is still gated on the routing question in
#1750. This one is 26 lines of my own prose in the wrong place, so it is separable and
I kept it separate.