### PR TITLE
docs(#2487): correct the stale ctest_mode rationale on eleven registrations

### DIFF
--- a/.github/scripts/iccdev-issue-2414-console-sanitize-sweep-tests.sh
+++ b/.github/scripts/iccdev-issue-2414-console-sanitize-sweep-tests.sh
@@ -53,8 +53,10 @@
 # Red/green against 764fc176: all eight defect cases fail (raw ESC present,
 # escaped form absent).  Both controls pass on BOTH builds.
 #
-# NOT labelled "slow": ci-pr-action.yml pins ctest_mode=fast, which drops the
-# slow label, and this suite needs to run on the pull_request path (#2412).
+# NOT labelled "slow": this suite has to stay in the routine set, and
+# check-fast and the dispatch-only Unix and fast-lane runs all exclude
+# that label.  Not a PR-path concern since #2201 (029dc30c) made ctest_mode
+# default to full (#2412).
 #
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -7796,8 +7796,10 @@ iccdev_add_script_test(
 # iccdev.specsep-usage-exit-code-regression above: a malformed invocation must not
 # report success, an unrecognised option must not be skipped in silence, -v must not
 # fail open, and -noid must leave no profile ID behind (#2387).  Deliberately NOT
-# labelled "slow", so it runs on the pull_request path -- ci-pr-action.yml pins
-# ctest_mode=fast, which drops the slow label.
+# labelled "slow": check-fast and the dispatch-only Unix and fast-lane
+# runs all exclude that label, so applying it would drop this suite from each.
+# Not a PR-path concern since #2201 (029dc30c) made ctest_mode default to full;
+# the iccdev.xml-parser-regressions block below carries the measured account.
 if(TARGET iccFromXml)
   iccdev_add_script_test(
     iccdev.fromxml-cli-contract-regression
@@ -7816,8 +7818,9 @@ if(TARGET iccFromXml)
 endif()
 
 # #2401: the element (<n>) and text spellings of one XML array must agree.  Not
-# labelled "slow", so it runs on the pull_request path (ci-pr-action.yml pins
-# ctest_mode=fast, which drops the slow label).
+# labelled "slow": check-fast and the dispatch-only Unix and fast-lane
+# runs all exclude that label, so applying it would drop this suite from each.
+# Not a PR-path concern since #2201 (029dc30c) made ctest_mode default to full.
 if(TARGET iccFromXml)
   iccdev_add_script_test(
     iccdev.xml-array-element-form-regression
@@ -7835,9 +7838,10 @@ if(TARGET iccFromXml)
 endif()
 
 # #2406: profile and data-file paths must not carry terminal control sequences
-# into the tools' diagnostics (CWE-150/CWE-117).  Not labelled "slow", so it
-# runs on the pull_request path (ci-pr-action.yml pins ctest_mode=fast, which
-# drops the slow label).  Four cases x "timeout 60" is a 240s worst case.
+# into the tools' diagnostics (CWE-150/CWE-117).  Not labelled "slow":
+# check-fast and the dispatch-only Unix and fast-lane runs all exclude
+# that label.  Not a PR-path concern since #2201 (029dc30c) made ctest_mode
+# default to full.  Four cases x "timeout 60" is a 240s worst case.
 if(TARGET iccApplyProfiles AND TARGET iccApplySearch
    AND TARGET iccApplyNamedCmm AND TARGET iccApplyToLink)
   iccdev_add_script_test(
@@ -7863,8 +7867,10 @@ endif()
 # FIX rather than the defect: a path probe before open() takes a named pipe from
 # 254 to 124, which is why iccFromCube does not use the shared guard.
 #
-# Deliberately NOT labelled "slow", so it runs on the pull_request path:
-# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+# Deliberately NOT labelled "slow": check-fast and the dispatch-only Unix
+# and fast-lane runs all exclude that label, so applying it would drop
+# this suite from each.  Not a PR-path concern since #2201 (029dc30c) made
+# ctest_mode default to full (#2412).
 #
 # 300s for a 220s worst case (7 spawns: 20+60+20+20+20+60+20), matching the two
 # registrations above.  240 would leave 20s for eight process spawns, and on a
@@ -7896,8 +7902,10 @@ endif()
 # Guarded on iccFromCube alone: unlike the #2414 suite this measures one tool,
 # so a partial build has nothing to hide.
 #
-# Deliberately NOT labelled "slow", so it runs on the pull_request path:
-# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+# Deliberately NOT labelled "slow": check-fast and the dispatch-only Unix
+# and fast-lane runs all exclude that label, so applying it would drop
+# this suite from each.  Not a PR-path concern since #2201 (029dc30c) made
+# ctest_mode default to full (#2412).
 #
 # 400s for a 290s worst case (10 spawns: 15+15+30+30+30+30+30+30+20+60).  As
 # with the registration above, the budget is set over the SUM of the per-case
@@ -7931,8 +7939,10 @@ endif()
 # three of its named-colour profiles from tracked XML rather than from
 # Testing/*.icc, every one of which is generated.
 #
-# Deliberately NOT labelled "slow", so it runs on the pull_request path --
-# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+# Deliberately NOT labelled "slow": check-fast and the dispatch-only Unix
+# and fast-lane runs all exclude that label, so applying it would drop
+# this suite from each.  Not a PR-path concern since #2201 (029dc30c) made
+# ctest_mode default to full (#2412).
 #
 # 300s for a ~200s worst case: 3 iccFromXml profile builds at 120s each is the
 # ceiling, but they complete in well under a second on every lane measured, and
@@ -7968,8 +7978,9 @@ endif()
 # precisely the regression this suite exists to diagnose.
 #
 # Deliberately NOT labelled "slow", for the same reason as the apply-usage suite
-# below: ci-pr-action.yml pins ctest_mode=fast, which drops the slow label, and
-# a console-injection regression that runs on no PR leg is not a regression test
+# below: check-fast and the dispatch-only Unix and fast-lane runs all
+# exclude that label, so applying it would drop this suite from each.  Not a
+# PR-path concern since #2201 (029dc30c) made ctest_mode default to full
 # (#2412).
 if(TARGET iccDumpProfile AND TARGET iccToXml)
   iccdev_add_script_test(
@@ -7987,8 +7998,10 @@ endif()
 # The iccApply* half of the same CLI-contract family (#2405).  Guarded on all
 # four targets because the script measures all four and its "nothing measured"
 # guard would otherwise turn a partial build into a skip that hides real cases.
-# Deliberately NOT labelled "slow", so it runs on the pull_request path --
-# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+# Deliberately NOT labelled "slow": check-fast and the dispatch-only Unix
+# and fast-lane runs all exclude that label, so applying it would drop
+# this suite from each.  Not a PR-path concern since #2201 (029dc30c) made
+# ctest_mode default to full (#2412).
 if(TARGET iccApplyProfiles AND TARGET iccApplySearch
    AND TARGET iccApplyNamedCmm AND TARGET iccApplyToLink)
   iccdev_add_script_test(
@@ -8010,8 +8023,10 @@ endif()
 # random bytes alike.  Guarded on the target so a lane that does not build the
 # Tools skips rather than going red.
 #
-# Deliberately NOT labelled "slow", for the same reason as the siblings above --
-# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+# Deliberately NOT labelled "slow", for the same reason as the siblings above:
+# check-fast and the dispatch-only Unix and fast-lane runs all exclude
+# that label.  Not a PR-path concern since #2201 (029dc30c) made ctest_mode
+# default to full (#2412).
 if(TARGET iccDumpProfile)
   iccdev_add_script_test(
     iccdev.dumpprofile-exit-code-regression
@@ -8030,8 +8045,10 @@ endif()
 # measured" guard would otherwise turn a partial build into a skip that hides
 # the half that did build.
 #
-# Deliberately NOT labelled "slow", for the same reason as the sibling above --
-# ci-pr-action.yml pins ctest_mode=fast, which drops the slow label (#2412).
+# Deliberately NOT labelled "slow", for the same reason as the sibling above:
+# check-fast and the dispatch-only Unix and fast-lane runs all exclude
+# that label.  Not a PR-path concern since #2201 (029dc30c) made ctest_mode
+# default to full (#2412).
 if(TARGET iccFromXml AND TARGET iccFromJson)
   iccdev_add_script_test(
     iccdev.invalid-profile-exit-code-regression


### PR DESCRIPTION
Fixes #2487.

Eleven comments of mine justified leaving a suite unlabelled `"slow"` with
*"ci-pr-action.yml pins ctest_mode=fast, which drops the slow label"*. That was
true when written and stopped being true on 2026-08-20.

## Why the rationale died

Before #2201 (`029dc30c`) `ci-pr-action.yml` passed **no** `ctest_mode`, so
`ci-iccdev-tool-tests.yml`'s own fallback `inputs.ctest_mode || 'fast'` (`:288`)
made every PR leg `fast` — and `fast` is the mode that adds
`--label-exclude slow --label-exclude calculator` (`:543`, feeding `ctest_args`
into the run at `:553`). #2201 introduced the plumbing with `full` as the
default (`ci-pr-action.yml:297`); `full` excludes only `known-red` (`:529`).

## What still justifies omitting the label

The PR path no longer does. Four other exclusions do, and **none consults
`ctest_mode`**:

| site | exclusion |
|---|---|
| `check-fast` target (`Testing/CMakeLists.txt:68`) | `--label-exclude "slow\|known-red"` |
| `_build-test-unix.yml:287` and `:292` | `--label-exclude slow`, every run |
| `apply_fast_lane_defaults` (`ci-pr-action.yml:413`) | sets `ctest_mode=fast` |

That last one is the only `ctest_mode=fast` site that can still reach CTest.
`apply_docs_only_defaults` (`:422`) also sets `fast` and is deliberately not
listed: `tool-tests` gates on `native_changed` (`:1020`, governing the `uses:`
at `:1024`), `native_changed` has exactly one producer (`:602`) and it follows
`source_changed` (`:601`), which needs a `.c/.cpp/.h` edit — so a docs-only diff
sets the mode but never reaches CTest.

Both workflow lanes are `workflow_dispatch`-only today — `_build-test-unix`
← `_build-matrix` ← `ci-build-test-no-fuzzers` / `ci-comprehensive-build-test`,
and `ci-json-python`. So the PR-path correction holds, but the reason to omit
the label survives on the local `check-fast` target and those lanes — and that
is what the comments now say. Stating only the dead mechanism would have read
as an argument that the label is harmless.

### Why Docker is not in that table

`ci-docker-pr.yml:433` does exclude `^(slow|calculator)$`, and an earlier draft
of this change listed it. It is **deliberately excluded now**: that workflow
declares only `workflow_call:` and **no workflow anywhere has a `uses:` pointing
at it**, so it cannot run — the sole other mention, `ci-pr-action.yml:573`, is a
changed-path regex, not an invocation. The Docker lane that *does* run,
`ci-docker.yml` (`push` + `workflow_dispatch`), carries no `--label-exclude` at
all. Naming Docker as a reason would put a lane that cannot execute into
load-bearing rationale — the same substitution of a false claim for a stale one
that this PR exists to remove. Caught by self-review, not by me.

The first block now points at the `iccdev.xml-parser-regressions` note
(`:8433` on master), which carries the measured account with run and job IDs,
so the history has one source of truth rather than twelve.

## Scope

Comments only — **0 non-comment lines changed**, verified by diffing with
`-U0` and filtering for lines not beginning with `#`.

- `Build/Cmake/Testing/CMakeLists.txt` — 10 comment blocks
- `.github/scripts/iccdev-issue-2414-console-sanitize-sweep-tests.sh` — 1

## Evidence

- `cmake -S Build/Cmake -B <out>` configures clean, rc=0.
- `shellcheck` passes bare on the changed script.
- All 13 affected registrations survive `ctest -N --label-exclude slow`
  (13 listed with the exclusion, 13 without) — no label was added or removed.
- No occurrence of the stale phrase remains in any tracked file.

**This change runs zero CTests by construction**: `native_changed` requires a
`.c/.cpp/.h` edit, and this PR touches neither.
