### PR TITLE
fix(#2086): implement the three ICC.2:2023 Table 102 operators iccDEV lacked

### DIFF
--- a/.github/ci/regression/issue-2086-noop-scnt-operators.xml
+++ b/.github/ci/regression/issue-2086-noop-scnt-operators.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ICC.2:2023 Table 102 'noop' (6e6f6f70h) and 'scnt' (73636e74h), which iccDEV
+  did not implement (#2086).
+
+  Table 102 gives noop no stack arguments and no results, and scnt arguments
+  X1 ... XN with results X1 ... XN N: it reads the stack depth and pushes it
+  without consuming the operands.
+
+  Both are pinned by one ladder. Each scnt reports the depth at that point, so
+  the run must be 0, 1, 2, which holds only if scnt pushes exactly one value
+  and reads the CURRENT depth, and only if neither noop pushes nor consumes
+  anything. A noop that touched the stack, or a scnt that pushed a constant or
+  consumed its operands, shifts the ladder.
+
+  The function takes no input, so the expected output is the fixed triple
+  (0, 1, 2) on every row.
+-->
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.0</ProfileVersion>
+    <ProfileDeviceClass>spac</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <RenderingIntent>Relative</RenderingIntent>
+    <PCSIlluminant><XYZNumber X="0.9505" Y="1.00000000" Z="1.0891"/></PCSIlluminant>
+    <ProfileCreator>ICC </ProfileCreator>
+  </Header>
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[issue-2086 noop scnt]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <multiProcessElementType>
+      <TagSignature>A2B1</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+        <CalculatorElement InputChannels="3" OutputChannels="3">
+          <MainFunction>
+{
+noop
+scnt
+noop
+scnt
+scnt
+out(0,3)
+}
+          </MainFunction>
+        </CalculatorElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+    <multiProcessElementType>
+      <TagSignature>B2A1</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+        <CalculatorElement InputChannels="3" OutputChannels="3">
+          <MainFunction>{ in(0,3) out(0,3) }</MainFunction>
+        </CalculatorElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+    <XYZType>
+      <TagSignature>wtpt</TagSignature>
+      <XYZNumber X="0.9505" Y="1.00000000" Z="1.0891"/>
+    </XYZType>
+    <multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+  </Tags>
+</IccProfile>

--- a/.github/ci/regression/issue-2086-table102-operands.txt
+++ b/.github/ci/regression/issue-2086-table102-operands.txt
@@ -1,0 +1,5 @@
+'RGB ' ; Data Format
+icEncodeUnitFloat ; Encoding
+0.2 0.2 0.2
+0.8 0.8 0.8
+0.2 0.8 0.2

--- a/.github/ci/regression/issue-2086-vxor-operator.xml
+++ b/.github/ci/regression/issue-2086-vxor-operator.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ICC.2:2023 Table 102 'vxor' (76786f72h), which iccDEV did not implement
+  (#2086). Before the fix iccFromXml rejected this file with
+  Invalid Operator "vxor" and the whole calculator tag failed to parse.
+
+  vxor is exercised at width 3 so the (S) selector operand is genuinely used:
+  at width 1 the selector is 0 whether or not vxor reaches ParseFuncDef's
+  index-operand case list, which would leave that path uncovered.
+
+  Operands are fractional and straddle the 0,5 threshold that DEFINES the
+  operator, rather than being exactly 1 and 0:
+
+    X = 0,7  0,6  0,4      Y = 0,4  0,5  0,3
+
+    channel 0   0,7 >= 0,5 xor 0,4 <  0,5   ->  1   exactly one operand
+    channel 1   0,6 >= 0,5 xor 0,5 >= 0,5   ->  0   both, and 0,5 pins that
+                                                    the comparison is >= not >
+    channel 2   0,4 <  0,5 xor 0,3 <  0,5   ->  0   neither
+
+  Channel 1 is what separates vxor from vand and from vor, which both yield 1
+  there, and channels 1 and 2 together reject a threshold-free implementation
+  such as (Xi != Yi), which would return 1 for all three.
+
+  The function takes no input, so the expected output is the fixed triple
+  (1, 0, 0) on every row.
+-->
+<IccProfile>
+  <Header>
+    <ProfileVersion>5.0</ProfileVersion>
+    <ProfileDeviceClass>spac</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <RenderingIntent>Relative</RenderingIntent>
+    <PCSIlluminant><XYZNumber X="0.9505" Y="1.00000000" Z="1.0891"/></PCSIlluminant>
+    <ProfileCreator>ICC </ProfileCreator>
+  </Header>
+  <Tags>
+    <multiLocalizedUnicodeType>
+      <TagSignature>desc</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[issue-2086 vxor]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+    <multiProcessElementType>
+      <TagSignature>A2B1</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+        <CalculatorElement InputChannels="3" OutputChannels="3">
+          <MainFunction>
+{
+0.7 0.6 0.4
+0.4 0.5 0.3
+vxor(3)
+out(0,3)
+}
+          </MainFunction>
+        </CalculatorElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+    <multiProcessElementType>
+      <TagSignature>B2A1</TagSignature>
+      <MultiProcessElements InputChannels="3" OutputChannels="3">
+        <CalculatorElement InputChannels="3" OutputChannels="3">
+          <MainFunction>{ in(0,3) out(0,3) }</MainFunction>
+        </CalculatorElement>
+      </MultiProcessElements>
+    </multiProcessElementType>
+    <XYZType>
+      <TagSignature>wtpt</TagSignature>
+      <XYZNumber X="0.9505" Y="1.00000000" Z="1.0891"/>
+    </XYZType>
+    <multiLocalizedUnicodeType>
+      <TagSignature>cprt</TagSignature>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType>
+  </Tags>
+</IccProfile>

--- a/.github/scripts/iccdev-calculator-regression-tests.sh
+++ b/.github/scripts/iccdev-calculator-regression-tests.sh
@@ -260,6 +260,88 @@ run_reject_profile() {
   pass_case "$name"
 }
 
+# ICC.2:2023 Table 102 'noop', 'scnt' and 'vxor' (#2086). Before the fix
+# iccFromXml rejected these fixtures with Invalid Operator "..." and wrote no
+# profile, so the conversion alone is the red/green check for acceptance.
+#
+# Acceptance is not enough on its own: an operator can be added to the enum and
+# still compute the wrong thing, so each fixture's function takes no input and
+# every row must come back as one fixed triple. The operand choices that make
+# these discriminating are documented in the fixtures themselves -- in short,
+# vxor is exercised at width 3 across the 0,5 threshold so that vand, vor and a
+# threshold-free (Xi != Yi) all produce a different triple, and the noop/scnt
+# ladder must read 0, 1, 2.
+run_table102_operator_fixture() {
+  local name="$1"
+  local fixture="$2"
+  local expected="$3"
+  local source_xml="$REPO_ROOT/.github/ci/regression/${fixture}.xml"
+  local source_txt="$REPO_ROOT/.github/ci/regression/issue-2086-table102-operands.txt"
+  local built_icc="$OUTDIR/${fixture}.icc"
+  local fromxml_log="$OUTDIR/${fixture}-fromxml.log"
+  local apply_log="$OUTDIR/${fixture}-apply.log"
+  local exit_code=0
+  local rows=0
+  local row
+
+  TOTAL=$((TOTAL + 1))
+  rm -f "$built_icc" "$fromxml_log" "$apply_log"
+
+  if [ ! -f "$source_xml" ] || [ ! -f "$source_txt" ]; then
+    fail_case "$name" "missing Table 102 fixture"
+    return
+  fi
+
+  timeout 30 "$FROMXML" "$source_xml" "$built_icc" > "$fromxml_log" 2>&1 || exit_code=$?
+  if ! check_log "$name/fromxml" "$fromxml_log"; then
+    return
+  fi
+  if [ "$exit_code" -ne 0 ] || [ ! -s "$built_icc" ]; then
+    fail_case "$name" "iccFromXml rejected the Table 102 operators (exit=$exit_code)"
+    sed -n '1,10p' "$fromxml_log"
+    return
+  fi
+
+  exit_code=0
+  timeout 30 "$APPLYNCM" "$source_txt" 3 0 "$built_icc" 1 > "$apply_log" 2>&1 || exit_code=$?
+  if ! check_log "$name/apply" "$apply_log"; then
+    return
+  fi
+  if [ "$exit_code" -ne 0 ]; then
+    fail_case "$name" "iccApplyNamedCmm failed with exit=$exit_code"
+    return
+  fi
+
+  # Data rows carry the source values after a ';'. Compare only the result
+  # triple, and count the rows so that "no output at all" cannot pass.
+  while IFS= read -r row; do
+    rows=$((rows + 1))
+    if [ "$row" != "$expected" ]; then
+      fail_case "$name" "row $rows was '$row', expected '$expected'"
+      return
+    fi
+  done < <(awk -F';' '/;/ && $1 ~ /[0-9]/ {print $1}' "$apply_log" |
+             awk '{ if (NF==3) printf "%s %s %s\n", $1, $2, $3 }')
+
+  if [ "$rows" -ne 3 ]; then
+    fail_case "$name" "expected 3 result rows, saw $rows"
+    return
+  fi
+
+  pass_case "$name"
+}
+
+run_table102_operators() {
+  run_table102_operator_fixture \
+    "issue-2086-vxor-operator" \
+    "issue-2086-vxor-operator" \
+    "1.0000 0.0000 0.0000"
+  run_table102_operator_fixture \
+    "issue-2086-noop-scnt-operators" \
+    "issue-2086-noop-scnt-operators" \
+    "0.0000 1.0000 2.0000"
+}
+
 run_issue_1103_dump_profile_regression() {
   local name="issue-1103-calculator-window-underflow"
   local profile="$ISSUE_1103_CALC_UNDERFLOW_PROFILE"
@@ -314,6 +396,7 @@ if [ "$FAIL" -eq 0 ]; then
   run_reject_profile "calcOverMem_tput.icc"
   run_reject_profile "calcOverMem_tsav.icc"
   run_issue_1103_dump_profile_regression
+  run_table102_operators
 fi
 
 echo "Calculator regression tests: $PASS passed, $FAIL failed, $TOTAL total"

--- a/IccProfLib/IccMpeCalc.cpp
+++ b/IccProfLib/IccMpeCalc.cpp
@@ -677,6 +677,30 @@ public:
   }
 };
 
+// ICC.2:2023 Table 102 row 1: no stack arguments, no stack results (#2086).
+class CIccOpDefNoOperation : public IIccOpDef
+{
+public:
+  virtual bool Exec(SIccCalcOp * /* op */, SIccOpState & /* os */)
+  {
+    return true;
+  }
+};
+
+// ICC.2:2023 Table 102 row 2: "Stack size count". The arguments column is
+// X1 ... XN and the results column X1 ... XN N, so the operand vector is left
+// in place and the count is pushed on top -- it reads the stack depth rather
+// than consuming it (#2086).
+class CIccOpDefStackCount : public IIccOpDef
+{
+public:
+  virtual bool Exec(SIccCalcOp * /* op */, SIccOpState &os)
+  {
+    OsPushArg(os,(icFloatNumber)os.pStack->size());
+    return true;
+  }
+};
+
 class CIccOpDefPi : public IIccOpDef
 {
 public:
@@ -918,6 +942,26 @@ public:
     icFloatNumber *s = &(*os.pStack)[ss-tn];
     for (j=0; j<n; j++) {
       s[j] = (s[j]>=0.5f && s[j+n]>=0.5) ? 1.0f : 0.0f;
+    }
+    return OsShrinkArgs(os,n);
+  }
+};
+
+// ICC.2:2023 Table 102 prints 'vxor' between 'vand' and 'vor ', and gives it the
+// same two-vector shape: Zi = 1,0 when exactly one of Xi, Yi is >= 0,5 (#2086).
+class CIccOpDefVectorXor : public IIccOpDef
+{
+public:
+  virtual bool Exec(SIccCalcOp *op, SIccOpState &os)
+  {
+    int j, n = op->data.select.v1+1;
+    int tn = n*2;
+    size_t ss = os.pStack->size();
+    if (tn>(int)ss)
+      return false;
+    icFloatNumber *s = &(*os.pStack)[ss-tn];
+    for (j=0; j<n; j++) {
+      s[j] = ((s[j]>=0.5f) != (s[j+n]>=0.5f)) ? 1.0f : 0.0f;
     }
     return OsShrinkArgs(os,n);
   }
@@ -2059,6 +2103,7 @@ void SIccCalcOp::Describe(std::string &desc, int /* nVerboseness */)
     case icSigVectorMinimumOp:
     case icSigVectorMaximumOp:
     case icSigVectorAndOp:
+    case icSigVectorXorOp:
     case icSigVectorOrOp:
       if (data.select.v1) {
         snprintf(buf, bufSize, "[%d]", data.select.v1+1);
@@ -2112,7 +2157,9 @@ CIccCalcOpMgr::CIccCalcOpMgr()
   m_map[icSigPopOp] = new CIccOpDefPop();
   m_map[icSigSolveOp] = new CIccOpDefSolve();
   m_map[icSigTransposeOp] = new CIccOpDefTranspose();
-  m_map[icSigPiOp] = new CIccOpDefPi(); 
+  m_map[icSigNoOperationOp] = new CIccOpDefNoOperation();
+  m_map[icSigStackCountOp] = new CIccOpDefStackCount();
+  m_map[icSigPiOp] = new CIccOpDefPi();
   m_map[icSigPosInfinityOp] = new CIccOpDefPosInfinity();
   m_map[icSigNegInfinityOp] = new CIccOpDefNegInfinity();
   m_map[icSigNotaNumberOp] = new CIccOpDefNotANumber(); 
@@ -2155,6 +2202,7 @@ CIccCalcOpMgr::CIccCalcOpMgr()
   m_map[icSigVectorMinimumOp] = new CIccOpDefVectorMinimum();
   m_map[icSigVectorMaximumOp] = new CIccOpDefVectorMaximum();
   m_map[icSigVectorAndOp] = new CIccOpDefVectorAnd();
+  m_map[icSigVectorXorOp] = new CIccOpDefVectorXor();
   m_map[icSigVectorOrOp] = new CIccOpDefVectorOr();
   m_map[icSigMinimumOp] = new CIccOpDefMinimum();          
   m_map[icSigMaximumOp] = new CIccOpDefMaximum();          
@@ -2217,7 +2265,9 @@ bool SIccCalcOp::IsValidOp(icSigCalcOp sig)
     case icSigPopOp:
     case icSigSolveOp:
     case icSigTransposeOp:
-    case icSigPiOp: 
+    case icSigNoOperationOp:
+    case icSigStackCountOp:
+    case icSigPiOp:
     case icSigPosInfinityOp:
     case icSigNegInfinityOp:
     case icSigNotaNumberOp:
@@ -2260,8 +2310,9 @@ bool SIccCalcOp::IsValidOp(icSigCalcOp sig)
     case icSigVectorMinimumOp:
     case icSigVectorMaximumOp:
     case icSigVectorAndOp:
+    case icSigVectorXorOp:
     case icSigVectorOrOp:
-    case icSigMinimumOp:          
+    case icSigMinimumOp:
     case icSigMaximumOp:          
     case icSigRealNumberOp:
     case icSigLessThanOp:         
@@ -2347,11 +2398,16 @@ icUInt16Number SIccCalcOp::ArgsUsed(CIccMpeCalculator *pCalc)
   
   switch (sig) {
     case icSigDataOp:
+    // 'noop' and 'scnt' consume nothing: Table 102 gives noop no stack
+    // arguments at all, and scnt's results column repeats its X1 ... XN
+    // arguments unchanged before the pushed count (#2086).
+    case icSigNoOperationOp:
+    case icSigStackCountOp:
     case icSigPiOp:
     case icSigPosInfinityOp:
     case icSigNegInfinityOp:
     case icSigNotaNumberOp:
-    case icSigInputChanOp:        
+    case icSigInputChanOp:
     case icSigTempGetChanOp:
     case icSigEnvVarOp:
       return 0;
@@ -2448,6 +2504,7 @@ icUInt16Number SIccCalcOp::ArgsUsed(CIccMpeCalculator *pCalc)
     case icSigVectorMinimumOp:
     case icSigVectorMaximumOp:
     case icSigVectorAndOp:
+    case icSigVectorXorOp:
     case icSigVectorOrOp:
       {
       uint32_t fullSum = 2*((uint32_t)data.select.v1+1);
@@ -2523,6 +2580,9 @@ icUInt16Number SIccCalcOp::ArgsPushed(CIccMpeCalculator *pCalc)
     case icSigOutputChanOp:
     case icSigTempPutChanOp:
 
+    // 'noop' is the one operator in Table 102 whose results column is None.
+    case icSigNoOperationOp:
+
     case icSigPopOp:
     case icSigIfOp:
     case icSigSelectOp:
@@ -2531,7 +2591,10 @@ icUInt16Number SIccCalcOp::ArgsPushed(CIccMpeCalculator *pCalc)
       /*case icSigDefaultOp:*/  //This is only valid after an icSigSelectOp is parsed
       return 0;
 
-    case icSigDataOp:            
+    case icSigDataOp:
+    // 'scnt' leaves its arguments in place and pushes the count on top, so it
+    // grows the stack by exactly one (#2086).
+    case icSigStackCountOp:
     case icSigPiOp:
     case icSigPosInfinityOp:
     case icSigNegInfinityOp:
@@ -2667,6 +2730,7 @@ icUInt16Number SIccCalcOp::ArgsPushed(CIccMpeCalculator *pCalc)
     case icSigVectorMinimumOp:
     case icSigVectorMaximumOp:
     case icSigVectorAndOp:
+    case icSigVectorXorOp:
     case icSigVectorOrOp:
       {
       uint32_t fullSum = ((uint32_t)data.select.v1+1);
@@ -3468,6 +3532,7 @@ const char *CIccCalculatorFunc::ParseFuncDef(const char *szFuncDef, CIccCalcOpLi
       case icSigVectorMinimumOp:
       case icSigVectorMaximumOp:
       case icSigVectorAndOp:
+      case icSigVectorXorOp:
       case icSigVectorOrOp:
         if (!scan.GetIndex(op.data.select.v1, op.data.select.v2, 1))
           return NULL;

--- a/IccProfLib/IccMpeCalc.h
+++ b/IccProfLib/IccMpeCalc.h
@@ -128,6 +128,15 @@ typedef enum {
   // useful value that is not defined by the spec.
   icSigNullDataOp                   = 0x00000000, /* not valid, used for data range */
 
+  //ICC.2:2023 Table 102 rows 1 and 2. Neither carries an (S) selector, but they
+  //differ in what they touch: 'noop' takes no stack argument and leaves no
+  //result, while 'scnt' takes X1...XN and leaves X1...XN N -- it reads the stack
+  //depth and pushes it WITHOUT consuming the operands. Both are specified with
+  //"S shall be zero"; iccDEV does not enforce that, matching how it already
+  //treats the pi/+INF/-INF/NaN rows of the same table (#2086).
+  icSigNoOperationOp                = 0x6e6f6f70,  /* 'noop' */
+  icSigStackCountOp                 = 0x73636e74,  /* 'scnt' */
+
   //Floating point constant operation
   icSigDataOp                       = 0x64617461,  /* 'data' */
   icSigPiOp                         = 0x70692020,  /* 'pi  ' */
@@ -220,6 +229,7 @@ typedef enum {
   icSigVectorMinimumOp              = 0x766d696e,  /* 'vmin' */
   icSigVectorMaximumOp              = 0x766d6178,  /* 'vmax' */
   icSigVectorAndOp                  = 0x76616e64,  /* 'vand' */
+  icSigVectorXorOp                  = 0x76786f72,  /* 'vxor' */
   icSigVectorOrOp                   = 0x766f7220,  /* 'vor ' */
 
   //Matrix Operations


### PR DESCRIPTION
Closes #2086.

`noop` (6e6f6f70h), `scnt` (73636e74h) and `vxor` (76786f72h) are printed in
ICC.2:2023 Table 102 and none were implemented. A conforming profile using any
of them was refused outright, and the **whole calculator tag** failed to parse
rather than just the operator.

Semantics from ICC.2:2023 (archive.color.org, sha256
`fce5300e69b80705cef2eb1f372387967d15c2e74f9d021fd67e218f28eec390`):

| op | arguments | results | definition |
|---|---|---|---|
| `noop` | None | None | performs no operation |
| `scnt` | X1…XN | X1…XN N | stack size count |
| `vxor` | X0…XS Y0…YS | Z0…ZS | Zi = 1,0 when exactly one of Xi, Yi is >= 0,5 |

`scnt`'s results column repeats its arguments before the count, so it reads the
stack depth and pushes it — it does not consume.

### Where they had to go

`vxor` carries the same `(S)` selector as `vand`/`vor `, so it joins them at all
**six** switches — `Describe`, the operator map, `IsValidOp`, `ArgsUsed`,
`ArgsPushed` and `ParseFuncDef`. My note on the issue said "the case list at
:3468-3477, not just the enum", which undercounted: one case list is not enough.

`noop`/`scnt` take no selector and reach `ParseFuncDef`'s `default:` arm once
`IsValidOp` accepts them, so they need no parse case. They differ from the
`pi `/`+INF`/`NaN ` group only in `ArgsPushed`: `noop` pushes nothing (the one
Table 102 row whose results column is None), `scnt` pushes one.

### Evidence

Two fixtures in `iccdev.calculator-regressions`, both taking no input so each
must return one fixed triple:

| fixture | expected |
|---|---|
| `issue-2086-vxor-operator` | `(1, 0, 0)` |
| `issue-2086-noop-scnt-operators` | `(0, 1, 2)` |

`vxor` runs at **width 3** so the `(S)` operand path is genuinely used — at
width 1 the selector is 0 whether or not `vxor` reaches `ParseFuncDef`'s
index-operand case, which would leave that path uncovered. Its operands are
fractional and straddle the threshold rather than being exactly 1 and 0, with
one pair sitting **on** 0,5:

```
X = 0,7  0,6  0,4      Y = 0,4  0,5  0,3   ->   1, 0, 0
```

Verified red **eight** ways, each rebuilt:

| build | vxor fixture | noop/scnt fixture |
|---|---|---|
| master (operators absent) | rejected | rejected |
| `vxor` as `vand` | `0.0000 1.0000 0.0000` | pass |
| `vxor` as `vor ` | `1.0000 1.0000 0.0000` | pass |
| `vxor` as a threshold-free `(Xi != Yi)` | `1.0000 1.0000 1.0000` | pass |
| `>` instead of `>=` | `1.0000 1.0000 0.0000` | pass |
| `scnt` as a constant | pass | `0.0000 0.0000 0.0000` |
| `scnt` consuming an operand | pass | `-1.0000 -1.0000 -1.0000` |
| `noop` touching the stack | pass | `0.0000 3.0000 4.0000` |

Green 13/13, with the 11 pre-existing calculator cases unchanged. All 10
tracked calc profiles still convert; `vxor` round-trips through the binary form
as `vxor[3]`.

The last four red rows exist because the first version of this fixture used
operands of exactly 1 and 0 at width 1, and a self-review proved it still
passed against a threshold-free implementation — accepting an operator and
computing it correctly are different claims.

Fixtures live in `.github/ci/regression/` rather than `Testing/`, following the
note already in this script: `Testing/` is the generated corpus that
`CreateAllProfiles.sh` rewrites.

### One thing for you, not changed here

`HasUnsupportedOperations` (`IccMpeCalc.cpp:4617`) warns that `not `/`!=` are
"not supported by profile version" below `icVersionNumberV5_1`. `not ` arrived
in ICC.2:2023, the same edition as these three, which are left ungated — so
that check is inconsistent either way. I did **not** add a gate, for two
reasons: the existing one is unreachable, because
`CIccTagMultiProcessElement::Validate` (`IccTagMPE.cpp:1971`) calls
`last->Validate(..., sReport, this)` without forwarding `pProfile`, so
`pProfile` is always NULL there; and clause 7.2.6 of **both** editions gives the
conforming version as `"5.0.0.0" (05000000h)`, so the version field cannot
distinguish them at all. Worth a ruling on its own rather than a guess here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTQQ6sMWnHkNEA9QedNpMT
