### PR TITLE
fix(#2535,#2536): reject a colorant count wider than the tag's 16-bit size

### DIFF
--- a/.github/ci/regression/colorant-count-narrowing-json.cpp
+++ b/.github/ci/regression/colorant-count-narrowing-json.cpp
@@ -1,0 +1,236 @@
+/*
+    File:       colorant-count-narrowing-json.cpp
+
+    Contains:   CTest helper for the colorant-count narrowing in
+                CIccTagJsonColorantOrder::ParseJson() (#2536) and
+                CIccTagJsonColorantTable::ParseJson() (#2535).
+
+    Both readers sized their allocation from a JSON array count that had been
+    narrowed on the way in.  The count was computed as an icUInt32Number and
+    guarded against size_t overflow, but CIccTagColorantOrder::SetSize() and
+    CIccTagColorantTable::SetSize() each take an icUInt16Number, so the value
+    narrowed a second time at the call -- 65537 became 1 -- while the loop that
+    follows still ran the untruncated count of times.  SetSize(1) is answered by
+    "if (m_nCount == nSize) return true;" against the one entry the constructor
+    already allocated, so the tag kept its original one-entry buffer and the
+    parse wrote through it.
+
+    Measured on master 896e9c06 with iccFromJson, the reported entry point
+    (CIccProfileJson::LoadJson -> ParseJson -> ParseTag -> the reader below):
+
+      #2536  WRITE of size 1  at IccTagJson.cpp:1099, 0 bytes after a 1-byte
+             region allocated in CIccTagColorantOrder::CIccTagColorantOrder(int)
+      #2535  WRITE of size 31 via strncpy at IccTagJson.cpp:1167, 0 bytes after
+             a 38-byte region -- one icColorantTableEntry -- allocated in
+             CIccTagColorantTable::CIccTagColorantTable(int)
+
+    The readers are driven directly here rather than through a profile document.
+    ParseJson() is the function under fix, the document wrapper adds nothing to
+    what is being asserted, and a direct call keeps the oversize cases off the
+    profile validator, which reports its own unrelated failures for a profile
+    carrying one tag.
+
+    The oversize cases are the memory-safety cases, and the count that carries
+    them is 65537, not 65536.  The difference is what makes them mean anything
+    off a sanitizer lane.  65537 narrows to 1, SetSize(1) is answered "true" by
+    the one entry the constructor already allocated, and the unfixed reader then
+    writes 65537 entries through it.  65536 narrows to 0, where SetSize(0)
+    reallocates to nothing and reports failure, so the unfixed reader ALREADY
+    refused it: that case on its own would pass against the very defect it is
+    meant to catch.  Both are kept, since the guard covers both counts, but
+    65537 is the one that carries the red.
+
+    Measured against master 896e9c06, the unfixed helper fails on every lane and
+    never on an assertion of its own: a plain clang-18 Release build aborts
+    inside the first oversize case with glibc's "free(): invalid size" (exit
+    134), and a sanitizer lane aborts earlier still, at the narrowing itself,
+    which -fno-sanitize-recover=integer makes fatal.  The FALSE the case asks
+    for is therefore the weaker of its two signals -- it is what a build that
+    survives the overrun would report -- and the case does not depend on a
+    sanitizer either way.
+
+    The 65535 cases are the boundary discriminators.  That count is
+    representable and must still be accepted with every entry present, so a
+    guard written ">= 0xFFFF" instead of "> 0xFFFF" fails them while passing
+    every other case here.
+
+    The empty-array cases pin behaviour this fix did NOT change: an empty array
+    was refused before it, because SetSize(0) reallocates to nothing and reports
+    failure.  They are here so that "simplifying" the new guard to
+    "if (!nValues) return false;" is not mistaken for a no-op.
+
+    Exit codes:
+      0 - expected results observed
+      1 - unexpected result
+*/
+
+#include "IccTagJson.h"
+
+#include <cstdio>
+#include <string>
+
+static int check(bool condition, const char *label)
+{
+  if (condition) {
+    std::fprintf(stdout, "colorant-count-narrowing-json: PASS  %s\n", label);
+    return 0;
+  }
+
+  std::fprintf(stderr, "colorant-count-narrowing-json: FAIL  %s\n", label);
+  return 1;
+}
+
+// A colorantOrder document carrying nEntries positions.
+static IccJson makeOrder(size_t nEntries)
+{
+  IccJson arr = IccJson::array();
+  for (size_t i = 0; i < nEntries; i++)
+    arr.push_back((int)(i % 256));
+
+  IccJson j = IccJson::object();
+  j["colorantOrder"] = arr;
+  return j;
+}
+
+// A colorantTable document carrying nEntries colorants.  Only "name" is
+// emitted: the overrunning write in the reader is the strncpy of that field,
+// and leaving "pcs" out keeps the boundary case from building 65535 further
+// sub-arrays for an assertion that does not read them.
+static IccJson makeTable(size_t nEntries)
+{
+  IccJson arr = IccJson::array();
+  for (size_t i = 0; i < nEntries; i++) {
+    IccJson c = IccJson::object();
+    char name[32];
+    std::snprintf(name, sizeof(name), "colorant-%u", (unsigned)i);
+    c["name"] = name;
+    arr.push_back(c);
+  }
+
+  IccJson j = IccJson::object();
+  j["colorantTable"] = arr;
+  return j;
+}
+
+static int orderCase(size_t nEntries, bool bExpectParsed, const char *label)
+{
+  CIccTagJsonColorantOrder tag;
+  std::string parseStr;
+
+  const bool bParsed = tag.ParseJson(makeOrder(nEntries), parseStr);
+
+  if (bParsed != bExpectParsed) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-json: FAIL  %s (ParseJson returned "
+                 "%s, expected %s)\n",
+                 label, bParsed ? "true" : "false",
+                 bExpectParsed ? "true" : "false");
+    return 1;
+  }
+
+  if (!bExpectParsed)
+    return check(true, label);
+
+  // An accepted document must have every position it declared, and the last
+  // one must hold the value it was given -- a reader that accepted the count
+  // and then filled a shorter table would otherwise pass on the count alone.
+  if (tag.GetSize() != nEntries) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-json: FAIL  %s (GetSize %u, expected "
+                 "%u)\n",
+                 label, (unsigned)tag.GetSize(), (unsigned)nEntries);
+    return 1;
+  }
+
+  const icUInt8Number *pData = tag.GetData(0);
+  const icUInt8Number expect = (icUInt8Number)((nEntries - 1) % 256);
+  if (!pData || pData[nEntries - 1] != expect) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-json: FAIL  %s (last position %d, "
+                 "expected %d)\n",
+                 label, pData ? (int)pData[nEntries - 1] : -1, (int)expect);
+    return 1;
+  }
+
+  return check(true, label);
+}
+
+static int tableCase(size_t nEntries, bool bExpectParsed, const char *label)
+{
+  CIccTagJsonColorantTable tag;
+  std::string parseStr;
+
+  const bool bParsed = tag.ParseJson(makeTable(nEntries), parseStr);
+
+  if (bParsed != bExpectParsed) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-json: FAIL  %s (ParseJson returned "
+                 "%s, expected %s)\n",
+                 label, bParsed ? "true" : "false",
+                 bExpectParsed ? "true" : "false");
+    return 1;
+  }
+
+  if (!bExpectParsed)
+    return check(true, label);
+
+  if (tag.GetSize() != nEntries) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-json: FAIL  %s (GetSize %u, expected "
+                 "%u)\n",
+                 label, (unsigned)tag.GetSize(), (unsigned)nEntries);
+    return 1;
+  }
+
+  char expect[32];
+  std::snprintf(expect, sizeof(expect), "colorant-%u", (unsigned)(nEntries - 1));
+
+  const icColorantTableEntry *pEntry = tag.GetEntry((icUInt32Number)(nEntries - 1));
+  if (!pEntry || std::string(pEntry->name) != expect) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-json: FAIL  %s (last name \"%s\", "
+                 "expected \"%s\")\n",
+                 label, pEntry ? pEntry->name : "(null)", expect);
+    return 1;
+  }
+
+  return check(true, label);
+}
+
+int main()
+{
+  int failures = 0;
+
+  // #2536 -- colorantOrder.
+  failures += orderCase(65537, false,
+                        "colorantOrder at 65537, which narrowed to a writable 1, is refused");
+  failures += orderCase(65536, false,
+                        "colorantOrder at 65536, which narrowed to 0, is refused for the same reason");
+  failures += orderCase(65535, true,
+                        "colorantOrder at exactly 65535 is still accepted in full");
+  failures += orderCase(4, true,
+                        "an ordinary colorantOrder is unaffected");
+  failures += orderCase(0, false,
+                        "an empty colorantOrder is refused, as before the fix");
+
+  // #2535 -- colorantTable.
+  failures += tableCase(65537, false,
+                        "colorantTable at 65537, which narrowed to a writable 1, is refused");
+  failures += tableCase(65536, false,
+                        "colorantTable at 65536, which narrowed to 0, is refused for the same reason");
+  failures += tableCase(65535, true,
+                        "colorantTable at exactly 65535 is still accepted in full");
+  failures += tableCase(4, true,
+                        "an ordinary colorantTable is unaffected");
+  failures += tableCase(0, false,
+                        "an empty colorantTable is refused, as before the fix");
+
+  if (failures) {
+    std::fprintf(stderr, "colorant-count-narrowing-json: %d case(s) failed\n",
+                 failures);
+    return 1;
+  }
+
+  std::fprintf(stdout, "colorant-count-narrowing-json: all cases passed\n");
+  return 0;
+}

