### PR TITLE
ci: avoid duplicate Windows CTest rebuild

### DIFF
--- a/.github/workflows/_build-test-windows.yml
+++ b/.github/workflows/_build-test-windows.yml
@@ -179,12 +179,6 @@ jobs:
             throw "CTest execution failed with exit code $LASTEXITCODE"
           }
 
-          Write-Host "Running check target..."
-          cmake --build out\vs2022-vcpkg --config Release --target check --parallel
-          if ($LASTEXITCODE -ne 0) {
-            throw "check target failed with exit code $LASTEXITCODE"
-          }
-
       # ---------------------------------------------------------------
       # Phase 5: Build Python wheel
       # ---------------------------------------------------------------

--- a/docs/ctest.md
+++ b/docs/ctest.md
@@ -464,10 +464,10 @@ script output and still leave a deterministic pass/fail condition.
 ## CI Coverage
 
 The `ci-json-python` orchestrator calls the reusable Unix and Windows build
-workflows. The Windows reusable workflow runs CTest discovery, executes CTest
-with JUnit output, and then runs the `check` target. The Unix reusable workflow
-runs the Linux CTest gate for full-test jobs and verifies its discovered suite
-set before execution. `ci-pr-win` uses a non-cancelling, Windows-specific
+workflows. The Windows reusable workflow serially builds its CTest helper
+binaries, runs CTest discovery, and executes CTest with JUnit output. The Unix
+reusable workflow runs the Linux CTest gate for full-test jobs and verifies its
+discovered suite set before execution. `ci-pr-win` uses a non-cancelling, Windows-specific
 concurrency group so a direct Windows dispatch cannot interrupt an active
 reusable Windows gate. `ci-pr-unix` supports direct `workflow_dispatch` with
 the same safe matrix defaults as its reusable invocation. `CI Comprehensive


### PR DESCRIPTION
## Summary

#2506: corrects the prior PR's Copilot Cloud Agent-forced change that produced the Windows Python failure reported in [issue comment 5628719184](https://github.com/InternationalColorConsortium/iccDEV/issues/2506#issuecomment-5628719184).

The workflow continues to serially build CTest helper binaries, discover the test suite, and execute CTest with JUnit output; it no longer repeats the CTest gate through `check`.

## Validation

- The reusable workflow builds `build-test-binaries` serially before direct CTest execution.
- `docs/ctest.md` describes the single Windows CTest gate.

## Maintainer Review Required

This changes maintainer-owned CI infrastructure and requires maintainer review.