### PR TITLE
test(#2512): cover the dictType XML and JSON writers and readers

### DIFF
--- a/.github/ci/test-data/dict-entries-2512.xml
+++ b/.github/ci/test-data/dict-entries-2512.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  #2512 fixture.  A well-formed RGB matrix/TRC display profile carrying a
+  metaDataTag of dictType.  Until this file, no tracked XML contained a
+  DictEntry, so the dict writers in IccTagXml.cpp and IccTagJson.cpp and the
+  XML reader never ran under any test.
+
+  Each entry exercises a different shape the binary format can represent:
+
+    ManufacturerName    name and value, plain ASCII
+    NameOnly            no value at all (value offset 0 in the binary record)
+    EmptyValue          a value that is set but empty.  The binary record
+                        keeps this apart from NameOnly, and so must the
+                        round trip
+    Grüße               two- and three-byte UTF-8 in both name and value,
+                        which is what reaches icWCharToUtf8
+    Escapes             all five characters icFixXml escapes (& < > " ')
+    Localized           localized names (two languages) and a localized value,
+                        so the record is 32 bytes wide
+    ValueLocalizedOnly  a localized value with no localized name, so the
+                        localized-name slot of a 32-byte record is empty
+
+  Every character is inside the Basic Multilingual Plane.  A character above
+  U+FFFF does not survive the XML round trip on platforms with a 32-bit
+  wchar_t.  That is a separate defect, and this file is the control that
+  shows the BMP path works.
+
+  The DictEntry lines are written exactly as CIccTagXmlDict::ToXml emits them
+  (attribute order, CDATA sections), because the regression script compares
+  them against the writer's output line for line.  Keep that form if you add
+  an entry.
+-->
+<IccProfile>
+  <Header>
+    <PreferredCMMType>ICCD</PreferredCMMType>
+    <ProfileVersion>4.30</ProfileVersion>
+    <ProfileDeviceClass>mntr</ProfileDeviceClass>
+    <DataColourSpace>RGB </DataColourSpace>
+    <PCS>XYZ </PCS>
+    <CreationDateTime>now</CreationDateTime>
+    <ProfileFlags EmbeddedInFile="false" UseWithEmbeddedDataOnly="false"/>
+    <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
+    <RenderingIntent>Relative Colorimetric</RenderingIntent>
+    <PCSIlluminant> <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/> </PCSIlluminant>
+    <ProfileCreator>ICCD</ProfileCreator>
+    <ProfileID>0</ProfileID>
+  </Header>
+
+  <Tags>
+    <profileDescriptionTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[iccDEV #2512 dictType fixture]]></LocalizedText>
+    </multiLocalizedUnicodeType> </profileDescriptionTag>
+
+    <mediaWhitePointTag> <XYZArrayType>
+      <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
+    </XYZArrayType> </mediaWhitePointTag>
+
+    <redColorantTag> <XYZArrayType>
+      <XYZNumber X="0.43606567" Y="0.22248840" Z="0.01391602"/>
+    </XYZArrayType> </redColorantTag>
+
+    <greenColorantTag> <XYZArrayType>
+      <XYZNumber X="0.38514709" Y="0.71687317" Z="0.09707642"/>
+    </XYZArrayType> </greenColorantTag>
+
+    <blueColorantTag> <XYZArrayType>
+      <XYZNumber X="0.14306641" Y="0.06060791" Z="0.71409607"/>
+    </XYZArrayType> </blueColorantTag>
+
+    <redTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </redTRCTag>
+
+    <greenTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </greenTRCTag>
+
+    <blueTRCTag> <parametricCurveType>
+      <ParametricCurve FunctionType="4">
+        2.39999390 0.94786072 0.05213928 0.07739258 0.04045105 0.00000000 0.00000000
+      </ParametricCurve>
+    </parametricCurveType> </blueTRCTag>
+
+    <copyrightTag> <multiLocalizedUnicodeType>
+      <LocalizedText LanguageCountry="enUS"><![CDATA[Copyright 2026 International Color Consortium]]></LocalizedText>
+    </multiLocalizedUnicodeType> </copyrightTag>
+
+    <metaDataTag> <dictType>
+      <DictEntry Name="ManufacturerName" Value="iccDEV"/>
+      <DictEntry Name="NameOnly"/>
+      <DictEntry Name="EmptyValue" Value=""/>
+      <DictEntry Name="Grüße" Value="Café 色"/>
+      <DictEntry Name="Escapes" Value="a &amp; b &lt;c&gt; &quot;q&quot; &apos;s&apos;"/>
+      <DictEntry Name="Localized" Value="plain">
+        <LocalizedName LanguageCountry="enUS"><![CDATA[Localized]]></LocalizedName>
+        <LocalizedName LanguageCountry="deDE"><![CDATA[Lokalisiert]]></LocalizedName>
+        <LocalizedValue LanguageCountry="enUS"><![CDATA[plain]]></LocalizedValue>
+      </DictEntry>
+      <DictEntry Name="ValueLocalizedOnly" Value="v">
+        <LocalizedValue LanguageCountry="frFR"><![CDATA[valeur]]></LocalizedValue>
+      </DictEntry>
+    </dictType> </metaDataTag>
+
+  </Tags>
+</IccProfile>

--- a/.github/scripts/iccdev-issue-2512-dict-roundtrip-regression.sh
+++ b/.github/scripts/iccdev-issue-2512-dict-roundtrip-regression.sh
@@ -1,0 +1,255 @@
+#!/bin/bash
+###############################################################################
+# dictType XML/JSON round-trip coverage (issue #2512)
+###############################################################################
+#
+# Before this test, no tracked XML fixture contained a DictEntry and no CTest
+# named dict, so none of the dictType text code ran under test:
+#
+#   CIccTagXmlDict::ToXml     IccTagXml.cpp   -- name/value via icWCharToUtf8,
+#                                                localized text via icUtf16ToUtf8
+#   CIccTagXmlDict::ParseXml  IccTagXml.cpp
+#   CIccTagJsonDict::ToJson   IccTagJson.cpp  -- the same two converters
+#   CIccTagJsonDict::ParseJson IccTagJson.cpp
+#
+# The gap was measured rather than inferred (on a9daa06a): corrupting
+# icWCharToUtf8's output length by one byte left all 264 tests green, while the
+# same corruption in its sibling icUtf16ToUtf8 turned four red.
+#
+# The fixture, .github/ci/test-data/dict-entries-2512.xml, has one entry per
+# record shape the binary format can hold; its header lists them.  The test
+# builds a profile from it and then checks each direction separately:
+#
+#   1. The profile carries all seven entries and validates.  Without this, a
+#      reader that dropped the tag would make every later comparison pass on
+#      an empty dict.
+#   2. ICC -> XML writes back exactly the DictEntry lines the fixture holds.
+#   3. XML -> ICC reproduces the profile byte for byte.
+#   4. ICC -> JSON writes each entry's fields with the right values, and keeps
+#      "no value" apart from "empty value".
+#   5. JSON -> ICC reproduces the profile byte for byte.
+#
+# Steps 2 and 4 check the text as well as the bytes, because a byte comparison
+# alone passes when writer and reader are wrong in matching ways -- for
+# example, both using the same misspelt key.
+#
+# Environment variables:
+#   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
+#   ICCDEV_TEST_OUTDIR -- output directory for temporary files and logs
+#
+# Exit codes: 0 pass or clean skip; 1 regression.
+###############################################################################
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS_DIR="${ICCDEV_TOOLS_DIR:-$REPO_ROOT/Build/Tools}"
+OUTDIR="${ICCDEV_TEST_OUTDIR:-/tmp/iccdev-issue-2512-dict-roundtrip}"
+mkdir -p "$OUTDIR"
+
+if [ ! -d "$TOOLS_DIR" ]; then
+  for candidate in "$REPO_ROOT/build/Tools" "$REPO_ROOT/Build/Tools"; do
+    if [ -d "$candidate" ]; then
+      TOOLS_DIR="$candidate"
+      break
+    fi
+  done
+fi
+
+BUILD_ROOT="$(cd "$TOOLS_DIR/.." 2>/dev/null && pwd -P)"
+if [ -n "$BUILD_ROOT" ]; then
+  export LD_LIBRARY_PATH="$BUILD_ROOT/IccProfLib:$BUILD_ROOT/IccXML:$BUILD_ROOT/IccJSON${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+fi
+export ASAN_OPTIONS="${ASAN_OPTIONS:-print_scariness=1:halt_on_error=0:detect_leaks=0}"
+export UBSAN_OPTIONS="${UBSAN_OPTIONS:-halt_on_error=0:print_stacktrace=1}"
+
+find_tool() {
+  find "$TOOLS_DIR" -maxdepth 2 -name "$1" -type f 2>/dev/null | head -1
+}
+
+TOXML="$(find_tool iccToXml)"
+FROMXML="$(find_tool iccFromXml)"
+TOJSON="$(find_tool iccToJson)"
+FROMJSON="$(find_tool iccFromJson)"
+DUMP="$(find_tool iccDumpProfile)"
+
+fail() {
+  echo "  [FAIL] issue-2512-dict-roundtrip -- $1"
+  exit 1
+}
+
+echo "=== dictType XML/JSON round-trip coverage (issue #2512) ==="
+
+for tool in "$TOXML" "$FROMXML" "$TOJSON" "$FROMJSON" "$DUMP"; do
+  if [ -z "$tool" ] || [ ! -x "$tool" ]; then
+    echo "  [SKIP] XML/JSON round-trip tools not all built under $TOOLS_DIR"
+    exit 0
+  fi
+done
+
+FIXTURE="$REPO_ROOT/.github/ci/test-data/dict-entries-2512.xml"
+[ -f "$FIXTURE" ] || fail "missing fixture $FIXTURE"
+
+# The fixture's entry count, for steps 1 and 2.  Those follow the fixture on
+# their own; step 4 keeps its own copy of the entries and needs editing too.
+EXPECTED_ENTRIES="$(grep -c '<DictEntry ' "$FIXTURE")"
+[ "$EXPECTED_ENTRIES" -gt 0 ] || fail "the fixture has no DictEntry elements"
+
+# ---------------------------------------------------------------------------
+# run <label> <tool> <args...> -- run a tool, showing its log if it fails.
+# ---------------------------------------------------------------------------
+run() {
+  local label="$1"; shift
+  local log="$OUTDIR/$label.log"
+
+  if ! "$@" > "$log" 2>&1; then
+    sed -n '1,20p' "$log"
+    fail "$label failed"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# same_bytes <reference> <candidate> <what> -- byte-exact comparison.
+# ---------------------------------------------------------------------------
+same_bytes() {
+  if ! cmp -s "$1" "$2"; then
+    cmp -l "$1" "$2" 2>/dev/null | sed -n '1,6p' | sed 's/^/    /'
+    fail "$3 changed the bytes of the dict profile (#2512)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# dict_lines <xml> -- the lines between <dictType> and </dictType>, with the
+# indentation removed.  The writer indents differently from the fixture, and
+# indentation carries no data here: every value is in an attribute or a CDATA
+# section.
+# ---------------------------------------------------------------------------
+dict_lines() {
+  sed -n '/<dictType>/,/<\/dictType>/p' "$1" \
+    | sed -e 's/^[[:space:]]*//' -e '/<dictType>/d' -e '/<\/dictType>/d'
+}
+
+# ===========================================================================
+# 1. Build the profile, and prove the dict is in it.
+# ===========================================================================
+run build "$FROMXML" "$FIXTURE" "$OUTDIR/dict.icc"
+
+"$DUMP" -v "$OUTDIR/dict.icc" ALL > "$OUTDIR/dump.log" 2>&1
+got="$(grep -c '^BEGIN DICT_ENTRY' "$OUTDIR/dump.log")"
+if [ "$got" -ne "$EXPECTED_ENTRIES" ]; then
+  sed -n '/BEGIN DICT_TAG/,/END DICT_TAG/p' "$OUTDIR/dump.log" | sed -n '1,20p' | sed 's/^/    /'
+  fail "the built profile holds $got dict entries, the fixture has $EXPECTED_ENTRIES"
+fi
+# Ask for "valid" rather than only rejecting "NonCompliant": a critical error
+# prints "Error! - ...", and a dump that crashed after listing the entries
+# prints no verdict at all.  Either would pass a negative check.
+if ! grep -Fq "Profile is valid" "$OUTDIR/dump.log"; then
+  sed -n '/Validation Report/,$p' "$OUTDIR/dump.log" | sed -n '1,10p' | sed 's/^/    /'
+  fail "the fixture profile does not validate"
+fi
+echo "    built: $got dict entries, profile validates"
+
+# ===========================================================================
+# 2 + 3. XML.
+#
+# The fixture is written in the writer's own form, so the DictEntry lines that
+# come back out must equal the ones that went in.  This checks the writer
+# directly: names and values through icWCharToUtf8 and icFixXml, the localized
+# sub-elements through icUtf16ToUtf8, and whether Value is present at all.
+# ===========================================================================
+run toxml "$TOXML" "$OUTDIR/dict.icc" "$OUTDIR/dict.xml"
+
+dict_lines "$FIXTURE"        > "$OUTDIR/dict-expected.txt"
+dict_lines "$OUTDIR/dict.xml" > "$OUTDIR/dict-written.txt"
+[ -s "$OUTDIR/dict-written.txt" ] || fail "iccToXml wrote no dictType element"
+if ! diff -u "$OUTDIR/dict-expected.txt" "$OUTDIR/dict-written.txt" > "$OUTDIR/dict-xml.diff"; then
+  sed -n '1,20p' "$OUTDIR/dict-xml.diff" | sed 's/^/    /'
+  fail "iccToXml did not write back the fixture's DictEntry lines"
+fi
+
+run fromxml "$FROMXML" "$OUTDIR/dict.xml" "$OUTDIR/dict-rt-xml.icc"
+same_bytes "$OUTDIR/dict.icc" "$OUTDIR/dict-rt-xml.icc" "an ICC -> XML -> ICC round trip"
+echo "    XML: writer reproduces the fixture's entries; round trip is byte-exact"
+
+# ===========================================================================
+# 4 + 5. JSON.
+#
+# The expected entries are the fixture's, spelled out as JSON values.  Python
+# compares whole entries, so a missing key, an extra key (a "value" on
+# NameOnly) and a wrong value all fail, and key order does not matter.
+# ===========================================================================
+run tojson "$TOJSON" "$OUTDIR/dict.icc" "$OUTDIR/dict.json"
+
+if command -v python3 >/dev/null 2>&1; then
+  if ! python3 - "$OUTDIR/dict.json" > "$OUTDIR/dict-json-check.log" 2>&1 <<'PY'
+import json
+import sys
+
+
+def loc(language, country, text):
+    return {"language": language, "country": country, "text": text}
+
+
+EXPECTED = [
+    {"name": "ManufacturerName", "value": "iccDEV"},
+    {"name": "NameOnly"},
+    {"name": "EmptyValue", "value": ""},
+    {"name": "Gr\u00fc\u00dfe", "value": "Caf\u00e9 \u8272"},
+    {"name": "Escapes", "value": "a & b <c> \"q\" 's'"},
+    {"name": "Localized", "value": "plain",
+     "localizedNames": [loc("en", "US", "Localized"), loc("de", "DE", "Lokalisiert")],
+     "localizedValues": [loc("en", "US", "plain")]},
+    {"name": "ValueLocalizedOnly", "value": "v",
+     "localizedValues": [loc("fr", "FR", "valeur")]},
+]
+
+
+def find_dict(node):
+    if isinstance(node, dict):
+        if node.get("type") == "dictType":
+            return node
+        for child in node.values():
+            found = find_dict(child)
+            if found is not None:
+                return found
+    elif isinstance(node, list):
+        for child in node:
+            found = find_dict(child)
+            if found is not None:
+                return found
+    return None
+
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    tag = find_dict(json.load(handle))
+
+if tag is None:
+    raise SystemExit("no dictType object in the JSON")
+
+entries = tag.get("entries")
+if entries != EXPECTED:
+    print("expected:", json.dumps(EXPECTED, ensure_ascii=True, indent=1))
+    print("written: ", json.dumps(entries, ensure_ascii=True, indent=1))
+    if isinstance(entries, list) and len(entries) != len(EXPECTED):
+        # EXPECTED is a second copy of the fixture, so a fixture that gained an
+        # entry fails here too.  Say which it is likely to be.
+        print(f"{len(entries)} entries written, {len(EXPECTED)} expected: if the "
+              "fixture changed, update EXPECTED in this script to match")
+    raise SystemExit("the JSON dict entries differ from the fixture")
+PY
+  then
+    sed -n '1,40p' "$OUTDIR/dict-json-check.log" | sed 's/^/    /'
+    fail "iccToJson did not write the fixture's dict entries"
+  fi
+  json_note=""
+else
+  json_note=" (python3 absent: JSON field check skipped)"
+fi
+
+run fromjson "$FROMJSON" "$OUTDIR/dict.json" "$OUTDIR/dict-rt-json.icc"
+same_bytes "$OUTDIR/dict.icc" "$OUTDIR/dict-rt-json.icc" "an ICC -> JSON -> ICC round trip"
+echo "    JSON: writer emits every entry's fields; round trip is byte-exact$json_note"
+
+echo "  [PASS] issue-2512-dict-roundtrip -- all $EXPECTED_ENTRIES dict entries survive XML and JSON"
+exit 0

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -9296,6 +9296,25 @@ iccdev_add_script_test(
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2097-nul-signature-roundtrip-regression.sh"
 )
 
+# #2512: until this test, no tracked XML carried a DictEntry, so the dictType
+# writers in IccTagXml.cpp and IccTagJson.cpp, and the XML reader, ran under no
+# test at all.  Corrupting icWCharToUtf8's output length by one byte left the
+# whole suite green.  The fixture lives in .github/ci/test-data rather than
+# Testing/, so the generated corpus is unchanged.  It has one entry per binary
+# record shape, including a value that is set but empty, which the round trip
+# must keep apart from an entry with no value.  Each direction is checked on
+# its own: the text each writer emits, and the bytes each reader rebuilds.
+# The fixture is BMP-only.  Not registered on Windows (see the WIN32 branch
+# above), which is the one platform where wchar_t is 16 bits.
+# Plain functional test -- skips cleanly if the tools/fixtures are absent.
+iccdev_add_script_test(
+  iccdev.issue-2512-dict-roundtrip
+  90
+  "iccdev;xml;json;dict;roundtrip;issue-2512;regression"
+  "${ICCDEV_REPO_ROOT}"
+  "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2512-dict-roundtrip-regression.sh"
+)
+
 # #1355 - matrix/TRC (PCSXYZ) profiles must round-trip near-exactly. Guards the
 # two CMM/eval fixes (ConnectFirst actual->internal XYZ rescale; native-PCS
 # round-trip connection): iccRoundTrip RT1 mean dE was ~20 before, ~0 after.


### PR DESCRIPTION
Fixes #2512.

No tracked XML carried a `DictEntry`, so `CIccTagXmlDict::ToXml`/`ParseXml` and `CIccTagJsonDict::ToJson`/`ParseJson` ran under no test. Test-only: no library change.

## Fixture: `.github/ci/test-data/dict-entries-2512.xml`

A valid v4.3 display profile (validates clean) with a `metaDataTag` of `dictType`. It lives outside `Testing/`, so the generated corpus does not change. One entry per record shape:

| entry | shape |
|---|---|
| `ManufacturerName` | name + value, ASCII |
| `NameOnly` | no value (value offset 0) |
| `EmptyValue` | value set but empty; must stay distinct from `NameOnly` |
| `Grüße` = `Café 色` | 2- and 3-byte UTF-8, the input to `icWCharToUtf8` |
| `Escapes` | all five `icFixXml` escapes: `& < > " '` |
| `Localized` | two localized names + a localized value (32-byte record) |
| `ValueLocalizedOnly` | localized value, empty localized-name slot |

## Test: `iccdev.issue-2512-dict-roundtrip`

1. Build from the fixture; `iccDumpProfile` must list 7 dict entries and no `NonCompliant`. This is the anti-vacuity guard: a reader that dropped the tag would pass every later byte comparison on an empty dict.
2. `iccToXml` must write back the fixture's `DictEntry` lines, line for line (indentation stripped).
3. XML → ICC is byte-exact.
4. `iccToJson` entries must equal the expected list, compared as whole objects, so an extra `"value"` on `NameOnly` fails.
5. JSON → ICC is byte-exact.

### Red/green: every mutation fails

ASan+UBSan Debug (clang 18), `detect_leaks=1`. Each mutation was applied to one committed file, the tools rebuilt, and the test run.

| mutation | fails at |
|---|---|
| `icWCharToUtf8` output length − 1 (the #2512 experiment) | 2 |
| XML writer omits an empty `Value` | 2 |
| XML reader ignores `LocalizedValue` | 2 |
| JSON writer drops `localizedValues` | 4 |
| JSON writer **and** reader both use key `"valu"` | 4 |
| XML reader treats `Value=""` as absent | 2 |
| binary reader (`IccTagDict.cpp:707`) treats a 0-size value as unset | 2 |
| XML reader parses no entries | 1 (0 of 7) |
| none | passes |

The `"valu"` row is why steps 2 and 4 check text as well as bytes: under that mutation the JSON round trip is **byte-identical**, and only the field check fails.

Also passes under `LC_ALL=C`. `shellcheck` 0.9.0 clean. Runtime 0.15 s.

### CI, before opening

`ci-pr-action` dispatched on `85ba1679` with `ci_scope=auto`: run 34580005594, success. Every build job ran: GCC 15.2 Strict LTO, macOS Debug and Release, Windows MSVC/ClangCL/MinGW, and Tool Smoke. In Tool Smoke (job 103201227324), `Test #247: iccdev.issue-2512-dict-roundtrip ... Passed 0.27 sec`, with 263/263 passing. The uploaded `LastTest.log` shows the script's own output (`built: 7 dict entries`, both round trips byte-exact, `[PASS]`), so this is a real pass, not a clean skip.

## Coverage limits

- **Not on Windows.** The `if(WIN32)` branch in `Build/Cmake/Testing/CMakeLists.txt` returns before script tests are registered, and Windows is the one platform with a 16-bit `wchar_t`. In CI it runs on the Linux ctest legs; the macOS jobs do not run ctest.
- **BMP only.** See below.

## Found, not fixed here (follow-up to come)

1. **Characters above U+FFFF in a dict name or value** do not survive on 32-bit `wchar_t` platforms. `ToWString` stores UTF-16 code units in `wchar_t`, and `icWCharToUtf8` (`IccUtil.cpp:3194`) and `wstringToUTF8Converter` (`IccTagDict.cpp:230`) read them as UTF-32. `U+1F600` is written as CESU-8 (`ED A0 BD ED B8 80`), `iccFromXml` then refuses the XML, and the JSON round trip changes 24 bytes. This is why the fixture is BMP-only.
2. **`IccTagDict.cpp:662`**: the empty-*name* branch calls `SetValue`, so `Name=""` with no value reads back with an empty value set. Reachable only through an entry that is already invalid (#2088).
