### PR TITLE
fix(#2511): replace a lone UTF-16 surrogate with U+FFFD instead of encoding it as CESU-8

### DIFF
--- a/.github/ci/regression/utf8-converter-cursor-contract.cpp
+++ b/.github/ci/regression/utf8-converter-cursor-contract.cpp
@@ -30,9 +30,20 @@
 // over-long cursor changes size() while c_str() can still compare equal up to
 // the NUL.
 //
+// #2511 added the lone-surrogate cases.  Lenient mode used to encode a UTF-16
+// surrogate with no partner as three bytes (U+D83D -> ED A0 BD) -- CESU-8, not
+// UTF-8 -- so iccToXml wrote XML that libxml2 refuses and iccFromXml could not
+// read back.  It now substitutes U+FFFD.  Each of those cases asserts the exact
+// bytes AND runs the output through isLegalUTF8String(), the library's own
+// validator, so a fix that produced some other ill-formed sequence would still
+// fail.  Every lone-surrogate case below fails against the unfixed converter;
+// the strict-mode cases pass on both and guard the branch that #2511
+// restructured.
+//
 // Returns 0 on success; the number of failed assertions otherwise.
 
 #include "IccUtil.h"
+#include "IccConvertUTF.h"
 #include "icProfileHeader.h"
 
 #include <string>
@@ -50,6 +61,16 @@ void check(bool ok, const char *what)
     ++g_fail;
     printf("FAIL: %s\n", what);
   }
+}
+
+// #2511: the converter's output must be well-formed UTF-8 by the library's own
+// definition.  isLegalUTF8String() rejects any encoded surrogate, so this is
+// the check that catches CESU-8 whatever the exact bytes are.
+void checkLegal(const std::string &buf, const char *what)
+{
+  char msg[256];
+  snprintf(msg, sizeof(msg), "%s: output is legal UTF-8", what);
+  check(isLegalUTF8String((const UTF8*)buf.data(), (int)buf.size()) != 0, msg);
 }
 
 // Compares both the reported length and the bytes.  size() is checked first and
