### PR TITLE
fix(#2494): scope the CodeQL database to the product build

### DIFF
--- a/.github/codeql-config.yml
+++ b/.github/codeql-config.yml
@@ -1,5 +1,14 @@
 name: "iccDEV CodeQL Security Analysis"
 
+# NOTE: ci-codeql-security.yml does not consult this file. It drives the CodeQL
+# CLI directly (`codeql database create --source-root="."`) with no
+# codeql-action/init step, so the `paths`/`paths-ignore` keys below are inert
+# there; the workflow lists this file only as a `push:` trigger filter. Scan
+# scope is set by the CMake configure step in that workflow -- currently
+# -DENABLE_TESTS=OFF. Changing scope by editing the keys below will trigger a
+# green run that scans exactly what it did before. See #2494; whether to wire
+# this config up or retire it is an open maintainer decision.
+
 queries:
   - uses: ./.github/codeql-queries/iccdev-security-suite.qls
   - uses: ./.github/codeql-queries/iccdev-jsonlib-suite.qls

--- a/.github/scripts/run-codeql-local.sh
+++ b/.github/scripts/run-codeql-local.sh
@@ -62,6 +62,11 @@ Build configuration:
   The CodeQL database is built out-of-tree with ICC_JSON_ORDERED=ON so CI and
   local analysis use deterministic JSON key ordering.
 
+  Scope is the product build only: ENABLE_TESTS=OFF, matching
+  ci-codeql-security.yml. The regression suite under .github/ci/regression is
+  NOT in the database, so an alert reported there will not reproduce here --
+  that is expected, not evidence the alert is fixed.
+
 Examples:
   # Full analysis from scratch
   $(basename "$0")
@@ -137,9 +142,13 @@ if [ "$SKIP_BUILD" -eq 0 ]; then
 
     rm -rf "$BUILD_DIR"
     mkdir -p "$BUILD_DIR"
+    # ENABLE_TESTS=OFF to match ci-codeql-security.yml: the database covers
+    # whatever `all` builds, so without it a local scan sees the regression
+    # suite and reports alerts CI would not.
     cmake -S "$REPO_ROOT/Build/Cmake" -B "$BUILD_DIR" \
         -DCMAKE_BUILD_TYPE=Debug \
         -DENABLE_TOOLS=ON \
+        -DENABLE_TESTS=OFF \
         -DICC_JSON_ORDERED=ON \
         -DCMAKE_C_COMPILER=clang \
         -DCMAKE_CXX_COMPILER=clang++

--- a/.github/workflows/ci-codeql-security.yml
+++ b/.github/workflows/ci-codeql-security.yml
@@ -149,9 +149,19 @@ jobs:
           git config --global credential.helper ""
           unset GITHUB_TOKEN || true
           source "$TRUSTED_SCRIPTS/sanitize-sed.sh"
+          # ENABLE_TESTS=OFF keeps the regression suite out of the database.
+          # `codeql database create --command=` builds the default target, so
+          # scan scope is whatever `all` compiles -- .github/codeql-config.yml
+          # is a push-trigger filter here and never reaches the CLI. Since #2480
+          # dropped EXCLUDE_FROM_ALL the suite is in `all`: its 105 test TUs
+          # entered the database and produced 29 of the 30 alerts on that scan.
+          # ENABLE_TESTS gates only ENABLE_TESTING() and the
+          # Testing subdirectory (Build/Cmake/CMakeLists.txt:2133-2136), so no
+          # product target is lost.
           cmake -S Build/Cmake -B /tmp/iccdev-codeql-build \
             -DCMAKE_BUILD_TYPE=Debug \
             -DENABLE_TOOLS=ON \
+            -DENABLE_TESTS=OFF \
             -DICC_JSON_ORDERED=ON \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++


### PR DESCRIPTION
## PR Summary

Part of #2494. Implements the maintainer's Suggestion Box ask — ban CodeQL from
processing `.github/ci/regression/` — by keeping the suite out of the database.

`codeql database create --command="cmake --build ..."` passes no `--target`, so the
database covers whatever `all` compiles. `.github/codeql-config.yml` declares
`paths`/`paths-ignore` but never reaches the CLI: there is no `codeql-action/init`
step in this workflow, and the file appears only as a `push:` trigger filter. So
`paths-ignore` cannot deliver the ban; excluding the translation units from the
build is the only mechanism that does.

Since #2480 dropped `EXCLUDE_FROM_ALL` from `iccdev_add_regression_executable`, the
suite is in `all`. `ENABLE_TESTS` gates exactly `ENABLE_TESTING()` and
`ADD_SUBDIRECTORY( Testing )` at `Build/Cmake/CMakeLists.txt:2133-2136`, with no
library-type or product side effects. `-DENABLE_TESTS=OFF` is already the repo
convention for scan-only builds (`ports/iccdev/portfile.cmake:83`,
`docs/maintainer-qa-scans.md:276`).

## Measured

Workflow's own configure recipe, Debug/clang, targets counted with
`cmake --build DIR --target help`:

| | baseline | `ENABLE_TESTS=OFF` |
|---|---|---|
| targets | 155 | 46 |
| regression TUs in the database | **106** | **1** |
| product targets lost | — | **0** |

The 109 dropped targets are 105 regression executables plus the
`build-test-binaries`, `check` and `check-fast` aggregates and the `test` driver
that `ENABLE_TESTING()` creates. All four libraries (static and shared) and all 23
tools survive.

The surviving TU is `iccDescribeSinkTest.cpp`, which belongs to a Tools target in
the default build. That is the same single TU the last clean scan compiled at
`6b71794f`, so this restores the pre-#2480 scan scope rather than narrowing it.

## Root cause: scan scope, not the monthly image roll

Both master scans, read from the run logs:

| | `6b71794f` clean (run 34293293753) | `308e561e` alerts (run 34403360741) |
|---|---|---|
| runner image | ubuntu-24.04 `20260907.300.1` | ubuntu-24.04 **`20260831.293.1`** |
| CodeQL bundle | 2.26.4 | 2.26.4, same pinned SHA-256 |
| query suite | — | unchanged, no commits between |
| clang | 18.1.3 | 18.1.3 |
| `Building CXX object Testing/` | **0** | **113** |
| distinct regression TUs | **1** | **106** |

The clean scan ran on the *newer* image. Bundle, queries and compiler are identical
across both. The only variable that moved is scan scope, so this does not recur
monthly — it recurs whenever the suite is in `all`.

The same reasoning covers the one product-file alert
(`IccProfLib/IccTagEmbedIcc.cpp:148`, `cpp/inconsistent-null-check`): that file is
unchanged between the two commits and was compiled in both scans, and the only
IccProfLib change in between was `IccCmm.cpp`/`.h` from #2491, unrelated to
`NewCopy`. By elimination the added test translation units are what moved the
proportion this query keys on. Hand-counting the call sites does not reproduce the
"75%" the message quotes, which suggests the query groups calls differently than a
source grep does — recorded as unresolved rather than claimed.

On the merits that alert is a false positive regardless: the result is stored and
never dereferenced, and a NULL `m_pProfile` is a deliberately valid state.

## Why not dismiss the alerts by hand

Once the translation units leave the database, the next analysis on the same ref and
category closes those 29 as fixed. Hand-dismissals are 29 actions that resurrect
under new alert numbers when fingerprints drift.

## Also in this PR

- `run-codeql-local.sh` carries the same configure block and gets the same flag —
  without it a local scan reports alerts CI does not. Its `--help` now records the
  narrowed scope, because `docs/codeql.md:11` asks that the local runner help track
  scope changes, and a maintainer who cannot reproduce a regression-suite alert
  locally must not read that as the alert being fixed.
- `codeql-config.yml` gains a note that its `paths` keys are inert for this
  workflow. Editing them is the obvious way to change scope and would produce a
  green run that scanned exactly what it did before — the same defect class as this
  issue.

## Left open for a maintainer decision

Whether to wire `codeql-config.yml` up or retire it, and correct `docs/codeql.md:11`
accordingly. This PR only annotates the file; it does not make that call, which is
why this is "Part of" rather than "Fixes".

## Verification

No C or C++ source changes, so no compiler-warning gate applies. The gates
`ci-preflight-safety` runs over `.github/**` were run locally and are clean:

- `actionlint .github/workflows/ci-codeql-security.yml` — exit 0
- `yamllint` with the preflight ruleset over both YAML files — exit 0
- `shellcheck .github/scripts/run-codeql-local.sh` — exit 0
- `bash -n` on the script — exit 0
- longest added line 80 chars

Both edited paths are in this workflow's `push:` filter, so the scan re-runs on
merge. Whether alert 2397 survives that run is the test of the elimination argument
above: if it clears with the test TUs gone, the attribution here is right.

## Checklist

- [x] Signed all Commits in PR
- [x] Built locally according to `docs/build.md`
- [x] Followed the guidelines in [Contributing](https://github.com/InternationalColorConsortium/iccDEV/blob/master/CONTRIBUTING.md) document
- [x] Ran relevant CTest/profile tests from `docs/ctest.md` — n/a, no source change
- [x] Updated documentation for user-visible behavior changes
- [ ] Ran sanitizer coverage for memory-safety or parser changes — n/a
- [ ] Added or updated regression coverage for behavior changes — n/a, CI config only
- [x] Attached a `base...HEAD` contract matrix for cross-cutting changes
