### PR TITLE
fix(#2526): write a dict character above U+FFFF as UTF-8 instead of CESU-8 where wchar_t is 32 bits

### DIFF
--- a/.github/ci/regression/utf8-converter-cursor-contract.cpp
+++ b/.github/ci/regression/utf8-converter-cursor-contract.cpp
@@ -40,6 +40,13 @@
 // the strict-mode cases pass on both and guard the branch that #2511
 // restructured.
 //
+// #2526 added the icWCharToUtf8 surrogate cases.  Where wchar_t is 32 bits,
+// that function read its input as UTF-32, but the dictType text it converts
+// holds UTF-16 code units, one per wchar_t -- so a valid U+1F600 came out as
+// six bytes of CESU-8.  Every case that gives a surrogate its own wchar_t
+// fails against that converter on Linux and macOS.  On Windows they pass
+// before and after: that arm already went through icConvertUTF16toUTF8().
+//
 // Returns 0 on success; the number of failed assertions otherwise.
 
 #include "IccUtil.h"
@@ -177,6 +184,9 @@ void checkWChar(const wchar_t *src, size_t len,
   // See checkUtf16: provenance, not cursor position.
   snprintf(msg, sizeof(msg), "%s: returns the string's own storage", what);
   check(rv == buf.c_str() && rv[buf.size()] == '\0', msg);
+
+  // #2526: as in checkUtf16, every case.
+  checkLegal(buf, what);
 }
 
 } // namespace
@@ -289,15 +299,11 @@ int main()
   }
 
   // --- icWCharToUtf8 -------------------------------------------------------
-  // Reached in production only through the dictType writers.  Which arm of the
-  // WCHAR_MAX branch runs is platform-dependent (UTF-32 where wchar_t is wide,
-  // UTF-16 on Windows); these cases are chosen to hold on both.
-  //
-  // #2511 has no lone-surrogate case here on purpose.  The Windows arm goes
-  // through the fixed icConvertUTF16toUTF8(); the UTF-32 arm goes through
-  // icConvertUTF32toUTF8(), which #2511 deliberately left alone (see the
-  // comment there, and #2526), so the same input gives different bytes per
-  // platform.
+  // Reached in production only through the dictType writers, whose text holds
+  // UTF-16 code units one per wchar_t on every platform.  Which arm of the
+  // WCHAR_MAX branch runs depends on the platform, but since #2526 both end in
+  // icConvertUTF16toUTF8(), so the cases in this block give the same bytes on
+  // both.  The block after it runs only where wchar_t is 32 bits.
   {
     const wchar_t ascii[] = L"iccDEV";
     checkWChar(ascii, 6, "iccDEV", 6, "wchar ascii, explicit length");
@@ -311,6 +317,26 @@ int main()
     const wchar_t embedded[] = { L'a', 0, L'b', 0 };
     checkWChar(embedded, 3, "a\0b", 3, "wchar interior NUL kept");
 
+    // #2526: U+1F600 as a surrogate pair, one unit per wchar_t -- the form a
+    // dict entry holds.  Read as UTF-32 it came out as ED A0 BD ED B8 80.
+    const wchar_t pairUnits[] = { L'a', 0xD83D, 0xDE00, L'b', 0 };
+    checkWChar(pairUnits, 4, "a\xF0\x9F\x98\x80" "b", 6, "wchar surrogate pair in two units");
+
+    // #2526 takes the #2511 lone-surrogate cases along with it.  The UTF-32
+    // arm passed them through as CESU-8; they now match icUtf16ToUtf8 above.
+    const wchar_t loneHigh[] = { 0xD83D, L'a', 0 };
+    checkWChar(loneHigh, 2, "\xEF\xBF\xBD" "a", 4, "wchar interior unpaired high surrogate -> U+FFFD");
+
+    const wchar_t loneLow[] = { L'a', 0xDE00, L'b', 0 };
+    checkWChar(loneLow, 3, "a" "\xEF\xBF\xBD" "b", 5, "wchar lone low surrogate -> U+FFFD");
+
+    const wchar_t reversed[] = { 0xDE00, 0xD83D, L'a', 0 };
+    checkWChar(reversed, 3, "\xEF\xBF\xBD" "\xEF\xBF\xBD" "a", 7, "wchar reversed pair -> two U+FFFD");
+
+    // A trailing high surrogate is dropped, as in icUtf16ToUtf8.
+    const wchar_t truncated[] = { L'a', 0xD83D, 0 };
+    checkWChar(truncated, 2, "a", 1, "wchar trailing unpaired surrogate dropped");
+
     {
       std::string buf("stale");
       icWCharToUtf8(buf, NULL, 4);
@@ -323,6 +349,30 @@ int main()
       check(buf.empty(), "wchar empty source clears the buffer");
     }
   }