@@ -76,6 +97,68 @@ void checkUtf16(const icUInt16Number *src, int len,
   // that returned the scratch pointer instead would fail here.
   snprintf(msg, sizeof(msg), "%s: returns the string's own storage", what);
   check(rv == buf.c_str() && rv[buf.size()] == '\0', msg);
+
+  // #2511: every case, not only the lone-surrogate ones -- the pre-existing
+  // cases are all well-formed, and must stay that way.
+  checkLegal(buf, what);
+}
+
+// Same pair of assertions for the std::vector overload of
+// icConvertUTF16toUTF8().  icUtf16ToUtf8() above reaches the pointer overload
+// only; the vector overload is the one CIccTagUtf16Text::GetText() and both
+// CIccTagUtf8Text/CIccTagZipUtf8Text::SetText(const icUChar16*) call, and #2511
+// changed both overloads.
+void checkUtf16Vector(const icUInt16Number *src, size_t len,
+                      const char *expect, size_t expectLen, const char *what)
+{
+  icUtf8Vector out;
+  icUtfConversionResult rc = icConvertUTF16toUTF8((const UTF16*)src, (const UTF16*)src + len,
+                                                  out, lenientConversion);
+  // Copy as bytes, not element by element: std::string(out.begin(), out.end())
+  // converts each UTF8 (unsigned char) to char implicitly.  Under clang,
+  // ENABLE_SANITIZERS adds -fsanitize=integer, whose implicit sign-change check
+  // stops on the first byte >= 0x80 -- measured, on the U+FFFD cases below.
+  std::string buf;
+  if (!out.empty())
+    buf.assign(reinterpret_cast<const char*>(out.data()), out.size());
+  char msg[256];
+
+  snprintf(msg, sizeof(msg), "%s: result (got %d, want conversionOK)", what, (int)rc);
+  check(rc == conversionOK, msg);
+
+  snprintf(msg, sizeof(msg), "%s: length (got %zu, want %zu)", what, buf.size(), expectLen);
+  check(buf.size() == expectLen, msg);
+
+  snprintf(msg, sizeof(msg), "%s: bytes", what);
+  check(buf.size() == expectLen && memcmp(buf.data(), expect, expectLen) == 0, msg);
+
+  checkLegal(buf, what);
+}
+
+// Strict mode must still stop at a lone surrogate and report it, with the
+// source cursor left ON the offending unit and nothing written for it.  #2511
+// moved the lone-low test out from under "if (flags == strictConversion)" so
+// that lenient mode could reach it; this pins that strict mode kept its old
+// behaviour through the move.
+void checkStrictStops(const icUInt16Number *src, size_t len, size_t stopAt,
+                      size_t bytesBefore, const char *what)
+{
+  UTF8 out[32];
+  const UTF16 *s = (const UTF16*)src;
+  UTF8 *d = out;
+  icUtfConversionResult rc = icConvertUTF16toUTF8(&s, (const UTF16*)src + len,
+                                                  &d, out + sizeof(out), strictConversion);
+  char msg[256];
+
+  snprintf(msg, sizeof(msg), "%s: result (got %d, want sourceIllegal)", what, (int)rc);
+  check(rc == sourceIllegal, msg);
+
+  snprintf(msg, sizeof(msg), "%s: source cursor (got %td, want %zu)", what,
+           s - (const UTF16*)src, stopAt);
+  check(s == (const UTF16*)src + stopAt, msg);
+
+  snprintf(msg, sizeof(msg), "%s: bytes written (got %td, want %zu)", what, d - out, bytesBefore);
+  check(d == out + bytesBefore, msg);
 }
 
 void checkWChar(const wchar_t *src, size_t len,
@@ -128,13 +211,31 @@ int main()
     const icUInt16Number truncated[] = { 'a', 0xD83D, 0 };
     checkUtf16(truncated, 2, "a", 1, "utf16 trailing unpaired surrogate dropped");
 
-    // An unpaired surrogate NOT at the end is passed through as a 3-byte
-    // sequence (U+D83D -> ED A0 BD) rather than replaced.  That output is
-    // CESU-8, and iccDEV's own isLegalUTF8String() rejects it -- measured, and
-    // reported separately; this case pins today's behaviour so a later fix to
-    // that is a deliberate, visible change rather than a silent one.
-    const icUInt16Number cesu[] = { 0xD83D, 'a', 0 };
-    checkUtf16(cesu, 2, "\xED\xA0\xBD" "a", 4, "utf16 interior unpaired surrogate (CESU-8, current behaviour)");
+    // #2511: an unpaired high surrogate NOT at the end becomes U+FFFD (EF BF BD).
+    // This case used to pin the CESU-8 output (ED A0 BD) that #2510 found, so
+    // the fix would be a visible change -- this is that change.  Same length
+    // as before (3 bytes for the surrogate, 1 for 'a'), so only the bytes and
+    // the legality check tell the two behaviours apart.
+    const icUInt16Number loneHigh[] = { 0xD83D, 'a', 0 };
+    checkUtf16(loneHigh, 2, "\xEF\xBF\xBD" "a", 4, "utf16 interior unpaired high surrogate -> U+FFFD");
+
+    // #2511: a lone LOW surrogate leaked the same way (U+DE00 -> ED B8 80).
+    // It takes a different arm of the converter from the high case above.
+    const icUInt16Number loneLow[] = { 'a', 0xDE00, 'b', 0 };
+    checkUtf16(loneLow, 3, "a" "\xEF\xBF\xBD" "b", 5, "utf16 lone low surrogate -> U+FFFD");
+
+    // #2511: the substitution must not swallow the unit after a lone high
+    // surrogate.  Here that unit is itself the start of a valid pair, so the
+    // right answer is U+FFFD followed by an intact U+1F600.  A fix that
+    // advanced past the unit it peeked at would lose the emoji.
+    const icUInt16Number highThenPair[] = { 0xD83D, 0xD83D, 0xDE00, 0 };
+    checkUtf16(highThenPair, 3, "\xEF\xBF\xBD" "\xF0\x9F\x98\x80", 7,
+               "utf16 lone high surrogate then a valid pair");
+
+    // #2511: a low surrogate before a high one is not a pair.  Both are lone,
+    // and the trailing 'a' is what makes the high one interior.
+    const icUInt16Number reversed[] = { 0xDE00, 0xD83D, 'a', 0 };
+    checkUtf16(reversed, 3, "\xEF\xBF\xBD" "\xEF\xBF\xBD" "a", 7, "utf16 reversed pair -> two U+FFFD");
 
     // Interior NUL: the converter is length-driven, so it must not stop early.
     // buf.assign(ptr, len) preserves it; a c_str()-based length would not.
@@ -156,10 +257,47 @@ int main()
     }
   }
 
