### PR TITLE
fix(#2463): decode before dropping a raw C1 byte

### DIFF
--- a/.github/scripts/sanitize-sed.sh
+++ b/.github/scripts/sanitize-sed.sh
@@ -102,6 +102,74 @@ escape_html() {
 # below is: CSI (ESC [ ... final), OSC (ESC ] ... BEL), then any remaining bare ESC.
 _SAN_ANSI_RE=$'s/\x1b\[[0-9;]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b//g'
 
+# _strip_stray_c1 STRING
+# Remove raw 0x80-0x9F bytes that are NOT part of a well-formed UTF-8 sequence.
+#
+# These cannot be removed with tr: the same byte values are legitimate UTF-8
+# continuation bytes, so blanket deletion corrupts ordinary text -- the suite's
+# own UTF-8 case is E4 B8 96 E7 95 8C, which contains 0x96.  Telling the two
+# apart needs an actual decode, so this walks the byte stream the way
+# icDecodeUtf8() (IccProfLib/IccFileUtil.h) does and drops a 0x80-0x9F byte only
+# where no well-formed sequence claims it.  U+009B is CSI -- the same introducer
+# the ANSI rule strips in its ESC [ form -- and a terminal in a single-byte mode
+# acts on the raw byte, so leaving it reopened log spoofing from a third side.
+#
+# Deliberately narrow: a malformed byte OUTSIDE 0x80-0x9F is still passed
+# through, which is what the "overlong UTF-8 bytes preserved (no decode)" case in
+# test_sanitization.sh asserts.  Widening this to drop every ill-formed byte
+# would reverse that decision silently -- that test only checks no ASCII '<'/'>'
+# is synthesized, which dropping satisfies just as well as preserving.
+#
+# awk rather than perl: the perl-less fallback is the path #2463 found stripping
+# nothing at all, so this rule must not depend on perl being installed.  awk is
+# not guarded here because it is already an unguarded hard dependency of this
+# file -- _trim_whitespace() below pipes through it, and sanitize_line() calls
+# that.  A `command -v awk` fallback would therefore rescue only sanitize_print(),
+# and would rescue it by silently returning the input unfiltered, which is the
+# raw-CSI residue this function exists to remove.  Failing loudly is correct.
+_strip_stray_c1() {
+  local s="$1"
+  printf '%s' "$s" | LC_ALL=C awk '
+    BEGIN {
+      for (i = 0; i < 256; i++) ord[sprintf("%c", i)] = i
+      # Second-byte bounds mirror icDecodeUtf8(): E0 A0 rejects the overlong
+      # 3-byte forms, ED 9F the surrogates, F0 90 the overlong 4-byte forms,
+      # and F4 8F caps at U+10FFFF.
+      lo[224] = 160; hi[224] = 191
+      lo[237] = 128; hi[237] = 159
+      lo[240] = 144; hi[240] = 191
+      lo[244] = 128; hi[244] = 143
+    }
+    {
+      out = ""; n = length($0); i = 1
+      while (i <= n) {
+        c = ord[substr($0, i, 1)]
+        len = 0
+        if (c < 128)                   len = 1
+        else if (c >= 194 && c <= 223) len = 2
+        else if (c >= 224 && c <= 239) len = 3
+        else if (c >= 240 && c <= 244) len = 4
+        if (len == 1) { out = out substr($0, i, 1); i++; continue }
+        if (len > 1) {
+          L = (c in lo) ? lo[c] : 128
+          H = (c in hi) ? hi[c] : 191
+          ok = (i + len - 1 <= n)
+          for (k = 2; ok && k <= len; k++) {
+            b = ord[substr($0, i + k - 1, 1)]
+            if (k == 2) { if (b < L   || b > H)   ok = 0 }
+            else        { if (b < 128 || b > 191) ok = 0 }
+          }
+          if (ok) { out = out substr($0, i, len); i += len; continue }
+        }
+        # Not the start of a well-formed sequence: drop only a stray C1.
+        if (c < 128 || c > 159) out = out substr($0, i, 1)
+        i++
+      }
+      print out
+    }
+  '
+}
+
 # _strip_unicode_control STRING
 # Remove Unicode control/formatting characters that enable Trojan Source,
 # invisible padding, and homoglyph attacks:
@@ -110,18 +178,20 @@ _SAN_ANSI_RE=$'s/\x1b\[[0-9;]*[A-Za-z]//g; s/\x1b\][^\x07]*\x07//g; s/\x1b//g'
 #     leaving it reopens log spoofing from the other side.  sanitize.ps1 already
 #     drops this block (keep-set 0x20..0x7E plus >= 0xA0), as does the library's
 #     icSanitizeConsoleText().
-#     KNOWN RESIDUE: a RAW 0x80-0x9F byte -- malformed UTF-8, not a codepoint -- is
-#     still passed through here.  It cannot be removed with tr: those same byte
-#     values are legitimate UTF-8 continuation bytes, and blanket-deleting them
-#     would corrupt ordinary text (the suite's own UTF-8 case is E4 B8 96 E7 95 8C,
-#     which contains 0x96).  Removing it needs a real UTF-8 decode, as the library
-#     side does; sanitize_ref() is unaffected because it whitelists to ASCII.
+#     A RAW 0x80-0x9F byte -- malformed UTF-8, not a codepoint -- is handled by
+#     _strip_stray_c1() below rather than here, because neither branch of this
+#     function can see one: perl works on decoded codepoints and the sed rules
+#     match well-formed spellings.  sanitize_ref() is unaffected either way
+#     because it whitelists to ASCII.
 #   - Bidi overrides/embeddings (U+202A-202E, U+2066-2069)
 #   - Zero-width chars (U+200B-200F, U+2060, U+FEFF)
 #   - Tag characters (U+E0001-E007F) - used in emoji but abusable
 # Uses perl for reliable multi-byte removal; falls back to sed byte patterns.
 _strip_unicode_control() {
   local s="$1"
+  # Stray C1 bytes first, for the reason given above: neither branch below can
+  # see a byte that is not a codepoint and not a well-formed spelling.
+  s="$(_strip_stray_c1 "$s")"
   if command -v perl >/dev/null 2>&1; then
     s="$(printf '%s' "$s" | perl -CS -pe '
       s/[\x{0080}-\x{009F}]//g;
@@ -372,7 +442,13 @@ detect_hidden_chars() {
 
   # Check for C1 controls (U+0080-U+009F = C2 80-9F).  Listed so a CSI-carrying ref
   # is named rather than falling through to the "unknown category" catch-all below.
-  if printf '%s' "$input" | LC_ALL=C grep -qP '\xc2[\x80-\x9f]' 2>/dev/null; then
+  # The raw-byte half needs the same decode _strip_stray_c1() does: a bare
+  # [\x80-\x9f] grep here would mislabel every CJK ref, because the 0x96 in
+  # E4 B8 96 is a continuation byte.  If the decoder removes anything, the input
+  # carried a stray C1.  Both sides go through $( ) so trailing-newline handling
+  # cannot make them differ spuriously.
+  if printf '%s' "$input" | LC_ALL=C grep -qP '\xc2[\x80-\x9f]' 2>/dev/null ||
+     [ "$(_strip_stray_c1 "$input")" != "$(printf '%s' "$input")" ]; then
     details="${details}  - U+0080-U+009F (C1 Control)\n"
     found=0
   fi

--- a/.github/tests/test_sanitization.sh
+++ b/.github/tests/test_sanitization.sh
@@ -49,6 +49,33 @@ _log_value() {
   fi
 }
 
+# run_detect_test NAME INPUT LABEL EXPECT(yes|no)
+# detect_hidden_chars() reports rather than transforms, so it needs a
+# contains/not-contains assertion instead of run_test's exact match.
+run_detect_test() {
+  local test_name="$1" input="$2" label="$3" expect="$4"
+
+  echo "Test $((pass + fail + 1)): $test_name"
+  echo "  Input:    $(_log_value "$input")"
+  echo "  Expected: $expect \"$label\""
+
+  local out
+  out=$(detect_hidden_chars "$input" 2>&1 || true)
+
+  local got="no"
+  case "$out" in *"$label"*) got="yes" ;; esac
+  echo "  Result:   $got"
+
+  if [ "$got" = "$expect" ]; then
+    echo "  [PASS]"
+    pass=$((pass + 1))
+  else
+    echo "  [FAIL]"
+    fail=$((fail + 1))
+  fi
+  echo ""
+}
+
 run_test() {
   local test_name="$1"
   local input="$2"
@@ -171,6 +198,54 @@ run_test "C1 CSI stripped by sanitize_print" \
   "sanitize_print"
 
 # -----------------------------------------------------------------------------
+# RAW C1 bytes (0x80-0x9F not in a well-formed UTF-8 sequence)
+#
+# The cases above are the well-formed spelling C2 80..C2 9F.  A RAW 0x9B byte is
+# not a codepoint at all, so perl (which decodes) and the sed rules (which match
+# spellings) both used to pass it straight through -- the residue #2463 left
+# behind.  _strip_stray_c1() decodes byte-wise to tell a stray C1 from a
+# legitimate continuation byte.
+#
+# ANTI-VACUITY: the CJK and U+00A0 cases below are the point of the exercise.
+# The obvious "fix" -- tr -d '\200-\237' -- passes every stray-C1 case here and
+# CORRUPTS both of these, because 世 is E4 B8 96 and that 0x96 is a continuation
+# byte, not a control.  A future simplification that loses the decode fails here.
+# -----------------------------------------------------------------------------
+
+run_test "Raw C1 CSI 0x9B stripped" \
+  "$(from_hex '6c6f679b32334b')" \
+  "log23K"
+
+run_test "Raw C1 low bound 0x80 stripped" \
+  "$(from_hex '618062')" \
+  "ab"
+
+run_test "Raw C1 high bound 0x9F stripped" \
+  "$(from_hex '619f62')" \
+  "ab"
+
+run_test "Raw C1 after a valid multi-byte sequence stripped" \
+  "$(from_hex '61e4b8969b62')" \
+  "$(from_hex '61e4b89662')"
+
+run_test "Raw 0xA0 just above the C1 block preserved" \
+  "$(from_hex '61a062')" \
+  "$(from_hex '61a062')"
+
+run_test "CJK survives raw-C1 stripping (0x96 is a continuation byte)" \
+  "$(from_hex '48656c6c6f20e4b896e7958c')" \
+  "$(from_hex '48656c6c6f20e4b896e7958c')"
+
+run_test "Truncated lead drops only the stray C1 it swallowed" \
+  "$(from_hex '61e49b62')" \
+  "$(from_hex '61e462')"
+
+run_test "Raw C1 stripped by sanitize_print" \
+  "$(from_hex '6c6f679b324b')" \
+  "log2K" \
+  "sanitize_print"
+
+# -----------------------------------------------------------------------------
 # The perl-less fallback in _strip_unicode_control
 #
 # The fallback is a safety net that nothing ever exercised: every CI runner has
@@ -234,6 +309,45 @@ run_test "Fallback: C1 CSI U+009B stripped" \
   "$(from_hex '61c29b62')" \
   "ab" \
   "sanitize_line_no_perl"
+
+# Raw C1 on the perl-less path.  #2463's finding was that this branch stripped
+# nothing but the BOM; the stray-C1 decode must not depend on perl either.
+run_test "Fallback: raw C1 CSI 0x9B stripped" \
+  "$(from_hex '619b62')" \
+  "ab" \
+  "sanitize_line_no_perl"
+
+run_test "Fallback: CJK survives raw-C1 stripping" \
+  "$(from_hex '61e4b89662')" \
+  "$(from_hex '61e4b89662')" \
+  "sanitize_line_no_perl"
+
+# -----------------------------------------------------------------------------
+# detect_hidden_chars() parity with the strip side
+#
+# The reporting half greps the well-formed spelling C2 80..C2 9F, so a RAW C1
+# used to fall through to the "unknown category" catch-all -- detected, but
+# misnamed, which costs triage time.  It now also consults _strip_stray_c1().
+#
+# ANTI-VACUITY: the CJK case is why the obvious widening is wrong.  A bare
+# [\x80-\x9f] grep names every CJK ref a C1 control, because the 0x96 in
+# E4 B8 96 is a continuation byte.  That case must stay "no".
+# -----------------------------------------------------------------------------
+
+run_detect_test "Detect: raw C1 named, not 'unknown category'" \
+  "$(from_hex '6c6f679b32')" \
+  "U+0080-U+009F (C1 Control)" \
+  "yes"
+
+run_detect_test "Detect: well-formed C1 still named" \
+  "$(from_hex '6c6f67c29b32')" \
+  "U+0080-U+009F (C1 Control)" \
+  "yes"
+
+run_detect_test "Detect: CJK is NOT named a C1 control" \
+  "$(from_hex '48656c6c6f20e4b89620')" \
+  "U+0080-U+009F (C1 Control)" \
+  "no"
 
 run_test "Fallback: U+2027 below the range preserved" \
   "$(from_hex '61e280a762')" \


### PR DESCRIPTION
Part of #2463 — the residue you asked me to clear.

#2464 taught the Bash sanitizer to drop the C1 block in its well-formed spelling
`C2 80..C2 9F`. A **raw** `0x80-0x9F` byte still passed: it is not a codepoint,
so perl (which decodes) never sees one, and the sed rules match spellings rather
than bytes. `U+009B` is CSI, and a terminal in a single-byte mode acts on the raw
byte — so the introducer the ANSI rule strips in its `ESC [` form stayed
reachable from a third side.

`tr` cannot fix this. Those byte values are also legitimate UTF-8 continuation
bytes — the suite's own sample is `E4 B8 96 E7 95 8C`, whose `0x96` is part of
`世` — so blanket deletion corrupts ordinary text. `_strip_stray_c1()` walks the
byte stream with the same second-byte bounds as `icDecodeUtf8()`
(`E0 A0`, `ED 9F`, `F0 90`, `F4 8F`) and drops a `0x80-0x9F` byte only where no
well-formed sequence claims it.

### Three decisions worth a look

**Narrow by design.** A malformed byte *outside* `0x80-0x9F` still passes,
preserving the "overlong UTF-8 bytes preserved (no decode)" contract the suite
already asserts. Widening it would reverse that decision **silently** — that test
only checks no ASCII `<`/`>` is synthesized, which dropping satisfies just as
well as preserving. If the wider rule is wanted it should be its own change with
its own assertions.

**awk, not perl.** The perl-less branch is exactly where #2463 found the
sanitizer stripping nothing but the BOM, so this rule must not depend on perl.
There is deliberately **no `command -v awk` fallback**: awk is already an
unguarded hard dependency of this file via `_trim_whitespace()`, which
`sanitize_line()` calls. A guard would rescue only `sanitize_print()`, and would
do it by returning the input unfiltered — reinstating the residue this removes.

**`detect_hidden_chars()` brought to parity in the same commit**, since it had
the same blind spot: a raw C1 was detected but reported as "unknown category"
rather than named. It now also consults the decoder. Widening its grep to a bare
`[\x80-\x9f]` instead would name every CJK ref a C1 control.

`sanitize.ps1` needs no change — it works on decoded UTF-16 code points with a
`>= 0xA0` keep-set, so a raw byte cannot reach it.

### Evidence

Local, 114/114. `detect_hidden_chars()` had **no suite coverage at all** before
this. Eight of the 13 new cases fail against the unfixed script; the other five
are guards that discriminate against both plausible wrong fixes:

| | unfixed | this PR | `tr -d '\200-\237'` | widened `[\x80-\x9f]` grep |
|---|---|---|---|---|
| 8 stray-C1 / detect cases | **FAIL** | PASS | PASS | PASS |
| CJK + U+00A0 guards | PASS | PASS | **FAIL** (30 red) | **FAIL** (CJK guard) |

`shellcheck` rc=0 on both files. The awk program was checked against
`icDecodeUtf8()` byte class by byte class.

### CI honesty note

Pre-open dispatch `ci-pr-action` run
[34269460761](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34269460761)
is green, **but it is not evidence for this change**: it skipped every
substantive job and `ci-sanitizer-tests.yml` is `pull_request`-only, so the suite
did not run in it. The first real execution of the 114 cases is this PR's own
run. Flagging it rather than citing the green — this is the same trap I got wrong
on #2463 and had to correct there.
