### PR TITLE
ci: Align Python setuptools cap across workflows

### DIFF
--- a/.github/instructions/python-bindings.instructions.md
+++ b/.github/instructions/python-bindings.instructions.md
@@ -68,7 +68,7 @@ locations.
 - Python 3.9+
 - Cython >= 3.0,<3.2 for all source builds
 - NumPy >= 1.23,<3 for array operations
-- setuptools >= 64,<81
+- setuptools >= 64,<85
 - Dev extras: pytest, numpy, build, wheel, twine, cibuildwheel
 
 All GitHub Actions `pip install` lines for this package must use bounded

--- a/.github/workflows/_build-test-unix.yml
+++ b/.github/workflows/_build-test-unix.yml
@@ -722,7 +722,7 @@ jobs:
             "numpy>=1.23,<3" \
             "pytest>=7.0,<9; python_version < '3.10'" \
             "pytest>=9.0.3,<10; python_version >= '3.10'" \
-            "setuptools>=64,<81" \
+            "setuptools>=64,<85" \
             "twine>=5.0,<7" \
             "wheel>=0.46.2,<0.47" \
             --quiet
@@ -772,7 +772,7 @@ jobs:
             "cython>=3.0,<3.2" \
             "pytest>=7.0,<9; python_version < '3.10'" \
             "pytest>=9.0.3,<10; python_version >= '3.10'" \
-            "setuptools>=64,<81" \
+            "setuptools>=64,<85" \
             "twine>=5.0,<7" \
             "wheel>=0.46.2,<0.47" \
             --quiet

--- a/.github/workflows/_build-test-windows.yml
+++ b/.github/workflows/_build-test-windows.yml
@@ -207,7 +207,7 @@ jobs:
           python -m pip install `
             'build>=1.2,<1.4' `
             'cython>=3.0,<3.2' `
-            'setuptools>=64,<81' `
+            'setuptools>=64,<85' `
             'wheel>=0.46.2,<0.47'
 
           cd python


### PR DESCRIPTION
Align the Python build workflow dependency installs and binding instructions with the setuptools >=64,<85 cap merged in #2514.\n\nValidation:\n- Built the Linux CPython 3.14 wheel using setuptools 84.0.0, wheel 0.48.0, and Cython 3.1.8.\n- Installed the produced wheel in a clean virtual environment.\n- python/tests/test_packaging.py: 5 passed.\n- actionlint passed for both edited workflows; yamllint reported only pre-existing line-length warnings.