+
+#if WCHAR_MAX > 65535
+  // --- icWCharToUtf8, 32-bit wchar_t only (#2526) ---------------------------
+  // Real UTF-32, a form a 16-bit wchar_t cannot hold.  These passed before
+  // #2526 as well; they guard the step it added, which splits a wchar_t above
+  // U+FFFF into a surrogate pair before the UTF-16 converter joins it again.
+  {
+    const wchar_t oneUnit[] = { L'a', (wchar_t)0x1F600, L'b', 0 };
+    checkWChar(oneUnit, 3, "a\xF0\x9F\x98\x80" "b", 6, "wchar U+1F600 as one UTF-32 unit");
+
+    // U+10FFFF is the last code point; one past it has no encoding.
+    const wchar_t last[] = { (wchar_t)0x10FFFF, 0 };
+    checkWChar(last, 1, "\xF4\x8F\xBF\xBF", 4, "wchar U+10FFFF as one UTF-32 unit");
+
+    const wchar_t beyond[] = { L'a', (wchar_t)0x110000, 0 };
+    checkWChar(beyond, 2, "a\xEF\xBF\xBD", 4, "wchar past U+10FFFF -> U+FFFD");
+
+    // Both forms in one string: a UTF-32 unit, then the same character as
+    // a pair of UTF-16 units.
+    const wchar_t bothForms[] = { (wchar_t)0x1F600, 0xD83D, 0xDE00, 0 };
+    checkWChar(bothForms, 3, "\xF0\x9F\x98\x80" "\xF0\x9F\x98\x80", 8,
+               "wchar U+1F600 as one unit, then as two");
+  }
+#endif
 
   if (g_fail)
     printf("%d assertion(s) failed\n", g_fail);

--- a/.github/ci/test-data/dict-entries-2512.xml
+++ b/.github/ci/test-data/dict-entries-2512.xml
@@ -14,16 +14,16 @@
                         round trip
     Grüße               two- and three-byte UTF-8 in both name and value,
                         which is what reaches icWCharToUtf8