--- a/.github/ci/regression/colorant-count-narrowing-xml.cpp
+++ b/.github/ci/regression/colorant-count-narrowing-xml.cpp
@@ -1,0 +1,276 @@
+/*
+    File:       colorant-count-narrowing-xml.cpp
+
+    Contains:   CTest helper for the XML twin of the colorantOrder count
+                narrowing fixed for JSON in #2536.
+
+    CIccTagXmlColorantOrder::ParseXml() counted its <n> elements into an int and
+    passed that to SetSize(), which takes an icUInt16Number, so 65537 elements
+    narrowed to a one-entry allocation.  The count then went on UNNARROWED to
+    CIccUInt8Array::ParseArray() as its buffer size, and that function's own
+    "n > nBufSize" test cannot catch this: the size it is handed is the element
+    count, not the size of the allocation, so the two agree and it writes every
+    element through a one-byte buffer.
+
+    This is a separate reachable entry point from the JSON readers, not a
+    restatement of them -- iccFromXml on a hand-authored document reaches it
+    with no JSON involved.  Measured on master 896e9c06:
+
+      WRITE of size 1 in CIccXmlArrayType<unsigned char>::ParseArray at
+      IccUtilXml.cpp:1352, called from IccTagXml.cpp:2365, 0 bytes after a
+      1-byte region allocated in CIccTagColorantOrder::CIccTagColorantOrder(int)
+
+    It is registered separately from the JSON helper so that neither masks the
+    other: this one is skipped where IccXML is not built, and the JSON coverage
+    does not disappear with it.
+
+    CIccTagXmlColorantTable::ParseXml() is deliberately NOT asserted as a defect
+    here.  It was measured on the same tree with an equivalent 65537-colorant
+    document and does not overrun: it casts to icUInt16Number explicitly and
+    bounds its own write loop by that same narrowed count, so it silently
+    truncates the colorant list instead.
+
+    The last case records that truncation.  Read it as a measurement, NOT as an
+    endorsement: its only job is to show that a fix aimed at the neighbouring
+    reader did not change this one.  Truncating is very likely the WRONG
+    answer -- it accepts a document and silently discards colorants -- and after
+    this commit the two front ends disagree about the same shape, because
+    CIccTagJsonColorantTable::ParseJson() now refuses a 65537-entry table that
+    this reader still accepts as one colorant.  Settling that is a spec and
+    compatibility question for the maintainers, not something a memory-safety
+    fix should decide by itself.  Whoever settles it should expect to INVERT
+    this case rather than to work around it.
+
+    The oversize cases are the memory-safety cases, and the count that carries
+    them is 65537, not 65536.  65537 narrows to 1, SetSize(1) is answered "true"
+    by the one entry the constructor already allocated, and the unfixed reader
+    then writes 65537 elements through it.  65536 narrows to 0, where SetSize(0)
+    reallocates to nothing and reports failure, so the unfixed reader ALREADY
+    refused it: that case on its own would pass against the very defect it is
+    meant to catch.  Both are kept, but 65537 is the one that carries the red.
+
+    Measured against master 896e9c06, the unfixed helper fails on every lane and
+    never on an assertion of its own: a plain clang-18 Release build aborts
+    inside the first oversize case with glibc's "malloc(): corrupted top size"
+    (exit 134), and a sanitizer lane aborts earlier still, at the narrowing
+    itself, which -fno-sanitize-recover=integer makes fatal.  The refusal the
+    case asks for is the weaker of its two signals -- what a build that survives
+    the overrun would report -- and the case does not depend on a sanitizer.
+
+    The 65535 case is the boundary discriminator: that many elements are
+    representable and must still load in full, so a guard written ">= 0xFFFF"
+    fails it while passing every other case here.
+
+    Args:
+      argv[1] - scratch directory to generate fixtures in (created if absent)
+
+    Exit codes:
+      0 - expected results observed
+      1 - unexpected result
+*/
+
+#include "IccProfileXml.h"
+#include "IccTagXmlFactory.h"
+#include "IccTagBasic.h"
+
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+static int check(bool condition, const char *label)
+{
+  if (condition) {
+    std::fprintf(stdout, "colorant-count-narrowing-xml: PASS  %s\n", label);
+    return 0;
+  }
+
+  std::fprintf(stderr, "colorant-count-narrowing-xml: FAIL  %s\n", label);
+  return 1;
+}
+
+static const char *kHeader =
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+  "<IccProfile>\n"
+  "  <Header>\n"
+  "    <ProfileVersion>4.30</ProfileVersion>\n"
+  "    <ProfileDeviceClass>prtr</ProfileDeviceClass>\n"
+  "    <DataColourSpace>CMYK</DataColourSpace>\n"
+  "    <PCS>Lab </PCS>\n"
+  "    <CreationDateTime>now</CreationDateTime>\n"
+  "    <RenderingIntent>Perceptual</RenderingIntent>\n"
+  "    <PCSIlluminant>\n"
+  "      <XYZNumber X=\"0.964202880859\" Y=\"1.000000000000\" Z=\"0.824905395508\"/>\n"
+  "    </PCSIlluminant>\n"
+  "  </Header>\n"
+  "  <Tags>\n";
+
+static const char *kFooter =
+  "  </Tags>\n"
+  "</IccProfile>\n";
+
+static bool writeOrderFixture(const std::string &path, size_t nEntries)
+{
+  std::ofstream f(path, std::ios::binary);
+  if (!f)
+    return false;
+
+  f << kHeader;
+  f << "    <colorantOrderTag> <colorantOrderType>\n      <ColorantOrder>\n";
+  for (size_t i = 0; i < nEntries; i++)
+    f << "        <n>" << (unsigned)(i % 256) << "</n>\n";
+  f << "      </ColorantOrder>\n    </colorantOrderType> </colorantOrderTag>\n";
+  f << kFooter;
+
+  return f.good();
+}
+
+static bool writeTableFixture(const std::string &path, size_t nEntries)
+{
+  std::ofstream f(path, std::ios::binary);
+  if (!f)
+    return false;
+
+  f << kHeader;
+  f << "    <colorantTableTag> <colorantTableType>\n      <ColorantTable>\n";
+  for (size_t i = 0; i < nEntries; i++)
+    f << "        <Colorant Name=\"colorant-" << (unsigned)i
+      << "\" Channel1=\"50\" Channel2=\"0\" Channel3=\"0\"/>\n";
+  f << "      </ColorantTable>\n    </colorantTableType> </colorantTableTag>\n";
+  f << kFooter;
+
+  return f.good();
+}
+
+// Returns whether the document loaded.  A sanitizer abort inside here IS the
+// defect on an instrumented lane: the caller never gets its result back.
+static bool loadXml(CIccProfileXml &profile, const std::string &file)
+{
+  std::string parseStr;
+  return profile.LoadXml(file.c_str(), "", &parseStr);
+}
+
+static int orderCase(const std::filesystem::path &dir, size_t nEntries,
+                     bool bExpectLoaded, const char *file, const char *label)
+{
+  const std::string path = (dir / file).string();
+  if (!writeOrderFixture(path, nEntries)) {
+    std::fprintf(stderr, "colorant-count-narrowing-xml: could not write %s\n",
+                 path.c_str());
+    return 1;
+  }
+
+  CIccProfileXml profile;
+  const bool bLoaded = loadXml(profile, path);
+
+  if (bLoaded != bExpectLoaded) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: FAIL  %s (LoadXml returned %s, "
+                 "expected %s)\n",
+                 label, bLoaded ? "true" : "false",
+                 bExpectLoaded ? "true" : "false");
+    return 1;
+  }
+
+  if (!bExpectLoaded)
+    return check(true, label);
+
+  // Accepting the count is not enough: the tag must actually carry every
+  // position, or a reader that narrowed and then filled a shorter table would
+  // pass on the load result alone.
+  CIccTagColorantOrder *pTag =
+    (CIccTagColorantOrder *)profile.FindTag(icSigColorantOrderTag);
+  if (!pTag) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: FAIL  %s (no colorantOrderTag "
+                 "on the loaded profile)\n", label);
+    return 1;
+  }
+
+  if (pTag->GetSize() != nEntries) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: FAIL  %s (GetSize %u, expected "
+                 "%u)\n",
+                 label, (unsigned)pTag->GetSize(), (unsigned)nEntries);
+    return 1;
+  }
+
+  const icUInt8Number expect = (icUInt8Number)((nEntries - 1) % 256);
+  const icUInt8Number *pData = pTag->GetData(0);
+  if (!pData || pData[nEntries - 1] != expect) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: FAIL  %s (last position %d, "
+                 "expected %d)\n",
+                 label, pData ? (int)pData[nEntries - 1] : -1, (int)expect);
+    return 1;
+  }
+
+  return check(true, label);
+}
+
+int main(int argc, char *argv[])
+{
+  if (argc < 2) {
+    std::fprintf(stderr,
+                 "usage: colorant-count-narrowing-xml <scratch-directory>\n");
+    return 1;
+  }
+
+  std::filesystem::path dir(argv[1]);
+  std::error_code ec;
+  std::filesystem::create_directories(dir, ec);
+  if (ec) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: could not create %s: %s\n",
+                 argv[1], ec.message().c_str());
+    return 1;
+  }
+
+  // The factory iccFromXml pushes before LoadXml.  Without it no
+  // CIccTagXmlColorantOrder is ever constructed, the load fails for want of a
+  // tag handler, and case 1's "is refused" assertion would pass without the
+  // code under test being entered.  Cases 2 and 3 are what catch that.
+  CIccTagCreator::PushFactory(new CIccTagXmlFactory());
+
+  int failures = 0;
+
+  failures += orderCase(dir, 65537, false, "colorant-order-65537.xml",
+                        "a colorantOrder at 65537, which narrowed to a writable 1, is refused");
+  failures += orderCase(dir, 65536, false, "colorant-order-65536.xml",
+                        "a colorantOrder at 65536, which narrowed to 0, is refused for the same reason");
+  failures += orderCase(dir, 65535, true, "colorant-order-65535.xml",
+                        "a colorantOrder at exactly 65535 still loads in full");
+  failures += orderCase(dir, 4, true, "colorant-order-4.xml",
+                        "an ordinary colorantOrder is unaffected");
+
+  // The sibling reader, measured NOT to overrun.  This records that it still
+  // truncates, so the fix above can be shown not to have moved it -- see the
+  // header: truncation is being measured here, not endorsed, and it is the case
+  // to invert once the front-end divergence is ruled on.
+  {
+    const std::string path = (dir / "colorant-table-65537.xml").string();
+    if (!writeTableFixture(path, 65537)) {
+      std::fprintf(stderr, "colorant-count-narrowing-xml: could not write %s\n",
+                   path.c_str());
+      return 1;
+    }
+
+    CIccProfileXml profile;
+    const bool bLoaded = loadXml(profile, path);
+    CIccTagColorantTable *pTag =
+      bLoaded ? (CIccTagColorantTable *)profile.FindTag(icSigColorantTableTag)
+              : nullptr;
+
+    failures += check(bLoaded && pTag && pTag->GetSize() == 1,
+                      "the colorantTable reader still truncates an oversize list rather than overrunning it (measured, not endorsed)");
+  }
+
+  if (failures) {
+    std::fprintf(stderr, "colorant-count-narrowing-xml: %d case(s) failed\n",
+                 failures);
+    return 1;
+  }
+
+  std::fprintf(stdout, "colorant-count-narrowing-xml: all cases passed\n");
+  return 0;
+}

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4716,6 +4716,138 @@ function(iccdev_add_calc_channel_ref_unterminated_index_json_test)
   endif()
 endfunction()
 