+  // --- icConvertUTF16toUTF8, std::vector overload (#2511) ------------------
+  {
+    const icUInt16Number loneHigh[] = { 0xD83D, 'a' };
+    checkUtf16Vector(loneHigh, 2, "\xEF\xBF\xBD" "a", 4, "vector interior unpaired high surrogate -> U+FFFD");
+
+    const icUInt16Number loneLow[] = { 'a', 0xDE00, 'b' };
+    checkUtf16Vector(loneLow, 3, "a" "\xEF\xBF\xBD" "b", 5, "vector lone low surrogate -> U+FFFD");
+
+    const icUInt16Number highThenPair[] = { 0xD83D, 0xD83D, 0xDE00 };
+    checkUtf16Vector(highThenPair, 3, "\xEF\xBF\xBD" "\xF0\x9F\x98\x80", 7,
+                     "vector lone high surrogate then a valid pair");
+
+    const icUInt16Number reversed[] = { 0xDE00, 0xD83D, 'a' };
+    checkUtf16Vector(reversed, 3, "\xEF\xBF\xBD" "\xEF\xBF\xBD" "a", 7, "vector reversed pair -> two U+FFFD");
+
+    // A valid pair is untouched -- the control for the three cases above.
+    const icUInt16Number pair[] = { 0xD83D, 0xDE00 };
+    checkUtf16Vector(pair, 2, "\xF0\x9F\x98\x80", 4, "vector surrogate pair");
+  }
+
+  // --- icConvertUTF16toUTF8, strict mode (#2511 guard) ---------------------
+  {
+    // Stops on the lone high surrogate at index 1, after writing "a".
+    const icUInt16Number loneHigh[] = { 'a', 0xD83D, 'b' };
+    checkStrictStops(loneHigh, 3, 1, 1, "strict lone high surrogate");
+
+    // Stops on the lone low surrogate at index 1, after writing "a".
+    const icUInt16Number loneLow[] = { 'a', 0xDE00, 'b' };
+    checkStrictStops(loneLow, 3, 1, 1, "strict lone low surrogate");
+  }
+
   // --- icWCharToUtf8 -------------------------------------------------------
   // Reached in production only through the dictType writers.  Which arm of the
   // WCHAR_MAX branch runs is platform-dependent (UTF-32 where wchar_t is wide,
   // UTF-16 on Windows); these cases are chosen to hold on both.
