### PR TITLE
fix: refuse a colorant or chromaticity count wider than 16 bits in every reader

### DIFF
--- a/.github/ci/regression/colorant-count-narrowing-binary.cpp
+++ b/.github/ci/regression/colorant-count-narrowing-binary.cpp
@@ -1,0 +1,212 @@
+/*
+    File:       colorant-count-narrowing-binary.cpp
+
+    Contains:   CTest helper for the binary colorant-count readers --
+                CIccTagColorantOrder::Read() and CIccTagColorantTable::Read() --
+                the follow-up to #2535/#2536 that makes every front end refuse
+                a count wider than the tag's 16-bit SetSize() instead of
+                silently truncating it.
+
+    #2535/#2536 fixed the JSON readers, and the XML colorantOrder reader, where
+    the narrowed count overran the allocation.  Two binary-path siblings were
+    measured NOT to overrun and were left alone there.  One of them still
+    disagreed with the rest:
+
+      CIccTagColorantOrder::Read() cast nCount straight to icUInt16Number for
+      SetSize() and then read m_nCount bytes -- the NARROWED count -- so a tag
+      declaring 65537 positions loaded successfully as a one-position tag, and
+      the remaining 65536 bytes were never read and never reported.
+
+      CIccTagColorantTable::Read() already refused "nCount > 0xffff".  It is the
+      precedent the others now follow, and the cases for it here are controls:
+      they pass before this change and after it, and exist so that the two
+      binary readers' contracts are pinned side by side.
+
+    Pure library test -- the tags are read from a CIccMemIO over bytes built in
+    memory, with no fixtures on disk and no tool invocation -- so it needs only
+    IccProfLib and no scratch directory.
+
+    The colorantOrder oversize case uses 65537, not 65536.  65536 narrows to 0,
+    SetSize(0) reallocates to nothing and reports failure, so the unfixed reader
+    ALREADY refused it; only 65537, which narrows to a non-zero 1, shows the
+    silent truncation.  Both are asserted.  This reader never overran, so unlike
+    the #2535/#2536 helpers its red is an ordinary assertion failure on every
+    lane: before the fix Read() returns true with GetSize() == 1.
+
+    The 65535 cases are the boundary discriminators: that count is representable
+    and must still read in full, so a guard spelled ">= 0xffff" fails them while
+    passing every other case here.
+
+    Exit codes:
+      0 - expected results observed
+      1 - unexpected result
+*/
+
+#include "IccTagBasic.h"
+#include "IccIO.h"
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static int check(bool condition, const char *label)
+{
+  if (condition) {
+    std::fprintf(stdout, "colorant-count-narrowing-binary: PASS  %s\n", label);
+    return 0;
+  }
+
+  std::fprintf(stderr, "colorant-count-narrowing-binary: FAIL  %s\n", label);
+  return 1;
+}
+
+static void put32(std::vector<icUInt8Number> &b, icUInt32Number v)
+{
+  b.push_back((icUInt8Number)(v >> 24));
+  b.push_back((icUInt8Number)(v >> 16));
+  b.push_back((icUInt8Number)(v >> 8));
+  b.push_back((icUInt8Number)v);
+}
+
+// type signature, reserved, declared count -- the 12-byte prefix both
+// element types share.
+static std::vector<icUInt8Number> prefix(icTagTypeSignature sig,
+                                         icUInt32Number nCount)
+{
+  std::vector<icUInt8Number> b;
+  put32(b, (icUInt32Number)sig);
+  put32(b, 0);
+  put32(b, nCount);
+  return b;
+}
+
+// A colorantOrderType element whose body really carries nCount positions, so
+// the size-derived capacity guard in Read() passes and the declared count is
+// the only thing deciding the outcome.
+static std::vector<icUInt8Number> orderElement(icUInt32Number nCount)
+{
+  std::vector<icUInt8Number> b = prefix(icSigColorantOrderType, nCount);
+  for (icUInt32Number i = 0; i < nCount; i++)
+    b.push_back((icUInt8Number)(i % 256));
+  return b;
+}
+
+// A colorantTableType element carrying nCount 38-byte entries.
+static std::vector<icUInt8Number> tableElement(icUInt32Number nCount)
+{
+  std::vector<icUInt8Number> b = prefix(icSigColorantTableType, nCount);
+  b.reserve(b.size() + (size_t)nCount * 38);
+  for (icUInt32Number i = 0; i < nCount; i++) {
+    char name[32] = {0};
+    std::snprintf(name, sizeof(name), "colorant-%u", (unsigned)i);
+    b.insert(b.end(), name, name + sizeof(name));
+    for (int k = 0; k < 6; k++)
+      b.push_back(0);
+  }
+  return b;
+}
+
+static int orderCase(icUInt32Number nCount, bool bExpectRead, const char *label)
+{
+  std::vector<icUInt8Number> bytes = orderElement(nCount);
+
+  CIccMemIO io;
+  if (!io.Attach(bytes.data(), (icUInt32Number)bytes.size()))
+    return check(false, "the colorantOrder byte stream could be attached");
+
+  CIccTagColorantOrder tag;
+  const bool bRead = tag.Read((icUInt32Number)bytes.size(), &io);
+
+  if (bRead != bExpectRead) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-binary: FAIL  %s (Read returned %s, "
+                 "expected %s; GetSize %u)\n",
+                 label, bRead ? "true" : "false",
+                 bExpectRead ? "true" : "false", (unsigned)tag.GetSize());
+    return 1;
+  }
+
+  if (!bExpectRead)
+    return check(true, label);
+
+  const icUInt8Number expect = (icUInt8Number)((nCount - 1) % 256);
+  const icUInt8Number *pData = tag.GetData(0);
+  if (tag.GetSize() != nCount || !pData || pData[nCount - 1] != expect) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-binary: FAIL  %s (GetSize %u, expected "
+                 "%u)\n", label, (unsigned)tag.GetSize(), (unsigned)nCount);
+    return 1;
+  }
+
+  return check(true, label);
+}
+
+static int tableCase(icUInt32Number nCount, bool bExpectRead, const char *label)
+{
+  std::vector<icUInt8Number> bytes = tableElement(nCount);
+
+  CIccMemIO io;
+  if (!io.Attach(bytes.data(), (icUInt32Number)bytes.size()))
+    return check(false, "the colorantTable byte stream could be attached");
+
+  CIccTagColorantTable tag;
+  const bool bRead = tag.Read((icUInt32Number)bytes.size(), &io);
+
+  if (bRead != bExpectRead) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-binary: FAIL  %s (Read returned %s, "
+                 "expected %s; GetSize %u)\n",
+                 label, bRead ? "true" : "false",
+                 bExpectRead ? "true" : "false", (unsigned)tag.GetSize());
+    return 1;
+  }
+
+  if (!bExpectRead)
+    return check(true, label);
+
+  char expect[32];
+  std::snprintf(expect, sizeof(expect), "colorant-%u", (unsigned)(nCount - 1));
+  const icColorantTableEntry *pEntry = tag.GetEntry(nCount - 1);
+  if (tag.GetSize() != nCount || !pEntry || std::string(pEntry->name) != expect) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-binary: FAIL  %s (GetSize %u, expected "
+                 "%u)\n", label, (unsigned)tag.GetSize(), (unsigned)nCount);
+    return 1;
+  }
+
+  return check(true, label);
+}
+
+int main()
+{
+  int failures = 0;
+
+  // CIccTagColorantOrder::Read() -- the reader this change moves.
+  failures += orderCase(65537, false,
+                        "colorantOrder declaring 65537, which narrowed to 1, is refused rather than read as one position");
+  failures += orderCase(65536, false,
+                        "colorantOrder declaring 65536, which narrowed to 0, is refused");
+  failures += orderCase(65535, true,
+                        "colorantOrder declaring exactly 65535 still reads in full");
+  failures += orderCase(4, true,
+                        "an ordinary colorantOrder is unaffected");
+
+  // CIccTagColorantTable::Read() -- the existing precedent, unchanged.  These
+  // pass before and after; they pin the contract the other readers now share.
+  failures += tableCase(65537, false,
+                        "colorantTable declaring 65537 is refused, as it already was");
+  failures += tableCase(65535, true,
+                        "colorantTable declaring exactly 65535 still reads in full, as it already did");
+  failures += tableCase(4, true,
+                        "an ordinary colorantTable is unaffected");
+
+  if (failures) {
+    std::fprintf(stderr, "colorant-count-narrowing-binary: %d case(s) failed\n",
+                 failures);
+    return 1;
+  }
+
+  std::fprintf(stdout, "colorant-count-narrowing-binary: all cases passed\n");
+  return 0;
+}