+# #2535/#2536: CIccTagJsonColorantOrder::ParseJson() and
+# CIccTagJsonColorantTable::ParseJson() sized their allocation from a count that
+# was narrowed a second time at the SetSize() call -- both tags' SetSize() takes
+# an icUInt16Number -- while the loop that fills the table still ran the
+# untruncated count of times. 65537 became a one-entry allocation written 65537
+# times: a 1-byte write past a 1-byte region for colorantOrder, and a 31-byte
+# strncpy past a 38-byte entry for colorantTable. The helper drives both readers
+# directly, since ParseJson() is the function under fix and the profile wrapper
+# adds nothing to the assertion. Its boundary cases are the discriminators: a
+# count of exactly 65535 is representable and must still be accepted in full, so
+# a guard spelled ">= 0xFFFF" fails them and passes everything else.
+function(iccdev_add_colorant_count_narrowing_json_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCJSON}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccColorantCountNarrowingJsonTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/colorant-count-narrowing-json.cpp"
+  )
+  target_compile_features(iccColorantCountNarrowingJsonTest PRIVATE cxx_std_17)
+  target_include_directories(iccColorantCountNarrowingJsonTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccJSON/IccLibJSON"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccColorantCountNarrowingJsonTest PRIVATE
+    ${TARGET_LIB_ICCJSON} ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccColorantCountNarrowingJsonTest)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.colorant-count-narrowing-json
+      COMMAND "$<TARGET_FILE:iccColorantCountNarrowingJsonTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.colorant-count-narrowing-json
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccColorantCountNarrowingJsonTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.colorant-count-narrowing-json PROPERTIES
+    TIMEOUT 300
+    LABELS "iccdev;json;colorant;issue-2535;issue-2536;regression"
+  )
+  if(WIN32)
+    set(_colorant_narrowing_json_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccColorantCountNarrowingJsonTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCJSON}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _colorant_narrowing_json_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.colorant-count-narrowing-json PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_colorant_narrowing_json_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
+# The XML twin of #2536, found while fixing it and fixed in the same commit:
+# CIccTagXmlColorantOrder::ParseXml() narrowed the same way at SetSize() and then
+# handed the UNNARROWED count to CIccUInt8Array::ParseArray() as its buffer size,
+# so that function's own "n > nBufSize" test could not catch it -- the size it is
+# given is the element count, not the allocation. iccFromXml reaches it with no
+# JSON involved, so it is registered separately from the JSON helper rather than
+# folded into it: this one is skipped where IccXML is not built, and the JSON
+# coverage does not disappear with it. Its last case pins the sibling
+# colorantTable reader, measured NOT to overrun -- it casts explicitly and bounds
+# its own loop, so it truncates -- so that this fix is not read as licence to
+# change behaviour there.
+function(iccdev_add_colorant_count_narrowing_xml_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}" OR NOT TARGET "${TARGET_LIB_ICCXML}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccColorantCountNarrowingXmlTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/colorant-count-narrowing-xml.cpp"
+  )
+  target_compile_features(iccColorantCountNarrowingXmlTest PRIVATE cxx_std_17)
+  target_include_directories(iccColorantCountNarrowingXmlTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccXML/IccLibXML"
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+    ${LIBXML2_INCLUDE_DIR}
+  )
+  target_link_libraries(iccColorantCountNarrowingXmlTest PRIVATE
+    ${TARGET_LIB_ICCXML} ${TARGET_LIB_ICCPROFLIB} ${LIBXML2_LIBRARIES})
+  add_dependencies(check iccColorantCountNarrowingXmlTest)
+
+  # The helper writes its generated documents into this directory, so nothing
+  # lands in the source tree.
+  set(_colorant_narrowing_xml_scratch
+    "${CMAKE_CURRENT_BINARY_DIR}/ctest-output/colorant-count-narrowing-xml")
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.colorant-count-narrowing-xml
+      COMMAND "$<TARGET_FILE:iccColorantCountNarrowingXmlTest>"
+              "${_colorant_narrowing_xml_scratch}"
+    )
+  else()
+    add_test(
+      NAME iccdev.colorant-count-narrowing-xml
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccColorantCountNarrowingXmlTest>"
+        "${_colorant_narrowing_xml_scratch}"
+    )
+  endif()
+  set_tests_properties(iccdev.colorant-count-narrowing-xml PROPERTIES
+    TIMEOUT 300
+    LABELS "iccdev;xml;colorant;issue-2536;regression"
+  )
+  if(WIN32)
+    set(_colorant_narrowing_xml_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccColorantCountNarrowingXmlTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCXML}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _colorant_narrowing_xml_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.colorant-count-narrowing-xml PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_colorant_narrowing_xml_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #2006 part 4a: CIccTagCurve::SetSize() answered an over-cap request the same
 # way it answered SetSize(0) -- free the table, m_nSize = 0, return true -- so
 # the return value could not distinguish "emptied" (a success, and ICC.1 10.6's