+  //
+  // #2511 has no lone-surrogate case here on purpose.  The Windows arm goes
+  // through the fixed icConvertUTF16toUTF8(); the UTF-32 arm goes through
+  // icConvertUTF32toUTF8(), which #2511 deliberately left alone (see the
+  // comment there, and #2526), so the same input gives different bytes per
+  // platform.
   {
     const wchar_t ascii[] = L"iccDEV";
     checkWChar(ascii, 6, "iccDEV", 6, "wchar ascii, explicit length");

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5085,7 +5085,7 @@ function(iccdev_add_utf8_converter_cursor_test)
   endif()
   set_tests_properties(iccdev.utf8-converter-cursor-contract PROPERTIES
     TIMEOUT 120
-    LABELS "iccdev;iccprofLib;utf8;utf16;aliasing;issue-2504;regression"
+    LABELS "iccdev;iccprofLib;utf8;utf16;aliasing;issue-2504;issue-2511;regression"
   )
   if(WIN32)
     # icWCharToUtf8 takes the UTF-16 arm of its WCHAR_MAX branch here, which no

--- a/IccProfLib/IccConvertUTF.cpp
+++ b/IccProfLib/IccConvertUTF.cpp
@@ -327,19 +327,39 @@ icUtfConversionResult icConvertUTF16toUTF8 (const UTF16** sourceStart, const UTF
           --source; /* return to the illegal value itself */
           result = sourceIllegal;
           break;
+        } else {
+          /* #2511: lenient mode used to fall out of this if-chain with ch still
+             holding the lone high surrogate, and the byte-count ladder below
+             encoded it as three bytes (U+D83D -> ED A0 BD).  That is CESU-8,
+             not UTF-8: surrogate code points have no UTF-8 encoding, libxml2
+             refuses the XML that iccToXml wrote from it, and this file's own
+             isLegalUTF8String() rejects it.  Lenient mode now substitutes
+             U+FFFD, which is what it already does in icConvertUTF32toUTF16
+             and icConvertUTF8toUTF16.  source is NOT advanced past ch2, so the
+             unit after a lone high surrogate is decoded on its own next time
+             round -- a valid pair straight after one still comes out intact.
+             Strict mode is unchanged (the arm above), and so is the trailing
+             case below: a high surrogate that ends the buffer is reported as
+             sourceExhausted and dropped, which yields well-formed output. */
+          ch = UNI_REPLACEMENT_CHAR;
         }
       } else { /* We don't have the 16 bits following the high surrogate. */
         --source; /* return to the high surrogate */
         result = sourceExhausted;
         break;
       }
-    } else if (flags == strictConversion) {
+    } else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END) {
       /* UTF-16 surrogate values are illegal in UTF-32 */
-      if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END) {
+      if (flags == strictConversion) {
         --source; /* return to the illegal value itself */
         result = sourceIllegal;
         break;
       }
+      /* #2511: a lone low surrogate -- one not preceded by a high surrogate,
+         which the pairing arm above would have consumed -- is substituted
+         the same way.  This arm used to be reachable only in strict mode, so
+         lenient mode encoded the surrogate as CESU-8 exactly as above. */
+      ch = UNI_REPLACEMENT_CHAR;
     }
     /* Figure out how many bytes the result will require */
     if (ch < (UTF32)0x80) {	     bytesToWrite = 1;
@@ -394,19 +414,22 @@ icUtfConversionResult icConvertUTF16toUTF8 (const UTF16* source, const UTF16* so
           --source; /* return to the illegal value itself */
           result = sourceIllegal;
           break;
+        } else {
+          ch = UNI_REPLACEMENT_CHAR; /* #2511: see the pointer overload above */
         }
       } else { /* We don't have the 16 bits following the high surrogate. */
         --source; /* return to the high surrogate */
         result = sourceExhausted;
         break;
       }
