### PR TITLE
fix(schema): remove the duplicate top-level description key

### DIFF
--- a/docs/icc-connect-config.schema.json
+++ b/docs/icc-connect-config.schema.json
@@ -2,7 +2,6 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "icc-connect-config.schema.json",
   "title": "IccConnect Configuration Schema",
-  "description": "JSON Schema for IccConnect CMM configuration objects (IccCmmConfig.h/cpp)",
 
   "$defs": {
 
@@ -475,7 +474,7 @@
 
   },
 
-  "description": "Top-level IccConnect configuration document. Must contain an iccApplyNamedCmm data configuration (dataFiles + profileSequence), an iccApplyProfiles image configuration (imageFiles + profileSequence), an iccApplySearch configuration (dataFiles + searchApply), or a library create-link configuration (createLink + profileSequence).",
+  "description": "Top-level IccConnect configuration document, mirroring the CIccCfg* objects in IccCmmConfig.h/cpp. Must contain an iccApplyNamedCmm data configuration (dataFiles + profileSequence), an iccApplyProfiles image configuration (imageFiles + profileSequence), an iccApplySearch configuration (dataFiles + searchApply), or a library create-link configuration (createLink + profileSequence).",
   "type": "object",
   "anyOf": [
     { "required": ["dataFiles", "profileSequence"] },


### PR DESCRIPTION
﻿## Summary

`docs/icc-connect-config.schema.json` declares `"description"` **twice** in its
root object -- once at line 5 beside `$schema`/`$id`/`title`, and again 470
lines later beside `type`/`anyOf`/`properties`. This keeps the maintained one
and deletes the stale one.

## Why it matters

RFC 8259 says object names SHOULD be unique and leaves duplicate handling
undefined. Parsers diverge; the common behaviour -- Python's `json` and
nlohmann included -- is to keep the **last**. So the first declaration was
already dead text, but by accident rather than by design, and any consumer that
kept the first instead would see stale wording.

The two had drifted into saying different things:

- **line 5** (deleted) -- "JSON Schema for IccConnect CMM configuration objects
  (IccCmmConfig.h/cpp)"; describes the *file*
- **line 478** (kept) -- describes the *document shape*, enumerating the four
  `anyOf` combinations

## Which one is stale, and how I know

Not a guess -- the history settles it:

- Both appeared together in `11ff2009` (#1001), so this is an authoring slip in
  the original file, not a bad merge.
- `749203fe` (#1615) **rewrote line 478**, from "profileSequence + one of
  applyData/applyImage/createLink" to the current four-shape wording, in the
  same hunk that added the `anyOf` block it describes.
- Line 5 has not been touched since the file was created.

So line 478 is actively maintained and sits with the keywords it documents;
line 5 is boilerplate nobody has read in a year. The useful half of it -- that
the schema mirrors the `CIccCfg*` objects in `IccCmmConfig.h/cpp` -- is folded
into the surviving description rather than dropped.

## Verification

- No duplicate keys anywhere in the schema (checked with a parse hook over
  every object, not just the root)
- `.github/scripts/iccdev-connect-config-schema-tests.sh`: 33 configs
  validated, 5 negative shape checks rejected
- Diff is +1/-2

Note the repo validator cannot catch this class of defect: it validates
*documents against* the schema, and by the time `check_schema` sees the schema
the JSON parser has already collapsed the duplicate.

## How it was found

While adding a key to this schema on another branch, a
`json.load`/`json.dumps` round trip silently merged the two declarations --
which would have buried a semantic change inside a 179-line reformatting diff.
That edit was redone as a minimal text change, and this defect split out here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