@@ -7700,6 +7832,8 @@ if(WIN32)
   iccdev_add_sparsematrix_set_roundtrip_test()
   iccdev_add_cmmsearch_namedcolor_ownership_test()
   iccdev_add_namedcolor_findcolor_suffix_underflow_test()
+  iccdev_add_colorant_count_narrowing_json_test()
+  iccdev_add_colorant_count_narrowing_xml_test()
   iccdev_add_xform_create_tag_ownership_test()
   iccdev_add_xform_abstorel_adjust_test()
   iccdev_add_bpc_d2b_tag_family_test()
@@ -8083,6 +8217,8 @@ iccdev_add_mpecalc_rotate_operand_test()
 iccdev_add_sparsematrix_set_roundtrip_test()
 iccdev_add_cmmsearch_namedcolor_ownership_test()
 iccdev_add_namedcolor_findcolor_suffix_underflow_test()
+iccdev_add_colorant_count_narrowing_json_test()
+iccdev_add_colorant_count_narrowing_xml_test()
 iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_xform_abstorel_adjust_test()
 iccdev_add_bpc_d2b_tag_family_test()

--- a/IccJSON/IccLibJSON/IccTagJson.cpp
+++ b/IccJSON/IccLibJSON/IccTagJson.cpp
@@ -1089,10 +1089,17 @@ bool CIccTagJsonColorantOrder::ParseJson(const IccJson &j, std::string & /*parse
 {
   if (jsonExistsField(j, "colorantOrder") && j["colorantOrder"].is_array()) {
     const IccJson &arr = j["colorantOrder"];
-    bool sizeOverflow = false;
-    icUInt32Number nValues = icJsonSafeU32(arr.size(), &sizeOverflow);
-    if (sizeOverflow || !SetSize(nValues)) return false;
-    for (icUInt32Number i = 0; i < nValues; i++) {
+    // #2536: CIccTagColorantOrder::SetSize() takes an icUInt16Number, so a
+    // count the icJsonSafeU32 guard passed was narrowed again at the call --
+    // 65537 became 1 -- while the loop below still ran arr.size() times and
+    // wrote past the one-entry allocation.  Guard at the width the tag can
+    // actually hold, as CIccTagJsonChromaticity::ParseJson already does for the
+    // third tag whose SetSize() is 16-bit; the icJsonSafeU32 guard this
+    // replaces is subsumed, since nothing above 0xFFFF now reaches SetSize().
+    icUInt16Number nValues = icJsonSafeU16(arr.size());
+    if (arr.size() > 0 && !nValues) return false;
+    if (!SetSize(nValues)) return false;
+    for (icUInt16Number i = 0; i < nValues; i++) {
       int value = 0;
       if (!jsonToValue(arr[i], value))
         return false;
@@ -1157,10 +1164,14 @@ bool CIccTagJsonColorantTable::ParseJson(const IccJson &j, std::string & /*parse
 
   if (jsonExistsField(j, "colorantTable") && j["colorantTable"].is_array()) {
     const IccJson &arr = j["colorantTable"];
-    bool sizeOverflow = false;
-    icUInt32Number nColorants = icJsonSafeU32(arr.size(), &sizeOverflow);
-    if (sizeOverflow || !SetSize(nColorants)) return false;
-    for (icUInt32Number i = 0; i < nColorants; i++) {
+    // #2535: the same narrowing as CIccTagJsonColorantOrder::ParseJson above.
+    // CIccTagColorantTable::SetSize() also takes an icUInt16Number, and here
+    // the overflowing write is the unconditional strncpy into
+    // m_pData[i].name, a 32-byte field of a 38-byte entry.
+    icUInt16Number nColorants = icJsonSafeU16(arr.size());
+    if (arr.size() > 0 && !nColorants) return false;
+    if (!SetSize(nColorants)) return false;
+    for (icUInt16Number i = 0; i < nColorants; i++) {
       const IccJson &c = arr[i];
       std::string name;
       if (jGetString(c, "name", name))

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -2356,15 +2356,38 @@ bool CIccTagXmlColorantOrder::ParseXml(xmlNode *pNode, std::string & /*parseStr*
   pNode = icXmlFindNode(pNode, "ColorantOrder");
 
   if (pNode) {
-    int n = icXmlNodeCount(pNode->children, "n");
+    icUInt32Number n = icXmlNodeCount(pNode->children, "n");
+
+    // The XML twin of #2536, reached through iccFromXml rather than
+    // iccFromJson: SetSize() takes an icUInt16Number, so 65537 <n> elements
+    // narrowed to a one-entry allocation while ParseArray() below was still
+    // handed the untruncated count as its buffer size and wrote every element.
+    // ParseArray()'s own "n > nBufSize" test cannot catch it -- the size it is
+    // given is the count, not the allocation.  Reject above the width the tag
+    // can hold instead of narrowing into it.
+    //
+    // CIccTagXmlColorantTable::ParseXml below is not affected: it casts to
+    // icUInt16Number explicitly and bounds its own loop by the same narrowed
+    // count, so it truncates the colorant list rather than overrunning it.
+    if (n > 0xFFFF)
+      return false;
 
     if (n) {
-      SetSize(n);
+      // SetSize()'s answer was discarded here.  That was never a use-after-free:
+      // icRealloc() frees the old block and returns NULL on failure, SetSize()
+      // stores that NULL, and the "if (m_pData)" that used to sit below
+      // therefore already caught a failed reallocation and fell through to the
+      // return false.  Testing the answer directly says so in one place, and
+      // retires that indirect guard rather than leaving it dead beside it: with
+      // n >= 1 and SetSize() true, m_nCount >= 1, and both the constructor and
+      // SetSize() zero m_nCount whenever the allocation fails, so the pointer
+      // test could no longer come out false.  The sibling ColorantTable reader
+      // spells the check the same way for #2106.
+      if (!SetSize((icUInt16Number)n))
+        return false;
 
-      if (m_pData) {
-        if (CIccUInt8Array::ParseArray(m_pData, n, pNode->children))
-          return true;
-      }
+      if (CIccUInt8Array::ParseArray(m_pData, n, pNode->children))
+        return true;
     }
   }  
   return false;


### PR DESCRIPTION
Closes #2535
Closes #2536

## The defect

Both readers narrowed the colorant count **twice**. Each computed an `icUInt32Number` and
guarded it against `size_t` overflow with `icJsonSafeU32()`, but
`CIccTagColorantOrder::SetSize()` and `CIccTagColorantTable::SetSize()` both take an
`icUInt16Number` — so the value narrowed again *at the call*, while the loop that fills the
table still ran the untruncated count of times.

`65537` is the count that matters. It narrows to `1`, and `SetSize(1)` is answered by
`if (m_nCount == nSize) return true;` against the single entry the constructor already
allocated — so the tag kept that one-entry buffer and the parse wrote 65537 entries through it.

Reproduced on master `896e9c06` under clang-18 ASan/UBSan before any change, matching both
reports:

| issue | ASan | site | region |
|---|---|---|---|
| #2536 | `WRITE of size 1` | `IccTagJson.cpp:1099` | 0 bytes after a 1-byte region |
| #2535 | `WRITE of size 31` via `strncpy` | `IccTagJson.cpp:1167` | 0 bytes after a 38-byte region — one `icColorantTableEntry` |

Both regions are allocated in the tag constructor; both are reached from
`CIccProfileJson::LoadJson -> ParseJson -> ParseTag`.

## The fix

The remedy already existed in the same file. `CIccTagJsonChromaticity::ParseJson`
(`IccTagJson.cpp:526`) is the third reader whose `SetSize()` is 16-bit, and it guards with
`icJsonSafeU16()` and refuses a count that does not fit. Both sites now do the same. The
`icJsonSafeU32()` guard they replace is subsumed — nothing above `0xFFFF` reaches `SetSize()`
any more — and `icJsonSafeU32()` keeps its sixteen other call sites in the file.

The bound is `> 0xFFFF`, not `>= 0xFFFF`: 65535 colorants are representable and a document
carrying them must still load in full. That is also the spelling
`CIccTagColorantTable::Read()` already uses at `IccTagBasic.cpp:9907`.

## A third site: the XML twin, which neither issue covers

Cross-checking the XML readers found the same defect in `CIccTagXmlColorantOrder::ParseXml()`.
It counted into an `int`, narrowed at `SetSize()` the same way, and then passed the
**unnarrowed** count to `CIccUInt8Array::ParseArray()` as its buffer size. That function's own
`n > nBufSize` test cannot catch it, because the size it is handed is the element count and not
the allocation.

Measured on the same tree — `iccFromXml` on a 65537-element document:

```
WRITE of size 1 in CIccXmlArrayType<unsigned char>::ParseArray  IccUtilXml.cpp:1352
  called from CIccTagXmlColorantOrder::ParseXml                 IccTagXml.cpp:2365
0 bytes after a 1-byte region allocated in CIccTagColorantOrder::CIccTagColorantOrder(int)
```

It is a separate reachable entry point — `iccFromXml` on a hand-authored document, no JSON
involved — so it is fixed here rather than left standing.

That reader also discarded `SetSize()`'s answer. It is now checked, as the sibling
`ColorantTable` reader already does for #2106, and the `if (m_pData)` that stood below it is
removed in the same hunk rather than left dead beside the new test. The two are the same guard:
`icRealloc()` frees the old block and returns NULL on failure and `SetSize()` stores that NULL,
so the pointer test was already catching every failed reallocation, and with `n >= 1` and
`SetSize()` true it can no longer come out false.

## All six entry points, enumerated and measured

The discriminator is whether the fill loop is bounded by the **declared** count or by the
**post-`SetSize`** count:

| entry point | bound used | verdict |
|---|---|---|
| `CIccTagJsonColorantOrder::ParseJson` | declared `nValues` | **overflow — fixed** |
| `CIccTagJsonColorantTable::ParseJson` | declared `nColorants` | **overflow — fixed** |
| `CIccTagXmlColorantOrder::ParseXml` | declared `n`, via `ParseArray`'s `nBufSize` | **overflow — fixed** |
| `CIccTagXmlColorantTable::ParseXml` | narrowed `n` (explicit cast) | safe — truncates |
| `CIccTagColorantOrder::Read` | `m_nCount` (post-`SetSize`) | safe — truncates |
| `CIccTagColorantTable::Read` | rejects `nCount > 0xffff` outright | safe |

The three safe readers are **measured, not assumed** — an equivalent 65537-entry document
through each produces no sanitizer report. They silently truncate rather than overrun, so they
are deliberately left alone here: that is a data-loss question, not a memory-safety one.

### One consequence worth a maintainer's eye

After this PR the two front ends disagree about the same document.
`CIccTagJsonColorantTable::ParseJson()` now **refuses** a 65537-entry colorant table, while
`CIccTagXmlColorantTable::ParseXml()` still **accepts** it and silently keeps one colorant —
and the accepting side is the one that produces wrong data rather than an error. The same holds
for `CIccTagColorantOrder::Read()` on the binary path.

I have not resolved that, because refusing a document the library has always accepted is a spec
and compatibility call rather than a memory-safety one. The XML helper's last case records the
truncation as **measured, not endorsed**, and its comment says so explicitly and names itself as
the case to invert once the divergence is ruled on. Happy to follow up either way.

## Tests

Two helpers, registered in both the `if(WIN32)` call list and the unconditional one:

- `.github/ci/regression/colorant-count-narrowing-json.cpp` → `iccdev.colorant-count-narrowing-json` (10 cases)
- `.github/ci/regression/colorant-count-narrowing-xml.cpp` → `iccdev.colorant-count-narrowing-xml` (5 cases)

Separate helpers, as the #2323 XML/JSON twins are, so neither masks the other: each is skipped
where its own library is not built.

**The oversize cases use 65537 rather than 65536, and the difference is load-bearing.** 65536
narrows to `0`, where `SetSize(0)` reallocates to nothing and reports failure — so the unfixed
readers *already* refused it, and that count on its own would have passed against the very
defect it was written for. Both counts are asserted; 65537 is the one that carries the red.

**Red/green was executed on a plain build, not only a sanitizer lane.** Against master the
unfixed helpers fail everywhere and never on an assertion of their own: plain clang-18 Release
aborts inside the first oversize case with glibc's `free(): invalid size` and
`malloc(): corrupted top size` (exit 134); a sanitizer lane aborts earlier still, at the
narrowing itself, which `-fno-sanitize-recover=integer` makes fatal.

**The boundary cases were verified by mutation, not by assertion.** With the guard changed to
`>= 0xFFFF`, exactly the three 65535 cases fail and every other case in both helpers still
passes.

The empty-array cases pin behaviour this PR did **not** change — an empty array was refused
before it too, because `SetSize(0)` reports failure — so that folding the new guard into
`if (!nValues) return false;` cannot be mistaken for a no-op.

## Pre-flight

| lane | result |
|---|---|
| clang-18 Release, full suite (272 tests) | 1 failure, 2 skipped — the failure is `iccdev.spectral-tiff-preview`, which needs a local `imagecodecs` Python module |
| clang-18 ASan/UBSan Debug, full suite (272 tests) | 3 failures — the same `spectral-tiff-preview`, plus `c-validation-dlopen` (dlopens an instrumented IccProfLib and passes on the plain lane) and `tool-coverage` (passes on re-run; a `-j4` ordering effect) |
| clang 21.1.3, `-Wall -Wextra -Wpedantic -Werror` | 0 warnings |
| GCC 15.2.0 host, strict + LTO | 0 warnings |
| **GCC 15.2.0 in `ghcr.io/internationalcolorconsortium/iccdev:latest`, strict + LTO** | **0 warnings** — configure reports `strict warnings ENABLED (GNU 15.2.0)`; CI's own `grep -cE 'warning:' build.log` gate run on the container log |
| both new tests, `ASAN_OPTIONS=detect_leaks=1` | 0 leaks |

The three reported PoCs reproduce end to end on master and are cleanly rejected after the fix,
with zero sanitizer output. A 4-entry `colorantOrder` profile is byte-identical before and after.

## CI evidence (dispatched before opening)

`ci-pr-action` with `ci_scope=source` on `6bf07521` — [run 34712002397](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34712002397), **success**. Both new tests were confirmed *executed*, not just the jobs green, by reading each job log:

| job | `colorant-count-narrowing-json` | `colorant-count-narrowing-xml` |
|---|---|---|
| Tool Smoke Tests, GCC Strict ASAN+UBSAN Debug (269/269 passed) | Passed | Passed |
| Windows MSVC build and test | Passed | Passed |
| Windows ClangCL build and test | Passed | Passed |
| MinGW UCRT64 smoke | Passed | Passed |

GCC 15.2 Strict Release LTO and both macOS legs build clean; those legs do not run ctest.