--- a/.github/ci/regression/colorant-count-narrowing-xml.cpp
+++ b/.github/ci/regression/colorant-count-narrowing-xml.cpp
@@ -1,8 +1,11 @@
 /*
     File:       colorant-count-narrowing-xml.cpp
 
-    Contains:   CTest helper for the XML twin of the colorantOrder count
-                narrowing fixed for JSON in #2536.
+    Contains:   CTest helper for the XML readers of three tags whose SetSize()
+                takes an icUInt16Number: colorantOrderType, the XML twin of the
+                overrun fixed for JSON in #2536, and colorantTableType and
+                chromaticityType, which truncated instead and now refuse the
+                same over-wide count.
 
     CIccTagXmlColorantOrder::ParseXml() counted its <n> elements into an int and
     passed that to SetSize(), which takes an icUInt16Number, so 65537 elements
@@ -24,22 +27,26 @@
     other: this one is skipped where IccXML is not built, and the JSON coverage
     does not disappear with it.
 
-    CIccTagXmlColorantTable::ParseXml() is deliberately NOT asserted as a defect
-    here.  It was measured on the same tree with an equivalent 65537-colorant
-    document and does not overrun: it casts to icUInt16Number explicitly and
-    bounds its own write loop by that same narrowed count, so it silently
-    truncates the colorant list instead.
+    The same helper now also covers the two XML readers that did NOT overrun but
+    silently truncated instead, CIccTagXmlColorantTable::ParseXml() and
+    CIccTagXmlChromaticity::ParseXml().  Both counted with an explicit
+    (icUInt16Number) cast and bounded their own loops by that narrowed count, so
+    a 65537-entry document loaded as a one-entry tag with no error -- while the
+    JSON readers for the same two tags refused it outright.  Measured before the
+    follow-up change, and pinned there by the first version of this helper as
+    "measured, not endorsed"; those cases are now inverted to expect refusal,
+    matching the JSON readers, CIccTagXmlColorantOrder::ParseXml() above, and
+    CIccTagColorantTable::Read(), which has always refused a count above 0xffff.
 
-    The last case records that truncation.  Read it as a measurement, NOT as an
-    endorsement: its only job is to show that a fix aimed at the neighbouring
-    reader did not change this one.  Truncating is very likely the WRONG
-    answer -- it accepts a document and silently discards colorants -- and after
-    this commit the two front ends disagree about the same shape, because
-    CIccTagJsonColorantTable::ParseJson() now refuses a 65537-entry table that
-    this reader still accepts as one colorant.  Settling that is a spec and
-    compatibility question for the maintainers, not something a memory-safety
-    fix should decide by itself.  Whoever settles it should expect to INVERT
-    this case rather than to work around it.
+    Their red is an ordinary assertion failure on every lane, not an abort: the
+    unfixed readers return true for the oversize documents, which never touch
+    memory they do not own.  Each has a 65535 boundary case, and chromaticity
+    has an ordinary three-channel control -- no tracked profile carries a
+    chromaticityType in XML, so that control is the only proof the fixture's
+    element names reach the reader at all.
+
+    Fixtures are removed as soon as each case has read them; the oversize
+    colorantTable documents alone are several megabytes each.
 
     The oversize cases are the memory-safety cases, and the count that carries
     them is 65537, not 65536.  65537 narrows to 1, SetSize(1) is answered "true"
@@ -150,6 +157,15 @@ static bool loadXml(CIccProfileXml &profile, const std::string &file)
   return profile.LoadXml(file.c_str(), "", &parseStr);
 }
 
+// Load one generated document and remove it again, whatever the outcome.
+static bool loadAndRemove(CIccProfileXml &profile, const std::string &path)
+{
+  const bool bLoaded = loadXml(profile, path);
+  std::error_code ec;
+  std::filesystem::remove(path, ec);
+  return bLoaded;
+}
+
 static int orderCase(const std::filesystem::path &dir, size_t nEntries,
                      bool bExpectLoaded, const char *file, const char *label)
 {
@@ -161,7 +177,7 @@ static int orderCase(const std::filesystem::path &dir, size_t nEntries,
   }
 
   CIccProfileXml profile;
-  const bool bLoaded = loadXml(profile, path);
+  const bool bLoaded = loadAndRemove(profile, path);
 
   if (bLoaded != bExpectLoaded) {
     std::fprintf(stderr,
@@ -208,6 +224,107 @@ static int orderCase(const std::filesystem::path &dir, size_t nEntries,
   return check(true, label);
 }
 
+static bool writeChromaticityFixture(const std::string &path, size_t nEntries)
+{
+  std::ofstream f(path, std::ios::binary);
+  if (!f)
+    return false;
+
+  f << kHeader;
+  f << "    <chromaticityTag> <chromaticityType>\n      <Colorant>Unknown</Colorant>\n";
+  for (size_t i = 0; i < nEntries; i++)
+    f << "      <Channel x=\"0." << (unsigned)(i % 10) << "\" y=\"0.5\"/>\n";
+  f << "    </chromaticityType> </chromaticityTag>\n";
+  f << kFooter;
+
+  return f.good();
+}
+
+static int tableCase(const std::filesystem::path &dir, size_t nEntries,
+                     bool bExpectLoaded, const char *file, const char *label)
+{
+  const std::string path = (dir / file).string();
+  if (!writeTableFixture(path, nEntries)) {
+    std::fprintf(stderr, "colorant-count-narrowing-xml: could not write %s\n",
+                 path.c_str());
+    return 1;
+  }
+
+  CIccProfileXml profile;
+  const bool bLoaded = loadAndRemove(profile, path);
+  CIccTagColorantTable *pTag =
+    bLoaded ? (CIccTagColorantTable *)profile.FindTag(icSigColorantTableTag)
+            : nullptr;
+
+  if (bLoaded != bExpectLoaded) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: FAIL  %s (LoadXml returned %s, "
+                 "expected %s; GetSize %u)\n",
+                 label, bLoaded ? "true" : "false",
+                 bExpectLoaded ? "true" : "false",
+                 pTag ? (unsigned)pTag->GetSize() : 0u);
+    return 1;
+  }
+
+  if (!bExpectLoaded)
+    return check(true, label);
+
+  char expect[32];
+  std::snprintf(expect, sizeof(expect), "colorant-%u", (unsigned)(nEntries - 1));
+  const icColorantTableEntry *pEntry =
+    pTag ? pTag->GetEntry((icUInt32Number)(nEntries - 1)) : nullptr;
+  if (!pTag || pTag->GetSize() != nEntries || !pEntry ||
+      std::string(pEntry->name) != expect) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: FAIL  %s (GetSize %u, expected "
+                 "%u)\n", label, pTag ? (unsigned)pTag->GetSize() : 0u,
+                 (unsigned)nEntries);
+    return 1;
+  }
+
+  return check(true, label);
+}
+
+static int chromaCase(const std::filesystem::path &dir, size_t nEntries,
+                      bool bExpectLoaded, const char *file, const char *label)
+{
+  const std::string path = (dir / file).string();
+  if (!writeChromaticityFixture(path, nEntries)) {
+    std::fprintf(stderr, "colorant-count-narrowing-xml: could not write %s\n",
+                 path.c_str());
+    return 1;
+  }
+
+  CIccProfileXml profile;
+  const bool bLoaded = loadAndRemove(profile, path);
+  CIccTagChromaticity *pTag =
+    bLoaded ? (CIccTagChromaticity *)profile.FindTag(icSigChromaticityTag)
+            : nullptr;
+
+  if (bLoaded != bExpectLoaded) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: FAIL  %s (LoadXml returned %s, "
+                 "expected %s; GetSize %u)\n",
+                 label, bLoaded ? "true" : "false",
+                 bExpectLoaded ? "true" : "false",
+                 pTag ? (unsigned)pTag->GetSize() : 0u);
+    return 1;
+  }
+
+  if (!bExpectLoaded)
+    return check(true, label);
+
+  if (!pTag || pTag->GetSize() != nEntries) {
+    std::fprintf(stderr,
+                 "colorant-count-narrowing-xml: FAIL  %s (GetSize %u, expected "
+                 "%u)\n", label, pTag ? (unsigned)pTag->GetSize() : 0u,
+                 (unsigned)nEntries);
+    return 1;
+  }
+
+  return check(true, label);
+}
+
 int main(int argc, char *argv[])
 {
   if (argc < 2) {
@@ -243,27 +360,21 @@ int main(int argc, char *argv[])
   failures += orderCase(dir, 4, true, "colorant-order-4.xml",
                         "an ordinary colorantOrder is unaffected");
 
-  // The sibling reader, measured NOT to overrun.  This records that it still
-  // truncates, so the fix above can be shown not to have moved it -- see the
-  // header: truncation is being measured here, not endorsed, and it is the case
-  // to invert once the front-end divergence is ruled on.
-  {
-    const std::string path = (dir / "colorant-table-65537.xml").string();
-    if (!writeTableFixture(path, 65537)) {
-      std::fprintf(stderr, "colorant-count-narrowing-xml: could not write %s\n",
-                   path.c_str());
-      return 1;
-    }
+  // CIccTagXmlColorantTable::ParseXml() -- truncated before the follow-up.
+  failures += tableCase(dir, 65537, false, "colorant-table-65537.xml",
+                        "a colorantTable at 65537 is refused, not truncated to one colorant");
+  failures += tableCase(dir, 65535, true, "colorant-table-65535.xml",
+                        "a colorantTable at exactly 65535 still loads in full");
+  failures += tableCase(dir, 4, true, "colorant-table-4.xml",
+                        "an ordinary colorantTable is unaffected");
 
-    CIccProfileXml profile;
-    const bool bLoaded = loadXml(profile, path);
-    CIccTagColorantTable *pTag =
-      bLoaded ? (CIccTagColorantTable *)profile.FindTag(icSigColorantTableTag)
-              : nullptr;
-
-    failures += check(bLoaded && pTag && pTag->GetSize() == 1,
-                      "the colorantTable reader still truncates an oversize list rather than overrunning it (measured, not endorsed)");
-  }
+  // CIccTagXmlChromaticity::ParseXml() -- the same truncation, third tag.
+  failures += chromaCase(dir, 65537, false, "chromaticity-65537.xml",
+                         "a chromaticity at 65537 channels is refused, not truncated to one");
+  failures += chromaCase(dir, 65535, true, "chromaticity-65535.xml",
+                         "a chromaticity at exactly 65535 channels still loads in full");
+  failures += chromaCase(dir, 3, true, "chromaticity-3.xml",
+                         "an ordinary three-channel chromaticity loads (fixture control)");
 
   if (failures) {
     std::fprintf(stderr, "colorant-count-narrowing-xml: %d case(s) failed\n",

--- a/Build/Cmake/Testing/CMakeLists.txt
+++ b/Build/Cmake/Testing/CMakeLists.txt
@@ -4848,6 +4848,64 @@ function(iccdev_add_colorant_count_narrowing_xml_test)
   endif()
 endfunction()
 
+# Follow-up to #2535/#2536: CIccTagColorantOrder::Read() cast its declared count
+# straight to SetSize()'s icUInt16Number and then read the narrowed m_nCount
+# bytes, so a tag declaring 65537 positions loaded as one -- silently, while
+# CIccTagColorantTable::Read() next to it has always refused "nCount > 0xffff"
+# and every JSON and XML reader now does too. Pure library test -- the elements
+# are built in memory and read through CIccMemIO, no fixtures on disk and no
+# tool invocation -- so it needs only IccProfLib and no scratch directory. The
+# colorantTable cases are controls that pass before and after, pinning the two
+# binary readers' contracts side by side.
+function(iccdev_add_colorant_count_narrowing_binary_test)
+  if(NOT TARGET "${TARGET_LIB_ICCPROFLIB}")
+    return()
+  endif()
+
+  iccdev_add_regression_executable(iccColorantCountNarrowingBinaryTest
+    "${ICCDEV_REPO_ROOT}/.github/ci/regression/colorant-count-narrowing-binary.cpp"
+  )
+  target_compile_features(iccColorantCountNarrowingBinaryTest PRIVATE cxx_std_17)
+  target_include_directories(iccColorantCountNarrowingBinaryTest PRIVATE
+    "${ICCDEV_REPO_ROOT}/IccProfLib"
+  )
+  target_link_libraries(iccColorantCountNarrowingBinaryTest PRIVATE
+    ${TARGET_LIB_ICCPROFLIB})
+  add_dependencies(check iccColorantCountNarrowingBinaryTest)
+
+  if(WIN32)
+    add_test(
+      NAME iccdev.colorant-count-narrowing-binary
+      COMMAND "$<TARGET_FILE:iccColorantCountNarrowingBinaryTest>"
+    )
+  else()
+    add_test(
+      NAME iccdev.colorant-count-narrowing-binary
+      COMMAND
+        "${CMAKE_COMMAND}" -E env
+        ${ICCDEV_TEST_ENV}
+        "$<TARGET_FILE:iccColorantCountNarrowingBinaryTest>"
+    )
+  endif()
+  set_tests_properties(iccdev.colorant-count-narrowing-binary PROPERTIES
+    TIMEOUT 120
+    LABELS "iccdev;colorant;regression"
+  )
+  if(WIN32)
+    set(_colorant_narrowing_binary_windows_env_mods
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:iccColorantCountNarrowingBinaryTest>"
+      "PATH=path_list_prepend:$<TARGET_FILE_DIR:${TARGET_LIB_ICCPROFLIB}>"
+    )
+    foreach(_runtime_path IN LISTS ICCDEV_WINDOWS_RUNTIME_PATHS)
+      list(APPEND _colorant_narrowing_binary_windows_env_mods
+        "PATH=path_list_prepend:${_runtime_path}")
+    endforeach()
+    set_tests_properties(iccdev.colorant-count-narrowing-binary PROPERTIES
+      ENVIRONMENT_MODIFICATION "${_colorant_narrowing_binary_windows_env_mods}"
+    )
+  endif()
+endfunction()
+
 # #2006 part 4a: CIccTagCurve::SetSize() answered an over-cap request the same
 # way it answered SetSize(0) -- free the table, m_nSize = 0, return true -- so
 # the return value could not distinguish "emptied" (a success, and ICC.1 10.6's
@@ -7834,6 +7892,7 @@ if(WIN32)
   iccdev_add_namedcolor_findcolor_suffix_underflow_test()
   iccdev_add_colorant_count_narrowing_json_test()
   iccdev_add_colorant_count_narrowing_xml_test()
+  iccdev_add_colorant_count_narrowing_binary_test()
   iccdev_add_xform_create_tag_ownership_test()
   iccdev_add_xform_abstorel_adjust_test()
   iccdev_add_bpc_d2b_tag_family_test()
@@ -8219,6 +8278,7 @@ iccdev_add_cmmsearch_namedcolor_ownership_test()
 iccdev_add_namedcolor_findcolor_suffix_underflow_test()
 iccdev_add_colorant_count_narrowing_json_test()
 iccdev_add_colorant_count_narrowing_xml_test()
+iccdev_add_colorant_count_narrowing_binary_test()
 iccdev_add_xform_create_tag_ownership_test()
 iccdev_add_xform_abstorel_adjust_test()
 iccdev_add_bpc_d2b_tag_family_test()

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -9616,7 +9616,12 @@ bool CIccTagColorantOrder::Read(icUInt32Number size, CIccIO *pIO)
 
   icUInt32Number nNum = (size - 3*sizeof(icUInt32Number))/sizeof(icUInt8Number);
 
-  if (nNum < nCount)
+  // SetSize() takes an icUInt16Number and the read below is of m_nCount, the
+  // narrowed count, so a declared count above 0xffff used to load silently as
+  // a shorter tag -- 65537 became one position and the rest of the element was
+  // never read.  CIccTagColorantTable::Read() has always refused such a count,
+  // and every JSON and XML reader of these tags now does too.
+  if (nNum < nCount || nCount > 0xffff)
     return false;
 
   if (!SetSize((icUInt16Number)nCount))

--- a/IccXML/IccLibXML/IccTagXml.cpp
+++ b/IccXML/IccLibXML/IccTagXml.cpp
@@ -1341,7 +1341,14 @@ bool CIccTagXmlChromaticity::ParseXml(xmlNode *pNode, std::string & /*parseStr*/
     m_nColorantType = icGetColorantValue(pNode->children ? (const icChar*)pNode->children->content : ""); 
 
 
