### PR TITLE
fix(#2463): give the Bash sanitizer the C1 strip the other two already have, and make its fallback work

### DIFF
--- a/.github/scripts/sanitize-sed.sh
+++ b/.github/scripts/sanitize-sed.sh
@@ -98,9 +98,24 @@ escape_html() {
   printf '%s' "$s"
 }
 
+# ANSI escape rules, built from real bytes for the same reason the Unicode fallback
+# below is: CSI (ESC [ ... final), OSC (ESC ] ... BEL), then any remaining bare ESC.
+_SAN_ANSI_RE=$'s/\x1b\[[0-9;]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b//g'
+
 # _strip_unicode_control STRING
 # Remove Unicode control/formatting characters that enable Trojan Source,
 # invisible padding, and homoglyph attacks:
+#   - C1 controls (U+0080-U+009F), in their well-formed UTF-8 spelling C2 80..C2 9F.
+#     U+009B is CSI, the same introducer the ANSI rule strips in its ESC [ form, so
+#     leaving it reopens log spoofing from the other side.  sanitize.ps1 already
+#     drops this block (keep-set 0x20..0x7E plus >= 0xA0), as does the library's
+#     icSanitizeConsoleText().
+#     KNOWN RESIDUE: a RAW 0x80-0x9F byte -- malformed UTF-8, not a codepoint -- is
+#     still passed through here.  It cannot be removed with tr: those same byte
+#     values are legitimate UTF-8 continuation bytes, and blanket-deleting them
+#     would corrupt ordinary text (the suite's own UTF-8 case is E4 B8 96 E7 95 8C,
+#     which contains 0x96).  Removing it needs a real UTF-8 decode, as the library
+#     side does; sanitize_ref() is unaffected because it whitelists to ASCII.
 #   - Bidi overrides/embeddings (U+202A-202E, U+2066-2069)
 #   - Zero-width chars (U+200B-200F, U+2060, U+FEFF)
 #   - Tag characters (U+E0001-E007F) - used in emoji but abusable
@@ -109,6 +124,7 @@ _strip_unicode_control() {
   local s="$1"
   if command -v perl >/dev/null 2>&1; then
     s="$(printf '%s' "$s" | perl -CS -pe '
+      s/[\x{0080}-\x{009F}]//g;
       s/[\x{200B}-\x{200F}]//g;
       s/[\x{2028}-\x{202F}]//g;
       s/[\x{2060}-\x{2069}]//g;
@@ -117,15 +133,29 @@ _strip_unicode_control() {
       s/[\x{FFF9}-\x{FFFB}]//g;
     ')"
   else
-    # Fallback: strip known UTF-8 byte sequences for the most dangerous chars
-    s="$(printf '%s' "$s" | sed -E '
-      s/\xe2\x80[\x8b-\x8f]//g;
-      s/\xe2\x80[\xa8-\xaf]//g;
-      s/\xe2\x81[\xa0-\xa9]//g;
-      s/\xf3\xa0[\x80-\x81][\x80-\xbf]//g;
-      s/\xef\xbb\xbf//g;
-      s/\xef\xbf[\xb9-\xbb]//g;
-    ')"
+    # Fallback: strip known UTF-8 byte sequences for the most dangerous chars.
+    #
+    # LC_ALL=C is the load-bearing part, and it is why five of these six rules used
+    # to be dead.  In a UTF-8 locale a bracket expression like [\xa8-\xaf] is a
+    # CHARACTER range whose endpoints are not characters, so it matches nothing;
+    # only the bracket-free U+FEFF rule fired, and a U+202E filename came through
+    # sanitize_line() byte-identical on a perl-less runner.  Under LC_ALL=C the same
+    # ranges are byte ranges and match -- which is exactly why sanitize_ref() below
+    # already sets it.  (GNU sed does honour \xNN inside a bracket expression; the
+    # locale, not the escape, was the bug.)
+    #
+    # The $'...' expansion is belt-and-braces on top of that: it hands sed real bytes
+    # rather than escape text, so the rules also work on BSD sed, which does not
+    # interpret \xNN at all.  macOS runners source this file.
+    local re
+    re=$'s/\xc2[\x80-\x9f]//g;'                  # U+0080-U+009F C1 controls
+    re+=$'s/\xe2\x80[\x8b-\x8f]//g;'             # U+200B-U+200F zero-width
+    re+=$'s/\xe2\x80[\xa8-\xaf]//g;'             # U+2028-U+202F separators, bidi overrides
+    re+=$'s/\xe2\x81[\xa0-\xa9]//g;'             # U+2060-U+2069 word joiner, bidi isolates
+    re+=$'s/\xf3\xa0[\x80-\x81][\x80-\xbf]//g;'  # U+E0001-U+E007F tag characters
+    re+=$'s/\xef\xbb\xbf//g;'                    # U+FEFF BOM
+    re+=$'s/\xef\xbf[\xb9-\xbb]//g;'             # U+FFF9-U+FFFB interlinear annotation
+    s="$(printf '%s' "$s" | LC_ALL=C sed -E "$re")"
   fi
   printf '%s' "$s"
 }
@@ -139,8 +169,14 @@ _strip_ctrl_keep_newlines() {
   # remove CRs explicitly
   s="${s//$'\r'/}"
   # strip ANSI escape sequences: CSI (\x1b[...m), OSC (\x1b]...\x07), then any remaining bare ESC
-  s="$(printf '%s' "$s" | sed -E 's/\x1b\[[0-9;]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b//g')"
-  # strip Unicode bidi overrides, zero-width chars, and formatting controls
+  # Same escape/locale care as _strip_unicode_control: built from real bytes and
+  # matched under LC_ALL=C, so these rules also fire on BSD sed (macOS runners),
+  # which does not interpret \xNN.  Without that they matched the literal text
+  # "x1b" there and only the tr below removed the ESC, leaving "[31m" in the summary.
+  s="$(printf '%s' "$s" | LC_ALL=C sed -E "$_SAN_ANSI_RE")"
+  # strip Unicode bidi overrides, zero-width chars, and formatting controls.
+  # This is also what removes the C1 controls: the tr below works on BYTES and
+  # cannot see them, because UTF-8 spells U+0080-U+009F as C2 80..C2 9F.
   s="$(_strip_unicode_control "$s")"
   # remove NUL and other C0 control chars except LF (0x0A), plus DEL (0x7F)
   s="$(printf '%s' "$s" | tr -d '\000-\011\013\014\016-\037\177')"
@@ -157,8 +193,14 @@ _strip_ctrl_remove_newlines() {
   s="${s//$'\r'/}"
   s="${s//$'\n'/ }"
   # strip ANSI escape sequences: CSI (\x1b[...m), OSC (\x1b]...\x07), then any remaining bare ESC
-  s="$(printf '%s' "$s" | sed -E 's/\x1b\[[0-9;]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b//g')"
-  # strip Unicode bidi overrides, zero-width chars, and formatting controls
+  # Same escape/locale care as _strip_unicode_control: built from real bytes and
+  # matched under LC_ALL=C, so these rules also fire on BSD sed (macOS runners),
+  # which does not interpret \xNN.  Without that they matched the literal text
+  # "x1b" there and only the tr below removed the ESC, leaving "[31m" in the summary.
+  s="$(printf '%s' "$s" | LC_ALL=C sed -E "$_SAN_ANSI_RE")"
+  # strip Unicode bidi overrides, zero-width chars, and formatting controls.
+  # This is also what removes the C1 controls: the tr below works on BYTES and
+  # cannot see them, because UTF-8 spells U+0080-U+009F as C2 80..C2 9F.
   s="$(_strip_unicode_control "$s")"
   # remove other control characters (NUL, etc.) plus DEL (0x7F)
   s="$(printf '%s' "$s" | tr -d '\000-\011\013\014\016-\037\177')"
@@ -325,6 +367,13 @@ detect_hidden_chars() {
   # Check for BOM (U+FEFF = EF BB BF in UTF-8)
   if printf '%s' "$input" | LC_ALL=C grep -qP '\xef\xbb\xbf' 2>/dev/null; then
     details="${details}  - U+FEFF (BOM / Zero-Width No-Break Space)\n"
+    found=0
+  fi
+
+  # Check for C1 controls (U+0080-U+009F = C2 80-9F).  Listed so a CSI-carrying ref
+  # is named rather than falling through to the "unknown category" catch-all below.
+  if printf '%s' "$input" | LC_ALL=C grep -qP '\xc2[\x80-\x9f]' 2>/dev/null; then
+    details="${details}  - U+0080-U+009F (C1 Control)\n"
     found=0
   fi
 

--- a/.github/tests/test_powershell_sanitizer.ps1
+++ b/.github/tests/test_powershell_sanitizer.ps1
@@ -88,6 +88,41 @@ Assert-Eq "Filename path separators neutralized" `
     ".._.._etc_passwd" `
     (Sanitize-Filename -InputString "../../etc/passwd")
 
+# -----------------------------------------------------------------------------
+# C1 controls (U+0080-U+009F) -- Bash/PowerShell parity anchors
+#
+# Strip-CtrlRemoveNewlines keeps 0x20..0x7E plus >= 0xA0, so this block is already
+# dropped here; U+009B is CSI, the same introducer the ANSI rule above strips in
+# its ESC-bracket form.  The Bash side could not see it at all until now: its C0
+# strip is tr, which works on BYTES, and UTF-8 spells this block C2 80..C2 9F.
+# These cases pin the behaviour sanitize-sed.sh was just corrected to match, so a
+# future edit to either script cannot silently drift from the other.
+# -----------------------------------------------------------------------------
+
+Assert-Eq "C1 CSI U+009B stripped" `
+    "log2K1Gsp" `
+    (Sanitize-Line -InputString "log$([char]0x9B)2K$([char]0x9B)1Gsp")
+
+Assert-Eq "C1 low bound U+0080 stripped" `
+    "ab" `
+    (Sanitize-Line -InputString "a$([char]0x80)b")
+
+Assert-Eq "C1 high bound U+009F stripped" `
+    "ab" `
+    (Sanitize-Line -InputString "a$([char]0x9F)b")
+
+Assert-Eq "U+00A0 just above C1 preserved" `
+    "a$([char]0xA0)b" `
+    (Sanitize-Line -InputString "a$([char]0xA0)b")
+
+Assert-Eq "Latin-1 letter above C1 preserved" `
+    "a$([char]0xE9)b" `
+    (Sanitize-Line -InputString "a$([char]0xE9)b")
+
+Assert-Eq "C1 CSI stripped by Sanitize-Print" `
+    "log2K" `
+    (Sanitize-Print -InputString "log$([char]0x9B)2K")
+
 Assert-Eq "Version marker" `
     "iccDEV-sanitizer-v4" `
     (Sanitizer-Version)

--- a/.github/tests/test_sanitization.sh
+++ b/.github/tests/test_sanitization.sh
@@ -32,6 +32,23 @@ echo ""
 pass=0
 fail=0
 
+# _log_value STRING
+# Render a value for the log.  The payloads here are attack strings by design, so
+# echoing them raw writes live CSI, bidi and zero-width sequences into the Actions
+# log -- the exact spoofing this suite exists to prevent, and it lands in the one
+# place a human reads closely, the FAIL diagnostic.  Anything that is not printable
+# ASCII is shown as hex instead.  Filtering with tr rather than a grep guard keeps
+# this correct under the `set -o pipefail` above.
+_log_value() {
+  local stripped
+  stripped=$(printf '%s' "$1" | LC_ALL=C tr -dc '\040-\176')
+  if [ "$stripped" = "$1" ]; then
+    printf '%s' "$1"
+  else
+    printf 'hex:%s' "$(printf '%s' "$1" | xxd -p | tr -d '\n')"
+  fi
+}
+
 run_test() {
   local test_name="$1"
   local input="$2"
@@ -39,12 +56,12 @@ run_test() {
   local func="${4:-sanitize_line}"
 
   echo "Test $((pass + fail + 1)): $test_name"
-  echo "  Input:    $input"
-  echo "  Expected: $expected"
+  echo "  Input:    $(_log_value "$input")"
+  echo "  Expected: $(_log_value "$expected")"
 
   local result
   result=$("$func" "$input")
-  echo "  Result:   $result"
+  echo "  Result:   $(_log_value "$result")"
 
   if [ "$result" = "$expected" ]; then
     echo "  [PASS]"
@@ -115,6 +132,113 @@ run_test "Zero-width characters (stripped by v3)" \
 run_test "Unicode tag characters stripped" \
   "$(printf 'tag\xf3\xa0\x81\xa1char')" \
   "tagchar"
+
+# -----------------------------------------------------------------------------
+# C1 controls (U+0080-U+009F)
+#
+# tr works on BYTES, so the C0/DEL strip in _strip_ctrl_* cannot see these: UTF-8
+# spells them C2 80..C2 9F.  U+009B is CSI -- the same introducer the ANSI rule
+# strips in its ESC [ form -- so a C1 that survives reopens log spoofing from the
+# other side.  sanitize.ps1 already drops the block (keep-set 0x20..0x7E plus
+# >= 0xA0) and the library's icSanitizeConsoleText() escapes it as the six
+# characters backslash-u-0-0-9-B, so these cases pin Bash to the behaviour the
+# other two implementations already have.
+# -----------------------------------------------------------------------------
+
+run_test "C1 CSI U+009B stripped" \
+  "$(from_hex '6c6f67c29b324bc29b31477370')" \
+  "log2K1Gsp"
+
+run_test "C1 low bound U+0080 stripped" \
+  "$(from_hex '61c28062')" \
+  "ab"
+
+run_test "C1 high bound U+009F stripped" \
+  "$(from_hex '61c29f62')" \
+  "ab"
+
+run_test "U+00A0 just above C1 preserved" \
+  "$(from_hex '61c2a062')" \
+  "$(from_hex '61c2a062')"
+
+run_test "Latin-1 letter above C1 preserved" \
+  "$(from_hex '61c3a962')" \
+  "$(from_hex '61c3a962')"
+
+run_test "C1 CSI stripped by sanitize_print" \
+  "$(from_hex '6c6f67c29b324b')" \
+  "log2K" \
+  "sanitize_print"
+
+# -----------------------------------------------------------------------------
+# The perl-less fallback in _strip_unicode_control
+#
+# The fallback is a safety net that nothing ever exercised: every CI runner has
+# perl, so the sed branch was dead code, and five of its six rules had never
+# removed anything.  They were written as backslash-x-N-N inside bracket
+# expressions, and GNU sed honours that escape outside a bracket expression but
+# not inside one -- so only the bracket-free U+FEFF rule fired, and a U+202E
+# filename came through sanitize_line() byte-identical.  These cases run the
+# fallback on every runner by masking perl, holding both branches to one answer.
+# -----------------------------------------------------------------------------
+
+# Shadow `command` inside a subshell so `command -v perl` fails and the sed branch
+# runs.  Production code is untouched: nothing here adds a test-only switch to it.
+# shellcheck disable=SC2317  # reached indirectly, as run_test's "$func"
+sanitize_line_no_perl() {
+  (
+    command() {
+      if [ "${2:-}" = "perl" ]; then return 1; fi
+      builtin command "$@"
+    }
+    sanitize_line "$1"
+  )
+}
+
+run_test "Fallback: control case, plain ASCII survives" \
+  "no-perl-plain-ascii" \
+  "no-perl-plain-ascii" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: U+202E bidi override stripped" \
+  "$(from_hex '676e702ee280ae636369')" \
+  "gnp.cci" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: U+200B zero-width stripped" \
+  "$(from_hex '61e2808b62')" \
+  "ab" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: U+2066 bidi isolate stripped" \
+  "$(from_hex '61e281a662')" \
+  "ab" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: U+E0001 tag character stripped" \
+  "$(from_hex '61f3a0808162')" \
+  "ab" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: U+FFF9 interlinear annotation stripped" \
+  "$(from_hex '61efbfb962')" \
+  "ab" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: U+FEFF BOM stripped" \
+  "$(from_hex '61efbbbf62')" \
+  "ab" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: C1 CSI U+009B stripped" \
+  "$(from_hex '61c29b62')" \
+  "ab" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: U+2027 below the range preserved" \
+  "$(from_hex '61e280a762')" \
+  "$(from_hex '61e280a762')" \
+  "sanitize_line_no_perl"
 
 # =============================================================================
 # Control Character and Injection Tests


### PR DESCRIPTION
Part of #2463 — the two defects. The orphaned PowerShell suite reported in that
issue is left open for your ruling, so this does not close it.

Origin: the pre-merge note on #2437, *"sanitizer-sed & windows equiv CI scripts
needs same manual review and tests"*.

## 1. The C1 controls passed through

`sanitize_line()` / `sanitize_print()` strip C0 with `tr -d`. `tr` works on
**bytes**; UTF-8 spells U+0080-U+009F as `C2 80..C2 9F`, so it never saw them.
U+009B is CSI — the same introducer the ANSI rule two lines above strips in its
`ESC [` form.

```
in  6c6f67 c29b 324b c29b 3147 7370 6f6f66
out 6c6f67 c29b 324b c29b 3147 7370 6f6f66     before: byte-identical
out 6c6f67      324b      3147 7370 6f6f66     after
```

Bash was the only one of the three implementations that admitted the block —
`sanitize.ps1` keeps `0x20..0x7E` plus `>= 0xA0`, and `icSanitizeConsoleText()`
escapes by codepoint. `sanitizer-scripts.instructions.md` asks for that parity
explicitly.

## 2. The perl-less fallback stripped nothing but the BOM

Five of its six rules had never removed anything, so on a perl-less runner a
Trojan Source filename came through `sanitize_line()` unchanged:

```
gnp.<U+202E>cci -> gnp.<U+202E>cci
```

**The cause is the missing `LC_ALL=C`, not the escape spelling.** In a UTF-8
locale `[\xa8-\xaf]` is a *character* range whose endpoints are not characters, so
it matches nothing and `sed` still exits 0. The four-way that isolates it:

| pattern form | locale | result |
|---|---|---|
| `\xNN` text | UTF-8 | `41e280ae42` dead |
| `\xNN` text | `LC_ALL=C` | `4142` works |
| `$''` bytes | UTF-8 | `41e280ae42` dead |
| `$''` bytes | `LC_ALL=C` | `4142` works |

`sanitize_ref()` already sets `LC_ALL=C` for exactly this reason. GNU sed *does*
honour `\xNN` inside a bracket expression — I had this wrong in an earlier draft
and `/code-review` caught it; the comment now records the real mechanism, because
a maintainer trusting the wrong one would drop `LC_ALL=C` as redundant and
silently reopen the bug. Building the patterns from real bytes is kept on top: it
buys BSD sed, which does not interpret `\xNN` at all, and macOS runners source
this file. The adjacent ANSI rules had the same gap and get the same treatment.

## Scope, stated rather than implied

This removes the C1 block in its **well-formed UTF-8** spelling. A **raw**
`0x80-0x9F` byte still passes, and `tr` cannot be used to catch it: those byte
values are also legitimate UTF-8 continuation bytes — the suite's own UTF-8 case
is `E4 B8 96 E7 95 8C`, which contains `0x96` — so a blanket delete would corrupt
ordinary text. Removing that residue needs a real UTF-8 decode, as the library
side does. It is recorded in the header comment rather than papered over.
`sanitize_ref()` is unaffected; it whitelists to ASCII.

## Tests

`test_sanitization.sh` gains 15 cases: the C1 block through both entry points,
and the fallback exercised **on every runner** by masking perl in a subshell, so
the two branches are held to one answer. Production code takes no test-only
switch.

| | result |
|---|---|
| against the unfixed script | **10 fail** |
| with the fix | **101 pass, 0 fail** |

The control cases — U+00A0 and U+00E9 preserved, U+2027 preserved, plain ASCII
preserved, U+FEFF stripped either way — pass in **both** states, so they are not
vacuous and the fix does not over-strip.

`run_test()` now logs non-ASCII values as hex. These payloads are attack strings
by design, and echoing them raw wrote live CSI and bidi sequences into the Actions
log — into the FAIL diagnostic a human reads most closely.

`detect_hidden_chars()` gains the matching C1 category, so a CSI-carrying ref is
named instead of falling through to its "unknown category" catch-all.

`test_powershell_sanitizer.ps1` gains the same six anchors on the Windows leg.
**Stated plainly: these are read from `sanitize.ps1`'s keep-set, not run** — there
is no pwsh in my environment, so they execute for the first time on that runner.

## Verification

- `test_sanitization.sh` 101/101; the three sibling signature suites pass.
- The `trivy#10253` reproduction step in `ci-sanitizer-tests.yml` replayed
  verbatim: unchanged, rc=0.
- `shellcheck` clean on both changed shell files (bare, as the pre-flight gate
  runs it).
- Local pre-flight: 0 failures, 2 skips.
- No live control character in any changed file or in this branch's commit
  message — checked with a byte-level scanner validated against a known positive
  first, because `grep -P` silently reported clean on a file that did contain one.


Pre-PR dispatched run (ci_scope=auto, per the Suggested PR Workflow): [34159997034](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34159997034) — concluded success before this PR was opened.
