### PR TITLE
fix(#2509): count cppcheck's real output format, and report the whole file

### DIFF
--- a/.github/workflows/ci-pr-lint.yml
+++ b/.github/workflows/ci-pr-lint.yml
@@ -363,14 +363,18 @@ jobs:
           [ -f lint_reports/cppcheck.txt ] || : > lint_reports/cppcheck.txt
           [ -f lint_reports/clang_tidy.txt ] || : > lint_reports/clang_tidy.txt
 
-          sanitize_code_line() {
-            local s="$1"
-            s="${s//$'\r'/}"
-            s="${s//$'\n'/ }"
-            s="$(printf '%s' "$s" | tr -d '\000-\011\013\014\016-\037\177')"
-            s="${s//\`\`\`/\` \` \`}"
-            sanitize_line "$s"
-          }
+          # The local sanitize_code_line() that stood here shadowed the trusted one from
+          # sanitize-sed.sh and finished by calling sanitize_line(), which runs
+          # escape_html(). Inside a ```text fence GitHub does not decode entities, so every
+          # quoted symbol in a diagnostic rendered literally as "&#39;strcpy&#39;" and
+          # cppcheck's template messages as "CIccTagFloatNum &lt; float &gt;". That was
+          # tolerable when only a 50-line tail was exposed; it is not, now that the whole
+          # analyzer view goes through it. The trusted sanitize_code_line() exists for
+          # exactly this case -- its own contract says "use it only inside fenced code
+          # blocks so JSON and command output remain readable" -- and it still strips CR/LF
+          # and every control character and still neutralizes ``` so a diagnostic cannot
+          # break out of the fence. It is the only difference: escaping is dropped, nothing
+          # else is.
 
           {
             echo "## ci-pr-lint Report"
@@ -386,12 +390,36 @@ jobs:
             echo ""
             echo "| Tool | Lines | Diagnostics | Errors |"
             echo "|------|------:|------------:|-------:|"
+
+            # cppcheck 2.x emits one diagnostic per line as
+            #   {file}:{line}:{column}: {severity}: {message} [{id}]
+            # followed by the offending source line and a caret. The patterns these
+            # replace anchored on cppcheck 1.x's "[{file}:{line}]: ({severity})" bracket
+            # template, which the installed cppcheck (2.x on ubuntu-24.04) never produces,
+            # so BOTH cppcheck counters reported 0 on every run. Measured on the reports
+            # of runs 34432960602 / 34483706504 / 34515122355: 47451 lines, 6854
+            # diagnostics, 1 error -- the error being the IccMpeSpectral.cpp:1693
+            # autovarInvalidDeallocation line that issue #2503 was opened from. The lane
+            # was therefore printing "Errors: 0" on the run carrying its only error.
+            # "note:" lines are cppcheck's secondary locations, not separate findings, and
+            # are deliberately excluded from the diagnostic total.
+            cpp_diag_re='^[^ ]+:[0-9]+:[0-9]+: (error|warning|style|performance|portability|information):'
+            cpp_err_re='^[^ ]+:[0-9]+:[0-9]+: error:'
             cpp_lines="$(wc -l < lint_reports/cppcheck.txt | tr -d ' ')"
-            cpp_warns="$(grep -Ec '^\[[^]]+:[0-9]+\]: \((warning|style|performance|portability|information)\)' lint_reports/cppcheck.txt || true)"
-            cpp_errs="$(grep -Ec '^\[[^]]+:[0-9]+\]: \(error\)' lint_reports/cppcheck.txt || true)"
+            cpp_warns="$(grep -Ec "$cpp_diag_re" lint_reports/cppcheck.txt || true)"
+            cpp_errs="$(grep -Ec "$cpp_err_re" lint_reports/cppcheck.txt || true)"
+
+            # clang-tidy's pattern was correct for warnings; "error:" is added so the
+            # Diagnostics column means the same thing on both rows. It previously counted
+            # only warnings while the cppcheck column counted every severity, so summing
+            # Diagnostics + Errors was right for one row and double-counted the other.
+            # clang-tidy emitted 0 errors on run 34515122355, so the printed number is
+            # unchanged at 43759; the semantics are what this fixes.
+            tidy_diag_re=':[0-9]+:[0-9]+: (warning|error):'
+            tidy_err_re=':[0-9]+:[0-9]+: error:'
             tidy_lines="$(wc -l < lint_reports/clang_tidy.txt | tr -d ' ')"
-            tidy_warns="$(grep -Ec ':[0-9]+:[0-9]+: warning:' lint_reports/clang_tidy.txt || true)"
-            tidy_errs="$(grep -Ec ':[0-9]+:[0-9]+: error:' lint_reports/clang_tidy.txt || true)"
+            tidy_warns="$(grep -Ec "$tidy_diag_re" lint_reports/clang_tidy.txt || true)"
+            tidy_errs="$(grep -Ec "$tidy_err_re" lint_reports/clang_tidy.txt || true)"
             printf '| cppcheck | %s | %s | %s |\n' \
               "$(sanitize_line "$cpp_lines")" \
               "$(sanitize_line "$cpp_warns")" \
@@ -401,6 +429,27 @@ jobs:
               "$(sanitize_line "$tidy_warns")" \
               "$(sanitize_line "$tidy_errs")"
             echo ""
+
+            # A counter that quietly reads 0 against a non-empty report is exactly how the
+            # stale cppcheck pattern above survived unnoticed: the summary looked like a
+            # clean lane rather than a broken parser. Assert the two disagree loudly, so
+            # the next output-format change is visible in the run instead of latent.
+            # Both variables are consumed after this block to raise a log annotation.
+            cpp_parse_warning=""
+            tidy_parse_warning=""
+            if [ "$cpp_lines" -gt 0 ] && [ "$cpp_warns" -eq 0 ]; then
+              cpp_parse_warning="cppcheck report has ${cpp_lines} lines but 0 parsed diagnostics; the output template no longer matches the pattern in this workflow"
+              printf '> **cppcheck output unparsed** -- %s lines, 0 diagnostics matched.\n' \
+                "$(sanitize_line "$cpp_lines")"
+              echo ""
+            fi
+            if [ "$tidy_lines" -gt 0 ] && [ "$tidy_warns" -eq 0 ]; then
+              tidy_parse_warning="clang-tidy report has ${tidy_lines} lines but 0 parsed diagnostics; the output format no longer matches the pattern in this workflow"
+              printf '> **clang-tidy output unparsed** -- %s lines, 0 diagnostics matched.\n' \
+                "$(sanitize_line "$tidy_lines")"
+              echo ""
+            fi
+
             echo "### Component coverage"
             echo ""
             echo "| Component | Selected files | cppcheck lines | clang-tidy lines |"
@@ -425,26 +474,119 @@ jobs:
                 "$(sanitize_line "$tidy_lines")"
             done
             echo ""
-            echo "<details><summary>cppcheck tail</summary>"
+            # The two blocks below replace `tail -n 50` over each report. The reports are
+            # concatenated in component order, so a fixed tail showed only whichever
+            # component sorted last: measured on run 34515122355, the last 50 lines of a
+            # 213889-line clang-tidy report carry 10 diagnostics from one file, and 50 lines
+            # of the 47451-line cppcheck report names two. IccProfLib's 141105 clang-tidy
+            # lines were never visible. One diagnostic can consume the whole window on its
+            # own -- the note behind issue #2509 prints every enumerator of the enum it
+            # cites. Report the distribution of the whole file plus the findings that carry
+            # severity, rather than an arbitrary window into one component.
+            #
+            # emit_capped SRC LIMIT -- sanitize each line of SRC into the open code fence,
+            # stopping after LIMIT lines and saying how many were withheld. Keeps a
+            # pathological report from exhausting the 1 MB step-summary budget.
+            emit_capped() {
+              local src="$1" limit="$2" shown=0 total
+              total="$(wc -l < "$src" | tr -d ' ')"
+              while IFS= read -r line; do
+                if [ "$shown" -ge "$limit" ]; then
+                  printf '... %s more, see the ci-pr-lint-reports artifact\n' \
+                    "$(sanitize_code_line "$((total - shown))")"
+                  break
+                fi
+                sanitize_code_line "$line"
+                echo ""
+                shown=$((shown + 1))
+              done < "$src"
+              if [ "$total" -eq 0 ]; then
+                echo "(none)"
+              fi
+            }
+
+            # These derived views are named outside the cppcheck_*/clang_tidy_* prefixes on
+            # purpose: those globs are what the two tool steps concatenate their
+            # per-component reports with, and a file matching them would be folded into a
+            # later report as though it were tool output.
+            grep -E "$cpp_diag_re" lint_reports/cppcheck.txt \
+              > lint_reports/summary_cpp_diags.txt || true
+            sed -E 's/^[^ ]+:[0-9]+:[0-9]+: ([a-z]+):.*/\1/' lint_reports/summary_cpp_diags.txt \
+              | sort | uniq -c | sort -rn > lint_reports/summary_cpp_severity.txt || true
+            grep -E "$cpp_err_re" lint_reports/summary_cpp_diags.txt \
+              > lint_reports/summary_cpp_errors.txt || true
+            grep -oE '\[[A-Za-z][A-Za-z0-9_]*\]$' lint_reports/summary_cpp_diags.txt \
+              | sort | uniq -c | sort -rn | head -n 25 > lint_reports/summary_cpp_ids.txt || true
+
+            echo "<details><summary>cppcheck: severity counts, top ids, and error-severity findings</summary>"
             echo ""
             echo '```text'
-            tail -n 50 lint_reports/cppcheck.txt | while IFS= read -r line; do
-              sanitize_code_line "$line"
-              echo ""
-            done
+            emit_capped lint_reports/summary_cpp_severity.txt 20
+            echo ""
+            echo "-- top 25 message ids --"
+            emit_capped lint_reports/summary_cpp_ids.txt 25
+            echo ""
+            # Labelled with its own bound rather than "in full": a summary that overstates
+            # its own completeness is the failure this change exists to close. The cap is set
+            # far above the observed count (1 on a 203-file run) so it should not bite.
+            echo "-- error severity, up to 200 --"
+            emit_capped lint_reports/summary_cpp_errors.txt 200
             echo '```'
             echo "</details>"
             echo ""
-            echo "<details><summary>clang-tidy tail</summary>"
+
+            # clang-tidy's style checks dominate the line count, so the check histogram is
+            # the only view that shows where the findings actually are, and the analyzer
+            # findings are the subset that describes behaviour rather than style.
+            grep -E "$tidy_diag_re" lint_reports/clang_tidy.txt \
+              > lint_reports/summary_tidy_diags.txt || true
+            grep -oE '\[[a-z][A-Za-z0-9.-]*(,[a-z][A-Za-z0-9.-]*)*\]$' lint_reports/summary_tidy_diags.txt \
+              | sort | uniq -c | sort -rn | head -n 30 > lint_reports/summary_tidy_checks.txt || true
+            grep -F '[clang-analyzer-' lint_reports/summary_tidy_diags.txt \
+              > lint_reports/summary_tidy_analyzer.txt || true
+            grep -oE '\[clang-analyzer-[A-Za-z0-9.]+\]$' lint_reports/summary_tidy_analyzer.txt \
+              | sort | uniq -c | sort -rn > lint_reports/summary_tidy_ancounts.txt || true
+
+            # Cap the verbatim analyzer findings PER CHECKER rather than overall. One
+            # checker can dominate the class for reasons that are by design: on run
+            # 34515122355, 252 of the 330 analyzer findings are EnumCastOutOfRange, 211 of
+            # them in IccUtil.cpp's CIccInfo::Get*SigName chain, which casts a raw
+            # icUInt32Number into each signature enum in turn precisely to ask whether it is
+            # a known member. A flat cap would spend the whole budget there and hide the
+            # single-instance core.* findings, which are the reason to read this at all.
+            awk -v per=8 '
+              match($0, /\[clang-analyzer-[A-Za-z0-9.]+\]$/) {
+                checker = substr($0, RSTART, RLENGTH)
+                seen[checker]++
+                if (seen[checker] <= per)
+                  print
+                else if (seen[checker] == per + 1)
+                  printf "... further %s findings withheld, see the artifact\n", checker
+              }' lint_reports/summary_tidy_analyzer.txt \
+              > lint_reports/summary_tidy_ancapped.txt || true
+
+            echo "<details><summary>clang-tidy: top 30 checks, and the analyzer findings</summary>"
             echo ""
             echo '```text'
-            tail -n 50 lint_reports/clang_tidy.txt | while IFS= read -r line; do
-              sanitize_code_line "$line"
-              echo ""
-            done
+            emit_capped lint_reports/summary_tidy_checks.txt 30
+            echo ""
+            echo "-- clang-analyzer findings by checker --"
+            emit_capped lint_reports/summary_tidy_ancounts.txt 40
+            echo ""
+            echo "-- clang-analyzer findings, up to 8 per checker --"
+            emit_capped lint_reports/summary_tidy_ancapped.txt 150
             echo '```'
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"  # elements-sanitized
+
+          # Annotations have to reach the step log, not the step summary the block above
+          # redirects into, so the parser-disagreement guards are raised here.
+          if [ -n "${cpp_parse_warning:-}" ]; then
+            printf '::warning title=ci-pr-lint::%s\n' "$(sanitize_line "$cpp_parse_warning")"
+          fi
+          if [ -n "${tidy_parse_warning:-}" ]; then
+            printf '::warning title=ci-pr-lint::%s\n' "$(sanitize_line "$tidy_parse_warning")"
+          fi
 
       - name: Upload lint reports
         if: always() && github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Part of #2509.

`ci-pr-lint`'s summary was reporting two numbers that could not be right and showing
0.03% of what it had measured. This fixes the counters and replaces the excerpt blocks.
It does not touch check *selection* — that half of #2509 is in flight separately on
`ci-qa-pr-docker-testing` (`6a1a5b9a`, `39493094`).

## 1. Both cppcheck counters read 0 on every run

The summary's cppcheck patterns anchored on cppcheck **1.x**'s bracket template,
`[{file}:{line}]: ({severity})`. cppcheck 2.x — what `ubuntu-24.04` installs — emits
`{file}:{line}:{column}: {severity}: {message} [{id}]`. Neither pattern could ever match.

Running the workflow's own predicates verbatim against the published report artifacts:

| predicate | result |
|---|---:|
| `wc -l` | 47451 |
| `cpp_warns` (pattern being replaced) | **0** |
| `cpp_errs` (pattern being replaced) | **0** |
| diagnostics, real format | **6854** |
| errors, real format | **1** |

That single error is
`IccProfLib/IccMpeSpectral.cpp:1693:14: error: Deallocation of an auto-variable (observer) results in undefined behaviour. [autovarInvalidDeallocation]`
— the line #2503 was opened from. **The lane printed "Errors: 0" on the run carrying its
only error.** The clang-tidy half of the same pattern pair was correct (43759) and is
unchanged in behaviour.

Severity split now visible: 6314 style, 294 performance, 232 warning, 13 portability,
1 error.

### Guard against the same class recurring

A counter that silently reads 0 against a non-empty report is *how this survived* — the
summary looked like a clean lane rather than a broken parser. When a report has lines but
no diagnostic parses, the step now raises a `::warning` annotation and a summary note.
Red/green: fires on a 1.x-format report, silent on the real reports, silent on empty ones.

## 2. The excerpt blocks showed one component

Reports are concatenated in component order, so `tail -n 50` showed only whichever sorted
last. Measured on run 34515122355:

| | total lines | what the last 50 lines contained |
|---|---:|---|
| clang-tidy | 213889 | 10 diagnostics, all from `IccVizModel.cpp` |
| cppcheck | 47451 | 2 files named |

`IccProfLib`'s 141105 clang-tidy lines were never visible. A single diagnostic can consume
the whole window — which is what #2509 is about: the note it cites prints every enumerator
of the enum.

Replaced with the distribution of the whole file plus the findings that carry severity:
cppcheck severity counts, top 25 message ids, error-severity findings; clang-tidy top 30
checks, per-checker analyzer counts, and analyzer findings capped **per checker**.

The per-checker cap is load-bearing. 252 of the 330 analyzer findings are
`EnumCastOutOfRange`, 211 of them in `IccUtil.cpp`'s `CIccInfo::Get*SigName` chain, which
casts a raw `icUInt32Number` into each signature enum in turn to ask whether it is a known
member — that is the function's purpose. My first version used a flat cap, spent the whole
budget there and hid the singletons. With the per-checker cap all 9 checkers appear and
this surfaces for the first time:

```
IccProfLib/IccCmm.cpp:3712:16: warning: The left operand of '==' is a garbage value [clang-analyzer-core.UndefinedBinaryOperatorResult]
IccProfLib/IccCmm.cpp:6857:17: warning: Assigned value is garbage or undefined [clang-analyzer-core.uninitialized.Assign]
IccProfLib/IccIO.cpp:541:3:   warning: Call to virtual method 'CIccFileIO::Close' during destruction bypasses virtual dispatch [clang-analyzer-optin.cplusplus.VirtualCall]
```

Summary size drops 32811 -> 14967 bytes.

## How this was verified

Not by reading. The `Generate lint summary` step's `run:` block was extracted from the YAML
and executed against the real report artifacts of runs 34432960602 (master `ae6a013d`),
34483706504 and 34515122355, plus synthetic drifted-format and empty inputs. All three
cases exit 0.

Gate, per `workflow-governance.instructions.md`: YAML parse, `actionlint -shellcheck`,
`yamllint`, `zizmor`, bare `shellcheck` 0.9.0 on the extracted block — all clean.
`preflight-safety-checks.sh` reports `failures: 2`; the identical two fail on unmodified
`origin/master` in a detached worktree (local codeql CLI 2.25.6 cannot parse a pack built
by 2.27.0; `doxygen` not installed locally). Environmental, not from this change.

### Pre-PR dispatch

`ci-pr-action` `ci_scope=auto`, run **34531072819**, dispatched before this PR was opened:
`completed/success`, 6 jobs green, 6 skipped. The green jobs include **Risk Analysis Gate /
Workflow Security Audit** and **Windows Security Audit (PowerShell)**, which are the gates
that actually bear on a workflow change. The build and CTest legs skipped, correctly — this
PR changes no C++, so nothing gates on `native_changed`. I am not claiming the matrix ran.

## Review findings folded in

`/security-review`: no findings. `/code-review high`: 6, four fixed here.

- **HTML entities inside the code fences.** The step carried a local `sanitize_code_line()`
  that shadowed the trusted one from `sanitize-sed.sh` and finished by calling
  `sanitize_line()`, so `escape_html()` ran on content bound for a ```` ```text ```` fence,
  where GitHub does not decode entities. Every finding read
  `Call to function &#39;strcpy&#39;`. Tolerable across a 50-line tail; not across the whole
  analyzer view. The shadow is removed in favour of the trusted helper, whose contract names
  this exact case and which still strips CR/LF and every control character and still
  neutralizes ```` ``` ````. Verified by feeding a report line containing a fence and
  confirming the emitted fence count stays even.
- **`Diagnostics` meant two things.** cppcheck counted every severity (a superset of
  `Errors`) while clang-tidy counted only warnings (disjoint from it), so summing the two
  columns was right for one row and double-counted the other. `tidy_diag_re` now includes
  `error:`; the printed number is unchanged at 43759 on this corpus.
- **A label that overstated its own bound** — "every error" / "in full" over a cap of 50.
  Now "up to 200" against a cap of 200. Overstating completeness is the defect this PR
  exists to close.
- **A wrong number in my own comment**: the last 50 clang-tidy lines carry 13
  warning/note lines but **10** diagnostics, and this file's own rule says notes are not
  diagnostics. Corrected to 10.

One suggestion **rejected**: firing the guard when an enabled tool produces an empty report.
Under `lint_scope=pr` a clean single-file diff legitimately yields an empty cppcheck report,
so that guard would fire as noise on exactly the runs it should stay quiet on.
Distinguishing "ran and found nothing" from "crashed" needs the tool exit status, which the
`|| true` on both invocations discards — a separate change.

## Notes for the reviewer

- Derived views are named `summary_*`, outside the `cppcheck_*`/`clang_tidy_*` globs the two
  tool steps concatenate with, so they cannot be folded into a later report as tool output.
- "see the ci-pr-lint-reports artifact" is accurate under `workflow_dispatch`; the upload
  step is gated on that event while `on:` also declares `workflow_call`. Latent — nothing
  currently calls this workflow.
- Separately found while answering #2509 and **not** changed here: the four
  `clang-analyzer-*` globs in `tidy_checks` are inert, because `-checks=` is appended to
  clang-tidy's default `clang-analyzer-*`. Detail in
  https://github.com/InternationalColorConsortium/iccDEV/issues/2509#issuecomment-5625517604.
  That belongs with the check-selection work, not here.

No behaviour change to either tool invocation, to file selection, or to the artifact upload.
Report generation only.