-  icUInt16Number n = (icUInt16Number)icXmlNodeCount(pNode, "Channel");  
+  // The same silent truncation as CIccTagXmlColorantTable::ParseXml: the cast
+  // narrowed 65537 <Channel> elements to a one-channel tag.  The JSON reader
+  // refuses that count and the binary reader cannot express it, so refuse it.
+  icUInt32Number nCount = icXmlNodeCount(pNode, "Channel");
+  if (nCount > 0xFFFF)
+    return false;
+
+  icUInt16Number n = (icUInt16Number)nCount;
 
   if (n) {
     icUInt32Number i;
@@ -2366,9 +2373,10 @@ bool CIccTagXmlColorantOrder::ParseXml(xmlNode *pNode, std::string & /*parseStr*
     // given is the count, not the allocation.  Reject above the width the tag
     // can hold instead of narrowing into it.
     //
-    // CIccTagXmlColorantTable::ParseXml below is not affected: it casts to
-    // icUInt16Number explicitly and bounds its own loop by the same narrowed
-    // count, so it truncates the colorant list rather than overrunning it.
+    // CIccTagXmlColorantTable::ParseXml and CIccTagXmlChromaticity::ParseXml
+    // narrowed the same way but bounded their own loops by the narrowed count,
+    // so they truncated rather than overran; they refuse above 0xFFFF as well,
+    // so every reader of a 16-bit count gives the same answer.
     if (n > 0xFFFF)
       return false;
 
@@ -2432,7 +2440,16 @@ bool CIccTagXmlColorantTable::ParseXml(xmlNode *pNode, std::string & /*parseStr*
   if (pNode && pNode->children) {
     pNode = pNode->children;
 
-    icUInt16Number n = (icUInt16Number)icXmlNodeCount(pNode, "Colorant");
+    // The explicit cast used to narrow a count above 0xFFFF and the loop below
+    // was bounded by the narrowed value, so 65537 <Colorant> elements loaded as
+    // a one-colorant tag with no error.  That never overran, but it disagreed
+    // with the JSON reader and with CIccTagColorantTable::Read(), which have
+    // both refused such a table; refuse it here too rather than drop entries.
+    icUInt32Number nCount = icXmlNodeCount(pNode, "Colorant");
+    if (nCount > 0xFFFF)
+      return false;
+
+    icUInt16Number n = (icUInt16Number)nCount;
 
     if (n) {
       icUInt32Number i;


### PR DESCRIPTION
Follow-up to #2540 (#2535/#2536), and the resolution of the reader divergence that PR described.

## The problem

#2540 made three readers refuse a colorant count their `icUInt16Number` `SetSize()` cannot hold, because those three **overran** their allocation. It deliberately left three other readers alone: they narrowed the same count but bounded their own loops by the narrowed value, so they **silently truncated** instead:

| reader | how it narrowed | 65537 entries, before this PR |
|---|---|---|
| `CIccTagXmlColorantTable::ParseXml()` | `(icUInt16Number)` cast of the node count | loads, 1 colorant, no error |
| `CIccTagXmlChromaticity::ParseXml()` | `(icUInt16Number)` cast of the node count | loads, 1 channel, no error |
| `CIccTagColorantOrder::Read()` | `SetSize((icUInt16Number)nCount)`, then reads `m_nCount` | loads, 1 position, no error |

The same document is refused by both JSON readers and the XML `colorantOrderType` reader (since #2540), and by `CIccTagColorantTable::Read()`, which has refused `nCount > 0xffff` since `63b8df20` (2020). Six readers of three 16-bit counts were giving two answers, and the accepting side was the one producing wrong data rather than an error.

`chromaticityType` was not in #2540's table. It turned up while measuring the other two: its JSON reader refuses, and its binary reader cannot express the count, since the field is itself 16-bit.

## The change

All six now refuse. Each fix has the same shape: read the count at full width, refuse above `0xFFFF`, and only then narrow. The bound is `> 0xFFFF`, the spelling `CIccTagColorantTable::Read()` already uses, so 65535 entries still load in full. The XML `colorantOrderType` comment that described its two siblings as unaffected is corrected.

No tracked profile is anywhere near the bound. The largest counts in the corpus are 15 `colorantTable` entries and 5 `colorantOrder` positions, and no XML document carries a `chromaticityType` at all, so no committed document changes acceptance.

## Tests

- **New:** `.github/ci/regression/colorant-count-narrowing-binary.cpp` → `iccdev.colorant-count-narrowing-binary`. It needs only IccProfLib and drives both binary readers from bytes in a `CIccMemIO`. Its `colorantTable` cases are controls that pass before and after, pinning the two binary contracts side by side.
- **Changed:** `.github/ci/regression/colorant-count-narrowing-xml.cpp`. The `colorantTable` case #2540 recorded as "measured, not endorsed" is inverted to expect refusal. It adds `colorantTable` and `chromaticity` 65535 boundary cases and a three-channel `chromaticity` control. Because no tracked XML carries that type, the control is the only proof the fixture reaches the reader. Generated documents are now deleted as each case reads them.

**Red, measured before the source change:** exactly the three 65537 cases fail, each reporting a successful load with `GetSize() == 1`, and every control passes. This red is an ordinary assertion failure on every lane, not a sanitizer abort, because none of these readers ever touched memory it did not own.

**Mutation:** each new guard changed on its own to `>= 0xFFFF` fails exactly that reader's 65535 case and nothing else. That's one case on the binary side and two on the XML side.

## Pre-flight

All measured on the commit this PR carries.

| lane | result |
|---|---|
| clang-18 Release, full suite (274 tests) | 1 failure, 2 skipped. The failure is `iccdev.spectral-tiff-preview`, which needs a local `imagecodecs` Python module |
| clang-18 ASan/UBSan Debug, xml/json/colorant subset | 62/62 |
| clang-18 ASan/UBSan Debug, full suite inside `check` (273) | 3 failures, all known and environmental: `spectral-tiff-preview`; `c-validation-dlopen` (dlopens an instrumented IccProfLib, passes on the plain lane); `tool-coverage` (`-j4` ordering) |
| clang 21.1.3, `-Wall -Wextra -Wpedantic -Werror` | 0 warnings, 3/3 helpers |
| **GCC 15.2.0 in `ghcr.io/internationalcolorconsortium/iccdev:latest`, strict + LTO** | **0 warnings.** Configure reports `strict warnings ENABLED (GNU 15.2.0)`; CI's own `grep -cE 'warning:'` gate run on the container log; 3/3 helpers |
| both changed helpers, `ASAN_OPTIONS=detect_leaks=1` | 0 leaks |

## CI evidence (dispatched before opening)

I ran `ci-pr-action` with `ci_scope=source` on `8813d12c`: [run 34716049376](https://github.com/InternationalColorConsortium/iccDEV/actions/runs/34716049376), **success**. I checked each job's log to confirm all three helpers actually ran, rather than relying on the job being green:

| job | `-binary` | `-xml` | `-json` |
|---|---|---|---|
| Tool Smoke Tests, GCC Strict ASAN+UBSAN Debug (270/270 passed) | Passed | Passed | Passed |
| Windows MSVC build and test | Passed | Passed | Passed |
| Windows ClangCL build and test | Passed | Passed | Passed |
| MinGW UCRT64 smoke | Passed | Passed | Passed |

GCC 15.2 Strict Release LTO and both macOS jobs built cleanly; those jobs don't run ctest.