+    Astral 😀           a character above U+FFFF in both name and value.
+                        The entry holds it as a UTF-16 surrogate pair, one
+                        code unit per wchar_t, and where wchar_t is 32 bits
+                        the writers used to encode each half on its own as
+                        CESU-8, which iccFromXml then refused (#2526)
     Escapes             all five characters icFixXml escapes (& < > " ')
     Localized           localized names (two languages) and a localized value,
                         so the record is 32 bytes wide
     ValueLocalizedOnly  a localized value with no localized name, so the
                         localized-name slot of a 32-byte record is empty
-
-  Every character is inside the Basic Multilingual Plane.  A character above
-  U+FFFF does not survive the XML round trip on platforms with a 32-bit
-  wchar_t.  That is a separate defect, and this file is the control that
-  shows the BMP path works.
 
   The DictEntry lines are written exactly as CIccTagXmlDict::ToXml emits them
   (attribute order, CDATA sections), because the regression script compares
@@ -94,6 +94,7 @@
       <DictEntry Name="NameOnly"/>
       <DictEntry Name="EmptyValue" Value=""/>
       <DictEntry Name="Grüße" Value="Café 色"/>
+      <DictEntry Name="Astral 😀" Value="G clef 𝄞"/>
       <DictEntry Name="Escapes" Value="a &amp; b &lt;c&gt; &quot;q&quot; &apos;s&apos;"/>
       <DictEntry Name="Localized" Value="plain">
         <LocalizedName LanguageCountry="enUS"><![CDATA[Localized]]></LocalizedName>

--- a/.github/scripts/iccdev-issue-2512-dict-roundtrip-regression.sh
+++ b/.github/scripts/iccdev-issue-2512-dict-roundtrip-regression.sh
@@ -20,9 +20,10 @@
 # record shape the binary format can hold; its header lists them.  The test
 # builds a profile from it and then checks each direction separately:
 #
-#   1. The profile carries all seven entries and validates.  Without this, a
+#   1. The profile carries every entry and validates.  Without this, a
 #      reader that dropped the tag would make every later comparison pass on
-#      an empty dict.
+#      an empty dict.  The dump must also print the entry above U+FFFF as
+#      UTF-8, which checks the third writer, CIccDictEntry::Describe.
 #   2. ICC -> XML writes back exactly the DictEntry lines the fixture holds.
 #   3. XML -> ICC reproduces the profile byte for byte.
 #   4. ICC -> JSON writes each entry's fields with the right values, and keeps
@@ -32,6 +33,12 @@
 # Steps 2 and 4 check the text as well as the bytes, because a byte comparison
 # alone passes when writer and reader are wrong in matching ways -- for
 # example, both using the same misspelt key.
+#
+# #2526: the "Astral" entry holds characters above U+FFFF.  Where wchar_t is
+# 32 bits, all three writers used to encode each half of the surrogate pair
+# as its own three-byte sequence (CESU-8).  Step 1 then saw \xED\xA0\xBD in
+# the dump, step 2 a line that differed from the fixture, and step 4 six
+# U+FFFD where there should be one character.
 #
 # Environment variables:
 #   ICCDEV_TOOLS_DIR   -- path to Build/Tools or build/Tools
@@ -148,6 +155,12 @@ if ! grep -Fq "Profile is valid" "$OUTDIR/dump.log"; then
   sed -n '/Validation Report/,$p' "$OUTDIR/dump.log" | sed -n '1,10p' | sed 's/^/    /'
   fail "the fixture profile does not validate"
 fi
+# iccDumpProfile prints every byte outside ASCII as \xHH, so this is the
+# UTF-8 of U+1F600.  The CESU-8 the dump printed before #2526 starts \xED.
+if ! grep -Fq 'Name=Astral \xF0\x9F\x98\x80' "$OUTDIR/dump.log"; then
+  grep -a '^Name=Astral' "$OUTDIR/dump.log" | sed 's/^/    /'
+  fail "iccDumpProfile did not print U+1F600 in the Astral entry as UTF-8 (#2526)"
+fi
 echo "    built: $got dict entries, profile validates"
 
 # ===========================================================================
@@ -196,6 +209,7 @@ EXPECTED = [
     {"name": "NameOnly"},
     {"name": "EmptyValue", "value": ""},
     {"name": "Gr\u00fc\u00dfe", "value": "Caf\u00e9 \u8272"},
+    {"name": "Astral \U0001F600", "value": "G clef \U0001D11E"},
     {"name": "Escapes", "value": "a & b <c> \"q\" 's'"},
     {"name": "Localized", "value": "plain",
      "localizedNames": [loc("en", "US", "Localized"), loc("de", "DE", "Lokalisiert")],

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -5085,7 +5085,7 @@ function(iccdev_add_utf8_converter_cursor_test)
   endif()
   set_tests_properties(iccdev.utf8-converter-cursor-contract PROPERTIES
     TIMEOUT 120
-    LABELS "iccdev;iccprofLib;utf8;utf16;aliasing;issue-2504;issue-2511;regression"
+    LABELS "iccdev;iccprofLib;utf8;utf16;aliasing;issue-2504;issue-2511;issue-2526;regression"
   )
   if(WIN32)
     # icWCharToUtf8 takes the UTF-16 arm of its WCHAR_MAX branch here, which no
@@ -9304,13 +9304,15 @@ iccdev_add_script_test(
 # record shape, including a value that is set but empty, which the round trip
 # must keep apart from an entry with no value.  Each direction is checked on
 # its own: the text each writer emits, and the bytes each reader rebuilds.
-# The fixture is BMP-only.  Not registered on Windows (see the WIN32 branch
-# above), which is the one platform where wchar_t is 16 bits.
+# #2526 added an entry above U+FFFF, which the writers encoded as CESU-8
+# where wchar_t is 32 bits.  Not registered on Windows (see the WIN32 branch
+# above), which is the one platform where wchar_t is 16 bits; the icWCharToUtf8
+# cases in iccdev.utf8-converter-cursor-contract cover both widths.
 # Plain functional test -- skips cleanly if the tools/fixtures are absent.
 iccdev_add_script_test(
   iccdev.issue-2512-dict-roundtrip
   90
-  "iccdev;xml;json;dict;roundtrip;issue-2512;regression"
+  "iccdev;xml;json;dict;roundtrip;issue-2512;issue-2526;regression"
   "${ICCDEV_REPO_ROOT}"
   "${ICCDEV_REPO_ROOT}/.github/scripts/iccdev-issue-2512-dict-roundtrip-regression.sh"
 )

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -2851,7 +2851,7 @@ bool CIccTagJsonDict::ToJson(IccJson &j)
 
     IccJson entry;
 
-    // Name (stored as wstring / UTF-16 on Windows)
+    // Name (UTF-16 code units, one per wchar_t, on every platform -- #2526)
     std::string name;
     const std::wstring &wname = nv->GetName();
     bool nameOverflow = false;

--- a/IccProfLib/IccConvertUTF.cpp
+++ b/IccProfLib/IccConvertUTF.cpp
@@ -754,14 +754,12 @@ icUtfConversionResult icConvertUTF32toUTF8 (const UTF32** sourceStart, const UTF
         break;
       }
     }
-    /* #2511 deliberately leaves lenient mode passing surrogates through here,
-       unlike icConvertUTF16toUTF8.  Where wchar_t is 32 bits, dictType text
-       reaches this function through icWCharToUtf8() and wstringToUTF8Converter()
-       as UTF-16 code units stored one per wchar_t, so a VALID character above
-       U+FFFF arrives as two lone surrogates.  Substituting U+FFFD here was
-       measured to turn U+1F600 in a dict name into two U+FFFD that iccFromXml
-       then accepts -- silent loss of valid text, where today the CESU-8 output
-       at least fails loudly.  The pairing has to be fixed first: #2526. */
+    /* Lenient mode still passes a surrogate through here as three bytes,
+       unlike icConvertUTF16toUTF8 since #2511.  No iccDEV code calls this
+       function any more.  The dictType text that used to reach it, through
+       icWCharToUtf8() where wchar_t is 32 bits, holds UTF-16 code units, and
+       it arrived here as two lone surrogates per character above U+FFFF.  It
+       now goes through icConvertUTF16toUTF8 on every platform (#2526). */
     /*
     * Figure out how many bytes the result will require. Turn any
     * illegally large UTF32 things (> Plane 17) into replacement chars.

--- a/IccProfLib/IccTagDict.cpp
+++ b/IccProfLib/IccTagDict.cpp
@@ -231,27 +231,15 @@ std::string wstringToUTF8Converter( std::wstring &input )
 {
 
 #if 1
-  size_t maxBufferSize = 6 * ( input.size() + 1 );  // assume worst case conversion to UTF8
-  std::vector<char> outputBuffer ( maxBufferSize );
-  UTF8 *output_data( (UTF8 *)outputBuffer.data() );
-  UTF8 *output_end = output_data + maxBufferSize;
-  UTF8 *output_start = output_data;  // because this will be modified in the conversion routine
-
-  // wstring can be 16 or 32 bits depending on platform - so we need a conditional implementation to convert to UTF8
-  static_assert( sizeof(wchar_t) == 4 || sizeof(wchar_t) == 2, "wchar_t has an unexpected size." );
-  if (sizeof(wchar_t) == 4) {
-    const UTF32 *input_data( (const UTF32 *)input.data() );
-    const UTF32 *input_end = input_data + input.size();
-    (void) icConvertUTF32toUTF8 ( &input_data, input_end, &output_start, output_end, lenientConversion );
-  } else  {
-    const UTF16 *input_data( (const UTF16 *)input.data() );
-    const UTF16 *input_end = input_data + input.size();
-    (void) icConvertUTF16toUTF8 ( &input_data, input_end, &output_start, output_end, lenientConversion );
-  }
-
-// output_start has been moved to point to the end of the output, and should have a terminating NULL
-
-  return std::string ( (char *)output_data );     // this makes a copy of the output string data
+  // #2526: the entry text holds UTF-16 code units, one per wchar_t, on every
+  // platform.  The UTF-32 arm this function had for a 32-bit wchar_t encoded
+  // each half of a surrogate pair on its own, so iccDumpProfile printed six
+  // bytes of CESU-8 for a character above U+FFFF.  icWCharToUtf8 handles
+  // both widths.  Building the result from c_str() keeps the old behaviour at
+  // an embedded NUL: the text is still cut there.
+  std::string buf;
+  icWCharToUtf8(buf, input.c_str(), input.size());
+  return std::string(buf.c_str());
 #else
 // deprecated implementation that still works for now, but is marked for removal in C++26
 // saving this, just in case the new code fails in testing

--- a/IccProfLib/IccUtil.cpp
+++ b/IccProfLib/IccUtil.cpp
@@ -3192,8 +3192,38 @@ const char *icWCharToUtf8(std::string &buf, const wchar_t *szSrc, size_t sizeSrc
     // the WCHAR_MAX branch.
     UTF8 *szDest = (UTF8*)szBuf;
 #if WCHAR_MAX > 65535
-    const UTF32 *szPtr = (const UTF32 *)szSrc;
-    icConvertUTF32toUTF8(&szPtr, &szPtr[sizeSrc], &szDest, (UTF8*)&szBuf[n], lenientConversion);
+    // #2526: a 32-bit wchar_t string is not always UTF-32 here.  The dictType
+    // names and values this function converts for IccTagXml.cpp and
+    // IccTagJson.cpp hold UTF-16 code units, one per wchar_t --
+    // CIccTagDict::Read and CIccUTF16String::ToWString store them that way,
+    // and CIccTagDict::Write narrows each wchar_t back to 16 bits.  Read as
+    // UTF-32, a character above U+FFFF arrived as two surrogates and came out
+    // as six bytes of CESU-8, which libxml2 refuses.
+    //
+    // So this arm now ends in icConvertUTF16toUTF8 too, as the Windows arm
+    // does.  A wchar_t above U+FFFF, which only real UTF-32 holds, is split
+    // into its surrogate pair first, and the UTF-16 converter joins a pair in
+    // whichever form it arrived.  Valid UTF-32 gives the same bytes as
+    // before.  Only surrogate values change, and UTF-32 cannot contain them:
+    // a pair is joined, and a lone one becomes U+FFFD -- or, if it is a high
+    // surrogate that ends the string, is dropped -- as on Windows (#2511).
+    // Every wchar_t yields at most 4 bytes, so n is still enough.
+    icUtf16Vector units;
+    units.reserve(sizeSrc);
+    for (size_t i = 0; i < sizeSrc; i++) {
+      UTF32 ch = (UTF32)szSrc[i];
+      if (ch <= 0xFFFF) {
+        units.push_back((UTF16)ch);
+      } else if (ch <= 0x10FFFF) {
+        ch -= 0x10000;
+        units.push_back((UTF16)(0xD800 + (ch >> 10)));
+        units.push_back((UTF16)(0xDC00 + (ch & 0x3FF)));
+      } else {
+        units.push_back(0xFFFD);  // past U+10FFFF, as icConvertUTF32toUTF8 did
+      }
+    }
+    const UTF16 *szPtr = units.data();
+    icConvertUTF16toUTF8(&szPtr, szPtr + units.size(), &szDest, (UTF8*)&szBuf[n], lenientConversion);
 #else
     const UTF16 *szPtr = (const UTF16 *)szSrc;
     icConvertUTF16toUTF8(&szPtr, &szPtr[sizeSrc], &szDest, (UTF8*)&szBuf[n], lenientConversion);


### PR DESCRIPTION
Fixes #2526.

dictType names and values hold UTF-16 code units, one per `wchar_t`, on every platform: `CIccTagDict::Read` and `CIccUTF16String::ToWString` store them that way, and `CIccTagDict::Write` narrows each `wchar_t` back to 16 bits. Where `wchar_t` is 32 bits (Linux, macOS), the three text writers read that buffer as UTF-32 instead, so each half of a surrogate pair was encoded on its own. Windows was not affected.

## Before and after (Linux, planted in the #2512 fixture)

| input in a dict name | writer | before | after |
|---|---|---|---|
| U+1F600 (valid pair) | `iccToXml` | `ED A0 BD ED B8 80`; `iccFromXml` then fails: `Char 0xD83D out of allowed range` | `F0 9F 98 80`; ICC → XML → ICC byte-exact |
| U+1F600 | `iccToJson` | six U+FFFD | `😀`; ICC → JSON → ICC byte-exact |
| U+1F600 | `iccDumpProfile -v` | `\xED\xA0\xBD\xED\xB8\x80` | `\xF0\x9F\x98\x80` |
| lone high (`D83D 'B'`) | XML / JSON | CESU-8, `iccFromXml` fails / three U+FFFD | `EF BF BD 42`, round-trips / one U+FFFD |
| lone low (`'A' DE00`) | XML / JSON | same | `41 EF BF BD` / one U+FFFD |
| high surrogate that ends the text | XML / JSON | same | dropped, as `icUtf16ToUtf8` does since #2511 |

The last three rows are the dict part of #2511, which #2528 left to this issue. All six now match what Windows already wrote.

## Change

- **`IccProfLib/IccUtil.cpp`, `icWCharToUtf8`**: the 32-bit arm now ends in `icConvertUTF16toUTF8`, as the Windows arm already did. A `wchar_t` above U+FFFF, which only real UTF-32 holds, is split into its surrogate pair first, and the UTF-16 converter joins a pair in either form.
- **`IccProfLib/IccTagDict.cpp`, `wstringToUTF8Converter`** (used by `CIccDictEntry::Describe`): now calls `icWCharToUtf8` instead of carrying its own copy of the same UTF-32 branch. It still cuts the text at an embedded NUL, as before.
- **`IccProfLib/IccConvertUTF.cpp`**: comment only. The #2511 note in `icConvertUTF32toUTF8` that deferred this to #2526 is replaced. Nothing in iccDEV calls that function now; lenient mode there still passes a surrogate through, and this PR leaves it.
- **`IccJSON/IccLibJSON/IccTagJson.cpp`**: comment only. "stored as wstring / UTF-16 on Windows" is the misreading that caused the defect.

### `icWCharToUtf8` is exported: what changes for other callers

Valid UTF-32 gives the same bytes as before. That includes U+10FFFF, and values past it still become U+FFFD. Only surrogate values change, and UTF-32 cannot contain them. An adjacent high + low pair is joined. A lone surrogate becomes U+FFFD, except a high surrogate that ends the string, which is dropped. That is what `icUtf16ToUtf8` and the Windows arm have done since #2511. The new test cases pin all of it.

One consequence of the drop, for a profile that is already malformed: on Linux, a dict name ending in a lone high surrogate used to fail loudly, because the CESU-8 made `iccFromXml` reject the file. It now loses that unit silently, as it already did on Windows. So names `A`+U+D800 and `A` both come out as `A`.

## Tests

**`iccdev.issue-2512-dict-roundtrip`**: the fixture gains `<DictEntry Name="Astral 😀" Value="G clef 𝄞"/>` (U+1F600 and U+1D11E), and its header no longer says the fixture is BMP-only. The script checks it through every writer: the dump prints the UTF-8 of U+1F600, the XML line matches the fixture, the JSON fields match, and both round trips stay byte-exact.

**`iccdev.utf8-converter-cursor-contract`**: `icWCharToUtf8` cases for a pair in two units, lone high, lone low, a reversed pair and a trailing high surrogate. These hold on both widths, so Windows runs them too. There are also 32-bit-only cases: U+1F600 and U+10FFFF as one unit, one past U+10FFFF, and both forms in one string. Every `icWCharToUtf8` result now also goes through `isLegalUTF8String()`.

### Red/green (master's three library files, this branch's tests)

| test | master library | this branch |
|---|---|---|
| `utf8-converter-cursor-contract` | 15 failed assertions, in the 6 surrogate cases (the 32-bit-only UTF-32 controls pass, as intended) | 0 |
| `issue-2512-dict-roundtrip` | fails at the dump check | passes, 8 entries |

The script stops at its first failure, so the other two writer checks were also run with the earlier ones removed. With the dump check removed, the XML line comparison fails. With the XML steps also removed, the JSON field comparison fails. Each check catches the defect on its own.

## Compatibility

Every ICC file on the machine was scanned for dict name/value records carrying surrogate code units. Excluding profiles I built for this and for #2511:

| set | unique profiles | dict tags | surrogate units |
|---|---|---|---|
| colord and ghostscript system profiles (`/usr/share/color`) | 51 | 38 | 0 |
| everything else on disk, including iccDEV's generated corpus | 837 | 63 | 0 |

The only output this PR changes is output that no conforming parser could read.

## Not changed

Setting a name through the public API as real UTF-32 on Linux (one `wchar_t` holding U+1F600) now comes out right in the text writers. `CIccTagDict::Write` still narrows that `wchar_t` to 16 bits, though, which is a separate API question. No in-tree code does this: every reader stores UTF-16 units.

## Local pre-flight

Run on `398e8f5c`. The head `d08d9102` differs from it in one source comment, which now says a trailing high surrogate is dropped (a `/code-review` finding), and in the commit message.

| lane | result |
|---|---|
| GCC 15.2 Strict Release LTO, `ci-pr-gcc15.yml` flags, in `ghcr.io/internationalcolorconsortium/iccdev:latest`, default target and `build-test-binaries` | exit 0, 0 `warning:` lines, both tests pass |
| clang 18 ASan+UBSan+IntSan Debug, `-Werror` | 0 warnings; `iccToXml` / `iccFromXml` / `iccToJson` / `iccFromJson` / `iccDumpProfile` on the fixture and three planted lone-surrogate profiles with `detect_leaks=1`, 0 sanitizer findings |
| same build, full `ctest -j4` | 264 passed, 2 failed, both environmental and failing identically on master: `spectral-tiff-preview` (no Python `imagecodecs` here) and `c-validation-dlopen` (a UBSan-instrumented shared library cannot be dlopened into an uninstrumented host: `undefined symbol: __ubsan_vptr_type_cache`) |

## CI before opening

`ci-pr-action`, `ci_scope=source`, run [34635568329](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34635568329) on `d08d9102`: success. The two tests ran, not skipped:

| job | result |
|---|---|
| GCC Strict ASAN+UBSAN (Debug) | 263/263; `utf8-converter-cursor-contract` and `issue-2512-dict-roundtrip` both passed |
| Windows MSVC, Windows ClangCL | 155/155 each; `utf8-converter-cursor-contract` passed, which covers the 16-bit `wchar_t` arm |
| GCC 15.2 Strict Release LTO, macOS clang Debug and Release LTO, MinGW UCRT64 | success |
