### PR TITLE
fix(#2527): keep an empty dict name from adding an empty value on read

### DIFF
--- a/.github/scripts/iccdev-issue-2512-dict-roundtrip-regression.sh
+++ b/.github/scripts/iccdev-issue-2512-dict-roundtrip-regression.sh
@@ -29,6 +29,7 @@
 #   4. ICC -> JSON writes each entry's fields with the right values, and keeps
 #      "no value" apart from "empty value".
 #   5. JSON -> ICC reproduces the profile byte for byte.
+#   6. An entry with an empty name and no value keeps having no value (#2527).
 #
 # Steps 2 and 4 check the text as well as the bytes, because a byte comparison
 # alone passes when writer and reader are wrong in matching ways -- for
@@ -264,6 +265,31 @@ fi
 run fromjson "$FROMJSON" "$OUTDIR/dict.json" "$OUTDIR/dict-rt-json.icc"
 same_bytes "$OUTDIR/dict.icc" "$OUTDIR/dict-rt-json.icc" "an ICC -> JSON -> ICC round trip"
 echo "    JSON: writer emits every entry's fields; round trip is byte-exact$json_note"
+
+# ===========================================================================
+# 6. An empty name (#2527).
+#
+# The binary writer gives an empty name a nonzero offset and a zero size.
+# CIccTagDict::Read's branch for that case called SetValue, so an entry with
+# an empty name and no value read back with an empty value: iccToXml wrote
+# Value="", and the profile rebuilt from that XML differed from the first.
+# An empty name is not valid -- the dump warns about it, and #2088 is why that
+# is only a warning -- so it is a variant of the fixture here, not an entry
+# in it: step 1 requires the fixture to validate.
+# ===========================================================================
+sed 's|<DictEntry Name="NameOnly"/>|<DictEntry Name=""/>|' "$FIXTURE" > "$OUTDIR/empty-name.xml"
+grep -Fq '<DictEntry Name=""/>' "$OUTDIR/empty-name.xml" \
+  || fail "could not make the empty-name variant of the fixture"
+
+run empty-build "$FROMXML" "$OUTDIR/empty-name.xml" "$OUTDIR/empty-name.icc"
+run empty-toxml "$TOXML" "$OUTDIR/empty-name.icc" "$OUTDIR/empty-name-rt.xml"
+if ! grep -Fq '<DictEntry Name=""/>' "$OUTDIR/empty-name-rt.xml"; then
+  grep -F '<DictEntry Name=""' "$OUTDIR/empty-name-rt.xml" | sed 's/^/    /'
+  fail "an entry with an empty name and no value read back with a value (#2527)"
+fi
+run empty-fromxml "$FROMXML" "$OUTDIR/empty-name-rt.xml" "$OUTDIR/empty-name-rt.icc"
+same_bytes "$OUTDIR/empty-name.icc" "$OUTDIR/empty-name-rt.icc" "an empty-name ICC -> XML -> ICC round trip"
+echo "    empty name: read back without a value; round trip is byte-exact"
 
 echo "  [PASS] issue-2512-dict-roundtrip -- all $EXPECTED_ENTRIES dict entries survive XML and JSON"
 exit 0

--- a/IccProfLib/IccTagDict.cpp
+++ b/IccProfLib/IccTagDict.cpp
@@ -646,8 +646,11 @@ bool CIccTagDict::Read(icUInt32Number size, CIccIO *pIO)
     //GetName
     if (pos[i].posName.offset) {
       if (!pos[i].posName.size) {
+        // #2527: this called SetValue, copied from the empty-value branch
+        // below, so an entry with an empty name and no value read back with
+        // an empty value that Write then stored.
         str.clear();
-        ptr.ptr->SetValue(str);
+        ptr.ptr->GetName() = str;
       }
       else {
         if (pos[i].posName.size > size || pos[i].posName.offset > size - pos[i].posName.size ||


### PR DESCRIPTION
Fixes #2527.

When a dict record has a name offset but a zero name size, `CIccTagDict::Read` took the branch at `IccTagDict.cpp:662`. That branch called `SetValue(str)`, a copy of the empty-value branch at `:707`, instead of setting the name. The name came out empty, as it should, but the entry also gained an empty value that the record never had.

`CIccTagDict::Write` gives every empty name a nonzero offset and a zero size, so an entry with an empty name and no value lost its "no value" state on its first read:

| step | before | after |
|---|---|---|
| `<DictEntry Name=""/>` → `iccFromXml` | exit 0 | exit 0 |
| → `iccToXml` | `<DictEntry Name="" Value=""/>` | `<DictEntry Name=""/>` |
| → `iccFromXml` again | a different profile | byte-identical |

## Change

`IccProfLib/IccTagDict.cpp`: the empty-name branch sets the name. It is one line, plus a comment.

## Reach

Only an entry that is already invalid gets here: `iccDumpProfile -v` warns about zero-length names, and #2088 covers why that check is only a warning. An entry that has a value is not affected, because the value branch that runs next overwrote the stray one anyway.

## Test: `iccdev.issue-2512-dict-roundtrip`, new step 6

The script generates a variant of its fixture with `NameOnly` renamed to `""`, builds it, and checks two things: `iccToXml` writes `<DictEntry Name=""/>` back without a `Value`, and ICC → XML → ICC is byte-exact. It is a generated variant rather than a new fixture entry, because step 1 requires the fixture to validate.

### Red/green (master's `IccTagDict.cpp`, this branch's test)

| library | result |
|---|---|
| master | fails at step 6: `<DictEntry Name="" Value=""/>` |
| this branch | passes |

With the XML line check removed, the byte-exact comparison fails on master as well, so each check catches the defect on its own.

This PR and #2529 (for #2526) both edit `iccdev-issue-2512-dict-roundtrip-regression.sh`, in separate hunks. `git merge-tree` combines the two branches without conflict, and the merged tree builds and passes both tests.

## Seen nearby, not changed

In `CIccTagDict::Write`, the loop that writes the record directory advances its index for every list element, including a null `ptr`. The loop that fills `pos[]` skips nulls, and `pos[]` is sized to the non-null count. So a null entry followed by real ones would make the directory read past the end of `pos[]` and write those bytes into the profile. No iccDEV reader puts a null entry in the list (every one returns before `push_back` when allocation fails). It is reachable only through a caller that edits the list directly, so this PR leaves it.

## Local pre-flight

Run on `53dedd48`.

| lane | result |
|---|---|
| GCC 15.2 Strict Release LTO, `ci-pr-gcc15.yml` flags, in `ghcr.io/internationalcolorconsortium/iccdev:latest`, default target and `build-test-binaries` | exit 0, 0 `warning:` lines, test passes |
| clang 18 ASan+UBSan+IntSan Debug, `-Werror`, full `ctest -j4` | 264 passed, 2 failed, both environmental and failing identically on master: `spectral-tiff-preview` (no Python `imagecodecs` here) and `c-validation-dlopen` (a UBSan-instrumented shared library cannot be dlopened into an uninstrumented host). On the first of two runs, `tool-coverage` also failed once; it passed when run alone and in the second full run. |
| merged tree of this branch and #2529's | builds, 0 warnings; `issue-2512-dict-roundtrip` (8 entries plus step 6) and `utf8-converter-cursor-contract` pass |

## CI before opening

`ci-pr-action`, `ci_scope=source`, run [34636895068](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34636895068) on `53dedd48`: success. In GCC Strict ASAN+UBSAN (Debug), 263/263 passed, `issue-2512-dict-roundtrip` included. GCC 15.2 Strict Release LTO, macOS clang Debug and Release LTO, Windows MSVC and ClangCL, and MinGW UCRT64 were all green. The dict script is not registered on Windows.
