### PR TITLE
fix(#2171): map the POSIX CRT names instead of suppressing their warning

### DIFF
--- a/IccProfLib/IccProfLibConf.h
+++ b/IccProfLib/IccProfLibConf.h
@@ -64,6 +64,20 @@
 //Define the following to use namespace
 //#define USEICCDEVNAMESPACE
 
+// Pulled in ahead of the namespace band for the stricmp/strnicmp mapping in the
+// MSVC arm below (#2171). The mapping needs the CRT header parsed *before* the
+// macros exist -- see the comment there -- and a system header must not be
+// dragged into namespace iccDEV, which is what including it at the point of use
+// would do when USEICCDEVNAMESPACE is defined.
+//
+// The condition is written out rather than reduced to _MSC_VER so that it stays
+// identical to the arm it serves: an MSVC-family compile that falls through to
+// the non-PC arm takes the strcasecmp mapping instead, and must not be given
+// this include on the way past.
+#if defined(_MSC_VER) && !defined(__MWERKS__) && (defined(_M_IX86) || defined(_M_X64) || defined(_M_ARM) || defined(_M_ARM64) || defined(_M_ARM64EC))
+  #include <string.h>
+#endif
+
 #ifdef USEICCDEVNAMESPACE
 namespace iccDEV {
 #endif
@@ -124,6 +138,28 @@ namespace iccDEV {
   #else //static lib, or a consumer of one
     #define ICCPROFLIB_DATA_API
   #endif
+
+  // Map the POSIX spellings onto the CRT's conformant names (#2171).
+  //
+  // The UCRT declares stricmp/strnicmp with _CRT_NONSTDC_DEPRECATE, so every
+  // call site raises C4996 unless _CRT_NONSTDC_NO_WARNINGS is defined. This
+  // resolves the names instead of suppressing the diagnostic, which keeps the
+  // warning class live for any *other* deprecated CRT name that appears later.
+  // The non-PC arm below already maps the same two names onto strcasecmp.
+  //
+  // <string.h> has to be parsed FIRST, which is why it is included above the
+  // namespace band rather than here. These are plain text substitutions, so if
+  // they are live when the CRT header is parsed, the UCRT's deprecated
+  // declaration of stricmp is rewritten into a deprecated declaration of
+  // _stricmp -- which moves the warning onto the conformant name instead of
+  // removing it. That matters beyond the sites being fixed here, because the
+  // conformant names are also called directly in the tree (for instance
+  // Tools/CmdLine/IccApplyProfiles/TiffImg.cpp:239-252), so a mis-ordered
+  // mapping would deprecate them for callers that never used the POSIX spelling
+  // at all. Whether a given TU is exposed depends on whether it reaches this
+  // header before <string.h>; including it above makes that ordering irrelevant.
+  #define stricmp  _stricmp
+  #define strnicmp _strnicmp
 
   //Since msvc doesn't support cbrtf use pow instead
   #define ICC_CBRTF(v) pow((double)(v), 1.0/3.0)


### PR DESCRIPTION
Part of #2171.

The bisect in #2171 does not hold — those warnings track the build preset, not
`1f0a9dd` — and you asked for the half of the suppress-vs-fix call that is
cheap. This is that half.

MSVC's UCRT declares `stricmp`/`strnicmp` with `_CRT_NONSTDC_DEPRECATE`, so
every call site raises C4996 unless `_CRT_NONSTDC_NO_WARNINGS` is defined. The
non-PC arm of `IccProfLibConf.h` has always mapped both names onto
`strcasecmp`/`strncasecmp`; the MSVC arm mapped nothing. This maps them onto the
CRT's conformant names there too, resolving the diagnostic instead of muting it.

### Two corrections to what I said on the issue

**The count.** I wrote "~31 tracked call sites". Measured at `37c15583` it is
**61** — 58 `stricmp` and 3 `strnicmp`, across 15 files. (`third_party/` is
untracked here and excluded.)

**"In one line" was wrong**, and the naive one-liner is actively harmful. These
are plain text substitutions, so if they are live when the CRT header is parsed,
the UCRT's deprecated declaration of `stricmp` is rewritten into a deprecated
declaration of `_stricmp`. Reproduced against a mock CRT header of the same
shape:

| | result |
|---|---|
| today | warns on `stricmp` |
| `#define` before `<string.h>` | warns on **`_stricmp`** — the attribute migrates to the conformant name |
| `#define` after `<string.h>` | clean |

That matters past the sites being fixed, because the conformant names are also
called directly in the tree (`TiffImg.cpp:239-252`) — a mis-ordered mapping
deprecates them for callers that never used the POSIX spelling. Which TUs are
exposed depends on include order, so the include goes above the namespace band
and the ordering stops mattering. It is also kept out of `namespace iccDEV`,
which including it at the point of use would not be, and it repeats the arm's
full condition so the two cannot drift.

### Which lane shows this: measured, and the answer is neither

I said on the issue that the ClangCL lane hides this. That is true but not the
whole story, and the honest answer is that **no current Windows lane surfaces
this warning class at all**:

- **`clangcl-build:` (`ci-pr-win.yml:633`)** passes
  `-DICCDEV_SUPPRESS_LEGACY_CRT_WARNINGS=ON` (`:799`), which defines
  `_CRT_NONSTDC_NO_WARNINGS` and mutes the class outright.
- **`build:` — Windows MSVC (`:57`)** sets no such flag — its log confirms
  `ICCDEV_SUPPRESS_LEGACY_CRT_WARNINGS = OFF` — but it compiles at **`/W1`**,
  and C4996 is a **level 3** warning. It is below the reporting threshold, so it
  never appears there either.

Measured rather than assumed, comparing the same lane with and without this
change:

| MSVC job | `warning C` lines | C4996 | `stricmp` mentions |
|---|---|---|---|
| baseline, run 34289165659 job 102271678631 | 0 | 0 | 0 |
| this branch, run 34290333348 job 102275341494 | 0 | 0 | 0 |

Both logs carry real compile output (175 distinct `.cpp` names), so this is not
a truncated-log artifact. Seeing the improvement needs `/W3` or higher with the
option OFF — the `vs2022-clangcl-x64-qa-flags` preset from your own repro is
where the warnings in the issue came from.

**So what CI does prove here is the thing actually worth proving:** adding an
include plus two macros to a header pulled in nearly everywhere breaks nothing.
Run 34290333348 is green across MSVC, ClangCL, MinGW UCRT64, macOS Debug and
Release LTO, GCC 15.2 Strict Release LTO and the ASAN+UBSAN tool smoke tests.
The correctness of the mapping itself rests on the mock-header reproduction
above, not on a green check.

Off-MSVC the change is inert: the non-PC arm is untouched and `stricmp` still
resolves to `strcasecmp`, checked with `-dM` both with and without
`USEICCDEVNAMESPACE`.

**Offer, not done here.** `ICCDEV_SUPPRESS_LEGACY_CRT_WARNINGS` adds *both*
`_CRT_SECURE_NO_WARNINGS` and `_CRT_NONSTDC_NO_WARNINGS`
(`Build/Cmake/CMakeLists.txt:919-922`), while the lane's own summary at `:885`
already describes the policy as `_CRT_SECURE_NO_WARNINGS` only. With this in,
the NONSTDC half looks like dead weight on Windows — I checked the rest of that
family: `fileno` is behind `#if !defined(_WIN32)` and `ICC_HAS_EXECINFO`;
`unlink`/`access`/`dup2` are only in the CFL fuzzer harness, which MSVC does not
build; the one `isatty` is inside a comment. So dropping just that define would
make the fix observable on ClangCL too and make the summary text true. I left it
alone because it is your CI policy. The `_CRT_SECURE` half (~121 sites,
different truncation semantics) I would still leave alone.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HTQQ6sMWnHkNEA9QedNpMT