-    } else if (flags == strictConversion) {
+    } else if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END) {
       /* UTF-16 surrogate values are illegal in UTF-32 */
-      if (ch >= UNI_SUR_LOW_START && ch <= UNI_SUR_LOW_END) {
+      if (flags == strictConversion) {
         --source; /* return to the illegal value itself */
         result = sourceIllegal;
         break;
       }
+      ch = UNI_REPLACEMENT_CHAR; /* #2511: see the pointer overload above */
     }
     /* Figure out how many bytes the result will require */
     if (ch < (UTF32)0x80) {	     bytesToWrite = 1;
@@ -731,6 +754,14 @@ icUtfConversionResult icConvertUTF32toUTF8 (const UTF32** sourceStart, const UTF
         break;
       }
     }
+    /* #2511 deliberately leaves lenient mode passing surrogates through here,
+       unlike icConvertUTF16toUTF8.  Where wchar_t is 32 bits, dictType text
+       reaches this function through icWCharToUtf8() and wstringToUTF8Converter()
+       as UTF-16 code units stored one per wchar_t, so a VALID character above
+       U+FFFF arrives as two lone surrogates.  Substituting U+FFFD here was
+       measured to turn U+1F600 in a dict name into two U+FFFD that iccFromXml
+       then accepts -- silent loss of valid text, where today the CESU-8 output
+       at least fails loudly.  The pairing has to be fixed first: #2526. */
     /*
     * Figure out how many bytes the result will require. Turn any
     * illegally large UTF32 things (> Plane 17) into replacement chars.


### PR DESCRIPTION
Fixes #2511.

In lenient mode, `icConvertUTF16toUTF8` encoded a UTF-16 surrogate with no partner as three bytes (`U+D83D` → `ED A0 BD`). That is CESU-8, not UTF-8: libxml2 refuses the XML `iccToXml` writes from it, and the library's own `isLegalUTF8String()` rejects it. Lenient mode now substitutes U+FFFD, which is what it already does in `icConvertUTF32toUTF16` and `icConvertUTF8toUTF16`.

## Change: `IccProfLib/IccConvertUTF.cpp`, both overloads of `icConvertUTF16toUTF8`

| input | before | after |
|---|---|---|
| lone high surrogate, not last (`D83D 'a'`) | `ED A0 BD 61` | `EF BF BD 61` |
| lone low surrogate (`'a' DE00 'b'`) | `61 ED B8 80 62` | `61 EF BF BD 62` |
| lone high, then a valid pair (`D83D D83D DE00`) | `ED A0 BD F0 9F 98 80` | `EF BF BD F0 9F 98 80` |
| reversed pair (`DE00 D83D 'a'`) | `ED B8 80 ED A0 BD 61` | `EF BF BD EF BF BD 61` |
| valid pair | `F0 9F 98 80` | unchanged |
| high surrogate that ends the buffer | dropped (`sourceExhausted`) | unchanged |
| strict mode | `sourceIllegal`, cursor on the unit | unchanged |

The lone-low test used to sit inside `if (flags == strictConversion)`, so lenient mode never reached it. It now runs for both modes and returns early in strict mode exactly as before. The unit after a lone high surrogate is not consumed, so a valid pair straight after one still decodes (row 3).

Both overloads are covered: the pointer one feeds `icUtf16ToUtf8()` (the XML and JSON writers), and the `std::vector` one feeds `CIccTagUtf16Text::GetText()` and both `SetText(const icUChar16*)` overloads of `CIccTagUtf8Text` / `CIccTagZipUtf8Text`.

## Correction to the issue body: which tags actually reach this

The issue says `mluc` does not enforce surrogate pairing on read. **That is wrong.** `CIccTagMultiLocalizedUnicode::Read()` has rejected unpaired surrogates since #933 (`icIsValidUtf16`, `IccTagBasic.cpp:8509`), so the `mluc`, `psid` and dict display-name sites the issue lists cannot be reached from a loaded profile. The issue also covered only high surrogates; lone low surrogates leak the same way.

Measured on master `90d36f40` by planting `A U+D83D B` (and `A U+DE00 B`) in each UTF-16 carrier of a copy of colord's `sRGB.icc`:

| carrier | load | `iccToXml` | `iccFromXml` of that XML | after this PR |
|---|---|---|---|---|
| `mluc` | refused (#933) | — | — | unchanged |
| `desc` (textDescriptionType, Unicode part) | loads | CESU-8 | fails: `Char 0xD83D out of allowed range` | round-trips as `A U+FFFD B` |
| `utf16TextType` | loads | CESU-8, as hex | exit 0, but the text reads back as `A` | round-trips as `A U+FFFD B` |
| `dictType` name or value | loads | CESU-8 | fails | **unchanged here, see below** |

## Not fixed here: dict on 32-bit `wchar_t` platforms → #2526

On Linux and macOS the dict writers go through `icWCharToUtf8()`'s UTF-32 arm and `icConvertUTF32toUTF8()`, not the UTF-16 converter, so this PR does not change dict output there. (Windows takes the UTF-16 arm and is covered.)

That converter is left alone on purpose, and the reason is in a comment at the site. Dict text reaches it as UTF-16 code units stored one per `wchar_t`, so a **valid** character above U+FFFF arrives as two lone surrogates. Substituting U+FFFD there was measured to turn `U+1F600` in a dict name into two U+FFFD that `iccFromXml` then accepts with exit 0. Today that case fails loudly; with the substitution it would lose valid text silently. The pairing has to be repaired first. #2526 tracks it, together with the dict lone-surrogate case, and this PR does not close it.

## Test: `iccdev.utf8-converter-cursor-contract` (extended)

The #2510 test pinned the CESU-8 output so that a fix would be a visible change; this is that change. Added cases:

- lone high, lone low, lone high followed by a valid pair, and a reversed pair, through `icUtf16ToUtf8()`
- the same through the `std::vector` overload, plus a valid-pair control
- strict mode still stops on a lone high and a lone low with the cursor on the unit and nothing written for it
- every `icUtf16ToUtf8()` and vector case also runs its output through `isLegalUTF8String()`, so a fix that produced some other ill-formed sequence would still fail

### Red/green

| library | failing assertions |
|---|---|
| master's `IccConvertUTF.cpp` | 16: every lone-surrogate case, both overloads, on both the bytes check and the legality check |
| this branch | 0 |

The strict-mode cases pass on both by design: they guard the branch this PR restructured.

## Compatibility

No profile I could find carries a lone surrogate. The scan read every `mluc`, `desc`, `ut16` and `dict` string:

| set | unique profiles | UTF-16 text tags | surrogate code units |
|---|---|---|---|
| system profiles shipped by colord and ghostscript (`/usr/share/color/icc`) | 51 | 179 | 0 |
| a local test corpus (mostly HDR test profiles) | 171 | 332 | 0 |
| every ICC file on the machine, including iccDEV's generated corpus and fuzz outputs | 2,235 | 4,395 | 13 valid pairs, 12 trailing high, **0 lone interior or lone low** |

The 12 trailing ones are all `mluc-unpaired-high-surrogate.icc`, which `iccdev.mluc-read-utf16-regressions` generates on purpose and `mluc` refuses on load. The only output this PR changes is output no conforming parser could read.

## Local pre-flight

Run on `cc877b92`. The pushed head `32d8a1cf` differs from it only in two comments, which now cite #2526.

Every row of the Change table was measured, with both overloads, by compiling the same probe against master's `IccConvertUTF.cpp` and against this branch's.

| lane | result |
|---|---|
| GCC 15.2 Strict Release LTO, `ci-pr-gcc15.yml` flags, in `ghcr.io/internationalcolorconsortium/iccdev:latest`, default target and `build-test-binaries` | exit 0, 0 `warning:` lines, test passes |
| clang 18 ASan+UBSan+IntSan Debug, `-Werror`, `detect_leaks=1` | test passes; `iccToXml` / `iccFromXml` / `iccToJson` / `iccDumpProfile` on 15 planted profiles, 0 sanitizer findings |
| clang 18 Debug, full `ctest -j4` | 264 passed, 2 skipped, 1 failed: `iccdev.spectral-tiff-preview`, which needs the Python `imagecodecs` module that this machine lacks (unrelated) |

### CI, before opening

`ci-pr-action` dispatched on `32d8a1cf` with `ci_scope=source`: run 34621408278, success. `iccdev.utf8-converter-cursor-contract` ran and passed in every leg that runs ctest:

| job | result |
|---|---|
| Tool Smoke Tests, GCC Strict ASAN+UBSAN Debug (103336161064) | `Test #74 ... Passed`, 263/263 |
| Windows MSVC (103336160938) | `Test #68 ... Passed`, 155/155 |
| Windows ClangCL (103336160899) | `Test #68 ... Passed`, 155/155 |

Windows is the 16-bit `wchar_t` platform, where `icWCharToUtf8` takes the fixed UTF-16 branch. GCC 15.2 Strict Release LTO, macOS Debug and Release, and MinGW UCRT64 are also green.
