### PR TITLE
fix(#2534): reject a named-colour lookup shorter than the tag's suffix

### DIFF
--- a/.github/ci/regression/namedcolor-findcolor-suffix-underflow.cpp
+++ b/.github/ci/regression/namedcolor-findcolor-suffix-underflow.cpp
@@ -1,0 +1,150 @@
+// Guards CIccTagNamedColor2::FindColor against the #2534 out-of-bounds read.
+//
+// The suffix fast-reject compares j = strlen(m_szSufix) bytes starting j bytes
+// from the end of szColor.  When the queried name is shorter than the suffix
+// that start pointer, szColor+(i-j), lands before the buffer and strncmp reads
+// memory the caller never owned (IccTagBasic.cpp:3762, unchanged since 1f0a9dd
+// in 2015).  m_szSufix is icChar[32] and is NUL-terminated on Read(), so a
+// profile can carry a 31-byte suffix and a one-byte name reaches 30 bytes back.
+//
+// The query names are heap-allocated at their exact length on purpose: a stack
+// buffer would place the underflowing read inside the caller's own frame, where
+// AddressSanitizer has nothing to report and the defect stays invisible.
+//
+// Cases 1 and 2 are the memory-safety cases -- their signal is the sanitizer
+// legs, and on a plain build they only assert the return value.  Cases 3, 4 and
+// 6 are deterministic everywhere and pin that the guard rejects only names that
+// are genuinely too short.  Case 6 is the boundary discriminator: a name whose
+// length is exactly strlen(m_szSufix) is a legal colour and must still be found,
+// so an off-by-one "i <= j" guard fails case 6 on every leg.  Case 4 alone does
+// not catch that -- its name does not match, so it answers -1 under either
+// spelling.  Case 5 is already in bounds today and is here to keep the prefix
+// block that way.
+
+#include "IccTagBasic.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+// 31 characters: the longest suffix a profile can carry in icChar[32].
+static const char *kLongSufix = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+static int check(const char *label, icInt32Number got, icInt32Number want)
+{
+  if (got != want) {
+    std::printf("%s: FindColor returned %d, expected %d\n", label, got, want);
+    return 1;
+  }
+  std::printf("%s: FindColor returned %d\n", label, got);
+  return 0;
+}
+
+// Copy szName onto the heap at exactly strlen+1 bytes so an underflowing read
+// crosses into the allocator's redzone rather than into unrelated live data.
+static int find_on_heap(const CIccTagNamedColor2 &tag, const char *szName,
+                        icInt32Number *pResult)
+{
+  const size_t n = std::strlen(szName) + 1;
+  char *heapName = (char *)std::malloc(n);
+  if (!heapName) {
+    std::printf("allocation of %zu bytes failed\n", n);
+    *pResult = -999;  // never a valid answer, so the caller's check fails loudly
+    return 1;
+  }
+  std::memcpy(heapName, szName, n);
+
+  *pResult = tag.FindColor(heapName);
+
+  std::free(heapName);
+  return 0;
+}
+
+static void init_tag(CIccTagNamedColor2 &tag, const char *szRootName,
+                     const char *szPrefix, const char *szSufix)
+{
+  SIccNamedColorEntry *entry = tag.GetEntry(0);
+  std::snprintf(entry->rootName, sizeof(entry->rootName), "%s", szRootName);
+
+  for (int i = 0; i < 3; ++i)
+    entry->pcsCoords[i] = 0.0f;
+  for (icUInt32Number i = 0; i < tag.GetDeviceCoords(); ++i)
+    entry->deviceCoords[i] = 0.0f;
+
+  tag.SetPrefix(szPrefix);
+  tag.SetSufix(szSufix);
+}
+
+int main()
+{
+  int failures = 0;
+  icInt32Number result = 0;
+
+  // 1. The reported case: one-byte name, 31-byte suffix.  szColor+(1-31)
+  //    reads 30 bytes before the allocation.
+  {
+    CIccTagNamedColor2 tag(1, 4);
+    init_tag(tag, "A", "", kLongSufix);
+    failures += find_on_heap(tag, "A", &result);
+    failures += check("short-name-long-sufix", result, -1);
+  }
+
+  // 2. Empty name against the same suffix: the largest underflow the tag can
+  //    produce, szColor-31.
+  {
+    CIccTagNamedColor2 tag(1, 4);
+    init_tag(tag, "A", "", kLongSufix);
+    failures += find_on_heap(tag, "", &result);
+    failures += check("empty-name-long-sufix", result, -1);
+  }
+
+  // 3. The name the tag really spells must still be found.  Without this a
+  //    guard that rejected every suffixed lookup would look correct.
+  {
+    CIccTagNamedColor2 tag(1, 4);
+    init_tag(tag, "Red", "Pre-", "-Post");
+    failures += find_on_heap(tag, "Pre-Red-Post", &result);
+    failures += check("exact-name-found", result, 0);
+  }
+
+  // 4. A name exactly as long as the suffix that does NOT match: the compare is
+  //    in bounds, starts at szColor+0, and must simply not match.  Note this
+  //    case answers -1 under an off-by-one guard too -- case 6 is what pins the
+  //    boundary.
+  {
+    CIccTagNamedColor2 tag(1, 4);
+    init_tag(tag, "Red", "", "-Post");
+    failures += find_on_heap(tag, "xxxxx", &result);
+    failures += check("name-length-equals-sufix", result, -1);
+  }
+
+  // 5. The prefix fast-reject on a name shorter than the prefix.  strncmp stops
+  //    at the name's NUL, so this one was already in bounds; pin it so a future
+  //    edit to that block cannot grow a second underflow.
+  {
+    CIccTagNamedColor2 tag(1, 4);
+    init_tag(tag, "Red", kLongSufix, "");
+    failures += find_on_heap(tag, "A", &result);
+    failures += check("short-name-long-prefix", result, -1);
+  }
+
+  // 6. The boundary.  An empty prefix and an empty rootName make the tag spell
+  //    exactly one colour, "-Post", whose length equals strlen(m_szSufix).  That
+  //    is a legal lookup and must return 0.  This is the case that fails if the
+  //    guard is written "i <= j" instead of "i < j" -- under that spelling
+  //    iccApplyNamedCmm would report icCmmStatColorNotFound for a colour the
+  //    profile actually carries.
+  {
+    CIccTagNamedColor2 tag(1, 4);
+    init_tag(tag, "", "", "-Post");
+    failures += find_on_heap(tag, "-Post", &result);
+    failures += check("name-length-equals-sufix-and-matches", result, 0);
+  }
+
+  if (failures)
+    std::printf("namedcolor-findcolor-suffix-underflow: %d failure(s)\n", failures);
+  else
+    std::printf("namedcolor-findcolor-suffix-underflow: all cases passed\n");
+
+  return failures ? 1 : 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -1410,6 +1410,57 @@ function(iccdev_add_cmmsearch_namedcolor_ownership_test)
   endif()
 endfunction()
 
+# Guards CIccTagNamedColor2::FindColor against the #2534 out-of-bounds read: the
+# suffix fast-reject starts its compare j = strlen(m_szSufix) bytes from the end
+# of the queried name, so a name shorter than the suffix points strncmp before
+# the buffer (IccTagBasic.cpp:3762, unchanged since 2015).  A 31-byte suffix --
+# the longest icChar[32] can hold -- against a one-byte name reaches 30 bytes
+# back; iccApplyNamedCmm reaches it from a profile and a name file.
+#
+# The helper queries names it allocated on the heap at their exact length, so the
+# underflow crosses an allocator redzone: the pass/fail signal for the memory
+# safety is the ASan legs, where the pre-fix code aborts and the guarded code
+# exits 0.  Measured on a plain Release build the same helper exits 0 either way,
+# so on non-sanitizer legs cases 1 and 2 are a smoke test.  Cases 3, 4 and 6 are
+# deterministic everywhere: the name the tag really spells is still found, a
+# non-matching equal-length name is still compared, and -- case 6, the boundary
+# discriminator -- a name whose length is exactly strlen(m_szSufix) is a legal
+# colour that must still be found, which is what fails an off-by-one "i <= j".
+function(iccdev_add_namedcolor_findcolor_suffix_underflow_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccNamedColorFindColorSuffixUnderflowTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/namedcolor-findcolor-suffix-underflow.cpp"
+  )
+  target_link_libraries(iccNamedColorFindColorSuffixUnderflowTest PRIVATE ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccNamedColorFindColorSuffixUnderflowTest)
+
+  add_test(
+    NAME iccdev.namedcolor-findcolor-suffix-underflow
+    COMMAND "$<TARGET_FILE:iccNamedColorFindColorSuffixUnderflowTest>"
+  )
+  set_tests_properties(iccdev.namedcolor-findcolor-suffix-underflow PROPERTIES
+    WORKING_DIRECTORY "${ICCDEV_REPO_ROOT}"
+    TIMEOUT 25
+    LABELS "iccdev;iccprofLib;namedcolor;oob;issue-2534;regression"
+  )
+  if(WIN32)
+    set(_namedcolor_findcolor_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccNamedColorFindColorSuffixUnderflowTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _namedcolor_findcolor_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.namedcolor-findcolor-suffix-underflow PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_namedcolor_findcolor_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # Guards CIccXform::Create(CIccProfile*, CIccTag*) profile ownership (#1308):
 # AddXform hands its owned profile to the tag-based Create overload, which must
 # free it when no xform can be built.  The helper feeds a valid profile plus a
@@ -7648,6 +7699,7 @@ if(WIN32)
   iccdev_add_mpecalc_rotate_operand_test()
   iccdev_add_sparsematrix_set_roundtrip_test()
   iccdev_add_cmmsearch_namedcolor_ownership_test()
+  iccdev_add_namedcolor_findcolor_suffix_underflow_test()
   iccdev_add_xform_create_tag_ownership_test()
   iccdev_add_xform_abstorel_adjust_test()
   iccdev_add_bpc_d2b_tag_family_test()
@@ -8030,6 +8082,7 @@ iccdev_add_mpecalc_matrix_overflow_test()
 iccdev_add_mpecalc_rotate_operand_test()
 iccdev_add_sparsematrix_set_roundtrip_test()
 iccdev_add_cmmsearch_namedcolor_ownership_test()
+iccdev_add_namedcolor_findcolor_suffix_underflow_test()
 iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_xform_abstorel_adjust_test()
 iccdev_add_bpc_d2b_tag_family_test()

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -3759,6 +3759,13 @@ icInt32Number CIccTagNamedColor2::FindColor(const icChar *szColor) const
   j = (icInt32Number)strlen(m_szSufix);
   i = (icInt32Number)strlen(szColor);
   if (j != 0) {
+    // CWE-125 (#2534): the suffix compare starts j bytes from the end of
+    // szColor, so a name shorter than the suffix makes szColor+(i-j) point
+    // before the buffer and strncmp reads out of bounds.  A name that short
+    // cannot equal prefix+rootName+suffix -- that is at least j bytes long --
+    // so the answer is "not found" without inspecting any memory.
+    if (i < j)
+      return -1;
     if (strncmp(szColor+(i-j), m_szSufix, j))
       return -1;    
   }


### PR DESCRIPTION
Closes #2534.

## The defect

`CIccTagNamedColor2::FindColor()` fast-rejects on the suffix by comparing
`j = strlen(m_szSufix)` bytes starting `j` bytes from the **end** of the queried name:

```cpp
j = (icInt32Number)strlen(m_szSufix);
i = (icInt32Number)strlen(szColor);
if (j != 0) {
  if (strncmp(szColor+(i-j), m_szSufix, j))   // i < j  =>  pointer before the buffer
    return -1;
}
```

When the name is shorter than the suffix, `szColor+(i-j)` points before the allocation and
`strncmp` reads memory the caller never owned. `m_szSufix` is `icChar[32]` and `Read()`
NUL-terminates it (`IccTagBasic.cpp:3372`), so a profile can carry a 31-byte suffix; a
one-byte name then reaches 30 bytes back.

`IccTagBasic.cpp:3762`, unchanged since `1f0a9dd` (2015) — the reported bisect is correct.

## Reach

`iccApplyNamedCmm` drives it from a profile plus a name file. Full chain, from the ASan
trace of the reporter's own PoC:

```
main                              iccApplyNamedCmm.cpp:724
CIccNamedColorCmm::Apply          IccCmm.cpp:12508
CIccApplyNamedColorCmm::Apply     IccCmm.cpp:11767
CIccXformNamedColor::Apply        IccCmm.cpp:8107
CIccTagNamedColor2::FindColor     IccTagBasic.cpp:3762
```

`CIccTagNamedColor2` is `ICCPROFLIB_API` with an installed header, so out-of-tree callers
reach it too. The v5 sibling `CIccArrayNamedColor::FindColor` (`IccArrayBasic.cpp:317`) is
`std::string`-keyed and unaffected; `FindRootColor` has no pointer arithmetic.

## The fix

```cpp
if (i < j)
  return -1;
```

A name shorter than the suffix cannot equal `prefix+rootName+suffix`, which is at least `j`
bytes long, so the answer is "not found" without inspecting any memory. Only the fast-reject
changes; the loop below still does the authoritative `strcmp`.

**No caller loses slack.** For `i < j` the pre-fix code could never return a valid index
either: the loop compares a name of `i` bytes against `prefix+rootName+suffix`, which is
`>= j > i` bytes, so no match was ever possible. The guard removes the out-of-bounds read
and nothing else — applying the profile's real 32-byte colour name produces byte-identical
output before and after (`diff` on the tool's stdout: identical).

## Scope check

This is the only site in the tree where a comparison starts at a computed negative offset.
Swept every `strcmp`/`strncmp`/`stricmp`/`memcmp` with offset arithmetic across `IccProfLib`,
`IccXML`, `IccJSON`, `IccConnect` and `Tools`: the two other offset sites are safe —
`icIsSpaceCLR`'s `szSig+1` / `szSig+2` index a local `icChar[5]` (`IccUtil.cpp:283,288`), and
the PNG `memcmp(m_pData+1, ...)` is guarded by `m_nSize > 4` (`IccTagBasic.cpp:13813`).

## Regression

`.github/ci/regression/namedcolor-findcolor-suffix-underflow.cpp`, registered as
`iccdev.namedcolor-findcolor-suffix-underflow`. Registered in **both** call lists in
`Build/Cmake/Testing/CMakeLists.txt` — the `if(WIN32)` branch ends in `return()`, so the two
are mutually exclusive and a single registration would run on one platform family only
(#2237).

The helper queries names it allocated on the heap at their exact length, so the underflow
crosses an allocator redzone; a stack buffer would put the read inside the caller's own frame
where ASan has nothing to report.

**What detects what — measured, not assumed:**

| leg | unfixed | fixed |
|---|---|---|
| clang-18 ASan Debug | aborts, SEGV in `strncmp` via `FindColor:3762` | exits 0 |
| plain Release (no sanitizer) | **exits 0** | exits 0 |

So on non-sanitizer legs cases 1 and 2 are a smoke test, and the memory-safety signal is the
sanitizer legs — the same posture as the existing `iccdev.iccprofileplot-clut-oob`. To keep
the test from being vacuous there, cases 3 and 4 are deterministic on every leg: the name the
tag really spells is still found (index 0), and a name exactly as long as the suffix is still
compared. An over-broad guard that rejected any suffixed lookup fails those on any leg. Both
facts are written into the fixture header and the CMake comment.

## Verification

- **Red/green through ctest**, clang-18 ASan Debug, on the committed tree: unfixed aborts at
  `IccTagBasic.cpp:3762`, fixed passes. Re-verified after the last edit.
- **Reporter's PoC reproduced end to end and resolved.** Unfixed `iccApplyNamedCmm poc.txt 2 0
  foo.bar 3` gives the reported signature — `heap-buffer-overflow`, `READ of size 1`, frame
  `#1 CIccTagNamedColor2::FindColor ... IccTagBasic.cpp:3762`. Fixed: `Profile application
  failed.`, exit 1, clean.
- **Strict clang 21.1.3 Release** (`-Wall -Wextra -Wpedantic -Werror`), configure line
  `strict warnings ENABLED (Clang 21.1.3)`: **0 warnings**, new test passes.
- **GCC 15.2.0 strict LTO Release in the CI container**
  (`ghcr.io/internationalcolorconsortium/iccdev:latest`, `strict warnings ENABLED (GNU
  15.2.0)`): **0 warnings, 0 errors**, `100% tests passed, 0 tests failed out of 1`.
- **Full Release CTest suite: 270/271.** The single failure,
  `iccdev.spectral-tiff-preview`, is `ModuleNotFoundError: No module named 'imagecodecs'` —
  a Python module absent from this box, unrelated to the change.
- **`ASAN_OPTIONS=detect_leaks=1`** on the new helper (CI's ctest env sets `detect_leaks=0`):
  no leaks.

## Pre-PR CI

Dispatched `ci-pr-action` with `ci_scope=source` before opening this PR, per the suggested PR
workflow: run
[34684240902](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34684240902)
— **success**, 14 jobs green, 2 skipped by design (Windows Security Audit PowerShell, the
manual thread-linkage job). `source` rather than `full`: this is a core-library change that
registers a new test target, so it needs Windows and the complete CTest set, but not `full`'s
matrix.

The new test is not merely built — it ran and passed in every lane that runs ctest:

| job | result |
|---|---|
| `103528362578` GCC Strict ASAN+UBSAN (Debug) | `110/267 Test #109 ... Passed`, 100% of 267 |
| `103528362629` Windows MSVC | compiles `namedcolor-findcolor-suffix-underflow.cpp`, `103/159 Test #103 ... Passed` |
| `103528362619` Windows ClangCL | `103/159 Test #103 ... Passed` |

The ASAN+UBSAN Debug lane is the one that carries the memory-safety signal for this fixture.
