### PR TITLE
fix(#2483): pin the vcpkg port to a commit that is on master

### DIFF
--- a/.github/ci/quality-assurance/scripts/iccApplyNamedCmm-quick-check.sh
+++ b/.github/ci/quality-assurance/scripts/iccApplyNamedCmm-quick-check.sh
@@ -16,7 +16,9 @@ qa_init "iccApplyNamedCmm-quick-check"
 BIN="$ICCDEV_TOOLS_DIR/IccApplyNamedCmm/iccApplyNamedCmm"
 FROM_XML="$ICCDEV_TOOLS_DIR/IccFromXml/iccFromXml"
 DATA="$ICCDEV_ROOT/.github/ci/test-data/test-data-rgb-16bit.txt"
+DATA8="$ICCDEV_ROOT/Testing/ApplyDataFiles/rgb8bit.txt"
 FLOAT_DATA="$ICCDEV_ROOT/.github/ci/test-data/test-data-rgb-float.txt"
+CMYK_DATA="$ICCDEV_ROOT/Testing/hybrid/Data/cmykGrays.txt"
 PROFILE="$ICCDEV_ROOT/Testing/sRGB_v4_ICC_preference.icc"
 BRDF_XML="$ICCDEV_ROOT/.github/ci/test-data/dtob-brdf.xml"
 CALC_XML="$ICCDEV_ROOT/Testing/Calc/argbCalc.xml"
@@ -30,8 +32,8 @@ CFG="$QA_OUTDIR/named.json"
 
 qa_require_tool "$BIN"
 qa_require_tool "$FROM_XML"
-for fixture in "$DATA" "$FLOAT_DATA" "$PROFILE" "$BRDF_XML" "$CALC_XML" \
-    "$HYBRID_XML" "$SPECTRAL_XML"; do
+for fixture in "$DATA" "$DATA8" "$FLOAT_DATA" "$CMYK_DATA" "$PROFILE" \
+    "$BRDF_XML" "$CALC_XML" "$HYBRID_XML" "$SPECTRAL_XML"; do
     qa_require_file "$fixture"
 done
 if [ "$QA_FAILURES" -ne 0 ]; then
@@ -44,10 +46,10 @@ qa_run build-calc success "" "$FROM_XML" "$CALC_XML" "$CALC"
 qa_run build-hybrid success "" "$FROM_XML" "$HYBRID_XML" "$HYBRID"
 qa_run build-spectral success "" "$FROM_XML" "$SPECTRAL_XML" "$SPECTRAL"
 
-qa_run basic success "" "$BIN" "$DATA" 0 0 "$PROFILE" 1
+qa_run basic success "" "$BIN" "$DATA8" 0 0 "$PROFILE" 1
 qa_run v5-brdf-direct success "" "$BIN" "$DATA" 6 1 "$BRDF" 10063
 qa_run v5-spectral-chain success "" "$BIN" \
-    "$ICCDEV_ROOT/Testing/hybrid/Data/cmykGrays.txt" 3 1 "$HYBRID" 10103 "$SPECTRAL" 10
+    "$CMYK_DATA" 3 1 "$HYBRID" 10103 "$SPECTRAL" 10
 qa_run debug success "" "$BIN" -debugcalc "$FLOAT_DATA" 3:8:12 0 "$CALC" 0
 qa_run environment success "" "$BIN" "$DATA" 0 0 \
     -ENV:bkgX 0.0985 -ENV:bkgY 0.159 -ENV:bkgZ 0.122 "$PROFILE" 1

--- a/.github/ci/quality-assurance/scripts/qa-common.sh
+++ b/.github/ci/quality-assurance/scripts/qa-common.sh
@@ -86,7 +86,7 @@ qa_run() {
     QA_LAST_LOG="$QA_OUTDIR/$name.log"
     QA_LAST_CMD="$QA_OUTDIR/$name.cmd"
     {
-        printf 'argc=%d\n' "$(( $# - 1 ))"
+        printf 'argc=%d\n' "$#"
         printf 'command='
         printf ' %q' "$@"
         printf '\n'

--- a/.github/scripts/iccdev-issue-1504-interp6d-nan-cast-regression-tests.sh
+++ b/.github/scripts/iccdev-issue-1504-interp6d-nan-cast-regression-tests.sh
@@ -14,6 +14,7 @@
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
 #   ICCDEV_BUILD_DIR   -- path to CMake build directory
+#   ICCDEV_CMAKE_CACHE -- path to the outer CMakeCache.txt for forwarded builds
 #   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
 ###############################################################################
 
@@ -23,6 +24,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
 BUILD_DIR="${ICCDEV_BUILD_DIR:-}"
+CMAKE_CACHE="${ICCDEV_CMAKE_CACHE:-}"
 OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-interp6d-nan-cast-regressions}"
 mkdir -p "$OUTDIR"
 
@@ -37,6 +39,10 @@ if [ -z "$BUILD_DIR" ] || [ ! -d "$BUILD_DIR/IccProfLib" ]; then
       break
     fi
   done
+fi
+
+if [ -z "$CMAKE_CACHE" ]; then
+  CMAKE_CACHE="$BUILD_DIR/CMakeCache.txt"
 fi
 
 if [ -z "${CXX:-}" ]; then
@@ -105,25 +111,25 @@ run_interp6d_helper() {
     return
   fi
 
-  if [ -f "$BUILD_DIR/CMakeCache.txt" ]; then
-    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+  if [ -f "$CMAKE_CACHE" ]; then
+    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$CMAKE_CACHE"; then
       if "$CXX" --version 2>/dev/null | grep -qi clang; then
         san_flags+=("-fsanitize=address,undefined,integer,float-divide-by-zero,float-cast-overflow")
       else
         san_flags+=("-fsanitize=address,undefined")
       fi
     else
-      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$CMAKE_CACHE"; then
         san_flags+=("-fsanitize=address")
       fi
-      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$CMAKE_CACHE"; then
         san_flags+=("-fsanitize=undefined")
       fi
-      if grep -q '^ENABLE_FLOAT_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
+      if grep -q '^ENABLE_FLOAT_SANITIZER:BOOL=ON$' "$CMAKE_CACHE" &&
          "$CXX" --version 2>/dev/null | grep -qi clang; then
         san_flags+=("-fsanitize=float-cast-overflow")
       fi
-      if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
+      if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$CMAKE_CACHE" &&
          "$CXX" --version 2>/dev/null | grep -qi clang; then
         san_flags+=("-fsanitize=integer")
       fi

--- a/.github/scripts/iccdev-issue-1505-encprofile-matrix-leak-regression-tests.sh
+++ b/.github/scripts/iccdev-issue-1505-encprofile-matrix-leak-regression-tests.sh
@@ -18,6 +18,7 @@
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
 #   ICCDEV_BUILD_DIR   -- path to CMake build directory
+#   ICCDEV_CMAKE_CACHE -- path to the outer CMakeCache.txt for forwarded builds
 #   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
 ###############################################################################
 
@@ -27,6 +28,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
 BUILD_DIR="${ICCDEV_BUILD_DIR:-}"
+CMAKE_CACHE="${ICCDEV_CMAKE_CACHE:-}"
 OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-encprofile-matrix-leak-regressions}"
 mkdir -p "$OUTDIR"
 
@@ -41,6 +43,10 @@ if [ -z "$BUILD_DIR" ] || [ ! -d "$BUILD_DIR/IccProfLib" ]; then
       break
     fi
   done
+fi
+
+if [ -z "$CMAKE_CACHE" ]; then
+  CMAKE_CACHE="$BUILD_DIR/CMakeCache.txt"
 fi
 
 if [ -z "${CXX:-}" ]; then
@@ -112,8 +118,8 @@ run_encprofile_helper() {
     return
   fi
 
-  if [ -f "$BUILD_DIR/CMakeCache.txt" ]; then
-    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+  if [ -f "$CMAKE_CACHE" ]; then
+    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$CMAKE_CACHE"; then
       if "$CXX" --version 2>/dev/null | grep -qi clang; then
         san_flags+=("-fsanitize=address,undefined,integer,float-divide-by-zero,float-cast-overflow")
       else
@@ -121,11 +127,11 @@ run_encprofile_helper() {
       fi
       has_asan=1
     else
-      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$CMAKE_CACHE"; then
         san_flags+=("-fsanitize=address")
         has_asan=1
       fi
-      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$CMAKE_CACHE"; then
         san_flags+=("-fsanitize=undefined")
       fi
     fi

--- a/.github/scripts/iccdev-tagcomposite-recursion-depth-regression-tests.sh
+++ b/.github/scripts/iccdev-tagcomposite-recursion-depth-regression-tests.sh
@@ -12,6 +12,7 @@
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
 #   ICCDEV_BUILD_DIR   -- path to CMake build directory
+#   ICCDEV_CMAKE_CACHE -- path to the outer CMakeCache.txt for forwarded builds
 #   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
 ###############################################################################
 
@@ -21,6 +22,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
 BUILD_DIR="${ICCDEV_BUILD_DIR:-}"
+CMAKE_CACHE="${ICCDEV_CMAKE_CACHE:-}"
 OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-tagcomposite-recursion-regressions}"
 mkdir -p "$OUTDIR"
 
@@ -35,6 +37,10 @@ if [ -z "$BUILD_DIR" ] || [ ! -d "$BUILD_DIR/IccProfLib" ]; then
       break
     fi
   done
+fi
+
+if [ -z "$CMAKE_CACHE" ]; then
+  CMAKE_CACHE="$BUILD_DIR/CMakeCache.txt"
 fi
 
 if [ -z "${CXX:-}" ]; then
@@ -103,21 +109,21 @@ run_recursion_depth_helper() {
     return
   fi
 
-  if [ -f "$BUILD_DIR/CMakeCache.txt" ]; then
-    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+  if [ -f "$CMAKE_CACHE" ]; then
+    if grep -q '^ENABLE_SANITIZERS:BOOL=ON$' "$CMAKE_CACHE"; then
       if "$CXX" --version 2>/dev/null | grep -qi clang; then
         san_flags+=("-fsanitize=address,undefined,integer,float-divide-by-zero,float-cast-overflow")
       else
         san_flags+=("-fsanitize=address,undefined")
       fi
     else
-      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      if grep -q '^ENABLE_ASAN:BOOL=ON$' "$CMAKE_CACHE"; then
         san_flags+=("-fsanitize=address")
       fi
-      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt"; then
+      if grep -q '^ENABLE_UBSAN:BOOL=ON$' "$CMAKE_CACHE"; then
         san_flags+=("-fsanitize=undefined")
       fi
-      if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$BUILD_DIR/CMakeCache.txt" &&
+      if grep -q '^ENABLE_INTEGER_SANITIZER:BOOL=ON$' "$CMAKE_CACHE" &&
          "$CXX" --version 2>/dev/null | grep -qi clang; then
         san_flags+=("-fsanitize=integer")
       fi

--- a/.github/workflows/ci-vcpkg-ports.yml
+++ b/.github/workflows/ci-vcpkg-ports.yml
@@ -219,7 +219,7 @@ jobs:
             errors=$((errors + 1))
           fi
           # Check tools
-          for tool in iccDumpProfile iccRoundTrip iccApplyNamedCmm iccFromXml iccToXml iccFromJson iccToJson; do
+          for tool in iccDumpProfile iccRoundTrip iccApplyNamedCmm iccFromXml iccToXml iccFromJson iccToJson iccBenchApply; do
             if [ -x "$PREFIX/tools/iccdev/$tool" ]; then
               echo "[OK] Tool $tool found"
             else
@@ -227,6 +227,13 @@ jobs:
               errors=$((errors + 1))
             fi
           done
+          if [ "$errors" -eq 0 ]; then
+            "$PREFIX/tools/iccdev/iccBenchApply" \
+              -pixels 4 -repeats 1 1 \
+              "$GITHUB_WORKSPACE/Testing/sRGB_v4_ICC_preference.icc" 0 \
+              >/dev/null
+            echo "[OK] Tool iccBenchApply smoke passed"
+          fi
           # Summary
           {
             echo "## vcpkg Port Verification - $(sanitize_line "$RUNNER_OS")"
@@ -294,13 +301,23 @@ jobs:
             $errors++
           }
           # Check tools
-          foreach ($tool in @('iccDumpProfile.exe','iccRoundTrip.exe','iccApplyNamedCmm.exe','iccFromXml.exe','iccToXml.exe','iccFromJson.exe','iccToJson.exe')) {
+          foreach ($tool in @('iccDumpProfile.exe','iccRoundTrip.exe','iccApplyNamedCmm.exe','iccFromXml.exe','iccToXml.exe','iccFromJson.exe','iccToJson.exe','iccBenchApply.exe')) {
             if (Test-Path "$prefix\tools\iccdev\$tool") {
               Write-Host "[OK] Tool $tool found"
             } else {
               Write-Host "[FAIL] Tool $tool NOT found"
               $errors++
             }
+          }
+          if ($errors -eq 0) {
+            & "$prefix\tools\iccdev\iccBenchApply.exe" `
+              -pixels 4 -repeats 1 1 `
+              "$env:GITHUB_WORKSPACE\Testing\sRGB_v4_ICC_preference.icc" 0 `
+              | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+              throw "iccBenchApply smoke failed with exit code $LASTEXITCODE"
+            }
+            Write-Host "[OK] Tool iccBenchApply smoke passed"
           }
           # Summary
           $os = Sanitize-Line "Windows"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,10 @@ jobs:
               autoconf-archive \
               automake \
               libtool \
-              libltdl-dev
+              libltdl-dev \
+              libx11-dev \
+              libxext-dev \
+              libxft-dev
           fi
 
           git clone https://github.com/microsoft/vcpkg.git "$RUNNER_TEMP/vcpkg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,8 @@ jobs:
               autoconf \
               autoconf-archive \
               automake \
-              libtool
+              libtool \
+              libltdl-dev
           fi
 
           git clone https://github.com/microsoft/vcpkg.git "$RUNNER_TEMP/vcpkg"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,16 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           source .github/scripts/sanitize-sed.sh
 
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            bash .github/scripts/ci-safe-apt-update.sh
+            # preflight: allow-package-install reason=vcpkg-libxcrypt-host-build-tools
+            sudo apt-get install -y --no-install-recommends \
+              autoconf \
+              autoconf-archive \
+              automake \
+              libtool
+          fi
+
           git clone https://github.com/microsoft/vcpkg.git "$RUNNER_TEMP/vcpkg"
           git -C "$RUNNER_TEMP/vcpkg" checkout "$VCPKG_BASELINE"
           "$RUNNER_TEMP/vcpkg/bootstrap-vcpkg.sh" -disableMetrics

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -48,7 +48,7 @@ if(TARGET iccdev-stage-windows-runtime)
 endif()
 
 function(iccdev_add_regression_executable TARGET_NAME)
-  add_executable("${TARGET_NAME}" EXCLUDE_FROM_ALL ${ARGN})
+  add_executable("${TARGET_NAME}" ${ARGN})
   add_dependencies(build-test-binaries "${TARGET_NAME}")
 endfunction()
 

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -48,7 +48,7 @@ if(TARGET iccdev-stage-windows-runtime)
 endif()
 
 function(iccdev_add_regression_executable TARGET_NAME)
-  add_executable("${TARGET_NAME}" ${ARGN})
+  add_executable("${TARGET_NAME}" EXCLUDE_FROM_ALL ${ARGN})
   add_dependencies(build-test-binaries "${TARGET_NAME}")
 endfunction()
 

--- a/Build/Cmake/Testing/RunWindowsBatchTest.cmake
+++ b/Build/Cmake/Testing/RunWindowsBatchTest.cmake
@@ -79,7 +79,11 @@ list(REMOVE_DUPLICATES _candidate_tool_suffixes)
 if(DEFINED ICCDEV_UNIFIED_RUNTIME_DIR AND
    EXISTS "${ICCDEV_UNIFIED_RUNTIME_DIR}/iccFromXml.exe")
   set(_resolved_runtime_dir "${ICCDEV_UNIFIED_RUNTIME_DIR}")
-  set(_resolved_config "${ICCDEV_CONFIG}")
+  if(DEFINED ICCDEV_CONFIG AND NOT "${ICCDEV_CONFIG}" STREQUAL "")
+    set(_resolved_config "${ICCDEV_CONFIG}")
+  else()
+    set(_resolved_config "unified-runtime")
+  endif()
 endif()
 
 if(_resolved_config STREQUAL "")

--- a/Build/Cmake/vcpkg.json
+++ b/Build/Cmake/vcpkg.json
@@ -15,5 +15,11 @@
     "libjpeg-turbo",
     "zlib"
   ],
-  "overrides": []
+  "overrides": [
+    {
+      "name": "libiconv",
+      "version": "1.18",
+      "port-version": 0
+    }
+  ]
 }

--- a/ports/iccdev/portfile.cmake
+++ b/ports/iccdev/portfile.cmake
@@ -42,8 +42,8 @@ else()
     vcpkg_from_github(
         OUT_SOURCE_PATH SOURCE_PATH
         REPO InternationalColorConsortium/iccDEV
-        REF 9faef90079563147e5fe1e9409b91f501f5f08aa
-        SHA512 f6cab490e9b7979a57ec79287e2bd39bedb8cdc8e307092d3289ca4355cd3016d0328239cb12e446b21c28c3a010ed7dd64997bdc25188aa2349ff45ac923dc3
+        REF 1a4a2892c0ba929d4c3dc6313663650dad90208f
+        SHA512 d15e2b3a0c25a351fa59fc9f21890922ec30f917a549207e51b44ecf0c56ed3e423f2e67fa69d6cc0de27e0ae28cca084578704d5baafc120b691f284f44e612
         HEAD_REF master
     )
 endif()

--- a/ports/iccdev/portfile.cmake
+++ b/ports/iccdev/portfile.cmake
@@ -132,6 +132,7 @@ if("tools" IN_LIST FEATURES)
         iccPawgReport
         iccV5DspObsToV4Dsp
         iccProfileVisualize
+        iccBenchApply
     )
     vcpkg_copy_tools(TOOL_NAMES ${_core_tools} AUTO_CLEAN)
 

--- a/ports/iccdev/vcpkg.json
+++ b/ports/iccdev/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "iccdev",
   "version": "2.3.2.3",
-  "port-version": 2,
+  "port-version": 3,
   "description": "ICC color profile libraries and tools (RefIccMAX / iccDEV)",
   "homepage": "https://github.com/InternationalColorConsortium/iccDEV",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## PR Summary

Fixes #2483.

`ports/iccdev/portfile.cmake` pinned `REF 9faef900`, a commit contained in no
branch. GitHub still served the unreferenced archive, but the port would fail
once that object was garbage-collected. This PR re-points the port at
`1a4a2892`, the #2480 merge commit on `master`, regenerates the SHA512, and
increments `port-version` from 2 to 3.

The cumulative branch also completes the coupled vcpkg and QA follow-up:

- Pins manifest-mode `libiconv` to 1.18.
- Ships and verifies `iccBenchApply` in the vcpkg tools feature.
- Adds the Ubuntu autotools, ltdl, and X11 development prerequisites required
  by the pinned vcpkg `libxcrypt` and Cairo ports.
- Preserves ordinary build-then-CTest behavior by keeping regression helpers in
  the default build.
- Supports forwarded CMake caches in three focused regression scripts.
- Handles an unnamed unified Windows runtime configuration.
- Corrects QA argument accounting and channel-appropriate
  `iccApplyNamedCmm` fixtures.

### Pin evidence

The archive hash was measured twice through both URL forms vcpkg may use:

```text
d15e2b3a0c25a351fa59fc9f21890922ec30f917a549207e51b44ecf0c56ed3e423f2e67fa69d6cc0de27e0ae28cca084578704d5baafc120b691f284f44e612
```

| REF | Ancestor of master | Contained in a branch |
|---|---|---|
| `9faef900` (before) | No | No |
| `1a4a2892` (after) | Yes | Yes |

### Contract matrix

| Surface | Producer | Consumer | Build/runtime behavior | Platform boundary | CI trigger/owner | Evidence |
|---|---|---|---|---|---|---|
| vcpkg source pin | `ports/iccdev/portfile.cmake` | Overlay-port installs | Fetches an immutable archive reachable from `master` | All vcpkg platforms | `ci-vcpkg-ports`; vcpkg maintainers | SHA512 and ancestry checks |
| Manifest dependency pin | `Build/Cmake/vcpkg.json` | CMake manifest-mode vcpkg | Resolves `libiconv` 1.18 consistently | Windows, Linux, macOS | Manual platform-package workflow; vcpkg registry | Windows manifest job passed on prior head; Linux dependency resolution reached `libxcrypt` |
| Packaged benchmark tool | `ports/iccdev/portfile.cmake` | Installed vcpkg tools feature | Installs `iccBenchApply` and runs a four-pixel smoke | Unix and Windows package layouts | `ci-vcpkg-ports`; port owner | Both artifact verification lists updated; local smoke passed |
| Linux vcpkg host tools | `.github/workflows/ci.yml` | vcpkg `libxcrypt` and Cairo builds | Installs the required autotools, ltdl, and X11 development packages before vcpkg bootstrap | Ubuntu only; macOS path unchanged | Manual `vcpkg platform packages` workflow | Runs 34347468003, 34351242567, and 34354270314 identified the staged host requirements; workflow preflight passed |
| Regression cache forwarding | Three `.github/scripts/iccdev-*-regression-tests.sh` scripts | Forwarded/nested build layouts | Reads sanitizer flags from `ICCDEV_CMAKE_CACHE`, falling back to the build cache | POSIX compiler and sanitizer builds | Tool coverage and focused regression owners | All three scripts passed against the fresh WSL build |
| Windows batch runtime label | `RunWindowsBatchTest.cmake` | Windows batch-backed CTest suites | Uses `unified-runtime` when no configuration name is supplied | Windows unified runtime layout | Windows full build/CTest owner | Branch logic reviewed; no empty configuration label remains |
| Named CMM QA fixtures | QA common and quick-check scripts | Maintainer apply-tool QA | Records the full command argc and uses data matching the declared channels | POSIX QA shell | Apply-tool QA owner | All 14 quick-check cases passed |

### Local validation

- Fresh WSL Clang 18 Release configure and default build with tools and tests
  enabled completed successfully.
- The default build produced
  `out/pr2484-linux/Testing/iccSignatureUtilsContractTest`, confirming regression
  helpers remain part of the ordinary build.
- The issue 1504, issue 1505, and composite recursion-depth scripts completed
  with zero failures. The issue 1505 leak probe reported its expected
  non-ASan skip.
- `iccApplyNamedCmm-quick-check.sh`: 14 checks passed.
- `iccBenchApply -pixels 4 -repeats 1 1 ...`: passed.
- `.github/scripts/preflight-safety-checks.sh --fast-lane`: zero failures.
  `zizmor` was the single unavailable local tool; actionlint, yamllint,
  ShellCheck, workflow policy, permissions, and security canaries passed.
- A focused `iccdev.applynamedcmm-cli-args` run passed before the maintainer
  directed that no further local CTest be run.
- Final read-only cumulative diff review found no actionable findings.

### Hosted validation

- `ci-vcpkg-ports` Windows overlay and manifest jobs passed on commit
  `1caae2b9`.
- Manual run 34347468003 identified the missing autotools prerequisites.
- Manual run 34351242567 advanced past autotools and identified the additional
  `libltdl-dev` requirement now installed by this branch.
- Manual run 34354270314 advanced past `libxcrypt`; Windows and macOS passed,
  while Linux identified Cairo's explicit `libx11-dev`, `libxft-dev`, and
  `libxext-dev` requirements now installed by this branch.
- Hosted checks for commit `bc32c21e` are pending.

## Checklist

- [x] Signed all commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md)
- [x] Ran focused relevant regression/profile validation
- [x] Updated the PR documentation for the complete changed surface
- [x] Ran the applicable sanitizer-aware regression scripts
- [x] Added or updated regression and package verification for behavior changes
- [x] Attached a `base...HEAD` contract matrix for cross-cutting changes
- [x] Reviewed active and suppressed automated findings
- [x] Maintainer-owned workflow, CTest, and vcpkg infrastructure changes were explicitly requested
- [x] No new source files were added
- [x] Code style matches nearby code

## Legal Requirements

All official software projects hosted by the International Color Consortium
(ICC) follow the open source software best practice policies. The
[International Color Consortium IP policy](https://www.color.org/iccip.xalter)
governs ICC specification development and contributions to ICC open source
software. Software contributions are also covered by the Contributor License
Agreement (CLA).

### Contributor License Agreements

Developers who wish to contribute code to be considered for inclusion in ICC
software must first complete a **Contributor License Agreement (CLA)**.

There is no cost or membership requirement to sign the ICC Contributor License
Agreement (CLA). This is different from membership in the International Color
Consortium (ICC). If your organization relies on our projects, please become a
member. Membership dues are an essential source of funding and investment in
these projects.

- If you are an individual writing the code on your own time and are the sole
  owner of the intellectual property, sign the
  [individual CLA](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).
- If you are writing the code as part of your job, or your employer may own the
  intellectual property, use the
  [corporate CLA](https://github.com/InternationalColorConsortium/.github/blob/main/docs/CLA.md).

### License

ICC software is licensed under the BSD 3-Clause "New" or "Revised" License.
Contributions should follow that license unless otherwise specified or
approved by the ICC.

### Copyright Notices

All new source files must begin with the ICC copyright notice and include or
reference the BSD 3-Clause "New" or "Revised" License.

### Intellectual Property and Patents

Participation in ICC development activities is subject to the
[ICC Patent Policy](https://www.color.org/iccip.xalter).

## Maintainer Review Required

For questions, contact a listed
[maintainer](https://github.com/InternationalColorConsortium/iccDEV/blob/master/.github/CODEOWNERS).
