### PR TITLE
fix(#2477): write the fixture DeviceCode instead of sed-ing it in

### DIFF
--- a/.github/ci/regression/extended-device-colorspace.cpp
+++ b/.github/ci/regression/extended-device-colorspace.cpp
@@ -76,7 +76,10 @@ void testSpectralRangeType()
 
   io.Seek(0, icSeekSet);
   CIccTagSpectralRange dst;
-  check(dst.Read(io.GetLength(), &io), "srng: Read() succeeds");
+  // CIccIO::GetLength() is size_t and Read() takes icUInt32Number, so the
+  // narrowing is spelled out the way curve-setsize-contract.cpp:108 spells it.
+  // The length is the 20 bytes asserted above, so the cast cannot lose a value.
+  check(dst.Read((icUInt32Number)io.GetLength(), &io), "srng: Read() succeeds");
 
   check(dst.m_spectralRange.start == pSrc->m_spectralRange.start &&
         dst.m_spectralRange.end   == pSrc->m_spectralRange.end   &&

--- a/.github/scripts/iccdev-xml-parser-regression-tests.sh
+++ b/.github/scripts/iccdev-xml-parser-regression-tests.sh
@@ -558,7 +558,16 @@ xyz_array_at_cap
 # what is under test: the resp tag, its CountOfChannels and its Measurement
 # rows are unchanged, and the round-trip cases only look for the resp tag.
 write_countofchannels_document() {
-  # write_countofchannels_document <path> <count-element>
+  # write_countofchannels_document <path> <count-element> [device-code]
+  #
+  # The DeviceCode is a parameter rather than a post-hoc "sed -i" edit because
+  # BSD sed takes the backup extension as a SEPARATE argument. On macOS,
+  # "sed -i 's|a|b|' file" consumed the s-expression as the suffix, tried to run
+  # the file path as the script, exited non-zero and left the document
+  # unmodified -- so both fixtures kept DeviceCode="0", the overflow case
+  # compared a document against itself, and it reported the library truncating
+  # 65537 to 1: a defect that does not exist (#2477).
+  local device_code="${3:-0}"
   cat > "$1" <<XMLEOF
 <?xml version="1.0" encoding="UTF-8"?>
 <IccProfile>
@@ -574,7 +583,7 @@ write_countofchannels_document() {
       $2
       <ResponseCurve MeasUnitSignature="Status A">
         <ChannelResponses X="0" Y="0" Z="0">
-          <Measurement DeviceCode="0" MeasValue="0"/>
+          <Measurement DeviceCode="${device_code}" MeasValue="0"/>
         </ChannelResponses>
       </ResponseCurve>
     </responseCurveSet16Type>
@@ -773,16 +782,26 @@ measurement_devicecode_overflow() {
   # function, 45 lines apart. Asserted the same way: the two documents must not
   # produce the same bytes.
   #
-  # Both documents are written from the helper rather than sed-ed out of another case's
-  # output.  The previous version read $OUTDIR/resp-ctrl.xml, which only exists once
-  # countofchannels_overflow_is_not_one() has run; its fallback arm wrote "$ctrl" and the
-  # unconditional redirect on the following line then truncated that same file to zero
-  # bytes before sed failed, with "|| true" swallowing the failure -- so the case reported
-  # a false "the DeviceCode=1 control no longer converts" instead of testing anything.
-  write_countofchannels_document "$ctrl" "<CountOfChannels>1</CountOfChannels>"
-  write_countofchannels_document "$over" "<CountOfChannels>1</CountOfChannels>"
-  sed -i 's|DeviceCode="0"|DeviceCode="1"|' "$ctrl"
-  sed -i 's|DeviceCode="0"|DeviceCode="65537"|' "$over"
+  # Both documents are written from the helper, DeviceCode included, rather than sed-ed
+  # out of another case's output.  The previous version read $OUTDIR/resp-ctrl.xml, which
+  # only exists once countofchannels_overflow_is_not_one() has run; its fallback arm wrote
+  # "$ctrl" and the unconditional redirect on the following line then truncated that same
+  # file to zero bytes before sed failed, with "|| true" swallowing the failure -- so the
+  # case reported a false "the DeviceCode=1 control no longer converts" instead of testing
+  # anything.  The version after that still patched the DeviceCode in with "sed -i", which
+  # is a GNU spelling: it is a no-op that exits 1 under BSD sed, so on macOS both documents
+  # kept DeviceCode="0" and this case compared a document against itself (#2477).
+  write_countofchannels_document "$ctrl" "<CountOfChannels>1</CountOfChannels>" "1"
+  write_countofchannels_document "$over" "<CountOfChannels>1</CountOfChannels>" "65537"
+
+  # The two fixtures differing is what makes the cmp below meaningful: when they were
+  # identical, "byte-identical to the control" read as a library truncation rather than as
+  # the harness defect it was.  Assert it here so that failure mode can never be reported
+  # as a defect in the tag parser again.
+  if cmp -s "$ctrl" "$over"; then
+    fail "$name" "harness: the control and overflow documents are identical, so the DeviceCode was never varied"
+    return
+  fi
 
   rm -f "$OUTDIR/${name}-over.icc" "$OUTDIR/${name}-ctrl.icc"
   "$FROMXML" "$over" "$OUTDIR/${name}-over.icc" >"$logfile" 2>&1
@@ -801,6 +820,22 @@ measurement_devicecode_overflow() {
     else
       fail "$name" "an out-of-range DeviceCode was accepted"
     fi
+    return
+  fi
+
+  if [ -s "$OUTDIR/${name}-over.icc" ]; then
+    fail "$name" "a rejected DeviceCode still left a profile behind"
+    return
+  fi
+
+  # Section 4's rule, which this case was the only one of the four to skip: exit
+  # status alone is not attribution, because every fixture in this script exits
+  # non-zero.  Without it a later document- or header-level refusal -- the shape
+  # #2384 already imposed on this fixture family once -- would reject the overflow
+  # document before the Measurement element is parsed at all, and this case would
+  # keep reporting PASS with the DeviceCode range guard deleted outright.
+  if ! grep -qE "$RESP_TAG_DIAG" "$logfile"; then
+    fail "$name" "refused, but not by the responseCurveSet16Type parser"
     return
   fi
 

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -8420,11 +8420,19 @@ set_tests_properties(iccdev.pcc-zero-illuminant-regressions PROPERTIES
 # true. Where that matters is ci-iccdev-tool-tests.yml run with ctest_mode=full
 # and the local check target; both exclude known-red and neither excludes slow.
 #
-# It does NOT put this test on the pull_request path: ci-pr-action.yml pins
-# ctest_mode=fast, which drops it on the slow label, and the Windows legs never
-# register it at all because the if(WIN32) branch above returns before the bash
-# script tests. Measured on dispatched run 31852372579 -- the case does not
-# execute on any PR leg. Widening that is a separate question from this fix.
+# That paragraph used to end by saying this test runs on no PR leg, because
+# ci-pr-action.yml pinned ctest_mode=fast and the slow label dropped it
+# (measured on dispatched run 31852372579). That stopped being true six days
+# later: #2201 (029dc30c) made ctest_mode default to full, and full excludes
+# only known-red. Measured on PR run 34291518125 (job 102279464003, an ordinary
+# source PR): "Test #200: iccdev.xml-parser-regressions .. Passed 18.51 sec".
+# The Windows legs still never register it, because the if(WIN32) branch above
+# returns before the bash script tests.
+#
+# What the PR legs cannot cover is the sed dialect: they are Linux and Windows
+# only, and #2477 was a GNU-only "sed -i" spelling inside the script that is a
+# failing no-op under BSD sed. It went red on a maintainer's local macOS run
+# while every PR leg stayed green.
 if(TARGET iccFromXml AND TARGET iccToXml AND TARGET iccApplyToLink)
   iccdev_add_script_test(
     iccdev.xml-parser-regressions


### PR DESCRIPTION
## PR Summary

Part of #2477. `iccdev.xml-parser-regressions` went red on your macOS arm64 run
while every CI leg stayed green. The cause is in the harness I shipped with
#2409, not in the tag parser.

### The failing case

`measurement_devicecode_overflow()` patched its two fixtures with

```
sed -i 's|DeviceCode="0"|DeviceCode="65537"|' "$over"
```

That is the GNU spelling. BSD sed takes the backup extension as a **separate**
argument, so it consumes the s-expression as the suffix, tries to run the file
path as the script, exits non-zero and leaves the document unmodified. Both
fixtures then carried `DeviceCode="0"`, so the case compared a document against
itself and printed

> `DeviceCode 65537 truncated to 1 -- output is byte-identical to the control`

— an accusation against `CIccTagResponseCurveSet16` for a truncation that does
not exist.

Reproduced on Linux with a shim that mimics BSD's `-i` argument parsing:

| | result |
|---|---|
| before, BSD shim | **15/16, exit 1**, that case, that message |
| after, BSD shim | 16/16, exit 0 |
| after, GNU sed | 16/16, exit 0 |

I have no macOS box, so the BSD behaviour is emulated, not observed: the shim
encodes `sed -i EXT script file` argument order and returns non-zero without
touching the file. If your run shows a different `[FAIL]` line than
`xml-responsecurve-devicecode-overflow`, this is the wrong diagnosis and I would
want the case-level output.

### The fix

`write_countofchannels_document()` takes the DeviceCode as an optional third
argument defaulting to `"0"`, so the five other callers are byte-for-byte
unchanged and there is no post-hoc edit that can fail silently. A guard ahead of
the comparison fails with an explicit `harness:` message if the two fixtures are
ever identical again — that narrows the byte-identical branch so only a genuine
library truncation can reach it.

Red/green on the repaired case, so it is not vacuous:

| probe | result |
|---|---|
| over document carries an **accepted** DeviceCode | `an out-of-range DeviceCode was accepted` |
| the two fixtures identical (the #2477 shape) | `harness: ... the DeviceCode was never varied` |

The library-side assertion is still live past the new guard.

### One more thing the self-review found

This case was also the only one of the four that passed on **exit status alone**.
Its three siblings require the parser to name the tag it refused, and section 4
of the script says why: every fixture here exits non-zero, so status is not
attribution. Without that, a later document- or header-level refusal — the shape
#2384 already imposed on this fixture family once — would reject the overflow
document before the `Measurement` element is parsed, and the case would keep
reporting PASS with the DeviceCode range guard deleted outright.

Added the sibling's two assertions (no leftover `.icc`, and `RESP_TAG_DIAG`).
Verified they bite: appending malformed XML so the refusal happens before the tag
parser now gives `refused, but not by the responseCurveSet16Type parser`, where
it previously passed. The leftover-`.icc` assertion mirrors the sibling and is
defensive — I could not construct a case that trips it without patching the tool,
so I have not red-tested that one.

### The warning half

`extended-device-colorspace.cpp:79` passed `size_t GetLength()` into
`Read(icUInt32Number)`. Reproduced verbatim on local clang with
`-Wshorten-64-to-32` (`79:21`, same wording), so it is a flag Xcode enables
rather than anything macOS-specific. Cast the way
`curve-setsize-contract.cpp:108` already casts. Compiling **all 105** TUs under
`.github/ci/regression` with that flag now reports nothing, and a canary with a
deliberate `size_t`->`unsigned int` narrowing does warn under the same command,
so the empty sweep is not vacuous.

### A stale claim corrected

The CMake comment for this test said it runs on no PR leg. That was true when I
wrote it on 08-14 and stopped being true six days later, when #2201
(`029dc30c`) made `ctest_mode` default to `full`. Corrected against a measured
run rather than a re-read: PR run 34291518125, job 102279464003, shows
`Test #200: iccdev.xml-parser-regressions .. Passed 18.51 sec`.

What the PR legs still cannot cover is the sed dialect — they are Linux and
Windows only, which is why this stayed green everywhere until your local macOS
run.

### Not changed

`Build/Cmake/wasm-package/regression.js:126` is the last GNU-only `sed -i` in the
tree — same class as this fix. It runs on ubuntu runners and is not a CTest, so a
local macOS `ctest` cannot reach it; left alone as out of scope, but `sed -i '' -e`
or `perl -pi -e` there would retire the class rather than one instance.

Two more GNU-only `stat -c` sites exist (`.github/ci/cfl/build.sh:305`,
`.github/scripts/iccdev-afl-smoke.sh:336`). Neither is CTest-registered, so
neither can produce a macOS ctest failure, and the portable idiom is already in
the tree at `iccdev-issue-1394-xml-num-array-dos.sh:115`. Left alone as out of
scope. Nine other CMakeLists comments repeat the now-stale `ctest_mode=fast`
claim; also left alone.

## Validation

- `iccdev.xml-parser-regressions` and `iccdev.extended-device-colorspace`: green.
- Strict clang 21.1.3 (`strict warnings ENABLED`) — **0 warnings**.
- GCC 15.2.0 in `ghcr.io/internationalcolorconsortium/iccdev:latest`
  (`strict warnings ENABLED`) — **0 warnings**.
- `shellcheck` on the changed script: rc=0.

Pre-open dispatch, `ci_scope=auto`: run **34294817657**, all lanes green. Read the
job log rather than the check name — job **102289111325** shows
`Test #200: iccdev.xml-parser-regressions .. Passed 22.10 sec` and
`Test #130: iccdev.extended-device-colorspace .. Passed`, 257/257 overall.
