### PR TITLE
fix(#2504): copy the bit pattern instead of punning it, in all three IccUtil sites

### DIFF
--- a/.github/ci/regression/utf8-converter-cursor-contract.cpp
+++ b/.github/ci/regression/utf8-converter-cursor-contract.cpp
@@ -1,0 +1,195 @@
+// Coverage for icUtf16ToUtf8() and icWCharToUtf8() (IccProfLib/IccUtil.cpp),
+// added with the strict-aliasing fix in #2504.
+//
+// What this test does NOT do: it cannot observe the aliasing violation it was
+// written alongside.  Both converters used to hand icConvertUTF16toUTF8() a
+// (UTF8**) aimed at a char* object, so the callee stored a UTF8* through a
+// char* lvalue and the caller read it back as char*.  That is undefined, but
+// it was measured not to misbehave: gcc 13 and clang 18 at -O2 and at
+// -O3 -flto all produce identical output before and after the fix.  A runtime
+// test asserting "the bytes are right" therefore passes against the unfixed
+// build too, and would be worth nothing on its own.
+//
+// What it does do is guard the rewrite.  Removing the pun meant re-typing the
+// output cursor as UTF8* and recomputing the assigned length against a UTF8*
+// base:
+//
+//     buf.assign(szBuf, (size_t)(szDest - szBuf));          // was
+//     buf.assign(szBuf, (size_t)(szDest - (UTF8*)szBuf));   // now
+//
+// That arithmetic is the part a careless edit breaks, and icWCharToUtf8() had
+// NO coverage at all when the fix was written -- deliberately corrupting its
+// length by one byte left all 264 tests green, because no tracked XML fixture
+// contains a DictEntry and there is no dict CTest, so the one path that reaches
+// it (the dictType writers in IccTagXml.cpp and IccTagJson.cpp) is never
+// exercised.  icUtf16ToUtf8() was covered only indirectly, by four tests that
+// happen to route through it.
+//
+// The length assertions below are the point: each one pins the exact byte count
+// the converter reports, not merely that the text looks right.  A truncated or
+// over-long cursor changes size() while c_str() can still compare equal up to
+// the NUL.
+//
+// Returns 0 on success; the number of failed assertions otherwise.
+
+#include "IccUtil.h"
+#include "icProfileHeader.h"
+
+#include <string>
+#include <cstdio>
+#include <cstring>
+#include <cwchar>
+
+namespace {
+
+int g_fail = 0;
+
+void check(bool ok, const char *what)
+{
+  if (!ok) {
+    ++g_fail;
+    printf("FAIL: %s\n", what);
+  }
+}
+
+// Compares both the reported length and the bytes.  size() is checked first and
+// separately because that is what the cursor arithmetic decides; a converter
+// that writes correct bytes but reports the wrong length still fails here.
+void checkUtf16(const icUInt16Number *src, int len,
+                const char *expect, size_t expectLen, const char *what)
+{
+  std::string buf;
+  const char *rv = icUtf16ToUtf8(buf, src, len);
+  char msg[256];
+
+  snprintf(msg, sizeof(msg), "%s: length (got %zu, want %zu)", what, buf.size(), expectLen);
+  check(buf.size() == expectLen, msg);
+
+  snprintf(msg, sizeof(msg), "%s: bytes", what);
+  check(buf.size() == expectLen && memcmp(buf.data(), expect, expectLen) == 0, msg);
+
+  // This does NOT pin the cursor: c_str()[size()] is '\0' by std::string's own
+  // contract whatever length was assigned, so a short or long cursor still
+  // satisfies it -- the length and byte checks above are what catch that.  What
+  // it does guard is the return value's provenance: both converters build into
+  // a malloc'd scratch buffer, free it, and return buf.c_str().  A future edit
+  // that returned the scratch pointer instead would fail here.
+  snprintf(msg, sizeof(msg), "%s: returns the string's own storage", what);
+  check(rv == buf.c_str() && rv[buf.size()] == '\0', msg);
+}
+
+void checkWChar(const wchar_t *src, size_t len,
+                const char *expect, size_t expectLen, const char *what)
+{
+  std::string buf;
+  const char *rv = icWCharToUtf8(buf, src, len);
+  char msg[256];
+
+  snprintf(msg, sizeof(msg), "%s: length (got %zu, want %zu)", what, buf.size(), expectLen);
+  check(buf.size() == expectLen, msg);
+
+  snprintf(msg, sizeof(msg), "%s: bytes", what);
+  check(buf.size() == expectLen && memcmp(buf.data(), expect, expectLen) == 0, msg);
+
+  // See checkUtf16: provenance, not cursor position.
+  snprintf(msg, sizeof(msg), "%s: returns the string's own storage", what);
+  check(rv == buf.c_str() && rv[buf.size()] == '\0', msg);
+}
+
+} // namespace
+
+int main()
+{
+  // --- icUtf16ToUtf8 -------------------------------------------------------
+  {
+    // ASCII: one UTF-16 unit per byte out.  The simplest case that still moves
+    // the cursor, so a base-pointer mistake shows up immediately.
+    const icUInt16Number ascii[] = { 'i', 'c', 'c', 'D', 'E', 'V', 0 };
+    checkUtf16(ascii, 6, "iccDEV", 6, "utf16 ascii, explicit length");
+
+    // sizeSrc = 0 means "measure it" (CIccUTF16String::WStrlen), a separate
+    // entry path into the same cursor code.
+    checkUtf16(ascii, 0, "iccDEV", 6, "utf16 ascii, measured length");
+
+    // U+00E9 -> 2 bytes, U+20AC -> 3 bytes.  Output length now differs from
+    // input length, which is what makes the cursor arithmetic load-bearing.
+    const icUInt16Number mixed[] = { 'a', 0x00E9, 0x20AC, 'z', 0 };
+    checkUtf16(mixed, 4, "a\xC3\xA9\xE2\x82\xACz", 7, "utf16 2- and 3-byte sequences");
+
+    // U+1F600 as a surrogate pair: 2 input units collapse to 4 output bytes.
+    const icUInt16Number surrogate[] = { 0xD83D, 0xDE00, 0 };
+    checkUtf16(surrogate, 2, "\xF0\x9F\x98\x80", 4, "utf16 surrogate pair");
+
+    // A trailing unpaired high surrogate is DROPPED: the converter stops at the
+    // incomplete pair and never emits it, so two input units yield one byte.
+    // This is the case that actually pins the cursor -- the reported length
+    // reflects where the converter stopped, not how much input it was given, so
+    // a length derived from sizeSrc rather than from the cursor fails here.
+    const icUInt16Number truncated[] = { 'a', 0xD83D, 0 };
+    checkUtf16(truncated, 2, "a", 1, "utf16 trailing unpaired surrogate dropped");
+
+    // An unpaired surrogate NOT at the end is passed through as a 3-byte
+    // sequence (U+D83D -> ED A0 BD) rather than replaced.  That output is
+    // CESU-8, and iccDEV's own isLegalUTF8String() rejects it -- measured, and
+    // reported separately; this case pins today's behaviour so a later fix to
+    // that is a deliberate, visible change rather than a silent one.
+    const icUInt16Number cesu[] = { 0xD83D, 'a', 0 };
+    checkUtf16(cesu, 2, "\xED\xA0\xBD" "a", 4, "utf16 interior unpaired surrogate (CESU-8, current behaviour)");
+
+    // Interior NUL: the converter is length-driven, so it must not stop early.
+    // buf.assign(ptr, len) preserves it; a c_str()-based length would not.
+    const icUInt16Number embedded[] = { 'a', 0x0000, 'b', 0 };
+    checkUtf16(embedded, 3, "a\0b", 3, "utf16 interior NUL kept");
+
+    // Degenerate inputs take the early-return arms, which never touch the
+    // cursor at all.
+    {
+      std::string buf("stale");
+      icUtf16ToUtf8(buf, NULL, 4);
+      check(buf.empty(), "utf16 NULL source clears the buffer");
+    }
+    {
+      std::string buf("stale");
+      const icUInt16Number empty[] = { 0 };
+      icUtf16ToUtf8(buf, empty, 0);
+      check(buf.empty(), "utf16 empty source clears the buffer");
+    }
+  }
+
+  // --- icWCharToUtf8 -------------------------------------------------------
+  // Reached in production only through the dictType writers.  Which arm of the
+  // WCHAR_MAX branch runs is platform-dependent (UTF-32 where wchar_t is wide,
+  // UTF-16 on Windows); these cases are chosen to hold on both.
+  {
+    const wchar_t ascii[] = L"iccDEV";
+    checkWChar(ascii, 6, "iccDEV", 6, "wchar ascii, explicit length");
+
+    // sizeSrc = 0 means wcslen().
+    checkWChar(ascii, 0, "iccDEV", 6, "wchar ascii, measured length");
+
+    const wchar_t mixed[] = { L'a', 0x00E9, 0x20AC, L'z', 0 };
+    checkWChar(mixed, 4, "a\xC3\xA9\xE2\x82\xACz", 7, "wchar 2- and 3-byte sequences");
+
+    const wchar_t embedded[] = { L'a', 0, L'b', 0 };
+    checkWChar(embedded, 3, "a\0b", 3, "wchar interior NUL kept");
+
+    {
+      std::string buf("stale");
+      icWCharToUtf8(buf, NULL, 4);
+      check(buf.empty(), "wchar NULL source clears the buffer");
+    }
+    {
+      std::string buf("stale");
+      const wchar_t empty[] = L"";
+      icWCharToUtf8(buf, empty, 0);
+      check(buf.empty(), "wchar empty source clears the buffer");
+    }
+  }
+
+  if (g_fail)
+    printf("%d assertion(s) failed\n", g_fail);
+  else
+    printf("utf8 converter cursor contract: all assertions passed\n");
+
+  return g_fail;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5013,6 +5013,58 @@ function(iccdev_add_signature_utils_contract_test)
   endif()
 endfunction()
 
+function(iccdev_add_utf8_converter_cursor_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccUtf8ConverterCursorTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/utf8-converter-cursor-contract.cpp"
+  )
+  target_compile_features(iccUtf8ConverterCursorTest PRIVATE cxx_std_17)
+
+  target_include_directories(iccUtf8ConverterCursorTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccUtf8ConverterCursorTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccUtf8ConverterCursorTest)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.utf8-converter-cursor-contract
+      COMMAND "$<TARGET_FILE:iccUtf8ConverterCursorTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.utf8-converter-cursor-contract
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccUtf8ConverterCursorTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.utf8-converter-cursor-contract PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;iccprofLib;utf8;utf16;aliasing;issue-2504;regression"
+  )
+  if(WIN32)
+    # icWCharToUtf8 takes the UTF-16 arm of its WCHAR_MAX branch here, which no
+    # other test compiles or runs; the runtime paths must resolve for it to run.
+    set(_utf8cursor_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccUtf8ConverterCursorTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _utf8cursor_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.utf8-converter-cursor-contract PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_utf8cursor_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 function(iccdev_add_mcs_colorspace_name_test)
   if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
     return()
@@ -7344,6 +7396,7 @@ if(WIN32)
   iccdev_add_struct_name_spelling_test()
   iccdev_add_mcs_colorspace_name_test()
   iccdev_add_signature_utils_contract_test()
+  iccdev_add_utf8_converter_cursor_test()
   iccdev_add_console_sanitize_codepoint_test()
   iccdev_add_tiff_create_overflow_test()
   iccdev_add_tiff_separated_strips_test()
@@ -7718,6 +7771,7 @@ iccdev_add_tag_name_spelling_test()
 iccdev_add_struct_name_spelling_test()
 iccdev_add_mcs_colorspace_name_test()
 iccdev_add_signature_utils_contract_test()
+iccdev_add_utf8_converter_cursor_test()
 iccdev_add_console_sanitize_codepoint_test()
 iccdev_add_tiff_create_overflow_test()
 iccdev_add_tiff_separated_strips_test()

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -701,11 +701,18 @@ icFloat16Number ICCPROFLIB_API icFtoF16(icFloat32Number num)
 {
   icUInt16Number rv;
   icUInt16Number rvsgn, rvexp, rvmnt;
-  icUInt32Number flt, *fltp, fltsgn, fltexp, fltmnt;
+  icUInt32Number flt, fltsgn, fltexp, fltmnt;
   int exp;
 
-  fltp = (icUInt32Number*)&num;
-  flt = *fltp;
+  // The bit pattern is copied out instead of being read through an
+  // icUInt32Number lvalue aimed at the float argument. num is a float object,
+  // and a wide-integer load of it is undefined -- the same defect #1948 fixed
+  // in CIccIO::Write16/32/64, reported here by cppcheck as invalidPointerCast
+  // (#2504). icF16toF above already returns its result through memcpy; only
+  // this direction was left punning, so it inherits the twin's idiom rather
+  // than a new one.
+  static_assert(sizeof(flt) == sizeof(num), "icFloat32Number must match icUInt32Number width for icFtoF16");
+  memcpy(&flt, &num, sizeof(flt));
   if (!(flt & 0x7FFFFFFF)) {
     rv = (icUInt16Number) (flt >> 16);
   } else { 
@@ -3136,10 +3143,16 @@ const char *icUtf16ToUtf8(std::string &buf, const icUInt16Number *szSrc, int siz
       buf.clear();
       return buf.c_str();
     }
-    char *szDest = szBuf;
-    icConvertUTF16toUTF8(&szSrc, &szSrc[sizeSrc], (UTF8**)&szDest, (UTF8*)&szBuf[n], lenientConversion);
+    // icConvertUTF16toUTF8 stores its advanced cursor through a UTF8** out
+    // parameter. The old (UTF8**)&szDest aimed that at a char* object, so the
+    // callee wrote a UTF8* through a char* lvalue and this function read it
+    // back as char* -- undefined for the same reason as :707 above. Declaring
+    // the cursor UTF8* removes the pun rather than hiding it; UTF8 is unsigned
+    // char, so the bytes written and the length computed are unchanged.
+    UTF8 *szDest = (UTF8*)szBuf;
+    icConvertUTF16toUTF8(&szSrc, &szSrc[sizeSrc], &szDest, (UTF8*)&szBuf[n], lenientConversion);
     *szDest = '\0';
-    buf.assign(szBuf, (size_t)(szDest - szBuf));
+    buf.assign(szBuf, (size_t)(szDest - (UTF8*)szBuf));
     free(szBuf);
   } else {
     buf.clear();
@@ -3175,16 +3188,18 @@ const char *icWCharToUtf8(std::string &buf, const wchar_t *szSrc, size_t sizeSrc
       buf.clear();
       return buf.c_str();
     }
-    char *szDest = szBuf;
+    // Same UTF8** out-parameter pun as icUtf16ToUtf8 above, on both arms of
+    // the WCHAR_MAX branch.
+    UTF8 *szDest = (UTF8*)szBuf;
 #if WCHAR_MAX > 65535
     const UTF32 *szPtr = (const UTF32 *)szSrc;
-    icConvertUTF32toUTF8(&szPtr, &szPtr[sizeSrc], (UTF8**)&szDest, (UTF8*)&szBuf[n], lenientConversion);
+    icConvertUTF32toUTF8(&szPtr, &szPtr[sizeSrc], &szDest, (UTF8*)&szBuf[n], lenientConversion);
 #else
     const UTF16 *szPtr = (const UTF16 *)szSrc;
-    icConvertUTF16toUTF8(&szPtr, &szPtr[sizeSrc], (UTF8**)&szDest, (UTF8*)&szBuf[n], lenientConversion);
+    icConvertUTF16toUTF8(&szPtr, &szPtr[sizeSrc], &szDest, (UTF8*)&szBuf[n], lenientConversion);
 #endif
     *szDest = '\0';
-    buf.assign(szBuf, (size_t)(szDest - szBuf));
+    buf.assign(szBuf, (size_t)(szDest - (UTF8*)szBuf));
     free(szBuf);
   } else {
     buf.clear();


### PR DESCRIPTION
Part of #2504.

## The issue named one site; GCC finds three

`icFtoF16` read its float argument through an `icUInt32Number` lvalue. Its twin
`icF16toF` ten lines above **already** had `static_assert` + `memcpy` — the fix
existed in the file and had only ever been applied to one direction. This
applies it to the other.

Two more sites in the same file carry the same defect and are **not** in the
issue: `icUtf16ToUtf8` and `icWCharToUtf8` both passed `icConvertUTF16toUTF8` a
`(UTF8**)` aimed at a `char*` object, so the callee stored a `UTF8*` through a
`char*` lvalue the caller then read back as `char*`.

**cppcheck reports those two only as `cstyleCast`, never as `invalidPointerCast`
— its check does not model pointer-to-pointer punning.** That, not the code, is
why the issue lists one site and `-Wstrict-aliasing=2` lists three. Worth
knowing when triaging the rest of the `ci-pr-lint` output.

## Deliberately not fixed, and not claimed safe

The `(const UTF32*)szSrc` / `(const UTF16*)szSrc` casts of the `wchar_t` input in
`icWCharToUtf8`. `wchar_t` is a distinct fundamental type in C++, not its
underlying type's signed/unsigned counterpart, so those reads are punned too.
What keeps them working is GCC/clang placing `wchar_t` in the underlying type's
TBAA alias set and MSVC doing no type-based aliasing analysis — compiler
tolerance, not a guarantee, and why `-Wstrict-aliasing=2` still reports 0.
Converting the input cursor means staging the whole string through a copy on a
serialization path, so I left it for a separate decision rather than folding it
in. **If you consider those out of scope, #2504's named site is fully fixed and
the issue can close.**

## This one is latent — which decided the test

The unfixed form does not misbehave: gcc 13 and clang 18, `-O2` and `-O3 -flto`,
give identical results. `num` is a by-value parameter, so the store and the
punned load sit in one function — unlike #1948, where they were in separate TUs
and LTO really did flatten segmented-curve breakpoints to 0.0.

**So a runtime test for the aliasing would pass against the unfixed build**, and
none is added for it. Proof used instead: the shipped `libIccProfLib2-static`
compared against the pre-fix body (built `-O0 -fno-strict-aliasing`) over all
2^32 float bit patterns — NaNs, infinities, subnormals, both zeros — **0
mismatches**. GCC warnings on the file: 3 to 0.

## What the new CTest does guard

The rewrite: re-typing the output cursor and recomputing the length against a
`UTF8*` base. `icWCharToUtf8` had **no coverage at all** — corrupting its length
by one byte left all 264 tests green, because no tracked XML fixture contains a
`DictEntry` and there is no dict CTest, so the dictType writers that reach it
never run. The same corruption now fails 8 assertions.

Cursor cases are chosen so a length taken from the input size also fails: a
trailing unpaired high surrogate is dropped, so 2 input units yield 1 byte.
ASCII cannot catch that — there the two numbers coincide.

## Pre-flight

| Profile | Result |
|---|---|
| Clang 21.1.3 strict, `-Wall -Wextra -Wpedantic -Werror` | 0 warnings, 0 errors |
| GCC 15.2.0 in `ghcr.io/internationalcolorconsortium/iccdev:latest`, `-Werror` + LTO | 0 warnings, 0 errors |
| ctest in that container | **265/265 passed** |

Dispatched `ci-pr-action` `ci_scope=source` before opening, per the documented
ordering: **run 34515683834 — 14 success / 2 skipped** (skips are the manual
thread-linkage job and the PowerShell audit).

Not just a green lane — the new test is confirmed to have **run** on Windows
MSVC (job 103000530333): `68/154 Test #68: iccdev.utf8-converter-cursor-contract
... Passed`. That is the leg that exercises the Windows-only UTF-16 arm of
`icWCharToUtf8`, which no Linux build compiles.

## Two things found in passing, not filed

1. `icUtf16ToUtf8` passes an interior unpaired surrogate through as 3-byte
   CESU-8 (`U+D83D` -> `ED A0 BD`). Measured: iccDEV's own
   `isLegalUTF8String()` returns **FALSE** on that output. Pre-existing; pinned
   as current behaviour in the new test so a later fix is deliberate. Happy to
   file if useful.
2. The dictType XML/JSON writers have no corpus coverage whatsoever — no tracked
   XML fixture has a `DictEntry`. Natural home is #2088.