### PR TITLE
fix(#2454): give the JSON sinks the whitelist the text sink already has

### DIFF
--- a/.github/ci/regression/json-escape-codepoint.cpp
+++ b/.github/ci/regression/json-escape-codepoint.cpp
@@ -1,0 +1,149 @@
+/*
+    File:       json-escape-codepoint.cpp
+
+    Contains:   CTest for icJsonEscape() appending well-formed UTF-8 unchanged,
+                so the --json / --evidence-json sinks emitted live U+202E and
+                the C1 controls the text sink escapes (#2454).
+
+    icJsonEscape() escaped the C0 controls and the JSON metacharacters, then
+    validated any non-ASCII sequence and appended its BYTES verbatim.  That is
+    correct JSON -- the document parses and a machine consumer decodes the same
+    string either way -- but it means one filename reached two sinks in the same
+    build and got opposite answers:
+
+        iccPawgReport <name>          text  -> \u202E  (escaped since #2419)
+        iccPawgReport <name> --json   JSON  -> raw E2 80 AE bytes
+
+    It stops being harmless when a human cat-s the output, which is the threat
+    model #2406 and #2437 established for this repo (CVE-2021-42574, Trojan
+    Source).  The fix escapes by codepoint using icDecodeUtf8() -- the decoder
+    #2437 added -- so both sinks now share ONE whitelist.
+
+    WHY THE SURROGATE-PAIR CASE IS NOT OPTIONAL.  JSON has no \U escape
+    (RFC 8259 s7): a codepoint above the BMP must be spelled as a UTF-16
+    surrogate pair.  The text sink spells U+1F600 as \U0001F600, which is valid
+    there and INVALID JSON here, so an implementation that simply reused the
+    text sink's spelling would emit a document that does not parse.  Case 4
+    fails against exactly that mistake as well as against master.
+
+    THE CONTROLS ARE THE POINT.  Cases 7-12 pass on BOTH builds.  Without them a
+    "fix" that escaped every byte >= 0x80 per byte (re-introducing the
+    \xC3\xA9 spelling #2437 removed), or that stopped escaping the JSON
+    metacharacters, or that lost the U+FFFD handling for ill-formed input, would
+    still satisfy a suite that only checked cases 1-6.  Case 12 in particular
+    pins that a sequence truncated by the terminating NUL is not read past.
+
+    WHAT EVERY CASE ACTUALLY ASSERTS, stated precisely because the distinction
+    matters: the escaped output equals a hand-written expected spelling, and the
+    output is pure ASCII.  It asserts the FIXED form is PRESENT rather than only
+    that the raw bytes are absent.  It does NOT link a JSON parser and does not
+    round-trip the result -- the surrogate-pair spelling in case 4 is checked
+    against a literal, not against a decoder.  That round-trip was verified
+    out-of-band when the fix landed (every case parsed with Python's json module
+    and decoded back to the input), but it is not what this binary does, and a
+    reader should not believe otherwise.
+*/
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include "IccCmdLineUtil.h"
+
+static int g_pass = 0;
+static int g_fail = 0;
+
+static bool isPureAscii(const std::string& s)
+{
+  for (size_t i = 0; i < s.size(); i++) {
+    if ((unsigned char)s[i] >= 0x80)
+      return false;
+  }
+  return true;
+}
+
+static void check(const char* label, const std::string& input, const char* expected)
+{
+  std::string got = icJsonEscape(input);
+  bool ok = (got == expected);
+  bool ascii = isPureAscii(got);
+
+  if (ok && ascii) {
+    // A passing result is ASCII by construction, so it needs no sanitizing.
+    printf("PASS  %-28s -> %s\n", label, got.c_str());
+    g_pass++;
+  }
+  else {
+    // The failing value is sanitized before it is printed.  On a regressed
+    // build `got` is exactly the raw terminal-active bytes this test exists to
+    // catch -- printing it verbatim would write a live U+202E RIGHT-TO-LEFT
+    // OVERRIDE into the CI log and reverse the rest of the line in any terminal
+    // that cats it, which is the CVE-2021-42574 exposure #2406/#2419/#2437
+    // closed.  A diagnostic must not reintroduce the defect it reports.
+    printf("FAIL  %-28s -> %s\n", label, icSanitizeConsoleText(got).c_str());
+    if (!ok)
+      printf("        expected: %s\n", expected);
+    if (!ascii)
+      printf("        output is not pure ASCII\n");
+    g_fail++;
+  }
+}
+
+int main()
+{
+  printf("== #2454: non-ASCII must be escaped by codepoint, not appended raw ==\n");
+
+  // U+202E RIGHT-TO-LEFT OVERRIDE -- the bidi attack the text sink already blocks.
+  check("1. U+202E bidi override", std::string("inv") + "\xE2\x80\xAE" + "cod.icc",
+        "inv\\u202ecod.icc");
+
+  // U+0085 NEL, a C1 control; UTF-8 spells it C2 85 and a terminal acts on it.
+  check("2. U+0085 C1 control", std::string("a") + "\xC2\x85" + "b.icc",
+        "a\\u0085b.icc");
+
+  // A legitimate accented name: escaped as ONE codepoint, not two raw bytes.
+  check("3. U+00E9 accented", std::string("\xC3\xA9") + "cran.icc",
+        "\\u00e9cran.icc");
+
+  // Above the BMP: MUST be a surrogate pair, not \U0001f600.
+  check("4. U+1F600 surrogate pair", std::string("\xF0\x9F\x98\x80") + ".icc",
+        "\\ud83d\\ude00.icc");
+
+  // A 3-byte BMP codepoint.
+  check("5. U+8272 CJK", std::string("\xE8\x89\xB2") + ".icc",
+        "\\u8272.icc");
+
+  // U+007F DEL is terminal-active and icSanitizeConsoleText() escapes it, so
+  // leaving it raw here would be the same sink divergence this fix is about,
+  // just below 0x80 instead of above it.  Master emits DEL raw, so this fails
+  // there -- it belongs with the cases above, not with the controls below.
+  check("6. U+007F DEL", std::string("a\x7f" "b.icc"),
+        "a\\u007fb.icc");
+
+  printf("== controls: these pass on BOTH builds and must not move ==\n");
+
+  check("7. plain ASCII untouched", std::string("plain-Profile.icc"),
+        "plain-Profile.icc");
+
+  check("8. JSON metacharacters", std::string("a\"b\\c"),
+        "a\\\"b\\\\c");
+
+  check("9. short-form C0 escapes", std::string("a\tb\nc\rd\be\ff"),
+        "a\\tb\\nc\\rd\\be\\ff");
+
+  check("10. other C0 as \\u00XX", std::string("a\x01" "b"),
+        "a\\u0001b");
+
+  // ED A0 80 is a UTF-16 surrogate, ill-formed in UTF-8; each byte becomes
+  // U+FFFD and the scan advances one byte at a time.
+  check("11. ill-formed surrogate", std::string("a") + "\xED\xA0\x80" + "b",
+        "a\\ufffd\\ufffd\\ufffdb");
+
+  // A 3-byte lead with only two bytes before the terminator: the decoder must
+  // stop at the NUL rather than read past it.
+  check("12. truncated at terminator", std::string("a") + "\xE8\x89",
+        "a\\ufffd\\ufffd");
+
+  printf("\ncases run: %d  passed: %d  failed: %d\n",
+         g_pass + g_fail, g_pass, g_fail);
+  return g_fail ? 1 : 0;
+}

--- a/.github/ci/regression/qa-evidence-helpers.cpp
+++ b/.github/ci/regression/qa-evidence-helpers.cpp
@@ -85,12 +85,20 @@ int main()
   expect("json control set", icJsonEscape("\b\f\n\r\t"), "\\b\\f\\n\\r\\t");
   expect("json other control byte", icJsonEscape("\x01"), "\\u0001");
 
-  // Well-formed UTF-8 passes through byte for byte. Escaping these as \u00XX
-  // would emit the code points U+00C3 U+00A9 instead of U+00E9 -- the #1853
-  // mojibake -- so this case is that bug turned into an assertion.
-  expect("json utf-8 passthrough", icJsonEscape("caf\xc3\xa9"), "caf\xc3\xa9");
-  expect("json utf-8 3-byte", icJsonEscape("\xe2\x82\xac"), "\xe2\x82\xac");
-  expect("json utf-8 4-byte", icJsonEscape("\xf0\x9f\x8e\xa8"), "\xf0\x9f\x8e\xa8");
+  // Well-formed UTF-8 is escaped by CODE POINT (#2454).  These three cases still
+  // guard the #1853 mojibake they were written for, and that is why they assert
+  // the single-code-point spelling rather than being deleted: escaping each BYTE
+  // as \u00XX would emit U+00C3 U+00A9 for an e-acute, so "caf\u00c3\u00a9"
+  // here would be that bug.  One escape per code point, and it decodes back to
+  // the character that went in.
+  //
+  // These used to assert byte-for-byte passthrough.  That is what #2454 removed:
+  // it left --json emitting live U+202E and the C1 controls while the text sink
+  // escaped the same string.  Above the BMP the spelling is a UTF-16 surrogate
+  // pair, because JSON has no \U escape (RFC 8259 section 7).
+  expect("json utf-8 by code point", icJsonEscape("caf\xc3\xa9"), "caf\\u00e9");
+  expect("json utf-8 3-byte", icJsonEscape("\xe2\x82\xac"), "\\u20ac");
+  expect("json utf-8 4-byte", icJsonEscape("\xf0\x9f\x8e\xa8"), "\\ud83c\\udfa8");
 
   // A JSON text must be valid UTF-8 (RFC 8259 8.1), and these strings carry
   // paths straight from argv, which on POSIX need not be UTF-8 at all. Passing

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1672,6 +1672,52 @@ function(iccdev_add_islegalutf8_bound_test)
 
 endfunction()
 
+# #2454: icJsonEscape() appended well-formed UTF-8 unchanged, so --json and
+# --evidence-json emitted live U+202E and the C1 controls while the text sink
+# escaped the same string.  Twelve hand-written cases, not an exhaustive walk:
+# six that fail against master and six controls that pass on both builds so a
+# blunter fix cannot satisfy the suite.  Header + IccProfLib only.
+function(iccdev_add_json_escape_codepoint_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccJsonEscapeCodepointTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/json-escape-codepoint.cpp"
+  )
+  # icJsonEscape() lives in Tools/CmdLine/IccCmdLineUtil.h, which is header-only
+  # and pulls in IccProfLib's IccFileUtil.h for the icDecodeUtf8() this fix
+  # reuses (#2437).  Linking the library keeps this consistent with its sibling
+  # regression executables rather than relying on the helper staying inline.
+  target_include_directories(iccJsonEscapeCodepointTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/Tools/CmdLine")
+  target_link_libraries(iccJsonEscapeCodepointTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccJsonEscapeCodepointTest)
+
+  add_test(
+    NAME iccdev.json-escape-codepoint
+    COMMAND "$<TARGET_FILE:iccJsonEscapeCodepointTest>"
+  )
+  set_tests_properties(iccdev.json-escape-codepoint PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 120
+    LABELS "iccdev;json;utf8;unicode;cli;security;issue-2454;regression")
+  if(WIN32)
+    set(_json_escape_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccJsonEscapeCodepointTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _json_escape_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.json-escape-codepoint PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_json_escape_windows_env_mods}")
+  endif()
+
+endfunction()
+
+
 # #2000: CIccTagCicp's copy constructor had an empty body and a commented-out
 # parameter (/* ITXYZ */, copy-paste residue from CIccTagXYZ), so the four
 # icUInt8Number members -- which have no in-class initialiser -- were left
@@ -7544,6 +7590,7 @@ iccdev_add_getvalues_nstart_test()
 iccdev_add_chromaticity_validate_test()
 iccdev_add_cicp_copy_ctor_test()
 iccdev_add_islegalutf8_bound_test()
+iccdev_add_json_escape_codepoint_test()
 iccdev_add_mpe_acs_zero_signature_test()
 iccdev_add_pawg_c5_cicp_test()
 iccdev_add_gamut_xform_semantics_test()

--- a/Tools/CmdLine/IccCmdLineUtil.h
+++ b/Tools/CmdLine/IccCmdLineUtil.h
@@ -168,6 +168,12 @@ inline std::string icSanitizeFileName(const std::string& text)
 // start one.  This is Unicode 15.0 table 3-7 verbatim, so it rejects the things
 // a naive "0xC0-0xFF starts a sequence" test lets through: over-long encodings,
 // UTF-16 surrogates (ED A0..BF), and anything above U+10FFFF.
+//
+// RETAINED DELIBERATELY, do not remove as dead code: #2454 moved icJsonEscape()
+// -- its only in-tree caller -- onto icDecodeUtf8(), so nothing in this repo
+// calls this any more.  It ships in the installed public header, so dropping it
+// is an API change for downstream consumers and needs a maintainer call rather
+// than a dead-code sweep.
 inline size_t icUtf8SequenceLength(const unsigned char* p)
 {
   const unsigned char c = p[0];
@@ -205,23 +211,35 @@ inline size_t icUtf8SequenceLength(const unsigned char* p)
 
 // Escape a string for use as a JSON string value.
 //
-// Bytes at or above 0x80 are passed through when, and only when, they form a
-// well-formed UTF-8 sequence.  Both halves of that rule are load-bearing (#1853):
+// A byte at or above 0x80 is decoded to its CODE POINT and escaped as \uXXXX
+// (a surrogate pair above the BMP).  #1853 and #2454 each rule out one of the
+// two simpler options, and the distinction between them is load-bearing:
 //
-//   - Escaping them as \u00XX, which PawgReport.cpp used to do, reads a UTF-8
-//     byte as if it were a code point.  U+00E9 is the two bytes C3 A9, which
-//     come out as \u00c3\u00a9 -- the two code points U+00C3 U+00A9 -- so
-//     "cafe" with an acute e reads back with two wrong characters in its place.
-//     The document is valid JSON and the text in it is wrong.
-//   - Passing them through unconditionally is no better.  A JSON text must be
+//   - Escaping each BYTE as \u00XX, which PawgReport.cpp used to do, reads a
+//     UTF-8 byte as if it were a code point.  U+00E9 is the two bytes C3 A9,
+//     which come out as \u00c3\u00a9 -- the two code points U+00C3 U+00A9 --
+//     so "cafe" with an acute e reads back with two wrong characters in its
+//     place.  The document is valid JSON and the text in it is wrong (#1853).
+//     Escaping by code point is NOT that mistake: U+00E9 becomes \u00e9, one
+//     escape, and it decodes back to the character that went in.
+//   - Passing a well-formed sequence through unchanged is what this used to do,
+//     and it left the JSON sinks emitting live U+202E RIGHT-TO-LEFT OVERRIDE
+//     and the C1 controls while the text sink escaped the same name -- one
+//     input, two sinks, opposite answers (#2454).  A JSON text must also be
 //     valid UTF-8 (RFC 8259 section 8.1), and these strings include paths taken
 //     straight from argv, which on POSIX are byte strings that need not be UTF-8
-//     at all.  A Latin-1 filename would put a lone 0xE9 inside a string and the
+//     at all; a Latin-1 filename would put a lone 0xE9 inside a string and the
 //     document would not decode.
 //
-// A byte that is not part of a well-formed sequence is therefore replaced with
-// U+FFFD.  Substituting \u00XX instead would assert the byte was Latin-1, which
-// is a guess; U+FFFD records that the input was not text, which is the fact.
+// Escaping by code point settles both: the output is pure ASCII, so it is valid
+// UTF-8 by construction, and it decodes back to exactly the input text.
+//
+// A byte that is not part of a well-formed sequence is replaced with U+FFFD.
+// Substituting \u00XX instead would assert the byte was Latin-1, which is a
+// guess; U+FFFD records that the input was not text, which is the fact.
+//
+// DEL (0x7F) is escaped too, so that this sink and icSanitizeConsoleText()
+// agree on the whole control set rather than only on the parts above 0x80.
 inline std::string icJsonEscape(const char* szText)
 {
   static const char hex[] = "0123456789abcdef";
@@ -274,24 +292,71 @@ inline std::string icJsonEscape(const char* szText)
       continue;
     }
 
+    // #2454: DEL is terminal-active and icSanitizeConsoleText() escapes it, so
+    // letting it through here would leave exactly the sink-divergence this fix
+    // is filed against, just at 0x7F instead of above 0x80.
+    if (ch == 0x7f) {
+      result += "\\u007f";
+      p++;
+      continue;
+    }
+
     if (ch < 0x80) {
       result += (char)ch;
       p++;
       continue;
     }
 
-    // icUtf8SequenceLength() reads up to three bytes past p.  That is safe here
-    // because it stops at the first byte outside the continuation range, and the
-    // terminating NUL is outside it -- a truncated sequence at the end of the
-    // string returns 0 rather than reading past the terminator.
-    size_t len = icUtf8SequenceLength(p);
-    if (!len) {
+    // #2454: escape non-ASCII by codepoint instead of appending it verbatim.
+    // Well-formed UTF-8 used to be copied through unchanged, so --json and
+    // --evidence-json still emitted U+202E RIGHT-TO-LEFT OVERRIDE and the C1
+    // controls -- the exact codepoints the text sink has escaped since #2419,
+    // and the ones #2437 re-spelled by codepoint.  One name reached two sinks
+    // and got opposite answers.
+    //
+    // This is transparent to a machine consumer: the raw bytes and the \uXXXX
+    // escape are the same string to any conformant JSON parser (RFC 8259 s7).
+    // What changes is that a human cat-ing the output no longer receives live
+    // terminal-active codepoints (CVE-2021-42574).  Output is now pure ASCII.
+    //
+    // icDecodeUtf8() is the decoder #2437 added, so both sinks now share one
+    // whitelist rather than two implementations of the same table.  It reads up
+    // to three bytes past p, which is safe for the same reason the previous
+    // length helper was: it stops at the first byte outside the continuation
+    // range, and the terminating NUL is outside it, so a truncated sequence at
+    // the end of the string returns 0 rather than reading past the terminator.
+    unsigned int cp = 0;
+    int len = icDecodeUtf8(p, &cp);
+    if (len < 1) {
       result += "\\ufffd";
       p++;
       continue;
     }
 
-    result.append((const char*)p, len);
+    // JSON has no \U escape.  A codepoint above the BMP must be spelled as a
+    // UTF-16 surrogate pair, which is why this cannot reuse the text sink's
+    // \U0001F600 spelling from icSanitizeConsoleText() -- that is valid there
+    // and would be invalid JSON here.
+    if (cp > 0xffffu) {
+      const unsigned int v = cp - 0x10000u;
+      const unsigned int hiSur = 0xd800u + (v >> 10);
+      const unsigned int loSur = 0xdc00u + (v & 0x3ffu);
+      int shift;
+
+      result += "\\u";
+      for (shift = 12; shift >= 0; shift -= 4)
+        result += hex[(hiSur >> shift) & 0xfu];
+      result += "\\u";
+      for (shift = 12; shift >= 0; shift -= 4)
+        result += hex[(loSur >> shift) & 0xfu];
+    }
+    else {
+      int shift;
+
+      result += "\\u";
+      for (shift = 12; shift >= 0; shift -= 4)
+        result += hex[(cp >> shift) & 0xfu];
+    }
     p += len;
   }
 

--- a/Tools/CmdLine/IccPawgReport/PawgReport.cpp
+++ b/Tools/CmdLine/IccPawgReport/PawgReport.cpp
@@ -2431,13 +2431,16 @@ int DumpPawgReport(const char *szFilename, bool bJson)
   // #2414: the report header echoes the operand, so a path carrying terminal
   // control sequences reached the console verbatim (#2406).
   //
-  // The JSON writer above is NOT equivalent cover, and an earlier draft of this
-  // comment claimed it was.  icJsonEscape() (Tools/CmdLine/IccCmdLineUtil.h)
-  // escapes ESC as \u001b but appends well-formed UTF-8 unchanged, so U+202E
-  // RIGHT-TO-LEFT OVERRIDE and the C1 controls -- exactly the codepoints #2437
-  // added the by-codepoint escape for -- still reach a terminal that cats the
-  // --json output.  Widening icJsonEscape() changes a shared helper and the
-  // shape of every JSON consumer's input, so it is filed rather than done here.
+  // The JSON writer above used NOT to be equivalent cover: icJsonEscape()
+  // escaped ESC as \u001b but appended well-formed UTF-8 unchanged, so U+202E
+  // RIGHT-TO-LEFT OVERRIDE and the C1 controls still reached a terminal that
+  // cats the --json output.  That was filed as #2454 rather than fixed here,
+  // because widening a shared helper changes every JSON consumer's input.
+  //
+  // #2454 has since landed: icJsonEscape() (Tools/CmdLine/IccCmdLineUtil.h) now
+  // escapes by codepoint using the same icDecodeUtf8() this text path reaches
+  // through icSanitizeConsoleText(), so both sinks carry one whitelist and the
+  // JSON output is pure ASCII.  The two paths agree; neither is a gap.
   printf("Profile:    %s\n",
          szFilename ? icSanitizeConsoleText(szFilename).c_str() : "(null)");
   printf("Size:       %zu bytes\n", raw.data.size());


### PR DESCRIPTION
Closes #2454. This is option 1 from the issue.

## The defect

`icJsonEscape()` escaped the C0 controls and the JSON metacharacters, then validated
any non-ASCII sequence and appended its BYTES verbatim. One filename reached two sinks
in the same build and got opposite answers:

| sink | output |
|---|---|
| `iccPawgReport <name>` (text) | escaped since #2419 |
| `iccPawgReport <name> --json` | raw `E2 80 AE` |

So `--json` and `--evidence-json` still emitted live U+202E RIGHT-TO-LEFT OVERRIDE and
the C1 controls — the codepoints #2437 had just re-spelled on the text side. Harmless
to a machine consumer; not harmless when a human cats the output, which is the threat
model #2406/#2437 established here (CVE-2021-42574).

## The fix

Escape by codepoint using `icDecodeUtf8()`, the decoder #2437 added, so both sinks
share **one** whitelist rather than two implementations of the same table. Output is
pure ASCII.

**JSON has no `\U` escape** (RFC 8259 §7), so a codepoint above the BMP is a UTF-16
surrogate pair — U+1F600 is `\ud83d\ude00`, not the `\U0001F600` the text sink uses.
Reusing the text sink's spelling would have emitted a document that does not parse.
Case 4 fails against that mistake as well as against master.

U+007F DEL is escaped too. `icSanitizeConsoleText()` escapes it and this sink did not,
so my first draft left the same divergence just below 0x80 — "both sinks share one
whitelist" was not true as first written. Case 6 pins it.

## What my survey missed

I swept stored fixtures, Python and MATLAB, and reported that nothing byte-compares a
tool's JSON. True, and it missed the thing that actually breaks:
`.github/ci/regression/qa-evidence-helpers.cpp` asserts the old passthrough inline in
three cases, so `iccdev.qa-evidence-helpers` would have gone **red on every lane**.
Those three keep the #1853 mojibake guard they were written for and now assert the
single-codepoint spelling rather than being deleted — escaping each *byte* as `\u00XX`
is the #1853 bug; escaping each *codepoint* is not.

Corrected survey: **5** tracked source files call the helper, not the 6 I posted. Of 23
tracked JSON files exactly one carries a non-ASCII byte and it is a schema under
`docs/`, not tool output. No script, test, Python or MATLAB compares JSON text.

## Two more things this fixes

- **The suite's own FAIL path printed the unescaped result.** On a regressed build
  that is exactly the raw terminal-active bytes the test exists to catch, so a failure
  would have written a live U+202E into the CI log and reversed the rest of the line —
  the exposure this repo closed, reintroduced where it is guaranteed to fire. The
  failing value now goes through `icSanitizeConsoleText()`; verified by compiling the
  suite against master's header and confirming the whole failure log is pure ASCII.
- **`PawgReport.cpp` carried this issue's own deferral note**, still saying the JSON
  sink is not equivalent cover and the widening "is filed rather than done here". Left
  alone it tells the next reader the defect is open at the sink that motivated it,
  which is how a closed issue gets re-filed. It now points at the landed fix.

`icUtf8SequenceLength()` is retained although this was its only in-tree caller: it
ships in the installed public header, so removing it is an API change outside this
issue's scope. It carries a note saying so, to survive a dead-code sweep. Happy to
drop it in a follow-up if you would rather.

## Red/green

12 cases: **1-6 fail against master**, all 12 pass here. Cases 7-12 pass on BOTH builds
so a blunter fix — escaping every byte >= 0x80 per byte, dropping the metacharacter
escapes, or losing the U+FFFD handling — cannot satisfy the suite.

End to end: `iccPawgReport --json` on a filename carrying U+202E emits `\u202e`, the
whole document is pure ASCII, it parses, and it decodes back to the original filename.

Strict clang build: 0 warnings, 0 errors. Pre-PR `ci_scope=source` dispatch
[34155985133](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34155985133):
all lanes green.
